### PR TITLE
[CPT] feat: Improve logging

### DIFF
--- a/testing/camunda-process-test-example/src/test/resources/application.yml
+++ b/testing/camunda-process-test-example/src/test/resources/application.yml
@@ -8,4 +8,4 @@ logging:
     # Hide default logging from Testcontainers
     org:
       testcontainers: warn
-    tc: warn
+    tc: error

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
@@ -33,6 +33,7 @@ public class CamundaContainer extends GenericContainer<CamundaContainer> {
   private static final String READY_ENDPOINT = "/ready";
 
   private static final String ACTIVE_SPRING_PROFILES = "operate,tasklist,broker,auth";
+  private static final String LOG_APPENDER_STACKDRIVER = "Stackdriver";
 
   private static final String GRPC_API = "localhost:" + ContainerRuntimePorts.CAMUNDA_GATEWAY_API;
   private static final String REST_API = "localhost:" + ContainerRuntimePorts.CAMUNDA_REST_API;
@@ -55,6 +56,7 @@ public class CamundaContainer extends GenericContainer<CamundaContainer> {
         .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_TASKLIST_ZEEBE_GATEWAYADDRESS, GRPC_API)
         .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_TASKLIST_ZEEBE_RESTADDRESS, REST_API)
         .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_TASKLIST_CSRF_PREVENTION_ENABLED, "false")
