### PR TITLE
test: make forbidden error message deterministic

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -363,7 +363,7 @@ public final class AuthorizationCheckBehavior {
       return resourceIdsContainsOnlyWildcard
           ? FORBIDDEN_ERROR_MESSAGE.formatted(permissionType, resourceType)
           : FORBIDDEN_ERROR_MESSAGE_WITH_RESOURCE.formatted(
-              permissionType, resourceType, resourceIds);
+              permissionType, resourceType, resourceIds.stream().sorted().toList());
     }
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/DecisionEvaluationEvaluateAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/DecisionEvaluationEvaluateAuthorizationIT.java
@@ -135,7 +135,7 @@ public class DecisionEvaluationEvaluateAuthorizationIT {
           .hasMessageContaining("title: FORBIDDEN")
           .hasMessageContaining("status: 403")
           .hasMessageContaining(
-              "Insufficient permissions to perform operation 'CREATE_DECISION_INSTANCE' on resource 'DECISION_DEFINITION', required resource identifiers are one of '[%s, *]",
+              "Insufficient permissions to perform operation 'CREATE_DECISION_INSTANCE' on resource 'DECISION_DEFINITION', required resource identifiers are one of '[*, %s]'",
               DECISION_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/IncidentResolveAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/IncidentResolveAuthorizationIT.java
@@ -133,7 +133,7 @@ public class IncidentResolveAuthorizationIT {
           .hasMessageContaining("title: FORBIDDEN")
           .hasMessageContaining("status: 403")
           .hasMessageContaining(
-              "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[%s, *]",
+              "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'",
               PROCESS_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/JobCompleteAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/JobCompleteAuthorizationIT.java
@@ -169,7 +169,7 @@ public class JobCompleteAuthorizationIT {
           .hasMessageContaining("title: FORBIDDEN")
           .hasMessageContaining("status: 403")
           .hasMessageContaining(
-              "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[%s, *]",
+              "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'",
               PROCESS_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/JobFailAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/JobFailAuthorizationIT.java
@@ -141,7 +141,7 @@ public class JobFailAuthorizationIT {
           .hasMessageContaining("title: FORBIDDEN")
           .hasMessageContaining("status: 403")
           .hasMessageContaining(
-              "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[%s, *]",
+              "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'",
               PROCESS_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/JobUpdateAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/JobUpdateAuthorizationIT.java
@@ -142,7 +142,7 @@ public class JobUpdateAuthorizationIT {
           .hasMessageContaining("title: FORBIDDEN")
           .hasMessageContaining("status: 403")
           .hasMessageContaining(
-              "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[%s, *]",
+              "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'",
               PROCESS_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/MessageCorrelationCorrelateAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/MessageCorrelationCorrelateAuthorizationIT.java
@@ -168,7 +168,7 @@ public class MessageCorrelationCorrelateAuthorizationIT {
           .hasMessageContaining("title: FORBIDDEN")
           .hasMessageContaining("status: 403")
           .hasMessageContaining(
-              "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[%s, *]",
+              "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'",
               PROCESS_ID);
     }
   }
@@ -238,7 +238,7 @@ public class MessageCorrelationCorrelateAuthorizationIT {
           .hasMessageContaining("title: FORBIDDEN")
           .hasMessageContaining("status: 403")
           .hasMessageContaining(
-              "Insufficient permissions to perform operation 'CREATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[%s, *]",
+              "Insufficient permissions to perform operation 'CREATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'",
               PROCESS_ID);
     }
   }
@@ -286,7 +286,7 @@ public class MessageCorrelationCorrelateAuthorizationIT {
           .hasMessageContaining("title: FORBIDDEN")
           .hasMessageContaining("status: 403")
           .hasMessageContaining(
-              "Insufficient permissions to perform operation 'CREATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[%s, *]",
+              "Insufficient permissions to perform operation 'CREATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'",
               unauthorizedProcessId);
 
       final var deploymentPosition =

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/ProcessInstanceCancelAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/ProcessInstanceCancelAuthorizationIT.java
@@ -151,7 +151,7 @@ public class ProcessInstanceCancelAuthorizationIT {
           .hasMessageContaining("title: FORBIDDEN")
           .hasMessageContaining("status: 403")
           .hasMessageContaining(
-              "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[%s, *]",
+              "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'",
               PROCESS_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/ProcessInstanceCreateAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/ProcessInstanceCreateAuthorizationIT.java
@@ -190,7 +190,7 @@ public class ProcessInstanceCreateAuthorizationIT {
           .hasMessageContaining("title: FORBIDDEN")
           .hasMessageContaining("status: 403")
           .hasMessageContaining(
-              "Insufficient permissions to perform operation 'CREATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[%s, *]",
+              "Insufficient permissions to perform operation 'CREATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'",
               PROCESS_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/ProcessInstanceMigrationMigrateAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/ProcessInstanceMigrationMigrateAuthorizationIT.java
@@ -191,7 +191,7 @@ public class ProcessInstanceMigrationMigrateAuthorizationIT {
           .hasMessageContaining("title: FORBIDDEN")
           .hasMessageContaining("status: 403")
           .hasMessageContaining(
-              "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[%s, *]",
+              "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'",
               PROCESS_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/ProcessInstanceModificationModifyAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/ProcessInstanceModificationModifyAuthorizationIT.java
@@ -150,7 +150,7 @@ public class ProcessInstanceModificationModifyAuthorizationIT {
           .hasMessageContaining("title: FORBIDDEN")
           .hasMessageContaining("status: 403")
           .hasMessageContaining(
-              "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[%s, *]",
+              "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'",
               PROCESS_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/ResourceDeletionAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/ResourceDeletionAuthorizationIT.java
@@ -179,7 +179,7 @@ public class ResourceDeletionAuthorizationIT {
           .hasMessageContaining("title: FORBIDDEN")
           .hasMessageContaining("status: 403")
           .hasMessageContaining(
-              "Insufficient permissions to perform operation 'DELETE_DRD' on resource 'DEPLOYMENT', required resource identifiers are one of '[%s, *]",
+              "Insufficient permissions to perform operation 'DELETE_DRD' on resource 'DEPLOYMENT', required resource identifiers are one of '[*, %s]'",
               drdId);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/SignalBroadcastAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/SignalBroadcastAuthorizationIT.java
@@ -145,7 +145,7 @@ public class SignalBroadcastAuthorizationIT {
           .hasMessageContaining("title: FORBIDDEN")
           .hasMessageContaining("status: 403")
           .hasMessageContaining(
-              "Insufficient permissions to perform operation 'CREATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[%s, *]",
+              "Insufficient permissions to perform operation 'CREATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'",
               PROCESS_ID);
     }
   }
@@ -174,7 +174,7 @@ public class SignalBroadcastAuthorizationIT {
           .hasMessageContaining("title: FORBIDDEN")
           .hasMessageContaining("status: 403")
           .hasMessageContaining(
-              "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[%s, *]",
+              "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'",
               PROCESS_ID);
 
       assertThat(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/UserTaskAssignAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/UserTaskAssignAuthorizationIT.java
@@ -155,7 +155,7 @@ public class UserTaskAssignAuthorizationIT {
           .hasMessageContaining("title: FORBIDDEN")
           .hasMessageContaining("status: 403")
           .hasMessageContaining(
-              "Insufficient permissions to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[%s, *]",
+              "Insufficient permissions to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'",
               PROCESS_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/UserTaskClaimAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/UserTaskClaimAuthorizationIT.java
@@ -140,7 +140,7 @@ public class UserTaskClaimAuthorizationIT {
           .hasMessageContaining("title: FORBIDDEN")
           .hasMessageContaining("status: 403")
           .hasMessageContaining(
-              "Insufficient permissions to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[%s, *]",
+              "Insufficient permissions to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'",
               PROCESS_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/UserTaskCompleteAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/UserTaskCompleteAuthorizationIT.java
@@ -138,7 +138,7 @@ public class UserTaskCompleteAuthorizationIT {
           .hasMessageContaining("title: FORBIDDEN")
           .hasMessageContaining("status: 403")
           .hasMessageContaining(
-              "Insufficient permissions to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[%s, *]",
+              "Insufficient permissions to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'",
               PROCESS_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/UserTaskUpdateAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/UserTaskUpdateAuthorizationIT.java
@@ -140,7 +140,7 @@ public class UserTaskUpdateAuthorizationIT {
           .hasMessageContaining("title: FORBIDDEN")
           .hasMessageContaining("status: 403")
           .hasMessageContaining(
-              "Insufficient permissions to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[%s, *]",
+              "Insufficient permissions to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'",
               PROCESS_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/VariableDocumentUpdateAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/VariableDocumentUpdateAuthorizationIT.java
@@ -143,7 +143,7 @@ public class VariableDocumentUpdateAuthorizationIT {
           .hasMessageContaining("title: FORBIDDEN")
           .hasMessageContaining("status: 403")
           .hasMessageContaining(
-              "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[%s, *]",
+              "Insufficient permissions to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, %s]'",
               PROCESS_ID);
     }
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
`resourceIds` is a `HashSet` so it can give indeterministic order in the error message

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
