### PR TITLE
Support corrections for `assigning` task listeners

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -131,7 +131,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
     switch (lifecycleState) {
       case COMPLETING ->
           writeRejectionForCommand(command, persistedRecord, UserTaskIntent.COMPLETION_DENIED);
-      case ASSIGNING ->
+      case ASSIGNING, CLAIMING ->
           writeRejectionForCommand(command, persistedRecord, UserTaskIntent.ASSIGNMENT_DENIED);
       default ->
           throw new IllegalArgumentException(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
@@ -21,8 +21,6 @@ import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
-import java.util.Objects;
-import org.apache.commons.lang3.StringUtils;
 
 public final class UserTaskAssignProcessor implements UserTaskCommandProcessor {
 
@@ -66,13 +64,6 @@ public final class UserTaskAssignProcessor implements UserTaskCommandProcessor {
   public void onFinalizeCommand(
       final TypedRecord<UserTaskRecord> command, final UserTaskRecord userTaskRecord) {
     final long userTaskKey = command.getKey();
-    final String action =
-        Objects.requireNonNullElse(
-            StringUtils.firstNonEmpty(command.getValue().getAction(), userTaskRecord.getAction()),
-            StringUtils.EMPTY);
-
-    userTaskRecord.setAssignee(command.getValue().getAssignee());
-    userTaskRecord.setAction(action);
 
     if (command.hasRequestMetadata()) {
       stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignedV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignedV2Applier.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import java.util.List;
 
 public final class UserTaskAssignedV2Applier
     implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
@@ -25,10 +26,9 @@ public final class UserTaskAssignedV2Applier
 
   @Override
   public void applyState(final long key, final UserTaskRecord value) {
-    final String assignee = value.getAssignee();
-    final UserTaskRecord userTask = userTaskState.getUserTask(key);
-    userTask.setAssignee(assignee);
-    userTaskState.update(userTask);
+    final var userTaskRecord = new UserTaskRecord();
+    userTaskRecord.wrapWithoutVariables(value);
+    userTaskState.update(userTaskRecord.setChangedAttributes(List.of()).setAction(""));
     userTaskState.updateUserTaskLifecycleState(key, LifecycleState.CREATED);
     userTaskState.deleteIntermediateState(key);
     userTaskState.deleteRecordRequestMetadata(key);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds support for correcting user task data in the `assigning` task listeners.

- Adds a bunch of test cases, building on existing correction tests for `completing` listeners
- Ensures that corrected user task data is persisted on `ASSIGNED` event
- Fixed a bug preventing to deny the `assigning` event when `CLAIMING`
- Cleaned up some redundant code

> [!NOTE]
> There are two solutions to persisting the data, which are b128494d33f279bca9351ac35f61a8da2ee03578 and 658c1fd39e253186b82e96764fc13681ccc91696. I'd like to discuss which we prefer. I've provided both to facilitate the discussion.
>
> Note that the alternative also requires 84f95c8, ands leads to some failing tests becaue we don't fully always set the changed attributes on every command/event correctly yet. It will require changes [more changes](https://github.com/camunda/camunda/compare/korthout-26032-corrections-on-assigning...korthout-26227-alternative), and even some more still. It may be better to look at that separately. But let me know what you think.

## Related issues

closes #26032 