### PR TITLE
feat: update corrected user task attributes for `ASSIGNED` and `COMPLETED` events

### DIFF
--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -191,6 +191,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -191,12 +191,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-protocol-impl</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -113,42 +113,6 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
     entity.setJoin(joinRelation);
   }
 
-  /**
-   * Applies changes to the user task fields based on the attributes in the {@link
-   * UserTaskRecordValue}.
-   *
-   * <p>This method can be used for updating fields either:
-   *
-   * <ul>
-   *   <li>As a result of user task corrections configured while completing task listener jobs.
-   *   <li>As a result of regular user task updates.
-   * </ul>
-   *
-   * @param record the record containing user task data and changed attributes
-   * @param entity the task entity to be updated
-   */
-  private void updateChangedAttributes(
-      final Record<UserTaskRecordValue> record, final TaskEntity entity) {
-    final var value = record.getValue();
-
-    for (final String attribute : value.getChangedAttributes()) {
-      entity.getChangedAttributes().add(attribute);
-
-      switch (attribute) {
-        case "assignee" -> entity.setAssignee(value.getAssignee());
-        case "candidateGroupsList" ->
-            entity.setCandidateGroups(value.getCandidateGroupsList().toArray(new String[0]));
-        case "candidateUsersList" ->
-            entity.setCandidateUsers(value.getCandidateUsersList().toArray(new String[0]));
-        case "dueDate" -> entity.setDueDate(ExporterUtil.toOffsetDateTime(value.getDueDate()));
-        case "followUpDate" ->
-            entity.setFollowUpDate(ExporterUtil.toOffsetDateTime(value.getFollowUpDate()));
-        case "priority" -> entity.setPriority(value.getPriority());
-        default -> LOGGER.warn(UNMAPPED_USER_TASK_ATTRIBUTE_WARNING, attribute);
-      }
-    }
-  }
-
   @Override
   public void flush(final TaskEntity entity, final BatchRequest batchRequest) {
 
@@ -278,6 +242,42 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
     }
 
     updateChangedAttributes(record, entity);
+  }
+
+  /**
+   * Applies changes to the user task fields based on the attributes in the {@link
+   * UserTaskRecordValue}.
+   *
+   * <p>This method can be used for updating fields either:
+   *
+   * <ul>
+   *   <li>As a result of user task corrections configured while completing task listener jobs.
+   *   <li>As a result of regular user task updates.
+   * </ul>
+   *
+   * @param record the record containing user task data and changed attributes
+   * @param entity the task entity to be updated
+   */
+  private void updateChangedAttributes(
+      final Record<UserTaskRecordValue> record, final TaskEntity entity) {
+    final var value = record.getValue();
+
+    for (final String attribute : value.getChangedAttributes()) {
+      entity.getChangedAttributes().add(attribute);
+
+      switch (attribute) {
+        case "assignee" -> entity.setAssignee(value.getAssignee());
+        case "candidateGroupsList" ->
+            entity.setCandidateGroups(value.getCandidateGroupsList().toArray(new String[0]));
+        case "candidateUsersList" ->
+            entity.setCandidateUsers(value.getCandidateUsersList().toArray(new String[0]));
+        case "dueDate" -> entity.setDueDate(ExporterUtil.toOffsetDateTime(value.getDueDate()));
+        case "followUpDate" ->
+            entity.setFollowUpDate(ExporterUtil.toOffsetDateTime(value.getFollowUpDate()));
+        case "priority" -> entity.setPriority(value.getPriority());
+        default -> LOGGER.warn(UNMAPPED_USER_TASK_ATTRIBUTE_WARNING, attribute);
+      }
+    }
   }
 
   private void handleCompletion(final Record<UserTaskRecordValue> record, final TaskEntity entity) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -108,28 +108,7 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
         }
         updateChangedAttributes(record, entity);
       }
