### PR TITLE
ci: refactor best practices rules into smaller files

### DIFF
--- a/.github/conftest-gha-best-practices.rego
+++ b/.github/conftest-gha-best-practices.rego
@@ -1,5 +1,8 @@
 package main
 
+# This file contains rules checking GitHub Action workflow files for
+# opinionated best practices in the C8 monorepo.
+
 # The `input` variable is a data structure that contains a YAML file's contents
 # as objects and arrays. See https://www.openpolicyagent.org/docs/latest/philosophy/#how-does-opa-work
 
@@ -11,79 +14,6 @@ deny[msg] {
     not input.name
 
     msg := "This GitHub Actions workflow has no name property!"
-}
-
-deny[msg] {
-    # only enforced on Unified CI and related workflows
-    input.name == ["CI", "Tasklist Frontend Jobs", "Zeebe CI"][_]
-
-    count(get_jobs_without_timeoutminutes(input.jobs)) > 0
-
-    msg := sprintf("There are GitHub Actions jobs without timeout-minutes! Affected job IDs: %s",
-        [concat(", ", get_jobs_without_timeoutminutes(input.jobs))])
-}
-
-warn[msg] {
-    # only enforced on Unified CI and related workflows
-    input.name == ["CI", "Tasklist Frontend Jobs", "Zeebe CI"][_]
-
-    count(get_jobs_with_timeoutminutes_higher_than(input.jobs, 15)) > 0
-
-    msg := sprintf("There are GitHub Actions jobs with too high (>15) timeout-minutes! Affected job IDs: %s",
-        [concat(", ", get_jobs_with_timeoutminutes_higher_than(input.jobs, 15))])
-}
-
-deny[msg] {
-    # only enforced on Unified CI and related workflows
-    input.name == ["CI", "Tasklist Frontend Jobs", "Zeebe CI"][_]
-
-    count(get_jobs_without_cihealth(input.jobs)) > 0
-
-    msg := sprintf("There are GitHub Actions jobs that don't send CI Health metrics! Affected job IDs: %s",
-        [concat(", ", get_jobs_without_cihealth(input.jobs))])
-}
-
-deny[msg] {
-    # only enforced on Unified CI since it is specific to detect-changes job
-    input.name == "CI"
-
-    count(get_jobs_not_needing_detectchanges(input.jobs)) > 0
-
-    msg := sprintf("There are GitHub Actions jobs in Unified CI that don't depend on detect-changes job! Affected job IDs: %s",
-        [concat(", ", get_jobs_not_needing_detectchanges(input.jobs))])
-}
-
-deny[msg] {
-    # only enforced on Unified CI and related workflows
-    input.name == ["CI", "Tasklist Frontend Jobs", "Zeebe CI"][_]
-
-    count(get_jobs_without_permissions(input.jobs)) > 0
-
-    msg := sprintf("There are GitHub Actions jobs using default GITHUB_TOKEN permissions which are too wide! Affected job IDs: %s",
-        [concat(", ", get_jobs_without_permissions(input.jobs))])
-}
-
-deny[msg] {
-    # only enforced on Unified CI since it is specific to check-results job
-    input.name == "CI"
-
-    jobs_that_should_fail_checkresults := { job_id |
-        job := input.jobs[job_id]
-
-        # no Unified CI jobs that are part of change detection control flow structure
-        job_id != "detect-changes"
-        job_id != "check-results"
-
-        # no Unified CI jobs running after "check-results" job
-        not startswith(job_id, "deploy-")
-    }
-
-    jobs_that_actually_fail_checkresults := {x | x := input.jobs["check-results"].needs[_]}
-
-    jobs_that_should_fail_checkresults != jobs_that_actually_fail_checkresults
-
-    msg := sprintf("There are GitHub Actions jobs in Unified CI that check-results job doesn't depend on! Affected job IDs: %s",
-        [concat(", ", jobs_that_should_fail_checkresults - jobs_that_actually_fail_checkresults)])
 }
 
 deny[msg] {
@@ -137,52 +67,6 @@ warn[msg] {
 
 ###########################   RULE HELPERS   ##################################
 
-get_jobs_without_timeoutminutes(jobInput) = jobs_without_timeoutminutes {
-    jobs_without_timeoutminutes := { job_id |
-        job := jobInput[job_id]
-
-        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
-        not job.uses
-
-        # check if there is timeout-minutes specified
-        not job["timeout-minutes"]
-    }
-}
-
-get_jobs_with_timeoutminutes_higher_than(jobInput, max_timeout) = jobs_without_timeoutminutes {
-    jobs_without_timeoutminutes := { job_id |
-        job := jobInput[job_id]
-
-        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
-        not job.uses
-
-        # check if timeout-minutes is higher than allowed maximum
-        job["timeout-minutes"] > max_timeout
-    }
-}
-
-get_jobs_without_cihealth(jobInput) = jobs_without_cihealth {
-    jobs_without_cihealth := { job_id |
-        job := jobInput[job_id]
-
-        # not enforced on "special" jobs needed for control flow in Unified CI
-        job_id != "detect-changes"
-        job_id != "check-results"
-        job_id != "test-summary"
-
-        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
-        not job.uses
-
-        # check that there is at least one step that invokes CI Health metric submission helper action
-        cihealth_steps := { step |
-            step := job.steps[_]
-            step.name == "Observe build status"
-            step.uses == "./.github/actions/observe-build-status"
-        }
-        count(cihealth_steps) < 1
-    }
-}
-
 get_jobs_with_setupnodecaching(jobInput) = jobs_with_setupnodecaching {
     jobs_with_setupnodecaching := { job_id |
         job := jobInput[job_id]
@@ -228,36 +112,5 @@ get_jobs_with_usesbutnosecrets(jobInput) = jobs_with_usesbutnosecrets {
         # check jobs that invoke other reusable workflows but don't specify "secrets: inherit"
         job.uses
         not job.secrets
-    }
-}
-
-get_jobs_not_needing_detectchanges(jobInput) = jobs_not_needing_detectchanges {
-    jobs_not_needing_detectchanges := { job_id |
-        job := jobInput[job_id]
-
-        # not enforced on Unified CI jobs that are part of change detection control flow structure
-        job_id != "detect-changes"
-        job_id != "check-results"
-
-        # not enforced on Unified CI jobs running after "check-results" job
-        not startswith(job_id, "deploy-")
-
-        # check if job declares dependency on "detect-changes" job anywhere
-        job_needs_detectchanges := { need |
-            need := job.needs[_]
-            need == "detect-changes"
-        }
-        count(job_needs_detectchanges) == 0
-    }
-}
-
-get_jobs_without_permissions(jobInput) = jobs_without_permissions {
-    jobs_without_permissions := { job_id |
-        job := jobInput[job_id]
-
-        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
-        not job.uses
-
-        not job.permissions
     }
 }

--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -1,0 +1,162 @@
+package main
+
+# This file contains rules checking GHA workflow files of the Unified CI to be
+# aligned with the inclusion criteria and best practices:
+# See https://github.com/camunda/camunda/wiki/CI-&-Automation#unified-ci
+
+unified_ci_workflow_names = ["CI", "Tasklist Frontend Jobs", "Zeebe CI"]
+
+# The `input` variable is a data structure that contains a YAML file's contents
+# as objects and arrays. See https://www.openpolicyagent.org/docs/latest/philosophy/#how-does-opa-work
+
+deny[msg] {
+    # only enforced on Unified CI and related workflows
+    input.name == unified_ci_workflow_names[_]
+
+    count(get_jobs_without_timeoutminutes(input.jobs)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs without timeout-minutes! Affected job IDs: %s",
+        [concat(", ", get_jobs_without_timeoutminutes(input.jobs))])
+}
+
+warn[msg] {
+    # only enforced on Unified CI and related workflows
+    input.name == unified_ci_workflow_names[_]
+
+    count(get_jobs_with_timeoutminutes_higher_than(input.jobs, 15)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs with too high (>15) timeout-minutes! Affected job IDs: %s",
+        [concat(", ", get_jobs_with_timeoutminutes_higher_than(input.jobs, 15))])
+}
+
+deny[msg] {
+    # only enforced on Unified CI and related workflows
+    input.name == unified_ci_workflow_names[_]
+
+    count(get_jobs_without_cihealth(input.jobs)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs that don't send CI Health metrics! Affected job IDs: %s",
+        [concat(", ", get_jobs_without_cihealth(input.jobs))])
+}
+
+deny[msg] {
+    # only enforced on Unified CI and related workflows
+    input.name == unified_ci_workflow_names[_]
+
+    count(get_jobs_without_permissions(input.jobs)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs using default GITHUB_TOKEN permissions which are too wide! Affected job IDs: %s",
+        [concat(", ", get_jobs_without_permissions(input.jobs))])
+}
+
+deny[msg] {
+    # only enforced on Unified CI since it is specific to detect-changes job
+    input.name == "CI"
+
+    count(get_jobs_not_needing_detectchanges(input.jobs)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs in Unified CI that don't depend on detect-changes job! Affected job IDs: %s",
+        [concat(", ", get_jobs_not_needing_detectchanges(input.jobs))])
+}
+
+deny[msg] {
+    # only enforced on Unified CI since it is specific to check-results job
+    input.name == "CI"
+
+    jobs_that_should_fail_checkresults := { job_id |
+        job := input.jobs[job_id]
+
+        # no Unified CI jobs that are part of change detection control flow structure
+        job_id != "detect-changes"
+        job_id != "check-results"
+
+        # no Unified CI jobs running after "check-results" job
+        not startswith(job_id, "deploy-")
+    }
+
+    jobs_that_actually_fail_checkresults := {x | x := input.jobs["check-results"].needs[_]}
+
+    jobs_that_should_fail_checkresults != jobs_that_actually_fail_checkresults
+
+    msg := sprintf("There are GitHub Actions jobs in Unified CI that check-results job doesn't depend on! Affected job IDs: %s",
+        [concat(", ", jobs_that_should_fail_checkresults - jobs_that_actually_fail_checkresults)])
+}
+
+###########################   RULE HELPERS   ##################################
+
+get_jobs_without_timeoutminutes(jobInput) = jobs_without_timeoutminutes {
+    jobs_without_timeoutminutes := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
+        not job.uses
+
+        # check if there is timeout-minutes specified
+        not job["timeout-minutes"]
+    }
+}
+
+get_jobs_with_timeoutminutes_higher_than(jobInput, max_timeout) = jobs_without_timeoutminutes {
+    jobs_without_timeoutminutes := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
+        not job.uses
+
+        # check if timeout-minutes is higher than allowed maximum
+        job["timeout-minutes"] > max_timeout
+    }
+}
+
+get_jobs_without_cihealth(jobInput) = jobs_without_cihealth {
+    jobs_without_cihealth := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on "special" jobs needed for control flow in Unified CI
+        job_id != "detect-changes"
+        job_id != "check-results"
+        job_id != "test-summary"
+
+        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
+        not job.uses
+
+        # check that there is at least one step that invokes CI Health metric submission helper action
+        cihealth_steps := { step |
+            step := job.steps[_]
+            step.name == "Observe build status"
+            step.uses == "./.github/actions/observe-build-status"
+        }
+        count(cihealth_steps) < 1
+    }
+}
+
+get_jobs_without_permissions(jobInput) = jobs_without_permissions {
+    jobs_without_permissions := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
+        not job.uses
+
+        not job.permissions
+    }
+}
+
+get_jobs_not_needing_detectchanges(jobInput) = jobs_not_needing_detectchanges {
+    jobs_not_needing_detectchanges := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on Unified CI jobs that are part of change detection control flow structure
+        job_id != "detect-changes"
+        job_id != "check-results"
+
+        # not enforced on Unified CI jobs running after "check-results" job
+        not startswith(job_id, "deploy-")
+
+        # check if job declares dependency on "detect-changes" job anywhere
+        job_needs_detectchanges := { need |
+            need := job.needs[_]
+            need == "detect-changes"
+        }
+        count(job_needs_detectchanges) == 0
+    }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
             object type "{}" cannot be filtered by object filtering `.*` since it has no object element
       - run: |
           curl -s -L "https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz" | tar xvz conftest
-          ./conftest test -o github --policy .github/conftest-*.rego .github/workflows/*.yml
+          ./conftest test -o github --policy .github .github/workflows/*.yml
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
## Description

I split the existing `.github/conftest-gha-best-practices.rego` file containing all rules into two files:

* `.github/conftest-gha-best-practices.rego` contains rules applying to _all_ GHA workflows in the C8 monorepo
* (new) `.github/conftest-unified-ci-rules.rego` contains rules applying to [Unified CI](https://github.com/camunda/camunda/wiki/CI-&-Automation#unified-ci) workflows only checking that they are aligned with the requirements

Thanks to @Kerruba for noticing this refactoring potential!

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

None
