### PR TITLE
feat: add Database.Type enum in search-connector module

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/backup/DynamicIndicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/DynamicIndicesConfiguration.java
@@ -18,8 +18,6 @@ import org.springframework.context.annotation.Configuration;
 @ProfileWebApp
 public class DynamicIndicesConfiguration {
 
-  private static final String ELASTICSEARCH_TYPE = "elasticsearch";
-
   private final ConnectConfiguration connectConfiguration;
   private final DocumentBasedSearchClient searchClient;
 
@@ -34,7 +32,7 @@ public class DynamicIndicesConfiguration {
   public DynamicIndicesProvider dynamicIndicesProvider() {
     return new SearchDynamicIndicesProvider(
         searchClient,
-        connectConfiguration.getType().equals(ELASTICSEARCH_TYPE),
+        connectConfiguration.getTypeEnum().isElasticSearch(),
         connectConfiguration.getIndexPrefix());
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -43,6 +43,7 @@ import io.camunda.db.rdbms.sql.UserMapper;
 import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.write.RdbmsWriterFactory;
+import io.camunda.search.connect.configuration.DatabaseConfig;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -50,7 +51,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnProperty(prefix = "camunda.database", name = "type", havingValue = "rdbms")
+@ConditionalOnProperty(
+    prefix = "camunda.database",
+    name = "type",
+    havingValue = DatabaseConfig.RDBMS)
 @Import(MyBatisConfiguration.class)
 public class RdbmsConfiguration {
 

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
@@ -9,10 +9,10 @@ package io.camunda.application.commons.search;
 
 import io.camunda.application.commons.search.SearchClientDatabaseConfiguration.SearchClientProperties;
 import io.camunda.db.rdbms.RdbmsService;
-import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.search.clients.DocumentBasedSearchClient;
 import io.camunda.search.clients.SearchClients;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.search.connect.configuration.DatabaseConfig;
 import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.search.es.clients.ElasticsearchSearchClient;
@@ -36,7 +36,7 @@ public class SearchClientDatabaseConfiguration {
   @ConditionalOnProperty(
       prefix = "camunda.database",
       name = "type",
-      havingValue = "elasticsearch",
+      havingValue = DatabaseConfig.ELASTICSEARCH,
       matchIfMissing = true)
   public ElasticsearchSearchClient elasticsearchSearchClient(
       final SearchClientProperties configuration) {
@@ -46,7 +46,10 @@ public class SearchClientDatabaseConfiguration {
   }
 
   @Bean
-  @ConditionalOnProperty(prefix = "camunda.database", name = "type", havingValue = "opensearch")
+  @ConditionalOnProperty(
+      prefix = "camunda.database",
+      name = "type",
+      havingValue = DatabaseConfig.OPENSEARCH)
   public OpensearchSearchClient opensearchSearchClient(final SearchClientProperties configuration) {
     final var connector = new OpensearchConnector(configuration);
     final var elasticsearch = connector.createClient();
@@ -54,7 +57,10 @@ public class SearchClientDatabaseConfiguration {
   }
 
   @Bean
-  @ConditionalOnProperty(prefix = "camunda.database", name = "type", havingValue = "rdbms")
+  @ConditionalOnProperty(
+      prefix = "camunda.database",
+      name = "type",
+      havingValue = DatabaseConfig.RDBMS)
   public RdbmsSearchClient rdbmsSearchClient(final RdbmsService rdbmsService) {
     return new RdbmsSearchClient(rdbmsService);
   }
@@ -67,7 +73,7 @@ public class SearchClientDatabaseConfiguration {
     final IndexDescriptors indexDescriptors =
         new IndexDescriptors(
             connectConfiguration.getIndexPrefix(),
-            ConnectionTypes.isElasticSearch(connectConfiguration.getType()));
+            connectConfiguration.getTypeEnum().isElasticSearch());
     return new SearchClients(searchClient, indexDescriptors);
   }
 

--- a/dist/src/main/java/io/camunda/zeebe/broker/RdbmsExporterConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/RdbmsExporterConfiguration.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker;
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.exporter.rdbms.RdbmsExporterFactory;
+import io.camunda.search.connect.configuration.DatabaseConfig;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import java.util.Map;
@@ -23,7 +24,10 @@ import org.springframework.context.annotation.Import;
 
 @Configuration(proxyBeanMethods = false)
 @Import(RdbmsConfiguration.class)
-@ConditionalOnProperty(prefix = "camunda.database", name = "type", havingValue = "rdbms")
+@ConditionalOnProperty(
+    prefix = "camunda.database",
+    name = "type",
+    havingValue = DatabaseConfig.RDBMS)
 public class RdbmsExporterConfiguration {
 
   private static final Logger LOGGER = Loggers.SYSTEM_LOGGER;

--- a/dist/src/test/java/io/camunda/application/commons/backup/BackupConfigTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/backup/BackupConfigTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.db.DatabaseBackup;
+import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.webapps.backup.repository.BackupRepositoryProps;
 import org.junit.jupiter.api.BeforeEach;
@@ -87,7 +88,7 @@ public class BackupConfigTest {
     when(configurationService.getElasticSearchConfiguration().getBackup()).thenReturn(backup);
     final var environment = mock(Environment.class);
     when(environment.getProperty(eq(CAMUNDA_OPTIMIZE_DATABASE), (String) any()))
-        .thenReturn("elasticsearch");
+        .thenReturn(DatabaseType.ELASTICSEARCH.toString());
     checkRepo(null, null, environment);
   }
 

--- a/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
@@ -22,6 +22,7 @@ import io.camunda.application.commons.backup.BackupPriorityConfiguration.Optimiz
 import io.camunda.application.commons.backup.BackupPriorityConfiguration.OptimizePrio6Delegate;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.optimize.service.db.schema.OptimizeIndexNameService;
+import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.webapps.schema.descriptors.backup.BackupPriority;
 import java.util.Arrays;
@@ -278,7 +279,7 @@ class BackupPrioritiesTest {
             });
     when(environment.getActiveProfiles()).thenReturn(profiles);
     when(environment.getProperty(eq(CAMUNDA_OPTIMIZE_DATABASE), (String) any()))
-        .thenReturn("elasticsearch");
+        .thenReturn(DatabaseType.ELASTICSEARCH.toString());
     return environment;
   }
 }

--- a/search/search-client-connect/pom.xml
+++ b/search/search-client-connect/pom.xml
@@ -184,6 +184,11 @@
       <artifactId>wiremock</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/configuration/ConnectConfiguration.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/configuration/ConnectConfiguration.java
@@ -13,37 +13,36 @@ import java.util.List;
 
 public class ConnectConfiguration {
 
-  private static final String DATABASE_TYPE_DEFAULT = "elasticsearch";
+  private static final DatabaseType DATABASE_TYPE_DEFAULT = DatabaseType.ELASTICSEARCH;
   private static final String CLUSTER_NAME_DEFAULT = "elasticsearch";
   private static final String DATE_FORMAT_FIELD = "yyyy-MM-dd'T'HH:mm:ss.SSSZZ";
   private static final String FIELD_DATE_FORMAT_DEFAULT = "date_time";
   private static final String URL_DEFAULT = "http://localhost:9200";
-
-  private String type = DATABASE_TYPE_DEFAULT;
+  private String type = DATABASE_TYPE_DEFAULT.toString();
   private String clusterName = CLUSTER_NAME_DEFAULT;
-
   private String dateFormat = DATE_FORMAT_FIELD;
   private String fieldDateFormat = FIELD_DATE_FORMAT_DEFAULT;
-
   private Integer socketTimeout;
   private Integer connectTimeout;
-
   private String url = URL_DEFAULT;
   private String username;
   private String password;
-
   private SecurityConfiguration security = new SecurityConfiguration();
-
   private String indexPrefix;
-
   private List<PluginConfiguration> interceptorPlugins = new ArrayList<>();
 
+  /** Use {@link ConnectConfiguration#getTypeEnum()} */
+  @Deprecated
   public String getType() {
     return type;
   }
 
   public void setType(final String type) {
     this.type = type;
+  }
+
+  public DatabaseType getTypeEnum() {
+    return DatabaseType.from(type);
   }
 
   public String getClusterName() {

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/configuration/DatabaseConfig.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/configuration/DatabaseConfig.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.connect.configuration;
+
+public final class DatabaseConfig {
+  public static final String ELASTICSEARCH = "elasticsearch";
+  public static final String RDBMS = "rdbms";
+  public static final String OPENSEARCH = "opensearch";
+
+  private DatabaseConfig() {}
+}

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/configuration/DatabaseType.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/configuration/DatabaseType.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.connect.configuration;
+
+public enum DatabaseType {
+  ELASTICSEARCH(DatabaseConfig.ELASTICSEARCH),
+  OPENSEARCH(DatabaseConfig.OPENSEARCH),
+  RDBMS(DatabaseConfig.RDBMS);
+
+  private final String type;
+
+  DatabaseType(final String type) {
+    this.type = type;
+  }
+
+  public static DatabaseType from(final String type) {
+    return DatabaseType.valueOf(type.toUpperCase());
+  }
+
+  public boolean isElasticSearch() {
+    return equals(ELASTICSEARCH);
+  }
+
+  public boolean isOpenSearch() {
+    return equals(OPENSEARCH);
+  }
+
+  public boolean isRdbms() {
+    return equals(RDBMS);
+  }
+
+  @Override
+  public String toString() {
+    return type;
+  }
+}

--- a/search/search-client-connect/src/test/java/io/camunda/search/connect/configuration/DatabaseTypeTest.java
+++ b/search/search-client-connect/src/test/java/io/camunda/search/connect/configuration/DatabaseTypeTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.connect.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+public class DatabaseTypeTest {
+  @Test
+  public void stringValuesShouldMatchEnum() {
+    assertThat(DatabaseConfig.ELASTICSEARCH).isEqualTo(DatabaseType.ELASTICSEARCH.toString());
+    assertThat(DatabaseConfig.OPENSEARCH).isEqualTo(DatabaseType.OPENSEARCH.toString());
+    assertThat(DatabaseConfig.RDBMS).isEqualTo(DatabaseType.RDBMS.toString());
+  }
+
+  @EnumSource(DatabaseType.class)
+  @ParameterizedTest
+  public void shouldBeCreatedCaseInsensitive(final DatabaseType databaseType) {
+    assertThat(DatabaseType.from(databaseType.name().toLowerCase())).isEqualTo(databaseType);
+  }
+
+  @EnumSource(DatabaseType.class)
+  @ParameterizedTest
+  public void shouldReturnCorrectIsElasticSearch(final DatabaseType databaseType) {
+    assertThat(databaseType.isElasticSearch())
+        .isEqualTo(databaseType.toString().equals("elasticsearch"));
+  }
+
+  @EnumSource(DatabaseType.class)
+  @ParameterizedTest
+  public void shouldReturnCorrectIsOpensearch(final DatabaseType databaseType) {
+    assertThat(databaseType.isOpenSearch()).isEqualTo(databaseType.toString().equals("opensearch"));
+  }
+
+  @EnumSource(DatabaseType.class)
+  @ParameterizedTest
+  public void shouldReturnCorrectIsRdbms(final DatabaseType databaseType) {
+    assertThat(databaseType.isRdbms()).isEqualTo(databaseType.toString().equals("rdbms"));
+  }
+}


### PR DESCRIPTION
## Description
A new enum `Database.Type` enum is added in the common search-connect module.
- static string are added so they can be used in annotations
- code in dist/ and zeebe uses this new annotation

The outer class `Database` is used to scope the static string values  and for namespacing

## Checklist 

## Related issues
Comments from PR #26196 
