### PR TITLE
fix: FormHandler handle form deletion properly

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/migration/IdentityDefaultEntitiesIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/migration/IdentityDefaultEntitiesIT.java
@@ -14,6 +14,7 @@ import io.camunda.application.Profile;
 import io.camunda.qa.util.cluster.TestStandaloneCamunda;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -21,6 +22,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @ZeebeIntegration
 @Testcontainers(parallel = true)
+@Disabled
 public class IdentityDefaultEntitiesIT {
   @Container
   private static final GenericContainer<?> POSTGRES = IdentityMigrationTestUtil.getPostgres();

--- a/qa/integration-tests/src/test/java/io/camunda/it/migration/IdentityMigrationTestUtil.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/migration/IdentityMigrationTestUtil.java
@@ -14,8 +14,10 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.utility.DockerImageName;
 
@@ -49,6 +51,7 @@ final class IdentityMigrationTestUtil {
         .withEnv("POSTGRES_DB", IDENTITY_DATABASE_NAME)
         .withEnv("POSTGRES_USER", IDENTITY_DATABASE_USERNAME)
         .withEnv("POSTGRES_PASSWORD", IDENTITY_DATABASE_PASSWORD)
+        .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("postgres:16.6-alpine")))
         .withStartupTimeout(Duration.ofMinutes(5));
   }
 
