### PR TITLE
feat: support m2m authentication for management identity

### DIFF
--- a/dist/src/main/resources/application-migration.properties
+++ b/dist/src/main/resources/application-migration.properties
@@ -1,3 +1,0 @@
-camunda.migration.identity.zeebe.gateway-address=localhost:26500
-camunda.migration.identity.management-identity.base-url=http://localhost:8080
-camunda.migration.identity.organization-id=

--- a/migration/identity-migration/pom.xml
+++ b/migration/identity-migration/pom.xml
@@ -37,6 +37,10 @@
       <artifactId>spring-web</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -75,6 +79,10 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-search-domain</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>identity-sdk</artifactId>
     </dependency>
 
     <!-- Test -->

--- a/migration/identity-migration/pom.xml
+++ b/migration/identity-migration/pom.xml
@@ -37,10 +37,6 @@
       <artifactId>spring-web</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-beans</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/TenantMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/TenantMigrationHandler.java
@@ -43,8 +43,8 @@ public class TenantMigrationHandler implements MigrationHandler {
     List<Tenant> tenants;
     do {
       tenants = managementIdentityClient.fetchTenants(SIZE);
-      /*      managementIdentityClient.updateMigrationStatus(
-      tenants.stream().map(this::createTenant).toList());*/
+      managementIdentityClient.updateMigrationStatus(
+          tenants.stream().map(this::createTenant).toList());
     } while (!tenants.isEmpty());
     LOG.debug("Finished migrating tenants");
   }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/TenantMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/TenantMigrationHandler.java
@@ -43,8 +43,8 @@ public class TenantMigrationHandler implements MigrationHandler {
     List<Tenant> tenants;
     do {
       tenants = managementIdentityClient.fetchTenants(SIZE);
-      managementIdentityClient.updateMigrationStatus(
-          tenants.stream().map(this::createTenant).toList());
+      /*      managementIdentityClient.updateMigrationStatus(
+      tenants.stream().map(this::createTenant).toList());*/
     } while (!tenants.isEmpty());
     LOG.debug("Finished migrating tenants");
   }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/ManagementIdentityConnector.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/ManagementIdentityConnector.java
@@ -7,27 +7,104 @@
  */
 package io.camunda.migration.identity.config;
 
+import io.camunda.identity.sdk.Identity;
+import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.DefaultResponseErrorHandler;
 
 @Configuration
 public class ManagementIdentityConnector {
 
-  @Bean // will be closed automatically
+  @Bean
+  public Identity identity(final IdentityMigrationProperties identityMigrationProperties) {
+    final var properties = identityMigrationProperties.getManagementIdentity();
+    final var configuration =
+        new IdentityConfiguration(
+            properties.getBaseUrl(),
+            properties.getIssuerBackendUrl(),
+            properties.getIssuerBackendUrl(),
+            properties.getClientId(),
+            properties.getClientSecret(),
+            properties.getAudience(),
+            properties.getIssuerType());
+    return new Identity(configuration);
+  }
+
+  @Bean
   public ManagementIdentityClient managementIdentityClient(
       final RestTemplateBuilder builder,
-      final IdentityMigrationProperties identityMigrationProperties) {
+      final IdentityMigrationProperties identityMigrationProperties,
+      final Identity identity) {
     final var properties = identityMigrationProperties.getManagementIdentity();
     final var restTemplate =
         builder
             .rootUri(properties.getBaseUrl())
-            .defaultHeader("Authorization", String.format("Bearer %s", properties.getM2mToken()))
+            .interceptors(new M2MTokenInterceptor(identity, properties.getAudience()))
+            .errorHandler(new CustomErrorHandler())
             .defaultHeader("Content-Type", "application/json")
             .defaultHeader("Accept", "application/json")
             .build();
     return new ManagementIdentityClient(
         restTemplate, identityMigrationProperties.getOrganizationId());
+  }
+
+  public static final class M2MTokenInterceptor implements ClientHttpRequestInterceptor {
+
+    final Identity identity;
+    final String audience;
+
+    public M2MTokenInterceptor(final Identity identity, final String audience) {
+      this.identity = identity;
+      this.audience = audience;
+    }
+
+    @Override
+    public ClientHttpResponse intercept(
+        final HttpRequest request, final byte[] body, final ClientHttpRequestExecution execution)
+        throws IOException {
+      final String token = identity.authentication().requestToken(audience).getAccessToken();
+      final HttpHeaders headers = request.getHeaders();
+      headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+      return execution.execute(request, body);
+    }
+  }
+
+  public static final class CustomErrorHandler extends DefaultResponseErrorHandler {
+
+    @Override
+    public boolean hasError(final ClientHttpResponse response) throws IOException {
+      return super.hasError(response) && response.getStatusCode() != HttpStatus.NOT_FOUND;
+    }
+
+    @Override
+    public void handleError(final ClientHttpResponse response) throws IOException {
+      if (response.getStatusCode() == HttpStatus.NOT_FOUND) {
+        return;
+      }
+      super.handleError(response);
+    }
+
+    @Override
+    public byte[] getResponseBody(final ClientHttpResponse response) {
+      try {
+        if (response.getStatusCode() == HttpStatus.NOT_FOUND) {
+          return "[]".getBytes(StandardCharsets.UTF_8);
+        }
+      } catch (final IOException ignored) {
+        // ignored exception
+      }
+      return super.getResponseBody(response);
+    }
   }
 }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/ManagementIdentityConnector.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/ManagementIdentityConnector.java
