### PR TITLE
test: migrate OS IT to exporter

### DIFF
--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
@@ -129,7 +129,7 @@ public class TaskStoreOpenSearch implements TaskStore {
             .fields(f -> f.field(TaskTemplate.KEY));
 
     try {
-      return OpenSearchUtil.scrollIdsToList(searchRequest, osClient);
+      return OpenSearchUtil.scrollUserTaskKeysToList(searchRequest, osClient);
     } catch (final IOException e) {
       throw new TasklistRuntimeException(e.getMessage(), e);
     }
@@ -581,8 +581,8 @@ public class TaskStoreOpenSearch implements TaskStore {
       followUpQ.range(
           r ->
               r.field(TaskTemplate.FOLLOW_UP_DATE)
-                  .from(JsonData.of(query.getFollowUpDate().getFrom()))
-                  .to(JsonData.of(query.getFollowUpDate().getTo())));
+                  .gte(JsonData.of(query.getFollowUpDate().getFrom()))
+                  .lte(JsonData.of(query.getFollowUpDate().getTo())));
     }
 
     Query.Builder dueDateQ = null;
@@ -591,8 +591,8 @@ public class TaskStoreOpenSearch implements TaskStore {
       dueDateQ.range(
           r ->
               r.field(TaskTemplate.DUE_DATE)
-                  .from(JsonData.of(query.getDueDate().getFrom()))
-                  .to(JsonData.of(query.getDueDate().getTo())));
+                  .gte(JsonData.of(query.getDueDate().getFrom()))
+                  .lte(JsonData.of(query.getDueDate().getTo())));
     }
 
     Query.Builder implementationQ = null;

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
@@ -60,6 +60,7 @@ import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.Time;
 import org.opensearch.client.opensearch._types.query_dsl.MatchAllQuery;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch._types.query_dsl.Query.Builder;
 import org.opensearch.client.opensearch.core.ScrollRequest;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
