### PR TITLE
fix: use a composite key for authorizations to avoid multiple authorizations being collapsed to a single export

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationHandler.java
@@ -43,7 +43,9 @@ public class AuthorizationHandler
 
   @Override
   public List<String> generateIds(final Record<AuthorizationRecordValue> record) {
-    return List.of(String.valueOf(record.getKey()));
+    return List.of(
+        String.format(
+            "%s-%s", record.getValue().getOwnerKey(), record.getValue().getResourceType().name()));
   }
 
   @Override


### PR DESCRIPTION
## Description
I noticed as part of testing the fix in https://github.com/camunda/camunda/pull/26119 that when authorizations are exported in bulk for a single owner as we use the single authorization ID the last permission written is the one that is exported instead of all permissions for that authorization. 

This meant that if I had multiple resource types and permissions in a single authorization, only one would appear.

In this PR I use a composite key of owner key + resource type to make sure we export all the permissions as expected

To do:
- [ ] Check the tests still pass with the ID change