+        .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_ZEEBE_LOG_APPENDER, LOG_APPENDER_STACKDRIVER)
         .addExposedPorts(
             ContainerRuntimePorts.CAMUNDA_GATEWAY_API,
             ContainerRuntimePorts.CAMUNDA_COMMAND_API,

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/ConnectorsContainer.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/ConnectorsContainer.java
@@ -32,6 +32,8 @@ public class ConnectorsContainer extends GenericContainer<ConnectorsContainer> {
   private static final Duration DEFAULT_STARTUP_TIMEOUT = Duration.ofMinutes(1);
   private static final String CONNECTORS_READY_ENDPOINT = "/actuator/health/readiness";
 
+  private static final String LOG_APPENDER_STACKDRIVER = "stackdriver";
+
   public ConnectorsContainer(final DockerImageName dockerImageName) {
     super(dockerImageName);
     applyDefaultConfiguration();
@@ -42,6 +44,7 @@ public class ConnectorsContainer extends GenericContainer<ConnectorsContainer> {
         .waitingFor(newDefaultWaitStrategy())
         .withEnv("management.endpoints.web.exposure.include", "health")
         .withEnv("management.endpoint.health.probes.enabled", "true")
+        .withEnv(ContainerRuntimeEnvs.CONNECTORS_ENV_LOG_APPENDER, LOG_APPENDER_STACKDRIVER)
         .addExposedPorts(ContainerRuntimePorts.CONNECTORS_REST_API);
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaContainerRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaContainerRuntime.java
@@ -18,6 +18,10 @@ package io.camunda.process.test.impl.runtime;
 import io.camunda.process.test.impl.containers.CamundaContainer;
 import io.camunda.process.test.impl.containers.ConnectorsContainer;
 import io.camunda.process.test.impl.containers.ContainerFactory;
+import io.camunda.process.test.impl.runtime.logging.CamundaLogEntry;
+import io.camunda.process.test.impl.runtime.logging.ConnectorsLogEntry;
+import io.camunda.process.test.impl.runtime.logging.LogEntry;
+import io.camunda.process.test.impl.runtime.logging.Slf4jJsonLogConsumer;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -90,7 +94,8 @@ public class CamundaContainerRuntime implements AutoCloseable {
         containerFactory
             .createCamundaContainer(
                 builder.getCamundaDockerImageName(), builder.getCamundaDockerImageVersion())
-            .withLogConsumer(createContainerLogger(builder.getCamundaLoggerName()))
+            .withLogConsumer(
+                createContainerJsonLogger(builder.getCamundaLoggerName(), CamundaLogEntry.class))
             .withNetwork(network)
             .withNetworkAliases(NETWORK_ALIAS_CAMUNDA)
             .withElasticsearchUrl(ELASTICSEARCH_URL)
@@ -107,7 +112,9 @@ public class CamundaContainerRuntime implements AutoCloseable {
         containerFactory
             .createConnectorsContainer(
                 builder.getConnectorsDockerImageName(), builder.getConnectorsDockerImageVersion())
-            .withLogConsumer(createContainerLogger(builder.getConnectorsLoggerName()))
+            .withLogConsumer(
+                createContainerJsonLogger(
+                    builder.getConnectorsLoggerName(), ConnectorsLogEntry.class))
             .withNetwork(network)
             .withNetworkAliases(NETWORK_ALIAS_CONNECTORS)
             .withZeebeGrpcApi(CAMUNDA_GRPC_API)
@@ -175,6 +182,12 @@ public class CamundaContainerRuntime implements AutoCloseable {
   private static Slf4jLogConsumer createContainerLogger(final String name) {
     final Logger logger = LoggerFactory.getLogger(name);
     return new Slf4jLogConsumer(logger, true);
+  }
+
+  private static <T extends LogEntry> Slf4jJsonLogConsumer createContainerJsonLogger(
+      final String name, final Class<T> logEntryType) {
+    final Logger logger = LoggerFactory.getLogger(name);
+    return new Slf4jJsonLogConsumer(logger, logEntryType);
   }
 
   public static CamundaContainerRuntimeBuilder newBuilder() {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaContainerRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaContainerRuntime.java
@@ -174,7 +174,7 @@ public class CamundaContainerRuntime implements AutoCloseable {
 
   private static Slf4jLogConsumer createContainerLogger(final String name) {
     final Logger logger = LoggerFactory.getLogger(name);
-    return new Slf4jLogConsumer(logger);
+    return new Slf4jLogConsumer(logger, true);
   }
 
   public static CamundaContainerRuntimeBuilder newBuilder() {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimeEnvs.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimeEnvs.java
@@ -20,6 +20,7 @@ public class ContainerRuntimeEnvs {
   // Camunda
   public static final String CAMUNDA_ENV_SPRING_PROFILES_ACTIVE = "SPRING_PROFILES_ACTIVE";
   public static final String CAMUNDA_ENV_ZEEBE_CLOCK_CONTROLLED = "ZEEBE_CLOCK_CONTROLLED";
+  public static final String CAMUNDA_ENV_ZEEBE_LOG_APPENDER = "ZEEBE_LOG_APPENDER";
 
   // Exporter
   public static final String CAMUNDA_ENV_CAMUNDA_EXPORTER_CLASSNAME =
@@ -63,4 +64,5 @@ public class ContainerRuntimeEnvs {
       "CAMUNDA_OPERATE_CLIENT_USERNAME";
   public static final String CONNECTORS_ENV_CAMUNDA_OPERATE_CLIENT_PASSWORD =
       "CAMUNDA_OPERATE_CLIENT_PASSWORD";
+  public static final String CONNECTORS_ENV_LOG_APPENDER = "CONNECTORS_LOG_APPENDER";
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/logging/CamundaLogContext.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/logging/CamundaLogContext.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.runtime.logging;
+
+public class CamundaLogContext {
+
+  private String loggerName;
+
+  public String getLoggerName() {
+    return loggerName;
+  }
+
+  public void setLoggerName(final String loggerName) {
+    this.loggerName = loggerName;
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/logging/CamundaLogEntry.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/logging/CamundaLogEntry.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.runtime.logging;
+
+import java.util.Optional;
+
+public class CamundaLogEntry implements LogEntry {
+
+  private String severity;
+  private String message;
+  private CamundaLogContext context;
+
+  @Override
+  public String getSeverity() {
+    return severity;
+  }
+
+  @Override
+  public String getLoggerName() {
+    return Optional.ofNullable(context).map(CamundaLogContext::getLoggerName).orElse("?");
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(final String message) {
+    this.message = message;
+  }
+
+  public void setSeverity(final String severity) {
+    this.severity = severity;
+  }
+
+  public CamundaLogContext getContext() {
+    return context;
+  }
+
+  public void setContext(final CamundaLogContext context) {
+    this.context = context;
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/logging/ConnectorsLogEntry.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/logging/ConnectorsLogEntry.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.runtime.logging;
+
+public class ConnectorsLogEntry implements LogEntry {
+
+  private String severity;
+  private String message;
+  private String logger;
+
+  @Override
+  public String getSeverity() {
+    return severity;
+  }
+
+  @Override
+  public String getLoggerName() {
+    return getLogger();
+  }
+
+  @Override
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(final String message) {
+    this.message = message;
+  }
+
+  public void setSeverity(final String severity) {
+    this.severity = severity;
+  }
+
+  public String getLogger() {
+    return logger;
+  }
+
+  public void setLogger(final String logger) {
+    this.logger = logger;
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/logging/LogEntry.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/logging/LogEntry.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.runtime.logging;
+
+public interface LogEntry {
+
+  String getSeverity();
+
+  String getLoggerName();
+
+  String getMessage();
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/logging/Slf4jJsonLogConsumer.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/logging/Slf4jJsonLogConsumer.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.runtime.logging;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
+import org.testcontainers.containers.output.OutputFrame;
+
+/**
+ * A logger for Docker containers that produce structured JSON log messages. It is inspired by
+ * {@link org.testcontainers.containers.output.Slf4jLogConsumer} but forward the log messages with
+ * the correct log level. STDOUT is mapped to INFO level and STDERR to ERROR level. The default
+ * level is INFO.
+ */
+public class Slf4jJsonLogConsumer implements Consumer<OutputFrame> {
+
+  private static final Map<String, Level> LOG_LEVEL_BY_SEVERITY;
+
+  static {
+    LOG_LEVEL_BY_SEVERITY = new HashMap<>();
+    LOG_LEVEL_BY_SEVERITY.put("TRACE", Level.TRACE);
+    LOG_LEVEL_BY_SEVERITY.put("DEBUG", Level.DEBUG);
+    LOG_LEVEL_BY_SEVERITY.put("INFO", Level.INFO);
+    LOG_LEVEL_BY_SEVERITY.put("WARNING", Level.WARN);
+    LOG_LEVEL_BY_SEVERITY.put("ERROR", Level.ERROR);
+  }
+
+  private final ObjectMapper objectMapper =
+      new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+  private final Logger logger;
+  private final Class<? extends LogEntry> logEntryType;
+
+  public Slf4jJsonLogConsumer(final Logger logger, final Class<? extends LogEntry> logEntryType) {
+    this.logger = logger;
+    this.logEntryType = logEntryType;
+  }
+
+  @Override
+  public void accept(final OutputFrame outputFrame) {
+    final OutputFrame.OutputType outputType = outputFrame.getType();
+    final String utf8String = outputFrame.getUtf8StringWithoutLineEnding();
+
+    switch (outputType) {
+      case END:
+        break;
+
+      case STDOUT:
+        if (isJsonLogMessage(utf8String)) {
+          logJsonMessage(utf8String);
+        } else {
+          logger.info("{}", utf8String);
+        }
+        break;
+
+      case STDERR:
+        logger.error("{}", utf8String);
+        break;
+
+      default:
+        throw new IllegalArgumentException("Unexpected outputType " + outputType);
+    }
+  }
+
+  private static boolean isJsonLogMessage(final String logMessage) {
+    return logMessage.startsWith("{") && logMessage.endsWith("}");
+  }
+
+  private void logJsonMessage(final String jsonMessage) {
+    try {
+      final LogEntry logEntry = objectMapper.readValue(jsonMessage, logEntryType);
+
+      final Level logLevel = LOG_LEVEL_BY_SEVERITY.getOrDefault(logEntry.getSeverity(), Level.INFO);
+      final String loggerName = logEntry.getLoggerName();
+      final String message = logEntry.getMessage();
+
+      logger.atLevel(logLevel).log("{} - {}", loggerName, message);
+
+    } catch (final JsonProcessingException e) {
+      // fallback, if the log format is different
+      logger.info("{}", jsonMessage);
+    }
+  }
+}

--- a/testing/camunda-process-test-java/src/test/resources/log4j2-test.xml
+++ b/testing/camunda-process-test-java/src/test/resources/log4j2-test.xml
@@ -17,7 +17,7 @@
 
     <!-- Hide default logging from Testcontainers -->
     <Logger name="org.testcontainers" level="warn"/>
-    <Logger name="tc" level="warn"/>
+    <Logger name="tc" level="error"/>
 
   </Loggers>
 

--- a/testing/camunda-process-test-spring/src/test/resources/application.yml
+++ b/testing/camunda-process-test-spring/src/test/resources/application.yml
@@ -16,4 +16,4 @@ logging:
     # Hide default logging from Testcontainers
     org:
       testcontainers: warn
-    tc: warn
+    tc: error


### PR DESCRIPTION
## Description

Extend the logging to print all Docker images on start-up (image name + version tag).

Adjust the logger for the containers to separate the output streams. Effect: Std-err to ERROR log level + remove
output type (STDOUT) from logging messages.

Add a new logger for the Camunda and the Connectors container. Compared to the existing logger, it forwards log entries with the correct log level instead of using the `INFO` level for all log messages. Enable JSON logging for containers ([Camunda](https://docs.camunda.io/docs/next/self-managed/zeebe-deployment/configuration/logging/#google-stackdriver-json-logging) + [Connectors](https://docs.camunda.io/docs/next/self-managed/connectors-deployment/connectors-configuration/#google-stackdriver-json-logging)).

**Review note**
I didn't add test cases for the logging because it is cumbersome to verify logging. Since it is just logging and doesn't impact CPT features, I think it is okay to have no tests. I verified the logging manually. 

## Related issues


