### PR TITLE
fix: add the filter for user task implementation

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
@@ -59,6 +59,7 @@ class UserTaskQueryTest {
 
     deployForm("form/form.form");
     delpoyProcessFromResourcePath("/process/process_with_form.bpmn", "process_with_form.bpmn");
+    delpoyProcessFromResourcePath("/process/job_worker_process.bpmn", "job_worker_process.bpmn");
 
     startProcessInstance("process");
     startProcessInstance("process-2");
@@ -67,6 +68,9 @@ class UserTaskQueryTest {
     startProcessInstance("bpmProcessVariable");
     startProcessInstance("processWithForm");
     startProcessInstance("processWithSubProcess");
+    startProcessInstance(
+        "jobWorkerProcess"); // Start a Job Worker instance in order to validate if User Tasks
+    // queries has the same result
 
     waitForTasksBeingExported();
   }

--- a/qa/integration-tests/src/test/resources/process/job_worker_process.bpmn
+++ b/qa/integration-tests/src/test/resources/process/job_worker_process.bpmn
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0txti4d" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="jobWorkerProcess" name="Job Worker" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1m7vk9w</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:userTask id="jobWorker" name="Job Worker">
+      <bpmn:incoming>Flow_1m7vk9w</bpmn:incoming>
+      <bpmn:outgoing>Flow_1m1zboc</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_1m7vk9w" sourceRef="StartEvent_1" targetRef="jobWorker" />
+    <bpmn:endEvent id="Event_1npkwal">
+      <bpmn:incoming>Flow_1m1zboc</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1m1zboc" sourceRef="jobWorker" targetRef="Event_1npkwal" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="jobWorkerProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0cc7qlo_di" bpmnElement="jobWorker">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1npkwal_di" bpmnElement="Event_1npkwal">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1m7vk9w_di" bpmnElement="Flow_1m7vk9w">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1m1zboc_di" bpmnElement="Flow_1m1zboc">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
@@ -22,6 +22,7 @@ import static io.camunda.webapps.schema.descriptors.tasklist.template.TaskTempla
 import static io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate.CANDIDATE_USERS;
 import static io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate.FLOW_NODE_BPMN_ID;
 import static io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate.FLOW_NODE_INSTANCE_ID;
+import static io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate.IMPLEMENTATION;
 import static io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate.KEY;
 import static io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate.PRIORITY;
 import static io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate.PROCESS_DEFINITION_ID;
@@ -36,6 +37,7 @@ import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.UserTaskFilter;
 import io.camunda.search.filter.VariableValueFilter;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
 import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship.TaskJoinRelationshipType;
 import java.util.ArrayList;
 import java.util.List;
@@ -79,6 +81,7 @@ public class UserTaskFilterTransformer extends IndexFilterTransformer<UserTaskFi
     ofNullable(getLocalVariablesQuery(filter.localVariableFilters())).ifPresent(queries::add);
 
     queries.add(exists("flowNodeInstanceId")); // Default to task
+    queries.add(stringTerms(IMPLEMENTATION, List.of(TaskImplementation.ZEEBE_USER_TASK.name())));
 
     return and(queries);
   }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserTaskQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserTaskQueryTransformerTest.java
@@ -37,11 +37,34 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
 
     // then
     final SearchQueryOption queryVariant = searchRequest.queryOption();
+
     assertThat(queryVariant)
         .isInstanceOfSatisfying(
-            SearchExistsQuery.class,
+            SearchBoolQuery.class,
+            (boolQuery) -> {
+              assertThat(boolQuery.must())
+                  .anySatisfy(
+                      query ->
+                          assertThat(query.queryOption())
+                              .isInstanceOfSatisfying(
+                                  SearchExistsQuery.class,
+                                  (existsQuery) -> {
+                                    assertThat(existsQuery.field())
+                                        .isEqualTo("flowNodeInstanceId"); // Validate the field
+                                  }));
+            });
+
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
             (t) -> {
-              assertThat(t.field()).isEqualTo("flowNodeInstanceId"); // Retrieve only User Task
+              assertThat(t.must().get(1).queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchTermQuery.class,
+                      (term) -> {
+                        assertThat(term.field()).isEqualTo("implementation");
+                        assertThat(term.value().stringValue()).isEqualTo("ZEEBE_USER_TASK");
+                      });
             });
   }
 


### PR DESCRIPTION
## Description

Re-introduce the User Task implementation filter, in order to filter out the job workers from the User Task Search Query. 

In addition: Deploy/ start a process with a job worker, in order to validate it doesnt affect the existent integration tests.

## Related issues

closes https://github.com/camunda/camunda/issues/26155