@@ -11,17 +11,14 @@ import io.camunda.identity.sdk.Identity;
 import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.migration.identity.midentity.ManagementIdentityClient;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpRequest;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
-import org.springframework.web.client.DefaultResponseErrorHandler;
 
 @Configuration
 public class ManagementIdentityConnector {
@@ -51,7 +48,6 @@ public class ManagementIdentityConnector {
         builder
             .rootUri(properties.getBaseUrl())
             .interceptors(new M2MTokenInterceptor(identity, properties.getAudience()))
-            .errorHandler(new CustomErrorHandler())
             .defaultHeader("Content-Type", "application/json")
             .defaultHeader("Accept", "application/json")
             .build();
@@ -77,34 +73,6 @@ public class ManagementIdentityConnector {
       final HttpHeaders headers = request.getHeaders();
       headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + token);
       return execution.execute(request, body);
-    }
-  }
-
-  public static final class CustomErrorHandler extends DefaultResponseErrorHandler {
-
-    @Override
-    public boolean hasError(final ClientHttpResponse response) throws IOException {
-      return super.hasError(response) && response.getStatusCode() != HttpStatus.NOT_FOUND;
-    }
-
-    @Override
-    public void handleError(final ClientHttpResponse response) throws IOException {
-      if (response.getStatusCode() == HttpStatus.NOT_FOUND) {
-        return;
-      }
-      super.handleError(response);
-    }
-
-    @Override
-    public byte[] getResponseBody(final ClientHttpResponse response) {
-      try {
-        if (response.getStatusCode() == HttpStatus.NOT_FOUND) {
-          return "[]".getBytes(StandardCharsets.UTF_8);
-        }
-      } catch (final IOException ignored) {
-        // ignored exception
-      }
-      return super.getResponseBody(response);
     }
   }
 }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/ManagementIdentityProperties.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/config/ManagementIdentityProperties.java
