### PR TITLE
feat: auto enable migration when tasklist is enabled

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/migration/ProcessMigrationModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/ProcessMigrationModuleConfiguration.java
@@ -15,6 +15,6 @@ import org.springframework.context.annotation.Profile;
 
 @Configuration(proxyBeanMethods = false)
 @ComponentScan(basePackages = {"io.camunda.migration.process"})
-@Profile("process-migration")
+@Profile("process-migration|tasklist")
 @Import({SearchClientDatabaseConfiguration.class})
 public class ProcessMigrationModuleConfiguration {}


### PR DESCRIPTION
## Description

When Tasklist profile is enabled (default on StandloneCamunda) we should auto-enable the process migration profile, as it makes just sense to migrate related data.

We can make use of the camunda.database config, as it is inherited

## Related issues

related to https://github.com/camunda/camunda/issues/26162