@@ -115,14 +116,16 @@ public class TaskStoreOpenSearch implements TaskStore {
 
   @Override
   public List<String> getTaskIdsByProcessInstanceId(final String processInstanceId) {
+    final Query.Builder flowNodeInstanceQuery = new Query.Builder();
+    flowNodeInstanceQuery.exists(t -> t.field(TaskTemplate.FLOW_NODE_INSTANCE_ID));
+
+    final Query.Builder processInstanceIdQuery = new Query.Builder();
+    processInstanceIdQuery.term(
+        t -> t.field(TaskTemplate.PROCESS_INSTANCE_ID).value(FieldValue.of(processInstanceId)));
+
     final SearchRequest.Builder searchRequest =
         OpenSearchUtil.createSearchRequest(taskTemplate)
-            .query(
-                q ->
-                    q.term(
-                        term ->
-                            term.field(TaskTemplate.PROCESS_INSTANCE_ID)
-                                .value(FieldValue.of(processInstanceId))))
+            .query(q -> joinQueryBuilderWithAnd(flowNodeInstanceQuery, processInstanceIdQuery))
             .fields(f -> f.field(TaskTemplate.KEY));
 
     try {
@@ -135,16 +138,17 @@ public class TaskStoreOpenSearch implements TaskStore {
   @Override
   public Map<String, String> getTaskIdsWithIndexByProcessDefinitionId(
       final String processDefinitionId) {
+    final Query.Builder flowNodeInstanceQuery = new Query.Builder();
+    flowNodeInstanceQuery.exists(t -> t.field(TaskTemplate.FLOW_NODE_INSTANCE_ID));
+
+    final Query.Builder processInstanceIdQuery = new Query.Builder();
+    processInstanceIdQuery.term(
+        t -> t.field(TaskTemplate.PROCESS_DEFINITION_ID).value(FieldValue.of(processDefinitionId)));
+
     final SearchRequest.Builder searchRequest =
         OpenSearchUtil.createSearchRequest(taskTemplate)
-            .query(
-                q ->
-                    q.term(
-                        term ->
-                            term.field(TaskTemplate.PROCESS_DEFINITION_ID)
-                                .value(FieldValue.of(processDefinitionId))))
+            .query(q -> joinQueryBuilderWithAnd(flowNodeInstanceQuery, processInstanceIdQuery))
             .fields(f -> f.field(TaskTemplate.KEY));
-
     try {
       return OpenSearchUtil.scrollIdsWithIndexToMap(searchRequest, osClient);
     } catch (final IOException e) {
@@ -481,10 +485,14 @@ public class TaskStoreOpenSearch implements TaskStore {
     }
 
     Query.Builder taskIdsQuery = null;
+    Query.Builder flowNodeInstanceExistsQuery = null;
     if (taskIds != null) {
       final var terms = taskIds.stream().map(FieldValue::of).toList();
       taskIdsQuery = new Query.Builder();
       taskIdsQuery.terms(t -> t.field(TaskTemplate.KEY).terms(v -> v.value(terms)));
+    } else {
+      flowNodeInstanceExistsQuery = new Builder();
+      flowNodeInstanceExistsQuery.exists(t -> t.field(TaskTemplate.FLOW_NODE_INSTANCE_ID));
     }
 
     Query.Builder taskDefinitionQ = null;
@@ -605,6 +613,7 @@ public class TaskStoreOpenSearch implements TaskStore {
             assigneeQ,
             assigneesQ,
             taskIdsQuery,
+            flowNodeInstanceExistsQuery,
             taskDefinitionQ,
             candidateGroupQ,
             candidateGroupsQ,

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchTestExtension.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.extension.TestExecutionExceptionHandler;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch.core.DeleteByQueryRequest;
+import org.opensearch.client.opensearch.indices.FlushRequest;
 import org.opensearch.client.opensearch.indices.GetIndexResponse;
 import org.opensearch.client.opensearch.nodes.Stats;
 import org.slf4j.Logger;
@@ -145,11 +146,16 @@ public class OpenSearchTestExtension
   @Override
   public void refreshTasklistIndices() {
     try {
-      osClient
-          .indices()
-          .refresh(r -> r.index(tasklistProperties.getOpenSearch().getIndexPrefix() + "*"));
+
+      final FlushRequest flush =
+          FlushRequest.of(
+              builder ->
+                  builder
+                      .force(true)
+                      .index(tasklistProperties.getOpenSearch().getIndexPrefix() + "*"));
+      osClient.indices().flush(flush);
     } catch (final Exception t) {
-      LOGGER.error("Could not refresh Tasklist OpenSearch indices", t);
+      LOGGER.error("Could not refresh Tasklist Opensearch indices", t);
     }
   }
 
@@ -169,7 +175,8 @@ public class OpenSearchTestExtension
         areCreated = areIndicesAreCreated(indexPrefix, minCountOfIndices);
       } catch (final Exception t) {
         LOGGER.error(
-            "OpenSearch indices (min {}) are not created yet. Waiting {}/{}",
+            "OpenSearch {} indices (min {}) are not created yet. Waiting {}/{}",
+            indexPrefix,
             minCountOfIndices,
             checks,
             maxChecks);

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistTester.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistTester.java
@@ -21,6 +21,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.MigrationPlanBuilderImpl;
 import io.camunda.tasklist.qa.util.TestUtil;
 import io.camunda.tasklist.webapp.api.rest.v1.entities.TaskCompleteRequest;
+import io.camunda.tasklist.webapp.api.rest.v1.entities.TaskResponse;
 import io.camunda.tasklist.webapp.api.rest.v1.entities.TaskSearchRequest;
 import io.camunda.tasklist.webapp.api.rest.v1.entities.TaskSearchResponse;
 import io.camunda.tasklist.webapp.api.rest.v1.entities.VariableSearchResponse;
@@ -59,7 +60,7 @@ import org.springframework.web.context.WebApplicationContext;
 public class TasklistTester {
 
   private static final String REST_SEARCH_ENDPOINT = TasklistURIs.TASKS_URL_V1.concat("/search");
-  private static final String REST_GET_TASK = TasklistURIs.TASKS_URL_V1.concat("/search/{taskId}");
+  private static final String REST_GET_TASK = TasklistURIs.TASKS_URL_V1.concat("/{taskId}");
   private static final String REST_SEARCH_TASK_VARIABLES =
       TasklistURIs.TASKS_URL_V1.concat("/{taskId}/variables/search");
   private static final String REST_ASSIGN_ENDPOINT =
@@ -269,9 +270,9 @@ public class TasklistTester {
         result.getContentAsString(), new TypeReference<List<TaskSearchResponse>>() {});
   }
 
-  public TaskSearchResponse getTaskById(final String taskId) throws IOException {
-    final var result = mockMvcHelper.doRequest(get(REST_GET_TASK), taskId);
-    return objectMapper.readValue(result.getContentAsString(), TaskSearchResponse.class);
+  public TaskResponse getTaskById(final String taskId) throws IOException {
+    final var result = mockMvcHelper.doRequest(get(REST_GET_TASK, taskId));
+    return objectMapper.readValue(result.getContentAsString(), TaskResponse.class);
   }
 
   public List<VariableSearchResponse> getTaskVariables() throws IOException {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionOpenSearch.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionOpenSearch.java
@@ -9,6 +9,7 @@ package io.camunda.tasklist.util;
 
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
 
+import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.tasklist.qa.util.TestUtil;
 import java.io.IOException;
 import java.time.Instant;
@@ -59,22 +60,22 @@ public class TasklistZeebeExtensionOpenSearch extends TasklistZeebeExtension {
 
   @Override
   protected String getZeebeExporterIndexPrefixConfigParameterName() {
-    return "ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_PREFIX";
+    return "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_PREFIX";
   }
 
   @Override
   protected Map<String, String> getDatabaseEnvironmentVariables(final String indexPrefix) {
     return Map.of(
-        "ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_URL",
+        "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_URL",
         "http://host.testcontainers.internal:9205",
-        "ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_BULK_DELAY",
+        "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_TYPE",
+        ConnectionTypes.OPENSEARCH.name(),
+        "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_SIZE",
         "1",
-        "ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_BULK_SIZE",
-        "1",
-        "ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_PREFIX",
+        "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_PREFIX",
         indexPrefix,
-        "ZEEBE_BROKER_EXPORTERS_OPENSEARCH_CLASSNAME",
-        "io.camunda.zeebe.exporter.opensearch.OpensearchExporter");
+        "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME",
+        "io.camunda.exporter.CamundaExporter");
   }
 
   @Override

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
@@ -41,12 +41,14 @@ import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation
 import io.camunda.webapps.schema.entities.tasklist.TaskState;
 import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -985,6 +987,10 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
                 assertThat(task.getCompletionDate()).isNull();
                 assertThat(task.getImplementation()).isEqualTo(TaskImplementation.ZEEBE_USER_TASK);
               });
+
+      Awaitility.await()
+          .atMost(Duration.ofSeconds(5))
+          .until(() -> tester.getTaskById(taskId).getAssignee() != null);
 
       final var resultUnassign =
           mockMvcHelper.doRequest(

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
@@ -41,14 +41,12 @@ import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation
 import io.camunda.webapps.schema.entities.tasklist.TaskState;
 import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
 import java.nio.charset.StandardCharsets;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -987,10 +985,6 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
                 assertThat(task.getCompletionDate()).isNull();
                 assertThat(task.getImplementation()).isEqualTo(TaskImplementation.ZEEBE_USER_TASK);
               });
-
-      Awaitility.await()
-          .atMost(Duration.ofSeconds(5))
-          .until(() -> tester.getTaskById(taskId).getAssignee() != null);
 
       final var resultUnassign =
           mockMvcHelper.doRequest(


### PR DESCRIPTION
## Description

Migrate the Tasklist IT to make use of the Camunda Exporter. Focus on OS support.

1. Camunda Exporter is enabled in the IT infrastructure (OS only), replacing the ES exporter
2. Prefixes have been adjusted
3. Clean ups of Test infrastructure has been done, to make it simpler and straightforward

<!-- Describe the goal and purpose of this PR. -->

## Related issues

relates to https://github.com/camunda/camunda/issues/25798
