### PR TITLE
Tasklist opensearch schema validation fix

### DIFF
--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/IndexMapping.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/IndexMapping.java
@@ -10,10 +10,14 @@ package io.camunda.tasklist.schema;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 public class IndexMapping {
@@ -59,7 +63,37 @@ public class IndexMapping {
     return properties.stream()
         .collect(
             Collectors.toMap(
-                IndexMappingProperty::getName, IndexMappingProperty::getTypeDefinition));
+                IndexMappingProperty::getName,
+                property -> convertToOrderedStructures(property.getTypeDefinition())));
+  }
+
+  /**
+   * On Opensearch Schema validation fails when the schema is created by the Exporter (primarility
+   * for tasklist-task index and the `join` field), due to the order of parsed index mapping
+   * properties. Using TreeMap and sorting the Lists present in the properties ensures the order of
+   * properties when comparing the existing mappings with the ones defined in the schema.
+   */
+  private Object convertToOrderedStructures(final Object value) {
+    if (value instanceof LinkedHashMap<?, ?>) {
+      return ((LinkedHashMap<?, ?>) value)
+          .entrySet().stream()
+              .collect(
+                  Collectors.toMap(
+                      Entry::getKey,
+                      item -> {
+                        if (item.getValue() instanceof LinkedHashMap<?, ?>) {
+                          return convertToOrderedStructures(item.getValue());
+                        } else if (item.getValue() instanceof List<?>) {
+                          return ((ArrayList<?>) item.getValue())
+                              .stream().sorted().collect(Collectors.toList());
+                        } else {
+                          return item.getValue();
+                        }
+                      },
+                      (e1, e2) -> e1,
+                      TreeMap::new));
+    }
+    return value;
   }
 
   public Map<String, Object> getMetaProperties() {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
@@ -10,6 +10,8 @@ package io.camunda.tasklist.schema.manager;
 import static io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor.formatIndexPrefix;
 import static io.camunda.webapps.schema.descriptors.ComponentNames.TASK_LIST;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,19 +30,21 @@ import jakarta.json.stream.JsonParser;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
+import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.apache.http.util.EntityUtils;
-import org.opensearch.client.Request;
-import org.opensearch.client.Response;
-import org.opensearch.client.RestClient;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.jackson.JacksonJsonpGenerator;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.mapping.Property;
@@ -75,10 +79,6 @@ public class OpenSearchSchemaManager implements SchemaManager {
   @Autowired protected TasklistProperties tasklistProperties;
 
   @Autowired protected RetryOpenSearchClient retryOpenSearchClient;
-
-  @Autowired
-  @Qualifier("tasklistOsRestClient")
-  private RestClient opensearchRestClient;
 
   @Autowired private List<AbstractIndexDescriptor> indexDescriptors;
   @Autowired private List<IndexTemplateDescriptor> templateDescriptors;
@@ -132,34 +132,31 @@ public class OpenSearchSchemaManager implements SchemaManager {
       throws IOException {
     final Map<String, IndexMapping> mappings = new HashMap<>();
 
-    final Request request = new Request("GET", "/" + indexNamePattern + "/_mapping/");
-    final Response response = opensearchRestClient.performRequest(request);
-    final String responseBody = EntityUtils.toString(response.getEntity());
-
-    // Initialize ObjectMapper instance
-    final ObjectMapper objectMapper = new ObjectMapper();
-
-    // Parse the JSON response body
-    final Map<String, Map<String, Map<String, Object>>> parsedResponse =
-        objectMapper.readValue(responseBody, new TypeReference<>() {});
+    final Map<String, TypeMapping> indexMappings =
+        openSearchClient
+            .indices()
+            .getMapping(req -> req.index(indexNamePattern).ignoreUnavailable(true))
+            .result()
+            .entrySet()
+            .stream()
+            .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().mappings()));
 
     // Iterate over the parsed JSON to build the mappings
-    for (final Map.Entry<String, Map<String, Map<String, Object>>> indexEntry :
-        parsedResponse.entrySet()) {
+    for (final Entry<String, TypeMapping> indexEntry : indexMappings.entrySet()) {
       final String indexName = indexEntry.getKey();
-      final Map<String, Object> indexMappingData = indexEntry.getValue().get("mappings");
-      final String dynamicSetting = (String) indexMappingData.get("dynamic");
+      final Map<String, Property> indexMappingData = indexEntry.getValue().properties();
+      final String dynamic =
+          indexEntry.getValue().dynamic() == null
+              ? "strict"
+              : indexEntry.getValue().dynamic().toString().toLowerCase();
 
-      // Extract the properties
-      final Map<String, Object> propertiesData =
-          (Map<String, Object>) indexMappingData.get("properties");
       final Set<IndexMapping.IndexMappingProperty> propertiesSet = new HashSet<>();
 
-      for (final Map.Entry<String, Object> propertyEntry : propertiesData.entrySet()) {
+      for (final Map.Entry<String, Property> propertyEntry : indexMappingData.entrySet()) {
         final IndexMapping.IndexMappingProperty property =
             new IndexMapping.IndexMappingProperty()
                 .setName(propertyEntry.getKey())
-                .setTypeDefinition(propertyEntry.getValue());
+                .setTypeDefinition(propertyToMap(propertyEntry.getValue()));
         propertiesSet.add(property);
       }
 
@@ -167,7 +164,7 @@ public class OpenSearchSchemaManager implements SchemaManager {
       final IndexMapping indexMapping =
           new IndexMapping()
               .setIndexName(indexName)
-              .setDynamic(dynamicSetting)
+              .setDynamic(dynamic)
               .setProperties(propertiesSet);
 
       // Add to mappings map
@@ -429,6 +426,35 @@ public class OpenSearchSchemaManager implements SchemaManager {
     } catch (final Exception e) {
       throw new TasklistRuntimeException(
           "Exception occurred when reading template JSON: " + e.getMessage(), e);
+    }
+  }
+
+  // Ported from CamundaExporter
+  private Map<String, Object> serialize(
+      final Function<JsonGenerator, jakarta.json.stream.JsonGenerator> jacksonGenerator,
+      final Consumer<jakarta.json.stream.JsonGenerator> serialize)
+      throws IOException {
+    try (final var out = new StringWriter();
+        final var jsonGenerator = new JsonFactory().createGenerator(out);
+        final jakarta.json.stream.JsonGenerator jacksonJsonpGenerator =
+            jacksonGenerator.apply(jsonGenerator)) {
+      serialize.accept(jacksonJsonpGenerator);
+      jacksonJsonpGenerator.flush();
+
+      return objectMapper.readValue(out.toString(), new TypeReference<>() {});
+    }
+  }
+
+  // Ported from CamundaExporter
+  private Map<String, Object> propertyToMap(final Property property) {
+    try {
+      return serialize(
+          (JacksonJsonpGenerator::new),
+          (jacksonJsonpGenerator) ->
+              property.serialize(jacksonJsonpGenerator, new JacksonJsonpMapper(objectMapper)));
+    } catch (final IOException e) {
+      throw new TasklistRuntimeException(
+          String.format("Failed to serialize property [%s]", property.toString()), e);
     }
   }
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -441,7 +442,8 @@ public class OpenSearchSchemaManager implements SchemaManager {
       serialize.accept(jacksonJsonpGenerator);
       jacksonJsonpGenerator.flush();
 
-      return objectMapper.readValue(out.toString(), new TypeReference<>() {});
+      return objectMapper.readValue(
+          out.toString(), new TypeReference<TreeMap<String, Object>>() {});
     }
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Ported Opensearch schema parsing from CamundaExporter.

When on Opensearch, Tasklist schema validator registers falls positives as differences in regards to the `tasklist-task` index mappings, due to the order of elements returned from Opensearch. Before doings the diff of the existing mappings and the ones parsed from the JSON schema, elements are now ordered using `TreeMap` instead of `LinkedHashMap` and nested `Lists` are also sorted properly.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
