### PR TITLE
refactor: re-implement isApiUser() to be based on JwtTokenAuth

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
@@ -29,7 +29,6 @@ public final class CamundaUser extends User {
   private final String salesPlanType;
   private final Map<ClusterMetadata.AppName, String> c8Links;
   private final boolean canLogout;
-  private final boolean apiUser;
   private final String email;
 
   private CamundaUser(
@@ -45,8 +44,7 @@ public final class CamundaUser extends User {
       final List<String> groups,
       final String salesPlanType,
       final Map<ClusterMetadata.AppName, String> c8Links,
-      final boolean canLogout,
-      final boolean apiUser) {
+      final boolean canLogout) {
     super(username, password, authorities);
     this.roles = roles;
     this.userKey = userKey;
@@ -57,7 +55,6 @@ public final class CamundaUser extends User {
     this.salesPlanType = salesPlanType;
     this.c8Links = Objects.requireNonNullElse(c8Links, Collections.emptyMap());
     this.canLogout = canLogout;
-    this.apiUser = apiUser;
     this.email = email;
   }
 
@@ -105,10 +102,6 @@ public final class CamundaUser extends User {
     return canLogout;
   }
 
-  public boolean isApiUser() {
-    return apiUser;
-  }
-
   private static List<? extends GrantedAuthority> prepareAuthorities(
       final List<String> authorities) {
     return authorities.stream().map(SimpleGrantedAuthority::new).toList();
@@ -132,7 +125,6 @@ public final class CamundaUser extends User {
     private String salesPlanType;
     private Map<ClusterMetadata.AppName, String> c8Links = Map.of();
     private boolean canLogout;
-    private boolean apiUser;
 
     private CamundaUserBuilder() {}
 
@@ -206,11 +198,6 @@ public final class CamundaUser extends User {
       return this;
     }
 
-    public CamundaUserBuilder withApiUser(final boolean apiUser) {
-      this.apiUser = apiUser;
-      return this;
-    }
-
     public CamundaUser build() {
       return new CamundaUser(
           userKey,
@@ -225,8 +212,7 @@ public final class CamundaUser extends User {
           groups,
           salesPlanType,
           c8Links,
-          canLogout,
-          apiUser);
+          canLogout);
     }
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaUserDTO.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaUserDTO.java
@@ -24,5 +24,4 @@ public record CamundaUserDTO(
     List<String> roles,
     String salesPlanType,
     Map<ClusterMetadata.AppName, String> c8Links,
-    boolean canLogout,
-    boolean apiUser) {}
+    boolean canLogout) {}

--- a/authentication/src/main/java/io/camunda/authentication/service/BasicCamundaUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/BasicCamundaUserService.java
@@ -36,8 +36,7 @@ public class BasicCamundaUserService implements CamundaUserService {
         authenticatedUser.getRoles().stream().map(RoleEntity::name).toList(),
         authenticatedUser.getSalesPlanType(),
         authenticatedUser.getC8Links(),
-        authenticatedUser.canLogout(),
-        authenticatedUser.isApiUser());
+        authenticatedUser.canLogout());
   }
 
   @Override

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
@@ -1098,10 +1098,7 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
           new TaskAssignRequest().setAssignee("bill_doe").setAllowOverrideAssignment(false);
 
       setCurrentUser(
-          new UserDTO()
-              .setUserId("bob_doe")
-              .setPermissions(List.of(Permission.WRITE))
-              .setApiUser(true));
+          new UserDTO().setUserId("bob_doe").setPermissions(List.of(Permission.WRITE)), true);
 
       // when
       final var errorResult =
@@ -1396,7 +1393,7 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
       final String bpmnProcessId = "simpleTestProcess";
       final String flowNodeBpmnId = "taskD_".concat(UUID.randomUUID().toString());
       final var taskId = createTask(bpmnProcessId, flowNodeBpmnId, 1).getTaskId();
-      setCurrentUser(getDefaultCurrentUser().setApiUser(true));
+      setCurrentUser(getDefaultCurrentUser(), true);
 
       // when
       final var result =
@@ -1608,7 +1605,7 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
               .setVariables(
                   List.of(
                       new VariableInputDTO().setName("object_var").setValue("{\"test\": true}")));
-      setCurrentUser(getDefaultCurrentUser().setApiUser(true));
+      setCurrentUser(getDefaultCurrentUser(), true);
 
       // when
       final var errorResult =
@@ -1659,7 +1656,7 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
               .setVariables(
                   List.of(new VariableInputDTO().setName("array_var").setValue("[30, 8, 2022]")));
 
-      setCurrentUser(getDefaultCurrentUser().setUserId("user_B").setApiUser(true));
+      setCurrentUser(getDefaultCurrentUser().setUserId("user_B"), true);
 
       // when
       final var errorResult =

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskController.java
@@ -28,6 +28,7 @@ import io.camunda.tasklist.webapp.mapper.TaskMapper;
 import io.camunda.tasklist.webapp.rest.exception.Error;
 import io.camunda.tasklist.webapp.rest.exception.ForbiddenActionException;
 import io.camunda.tasklist.webapp.rest.exception.InvalidRequestException;
+import io.camunda.tasklist.webapp.security.TasklistAuthenticationUtil;
 import io.camunda.tasklist.webapp.security.TasklistURIs;
 import io.camunda.tasklist.webapp.security.UserReader;
 import io.camunda.tasklist.webapp.security.identity.IdentityAuthorizationService;
@@ -214,7 +215,7 @@ public class TaskController extends ApiErrorController {
 
   private void checkTaskImplementation(final LazySupplier<TaskDTO> taskSupplier) {
     if (taskSupplier.get().getImplementation() != TaskImplementation.JOB_WORKER
-        && userReader.getCurrentUser().isApiUser()) {
+        && TasklistAuthenticationUtil.isApiUser()) {
       final TaskDTO task = taskSupplier.get();
       LOGGER.warn(
           "V1 API is used for task with id={} implementation={}",

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/dto/UserDTO.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/dto/UserDTO.java
@@ -17,7 +17,6 @@ public class UserDTO {
 
   private String userId;
   private String displayName;
-  private boolean apiUser;
   private List<Permission> permissions;
   private List<String> roles;
   private String salesPlanType;
@@ -43,15 +42,6 @@ public class UserDTO {
 
   public UserDTO setDisplayName(final String displayName) {
     this.displayName = displayName;
-    return this;
-  }
-
-  public boolean isApiUser() {
-    return apiUser;
-  }
-
-  public UserDTO setApiUser(final boolean apiUser) {
-    this.apiUser = apiUser;
     return this;
   }
 
@@ -116,7 +106,7 @@ public class UserDTO {
   @Override
   public int hashCode() {
     return Objects.hash(
-        userId, displayName, apiUser, permissions, roles, salesPlanType, c8Links, tenants, groups);
+        userId, displayName, permissions, roles, salesPlanType, c8Links, tenants, groups);
   }
 
   @Override
@@ -128,8 +118,7 @@ public class UserDTO {
       return false;
     }
     final UserDTO userDTO = (UserDTO) o;
-    return apiUser == userDTO.apiUser
-        && Objects.equals(userId, userDTO.userId)
+    return Objects.equals(userId, userDTO.userId)
         && Objects.equals(displayName, userDTO.displayName)
         && Objects.equals(permissions, userDTO.permissions)
         && Objects.equals(roles, userDTO.roles)
@@ -148,8 +137,6 @@ public class UserDTO {
         + ", displayName='"
         + displayName
         + '\''
-        + ", apiUser="
-        + apiUser
         + ", permissions="
         + permissions
         + ", roles="

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/TaskValidator.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/TaskValidator.java
@@ -9,6 +9,7 @@ package io.camunda.tasklist.webapp.es;
 
 import io.camunda.tasklist.webapp.dto.UserDTO;
 import io.camunda.tasklist.webapp.rest.exception.InvalidRequestException;
+import io.camunda.tasklist.webapp.security.TasklistAuthenticationUtil;
 import io.camunda.tasklist.webapp.security.UserReader;
 import io.camunda.webapps.schema.entities.tasklist.TaskEntity;
 import io.camunda.webapps.schema.entities.tasklist.TaskState;
@@ -48,13 +49,14 @@ public class TaskValidator {
   private void validateTaskStateAndAssignment(final TaskEntity task) {
     validateTaskIsActive(task);
 
-    final UserDTO currentUser = getCurrentUser();
-    if (currentUser.isApiUser()) {
+    if (TasklistAuthenticationUtil.isApiUser()) {
       // JWT Token/API users are allowed to complete task assigned to anyone
       return;
     }
 
     validateTaskIsAssigned(task);
+
+    final UserDTO currentUser = getCurrentUser();
     if (!task.getAssignee().equals(currentUser.getUserId())) {
       throw new InvalidRequestException("Task is not assigned to " + currentUser.getUserId());
     }
@@ -64,7 +66,7 @@ public class TaskValidator {
       final TaskEntity taskBefore, final boolean allowOverrideAssignment) {
     validateTaskIsActive(taskBefore);
 
-    if (getCurrentUser().isApiUser() && allowOverrideAssignment) {
+    if (TasklistAuthenticationUtil.isApiUser() && allowOverrideAssignment) {
       // JWT Token/API users can reassign task
       return;
     }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/TasklistAuthenticationUtil.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/TasklistAuthenticationUtil.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.webapp.security;
+
+import java.util.Optional;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+
+public final class TasklistAuthenticationUtil {
+
+  private TasklistAuthenticationUtil() {}
+
+  public static boolean isApiUser() {
+    return Optional.ofNullable(SecurityContextHolder.getContext().getAuthentication())
+        .map(JwtAuthenticationToken.class::isInstance)
+        .orElse(false);
+  }
+}

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/identity/IdentityUserReader.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/identity/IdentityUserReader.java
@@ -60,7 +60,6 @@ public class IdentityUserReader implements UserReader {
           new UserDTO()
               .setUserId(identityTenantAwareToken.getName())
               .setDisplayName(userDisplayName)
-              .setApiUser(true)
               .setPermissions(permissions)
               .setTenants(identityTenantAwareToken.getTenants()));
     } else {

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/SearchEngineUserReader.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/SearchEngineUserReader.java
@@ -45,8 +45,7 @@ public class SearchEngineUserReader implements UserReader {
                       user.getAuthorities().stream()
                           .map(GrantedAuthority::getAuthority)
                           .map(Role::fromString)
-                          .toList()))
-              .setApiUser(false));
+                          .toList())));
     }
     return Optional.empty();
   }
@@ -63,8 +62,7 @@ public class SearchEngineUserReader implements UserReader {
         userEntity ->
             new UserDTO()
                 .setUserId(userEntity.getUserId())
-                .setDisplayName(userEntity.getDisplayName())
-                .setApiUser(false));
+                .setDisplayName(userEntity.getDisplayName()));
   }
 
   @Override

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/sso/SSOUserReader.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/sso/SSOUserReader.java
@@ -59,7 +59,6 @@ public class SSOUserReader implements UserReader {
               // For testing assignee migration locally use 'authentication.getName()'
               .setUserId(/*authentication.getName()*/ email)
               .setDisplayName(name)
-              .setApiUser(false)
               .setGroups(identityAuthorizationService.getUserGroups())
               .setPermissions(tokenAuthentication.getPermissions())
               .setRoles(
@@ -74,7 +73,6 @@ public class SSOUserReader implements UserReader {
           new UserDTO()
               .setUserId(name)
               .setDisplayName(name)
-              .setApiUser(true)
               // M2M token in the cloud always has WRITE permissions
               .setPermissions(List.of(Permission.WRITE)));
     }
@@ -88,8 +86,7 @@ public class SSOUserReader implements UserReader {
 
   @Override
   public List<UserDTO> getUsersByUsernames(final List<String> usernames) {
-    return map(
-        usernames, name -> new UserDTO().setDisplayName(name).setUserId(name).setApiUser(false));
+    return map(usernames, name -> new UserDTO().setDisplayName(name).setUserId(name));
   }
 
   @Override

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TaskService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TaskService.java
@@ -30,6 +30,7 @@ import io.camunda.tasklist.webapp.es.TaskValidator;
 import io.camunda.tasklist.webapp.rest.exception.ForbiddenActionException;
 import io.camunda.tasklist.webapp.rest.exception.InvalidRequestException;
 import io.camunda.tasklist.webapp.security.AssigneeMigrator;
+import io.camunda.tasklist.webapp.security.TasklistAuthenticationUtil;
 import io.camunda.tasklist.webapp.security.UserReader;
 import io.camunda.webapps.schema.entities.tasklist.TaskEntity;
 import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
@@ -159,14 +160,14 @@ public class TaskService {
       allowOverrideAssignment = true;
     }
 
-    final UserDTO currentUser = getCurrentUser();
-    if (StringUtils.isEmpty(assignee) && currentUser.isApiUser()) {
+    final var isApiUser = TasklistAuthenticationUtil.isApiUser();
+    if (StringUtils.isEmpty(assignee) && isApiUser) {
       throw new InvalidRequestException("Assignee must be specified");
     }
 
     if (StringUtils.isNotEmpty(assignee)
-        && !currentUser.isApiUser()
-        && !assignee.equals(currentUser.getUserId())) {
+        && !isApiUser
+        && !assignee.equals(getCurrentUser().getUserId())) {
       throw new ForbiddenActionException(
           "User doesn't have the permission to assign another user to this task");
     }
@@ -195,9 +196,8 @@ public class TaskService {
   }
 
   private String determineTaskAssignee(final String assignee) {
-    final UserDTO currentUser = getCurrentUser();
-    return StringUtils.isEmpty(assignee) && !currentUser.isApiUser()
-        ? currentUser.getUserId()
+    return StringUtils.isEmpty(assignee) && !TasklistAuthenticationUtil.isApiUser()
+        ? getCurrentUser().getUserId()
         : assignee;
   }
 
@@ -347,7 +347,7 @@ public class TaskService {
   private String[] getTaskMetricLabels(final TaskEntity task) {
     final String keyUserId;
 
-    if (getCurrentUser().isApiUser()) {
+    if (TasklistAuthenticationUtil.isApiUser()) {
       if (task.getAssignee() != null) {
         keyUserId = task.getAssignee();
       } else {

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerTest.java
@@ -32,6 +32,7 @@ import io.camunda.tasklist.webapp.dto.VariableDTO;
 import io.camunda.tasklist.webapp.dto.VariableInputDTO;
 import io.camunda.tasklist.webapp.mapper.TaskMapper;
 import io.camunda.tasklist.webapp.rest.exception.InvalidRequestException;
+import io.camunda.tasklist.webapp.security.TasklistAuthenticationUtil;
 import io.camunda.tasklist.webapp.security.TasklistURIs;
 import io.camunda.tasklist.webapp.security.UserReader;
 import io.camunda.tasklist.webapp.security.identity.IdentityAuthorizationService;
@@ -43,6 +44,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -50,6 +52,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
@@ -1829,6 +1832,7 @@ class TaskControllerTest {
         "This operation is not supported using Tasklist V1 API. Please use the latest API. For more information, refer to the documentation: https://docs.camunda.tasklist";
 
     private final String taskId = "taskId";
+    private MockedStatic<TasklistAuthenticationUtil> authenticationUtil;
 
     @BeforeEach
     public void setUp() {
@@ -1837,7 +1841,15 @@ class TaskControllerTest {
       when(taskService.getTask(taskId))
           .thenReturn(
               new TaskDTO().setId(taskId).setImplementation(TaskImplementation.ZEEBE_USER_TASK));
-      when(userReader.getCurrentUser()).thenReturn(new UserDTO().setApiUser(true));
+      when(userReader.getCurrentUser()).thenReturn(new UserDTO());
+
+      authenticationUtil = mockStatic(TasklistAuthenticationUtil.class);
+      authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(true);
+    }
+
+    @AfterEach
+    public void tearDown() {
+      authenticationUtil.close();
     }
 
     @Test

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/security/identity/IdentityUserReaderTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/security/identity/IdentityUserReaderTest.java
@@ -104,7 +104,6 @@ class IdentityUserReaderTest {
             new UserDTO()
                 .setUserId("demo")
                 .setDisplayName("demo")
-                .setApiUser(true)
                 .setPermissions(Collections.emptyList())
                 .setC8Links(Collections.emptyList())
                 .setTenants(Collections.emptyList()));

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/TaskServiceTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/TaskServiceTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -39,6 +40,7 @@ import io.camunda.tasklist.webapp.es.TaskValidator;
 import io.camunda.tasklist.webapp.rest.exception.ForbiddenActionException;
 import io.camunda.tasklist.webapp.rest.exception.InvalidRequestException;
 import io.camunda.tasklist.webapp.security.AssigneeMigrator;
+import io.camunda.tasklist.webapp.security.TasklistAuthenticationUtil;
 import io.camunda.tasklist.webapp.security.UserReader;
 import io.camunda.webapps.schema.entities.tasklist.TaskEntity;
 import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
@@ -55,6 +57,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -62,10 +66,14 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class TaskServiceTest {
 
   @Mock private UserReader userReader;
@@ -79,6 +87,18 @@ class TaskServiceTest {
   @Mock private TaskValidator taskValidator;
 
   @InjectMocks private TaskService instance;
+
+  private MockedStatic<TasklistAuthenticationUtil> authenticationUtil;
+
+  @BeforeEach
+  public void setUp() {
+    authenticationUtil = mockStatic(TasklistAuthenticationUtil.class);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    authenticationUtil.close();
+  }
 
   @Test
   void getTasks() {
@@ -283,10 +303,10 @@ class TaskServiceTest {
     final var userA = "userA";
     final var userB = "userB";
     return Stream.of(
-        Arguments.of(null, true, userA, new UserDTO().setUserId(userA), userA),
-        Arguments.of(false, false, userA, new UserDTO().setUserId(userB).setApiUser(true), userA),
-        Arguments.of(true, true, null, new UserDTO().setUserId(userB), userB),
-        Arguments.of(true, true, "", new UserDTO().setUserId(userB), userB));
+        Arguments.of(null, true, userA, new UserDTO().setUserId(userA), false, userA),
+        Arguments.of(false, false, userA, new UserDTO().setUserId(userB), true, userA),
+        Arguments.of(true, true, null, new UserDTO().setUserId(userB), false, userB),
+        Arguments.of(true, true, "", new UserDTO().setUserId(userB), false, userB));
   }
 
   @ParameterizedTest
@@ -296,9 +316,11 @@ class TaskServiceTest {
       final boolean expectedAllowOverrideAssignment,
       final String providedAssignee,
       final UserDTO user,
+      final boolean isApiUser,
       final String expectedAssignee) {
 
     // Given
+    authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(isApiUser);
     final var taskId = "123";
     final var taskBefore = mock(TaskEntity.class);
     when(taskStore.getTask(taskId)).thenReturn(taskBefore);
@@ -319,8 +341,9 @@ class TaskServiceTest {
   @Test
   public void assignTaskByApiUser() {
     // given
+    authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(true);
     final var taskId = "123";
-    when(userReader.getCurrentUser()).thenReturn(new UserDTO().setUserId("userA").setApiUser(true));
+    when(userReader.getCurrentUser()).thenReturn(new UserDTO().setUserId("userA"));
 
     // when - then
     verifyNoInteractions(taskStore, taskValidator);
@@ -332,8 +355,9 @@ class TaskServiceTest {
   @Test
   public void assignTaskToEmptyUser() {
     // given
+    authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(true);
     final var taskId = "123";
-    when(userReader.getCurrentUser()).thenReturn(new UserDTO().setUserId("userA").setApiUser(true));
+    when(userReader.getCurrentUser()).thenReturn(new UserDTO().setUserId("userA"));
 
     // when - then
     verifyNoInteractions(taskStore, taskValidator);
@@ -345,8 +369,9 @@ class TaskServiceTest {
   @Test
   public void assignTaskToInvalidTask() {
     // given
+    authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(true);
     final var taskId = "123";
-    when(userReader.getCurrentUser()).thenReturn(new UserDTO().setUserId("userA").setApiUser(true));
+    when(userReader.getCurrentUser()).thenReturn(new UserDTO().setUserId("userA"));
     when(taskStore.getTask(taskId))
         .thenThrow(new NotFoundException("task with id " + taskId + " was not found "));
 
@@ -557,8 +582,10 @@ class TaskServiceTest {
       final boolean expectedAllowOverrideAssignment,
       final String providedAssignee,
       final UserDTO user,
+      final boolean isApiUser,
       final String expectedAssignee) {
     // Given
+    authenticationUtil.when(TasklistAuthenticationUtil::isApiUser).thenReturn(isApiUser);
     final var taskId = "123";
     final var taskBefore = mock(TaskEntity.class);
 


### PR DESCRIPTION
## Description

* Re-implements the `#isApiUser()` check in Tasklist v1 API
* If a `JwtTokenAuthentication` is provided, then return this indicates a client is using the API (and not a user who logged in)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to #24665 
