### PR TITLE
fix 19883 bug on REST connection pooling

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/http/ApiEntityConsumer.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/ApiEntityConsumer.java
@@ -52,14 +52,14 @@ final class ApiEntityConsumer<T> extends AbstractBinAsyncEntityConsumer<ApiEntit
       Arrays.asList(ContentType.TEXT_XML);
   private final ObjectMapper json;
   private final Class<T> type;
-  private final int maxCapacity;
+  private final int chunkSize;
 
   private TypedApiEntityConsumer<T> entityConsumer;
 
-  ApiEntityConsumer(final ObjectMapper json, final Class<T> type, final int maxCapacity) {
+  ApiEntityConsumer(final ObjectMapper json, final Class<T> type, final int chunkSize) {
     this.json = json;
     this.type = type;
-    this.maxCapacity = maxCapacity;
+    this.chunkSize = chunkSize;
   }
 
   @Override
@@ -72,7 +72,7 @@ final class ApiEntityConsumer<T> extends AbstractBinAsyncEntityConsumer<ApiEntit
       final boolean isResponse =
           String.class.equals(type)
               && SUPPORTED_TEXT_CONTENT_TYPES.stream().anyMatch(t -> t.isSameMimeType(contentType));
-      entityConsumer = new RawApiEntityConsumer<>(isResponse, maxCapacity);
+      entityConsumer = new RawApiEntityConsumer<>(isResponse, chunkSize);
     }
   }
 
@@ -83,7 +83,7 @@ final class ApiEntityConsumer<T> extends AbstractBinAsyncEntityConsumer<ApiEntit
 
   @Override
   protected int capacityIncrement() {
-    return maxCapacity - entityConsumer.getBufferedBytes();
+    return chunkSize;
   }
 
   @Override

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -68,15 +68,19 @@ import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 public final class ResponseMapper {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ResponseMapper.class);
 
   /**
    * Date format <code>uuuu-MM-dd'T'HH:mm:ss.SSS[SSSSSS]Z</code>, always creating
@@ -115,17 +119,30 @@ public final class ResponseMapper {
     final Iterator<LongValue> jobKeys = activationResponse.brokerResponse().jobKeys().iterator();
     final Iterator<JobRecord> jobs = activationResponse.brokerResponse().jobs().iterator();
 
+    long currentResponseSize = 0L;
     final JobActivationResponse response = new JobActivationResponse();
+
+    final List<ActivatedJob> sizeExceedingJobs = new ArrayList<>();
+    final List<ActivatedJob> responseJobs = new ArrayList<>();
 
     while (jobKeys.hasNext() && jobs.hasNext()) {
       final LongValue jobKey = jobKeys.next();
       final JobRecord job = jobs.next();
       final ActivatedJob activatedJob = toActivatedJob(jobKey.getValue(), job);
 
-      response.addJobsItem(activatedJob);
+      // This is the message size of the message from the broker, not the size of the REST message
+      final int activatedJobSize = job.getLength();
+      if (currentResponseSize + activatedJobSize <= activationResponse.maxResponseSize()) {
+        responseJobs.add(activatedJob);
+        currentResponseSize += activatedJobSize;
+      } else {
+        sizeExceedingJobs.add(activatedJob);
+      }
     }
 
-    return new RestJobActivationResult(response);
+    response.setJobs(responseJobs);
+
+    return new RestJobActivationResult(response, sizeExceedingJobs);
   }
 
   private static ActivatedJob toActivatedJob(final long jobKey, final JobRecord job) {
@@ -448,9 +465,13 @@ public final class ResponseMapper {
   static class RestJobActivationResult implements JobActivationResult<JobActivationResponse> {
 
     private final JobActivationResponse response;
+    private final List<io.camunda.zeebe.gateway.protocol.rest.ActivatedJob> sizeExceedingJobs;
 
-    RestJobActivationResult(final JobActivationResponse response) {
+    RestJobActivationResult(
+        final JobActivationResponse response,
+        final List<io.camunda.zeebe.gateway.protocol.rest.ActivatedJob> sizeExceedingJobs) {
       this.response = response;
+      this.sizeExceedingJobs = sizeExceedingJobs;
     }
 
     @Override
@@ -472,7 +493,19 @@ public final class ResponseMapper {
 
     @Override
     public List<ActivatedJob> getJobsToDefer() {
-      return Collections.emptyList();
+      final var result = new ArrayList<ActivatedJob>(sizeExceedingJobs.size());
+      for (final var job : sizeExceedingJobs) {
+        try {
+          final var key = Long.parseLong(job.getJobKey());
+          result.add(new ActivatedJob(key, job.getRetries()));
+        } catch (final NumberFormatException ignored) {
+          // could happen
+          LOG.warn(
+              "Expected job key to be numeric, but was {}. The job cannot be returned to the broker, but it will be retried after timeout",
+              job.getJobKey());
+        }
+      }
+      return result;
     }
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/LongPollingActivateJobsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/LongPollingActivateJobsTest.java
@@ -65,10 +65,8 @@ public class LongPollingActivateJobsTest {
     assertThat(response.getJobs()).hasSize(activateJobs);
   }
 
-  // TODO: the REST use case is currently not working, see
-  // https://github.com/camunda/camunda/issues/19883
   @ParameterizedTest
-  @ValueSource(booleans = {false})
+  @ValueSource(booleans = {false, true})
   public void shouldActivateJobsIfBatchIsTruncated(final boolean useRest, final TestInfo testInfo) {
     // given
     final int availableJobs = 10;


### PR DESCRIPTION
## Description
- the HTTP client does not limit the amount of data it receives (we could still add a safety limit on top as a multiplier of the current capacity)
- The broker response size (in SBE) is used to bound the maximum amount of data sent to the rest client as it cannot be known before hand (and serializing it at that stage is wasteful)

> [!WARNING]
> shouldActivateJobForOpenRequest in the [LongPollingActivateJobsTest](https://github.com/camunda/camunda/blob/main/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/LongPollingActivateJobsTest.java)
It's still not passing, but I'm not sure how if it's related to the same issue?


## Related issues

relates #19883