-      case UserTaskIntent.UPDATED -> {
-        for (final String attribute : record.getValue().getChangedAttributes()) {
-          entity.getChangedAttributes().add(attribute);
-          switch (attribute) {
-            case "candidateGroupsList" ->
-                entity.setCandidateGroups(
-                    record.getValue().getCandidateGroupsList().toArray(new String[0]));
-            case "candidateUsersList" ->
-                entity.setCandidateUsers(
-                    record.getValue().getCandidateUsersList().toArray(new String[0]));
-            case "dueDate" ->
-                entity.setDueDate(ExporterUtil.toOffsetDateTime(record.getValue().getDueDate()));
-            case "followUpDate" ->
-                entity.setFollowUpDate(
-                    ExporterUtil.toOffsetDateTime(record.getValue().getFollowUpDate()));
-            case "priority" -> entity.setPriority(record.getValue().getPriority());
-            default ->
-                LOGGER.warn(
-                    "Attribute update not mapped while importing ZEEBE_USER_TASKS: {}", attribute);
-          }
-        }
-      }
+      case UserTaskIntent.UPDATED -> updateChangedAttributes(record, entity);
       case UserTaskIntent.COMPLETED -> {
         entity
             .setState(TaskState.COMPLETED)

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -106,6 +106,7 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
         } else {
           entity.setAssignee(record.getValue().getAssignee());
         }
+        updateChangedAttributes(record, entity);
       }
       case UserTaskIntent.UPDATED -> {
         for (final String attribute : record.getValue().getChangedAttributes()) {
@@ -129,11 +130,13 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
           }
         }
       }
-      case UserTaskIntent.COMPLETED ->
-          entity
-              .setState(TaskState.COMPLETED)
-              .setCompletionTime(
-                  ExporterUtil.toZonedOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
+      case UserTaskIntent.COMPLETED -> {
+        entity
+            .setState(TaskState.COMPLETED)
+            .setCompletionTime(
+                ExporterUtil.toZonedOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
+        updateChangedAttributes(record, entity);
+      }
       case UserTaskIntent.CANCELED ->
           entity
               .setState(TaskState.CANCELED)

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -43,6 +43,9 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
           UserTaskIntent.MIGRATED,
           UserTaskIntent.ASSIGNED,
           UserTaskIntent.UPDATED);
+  private static final String UNMAPPED_USER_TASK_ATTRIBUTE_WARNING =
+      "Attribute update not mapped while importing ZEEBE_USER_TASKS: {}";
+
   private final String indexName;
   private final ExporterEntityCache<String, CachedFormEntity> formCache;
   private final ExporterMetadata exporterMetadata;
@@ -149,6 +152,42 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
     entity.setJoin(joinRelation);
   }
 
+  /**
+   * Applies changes to the user task fields based on the attributes in the
+   * {@link UserTaskRecordValue}.
+   *
+   * <p>This method can be used for updating fields either:
+   *
+   * <ul>
+   *   <li>As a result of user task corrections configured while completing task listener jobs.
+   *   <li>As a result of regular user task updates.
+   * </ul>
+   *
+   * @param record the record containing user task data and changed attributes
+   * @param entity the task entity to be updated
+   */
+  private void updateChangedAttributes(
+      final Record<UserTaskRecordValue> record, final TaskEntity entity) {
+    final var value = record.getValue();
+
+    for (final String attribute : value.getChangedAttributes()) {
+      entity.getChangedAttributes().add(attribute);
+
+      switch (attribute) {
+        case "assignee" -> entity.setAssignee(value.getAssignee());
+        case "candidateGroupsList" ->
+            entity.setCandidateGroups(value.getCandidateGroupsList().toArray(new String[0]));
+        case "candidateUsersList" ->
+            entity.setCandidateUsers(value.getCandidateUsersList().toArray(new String[0]));
+        case "dueDate" -> entity.setDueDate(ExporterUtil.toOffsetDateTime(value.getDueDate()));
+        case "followUpDate" ->
+            entity.setFollowUpDate(ExporterUtil.toOffsetDateTime(value.getFollowUpDate()));
+        case "priority" -> entity.setPriority(value.getPriority());
+        default -> LOGGER.warn(UNMAPPED_USER_TASK_ATTRIBUTE_WARNING, attribute);
+      }
+    }
+  }
+
   @Override
   public void flush(final TaskEntity entity, final BatchRequest batchRequest) {
 
@@ -184,10 +223,7 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
           case "followUpDate" ->
               updateFields.put(TaskTemplate.FOLLOW_UP_DATE, entity.getFollowUpDate());
           case "priority" -> updateFields.put(TaskTemplate.PRIORITY, entity.getPriority());
-          default ->
-              LOGGER.warn(
-                  "Attribute update not mapped while importing ZEEBE_USER_TASKS: {}",
-                  changedAttribute);
+          default -> LOGGER.warn(UNMAPPED_USER_TASK_ATTRIBUTE_WARNING, changedAttribute);
         }
       }
     }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -129,12 +129,14 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
           }
         }
       }
