### PR TITLE
test: migrate ES IT to exporter

### DIFF
--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
@@ -161,7 +161,7 @@ public class TaskStoreElasticSearch implements TaskStore {
             .source(
                 SearchSourceBuilder.searchSource().query(finalQuery).fetchField(TaskTemplate.KEY));
     try {
-      return ElasticsearchUtil.scrollIdsToList(searchRequest, esClient);
+      return ElasticsearchUtil.scrollUserTaskKeysToList(searchRequest, esClient);
     } catch (final IOException e) {
       throw new TasklistRuntimeException(e.getMessage(), e);
     }
@@ -542,8 +542,8 @@ public class TaskStoreElasticSearch implements TaskStore {
     if (query.getFollowUpDate() != null) {
       followUpQ =
           rangeQuery(TaskTemplate.FOLLOW_UP_DATE)
-              .from(query.getFollowUpDate().getFrom())
-              .to(query.getFollowUpDate().getTo());
+              .gte(query.getFollowUpDate().getFrom())
+              .lte(query.getFollowUpDate().getTo());
     }
 
     QueryBuilder dueDateQ = null;
@@ -551,7 +551,7 @@ public class TaskStoreElasticSearch implements TaskStore {
       dueDateQ =
           rangeQuery(TaskTemplate.DUE_DATE)
               .from(query.getDueDate().getFrom())
-              .to(query.getDueDate().getTo());
+              .lte(query.getDueDate().getTo());
     }
     QueryBuilder implementationQ = null;
     if (query.getImplementation() != null) {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
@@ -129,7 +129,7 @@ public class TaskStoreOpenSearch implements TaskStore {
             .fields(f -> f.field(TaskTemplate.KEY));
 
     try {
-      return OpenSearchUtil.scrollIdsToList(searchRequest, osClient);
+      return OpenSearchUtil.scrollUserTaskKeysToList(searchRequest, osClient);
     } catch (final IOException e) {
       throw new TasklistRuntimeException(e.getMessage(), e);
     }
@@ -581,8 +581,8 @@ public class TaskStoreOpenSearch implements TaskStore {
       followUpQ.range(
           r ->
               r.field(TaskTemplate.FOLLOW_UP_DATE)
-                  .from(JsonData.of(query.getFollowUpDate().getFrom()))
-                  .to(JsonData.of(query.getFollowUpDate().getTo())));
+                  .gte(JsonData.of(query.getFollowUpDate().getFrom()))
+                  .lte(JsonData.of(query.getFollowUpDate().getTo())));
     }
 
     Query.Builder dueDateQ = null;
@@ -591,8 +591,8 @@ public class TaskStoreOpenSearch implements TaskStore {
       dueDateQ.range(
           r ->
               r.field(TaskTemplate.DUE_DATE)
-                  .from(JsonData.of(query.getDueDate().getFrom()))
-                  .to(JsonData.of(query.getDueDate().getTo())));
+                  .gte(JsonData.of(query.getDueDate().getFrom()))
+                  .lte(JsonData.of(query.getDueDate().getTo())));
     }
 
     Query.Builder implementationQ = null;

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
@@ -60,6 +60,7 @@ import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch._types.query_dsl.MatchAllQuery;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch._types.query_dsl.Query.Builder;
 import org.opensearch.client.opensearch.core.ScrollRequest;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
@@ -115,14 +116,16 @@ public class TaskStoreOpenSearch implements TaskStore {
 
   @Override
   public List<String> getTaskIdsByProcessInstanceId(final String processInstanceId) {
+    final Query.Builder flowNodeInstanceQuery = new Query.Builder();
+    flowNodeInstanceQuery.exists(t -> t.field(TaskTemplate.FLOW_NODE_INSTANCE_ID));
+
+    final Query.Builder processInstanceIdQuery = new Query.Builder();
+    processInstanceIdQuery.term(
+        t -> t.field(TaskTemplate.PROCESS_INSTANCE_ID).value(FieldValue.of(processInstanceId)));
+
     final SearchRequest.Builder searchRequest =
         OpenSearchUtil.createSearchRequest(taskTemplate)
-            .query(
-                q ->
-                    q.term(
-                        term ->
-                            term.field(TaskTemplate.PROCESS_INSTANCE_ID)
-                                .value(FieldValue.of(processInstanceId))))
+            .query(q -> joinQueryBuilderWithAnd(flowNodeInstanceQuery, processInstanceIdQuery))
             .fields(f -> f.field(TaskTemplate.KEY));
 
     try {
@@ -135,16 +138,17 @@ public class TaskStoreOpenSearch implements TaskStore {
   @Override
   public Map<String, String> getTaskIdsWithIndexByProcessDefinitionId(
       final String processDefinitionId) {
+    final Query.Builder flowNodeInstanceQuery = new Query.Builder();
+    flowNodeInstanceQuery.exists(t -> t.field(TaskTemplate.FLOW_NODE_INSTANCE_ID));
+
+    final Query.Builder processInstanceIdQuery = new Query.Builder();
+    processInstanceIdQuery.term(
+        t -> t.field(TaskTemplate.PROCESS_DEFINITION_ID).value(FieldValue.of(processDefinitionId)));
+
     final SearchRequest.Builder searchRequest =
         OpenSearchUtil.createSearchRequest(taskTemplate)
-            .query(
-                q ->
-                    q.term(
-                        term ->
-                            term.field(TaskTemplate.PROCESS_DEFINITION_ID)
-                                .value(FieldValue.of(processDefinitionId))))
+            .query(q -> joinQueryBuilderWithAnd(flowNodeInstanceQuery, processInstanceIdQuery))
             .fields(f -> f.field(TaskTemplate.KEY));
-
     try {
       return OpenSearchUtil.scrollIdsWithIndexToMap(searchRequest, osClient);
     } catch (final IOException e) {
@@ -481,10 +485,14 @@ public class TaskStoreOpenSearch implements TaskStore {
     }
 
     Query.Builder taskIdsQuery = null;
+    Query.Builder flowNodeInstanceExistsQuery = null;
     if (taskIds != null) {
       final var terms = taskIds.stream().map(FieldValue::of).toList();
       taskIdsQuery = new Query.Builder();
       taskIdsQuery.terms(t -> t.field(TaskTemplate.KEY).terms(v -> v.value(terms)));
+    } else {
+      flowNodeInstanceExistsQuery = new Builder();
+      flowNodeInstanceExistsQuery.exists(t -> t.field(TaskTemplate.FLOW_NODE_INSTANCE_ID));
     }
 
     Query.Builder taskDefinitionQ = null;
@@ -605,6 +613,7 @@ public class TaskStoreOpenSearch implements TaskStore {
             assigneeQ,
             assigneesQ,
             taskIdsQuery,
+            flowNodeInstanceExistsQuery,
             taskDefinitionQ,
             candidateGroupQ,
             candidateGroupsQ,

--- a/tasklist/qa/integration-tests/pom.xml
+++ b/tasklist/qa/integration-tests/pom.xml
@@ -474,6 +474,12 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-exporter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-opensearch-exporter</artifactId>
       <scope>test</scope>
     </dependency>

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/metric/UsageMetricIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/metric/UsageMetricIT.java
@@ -24,6 +24,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -91,17 +92,21 @@ public class UsageMetricIT extends TasklistZeebeIntegrationTest {
     final Map<String, String> parameters = new HashMap<>();
     parameters.put("startTime", now.minusSeconds(1L).format(FORMATTER));
     parameters.put("endTime", now.plusSeconds(1L).format(FORMATTER));
-    final ResponseEntity<UsageMetricDTO> response =
-        testRestTemplate.getForEntity(
-            "http://localhost:" + managementPort + ASSIGNEE_ENDPOINT,
-            UsageMetricDTO.class,
-            parameters);
 
     final UsageMetricDTO expectedDto =
         new UsageMetricDTO(List.of("Angela Merkel", "John Lennon")); // just repeat once
 
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-    assertThat(response.getBody()).isEqualTo(expectedDto);
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              final ResponseEntity<UsageMetricDTO> response =
+                  testRestTemplate.getForEntity(
+                      "http://localhost:" + managementPort + ASSIGNEE_ENDPOINT,
+                      UsageMetricDTO.class,
+                      parameters);
+              assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+              assertThat(response.getBody()).isEqualTo(expectedDto);
+            });
   }
 
   @Test

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/DatabaseTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/DatabaseTestExtension.java
@@ -27,17 +27,8 @@ public interface DatabaseTestExtension extends Extension {
 
   void processAllRecordsAndWait(TestCheck testCheck, Object... arguments);
 
-  void processAllRecordsAndWait(
-      TestCheck testCheck, Supplier<Object> supplier, Object... arguments);
-
-  void processRecordsWithTypeAndWait(
-      ImportValueType importValueType, TestCheck testCheck, Object... arguments);
-
   void processRecordsAndWaitFor(
-      Collection<RecordsReader> readers,
-      TestCheck testCheck,
-      Supplier<Object> supplier,
-      Object... arguments);
+      TestCheck testCheck, Supplier<Object> supplier, Object... arguments);
 
   boolean areIndicesCreatedAfterChecks(String indexPrefix, int minCountOfIndices, int maxChecks);
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchHelper.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchHelper.java
@@ -23,8 +23,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import org.elasticsearch.action.delete.DeleteRequest;
-import org.elasticsearch.action.get.GetRequest;
-import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.update.UpdateRequest;
@@ -72,10 +70,13 @@ public class ElasticsearchHelper implements NoSqlHelper {
   @Override
   public TaskEntity getTask(final String taskId) {
     try {
-      final GetRequest getRequest = new GetRequest(taskTemplate.getAlias()).id(taskId);
-      final GetResponse response = esClient.get(getRequest, RequestOptions.DEFAULT);
-      if (response.isExists()) {
-        return fromSearchHit(response.getSourceAsString(), objectMapper, TaskEntity.class);
+      final SearchRequest searchRequest =
+          new SearchRequest(taskTemplate.getAlias())
+              .source(new SearchSourceBuilder().query(termQuery(TaskTemplate.KEY, taskId)));
+      final SearchResponse response = esClient.search(searchRequest, RequestOptions.DEFAULT);
+      if (response.getHits().getHits().length == 1) {
+        return fromSearchHit(
+            response.getHits().getHits()[0].getSourceAsString(), objectMapper, TaskEntity.class);
       } else {
         throw new NotFoundApiException(
             String.format("Could not find  task for taskId [%s].", taskId));

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchTestExtension.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import org.elasticsearch.action.admin.indices.flush.FlushRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
@@ -93,16 +94,15 @@ public class ElasticsearchTestExtension
 
   @Override
   public void beforeEach(final ExtensionContext extensionContext) {
-    if (indexPrefix == null) {
-      indexPrefix = indexPrefixHolder.createNewIndexPrefix();
+    indexPrefix = tasklistProperties.getElasticsearch().getIndexPrefix();
+    if (indexPrefix == null || indexPrefix.isBlank()) {
+      indexPrefix =
+          Optional.ofNullable(indexPrefixHolder.createNewIndexPrefix()).orElse(indexPrefix);
+      tasklistProperties.getElasticsearch().setIndexPrefix(indexPrefix);
+      tasklistProperties.getZeebeElasticsearch().setPrefix(indexPrefix);
     }
-    tasklistProperties.getElasticsearch().setIndexPrefix(indexPrefix);
-    if (tasklistProperties.getElasticsearch().isCreateSchema()) {
-      elasticsearchSchemaManager.createSchema();
-      assertThat(areIndicesCreatedAfterChecks(indexPrefix, 4, 5 * 60 /*sec*/))
-          .describedAs("Elasticsearch %s (min %d) indices are created", indexPrefix, 5)
-          .isTrue();
-    }
+    /* Needed for the tasklist-user index */
+    elasticsearchSchemaManager.createSchema();
   }
 
   @Override
@@ -151,9 +151,12 @@ public class ElasticsearchTestExtension
   @Override
   public void refreshTasklistIndices() {
     try {
-      final RefreshRequest refreshRequest =
-          new RefreshRequest(tasklistProperties.getElasticsearch().getIndexPrefix() + "*");
-      esClient.indices().refresh(refreshRequest, RequestOptions.DEFAULT);
+
+      final FlushRequest flush =
+          new FlushRequest(tasklistProperties.getElasticsearch().getIndexPrefix() + "*");
+      esClient
+          .indices()
+          .flush(flush, RequestOptions.DEFAULT.toBuilder().addParameter("force", "true").build());
     } catch (final Exception t) {
       LOGGER.error("Could not refresh Tasklist Elasticsearch indices", t);
     }
@@ -184,41 +187,19 @@ public class ElasticsearchTestExtension
       final TestCheck testCheck,
       final Supplier<Object> supplier,
       final Object... arguments) {
-    long shouldImportCount = 0;
     int waitingRound = 0;
     final int maxRounds = 50;
     boolean found = testCheck.test(arguments);
     final long start = System.currentTimeMillis();
     while (!found && waitingRound < maxRounds) {
-      testImportListener.resetCounters();
-      shouldImportCount = 0;
       try {
         if (supplier != null) {
           supplier.get();
         }
         refreshIndexesInElasticsearch();
-        shouldImportCount += zeebeImporter.performOneRoundOfImportFor(readers);
       } catch (final Exception e) {
         LOGGER.error(e.getMessage(), e);
       }
-      long imported = testImportListener.getImported();
-      int waitForImports = 0;
-      // Wait for imports max 30 sec (60 * 500 ms)
-      while (shouldImportCount != 0 && imported < shouldImportCount && waitForImports < 60) {
-        waitForImports++;
-        try {
-          sleepFor(500);
-          shouldImportCount += zeebeImporter.performOneRoundOfImportFor(readers);
-        } catch (final Exception e) {
-          waitingRound = 0;
-          testImportListener.resetCounters();
-          shouldImportCount = 0;
-          LOGGER.error(e.getMessage(), e);
-        }
-        imported = testImportListener.getImported();
-        LOGGER.debug(" {} of {} records processed", imported, shouldImportCount);
-      }
-      refreshTasklistIndices();
       found = testCheck.test(arguments);
       if (!found) {
         sleepFor(500);
@@ -253,7 +234,8 @@ public class ElasticsearchTestExtension
         areCreated = areIndicesAreCreated(indexPrefix, minCountOfIndices);
       } catch (final Exception t) {
         LOGGER.error(
-            "Elasticsearch indices (min {}) are not created yet. Waiting {}/{}",
+            "Elasticsearch {} indices (min {}) are not created yet. Waiting {}/{}",
+            indexPrefix,
             minCountOfIndices,
             checks,
             maxChecks);

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchTestExtension.java
@@ -164,29 +164,12 @@ public class ElasticsearchTestExtension
 
   @Override
   public void processAllRecordsAndWait(final TestCheck testCheck, final Object... arguments) {
-    processRecordsAndWaitFor(
-        recordsReaderHolder.getAllRecordsReaders(), testCheck, null, arguments);
-  }
-
-  @Override
-  public void processAllRecordsAndWait(
-      final TestCheck testCheck, final Supplier<Object> supplier, final Object... arguments) {
-    processRecordsAndWaitFor(
-        recordsReaderHolder.getAllRecordsReaders(), testCheck, supplier, arguments);
-  }
-
-  @Override
-  public void processRecordsWithTypeAndWait(
-      final ImportValueType importValueType, final TestCheck testCheck, final Object... arguments) {
-    processRecordsAndWaitFor(getRecordsReaders(importValueType), testCheck, null, arguments);
+    processRecordsAndWaitFor(testCheck, null, arguments);
   }
 
   @Override
   public void processRecordsAndWaitFor(
-      final Collection<RecordsReader> readers,
-      final TestCheck testCheck,
-      final Supplier<Object> supplier,
-      final Object... arguments) {
+      final TestCheck testCheck, final Supplier<Object> supplier, final Object... arguments) {
     int waitingRound = 0;
     final int maxRounds = 50;
     boolean found = testCheck.test(arguments);

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchTestExtension.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -86,16 +87,15 @@ public class OpenSearchTestExtension
 
   @Override
   public void beforeEach(final ExtensionContext extensionContext) {
-    if (indexPrefix == null) {
-      indexPrefix = indexPrefixHolder.createNewIndexPrefix();
+    indexPrefix = tasklistProperties.getOpenSearch().getIndexPrefix();
+    if (indexPrefix.isBlank()) {
+      indexPrefix =
+          Optional.ofNullable(indexPrefixHolder.createNewIndexPrefix()).orElse(indexPrefix);
+      tasklistProperties.getOpenSearch().setIndexPrefix(indexPrefix);
+      tasklistProperties.getZeebeOpenSearch().setPrefix(indexPrefix);
     }
-    tasklistProperties.getOpenSearch().setIndexPrefix(indexPrefix);
-    if (tasklistProperties.getOpenSearch().isCreateSchema()) {
-      schemaManager.createSchema();
-      assertThat(areIndicesCreatedAfterChecks(indexPrefix, 4, 5 * 60 /*sec*/))
-          .describedAs("OpenSearch %s (min %d) indices are created", indexPrefix, 5)
-          .isTrue();
-    }
+    /* Needed for the tasklist-user index */
+    schemaManager.createSchema();
   }
 
   @Override
@@ -155,85 +155,7 @@ public class OpenSearchTestExtension
 
   @Override
   public void processAllRecordsAndWait(final TestCheck testCheck, final Object... arguments) {
-    processRecordsAndWaitFor(
-        recordsReaderHolder.getAllRecordsReaders(), testCheck, null, arguments);
-  }
-
-  @Override
-  public void processAllRecordsAndWait(
-      final TestCheck testCheck, final Supplier<Object> supplier, final Object... arguments) {
-    processRecordsAndWaitFor(
-        recordsReaderHolder.getAllRecordsReaders(), testCheck, supplier, arguments);
-  }
-
-  @Override
-  public void processRecordsWithTypeAndWait(
-      final ImportValueType importValueType, final TestCheck testCheck, final Object... arguments) {
-    processRecordsAndWaitFor(getRecordsReaders(importValueType), testCheck, null, arguments);
-  }
-
-  @Override
-  public void processRecordsAndWaitFor(
-      final Collection<RecordsReader> readers,
-      final TestCheck testCheck,
-      final Supplier<Object> supplier,
-      final Object... arguments) {
-    long shouldImportCount = 0;
-    int waitingRound = 0;
-    final int maxRounds = 50;
-    boolean found = testCheck.test(arguments);
-    final long start = System.currentTimeMillis();
-    while (!found && waitingRound < maxRounds) {
-      testImportListener.resetCounters();
-      shouldImportCount = 0;
-      try {
-        if (supplier != null) {
-          supplier.get();
-        }
-        refreshIndexesInElasticsearch();
-        shouldImportCount += zeebeImporter.performOneRoundOfImportFor(readers);
-      } catch (final Exception e) {
-        LOGGER.error(e.getMessage(), e);
-      }
-      long imported = testImportListener.getImported();
-      int waitForImports = 0;
-      // Wait for imports max 30 sec (60 * 500 ms)
-      while (shouldImportCount != 0 && imported < shouldImportCount && waitForImports < 60) {
-        waitForImports++;
-        try {
-          sleepFor(500);
-          shouldImportCount += zeebeImporter.performOneRoundOfImportFor(readers);
-        } catch (final Exception e) {
-          waitingRound = 0;
-          testImportListener.resetCounters();
-          shouldImportCount = 0;
-          LOGGER.error(e.getMessage(), e);
-        }
-        imported = testImportListener.getImported();
-        LOGGER.debug(" {} of {} records processed", imported, shouldImportCount);
-      }
-      refreshTasklistIndices();
-      found = testCheck.test(arguments);
-      if (!found) {
-        sleepFor(500);
-        waitingRound++;
-      }
-    }
-    final long finishedTime = System.currentTimeMillis() - start;
-
-    if (found) {
-      LOGGER.debug(
-          "Condition {} was met in round {} ({} ms).",
-          testCheck.getName(),
-          waitingRound,
-          finishedTime);
-    } else {
-      LOGGER.error(
-          "Condition {} was not met after {} rounds ({} ms).",
-          testCheck.getName(),
-          waitingRound,
-          finishedTime);
-    }
+    processRecordsAndWaitFor(testCheck, null, arguments);
   }
 
   @Override
@@ -313,6 +235,45 @@ public class OpenSearchTestExtension
                                                     .collect(Collectors.toList())))))
                 .build())
         .deleted();
+  }
+
+  @Override
+  public void processRecordsAndWaitFor(
+      final TestCheck testCheck, final Supplier<Object> supplier, final Object... arguments) {
+    int waitingRound = 0;
+    final int maxRounds = 50;
+    boolean found = testCheck.test(arguments);
+    final long start = System.currentTimeMillis();
+    while (!found && waitingRound < maxRounds) {
+      try {
+        if (supplier != null) {
+          supplier.get();
+        }
+        refreshIndexesInElasticsearch();
+      } catch (final Exception e) {
+        LOGGER.error(e.getMessage(), e);
+      }
+      found = testCheck.test(arguments);
+      if (!found) {
+        sleepFor(500);
+        waitingRound++;
+      }
+    }
+    final long finishedTime = System.currentTimeMillis() - start;
+
+    if (found) {
+      LOGGER.debug(
+          "Condition {} was met in round {} ({} ms).",
+          testCheck.getName(),
+          waitingRound,
+          finishedTime);
+    } else {
+      LOGGER.error(
+          "Condition {} was not met after {} rounds ({} ms).",
+          testCheck.getName(),
+          waitingRound,
+          finishedTime);
+    }
   }
 
   private boolean areIndicesAreCreated(final String indexPrefix, final int minCountOfIndices)

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchTestExtension.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch.core.DeleteByQueryRequest;
+import org.opensearch.client.opensearch.indices.FlushRequest;
 import org.opensearch.client.opensearch.indices.GetIndexResponse;
 import org.opensearch.client.opensearch.nodes.Stats;
 import org.slf4j.Logger;
@@ -145,11 +146,16 @@ public class OpenSearchTestExtension
   @Override
   public void refreshTasklistIndices() {
     try {
-      osClient
-          .indices()
-          .refresh(r -> r.index(tasklistProperties.getOpenSearch().getIndexPrefix() + "*"));
+
+      final FlushRequest flush =
+          FlushRequest.of(
+              builder ->
+                  builder
+                      .force(true)
+                      .index(tasklistProperties.getOpenSearch().getIndexPrefix() + "*"));
+      osClient.indices().flush(flush);
     } catch (final Exception t) {
-      LOGGER.error("Could not refresh Tasklist OpenSearch indices", t);
+      LOGGER.error("Could not refresh Tasklist Opensearch indices", t);
     }
   }
 
@@ -169,7 +175,8 @@ public class OpenSearchTestExtension
         areCreated = areIndicesAreCreated(indexPrefix, minCountOfIndices);
       } catch (final Exception t) {
         LOGGER.error(
-            "OpenSearch indices (min {}) are not created yet. Waiting {}/{}",
+            "OpenSearch {} indices (min {}) are not created yet. Waiting {}/{}",
+            indexPrefix,
             minCountOfIndices,
             checks,
             maxChecks);

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistTester.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistTester.java
@@ -21,6 +21,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.MigrationPlanBuilderImpl;
 import io.camunda.tasklist.qa.util.TestUtil;
 import io.camunda.tasklist.webapp.api.rest.v1.entities.TaskCompleteRequest;
+import io.camunda.tasklist.webapp.api.rest.v1.entities.TaskResponse;
 import io.camunda.tasklist.webapp.api.rest.v1.entities.TaskSearchRequest;
 import io.camunda.tasklist.webapp.api.rest.v1.entities.TaskSearchResponse;
 import io.camunda.tasklist.webapp.api.rest.v1.entities.VariableSearchResponse;
@@ -59,7 +60,7 @@ import org.springframework.web.context.WebApplicationContext;
 public class TasklistTester {
 
   private static final String REST_SEARCH_ENDPOINT = TasklistURIs.TASKS_URL_V1.concat("/search");
-  private static final String REST_GET_TASK = TasklistURIs.TASKS_URL_V1.concat("/search/{taskId}");
+  private static final String REST_GET_TASK = TasklistURIs.TASKS_URL_V1.concat("/{taskId}");
   private static final String REST_SEARCH_TASK_VARIABLES =
       TasklistURIs.TASKS_URL_V1.concat("/{taskId}/variables/search");
   private static final String REST_ASSIGN_ENDPOINT =
@@ -269,9 +270,9 @@ public class TasklistTester {
         result.getContentAsString(), new TypeReference<List<TaskSearchResponse>>() {});
   }
 
-  public TaskSearchResponse getTaskById(final String taskId) throws IOException {
-    final var result = mockMvcHelper.doRequest(get(REST_GET_TASK), taskId);
-    return objectMapper.readValue(result.getContentAsString(), TaskSearchResponse.class);
+  public TaskResponse getTaskById(final String taskId) throws IOException {
+    final var result = mockMvcHelper.doRequest(get(REST_GET_TASK, taskId));
+    return objectMapper.readValue(result.getContentAsString(), TaskResponse.class);
   }
 
   public List<VariableSearchResponse> getTaskVariables() throws IOException {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtension.java
@@ -10,7 +10,7 @@ package io.camunda.tasklist.util;
 import io.camunda.client.CamundaClient;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.qa.util.ContainerVersionsUtil;
-import io.camunda.tasklist.qa.util.TestUtil;
+import io.camunda.tasklist.qa.util.TasklistIndexPrefixHolder;
 import io.camunda.tasklist.webapp.security.TasklistProfileService;
 import io.zeebe.containers.ZeebeContainer;
 import java.net.URI;
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.Environment;
 import org.testcontainers.Testcontainers;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.utility.DockerImageName;
 
 public abstract class TasklistZeebeExtension
@@ -41,9 +42,8 @@ public abstract class TasklistZeebeExtension
   private static ContainerPoolManager<ZeebeContainer> zeebeContainerContainerPoolManager;
 
   @Autowired protected TasklistProperties tasklistProperties;
-
+  @Autowired protected TasklistIndexPrefixHolder indexPrefixHolder;
   protected ZeebeContainer zeebeContainer;
-
   protected boolean failed = false;
 
   private CamundaClient client;
@@ -97,12 +97,8 @@ public abstract class TasklistZeebeExtension
                   String.valueOf(tasklistProperties.getMultiTenancy().isEnabled()));
       zeebeContainer.start();
     } else {
-      // for "standard" zeebe configuration, use a container from the pool
-      if (zeebeContainerContainerPoolManager == null) {
-        zeebeContainerContainerPoolManager =
-            new ContainerPoolManager<>(3, this::createZeebeContainer, ZeebeContainer.class).init();
-      }
-      zeebeContainer = zeebeContainerContainerPoolManager.getContainer();
+      zeebeContainer = createZeebeContainer();
+      zeebeContainer.start();
     }
     prefix = zeebeContainer.getEnvMap().get(getZeebeExporterIndexPrefixConfigParameterName());
     LOGGER.info("Using Zeebe container with indexPrefix={}", prefix);
@@ -126,7 +122,7 @@ public abstract class TasklistZeebeExtension
     final String zeebeVersion =
         ContainerVersionsUtil.readProperty(
             ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME);
-    final String indexPrefix = TestUtil.createRandomString(10);
+    final String indexPrefix = indexPrefixHolder.getIndexPrefix();
     LOGGER.info(
         "************ Starting Zeebe:{}, indexPrefix={} ************", zeebeVersion, indexPrefix);
     final ZeebeContainer zContainer =
@@ -137,8 +133,13 @@ public abstract class TasklistZeebeExtension
             .withEnv("ATOMIX_LOG_LEVEL", "ERROR")
             .withEnv("ZEEBE_CLOCK_CONTROLLED", "true")
             .withEnv("ZEEBE_BROKER_CLUSTER_PARTITIONSCOUNT", "2")
-            .withEnv("ZEEBE_BROKER_GATEWAY_ENABLE", "true");
+            .withEnv("ZEEBE_BROKER_GATEWAY_ENABLE", "true")
+            .withEnv(
+                "JAVA_OPTS",
+                "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005");
+    zContainer.withLogConsumer(new Slf4jLogConsumer(LOGGER));
     zContainer.addExposedPort(8080);
+    zContainer.addExposedPort(5005);
     return zContainer;
   }
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionElasticSearch.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionElasticSearch.java
@@ -9,6 +9,7 @@ package io.camunda.tasklist.util;
 
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
 
+import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.tasklist.qa.util.TestUtil;
 import java.io.IOException;
 import java.time.Instant;
@@ -65,22 +66,22 @@ public class TasklistZeebeExtensionElasticSearch extends TasklistZeebeExtension 
 
   @Override
   protected String getZeebeExporterIndexPrefixConfigParameterName() {
-    return "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_PREFIX";
+    return "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_PREFIX";
   }
 
   @Override
   protected Map<String, String> getDatabaseEnvironmentVariables(final String indexPrefix) {
     return Map.of(
-        "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL",
+        "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_URL",
         "http://host.testcontainers.internal:9200",
-        "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_DELAY",
+        "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_TYPE",
+        ConnectionTypes.ELASTICSEARCH.name(),
+        "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_SIZE",
         "1",
-        "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_SIZE",
-        "1",
-        "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_PREFIX",
+        "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_PREFIX",
         indexPrefix,
-        "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME",
-        "io.camunda.zeebe.exporter.ElasticsearchExporter");
+        "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME",
+        "io.camunda.exporter.CamundaExporter");
   }
 
   @Override

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionOpenSearch.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionOpenSearch.java
@@ -9,6 +9,7 @@ package io.camunda.tasklist.util;
 
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
 
+import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.tasklist.qa.util.TestUtil;
 import java.io.IOException;
 import java.time.Instant;
@@ -59,22 +60,22 @@ public class TasklistZeebeExtensionOpenSearch extends TasklistZeebeExtension {
 
   @Override
   protected String getZeebeExporterIndexPrefixConfigParameterName() {
-    return "ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_PREFIX";
+    return "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_PREFIX";
   }
 
   @Override
   protected Map<String, String> getDatabaseEnvironmentVariables(final String indexPrefix) {
     return Map.of(
-        "ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_URL",
+        "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_URL",
         "http://host.testcontainers.internal:9205",
-        "ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_BULK_DELAY",
+        "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_TYPE",
+        ConnectionTypes.OPENSEARCH.name(),
+        "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_SIZE",
         "1",
-        "ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_BULK_SIZE",
-        "1",
-        "ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_PREFIX",
+        "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_PREFIX",
         indexPrefix,
-        "ZEEBE_BROKER_EXPORTERS_OPENSEARCH_CLASSNAME",
-        "io.camunda.zeebe.exporter.opensearch.OpensearchExporter");
+        "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME",
+        "io.camunda.exporter.CamundaExporter");
   }
 
   @Override

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
@@ -30,6 +30,7 @@ import io.camunda.tasklist.util.MockMvcHelper;
 import io.camunda.tasklist.util.TasklistTester;
 import io.camunda.tasklist.util.TasklistZeebeIntegrationTest;
 import io.camunda.tasklist.webapp.api.rest.v1.entities.*;
+import io.camunda.tasklist.webapp.api.rest.v1.entities.VariableSearchResponse.DraftSearchVariableValue;
 import io.camunda.tasklist.webapp.dto.TaskQueryDTO;
 import io.camunda.tasklist.webapp.dto.UserDTO;
 import io.camunda.tasklist.webapp.dto.VariableInputDTO;
@@ -175,8 +176,8 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
       // when
       final var result =
           mockMvcHelper.doRequest(
-              post(TasklistURIs.TASKS_URL_V1.concat("/search"))
-                  .param("state", TaskState.CREATED.name()));
+              post(TasklistURIs.TASKS_URL_V1.concat("/search")),
+              new TaskSearchRequest().setState(TaskState.CREATED));
 
       // then
       assertThat(result)
@@ -437,16 +438,12 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
                   "var_1",
                   null,
                   false,
-                  new VariableSearchResponse.DraftSearchVariableValue()
-                      .setValue("1")
-                      .setPreviewValue("1")),
+                  new DraftSearchVariableValue().setValue("1").setPreviewValue("1")),
               tuple(
                   "var_2",
                   "2",
                   false,
-                  new VariableSearchResponse.DraftSearchVariableValue()
-                      .setValue("222")
-                      .setPreviewValue("222")));
+                  new DraftSearchVariableValue().setValue("222").setPreviewValue("222")));
     }
 
     @Test
@@ -650,15 +647,13 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
                   "128",
                   "128",
                   false,
-                  new VariableSearchResponse.DraftSearchVariableValue()
-                      .setValue("998")
-                      .setPreviewValue("998")),
+                  new DraftSearchVariableValue().setValue("998").setPreviewValue("998")),
               tuple(
                   "var_long_draft_str",
                   null,
                   null,
                   false,
-                  new VariableSearchResponse.DraftSearchVariableValue()
+                  new DraftSearchVariableValue()
                       .setValue(null)
                       .setIsValueTruncated(true)
                       .setPreviewValue(longDraftVarValue.substring(0, variableSizeThreshold))),
@@ -673,7 +668,7 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
                   null,
                   null,
                   false,
-                  new VariableSearchResponse.DraftSearchVariableValue()
+                  new DraftSearchVariableValue()
                       .setValue("{\"propA\": 12}")
                       .setPreviewValue("{\"propA\": 12}")));
     }
