### PR TITLE
test: increate wait for default user creation in AuthorizationsUtil

### DIFF
--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/AuthorizationsUtil.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/AuthorizationsUtil.java
@@ -149,7 +149,7 @@ public class AuthorizationsUtil {
     }
 
     Awaitility.await()
-        .atMost(Duration.ofSeconds(10))
+        .atMost(Duration.ofSeconds(15))
         .until(
             () -> {
               final var response = HTTP_CLIENT.send(request, BodyHandlers.ofString());


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Zeebe Authorization IT tests are flacky. It seems the default user creation takes more than 10 seconds to be reflected in Elasticsearch. 
Increasing it to 15 (as other tests) seems to fix the flakiness.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