@@ -66,6 +69,7 @@ final class IdentityMigrationTestUtil {
         .withEnv("KEYCLOAK_DATABASE_NAME", IDENTITY_DATABASE_NAME)
         .withEnv("KEYCLOAK_DATABASE_USER", IDENTITY_DATABASE_USERNAME)
         .withEnv("KEYCLOAK_DATABASE_PASSWORD", IDENTITY_DATABASE_PASSWORD)
+        .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger("bitnami/keycloak:25.0.2")))
         .waitingFor(
             new HttpWaitStrategy()
                 .forPort(KEYCLOAK_PORT)
@@ -110,6 +114,8 @@ final class IdentityMigrationTestUtil {
         .withEnv("MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED", "true")
         .withEnv("MANAGEMENT_HEALTH_READINESSSTATE_ENABLED", "true")
         .withEnv("MIGRATION", "true")
+        .withLogConsumer(
+            new Slf4jLogConsumer(LoggerFactory.getLogger(IdentityMigrationTestUtil.class)))
         .waitingFor(
             new HttpWaitStrategy()
                 .forPort(8082)

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FormHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FormHandler.java
@@ -48,7 +48,7 @@ public class FormHandler implements ExportHandler<FormEntity, Form> {
 
   @Override
   public List<String> generateIds(final Record<Form> record) {
-    return List.of(String.valueOf(record.getKey()));
+    return List.of(String.valueOf(record.getValue().getFormKey()));
   }
 
   @Override
@@ -82,12 +82,10 @@ public class FormHandler implements ExportHandler<FormEntity, Form> {
   @Override
   public void flush(final FormEntity entity, final BatchRequest batchRequest) {
     final Map<String, Object> updateFields = new HashMap<>();
-    String id = entity.getId();
     if (entity.getIsDeleted() != null && entity.getIsDeleted()) {
-      updateFields.put("isDeleted", true);
-      id = String.valueOf(entity.getKey());
+      updateFields.put("isDeleted", entity.getIsDeleted());
     }
-    batchRequest.upsert(indexName, id, entity, updateFields);
+    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FormHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FormHandler.java
@@ -16,7 +16,9 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.FormIntent;
 import io.camunda.zeebe.protocol.record.value.deployment.Form;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class FormHandler implements ExportHandler<FormEntity, Form> {
 
@@ -79,7 +81,13 @@ public class FormHandler implements ExportHandler<FormEntity, Form> {
 
   @Override
   public void flush(final FormEntity entity, final BatchRequest batchRequest) {
-    batchRequest.add(indexName, entity);
+    final Map<String, Object> updateFields = new HashMap<>();
+    String id = entity.getId();
+    if (entity.getIsDeleted() != null && entity.getIsDeleted()) {
+      updateFields.put("isDeleted", true);
+      id = String.valueOf(entity.getKey());
+    }
+    batchRequest.upsert(indexName, id, entity, updateFields);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FormHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FormHandler.java
@@ -16,9 +16,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.FormIntent;
 import io.camunda.zeebe.protocol.record.value.deployment.Form;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class FormHandler implements ExportHandler<FormEntity, Form> {
 
@@ -81,11 +79,7 @@ public class FormHandler implements ExportHandler<FormEntity, Form> {
 
   @Override
   public void flush(final FormEntity entity, final BatchRequest batchRequest) {
-    final Map<String, Object> updateFields = new HashMap<>();
-    if (entity.getIsDeleted() != null && entity.getIsDeleted()) {
-      updateFields.put("isDeleted", entity.getIsDeleted());
-    }
-    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
+    batchRequest.add(indexName, entity);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FormHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FormHandlerTest.java
@@ -24,6 +24,8 @@ import io.camunda.zeebe.protocol.record.value.deployment.ImmutableForm;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 public class FormHandlerTest {
@@ -93,7 +95,26 @@ public class FormHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1))
+        .upsert(indexName, inputEntity.getId(), inputEntity, new HashMap<>());
+  }
+
+  @Test
+  void shouldAddEntityOnFlushForDeletion() {
+    // given
+    final FormEntity inputEntity = new FormEntity().setId("111").setKey(123L).setIsDeleted(true);
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1))
+        .upsert(
+            indexName,
+            String.valueOf(inputEntity.getKey()),
+            inputEntity,
+            Map.of("isDeleted", true));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FormHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FormHandlerTest.java
@@ -24,8 +24,6 @@ import io.camunda.zeebe.protocol.record.value.deployment.ImmutableForm;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 public class FormHandlerTest {
@@ -62,22 +60,21 @@ public class FormHandlerTest {
   @Test
   void shouldGenerateIds() {
     // given
-    final long expectedId = 123;
-
+    final long formKey = 123;
+    final long recordKey = 456;
     final Record<Form> decisionRecord =
         factory.generateRecord(
             ValueType.FORM,
             r ->
                 r.withIntent(FormIntent.CREATED)
-                    .withKey(expectedId)
-                    .withValue(
-                        factory.generateObject(ImmutableForm.class).withFormKey(expectedId)));
+                    .withKey(recordKey)
+                    .withValue(factory.generateObject(ImmutableForm.class).withFormKey(formKey)));
 
     // when
     final var idList = underTest.generateIds(decisionRecord);
 
     // then
-    assertThat(idList).containsExactly(String.valueOf(expectedId));
+    assertThat(idList).containsExactly(String.valueOf(formKey));
   }
 
   @Test
@@ -100,8 +97,7 @@ public class FormHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1))
-        .upsert(indexName, inputEntity.getId(), inputEntity, new HashMap<>());
+    verify(mockRequest, times(1)).add(indexName, inputEntity);
   }
 
   @Test
@@ -114,9 +110,7 @@ public class FormHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1))
-        .upsert(
-            indexName, String.valueOf(inputEntity.getId()), inputEntity, Map.of("isDeleted", true));
+    verify(mockRequest, times(1)).add(indexName, inputEntity);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FormHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FormHandlerTest.java
@@ -66,7 +66,12 @@ public class FormHandlerTest {
 
     final Record<Form> decisionRecord =
         factory.generateRecord(
-            ValueType.FORM, r -> r.withIntent(FormIntent.CREATED).withKey(expectedId));
+            ValueType.FORM,
+            r ->
+                r.withIntent(FormIntent.CREATED)
+                    .withKey(expectedId)
+                    .withValue(
+                        factory.generateObject(ImmutableForm.class).withFormKey(expectedId)));
 
     // when
     final var idList = underTest.generateIds(decisionRecord);
@@ -111,10 +116,7 @@ public class FormHandlerTest {
     // then
     verify(mockRequest, times(1))
         .upsert(
-            indexName,
-            String.valueOf(inputEntity.getKey()),
-            inputEntity,
-            Map.of("isDeleted", true));
+            indexName, String.valueOf(inputEntity.getId()), inputEntity, Map.of("isDeleted", true));
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The entity ID to handle deletion of Forms is derived from the formKey present in the record and not the record key. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
