### PR TITLE
ci: install zeebe benchmark dependencies in local repository

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -409,7 +409,7 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      - run: ./mvnw -B -D skipTests -D skipChecks -pl zeebe/benchmarks/project -am package
+      - run: ./mvnw -B -D skipTests -D skipChecks -pl zeebe/benchmarks/project -am install
       - name: Build Starter Image
         run: ./mvnw -pl zeebe/benchmarks/project jib:build -P starter
       - name: Build Worker Image


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
```
 ./mvnw -B -D skipTests -D skipChecks -pl zeebe/benchmarks/project -am install
```
should build  zeebe benchmarks and its dependencies and deploy them in a local repository

It is actually done this way in [zeebe-benchmark.yml](https://github.com/camunda/camunda/blob/887e5c46fe8ebcb6fd389382e820120c68056695/.github/workflows/zeebe-benchmark.yml#L264)

it is working according to https://github.com/camunda/camunda/actions/runs/12413588783/job/34656380390?pr=26295

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #26289 