@@ -1321,15 +1316,13 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
       final String taskId =
           tester
               .createAndDeploySimpleProcess(
-                  bpmnProcessId,
-                  flowNodeBpmnId,
-                  AbstractUserTaskBuilder::zeebeUserTask,
-                  task -> task.zeebeAssignee("demo"))
+                  bpmnProcessId, flowNodeBpmnId, AbstractUserTaskBuilder::zeebeUserTask)
               .processIsDeployed()
               .then()
               .startProcessInstance(bpmnProcessId)
               .then()
               .taskIsCreated(flowNodeBpmnId)
+              .claimHumanTask(flowNodeBpmnId)
               .getTaskId();
 
       final var saveVariablesRequest =

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
@@ -41,12 +41,14 @@ import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation
 import io.camunda.webapps.schema.entities.tasklist.TaskState;
 import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -985,6 +987,10 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
                 assertThat(task.getCompletionDate()).isNull();
                 assertThat(task.getImplementation()).isEqualTo(TaskImplementation.ZEEBE_USER_TASK);
               });
+
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(5))
+          .until(() -> tester.getTaskById(taskId).getAssignee() != null);
 
       final var resultUnassign =
           mockMvcHelper.doRequest(

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
@@ -41,14 +41,12 @@ import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation
 import io.camunda.webapps.schema.entities.tasklist.TaskState;
 import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -987,10 +985,6 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
                 assertThat(task.getCompletionDate()).isNull();
                 assertThat(task.getImplementation()).isEqualTo(TaskImplementation.ZEEBE_USER_TASK);
               });
