### PR TITLE
fix: create Operate message template/index in exporter

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptors.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptors.java
@@ -19,6 +19,7 @@ import io.camunda.webapps.schema.descriptors.operate.template.FlowNodeInstanceTe
 import io.camunda.webapps.schema.descriptors.operate.template.IncidentTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.JobTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
+import io.camunda.webapps.schema.descriptors.operate.template.MessageTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.OperationTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.PostImporterQueueTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.SequenceFlowTemplate;
@@ -76,7 +77,8 @@ public class IndexDescriptors {
                 new TasklistMetricIndex(indexPrefix, isElasticsearch),
                 new TenantIndex(indexPrefix, isElasticsearch),
                 new UserIndex(indexPrefix, isElasticsearch),
-                new VariableTemplate(indexPrefix, isElasticsearch))
+                new VariableTemplate(indexPrefix, isElasticsearch),
+                new MessageTemplate(indexPrefix, isElasticsearch))
             .collect(Collectors.toMap(Object::getClass, Function.identity()));
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -306,6 +306,7 @@ final class CamundaExporterIT {
             "custom-prefix-operate-incident-8.3.1_",
             "custom-prefix-operate-list-view-8.3.0_",
             "custom-prefix-operate-metric-8.3.0_",
+            "custom-prefix-operate-message-8.5.0_",
             "custom-prefix-operate-operation-8.4.1_",
             "custom-prefix-operate-post-importer-queue-8.3.0_",
             "custom-prefix-operate-process-8.3.0_",


### PR DESCRIPTION
## Description

We have `operate-message` index which was introduce within https://github.com/camunda/camunda/issues/32856 and is not used currently. We decided to keep it in index structure, as it existed in older versions and if we decide to not have it anymore, we will need to perform some steps to remove it in older versions. 

This PR adds it to the list of other indices managed by Camunda exporter.