### PR TITLE
feat: migrate tenant membership for groups

### DIFF
--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/AuthorizationMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/AuthorizationMigrationHandler.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
-public class AuthorizationMigrationHandler {
+public class AuthorizationMigrationHandler implements MigrationHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(AuthorizationMigrationHandler.class);
   private final AuthorizationServices authorizationService;
@@ -40,6 +40,7 @@ public class AuthorizationMigrationHandler {
     this.managementIdentityProxy = managementIdentityProxy;
   }
 
+  @Override
   public void migrate() {
     LOG.debug("Migrating authorizations");
     UserResourceAuthorization lastRecord = null;

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupMigrationHandler.java
@@ -7,10 +7,11 @@
  */
 package io.camunda.migration.identity;
 
+import static io.camunda.migration.identity.midentity.ManagementIdentityTransformer.toMigrationStatusUpdateRequest;
+
 import io.camunda.migration.identity.dto.Group;
 import io.camunda.migration.identity.dto.MigrationStatusUpdateRequest;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
-import io.camunda.migration.identity.midentity.ManagementIdentityTransformer;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.GroupServices;
 import java.util.List;
@@ -20,16 +21,13 @@ import org.springframework.stereotype.Component;
 public class GroupMigrationHandler implements MigrationHandler {
 
   private final ManagementIdentityClient managementIdentityClient;
-  private final ManagementIdentityTransformer managementIdentityTransformer;
   private final GroupServices groupServices;
 
   public GroupMigrationHandler(
       final Authentication authentication,
       final ManagementIdentityClient managementIdentityClient,
-      final ManagementIdentityTransformer managementIdentityTransformer,
       final GroupServices groupServices) {
     this.managementIdentityClient = managementIdentityClient;
-    this.managementIdentityTransformer = managementIdentityTransformer;
     this.groupServices = groupServices.withAuthentication(authentication);
   }
 
@@ -48,9 +46,9 @@ public class GroupMigrationHandler implements MigrationHandler {
       groupServices.createGroup(group.name()).join();
     } catch (final Exception e) {
       if (!isConflictError(e)) {
-        return managementIdentityTransformer.toMigrationStatusUpdateRequest(group, e);
+        return toMigrationStatusUpdateRequest(group, e);
       }
     }
-    return managementIdentityTransformer.toMigrationStatusUpdateRequest(group, null);
+    return toMigrationStatusUpdateRequest(group, null);
   }
 }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupTenantsMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupTenantsMigrationHandler.java
@@ -12,6 +12,7 @@ import static io.camunda.migration.identity.midentity.ManagementIdentityTransfor
 import io.camunda.migration.identity.dto.GroupTenants;
 import io.camunda.migration.identity.dto.MigrationStatusUpdateRequest;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
+import io.camunda.security.auth.Authentication;
 import io.camunda.service.GroupServices;
 import io.camunda.service.TenantServices;
 import io.camunda.zeebe.protocol.record.value.EntityType;
@@ -29,12 +30,13 @@ final class GroupTenantsMigrationHandler implements MigrationHandler {
   private final TenantServices tenantServices;
 
   public GroupTenantsMigrationHandler(
+      final Authentication authentication,
       final ManagementIdentityClient managementIdentityClient,
       final GroupServices groupServices,
       final TenantServices tenantServices) {
     this.managementIdentityClient = managementIdentityClient;
-    this.groupServices = groupServices;
-    this.tenantServices = tenantServices;
+    this.groupServices = groupServices.withAuthentication(authentication);
+    this.tenantServices = tenantServices.withAuthentication(authentication);
   }
 
   @Override

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupTenantsMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupTenantsMigrationHandler.java
@@ -12,10 +12,10 @@ import static io.camunda.migration.identity.midentity.ManagementIdentityTransfor
 import io.camunda.migration.identity.dto.GroupTenants;
 import io.camunda.migration.identity.dto.MigrationStatusUpdateRequest;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
-import io.camunda.search.entities.GroupEntity;
 import io.camunda.service.GroupServices;
 import io.camunda.service.TenantServices;
 import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.NoSuchElementException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -57,8 +57,13 @@ final class GroupTenantsMigrationHandler implements MigrationHandler {
 
   private MigrationStatusUpdateRequest createGroupTenants(final GroupTenants groupTenants) {
     final var groupName = groupTenants.groupName();
-    final var groupKey =
-        groupServices.findGroup(groupName).map(GroupEntity::groupKey).orElseThrow();
+    final var group = groupServices.findGroup(groupName);
+    if (group.isEmpty()) {
+      LOG.warn("Group {} not found", groupName);
+      return toMigrationStatusUpdateRequest(
+          groupTenants, new NoSuchElementException("Group %s not found".formatted(groupName)));
+    }
+    final var groupKey = group.get().groupKey();
     for (final var tenant : groupTenants.tenants()) {
       final var tenantId = tenant.tenantId();
       LOG.trace("Assigning group {} to tenant {}", groupName, tenantId);

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupTenantsMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupTenantsMigrationHandler.java
@@ -56,7 +56,7 @@ final class GroupTenantsMigrationHandler implements MigrationHandler {
   }
 
   private MigrationStatusUpdateRequest createGroupTenants(final GroupTenants groupTenants) {
-    final var groupName = groupTenants.groupName();
+    final var groupName = groupTenants.name();
     final var group = groupServices.findGroup(groupName);
     if (group.isEmpty()) {
       LOG.warn("Group {} not found", groupName);

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupTenantsMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupTenantsMigrationHandler.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.identity;
+
+import io.camunda.migration.identity.dto.GroupTenants;
+import io.camunda.migration.identity.dto.MigrationStatusUpdateRequest;
+import io.camunda.migration.identity.midentity.ManagementIdentityClient;
+import io.camunda.migration.identity.midentity.ManagementIdentityTransformer;
+import io.camunda.search.entities.GroupEntity;
+import io.camunda.service.GroupServices;
+import io.camunda.service.TenantServices;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+final class GroupTenantsMigrationHandler implements MigrationHandler {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GroupTenantsMigrationHandler.class);
+  private final ManagementIdentityClient managementIdentityClient;
+  private final ManagementIdentityTransformer managementIdentityTransformer;
+  private final GroupServices groupServices;
+  private final TenantServices tenantServices;
+
+  public GroupTenantsMigrationHandler(
+      final ManagementIdentityClient managementIdentityClient,
+      final ManagementIdentityTransformer managementIdentityTransformer,
+      final GroupServices groupServices,
+      final TenantServices tenantServices) {
+    this.managementIdentityClient = managementIdentityClient;
+    this.managementIdentityTransformer = managementIdentityTransformer;
+    this.groupServices = groupServices;
+    this.tenantServices = tenantServices;
+  }
+
+  @Override
+  public void migrate() {
+    LOG.debug("Starting");
+
+    while (true) {
+      final var groupTenantsPage = managementIdentityClient.fetchGroupTenants(SIZE);
+      if (groupTenantsPage.isEmpty()) {
+        break;
+      }
+
+      LOG.trace("Found {} groups with tenants", groupTenantsPage.size());
+      final var updates = groupTenantsPage.stream().map(this::createGroupTenants).toList();
+      managementIdentityClient.updateMigrationStatus(updates);
+    }
+
+    LOG.debug("Finished");
+  }
+
+  private MigrationStatusUpdateRequest createGroupTenants(final GroupTenants groupTenants) {
+    final var groupName = groupTenants.groupName();
+    final var groupKey =
+        groupServices.findGroup(groupName).map(GroupEntity::groupKey).orElseThrow();
+    for (final var tenant : groupTenants.tenants()) {
+      final var tenantId = tenant.tenantId();
+      LOG.trace("Assigning group {} to tenant {}", groupName, tenantId);
+      try {
+        final var tenantKey = tenantServices.getById(tenantId).key();
+        tenantServices.addMember(tenantKey, EntityType.GROUP, groupKey);
+      } catch (final Exception e) {
+        if (!isConflictError(e)) {
+          LOG.warn("Failed to assign group {} to tenant {}", groupName, tenantId, e);
+          return managementIdentityTransformer.toMigrationStatusUpdateRequest(groupTenants, e);
+        }
+        LOG.trace("Group {} is already assigned to tenant {}", groupName, tenantId);
+      }
+    }
+
+    return managementIdentityTransformer.toMigrationStatusUpdateRequest(groupTenants, null);
+  }
+}

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupTenantsMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/GroupTenantsMigrationHandler.java
@@ -7,10 +7,11 @@
  */
 package io.camunda.migration.identity;
 
+import static io.camunda.migration.identity.midentity.ManagementIdentityTransformer.toMigrationStatusUpdateRequest;
+
 import io.camunda.migration.identity.dto.GroupTenants;
 import io.camunda.migration.identity.dto.MigrationStatusUpdateRequest;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
-import io.camunda.migration.identity.midentity.ManagementIdentityTransformer;
 import io.camunda.search.entities.GroupEntity;
 import io.camunda.service.GroupServices;
 import io.camunda.service.TenantServices;
@@ -24,17 +25,14 @@ final class GroupTenantsMigrationHandler implements MigrationHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(GroupTenantsMigrationHandler.class);
   private final ManagementIdentityClient managementIdentityClient;
-  private final ManagementIdentityTransformer managementIdentityTransformer;
   private final GroupServices groupServices;
   private final TenantServices tenantServices;
 
   public GroupTenantsMigrationHandler(
       final ManagementIdentityClient managementIdentityClient,
-      final ManagementIdentityTransformer managementIdentityTransformer,
       final GroupServices groupServices,
       final TenantServices tenantServices) {
     this.managementIdentityClient = managementIdentityClient;
-    this.managementIdentityTransformer = managementIdentityTransformer;
     this.groupServices = groupServices;
     this.tenantServices = tenantServices;
   }
@@ -70,12 +68,12 @@ final class GroupTenantsMigrationHandler implements MigrationHandler {
       } catch (final Exception e) {
         if (!isConflictError(e)) {
           LOG.warn("Failed to assign group {} to tenant {}", groupName, tenantId, e);
-          return managementIdentityTransformer.toMigrationStatusUpdateRequest(groupTenants, e);
+          return toMigrationStatusUpdateRequest(groupTenants, e);
         }
         LOG.trace("Group {} is already assigned to tenant {}", groupName, tenantId);
       }
     }
 
-    return managementIdentityTransformer.toMigrationStatusUpdateRequest(groupTenants, null);
+    return toMigrationStatusUpdateRequest(groupTenants, null);
   }
 }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/MigrationRunner.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/MigrationRunner.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Component;
 
 @EnableConfigurationProperties(IdentityMigrationProperties.class)
 @Component("identity-migrator")
-public class MigrationRunner implements Migrator {
+final class MigrationRunner implements Migrator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MigrationRunner.class);
 
@@ -26,16 +26,19 @@ public class MigrationRunner implements Migrator {
   private final TenantMigrationHandler tenantMigrationHandler;
   private final TenantMappingRuleMigrationHandler tenantMappingRuleMigrationHandler;
   private final UserTenantsMigrationHandler userTenantsMigrationHandler;
+  private final GroupTenantsMigrationHandler groupTenantsMigrationHandler;
 
   public MigrationRunner(
       final AuthorizationMigrationHandler authorizationMigrationHandler,
       final TenantMigrationHandler tenantMigrationHandler,
       final TenantMappingRuleMigrationHandler tenantMappingRuleMigrationHandler,
-      final UserTenantsMigrationHandler userTenantsMigrationHandler) {
+      final UserTenantsMigrationHandler userTenantsMigrationHandler,
+      final GroupTenantsMigrationHandler groupTenantsMigrationHandler) {
     this.authorizationMigrationHandler = authorizationMigrationHandler;
     this.tenantMigrationHandler = tenantMigrationHandler;
     this.tenantMappingRuleMigrationHandler = tenantMappingRuleMigrationHandler;
     this.userTenantsMigrationHandler = userTenantsMigrationHandler;
+    this.groupTenantsMigrationHandler = groupTenantsMigrationHandler;
   }
 
   @Override
@@ -51,6 +54,7 @@ public class MigrationRunner implements Migrator {
         tenantMappingRuleMigrationHandler.migrate();
         userTenantsMigrationHandler.migrate();
         authorizationMigrationHandler.migrate();
+        groupTenantsMigrationHandler.migrate();
         break;
       } catch (final Exception e) {
         LOGGER.warn("Migration failed, let's retry!", e);

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/TenantMappingRuleMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/TenantMappingRuleMigrationHandler.java
@@ -7,11 +7,12 @@
  */
 package io.camunda.migration.identity;
 
+import static io.camunda.migration.identity.midentity.ManagementIdentityTransformer.toMigrationStatusUpdateRequest;
+
 import io.camunda.migration.identity.dto.MigrationStatusUpdateRequest;
 import io.camunda.migration.identity.dto.Tenant;
 import io.camunda.migration.identity.dto.TenantMappingRule;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
-import io.camunda.migration.identity.midentity.ManagementIdentityTransformer;
 import io.camunda.search.entities.MappingEntity;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.MappingServices;
@@ -29,18 +30,15 @@ public class TenantMappingRuleMigrationHandler implements MigrationHandler {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(TenantMappingRuleMigrationHandler.class);
   private final ManagementIdentityClient managementIdentityClient;
-  private final ManagementIdentityTransformer managementIdentityTransformer;
   private final TenantServices tenantServices;
   private final MappingServices mappingServices;
 
   public TenantMappingRuleMigrationHandler(
       final Authentication authentication,
       final ManagementIdentityClient managementIdentityClient,
-      final ManagementIdentityTransformer managementIdentityTransformer,
       final TenantServices tenantServices,
       final MappingServices mappingServices) {
     this.managementIdentityClient = managementIdentityClient;
-    this.managementIdentityTransformer = managementIdentityTransformer;
     this.tenantServices = tenantServices.withAuthentication(authentication);
     this.mappingServices = mappingServices.withAuthentication(authentication);
   }
@@ -74,10 +72,10 @@ public class TenantMappingRuleMigrationHandler implements MigrationHandler {
         final var tenant = tenantServices.getById(mappingTenant.tenantId());
         assignMappingToTenant(tenant.key(), mappingKey);
       }
-      return managementIdentityTransformer.toMigrationStatusUpdateRequest(tenantMappingRule, null);
+      return toMigrationStatusUpdateRequest(tenantMappingRule, null);
     } catch (final Exception e) {
       LOGGER.error("Error creating tenant mapping rule", e);
-      return managementIdentityTransformer.toMigrationStatusUpdateRequest(tenantMappingRule, e);
+      return toMigrationStatusUpdateRequest(tenantMappingRule, e);
     }
   }
 

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/TenantMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/TenantMigrationHandler.java
@@ -7,10 +7,11 @@
  */
 package io.camunda.migration.identity;
 
+import static io.camunda.migration.identity.midentity.ManagementIdentityTransformer.toMigrationStatusUpdateRequest;
+
 import io.camunda.migration.identity.dto.MigrationStatusUpdateRequest;
 import io.camunda.migration.identity.dto.Tenant;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
-import io.camunda.migration.identity.midentity.ManagementIdentityTransformer;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.TenantServices;
 import io.camunda.service.TenantServices.TenantDTO;
@@ -24,16 +25,13 @@ public class TenantMigrationHandler implements MigrationHandler {
 
   private static final Logger LOG = LoggerFactory.getLogger(TenantMigrationHandler.class);
   private final ManagementIdentityClient managementIdentityClient;
-  private final ManagementIdentityTransformer managementIdentityTransformer;
   private final TenantServices tenantServices;
 
   public TenantMigrationHandler(
       final Authentication authentication,
       final ManagementIdentityClient managementIdentityClient,
-      final ManagementIdentityTransformer managementIdentityTransformer,
       final TenantServices tenantServices) {
     this.managementIdentityClient = managementIdentityClient;
-    this.managementIdentityTransformer = managementIdentityTransformer;
     this.tenantServices = tenantServices.withAuthentication(authentication);
   }
 
@@ -54,9 +52,9 @@ public class TenantMigrationHandler implements MigrationHandler {
       tenantServices.createTenant(new TenantDTO(null, tenant.tenantId(), tenant.name())).join();
     } catch (final Exception e) {
       if (!isConflictError(e)) {
-        return managementIdentityTransformer.toMigrationStatusUpdateRequest(tenant, e);
+        return toMigrationStatusUpdateRequest(tenant, e);
       }
     }
-    return managementIdentityTransformer.toMigrationStatusUpdateRequest(tenant, null);
+    return toMigrationStatusUpdateRequest(tenant, null);
   }
 }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/UserTenantsMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/UserTenantsMigrationHandler.java
@@ -7,11 +7,12 @@
  */
 package io.camunda.migration.identity;
 
+import static io.camunda.migration.identity.midentity.ManagementIdentityTransformer.toMigrationStatusUpdateRequest;
+
 import io.camunda.migration.identity.dto.MigrationStatusUpdateRequest;
 import io.camunda.migration.identity.dto.Tenant;
 import io.camunda.migration.identity.dto.UserTenants;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
-import io.camunda.migration.identity.midentity.ManagementIdentityTransformer;
 import io.camunda.search.entities.MappingEntity;
 import io.camunda.service.MappingServices;
 import io.camunda.service.MappingServices.MappingDTO;
@@ -24,17 +25,14 @@ import org.springframework.stereotype.Component;
 public class UserTenantsMigrationHandler implements MigrationHandler {
   private static final String USERNAME_CLAIM = "sub";
   private final ManagementIdentityClient managementIdentityClient;
-  private final ManagementIdentityTransformer managementIdentityTransformer;
   private final TenantServices tenantServices;
   private final MappingServices mappingServices;
 
   public UserTenantsMigrationHandler(
       final ManagementIdentityClient managementIdentityClient,
-      final ManagementIdentityTransformer managementIdentityTransformer,
       final TenantServices tenantServices,
       final MappingServices mappingServices) {
     this.managementIdentityClient = managementIdentityClient;
-    this.managementIdentityTransformer = managementIdentityTransformer;
     this.tenantServices = tenantServices;
     this.mappingServices = mappingServices;
   }
@@ -65,9 +63,9 @@ public class UserTenantsMigrationHandler implements MigrationHandler {
         final var tenantKey = tenantServices.getById(userTenant.tenantId()).key();
         assignMemberToTenant(tenantKey, mappingKey);
       }
-      return managementIdentityTransformer.toMigrationStatusUpdateRequest(userTenants, null);
+      return toMigrationStatusUpdateRequest(userTenants, null);
     } catch (final Exception e) {
-      return managementIdentityTransformer.toMigrationStatusUpdateRequest(userTenants, e);
+      return toMigrationStatusUpdateRequest(userTenants, e);
     }
   }
 

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/dto/GroupTenants.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/dto/GroupTenants.java
@@ -5,12 +5,8 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.migration.identity.midentity;
+package io.camunda.migration.identity.dto;
 
-public enum MigrationEntityType {
-  TENANT,
-  MAPPING_RULE,
-  TENANT_USER,
-  GROUP,
-  TENANT_GROUP,
-}
+import java.util.List;
+
+public record GroupTenants(String id, String groupName, List<Tenant> tenants) {}

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/dto/GroupTenants.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/dto/GroupTenants.java
@@ -9,4 +9,4 @@ package io.camunda.migration.identity.dto;
 
 import java.util.List;
 
-public record GroupTenants(String id, String groupName, List<Tenant> tenants) {}
+public record GroupTenants(String id, String name, List<Tenant> tenants) {}

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/midentity/ManagementIdentityClient.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/midentity/ManagementIdentityClient.java
@@ -32,7 +32,7 @@ public class ManagementIdentityClient {
   private static final String MIGRATION_USER_TENANTS_ENDPOINT =
       "/api/migration/tenant/user?" + URL_PARAMS;
   private static final String MIGRATION_GROUP_TENANTS_ENDPOINT =
-      "/api/migration/tenant/group?" + URL_PARAMS;
+      "/api/migration/tenant/group?" + URL_PARAMS + "&organizationId={1}";
   private static final String MIGRATION_MAPPING_RULE_ENDPOINT =
       "/api/migration/mapping-rule?" + URL_PARAMS + "&type={1}";
   private static final String MIGRATION_GROUPS_ENDPOINT =
@@ -76,7 +76,10 @@ public class ManagementIdentityClient {
     return Arrays.stream(
             Objects.requireNonNull(
                 restTemplate.getForObject(
-                    MIGRATION_GROUP_TENANTS_ENDPOINT, GroupTenants[].class, pageSize)))
+                    MIGRATION_GROUP_TENANTS_ENDPOINT,
+                    GroupTenants[].class,
+                    pageSize,
+                    organizationId)))
         .toList();
   }
 

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/midentity/ManagementIdentityClient.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/midentity/ManagementIdentityClient.java
@@ -8,6 +8,7 @@
 package io.camunda.migration.identity.midentity;
 
 import io.camunda.migration.identity.dto.Group;
