### PR TITLE
Importers not communicated completion

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FinishedImportingIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FinishedImportingIT.java
@@ -358,14 +358,17 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
 
   @Test
   public void shouldMarkRecordReadersCompletedEvenIfZeebeIndicesDontExist() throws IOException {
+    // given
     final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
     EXPORTER.export(record);
     esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
 
+    // when
     for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
+    // then
     for (final var type : ImportValueType.IMPORT_VALUE_TYPES) {
       await()
           .atMost(Duration.ofSeconds(30))

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FinishedImportingIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FinishedImportingIT.java
@@ -9,6 +9,7 @@ package io.camunda.operate.elasticsearch;
 
 import static io.camunda.operate.Metrics.GAUGE_NAME_IMPORT_POSITION_COMPLETED;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import io.camunda.operate.Metrics;
 import io.camunda.operate.property.OperateProperties;
@@ -35,13 +36,13 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Map;
-import org.awaitility.Awaitility;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Before;
 import org.junit.Test;
@@ -111,7 +112,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     }
 
     // the import position for
-    Awaitility.await()
+    await()
         .atMost(Duration.ofSeconds(30))
         .until(() -> isRecordReaderIsCompleted("1-process-instance"));
   }
@@ -145,7 +146,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
       zeebeImporter.performOneRoundOfImport();
     }
 
-    Awaitility.await()
+    await()
         .atMost(Duration.ofSeconds(30))
         .until(
             () ->
@@ -177,10 +178,10 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     }
 
     // the import position for
-    Awaitility.await()
+    await()
         .atMost(Duration.ofSeconds(30))
         .until(() -> isRecordReaderIsCompleted("1-process-instance"));
-    Awaitility.await()
+    await()
         .atMost(Duration.ofSeconds(30))
         .until(() -> isRecordReaderIsCompleted("2-process-instance"));
   }
@@ -200,7 +201,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     }
 
     // then
-    Awaitility.await()
+    await()
         .atMost(Duration.ofSeconds(30))
         .untilAsserted(
             () -> {
@@ -234,16 +235,16 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
       zeebeImporter.performOneRoundOfImport();
     }
 
-    Awaitility.await()
+    await()
         .atMost(Duration.ofSeconds(30))
         .until(() -> isRecordReaderIsCompleted("1-process-instance"));
-    Awaitility.await()
+    await()
         .atMost(Duration.ofSeconds(30))
         .until(() -> isRecordReaderIsCompleted("2-process-instance"));
 
     // then
 
-    Awaitility.await()
+    await()
         .atMost(Duration.ofSeconds(30))
         .untilAsserted(
             () -> {
@@ -291,7 +292,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
       zeebeImporter.performOneRoundOfImport();
     }
 
-    Awaitility.await()
+    await()
         .atMost(Duration.ofSeconds(30))
         .until(() -> isRecordReaderIsCompleted("1-process-instance"));
 
@@ -301,7 +302,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
 
     zeebeImporter.performOneRoundOfImport();
 
-    Awaitility.await()
+    await()
         .during(Duration.ofSeconds(10))
         .atMost(Duration.ofSeconds(12))
         .until(() -> isRecordReaderIsCompleted("1-process-instance"));
@@ -339,7 +340,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
         .map(ElasticsearchRecordsReader.class::cast)
         .forEach(ElasticsearchRecordsReader::postConstruct);
 
-    Awaitility.await()
+    await()
         .atMost(Duration.ofSeconds(30))
         .until(
             () -> {
@@ -357,7 +358,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
 
   private void assertImportPositionMatchesRecord(
       final Record<RecordValue> record, final ImportValueType type, final int partitionId) {
-    Awaitility.await()
+    await()
         .atMost(Duration.ofSeconds(30))
         .untilAsserted(
             () -> {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchFinishedImportingIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchFinishedImportingIT.java
@@ -281,14 +281,17 @@ public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
 
   @Test
   public void shouldMarkRecordReadersCompletedEvenIfZeebeIndicesDontExist() throws IOException {
+    // given
     final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
     EXPORTER.export(record);
     osClient.index().refresh("*");
 
+    // when
     for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
+    // then
     for (final var type : ImportValueType.IMPORT_VALUE_TYPES) {
       await()
           .atMost(Duration.ofSeconds(30))

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchFinishedImportingIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchFinishedImportingIT.java
@@ -381,7 +381,7 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
     EXPORTER.export(record);
     tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
 
-    // when 
+    // when
     for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
       zeebeImporter.performOneRoundOfImport();
     }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchFinishedImportingIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchFinishedImportingIT.java
@@ -376,14 +376,17 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
 
   @Test
   public void shouldMarkRecordReadersCompletedEvenIfZeebeIndicesDontExist() throws IOException {
+    // given
     final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
     EXPORTER.export(record);
     tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
 
+    // when 
     for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
+    // then
     for (final var type : ImportValueType.values()) {
       await()
           .atMost(Duration.ofSeconds(30))

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchFinishedImportingIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchFinishedImportingIT.java
@@ -9,6 +9,7 @@ package io.camunda.tasklist.es;
 
 import static io.camunda.tasklist.Metrics.GAUGE_NAME_IMPORT_POSITION_COMPLETED;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.camunda.tasklist.Metrics;
@@ -44,6 +45,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -372,6 +374,23 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
             });
   }
 
+  @Test
+  public void shouldMarkRecordReadersCompletedEvenIfZeebeIndicesDontExist() throws IOException {
+    final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
+    EXPORTER.export(record);
+    tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
+
+    for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+      zeebeImporter.performOneRoundOfImport();
+    }
+
+    for (final var type : ImportValueType.values()) {
+      await()
+          .atMost(Duration.ofSeconds(30))
+          .until(() -> isRecordReaderIsCompleted("1-" + type.getAliasTemplate()));
+    }
+  }
+
   @NotNull
   private static Gauge getGauge(final Metrics metrics, final String partition) {
     return metrics.getGauge(
@@ -387,7 +406,8 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
         Arrays.stream(
                 tasklistEsClient
                     .search(
-                        new SearchRequest(importPositionIndex.getFullQualifiedName()),
+                        new SearchRequest(importPositionIndex.getFullQualifiedName())
+                            .source(new SearchSourceBuilder().size(100)),
                         RequestOptions.DEFAULT)
                     .getHits()
                     .getHits())

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchFinishedImportingIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchFinishedImportingIT.java
@@ -371,7 +371,7 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
     EXPORTER.export(record);
     openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
 
-     // when
+    // when
     for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
       zeebeImporter.performOneRoundOfImport();
     }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchFinishedImportingIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchFinishedImportingIT.java
@@ -366,14 +366,17 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
 
   @Test
   public void shouldMarkRecordReadersCompletedEvenIfZeebeIndicesDontExist() throws IOException {
+    // given
     final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
     EXPORTER.export(record);
     openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
 
+     // when
     for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
+    // then
     for (final var type : ImportValueType.values()) {
       await()
           .atMost(Duration.ofSeconds(30))


### PR DESCRIPTION
## Description

The importers were not correctly marking their import position documents as completed to signify the record readers were done. This was due to missing zeebe indices causing a `NoSuchIndex` exception which means the path through which record reader completion was checked and set was missed.

The fix involves treating a no such index exception as an empty batch with regards to record reader completion check as they signify the same thing (no records to export).

## Checklist

- [x] Given missing zeebe indices record readers can still get marked as completed.

## Related issues

closes #26046 