-
-      Awaitility.await()
-          .atMost(Duration.ofSeconds(5))
-          .until(() -> tester.getTaskById(taskId).getAssignee() != null);
 
       final var resultUnassign =
           mockMvcHelper.doRequest(

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/se/SearchEngineUserDetailsServiceIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/se/SearchEngineUserDetailsServiceIT.java
@@ -22,9 +22,11 @@ import io.camunda.tasklist.util.TestApplication;
 import io.camunda.tasklist.webapp.security.WebSecurityConfig;
 import io.camunda.tasklist.webapp.security.oauth.OAuth2WebConfigurer;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -93,6 +95,10 @@ public class SearchEngineUserDetailsServiceIT extends TasklistIntegrationTest {
 
     // and
     updateUserRealName();
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(5))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(() -> userDetailsService.loadUserByUsername(TEST_USERNAME) != null);
 
     // then
     final UserDetails userDetails = userDetailsService.loadUserByUsername(TEST_USERNAME);

--- a/tasklist/qa/integration-tests/src/test/resources/log4j2.xml
+++ b/tasklist/qa/integration-tests/src/test/resources/log4j2.xml
@@ -11,9 +11,9 @@
   </Appenders>
   <Loggers>
     <Logger name="io.camunda.tasklist" level="debug" />
-    <Logger name="org.springframework" level="warn" />
+    <Logger name="org.springframework" level="info" />
 
-    <Root level="info">
+    <Root level="debug">
       <AppenderRef ref="Console"/>
     </Root>
   </Loggers>

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TasklistIndexPrefixHolder.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TasklistIndexPrefixHolder.java
@@ -15,7 +15,7 @@ public class TasklistIndexPrefixHolder {
   private String indexPrefix;
 
   public String createNewIndexPrefix() {
-    indexPrefix = TestUtil.createRandomString(10) + "-tasklist";
+    indexPrefix = TestUtil.createRandomString(10);
     return indexPrefix;
   }
 


### PR DESCRIPTION
## Description

Migrate the Tasklist IT to make use of the Camunda Exporter. Focus on ES support.

1. Camunda Exporter is enabled in the IT infrastructure (ES only), replacing the ES exporter
3. Prefixes have been adjusted
4. Clean ups of Test infrastructure has been done, to make it simpler and straightforward


## Related issues

relates to https://github.com/camunda/camunda/issues/25798
