### PR TITLE
Update zcl repo location

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -228,7 +228,7 @@ jobs:
           fetch-depth: 0 # To fetch tags as well - necessary for the changelog generation
       - name: Install Zeebe changelog tool
         run: |
-          gh release download --repo zeebe-io/zeebe-changelog --pattern '*_Linux_i386.tar.gz'
+          gh release download --repo camunda/zeebe-changelog --pattern '*_Linux_i386.tar.gz'
           tar -xzvf zeebe-changelog_*
           chmod +x zcl
       - name: Generate Changelog for patch release


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Updates the location of the `zcl` tool used in the release dry run jobs from `zeebe-io/zeebe-changelog` to `camunda/zeebe-changelog`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
