### PR TITLE
Add joining parallel gateway validations

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -454,12 +454,12 @@ public class ProcessInstanceMigrationMigrateProcessor
       final DeployedProcess targetProcessDefinition,
       final Map<String, String> sourceElementIdToTargetElementId,
       final ElementInstance elementInstance) {
-    final long flowScopeKey = elementInstance.getKey();
+    final long elementInstanceKey = elementInstance.getKey();
     final long processInstanceKey = elementInstance.getValue().getProcessInstanceKey();
 
     final List<ActiveSequenceFlow> activeSequenceFlows = new ArrayList<>();
     elementInstanceState.visitTakenSequenceFlows(
-        flowScopeKey,
+        elementInstanceKey,
         (scopeKey, gatewayElementId, sequenceFlowId, number) -> {
           final var sequenceFlow =
               sourceProcessDefinition
@@ -480,7 +480,7 @@ public class ProcessInstanceMigrationMigrateProcessor
               final ExecutableSequenceFlow activeFlow = activeSequenceFlow.sequenceFlow();
               final ExecutableFlowNode sourceGateway = activeSequenceFlow.target;
               requireNoConcurrentCommandForGateway(
-                  elementInstanceState, sourceGateway, flowScopeKey, processInstanceKey);
+                  elementInstanceState, sourceGateway, elementInstanceKey, processInstanceKey);
 
               final String targetGatewayId =
                   sourceElementIdToTargetElementId.get(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -480,11 +480,20 @@ public class ProcessInstanceMigrationMigrateProcessor
               final String targetGatewayId =
                   sourceElementIdToTargetElementId.get(
                       BufferUtil.bufferAsString(sourceGateway.getId()));
-
               requireValidGatewayMapping(
                   sourceGateway,
                   Optional.ofNullable(targetGatewayId),
                   targetProcessDefinition,
+                  elementInstance.getValue().getProcessInstanceKey());
+
+              final ExecutableFlowNode targetGateway =
+                  targetProcessDefinition
+                      .getProcess()
+                      .getElementById(targetGatewayId, ExecutableFlowNode.class);
+              requireSequenceFlowExistsInTarget(
+                  activeFlow.getId(),
+                  sourceGateway,
+                  targetGateway,
                   elementInstance.getValue().getProcessInstanceKey());
 
               return activeFlow;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -57,6 +57,7 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -480,13 +481,11 @@ public class ProcessInstanceMigrationMigrateProcessor
                   sourceElementIdToTargetElementId.get(
                       BufferUtil.bufferAsString(sourceGateway.getId()));
 
-              // TODO -  add validations: if gateway not mapped and if gateway type changed
-              // target gateway will be used for validations in the next PR, please ignore
-              // the assignment for now
-              final ExecutableFlowNode targetGateway =
-                  targetProcessDefinition
-                      .getProcess()
-                      .getElementById(targetGatewayId, ExecutableFlowNode.class);
+              requireValidGatewayMapping(
+                  sourceGateway,
+                  Optional.ofNullable(targetGatewayId),
+                  targetProcessDefinition,
+                  elementInstance.getValue().getProcessInstanceKey());
 
               return activeFlow;
             })

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -490,6 +490,8 @@ public class ProcessInstanceMigrationMigrateProcessor
                   targetProcessDefinition
                       .getProcess()
                       .getElementById(targetGatewayId, ExecutableFlowNode.class);
+              requireValidTargetIncomingFlowCount(
+                  sourceGateway, targetGateway, elementInstance.getValue().getProcessInstanceKey());
               requireSequenceFlowExistsInTarget(
                   activeFlow.getId(),
                   sourceGateway,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -57,7 +57,6 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -487,10 +486,7 @@ public class ProcessInstanceMigrationMigrateProcessor
                   sourceElementIdToTargetElementId.get(
                       BufferUtil.bufferAsString(sourceGateway.getId()));
               requireValidGatewayMapping(
-                  sourceGateway,
-                  Optional.ofNullable(targetGatewayId),
-                  targetProcessDefinition,
-                  processInstanceKey);
+                  sourceGateway, targetGatewayId, targetProcessDefinition, processInstanceKey);
 
               final ExecutableFlowNode targetGateway =
                   targetProcessDefinition

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -186,6 +186,13 @@ public final class ProcessInstanceMigrationPreconditions {
       Taken sequence flow with id '%s' must connect to the mapped target gateway \
       with id '%s' in the target process definition.""";
 
+  private static final String ERROR_TARGET_GATEWAY_HAS_LESS_INCOMING_SEQUENCE_FLOWS =
+      """
+      Expected to migrate process instance '%s' \
+      but target gateway with id '%s' has less incoming sequence flows \
+      than the source gateway with id '%s'. \
+      Target gateway must have at least the same number of incoming sequence flows as the source gateway.""";
+
   private static final String ZEEBE_USER_TASK_IMPLEMENTATION = "zeebe user task";
   private static final String JOB_WORKER_IMPLEMENTATION = "job worker";
 
@@ -943,6 +950,22 @@ public final class ProcessInstanceMigrationPreconditions {
               BufferUtil.bufferAsString(sourceGateway.getId()),
               BufferUtil.bufferAsString(activeSequenceFlowId),
               BufferUtil.bufferAsString(targetGateway.getId()));
+      throw new ProcessInstanceMigrationPreconditionFailedException(
+          reason, RejectionType.INVALID_ARGUMENT);
+    }
+  }
+
+  public static void requireValidTargetIncomingFlowCount(
+      final ExecutableFlowNode sourceGateway,
+      final ExecutableFlowNode targetGateway,
+      final long processInstanceKey) {
+    if (targetGateway.getIncoming().size() < sourceGateway.getIncoming().size()) {
+      final var reason =
+          String.format(
+              ERROR_TARGET_GATEWAY_HAS_LESS_INCOMING_SEQUENCE_FLOWS,
+              processInstanceKey,
+              BufferUtil.bufferAsString(targetGateway.getId()),
+              BufferUtil.bufferAsString(sourceGateway.getId()));
       throw new ProcessInstanceMigrationPreconditionFailedException(
           reason, RejectionType.INVALID_ARGUMENT);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -176,14 +176,14 @@ public final class ProcessInstanceMigrationPreconditions {
   private static final String ERROR_GATEWAY_NOT_MAPPED =
       """
       Expected to migrate process instance '%s' \
-      but gateway '%s' has at least one sequence flow taken. \
-      Joining gateways with at least one sequence flow taken must be mapped \
+      but gateway '%s' has at least one incoming sequence flow taken. \
+      Joining gateways with at least one incoming sequence flow taken must be mapped \
       to a gateway of the same type in the target process definition.""";
 
   private static final String ERROR_SEQUENCE_FLOW_NOT_CONNECTED_TO_TARGET_GATEWAY =
       """
       Expected to migrate process instance '%s' \
-      but gateway with id '%s' has a taken sequence flow mismatch. \
+      but gateway with id '%s' has a taken incoming sequence flow mismatch. \
       Taken sequence flow with id '%s' must connect to the mapped target gateway \
       with id '%s' in the target process definition.""";
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -37,7 +37,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
@@ -936,10 +935,10 @@ public final class ProcessInstanceMigrationPreconditions {
 
   public static void requireValidGatewayMapping(
       final ExecutableFlowNode sourceGateway,
-      final Optional<String> maybeTargetGatewayId,
+      final String targetGatewayId,
       final DeployedProcess targetProcessDefinition,
       final long processInstanceKey) {
-    if (maybeTargetGatewayId.isEmpty()) {
+    if (targetGatewayId == null) {
       final var reason =
           String.format(
               ERROR_GATEWAY_NOT_MAPPED,
@@ -949,7 +948,6 @@ public final class ProcessInstanceMigrationPreconditions {
           reason, RejectionType.INVALID_ARGUMENT);
     }
 
-    final String targetGatewayId = maybeTargetGatewayId.get();
     // no need to check if the target gateway exists because it is already validated
     final var targetGateway = targetProcessDefinition.getProcess().getElementById(targetGatewayId);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelGatewayTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelGatewayTest.java
@@ -405,6 +405,183 @@ public class MigrateParallelGatewayTest {
   }
 
   @Test
+  public void shouldRejectJoiningParallelGatewayMigrationIfGatewayNotMapped() {
+    final String sourceProcessId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "_v2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(sourceProcessId)
+                    .startEvent()
+                    .parallelGateway("fork")
+                    .serviceTask("task1", b -> b.zeebeJobType("type1"))
+                    .sequenceFlowId("flow1")
+                    .parallelGateway("join1")
+                    .endEvent("end")
+                    .moveToNode("fork")
+                    .serviceTask("task2", b -> b.zeebeJobType("type2"))
+                    .connectTo("join1")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .parallelGateway("fork")
+                    .serviceTask("task1", b -> b.zeebeJobType("type1"))
+                    .sequenceFlowId("flow1")
+                    .parallelGateway("join2")
+                    .endEvent("end")
+                    .moveToNode("fork")
+                    .serviceTask("task2", b -> b.zeebeJobType("type2"))
+                    .connectTo("join2")
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
+
+    AssertionsForInterfaceTypes.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SERVICE_TASK)
+                .limit(2))
+        .hasSize(2);
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("type1").complete();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId("flow1")
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to take the sequence flow to the join gateway")
+        .isNotNull();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("task2", "task2")
+        // gateway not mapped
+        .expectRejection()
+        .migrate();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst();
+
+    Assertions.assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            """
+            Expected to migrate process instance '%s' \
+            but gateway '%s' has at least one sequence flow taken. \
+            Joining gateways with at least one sequence flow taken must be mapped \
+            to a gateway of the same type in the target process definition."""
+                .formatted(processInstanceKey, "join1"))
+        .hasKey(processInstanceKey);
+  }
+
+  @Test
+  public void shouldRejectJoiningParallelGatewayMigrationIfMappedGatewayHasDifferentType() {
+    final String sourceProcessId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "_v2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(sourceProcessId)
+                    .startEvent()
+                    .parallelGateway("fork")
+                    .serviceTask("task1", b -> b.zeebeJobType("type1"))
+                    .sequenceFlowId("flow1")
+                    .parallelGateway("join1")
+                    .endEvent("end")
+                    .moveToNode("fork")
+                    .serviceTask("task2", b -> b.zeebeJobType("type2"))
+                    .connectTo("join1")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .inclusiveGateway("fork")
+                    .condition("= true")
+                    .serviceTask("task1", b -> b.zeebeJobType("type1"))
+                    .sequenceFlowId("flow1")
+                    .inclusiveGateway("join2")
+                    .endEvent("end")
+                    .moveToNode("fork")
+                    .condition("= true")
+                    .serviceTask("task2", b -> b.zeebeJobType("type2"))
+                    .connectTo("join2")
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
+
+    AssertionsForInterfaceTypes.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SERVICE_TASK)
+                .limit(2))
+        .hasSize(2);
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("type1").complete();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId("flow1")
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to take the sequence flow to the join gateway")
+        .isNotNull();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("task2", "task2")
+        .addMappingInstruction("join1", "join2")
+        .expectRejection()
+        .migrate();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst();
+
+    Assertions.assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            """
+            Expected to migrate process instance '%s' \
+            but active element with id '%s' and type '%s' is mapped to \
+            an element with id '%s' and different type '%s'. \
+            Elements must be mapped to elements of the same type."""
+                .formatted(
+                    processInstanceKey,
+                    "join1",
+                    BpmnElementType.PARALLEL_GATEWAY,
+                    "join2",
+                    BpmnElementType.INCLUSIVE_GATEWAY))
+        .hasKey(processInstanceKey);
+  }
+
+  @Test
   public void shouldRejectJoiningParallelGatewayMigrationIfMappedGatewayDoesNotExistInSource() {
     final String sourceProcessId = helper.getBpmnProcessId();
     final String targetProcessId = helper.getBpmnProcessId() + "_v2";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelGatewayTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelGatewayTest.java
@@ -479,8 +479,8 @@ public class MigrateParallelGatewayTest {
         .hasRejectionReason(
             """
             Expected to migrate process instance '%s' \
-            but gateway '%s' has at least one sequence flow taken. \
-            Joining gateways with at least one sequence flow taken must be mapped \
+            but gateway '%s' has at least one incoming sequence flow taken. \
+            Joining gateways with at least one incoming sequence flow taken must be mapped \
             to a gateway of the same type in the target process definition."""
                 .formatted(processInstanceKey, "join1"))
         .hasKey(processInstanceKey);
@@ -822,7 +822,7 @@ public class MigrateParallelGatewayTest {
         .hasRejectionReason(
             """
               Expected to migrate process instance '%s' \
-              but gateway with id '%s' has a taken sequence flow mismatch. \
+              but gateway with id '%s' has a taken incoming sequence flow mismatch. \
               Taken sequence flow with id '%s' must connect to the mapped target gateway \
               with id '%s' in the target process definition."""
                 .formatted(processInstanceKey, "join1", "flow1", "join2"))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelGatewayTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelGatewayTest.java
@@ -838,4 +838,95 @@ public class MigrateParallelGatewayTest {
                 .formatted(processInstanceKey, "join1", "flow1", "join2"))
         .hasKey(processInstanceKey);
   }
+
+  @Test
+  public void
+      shouldRejectJoiningParallelGatewayMigrationIfTargetGatewayHasLessIncomingSequenceFlows() {
+    final String sourceProcessId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "_v2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(sourceProcessId)
+                    .startEvent()
+                    .parallelGateway("fork")
+                    .serviceTask("task1", b -> b.zeebeJobType("type1"))
+                    .sequenceFlowId("flow1")
+                    .parallelGateway("join1")
+                    .endEvent("end")
+                    .moveToNode("fork")
+                    .serviceTask("task2", b -> b.zeebeJobType("type2"))
+                    .connectTo("join1")
+                    .moveToNode("fork")
+                    .serviceTask("task3", b -> b.zeebeJobType("type3"))
+                    .connectTo("join1")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .parallelGateway("fork")
+                    .serviceTask("task1", b -> b.zeebeJobType("type1"))
+                    .sequenceFlowId("flow1")
+                    .parallelGateway("join2")
+                    .serviceTask("task4", b -> b.zeebeJobType("type4"))
+                    .endEvent()
+                    .moveToNode("fork")
+                    .serviceTask("task2", b -> b.zeebeJobType("type2"))
+                    .connectTo("join2")
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SERVICE_TASK)
+                .limit(2))
+        .hasSize(2);
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("type1").complete();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId("flow1")
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to take the sequence flow to the join gateway")
+        .isNotNull();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("task2", "task2")
+        .addMappingInstruction("task3", "task4")
+        .addMappingInstruction("join1", "join2")
+        .expectRejection()
+        .migrate();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst();
+
+    Assertions.assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            """
+            Expected to migrate process instance '%s' \
+            but target gateway with id '%s' has less incoming sequence flows \
+            than the source gateway with id '%s'. \
+            Target gateway must have at least the same number of incoming sequence flows as the source gateway."""
+                .formatted(processInstanceKey, "join2", "join1"))
+        .hasKey(processInstanceKey);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelGatewayTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelGatewayTest.java
@@ -461,20 +461,18 @@ public class MigrateParallelGatewayTest {
         .isNotNull();
 
     // when
-    ENGINE
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .migration()
-        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
-        .addMappingInstruction("task2", "task2")
-        // gateway not mapped
-        .expectRejection()
-        .migrate();
+    final var rejectionRecord =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("task2", "task2")
+            // gateway not mapped
+            .expectRejection()
+            .migrate();
 
     // then
-    final var rejectionRecord =
-        RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst();
-
     Assertions.assertThat(rejectionRecord)
         .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
@@ -548,20 +546,18 @@ public class MigrateParallelGatewayTest {
         .isNotNull();
 
     // when
-    ENGINE
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .migration()
-        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
-        .addMappingInstruction("task2", "task2")
-        .addMappingInstruction("join1", "join2")
-        .expectRejection()
-        .migrate();
+    final var rejectionRecord =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("task2", "task2")
+            .addMappingInstruction("join1", "join2")
+            .expectRejection()
+            .migrate();
 
     // then
-    final var rejectionRecord =
-        RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst();
-
     Assertions.assertThat(rejectionRecord)
         .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
@@ -639,20 +635,18 @@ public class MigrateParallelGatewayTest {
 
     // when
     final String nonExistingSourceGatewayId = "nonExistingSourceGatewayId";
-    ENGINE
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .migration()
-        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
-        .addMappingInstruction("task2", "task2")
-        .addMappingInstruction(nonExistingSourceGatewayId, "join2")
-        .expectRejection()
-        .migrate();
+    final var rejectionRecord =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("task2", "task2")
+            .addMappingInstruction(nonExistingSourceGatewayId, "join2")
+            .expectRejection()
+            .migrate();
 
     // then
-    final var rejectionRecord =
-        RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst();
-
     Assertions.assertThat(rejectionRecord)
         .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
@@ -726,20 +720,18 @@ public class MigrateParallelGatewayTest {
 
     // when
     final String nonExistingTargetGatewayId = "nonExistingTargetGatewayId";
-    ENGINE
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .migration()
-        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
-        .addMappingInstruction("task2", "task2")
-        .addMappingInstruction("join1", nonExistingTargetGatewayId)
-        .expectRejection()
-        .migrate();
+    final var rejectionRecord =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("task2", "task2")
+            .addMappingInstruction("join1", nonExistingTargetGatewayId)
+            .expectRejection()
+            .migrate();
 
     // then
-    final var rejectionRecord =
-        RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst();
-
     Assertions.assertThat(rejectionRecord)
         .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
@@ -812,20 +804,18 @@ public class MigrateParallelGatewayTest {
         .isNotNull();
 
     // when
-    ENGINE
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .migration()
-        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
-        .addMappingInstruction("task2", "task3")
-        .addMappingInstruction("join1", "join2")
-        .expectRejection()
-        .migrate();
+    final var rejectionRecord =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("task2", "task3")
+            .addMappingInstruction("join1", "join2")
+            .expectRejection()
+            .migrate();
 
     // then
-    final var rejectionRecord =
-        RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst();
-
     Assertions.assertThat(rejectionRecord)
         .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
@@ -902,21 +892,19 @@ public class MigrateParallelGatewayTest {
         .isNotNull();
 
     // when
-    ENGINE
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .migration()
-        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
-        .addMappingInstruction("task2", "task2")
-        .addMappingInstruction("task3", "task4")
-        .addMappingInstruction("join1", "join2")
-        .expectRejection()
-        .migrate();
+    final var rejectionRecord =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("task2", "task2")
+            .addMappingInstruction("task3", "task4")
+            .addMappingInstruction("join1", "join2")
+            .expectRejection()
+            .migrate();
 
     // then
-    final var rejectionRecord =
-        RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst();
-
     Assertions.assertThat(rejectionRecord)
         .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelGatewayTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelGatewayTest.java
@@ -14,8 +14,10 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -400,5 +402,178 @@ public class MigrateParallelGatewayTest {
                 .getValue())
         .describedAs("Expected to activate the joining parallel gateway")
         .isNotNull();
+  }
+
+  @Test
+  public void shouldRejectJoiningParallelGatewayMigrationIfMappedGatewayDoesNotExistInSource() {
+    final String sourceProcessId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "_v2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(sourceProcessId)
+                    .startEvent()
+                    .parallelGateway("fork")
+                    .serviceTask("task1", b -> b.zeebeJobType("type1"))
+                    .sequenceFlowId("flow1")
+                    .parallelGateway("join1")
+                    .endEvent("end")
+                    .moveToNode("fork")
+                    .serviceTask("task2", b -> b.zeebeJobType("type2"))
+                    .connectTo("join1")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .parallelGateway("fork")
+                    .serviceTask("task1", b -> b.zeebeJobType("type1"))
+                    .sequenceFlowId("flow1")
+                    .parallelGateway("join2")
+                    .endEvent("end")
+                    .moveToNode("fork")
+                    .serviceTask("task2", b -> b.zeebeJobType("type2"))
+                    .connectTo("join2")
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
+
+    AssertionsForInterfaceTypes.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SERVICE_TASK)
+                .limit(2))
+        .hasSize(2);
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("type1").complete();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId("flow1")
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to take the sequence flow to the join gateway")
+        .isNotNull();
+
+    // when
+    final String nonExistingSourceGatewayId = "nonExistingSourceGatewayId";
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("task2", "task2")
+        .addMappingInstruction(nonExistingSourceGatewayId, "join2")
+        .expectRejection()
+        .migrate();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst();
+
+    Assertions.assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            String.format(
+                """
+              Expected to migrate process instance '%s' \
+              but mapping instructions contain a non-existing source element id '%s'. \
+              Elements provided in mapping instructions must exist \
+              in the source process definition.""",
+                processInstanceKey, nonExistingSourceGatewayId))
+        .hasKey(processInstanceKey);
+  }
+
+  @Test
+  public void shouldRejectJoiningParallelGatewayMigrationIfMappedGatewayDoesNotExistInTarget() {
+    final String sourceProcessId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "_v2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(sourceProcessId)
+                    .startEvent()
+                    .parallelGateway("fork")
+                    .serviceTask("task1", b -> b.zeebeJobType("type1"))
+                    .sequenceFlowId("flow1")
+                    .parallelGateway("join1")
+                    .endEvent("end")
+                    .moveToNode("fork")
+                    .serviceTask("task2", b -> b.zeebeJobType("type2"))
+                    .connectTo("join1")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .parallelGateway("fork")
+                    .serviceTask("task1", b -> b.zeebeJobType("type1"))
+                    .sequenceFlowId("flow1")
+                    .parallelGateway("join2")
+                    .endEvent("end")
+                    .moveToNode("fork")
+                    .serviceTask("task2", b -> b.zeebeJobType("type2"))
+                    .connectTo("join2")
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
+
+    AssertionsForInterfaceTypes.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SERVICE_TASK)
+                .limit(2))
+        .hasSize(2);
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("type1").complete();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId("flow1")
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to take the sequence flow to the join gateway")
+        .isNotNull();
+
+    // when
+    final String nonExistingTargetGatewayId = "nonExistingTargetGatewayId";
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("task2", "task2")
+        .addMappingInstruction("join1", nonExistingTargetGatewayId)
+        .expectRejection()
+        .migrate();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst();
+
+    Assertions.assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            """
+              Expected to migrate process instance '%s' \
+              but mapping instructions contain a non-existing target element id '%s'. \
+              Elements provided in mapping instructions must exist \
+              in the target process definition."""
+                .formatted(processInstanceKey, nonExistingTargetGatewayId))
+        .hasKey(processInstanceKey);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelGatewayTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelGatewayTest.java
@@ -165,15 +165,6 @@ public class MigrateParallelGatewayTest {
 
     ENGINE.job().ofInstance(processInstanceKey).withType("type1").complete();
 
-    Assertions.assertThat(
-            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN)
-                .withProcessInstanceKey(processInstanceKey)
-                .withElementId("flow1")
-                .getFirst()
-                .getValue())
-        .describedAs("Expected to take the sequence flow to the joining gateway")
-        .isNotNull();
-
     // when
     ENGINE
         .processInstance()
@@ -451,15 +442,6 @@ public class MigrateParallelGatewayTest {
 
     ENGINE.job().ofInstance(processInstanceKey).withType("type1").complete();
 
-    Assertions.assertThat(
-            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN)
-                .withProcessInstanceKey(processInstanceKey)
-                .withElementId("flow1")
-                .getFirst()
-                .getValue())
-        .describedAs("Expected to take the sequence flow to the join gateway")
-        .isNotNull();
-
     // when
     final var rejectionRecord =
         ENGINE
@@ -535,15 +517,6 @@ public class MigrateParallelGatewayTest {
         .hasSize(2);
 
     ENGINE.job().ofInstance(processInstanceKey).withType("type1").complete();
-
-    Assertions.assertThat(
-            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN)
-                .withProcessInstanceKey(processInstanceKey)
-                .withElementId("flow1")
-                .getFirst()
-                .getValue())
-        .describedAs("Expected to take the sequence flow to the join gateway")
-        .isNotNull();
 
     // when
     final var rejectionRecord =
@@ -624,15 +597,6 @@ public class MigrateParallelGatewayTest {
 
     ENGINE.job().ofInstance(processInstanceKey).withType("type1").complete();
 
-    Assertions.assertThat(
-            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN)
-                .withProcessInstanceKey(processInstanceKey)
-                .withElementId("flow1")
-                .getFirst()
-                .getValue())
-        .describedAs("Expected to take the sequence flow to the join gateway")
-        .isNotNull();
-
     // when
     final String nonExistingSourceGatewayId = "nonExistingSourceGatewayId";
     final var rejectionRecord =
@@ -709,15 +673,6 @@ public class MigrateParallelGatewayTest {
 
     ENGINE.job().ofInstance(processInstanceKey).withType("type1").complete();
 
-    Assertions.assertThat(
-            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN)
-                .withProcessInstanceKey(processInstanceKey)
-                .withElementId("flow1")
-                .getFirst()
-                .getValue())
-        .describedAs("Expected to take the sequence flow to the join gateway")
-        .isNotNull();
-
     // when
     final String nonExistingTargetGatewayId = "nonExistingTargetGatewayId";
     final var rejectionRecord =
@@ -793,15 +748,6 @@ public class MigrateParallelGatewayTest {
         .hasSize(2);
 
     ENGINE.job().ofInstance(processInstanceKey).withType("type1").complete();
-
-    Assertions.assertThat(
-            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN)
-                .withProcessInstanceKey(processInstanceKey)
-                .withElementId("flow1")
-                .getFirst()
-                .getValue())
-        .describedAs("Expected to take the sequence flow to the joining gateway")
-        .isNotNull();
 
     // when
     final var rejectionRecord =
@@ -881,15 +827,6 @@ public class MigrateParallelGatewayTest {
         .hasSize(2);
 
     ENGINE.job().ofInstance(processInstanceKey).withType("type1").complete();
-
-    Assertions.assertThat(
-            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN)
-                .withProcessInstanceKey(processInstanceKey)
-                .withElementId("flow1")
-                .getFirst()
-                .getValue())
-        .describedAs("Expected to take the sequence flow to the join gateway")
-        .isNotNull();
 
     // when
     final var rejectionRecord =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelGatewayTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelGatewayTest.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
-import org.assertj.core.api.AssertionsForInterfaceTypes;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -157,7 +156,7 @@ public class MigrateParallelGatewayTest {
     final long processInstanceKey =
         ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
 
-    AssertionsForInterfaceTypes.assertThat(
+    assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withProcessInstanceKey(processInstanceKey)
                 .withElementType(BpmnElementType.SERVICE_TASK)
@@ -246,7 +245,7 @@ public class MigrateParallelGatewayTest {
     final long processInstanceKey =
         ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
 
-    AssertionsForInterfaceTypes.assertThat(
+    assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withProcessInstanceKey(processInstanceKey)
                 .withElementType(BpmnElementType.SERVICE_TASK)
@@ -353,7 +352,7 @@ public class MigrateParallelGatewayTest {
     final long processInstanceKey =
         ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
 
-    AssertionsForInterfaceTypes.assertThat(
+    assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withProcessInstanceKey(processInstanceKey)
                 .withElementType(BpmnElementType.SERVICE_TASK)
@@ -443,7 +442,7 @@ public class MigrateParallelGatewayTest {
     final long processInstanceKey =
         ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
 
-    AssertionsForInterfaceTypes.assertThat(
+    assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withProcessInstanceKey(processInstanceKey)
                 .withElementType(BpmnElementType.SERVICE_TASK)
@@ -530,7 +529,7 @@ public class MigrateParallelGatewayTest {
     final long processInstanceKey =
         ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
 
-    AssertionsForInterfaceTypes.assertThat(
+    assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withProcessInstanceKey(processInstanceKey)
                 .withElementType(BpmnElementType.SERVICE_TASK)
@@ -620,7 +619,7 @@ public class MigrateParallelGatewayTest {
     final long processInstanceKey =
         ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
 
-    AssertionsForInterfaceTypes.assertThat(
+    assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withProcessInstanceKey(processInstanceKey)
                 .withElementType(BpmnElementType.SERVICE_TASK)
@@ -707,7 +706,7 @@ public class MigrateParallelGatewayTest {
     final long processInstanceKey =
         ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
 
-    AssertionsForInterfaceTypes.assertThat(
+    assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withProcessInstanceKey(processInstanceKey)
                 .withElementType(BpmnElementType.SERVICE_TASK)
@@ -794,7 +793,7 @@ public class MigrateParallelGatewayTest {
     final long processInstanceKey =
         ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
 
-    AssertionsForInterfaceTypes.assertThat(
+    assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withProcessInstanceKey(processInstanceKey)
                 .withElementType(BpmnElementType.SERVICE_TASK)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceConcurrentNoBatchingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceConcurrentNoBatchingTest.java
@@ -1048,6 +1048,116 @@ public class MigrateProcessInstanceConcurrentNoBatchingTest {
   }
 
   @Test
+  public void
+      shouldRejectJoiningParallelGatewayMigrationIfAllIncomingSequenceFlowsOfSourceGatewayIsTaken() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "_v2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .parallelGateway("fork")
+                    .serviceTask("task1", b -> b.zeebeJobType("type1"))
+                    .sequenceFlowId("flow1")
+                    .parallelGateway("join1")
+                    .endEvent("end1")
+                    .moveToNode("fork")
+                    .serviceTask("task2", b -> b.zeebeJobType("type2"))
+                    .sequenceFlowId("flow2")
+                    .connectTo("join1")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .parallelGateway("fork")
+                    .serviceTask("task1", b -> b.zeebeJobType("type1"))
+                    .sequenceFlowId("flow1")
+                    .parallelGateway("join2")
+                    .endEvent("end2")
+                    .moveToNode("fork")
+                    .serviceTask("task3", b -> b.zeebeJobType("type3"))
+                    .sequenceFlowId("flow2")
+                    .connectTo("join2")
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SERVICE_TASK)
+                .limit(2))
+        .hasSize(2);
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("type1").complete();
+
+    io.camunda.zeebe.protocol.record.Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId("flow1")
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to take the sequence flow to the joining gateway")
+        .isNotNull();
+
+    final var job2 =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withType("type2")
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    final var task2 =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("task2")
+            .getFirst();
+
+    ENGINE.pauseProcessing(1);
+    ENGINE.stop();
+
+    ENGINE.writeRecords(
+        RecordToWrite.command().job(JobIntent.COMPLETE, new JobRecord()).key(job2.getKey()),
+        RecordToWrite.command()
+            .key(task2.getKey())
+            .processInstance(ProcessInstanceIntent.COMPLETE_ELEMENT, task2.getValue()),
+        RecordToWrite.command()
+            .key(processInstanceKey)
+            .migration(
+                new ProcessInstanceMigrationRecord()
+                    .setProcessInstanceKey(processInstanceKey)
+                    .setTargetProcessDefinitionKey(targetProcessDefinitionKey)
+                    .addMappingInstruction(
+                        new ProcessInstanceMigrationMappingInstruction()
+                            .setSourceElementId("task2")
+                            .setTargetElementId("task3"))
+                    .addMappingInstruction(
+                        new ProcessInstanceMigrationMappingInstruction()
+                            .setSourceElementId("join1")
+                            .setTargetElementId("join2"))));
+
+    ENGINE.start();
+
+    // then
+    final var rejection =
+        RecordingExporter.processInstanceMigrationRecords(ProcessInstanceMigrationIntent.MIGRATE)
+            .withProcessInstanceKey(processInstanceKey)
+            .onlyCommandRejections()
+            .getFirst();
+
+    assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            createMigrationRejectionDueConcurrentModificationReason(processInstanceKey));
+  }
+
+  @Test
   public void shouldMigrateParallelMultiInstanceConcurrently() {
     // given
     final String sourceProcessId = helper.getBpmnProcessId();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Validations are added for the following cases:
- Reject parallel gateway migration if joining parallel gateway with at least one sequence flow taken is not mapped
- Reject parallel gateway migration if joining parallel gateway with at least one sequence flow taken is mapped to a different gateway type. E.g. mapped to an inclusive gateway
- Reject parallel gateway migration if all incoming sequence flows of the gateway are taken (concurrent command). It is because `ACTIVATE_ELEMENT` command for the joining gateway is written to the log but not processed before the `MIGRATE` command. If we do not reject this, it will cause wrong (with old process definition data) gateway record written to the log.
- Reject parallel gateway migration if the target gateway has less incoming sequence flows than the source gateway.
- Reject parallel gateway migration if a taken sequence flow does not exist in target definition

Additionally, test cases are added to verify the the existing validations works for the following:
- Reject parallel gateway migration if mapped gateway does not exist in source
- Reject parallel gateway migration if mapped gateway does not exist in target

## Related issues

closes #22199 
