### PR TITLE
feat: Inject document service URL into Tasklist forms

### DIFF
--- a/tasklist/client/src/modules/api.ts
+++ b/tasklist/client/src/modules/api.ts
@@ -329,6 +329,12 @@ const api = {
         body,
       });
     },
+    getDocument: async (id: string) => {
+      return new Request(getFullURL(`/v2/documents/${id}`), {
+        method: 'GET',
+        ...BASE_REQUEST_OPTIONS,
+      });
+    },
   },
 } as const;
 

--- a/tasklist/client/src/modules/components/FormJSRenderer/index.test.tsx
+++ b/tasklist/client/src/modules/components/FormJSRenderer/index.test.tsx
@@ -16,6 +16,21 @@ function noop() {
 }
 
 describe('<FormJSRenderer />', async () => {
+  beforeEach(() => {
+    global.IntersectionObserver = vi.fn(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      disconnect: vi.fn(),
+      root: null,
+      rootMargin: '',
+      thresholds: [],
+      takeRecords: () => [],
+    }));
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('should merge variables on submit', async () => {
     vi.useFakeTimers({
       shouldAdvanceTime: true,
@@ -73,5 +88,77 @@ describe('<FormJSRenderer />', async () => {
     ]);
 
     vi.useRealTimers();
+  });
+
+  it('should inject document service endpoint to preview documents', async () => {
+    render(
+      <FormJSRenderer
+        handleSubmit={noop}
+        schema={formMocks.formWithDocumentPreview.schema}
+        data={{
+          myDocuments: [
+            {
+              'camunda.document.type': 'camunda',
+              storeId: 'in-memory',
+              documentId: '8add9f73-776d-451d-81d0-fc167d4220c0',
+              metadata: {
+                contentType: 'application/octet-stream',
+                fileName: 'document0',
+                size: 663849,
+                customProperties: {},
+              },
+            },
+            {
+              'camunda.document.type': 'camunda',
+              storeId: 'in-memory',
+              documentId: '2ee85de7-ed39-4620-81aa-df73ccfd0344',
+              metadata: {
+                contentType: 'application/pdf',
+                fileName: 'Onboarding Guide.pdf',
+                size: 546904,
+                customProperties: {},
+              },
+            },
+            {
+              'camunda.document.type': 'camunda',
+              storeId: 'in-memory',
+              documentId: 'e2b09092-7994-4813-b1ef-eb29731aea3d',
+              metadata: {
+                contentType: 'application/pdf',
+                fileName: '766-st-1-vinicius-goulart.pdf',
+                size: 39993,
+                customProperties: {},
+              },
+            },
+          ],
+        }}
+        onMount={noop}
+        onRender={noop}
+        onImportError={noop}
+        onSubmitStart={noop}
+        onSubmitError={noop}
+        onSubmitSuccess={noop}
+        onValidationError={noop}
+      />,
+    );
+
+    expect(await screen.findByText('My documents')).toBeInTheDocument();
+
+    expect(screen.getByText('document0')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Download document0'}),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Onboarding Guide.pdf')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Download Onboarding Guide.pdf'}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('766-st-1-vinicius-goulart.pdf'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'Download 766-st-1-vinicius-goulart.pdf',
+      }),
+    ).toBeInTheDocument();
   });
 });

--- a/tasklist/client/src/modules/components/FormJSRenderer/index.tsx
+++ b/tasklist/client/src/modules/components/FormJSRenderer/index.tsx
@@ -18,6 +18,11 @@ import '@bpmn-io/form-js-viewer/dist/assets/form-js-base.css';
 import '@bpmn-io/form-js-carbon-styles/src/carbon-styles.scss';
 import type {FileUploadMetadata} from 'modules/mutations/useUploadDocuments';
 import set from 'lodash/set';
+import {api} from 'modules/api';
+
+const defaultDocumentsEndpointKey = decodeURIComponent(
+  (await api.v2.getDocument('{documentId}')).url,
+);
 
 type Props = {
   handleSubmit: (variables: Variable[]) => Promise<void>;
@@ -194,7 +199,10 @@ const FormJSRenderer: React.FC<Props> = ({
         formManager.render({
           container,
           schema,
-          data,
+          data: {
+            defaultDocumentsEndpointKey,
+            ...data,
+          },
           onImportError,
           onSubmit: async ({data: newData, errors, files = new Map()}) => {
             onSubmitStart?.();

--- a/tasklist/client/src/modules/mock-schema/mocks/form.tsx
+++ b/tasklist/client/src/modules/mock-schema/mocks/form.tsx
@@ -163,4 +163,33 @@ const noInputForm: Form = {
   isDeleted: false,
 };
 
-export {form, invalidForm, dynamicForm, nestedForm, noInputForm};
+const formWithDocumentPreview: Form = {
+  id: 'camunda-forms:bpmn:form-0',
+  processDefinitionKey: 'process',
+  title: 'A form',
+  version: null,
+  schema: JSON.stringify({
+    components: [
+      {
+        label: 'My documents',
+        endpointKey: '=defaultDocumentsEndpointKey',
+        type: 'documentPreview',
+        id: 'myDocuments',
+        dataSource: '=myDocuments',
+      },
+    ],
+    type: 'default',
+    id: 'integration_form',
+  }),
+  tenantId: '<default>',
+  isDeleted: false,
+};
+
+export {
+  form,
+  invalidForm,
+  dynamicForm,
+  nestedForm,
+  noInputForm,
+  formWithDocumentPreview,
+};

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/SecurityProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/SecurityProperties.java
@@ -9,7 +9,7 @@ package io.camunda.tasklist.property;
 
 public class SecurityProperties {
   public static final String CONTENT_SECURITY_POLICY =
-      "default-src 'self';connect-src 'self' https: *.mixpanel.com cloudflareinsights.com *.appcues.net wss://api.appcues.net;script-src 'self' https: *.chargebee.com *.mixpanel.com ajax.cloudflare.com static.cloudflareinsights.com;style-src 'self' https: 'unsafe-inline' *.googleapis.com *.chargebee.com;img-src * data: ;font-src 'self' data: https://fonts.gstatic.com https://fonts.camunda.io;frame-ancestors;frame-src 'self' https: *.chargebee.com ;child-src;worker-src 'self' blob:;base-uri 'self';form-action 'self';object-src 'none';script-src-attr 'none';";
+      "default-src 'self';connect-src 'self' https: *.mixpanel.com cloudflareinsights.com *.appcues.net wss://api.appcues.net;script-src 'self' https: *.chargebee.com *.mixpanel.com ajax.cloudflare.com static.cloudflareinsights.com;style-src 'self' https: 'unsafe-inline' *.googleapis.com *.chargebee.com;img-src * data: ;font-src 'self' data: https://fonts.gstatic.com https://fonts.camunda.io;frame-ancestors 'self';frame-src 'self' https: *.chargebee.com ;child-src;worker-src 'self' blob:;base-uri 'self';form-action 'self';object-src 'self';script-src-attr 'none';";
 
   private String contentSecurityPolicy = CONTENT_SECURITY_POLICY;
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This [Renovate PR](https://github.com/camunda/camunda/pull/26166) updated `form-js` to the latest version which introduces the new document preview component.
For this  component to work we need to inject the document service URL into the `form-js` context so the form can pull the documents

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #26221
