### PR TITLE
Migrate joining inclusive gateway with at least one incoming sequence flow is taken

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -467,8 +467,11 @@ public class ProcessInstanceMigrationMigrateProcessor
 
     return activeSequenceFlows.stream()
         .filter(
-            sequenceFlow ->
-                sequenceFlow.target().getElementType() == BpmnElementType.PARALLEL_GATEWAY)
+            sequenceFlow -> {
+              final BpmnElementType elementType = sequenceFlow.target().getElementType();
+              return elementType == BpmnElementType.PARALLEL_GATEWAY
+                  || elementType == BpmnElementType.INCLUSIVE_GATEWAY;
+            })
         .map(
             activeSequenceFlow -> {
               final ExecutableSequenceFlow activeFlow = activeSequenceFlow.sequenceFlow();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateInclusiveGatewayTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateInclusiveGatewayTest.java
@@ -12,19 +12,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.assertj.core.api.AssertionsForInterfaceTypes;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
 
 public class MigrateInclusiveGatewayTest {
-
   @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
@@ -115,5 +117,307 @@ public class MigrateInclusiveGatewayTest {
         .describedAs(
             "Expected to successfully evaluate execution listener job type and resolve incident")
         .contains("end2");
+  }
+
+  @Test
+  public void shouldMigrateJoiningInclusiveGatewayWithOneSequenceFlowTaken() {
+    final String sourceProcessId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "_v2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(sourceProcessId)
+                    .startEvent()
+                    .inclusiveGateway("fork")
+                    .conditionExpression("= true")
+                    .serviceTask("task1", b -> b.zeebeJobType("type1"))
+                    .sequenceFlowId("flow1")
+                    .inclusiveGateway("join1")
+                    .endEvent()
+                    .moveToNode("fork")
+                    .conditionExpression("= true")
+                    .serviceTask("task2", b -> b.zeebeJobType("type2"))
+                    .connectTo("join1")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .inclusiveGateway("fork")
+                    .conditionExpression("= true")
+                    .serviceTask("task1", b -> b.zeebeJobType("type1"))
+                    .sequenceFlowId("flow1")
+                    .inclusiveGateway("join2")
+                    .endEvent()
+                    .moveToNode("fork")
+                    .conditionExpression("= true")
+                    .serviceTask("task3", b -> b.zeebeJobType("type3"))
+                    .connectTo("join2")
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
+
+    AssertionsForInterfaceTypes.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SERVICE_TASK)
+                .limit(2))
+        .hasSize(2);
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("type1").complete();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId("flow1")
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to take the sequence flow to the joining gateway")
+        .isNotNull();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("task2", "task3")
+        .addMappingInstruction("join1", "join2")
+        .migrate();
+
+    // then
+    ENGINE.job().ofInstance(processInstanceKey).withType("type2").complete();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.INCLUSIVE_GATEWAY)
+                .withElementId("join2")
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to activate the joining inclusive gateway")
+        .isNotNull();
+  }
+
+  @Test
+  public void shouldMigrateJoiningInclusiveGatewayWithMultipleSequenceFlowsTaken() {
+    final String sourceProcessId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "_v2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(sourceProcessId)
+                    .startEvent()
+                    .inclusiveGateway("fork")
+                    .conditionExpression("= true")
+                    .serviceTask("task1", b -> b.zeebeJobType("type1"))
+                    .sequenceFlowId("flow1")
+                    .inclusiveGateway("join1")
+                    .endEvent()
+                    .moveToNode("fork")
+                    .conditionExpression("= true")
+                    .serviceTask("task2", b -> b.zeebeJobType("type2"))
+                    .sequenceFlowId("flow2")
+                    .connectTo("join1")
+                    .moveToNode("fork")
+                    .conditionExpression("= true")
+                    .serviceTask("task3", b -> b.zeebeJobType("type3"))
+                    .connectTo("join1")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .inclusiveGateway("fork")
+                    .conditionExpression("= true")
+                    .serviceTask("task1", b -> b.zeebeJobType("type1"))
+                    .sequenceFlowId("flow1")
+                    .inclusiveGateway("join2")
+                    .endEvent()
+                    .moveToNode("fork")
+                    .conditionExpression("= true")
+                    .serviceTask("task2", b -> b.zeebeJobType("type2"))
+                    .sequenceFlowId("flow2")
+                    .connectTo("join2")
+                    .moveToNode("fork")
+                    .conditionExpression("= true")
+                    .serviceTask("task4", b -> b.zeebeJobType("type4"))
+                    .connectTo("join2")
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
+
+    AssertionsForInterfaceTypes.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SERVICE_TASK)
+                .limit(2))
+        .hasSize(2);
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("type1").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType("type2").complete();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .skipUntil(
+                    r ->
+                        r.getIntent() == ProcessInstanceIntent.ELEMENT_COMPLETED
+                            && r.getValue().getElementId().equals("task1"))
+                .withIntent(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SEQUENCE_FLOW)
+                .limit(2))
+        .extracting(r -> r.getValue().getElementId())
+        .describedAs("Expected to take the sequence flows to the joining gateway")
+        .contains("flow1", "flow2");
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("task3", "task4")
+        .addMappingInstruction("join1", "join2")
+        .migrate();
+
+    // then
+    ENGINE.job().ofInstance(processInstanceKey).withType("type3").complete();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.INCLUSIVE_GATEWAY)
+                .withElementId("join2")
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to activate the joining inclusive gateway")
+        .isNotNull();
+  }
+
+  @Test
+  public void shouldMigrateJoiningInclusiveGatewayInsideSubprocess() {
+    final String sourceProcessId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "_v2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(sourceProcessId)
+                    .startEvent()
+                    .subProcess(
+                        "sub1",
+                        s ->
+                            s.embeddedSubProcess()
+                                .startEvent()
+                                .inclusiveGateway("fork")
+                                .conditionExpression("= true")
+                                .serviceTask("task1", b -> b.zeebeJobType("type1"))
+                                .sequenceFlowId("flow1")
+                                .inclusiveGateway("join1")
+                                .endEvent()
+                                .moveToNode("fork")
+                                .conditionExpression("= true")
+                                .serviceTask("task2", b -> b.zeebeJobType("type2"))
+                                .sequenceFlowId("flow2")
+                                .connectTo("join1")
+                                .moveToNode("fork")
+                                .conditionExpression("= true")
+                                .serviceTask("task3", b -> b.zeebeJobType("type3"))
+                                .connectTo("join1"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .subProcess(
+                        "sub2",
+                        s ->
+                            s.embeddedSubProcess()
+                                .startEvent()
+                                .inclusiveGateway("fork")
+                                .conditionExpression("= true")
+                                .serviceTask("task1", b -> b.zeebeJobType("type1"))
+                                .sequenceFlowId("flow1")
+                                .inclusiveGateway("join2")
+                                .endEvent()
+                                .moveToNode("fork")
+                                .conditionExpression("= true")
+                                .serviceTask("task2", b -> b.zeebeJobType("type2"))
+                                .sequenceFlowId("flow2")
+                                .connectTo("join2")
+                                .moveToNode("fork")
+                                .conditionExpression("= true")
+                                .serviceTask("task4", b -> b.zeebeJobType("type4"))
+                                .connectTo("join2"))
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
+
+    AssertionsForInterfaceTypes.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SERVICE_TASK)
+                .limit(2))
+        .hasSize(2);
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("type1").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType("type2").complete();
+
+    assertThat(
+            RecordingExporter.records()
+                .skipUntil(
+                    r ->
+                        r.getValue() instanceof ProcessInstanceRecord
+                            && ((ProcessInstanceRecord) r.getValue()).getElementId().equals("task1")
+                            && r.getIntent() == ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .processInstanceRecords()
+                .withIntent(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SEQUENCE_FLOW)
+                .limit(2))
+        .extracting(r -> r.getValue().getElementId())
+        .describedAs("Expected to take the sequence flows to the joining gateway")
+        .contains("flow1", "flow2");
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("sub1", "sub2")
+        .addMappingInstruction("task3", "task4")
+        .addMappingInstruction("join1", "join2")
+        .migrate();
+
+    // then
+    ENGINE.job().ofInstance(processInstanceKey).withType("type3").complete();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.INCLUSIVE_GATEWAY)
+                .withElementId("join2")
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to activate the joining inclusive gateway")
+        .isNotNull();
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Similar to migrating parallel gateways, migrating inclusive gateways with at least one incoming sequence flow is taken is enabled in this PR. See the actual implementation in #25998 

## Related issues

closes #25674
