### PR TITLE
fix: use owner key and resource type as primary key for authorizations

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationHandler.java
@@ -18,8 +18,9 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue.Permissio
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class AuthorizationHandler
+public final class AuthorizationHandler
     implements ExportHandler<AuthorizationEntity, AuthorizationRecordValue> {
+
   private final String indexName;
 
   public AuthorizationHandler(final String indexName) {
@@ -43,7 +44,8 @@ public class AuthorizationHandler
 
   @Override
   public List<String> generateIds(final Record<AuthorizationRecordValue> record) {
-    return List.of(String.valueOf(record.getKey()));
+    return List.of(
+        "%s-%s".formatted(record.getValue().getOwnerKey(), record.getValue().getResourceType()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationHandlerTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+final class AuthorizationHandlerTest {
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-authorizations";
+  private final AuthorizationHandler underTest = new AuthorizationHandler(indexName);
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final var authorizationRecordValue = factory.generateObject(AuthorizationRecordValue.class);
+
+    final var authorizationRecord =
+        factory.<AuthorizationRecordValue>generateRecord(
+            ValueType.AUTHORIZATION, r -> r.withValue(authorizationRecordValue));
+
+    // when
+    final var idList = underTest.generateIds(authorizationRecord);
+
+    // then
+    assertThat(idList)
+        .containsExactly(
+            authorizationRecordValue.getOwnerKey()
+                + "-"
+                + authorizationRecordValue.getResourceType());
+  }
+}


### PR DESCRIPTION
This fixes a bug where the authorization record key was used for the document id of exported authorizations. This is incorrect as the record key can be arbitrary. Instead, we now use a composite of owner key and resource type which uniquely identifies the authorization. The engine uses the same composite key internally. This is also similar to the RDBMS exporter which uses owner key + owner type + resource type. Since owner key is unique across all owner types, we can safely omit this in the Camunda exporter.

Closes #26324