+import io.camunda.migration.identity.dto.GroupTenants;
 import io.camunda.migration.identity.dto.MappingRule.MappingRuleType;
 import io.camunda.migration.identity.dto.MigrationStatusUpdateRequest;
 import io.camunda.migration.identity.dto.Tenant;
@@ -30,6 +31,8 @@ public class ManagementIdentityClient {
   private static final String MIGRATION_TENANTS_ENDPOINT = "/api/migration/tenant?" + URL_PARAMS;
   private static final String MIGRATION_USER_TENANTS_ENDPOINT =
       "/api/migration/tenant/user?" + URL_PARAMS;
+  private static final String MIGRATION_GROUP_TENANTS_ENDPOINT =
+      "/api/migration/tenant/group?" + URL_PARAMS;
   private static final String MIGRATION_MAPPING_RULE_ENDPOINT =
       "/api/migration/mapping-rule?" + URL_PARAMS + "&type={1}";
   private static final String MIGRATION_GROUPS_ENDPOINT =
@@ -66,6 +69,14 @@ public class ManagementIdentityClient {
             Objects.requireNonNull(
                 restTemplate.getForObject(
                     MIGRATION_USER_TENANTS_ENDPOINT, UserTenants[].class, pageSize)))
+        .toList();
+  }
+
+  public List<GroupTenants> fetchGroupTenants(final int pageSize) {
+    return Arrays.stream(
+            Objects.requireNonNull(
+                restTemplate.getForObject(
+                    MIGRATION_GROUP_TENANTS_ENDPOINT, GroupTenants[].class, pageSize)))
         .toList();
   }
 

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/midentity/ManagementIdentityTransformer.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/midentity/ManagementIdentityTransformer.java
@@ -8,6 +8,7 @@
 package io.camunda.migration.identity.midentity;
 
 import io.camunda.migration.identity.dto.Group;
