### PR TITLE
feat: authorize the identity migration

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/AuthConfig.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/AuthConfig.java
@@ -17,7 +17,11 @@ public class AuthConfig {
 
   @Bean
   public Authentication servicesAuthentication() {
-    // TODO: implement later
-    return new Authentication.Builder().token(Authorization.jwtEncoder().build()).build();
+    return new Authentication.Builder()
+        .token(
+            Authorization.jwtEncoder()
+                .withClaim(Authorization.AUTHORIZED_ANONYMOUS_USER, true)
+                .build())
+        .build();
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/it/migration/IdentityDefaultEntitiesIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/migration/IdentityDefaultEntitiesIT.java
@@ -34,7 +34,9 @@ public class IdentityDefaultEntitiesIT {
       IdentityMigrationTestUtil.getManagementIdentity(POSTGRES, KEYCLOAK);
 
   @TestZeebe(autoStart = false)
-  final TestStandaloneCamunda camunda = new TestStandaloneCamunda();
+  final TestStandaloneCamunda camunda =
+      new TestStandaloneCamunda()
+          .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true));
 
   @Test
   void canMigrateOldDefaultEntities() {


### PR DESCRIPTION
This authorizes the identity migration app by using the anonymous user. All service requests are fully authorized.

We can test this by enabling resource authorizations. Without using the anonymous user, all requests would fail as unauthorized.

closes #25825