### PR TITLE
fix: xmlutil not including start events in flownodes

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/XMLUtil.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/XMLUtil.java
@@ -135,10 +135,11 @@ public class XMLUtil {
             new ProcessEntity().setBpmnProcessId(elementId).setName(attributes.getValue("name")));
         processChildrenIds.put(elementId, new LinkedHashSet<>());
         currentProcessId = elementId;
-      } else if (startEventElement.equalsIgnoreCase(localName)) {
-        isStartEvent = true;
       } else if (currentProcessId != null && elementId != null) {
         processChildrenIds.get(currentProcessId).add(elementId);
+        if (startEventElement.equalsIgnoreCase(localName)) {
+          isStartEvent = true;
+        }
       } else if (isStartEvent) {
         if ("property".equalsIgnoreCase(localName)) {
           final String name = attributes.getValue("name");

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessHandlerTest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class ProcessHandlerTest {
@@ -138,6 +139,12 @@ public class ProcessHandlerTest {
     assertThat(processEntity.getResourceName()).isEqualTo(processRecordValue.getResourceName());
     assertThat(processEntity.getBpmnXml())
         .isEqualTo(new String(processRecordValue.getResource(), StandardCharsets.UTF_8));
+    Assertions.assertThat(processEntity.getFlowNodes())
+        .filteredOn(flowNode -> flowNode.getId().equals("startEvent"))
+        .hasSize(1);
+    Assertions.assertThat(processEntity.getFlowNodes())
+        .filteredOn(flowNode -> flowNode.getId().equals("endEvent"))
+        .hasSize(1);
     assertThat(processEntity.getTenantId()).isEqualTo(processRecordValue.getTenantId());
     assertThat(processEntity.getIsPublic()).isFalse();
     assertThat(processEntity.getFormId()).isNull();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
ProcessHandler XMLUtil was not including `StartEvents` in the list of BPMN FlowNodes

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