+import io.camunda.migration.identity.dto.GroupTenants;
 import io.camunda.migration.identity.dto.MappingRule;
 import io.camunda.migration.identity.dto.MigrationStatusUpdateRequest;
 import io.camunda.migration.identity.dto.Tenant;
@@ -50,5 +51,15 @@ public class ManagementIdentityTransformer {
       final Group group, final Exception e) {
     return new MigrationStatusUpdateRequest(
         group.id(), MigrationEntityType.GROUP, null, e == null, e == null ? null : e.getMessage());
+  }
+
+  public MigrationStatusUpdateRequest toMigrationStatusUpdateRequest(
+      final GroupTenants groupTenants, final Exception e) {
+    return new MigrationStatusUpdateRequest(
+        groupTenants.id(),
+        MigrationEntityType.TENANT_GROUP,
+        null,
+        e == null,
+        e == null ? null : e.getMessage());
   }
 }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/midentity/ManagementIdentityTransformer.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/midentity/ManagementIdentityTransformer.java
@@ -13,11 +13,11 @@ import io.camunda.migration.identity.dto.MappingRule;
 import io.camunda.migration.identity.dto.MigrationStatusUpdateRequest;
 import io.camunda.migration.identity.dto.Tenant;
 import io.camunda.migration.identity.dto.UserTenants;
