### PR TITLE
ci: update zeebe-performance-test link

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -274,7 +274,7 @@ jobs:
       - calculate-image-tag
       - build-zeebe-image
       - build-benchmark-images
-    uses: zeebe-io/zeebe-performance-test/.github/workflows/measure.yaml@main
+    uses: camunda/zeebe-performance-test/.github/workflows/measure.yaml@main
     secrets: inherit
     if: inputs.measure
     with:


### PR DESCRIPTION
Follows the transfer of https://github.com/zeebe-io/zeebe-engineering-processes to the `camunda` organization.