@@ -9,7 +9,11 @@ package io.camunda.migration.identity.config;
 
 public class ManagementIdentityProperties {
   private String baseUrl;
-  private String m2mToken;
+  private String issuerBackendUrl;
+  private String clientId;
+  private String clientSecret;
+  private String audience;
+  private String issuerType;
 
   public String getBaseUrl() {
     return baseUrl;
@@ -19,11 +23,43 @@ public class ManagementIdentityProperties {
     this.baseUrl = baseUrl;
   }
 
-  public String getM2mToken() {
-    return m2mToken;
+  public String getClientId() {
+    return clientId;
   }
 
-  public void setM2mToken(final String m2mToken) {
-    this.m2mToken = m2mToken;
+  public void setClientId(final String clientId) {
+    this.clientId = clientId;
+  }
+
+  public String getClientSecret() {
+    return clientSecret;
+  }
+
+  public void setClientSecret(final String clientSecret) {
+    this.clientSecret = clientSecret;
+  }
+
+  public String getAudience() {
+    return audience;
+  }
+
+  public void setAudience(final String audience) {
+    this.audience = audience;
+  }
+
+  public String getIssuerBackendUrl() {
+    return issuerBackendUrl;
+  }
+
+  public void setIssuerBackendUrl(final String issuerBackendUrl) {
+    this.issuerBackendUrl = issuerBackendUrl;
+  }
+
+  public String getIssuerType() {
+    return issuerType;
+  }
+
+  public void setIssuerType(final String issuerType) {
+    this.issuerType = issuerType;
   }
 }

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/midentity/ManagementIdentityClient.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/midentity/ManagementIdentityClient.java
@@ -21,6 +21,8 @@ import java.util.List;
 import java.util.Objects;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 
 public class ManagementIdentityClient {
@@ -51,14 +53,21 @@ public class ManagementIdentityClient {
   public void markAuthorizationsAsMigrated(final Collection<UserResourceAuthorization> migrated) {}
 
   public List<TenantMappingRule> fetchTenantMappingRules(final int pageSize) {
-    return Arrays.stream(
-            Objects.requireNonNull(
-                restTemplate.getForObject(
-                    MIGRATION_MAPPING_RULE_ENDPOINT,
-                    TenantMappingRule[].class,
-                    pageSize,
-                    MappingRuleType.TENANT)))
-        .toList();
+    try {
+      return Arrays.stream(
+              Objects.requireNonNull(
+                  restTemplate.getForObject(
+                      MIGRATION_MAPPING_RULE_ENDPOINT,
+                      TenantMappingRule[].class,
+                      pageSize,
+                      MappingRuleType.TENANT)))
+          .toList();
+    } catch (final HttpStatusCodeException e) {
+      if (e.getStatusCode() == HttpStatus.NO_CONTENT) {
+        return new ArrayList<>();
+      }
+      throw e;
+    }
   }
 
   public List<UserTenants> fetchUserTenants(final int pageSize) {

--- a/qa/integration-tests/src/test/java/io/camunda/it/migration/IdentityDefaultEntitiesIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/migration/IdentityDefaultEntitiesIT.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.it.migration;
 
+import static io.camunda.it.migration.IdentityMigrationTestUtil.CAMUNDA_IDENTITY_RESOURCE_SERVER;
+import static io.camunda.it.migration.IdentityMigrationTestUtil.IDENTITY_CLIENT;
+import static io.camunda.it.migration.IdentityMigrationTestUtil.IDENTITY_CLIENT_SECRET;
 import static io.camunda.it.migration.IdentityMigrationTestUtil.externalIdentityUrl;
 
 import io.camunda.application.Profile;
@@ -21,6 +24,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @ZeebeIntegration
 @Testcontainers(parallel = true)
 public class IdentityDefaultEntitiesIT {
+
   @Container
   private static final GenericContainer<?> POSTGRES = IdentityMigrationTestUtil.getPostgres();
 
@@ -51,11 +55,12 @@ public class IdentityDefaultEntitiesIT {
             "camunda.migration.identity.management-identity.issuer-backend-url",
             IdentityMigrationTestUtil.externalKeycloakUrl(KEYCLOAK) + "/realms/camunda-platform/")
         .withProperty("camunda.migration.identity.management-identity.issuer-type", "KEYCLOAK")
-        .withProperty("camunda.migration.identity.management-identity.client-id", "migration-app")
-        .withProperty("camunda.migration.identity.management-identity.client-secret", "secret")
+        .withProperty("camunda.migration.identity.management-identity.client-id", IDENTITY_CLIENT)
+        .withProperty(
+            "camunda.migration.identity.management-identity.client-secret", IDENTITY_CLIENT_SECRET)
         .withProperty(
             "camunda.migration.identity.management-identity.audience",
-            "camunda-identity-resource-server")
+            CAMUNDA_IDENTITY_RESOURCE_SERVER)
         .start();
 
     // then -- the migration did not fail

--- a/qa/integration-tests/src/test/java/io/camunda/it/migration/IdentityDefaultEntitiesIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/migration/IdentityDefaultEntitiesIT.java
@@ -8,7 +8,6 @@
 package io.camunda.it.migration;
 
 import static io.camunda.it.migration.IdentityMigrationTestUtil.externalIdentityUrl;
-import static io.camunda.it.migration.IdentityMigrationTestUtil.getIdentityAccessToken;
 
 import io.camunda.application.Profile;
 import io.camunda.qa.util.cluster.TestStandaloneCamunda;
@@ -49,8 +48,14 @@ public class IdentityDefaultEntitiesIT {
         .withProperty(
             "camunda.migration.identity.managementIdentity.baseUrl", externalIdentityUrl(IDENTITY))
         .withProperty(
-            "camunda.migration.identity.managementIdentity.m2mToken",
-            getIdentityAccessToken(KEYCLOAK))
+            "camunda.migration.identity.management-identity.issuer-backend-url",
+            IdentityMigrationTestUtil.externalKeycloakUrl(KEYCLOAK) + "/realms/camunda-platform/")
+        .withProperty("camunda.migration.identity.management-identity.issuer-type", "KEYCLOAK")
+        .withProperty("camunda.migration.identity.management-identity.client-id", "migration-app")
+        .withProperty("camunda.migration.identity.management-identity.client-secret", "secret")
+        .withProperty(
+            "camunda.migration.identity.management-identity.audience",
+            "camunda-identity-resource-server")
         .start();
 
     // then -- the migration did not fail


### PR DESCRIPTION
## Description

Provide m2m token for calling the management identity endpoint.

Also a bug fixed: when management identity endpoint is not available, it caused never ending retries on migration app, now it fixed by returning an empty array in this case.

## Related issues

closes #25823 