-import org.springframework.stereotype.Component;
 
-@Component
-public class ManagementIdentityTransformer {
-  public MigrationStatusUpdateRequest toMigrationStatusUpdateRequest(
+public final class ManagementIdentityTransformer {
+  private ManagementIdentityTransformer() {}
+
+  public static MigrationStatusUpdateRequest toMigrationStatusUpdateRequest(
       final Tenant tenant, final Exception e) {
     return new MigrationStatusUpdateRequest(
         tenant.tenantId(),
@@ -27,7 +27,7 @@ public class ManagementIdentityTransformer {
         e == null ? null : e.getMessage());
   }
 
-  public MigrationStatusUpdateRequest toMigrationStatusUpdateRequest(
+  public static MigrationStatusUpdateRequest toMigrationStatusUpdateRequest(
       final MappingRule mappingRule, final Exception e) {
     return new MigrationStatusUpdateRequest(
         mappingRule.getName(),
@@ -37,7 +37,7 @@ public class ManagementIdentityTransformer {
         e == null ? null : e.getMessage());
   }
 
-  public MigrationStatusUpdateRequest toMigrationStatusUpdateRequest(
+  public static MigrationStatusUpdateRequest toMigrationStatusUpdateRequest(
       final UserTenants tenantUser, final Exception e) {
     return new MigrationStatusUpdateRequest(
         tenantUser.id(),
@@ -47,13 +47,13 @@ public class ManagementIdentityTransformer {
         e == null ? null : e.getMessage());
   }
 
-  public MigrationStatusUpdateRequest toMigrationStatusUpdateRequest(
+  public static MigrationStatusUpdateRequest toMigrationStatusUpdateRequest(
       final Group group, final Exception e) {
     return new MigrationStatusUpdateRequest(
         group.id(), MigrationEntityType.GROUP, null, e == null, e == null ? null : e.getMessage());
   }
 
-  public MigrationStatusUpdateRequest toMigrationStatusUpdateRequest(
+  public static MigrationStatusUpdateRequest toMigrationStatusUpdateRequest(
       final GroupTenants groupTenants, final Exception e) {
     return new MigrationStatusUpdateRequest(
         groupTenants.id(),

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/GroupMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/GroupMigrationHandlerTest.java
@@ -18,7 +18,6 @@ import static org.mockito.Mockito.when;
 import io.camunda.migration.identity.dto.Group;
 import io.camunda.migration.identity.dto.MigrationStatusUpdateRequest;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
-import io.camunda.migration.identity.midentity.ManagementIdentityTransformer;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.GroupServices;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
@@ -47,11 +46,7 @@ public class GroupMigrationHandlerTest {
     this.managementIdentityClient = managementIdentityClient;
     this.groupService = groupService;
     migrationHandler =
-        new GroupMigrationHandler(
-            Authentication.none(),
-            managementIdentityClient,
-            new ManagementIdentityTransformer(),
-            groupService);
+        new GroupMigrationHandler(Authentication.none(), managementIdentityClient, groupService);
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/GroupTenantsMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/GroupTenantsMigrationHandlerTest.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.migration.identity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import io.camunda.migration.identity.dto.GroupTenants;
+import io.camunda.migration.identity.dto.MigrationStatusUpdateRequest;
+import io.camunda.migration.identity.dto.Tenant;
+import io.camunda.migration.identity.midentity.ManagementIdentityClient;
+import io.camunda.search.entities.GroupEntity;
+import io.camunda.search.entities.TenantEntity;
+import io.camunda.service.GroupServices;
+import io.camunda.service.TenantServices;
+import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
+import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
+import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.TenantIntent;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+final class GroupTenantsMigrationHandlerTest {
+
+  @Mock private ManagementIdentityClient managementIdentityClient;
+  @Mock private GroupServices groupServices;
+  @Mock private TenantServices tenantServices;
+
+  @InjectMocks private GroupTenantsMigrationHandler handler;
+
+  @Test
+  void stopWhenNoMoreRecords() {
+    // given
+    givenGroupTenants();
+    when(tenantServices.getById(any()))
+        .thenReturn(new TenantEntity(1L, "", "", Collections.emptySet()));
+    when(groupServices.findGroup(anyString()))
+        .thenReturn(Optional.of(new GroupEntity(1L, "", Collections.emptySet())));
+    when(tenantServices.addMember(any(), any(), anyLong()))
+        .thenReturn(CompletableFuture.completedFuture(new TenantRecord()));
+
+    // when
+    handler.migrate();
+
+    // then
+    verify(managementIdentityClient, times(2)).fetchGroupTenants(anyInt());
+    verify(tenantServices, times(4)).getById(any());
+    verify(groupServices, times(2)).findGroup(anyString());
+    verify(tenantServices, times(4)).addMember(any(), any(), anyLong());
+  }
+
+  @Test
+  void setErrorWhenGroupNotFound() {
+    // given
+    givenGroupTenants();
+    when(groupServices.findGroup(anyString())).thenReturn(Optional.empty());
+
+    // when
+    handler.migrate();
+
+    // then
+    verify(managementIdentityClient, times(2)).fetchGroupTenants(anyInt());
+    verify(groupServices, times(2)).findGroup(anyString());
+    verify(tenantServices, never()).getById(any());
+    verify(managementIdentityClient, times(1))
+        .updateMigrationStatus(
+            assertArg(
+                migrationStatusUpdateRequests -> {
+                  assertThat(migrationStatusUpdateRequests)
+                      .describedAs("All migrations have failed")
+                      .noneMatch(MigrationStatusUpdateRequest::success);
+                }));
+  }
+
+  @Test
+  void setErrorWhenTenantNotFound() {
+    // given
+    givenGroupTenants();
+    when(groupServices.findGroup(anyString()))
+        .thenReturn(Optional.of(new GroupEntity(1L, "", Collections.emptySet())));
+    when(tenantServices.getById(any())).thenThrow(new RuntimeException());
+
+    // when
+    handler.migrate();
+
+    // then
+    verify(managementIdentityClient, times(2)).fetchGroupTenants(anyInt());
+    verify(groupServices, times(2)).findGroup(anyString());
+    verify(tenantServices, times(2)).getById(any());
+    verify(managementIdentityClient, times(1))
+        .updateMigrationStatus(
+            assertArg(
+                migrationStatusUpdateRequests -> {
+                  assertThat(migrationStatusUpdateRequests)
+                      .describedAs("All migrations have failed")
+                      .noneMatch(MigrationStatusUpdateRequest::success);
+                }));
+  }
+
+  @Test
+  void ignoreWhenGroupAlreadyAssigned() {
+    // given
+    givenGroupTenants();
+    when(groupServices.findGroup(anyString()))
+        .thenReturn(Optional.of(new GroupEntity(1L, "", Collections.emptySet())));
+    when(tenantServices.getById(any()))
+        .thenReturn(new TenantEntity(1L, "", "", Collections.emptySet()));
+    doThrow(
+            new BrokerRejectionException(
+                new BrokerRejection(TenantIntent.ADD_ENTITY, -1, RejectionType.ALREADY_EXISTS, "")))
+        .when(tenantServices)
+        .addMember(any(), any(), anyLong());
+
+    // when
+    handler.migrate();
+
+    // then
+    verify(managementIdentityClient, times(2)).fetchGroupTenants(anyInt());
+    verify(groupServices, times(2)).findGroup(anyString());
+    verify(tenantServices, times(4)).getById(any());
+    verify(tenantServices, times(4)).addMember(any(), any(), anyLong());
+    verify(managementIdentityClient, times(1))
+        .updateMigrationStatus(
+            assertArg(
+                migrationStatusUpdateRequests ->
+                    assertThat(migrationStatusUpdateRequests)
+                        .describedAs("All migrations have succeeded")
+                        .allMatch(MigrationStatusUpdateRequest::success)));
+  }
+
+  private void givenGroupTenants() {
+    when(managementIdentityClient.fetchGroupTenants(anyInt()))
+        .thenReturn(
+            List.of(
+                new GroupTenants(
+                    "group1", "group1", List.of(new Tenant("id1", "t1"), new Tenant("id2", "t2"))),
+                new GroupTenants(
+                    "group2", "group2", List.of(new Tenant("id1", "t1"), new Tenant("id3", "t3")))))
+        .thenReturn(List.of());
+  }
+}

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/GroupTenantsMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/GroupTenantsMigrationHandlerTest.java
@@ -69,7 +69,7 @@ final class GroupTenantsMigrationHandlerTest {
   }
 
   @Test
-  void setErrorWhenGroupNotFound() {
+  void setErrorWhenGroupCantBeCreated() {
     // given
     givenGroupTenants();
     when(groupServices.findGroup(anyString())).thenReturn(Optional.empty());

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/GroupTenantsMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/GroupTenantsMigrationHandlerTest.java
@@ -29,6 +29,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -37,8 +38,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 final class GroupTenantsMigrationHandlerTest {
 
   @Mock private ManagementIdentityClient managementIdentityClient;
-  @Mock private GroupServices groupServices;
-  @Mock private TenantServices tenantServices;
+
+  @Mock(answer = Answers.RETURNS_SELF)
+  private GroupServices groupServices;
+
+  @Mock(answer = Answers.RETURNS_SELF)
+  private TenantServices tenantServices;
 
   @InjectMocks private GroupTenantsMigrationHandler handler;
 

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/TenantMappingRuleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/TenantMappingRuleMigrationHandlerTest.java
@@ -22,7 +22,6 @@ import io.camunda.migration.identity.dto.MigrationStatusUpdateRequest;
 import io.camunda.migration.identity.dto.Tenant;
 import io.camunda.migration.identity.dto.TenantMappingRule;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
-import io.camunda.migration.identity.midentity.ManagementIdentityTransformer;
 import io.camunda.search.entities.TenantEntity;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.MappingServices;
@@ -61,11 +60,7 @@ final class TenantMappingRuleMigrationHandlerTest {
     this.mappingServices = mappingServices;
     migrationHandler =
         new TenantMappingRuleMigrationHandler(
-            Authentication.none(),
-            managementIdentityClient,
-            new ManagementIdentityTransformer(),
-            tenantServices,
-            mappingServices);
+            Authentication.none(), managementIdentityClient, tenantServices, mappingServices);
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/TenantMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/TenantMigrationHandlerTest.java
@@ -18,7 +18,6 @@ import static org.mockito.Mockito.when;
 import io.camunda.migration.identity.dto.MigrationStatusUpdateRequest;
 import io.camunda.migration.identity.dto.Tenant;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
-import io.camunda.migration.identity.midentity.ManagementIdentityTransformer;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.TenantServices;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
@@ -46,10 +45,7 @@ final class TenantMigrationHandlerTest {
     this.tenantServices = tenantServices;
     migrationHandler =
         new TenantMigrationHandler(
-            Authentication.none(),
-            managementIdentityClient,
-            new ManagementIdentityTransformer(),
-            this.tenantServices);
+            Authentication.none(), managementIdentityClient, this.tenantServices);
   }
 
   @Test

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/UserTenantsMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/UserTenantsMigrationHandlerTest.java
@@ -21,7 +21,6 @@ import io.camunda.migration.identity.dto.MigrationStatusUpdateRequest;
 import io.camunda.migration.identity.dto.Tenant;
 import io.camunda.migration.identity.dto.UserTenants;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
-import io.camunda.migration.identity.midentity.ManagementIdentityTransformer;
 import io.camunda.search.entities.TenantEntity;
 import io.camunda.service.MappingServices;
 import io.camunda.service.MappingServices.MappingDTO;
@@ -66,11 +65,7 @@ final class UserTenantsMigrationHandlerTest {
     this.tenantServices = tenantServices;
     this.mappingServices = mappingServices;
     migrationHandler =
-        new UserTenantsMigrationHandler(
-            managementIdentityClient,
-            new ManagementIdentityTransformer(),
-            tenantServices,
-            mappingServices);
+        new UserTenantsMigrationHandler(managementIdentityClient, tenantServices, mappingServices);
   }
 
   @Test

--- a/qa/integration-tests/src/test/java/io/camunda/it/migration/IdentityDefaultEntitiesIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/migration/IdentityDefaultEntitiesIT.java
@@ -31,7 +31,22 @@ public class IdentityDefaultEntitiesIT {
 
   @Container
   private static final GenericContainer<?> IDENTITY =
-      IdentityMigrationTestUtil.getManagementIdentity(POSTGRES, KEYCLOAK);
+      IdentityMigrationTestUtil.getManagementIdentity(POSTGRES, KEYCLOAK)
+          .withEnv("KEYCLOAK_GROUPS_0_NAME", "group0")
+          .withEnv("KEYCLOAK_GROUPS_1_NAME", "group1")
+          .withEnv("KEYCLOAK_GROUPS_2_NAME", "group2")
+          .withEnv("IDENTITY_TENANTS_0_NAME", "tenant0")
+          .withEnv("IDENTITY_TENANTS_0_TENANTID", "tenant0")
+          .withEnv("IDENTITY_TENANTS_0_MEMBERS_0_TYPE", "GROUP")
+          .withEnv("IDENTITY_TENANTS_0_MEMBERS_0_GROUPNAME", "group0")
+          .withEnv("IDENTITY_TENANTS_0_MEMBERS_1_TYPE", "GROUP")
+          .withEnv("IDENTITY_TENANTS_0_MEMBERS_1_GROUPNAME", "group1")
+          .withEnv("IDENTITY_TENANTS_1_NAME", "tenant1")
+          .withEnv("IDENTITY_TENANTS_1_TENANTID", "tenant1")
+          .withEnv("IDENTITY_TENANTS_1_MEMBERS_0_TYPE", "GROUP")
+          .withEnv("IDENTITY_TENANTS_1_MEMBERS_0_GROUPNAME", "group1")
+          .withEnv("IDENTITY_TENANTS_1_MEMBERS_1_TYPE", "GROUP")
+          .withEnv("IDENTITY_TENANTS_1_MEMBERS_1_GROUPNAME", "group2");
 
   @TestZeebe(autoStart = false)
   final TestStandaloneCamunda camunda =

--- a/service/src/main/java/io/camunda/service/GroupServices.java
+++ b/service/src/main/java/io/camunda/service/GroupServices.java
@@ -81,6 +81,13 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
         .findFirst();
   }
 
+  public Optional<GroupEntity> findGroup(final String groupName) {
+    return search(SearchQueryBuilders.groupSearchQuery().filter(f -> f.name(groupName)).build())
+        .items()
+        .stream()
+        .findFirst();
+  }
+
   public CompletableFuture<GroupRecord> updateGroup(final long groupKey, final String name) {
     return sendBrokerRequest(new BrokerGroupUpdateRequest(groupKey).setName(name));
   }


### PR DESCRIPTION
This adds a new migration handler that migrates the assigned tenants of groups from the old management identity to 
This migration handler is disabled until the necessary endpoints in management identity are supported.

Since we do not migrate groups yet, I've mirrored the logic from `UserTenantsMigrationHandler` to create groups lazily, if they don't already exist.

The QA test is extended to initialize the old management identity with a couple of roles and tenants to migrate.

depends on https://github.com/camunda-cloud/identity/pull/3228
closes #25141
