### PR TITLE
Disable version check restriction

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1085,6 +1085,12 @@
       # are subject to change and can be dropped at any time.
       # It might be that also some of them are actually dangerous so be aware when you change one of these!
 
+      # Toggles the version check restriction, used for migration. Useful for testing migration logic on
+      # snapshot or alpha versions. Default: True, means it is not allowed to migrate to incompatible version
+      # like: SNAPSHOT or alpha.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_VERSIONCHECKRESTRICTIONENABLED
+      # versionCheckRestrictionEnabled = true
+
       # Sets the maximum of appends which are send per follower.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_MAXAPPENDSPERFOLLOWER
       # maxAppendsPerFollower = 6

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -968,6 +968,12 @@
       # are subject to change and can be dropped at any time.
       # It might be that also some of them are actually dangerous so be aware when you change one of these!
 
+      # Toggles the version check restriction, used for migration. Useful for testing migration logic on
+      # snapshot or alpha versions. Default: True, means it is not allowed to migrate to incompatible version
+      # like: SNAPSHOT or alpha.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_VERSIONCHECKRESTRICTIONENABLED
+      # versionCheckRestrictionEnabled = true
+
       # Sets the maximum of appends which are send per follower.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_MAXAPPENDSPERFOLLOWER
       # maxAppendsPerFollower = 6

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfg.java
@@ -22,6 +22,13 @@ public class ExperimentalCfg implements ConfigurationEntry {
   public static final int DEFAULT_MAX_APPENDS_PER_FOLLOWER = 6;
   public static final DataSize DEFAULT_MAX_APPEND_BATCH_SIZE = DataSize.ofKilobytes(32);
   public static final boolean DEFAULT_DISABLE_EXPLICIT_RAFT_FLUSH = false;
+  public static final boolean DEFAULT_VERSION_CHECK_ENABLED = true;
+
+  /**
+   * Allows to enable/disable the version check, that prevents us on migrating to alpha versions,
+   * etc.
+   */
+  private boolean versionCheckRestrictionEnabled = DEFAULT_VERSION_CHECK_ENABLED;
 
   private int maxAppendsPerFollower = DEFAULT_MAX_APPENDS_PER_FOLLOWER;
   private DataSize maxAppendBatchSize = DEFAULT_MAX_APPEND_BATCH_SIZE;
@@ -32,8 +39,15 @@ public class ExperimentalCfg implements ConfigurationEntry {
   private QueryApiCfg queryApi = new QueryApiCfg();
   private ConsistencyCheckCfg consistencyChecks = new ConsistencyCheckCfg();
   private EngineCfg engine = new EngineCfg();
-
   private FeatureFlagsCfg features = new FeatureFlagsCfg();
+
+  public boolean isVersionCheckRestrictionEnabled() {
+    return versionCheckRestrictionEnabled;
+  }
+
+  public void setVersionCheckRestrictionEnabled(final boolean versionCheckRestrictionEnabled) {
+    this.versionCheckRestrictionEnabled = versionCheckRestrictionEnabled;
+  }
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
@@ -51,7 +51,10 @@ public class MigrationTransitionStep implements PartitionTransitionStep {
             InstantSource.system());
 
     final var dbMigrator =
-        new DbMigratorImpl(new ClusterContextImpl(context.getPartitionCount()), processingState);
+        new DbMigratorImpl(
+            context.getBrokerCfg().getExperimental().isVersionCheckRestrictionEnabled(),
+            new ClusterContextImpl(context.getPartitionCount()),
+            processingState);
     try {
       dbMigrator.runMigrations();
       zeebeDbContext.getCurrentTransaction().commit();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExperimentalCfgTest.java
@@ -181,4 +181,39 @@ final class ExperimentalCfgTest {
     // then
     assertThat(raftCfg.isPreallocateSegmentFiles()).isTrue();
   }
+
+  @Test
+  void shouldHaveDefaultVersionCheckRestriction() {
+    // given
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("empty", environment);
+    final var experimental = cfg.getExperimental();
+
+    // then
+    assertThat(experimental.isVersionCheckRestrictionEnabled()).isTrue();
+  }
+
+  @Test
+  void shouldSetVersionCheckRestrictionFromEnv() {
+    // given
+    environment.put("zeebe.broker.experimental.versionCheckRestrictionEnabled", "false");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("empty", environment);
+    final var experimental = cfg.getExperimental();
+
+    // then
+    assertThat(experimental.isVersionCheckRestrictionEnabled()).isFalse();
+  }
+
+  @Test
+  void shouldSetVersionCheckRestrictionFromConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("experimental-cfg", environment);
+    final var experimental = cfg.getExperimental();
+
+    // then
+    assertThat(experimental.isVersionCheckRestrictionEnabled()).isFalse();
+  }
 }

--- a/zeebe/broker/src/test/resources/system/experimental-cfg.yaml
+++ b/zeebe/broker/src/test/resources/system/experimental-cfg.yaml
@@ -1,6 +1,7 @@
 zeebe:
   broker:
     experimental:
+      versionCheckRestrictionEnabled: false
       enablePriorityElection: true
       raft:
         requestTimeout: 10s

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
@@ -7,11 +7,13 @@
  */
 package io.camunda.zeebe.engine.state.migration;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -204,6 +206,42 @@ public class DbMigratorImplTest {
 
     // then -- migration is not run
     verify(mockMigration, never())
+        .runMigration(new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState));
+  }
+
+  @Test
+  void shouldNotThrowOnInvalidUpgrade() {
+    // given -- state that was migrated by version 1.0.0
+    final boolean versionCheckEnabled = false; // disable version check
+
+    final var mockProcessingState = mock(MutableProcessingState.class);
+    final var mockMigrationState = mock(MutableMigrationState.class);
+    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
+    when(mockMigrationState.getMigratedByVersion()).thenReturn("1.0.0");
+    final var mockMigration = mock(MigrationTask.class);
+    when(mockMigration.needsToRun(any())).thenReturn(true);
+    final var context =
+        new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState);
+    final var sut =
+        new DbMigratorImpl(versionCheckEnabled, context, Collections.singletonList(mockMigration));
+
+    // when -- upgrading to a version that is not compatible
+    try (final var util = Mockito.mockStatic(VersionUtil.class)) {
+      util.when(VersionUtil::getVersion).thenReturn("2.0.0");
+      // then -- running migrations throws
+      assertThatNoException().isThrownBy(sut::runMigrations);
+    }
+
+    // when - upgrading to a pre-release version
+    try (final var util = Mockito.mockStatic(VersionUtil.class)) {
+      util.when(VersionUtil::getVersion).thenReturn("2.0.0-alpha1");
+
+      // then -- running migrations throws
+      assertThatNoException().isThrownBy(sut::runMigrations);
+    }
+
+    // then -- migration is run
+    verify(mockMigration, times(2))
         .runMigration(new MigrationTaskContextImpl(new ClusterContextImpl(1), mockProcessingState));
   }
 


### PR DESCRIPTION
## Description

Allow to disable the version migration check restriction, useful for testing migration, especially by QA.

## Related issues

slack https://camunda.slack.com/archives/CSQ2E3BT4/p1734357369901219


See also migration testing for Camunda Exporter and Identity, etc.