-      case UserTaskIntent.COMPLETED, UserTaskIntent.CANCELED ->
+      case UserTaskIntent.COMPLETED ->
           entity
-              .setState(
-                  record.getIntent().equals(UserTaskIntent.COMPLETED)
-                      ? TaskState.COMPLETED
-                      : TaskState.CANCELED)
+              .setState(TaskState.COMPLETED)
+              .setCompletionTime(
+                  ExporterUtil.toZonedOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
+      case UserTaskIntent.CANCELED ->
+          entity
+              .setState(TaskState.CANCELED)
               .setCompletionTime(
                   ExporterUtil.toZonedOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
       case UserTaskIntent.MIGRATED ->
@@ -153,8 +155,8 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
   }
 
   /**
-   * Applies changes to the user task fields based on the attributes in the
-   * {@link UserTaskRecordValue}.
+   * Applies changes to the user task fields based on the attributes in the {@link
+   * UserTaskRecordValue}.
    *
    * <p>This method can be used for updating fields either:
    *

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
@@ -22,7 +22,6 @@ import io.camunda.webapps.schema.entities.tasklist.TaskEntity;
 import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
 import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship.TaskJoinRelationshipType;
 import io.camunda.webapps.schema.entities.tasklist.TaskState;
-import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
@@ -397,12 +396,12 @@ public class UserTaskHandlerTest {
             .withCandidateUsersList(List.of("corrected_user1", "corrected_user2"))
             .withChangedAttributes(
                 List.of(
-                    UserTaskRecord.ASSIGNEE,
-                    UserTaskRecord.DUE_DATE,
-                    UserTaskRecord.FOLLOW_UP_DATE,
-                    UserTaskRecord.PRIORITY,
-                    UserTaskRecord.CANDIDATE_GROUPS,
-                    UserTaskRecord.CANDIDATE_USERS))
+                    "assignee",
+                    "dueDate",
+                    "followUpDate",
+                    "priority",
+                    "candidateGroupsList",
+                    "candidateUsersList"))
             .build();
 
     final Record<UserTaskRecordValue> taskRecord =
@@ -495,12 +494,12 @@ public class UserTaskHandlerTest {
             .withCandidateUsersList(List.of("corrected_user1", "corrected_user2"))
             .withChangedAttributes(
                 List.of(
-                    UserTaskRecord.ASSIGNEE,
-                    UserTaskRecord.DUE_DATE,
-                    UserTaskRecord.FOLLOW_UP_DATE,
-                    UserTaskRecord.PRIORITY,
-                    UserTaskRecord.CANDIDATE_GROUPS,
-                    UserTaskRecord.CANDIDATE_USERS))
+                    "assignee",
+                    "dueDate",
+                    "followUpDate",
+                    "priority",
+                    "candidateGroupsList",
+                    "candidateUsersList"))
             .build();
 
     final Record<UserTaskRecordValue> taskRecord =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
@@ -356,7 +356,7 @@ public class UserTaskHandlerTest {
                     .withTimestamp(System.currentTimeMillis()));
 
     // when
-    final TaskEntity taskEntity = new TaskEntity().setId("id");
+    final TaskEntity taskEntity = underTest.createNewEntity("id");
     underTest.updateEntity(taskRecord, taskEntity);
 
     // then


### PR DESCRIPTION
## Description

This PR introduces the ability to update corrected user task attributes for the `ASSIGNED` and `COMPLETED` events in the `UserTaskHandler` class.

The changes ensure that any modifications made through task listener jobs are accurately reflected in the Tasklist application.

> This improvement leverages a new `updateChangedAttributes` method to handle attribute updates consistently and cleanly.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #26206 
