### PR TITLE
Feature/26334 rdbms metrics

### DIFF
--- a/db/rdbms/pom.xml
+++ b/db/rdbms/pom.xml
@@ -44,10 +44,19 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
     </dependency>
 
     <!-- test -->
@@ -78,10 +87,6 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
     </dependency>
   </dependencies>
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
@@ -18,18 +18,22 @@ public class RdbmsWriterFactory {
   private final SqlSessionFactory sqlSessionFactory;
   private final ExporterPositionMapper exporterPositionMapper;
   private final PurgeMapper purgeMapper;
+  private final RdbmsWriterMetrics metrics;
 
   public RdbmsWriterFactory(
       final SqlSessionFactory sqlSessionFactory,
       final ExporterPositionMapper exporterPositionMapper,
-      final PurgeMapper purgeMapper) {
+      final PurgeMapper purgeMapper,
+      final RdbmsWriterMetrics metrics) {
     this.sqlSessionFactory = sqlSessionFactory;
     this.exporterPositionMapper = exporterPositionMapper;
     this.purgeMapper = purgeMapper;
+    this.metrics = metrics;
   }
 
   public RdbmsWriter createWriter(final long partitionId, final int queueSize) {
-    final var executionQueue = new DefaultExecutionQueue(sqlSessionFactory, partitionId, queueSize);
+    final var executionQueue =
+        new DefaultExecutionQueue(sqlSessionFactory, partitionId, queueSize, metrics);
     return new RdbmsWriter(
         executionQueue,
         new ExporterPositionService(executionQueue, exporterPositionMapper),

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterMetrics.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterMetrics.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write;
+
+import io.camunda.db.rdbms.write.queue.ContextType;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.Timer.ResourceSample;
+import io.micrometer.core.instrument.Timer.Sample;
+import java.time.Duration;
+
+public class RdbmsWriterMetrics {
+
+  private static final String NAMESPACE = "zeebe.rdbms.exporter";
+
+  private final MeterRegistry meterRegistry;
+  private final Timer flushLatency;
+  private Sample flushLatencyMeasurement;
+
+  public RdbmsWriterMetrics(final MeterRegistry meterRegistry) {
+    this.meterRegistry = meterRegistry;
+
+    flushLatency =
+        Timer.builder(meterName("flush.latency"))
+            .description(
+                "Time of how long a export buffer is open and collects new records before flushing, meaning latency until the next flush is done.")
+            .publishPercentileHistogram()
+            .register(meterRegistry);
+  }
+
+  public ResourceSample measureFlushDuration() {
+    return Timer.resource(meterRegistry, meterName("flush.duration.seconds"))
+        .description("Flush duration of bulk exporters in seconds")
+        .publishPercentileHistogram()
+        .minimumExpectedValue(Duration.ofMillis(10));
+  }
+
+  public void recordBulkSize(final int bulkSize) {
+    DistributionSummary.builder(meterName("bulk.size"))
+        .description("Exporter bulk size")
+        .serviceLevelObjectives(1, 2, 5, 10, 20, 50, 100, 200, 500, 1_000, 2_000, 5_000, 10_000)
+        .register(meterRegistry)
+        .record(bulkSize);
+  }
+
+  public void recordFailedFlush() {
+    Counter.builder(meterName("failed.flush"))
+        .description("Number of failed flush operations")
+        .register(meterRegistry)
+        .increment();
+  }
+
+  public void recordMergedQueueItem(final ContextType contextType, final String statementId) {
+    Counter.builder(meterName("merged.queue.item"))
+        .tags("contextType", contextType.name(), "statementId", statementId)
+        .description("Queue item merged into another item")
+        .register(meterRegistry)
+        .increment();
+  }
+
+  public void recordEnqueuedStatement(final String statementId) {
+    Counter.builder(meterName("enqueued.statements"))
+        .tags("statementId", statementId)
+        .description("Number of enqueued statements")
+        .register(meterRegistry)
+        .increment();
+  }
+
+  public void recordExecutedStatement(final String statementId, final int batchCount) {
+    Counter.builder(meterName("executed.statements"))
+        .tags("statementId", statementId, "numBatches", String.valueOf(batchCount))
+        .description("Number of executed statements")
+        .register(meterRegistry)
+        .increment();
+
+    DistributionSummary.builder(meterName("num.batches"))
+        .tags("statementId", statementId)
+        .description("Exporter batch count")
+        .maximumExpectedValue(100.0)
+        .scale(100)
+        .serviceLevelObjectives(10, 50, 75, 85, 90, 95, 97, 98, 99, 100)
+        .register(meterRegistry)
+        .record(1.0 - 1.0 / batchCount);
+  }
+
+  public void startFlushLatencyMeasurement() {
+    flushLatencyMeasurement = Timer.start(meterRegistry);
+  }
+
+  public void stopFlushLatencyMeasurement() {
+    if (flushLatencyMeasurement != null) {
+      flushLatencyMeasurement.stop(flushLatency);
+    }
+  }
+
+  private String meterName(final String name) {
+    return NAMESPACE + "." + name;
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import io.camunda.db.rdbms.write.RdbmsWriterMetrics;
 import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
@@ -27,6 +28,7 @@ class DefaultExecutionQueueTest {
 
   private SqlSession session;
   private SqlSessionFactory sqlSessionFactory;
+  private RdbmsWriterMetrics metrics;
 
   private DefaultExecutionQueue executionQueue;
 
@@ -34,11 +36,12 @@ class DefaultExecutionQueueTest {
   public void beforeEach() {
     session = mock(SqlSession.class);
     sqlSessionFactory = mock(SqlSessionFactory.class);
+    metrics = mock(RdbmsWriterMetrics.class);
     when(sqlSessionFactory.openSession(
             ExecutorType.BATCH, TransactionIsolationLevel.READ_UNCOMMITTED))
         .thenReturn(session);
 
-    executionQueue = new DefaultExecutionQueue(sqlSessionFactory, 1, 5);
+    executionQueue = new DefaultExecutionQueue(sqlSessionFactory, 1, 5, metrics);
   }
 
   @Test
@@ -50,7 +53,7 @@ class DefaultExecutionQueueTest {
 
   @Test
   public void whenElementIsAddedNoFlushHappens() {
-    executionQueue = new DefaultExecutionQueue(sqlSessionFactory, 1, 0);
+    executionQueue = new DefaultExecutionQueue(sqlSessionFactory, 1, 0, metrics);
 
     executionQueue.executeInQueue(mock(QueueItem.class));
 

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -43,7 +43,9 @@ import io.camunda.db.rdbms.sql.UserMapper;
 import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.write.RdbmsWriterFactory;
+import io.camunda.db.rdbms.write.RdbmsWriterMetrics;
 import io.camunda.search.connect.configuration.DatabaseConfig;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -145,11 +147,17 @@ public class RdbmsConfiguration {
   }
 
   @Bean
+  public RdbmsWriterMetrics rdbmsExporterMetrics(final MeterRegistry meterRegistry) {
+    return new RdbmsWriterMetrics(meterRegistry);
+  }
+
+  @Bean
   public RdbmsWriterFactory rdbmsWriterFactory(
       final SqlSessionFactory sqlSessionFactory,
       final ExporterPositionMapper exporterPositionMapper,
-      final PurgeMapper purgeMapper) {
-    return new RdbmsWriterFactory(sqlSessionFactory, exporterPositionMapper, purgeMapper);
+      final PurgeMapper purgeMapper,
+      final RdbmsWriterMetrics metrics) {
+    return new RdbmsWriterFactory(sqlSessionFactory, exporterPositionMapper, purgeMapper, metrics);
   }
 
   @Bean

--- a/monitor/README.md
+++ b/monitor/README.md
@@ -24,6 +24,28 @@ namespace and pod label as `local` and `broker-*`.
 > will need to run either `docker-compose --project-directory ./ -f docker-compose.yml -f ../docker/compose/docker-compose.yaml down -v`
 > or `docker volume prune`
 
+### Testing with local Zeebe
+
+When you want to use a local Zeebe Broker, you need to locally modify the config:
+- enable Prometheus Docker container to access localhost ports:
+
+```yaml
+# add to the prometheus service
+extra_hosts:
+- "host.docker.internal:host-gateway"
+```
+
+- add the local Zeebe broker to Prometheus config:
+
+  ```yaml
+  # add to scrape_configs
+  - job_name: 'zeebe_local'
+    metrics_path: /actuator/prometheus
+    static_configs:
+         - targets: ['host.docker.internal:9600']
+
+  ```
+
 ### Grafana
 
 You can find [here](grafana/zeebe.json) a pre-built Grafana dashboard to

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -1,77 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__elements": {},
-  "__requires": [
-    {
-      "type": "panel",
-      "id": "bargauge",
-      "name": "Bar gauge",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "gauge",
-      "name": "Gauge",
-      "version": ""
-    },
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "10.4.0"
-    },
-    {
-      "type": "panel",
-      "id": "heatmap",
-      "name": "Heatmap",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "piechart",
-      "name": "Pie chart",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "stat",
-      "name": "Stat",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "state-timeline",
-      "name": "State timeline",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -99,6 +26,7 @@
         },
         "enable": true,
         "expr": "max(zeebe_cluster_changes_status{zeebe_cluster_changes_status=\"IN_PROGRESS\", namespace=~\"$namespace\", pod=~\"$pod\"}) > 0",
+        "hide": false,
         "iconColor": "light-blue",
         "name": "Scaling",
         "titleFormat": "Scaling"
@@ -110,6 +38,7 @@
         },
         "enable": true,
         "expr": "zeebe_flow_control_write_rate_maximum{namespace=~\"$namespace\", pod=~\"$pod\"} > zeebe_flow_control_write_rate_limit{namespace=~\"$namespace\", pod=~\"$pod\"}",
+        "hide": false,
         "iconColor": "orange",
         "name": "Throttling",
         "titleFormat": "Throttled write rate"
@@ -119,15 +48,11 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": null,
+  "id": 9,
   "links": [],
-  "liveNow": false,
   "panels": [
     {
       "collapsed": true,
-      "datasource": {
-        "uid": "${DS_PROMETHEUS}"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -187,8 +112,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red",
-                    "value": null
+                    "color": "red"
                   }
                 ]
               }
@@ -233,7 +157,7 @@
             "showHeader": true,
             "sortBy": []
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -296,8 +220,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -337,7 +260,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -406,8 +329,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -438,7 +360,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "9.5.2",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -484,8 +406,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -500,7 +421,7 @@
             "h": 2,
             "w": 9,
             "x": 8,
-            "y": 5
+            "y": 56
           },
           "id": 542,
           "options": {
@@ -520,7 +441,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -586,8 +507,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -603,7 +523,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 7
+            "y": 112
           },
           "id": 58,
           "options": {
@@ -619,7 +539,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -696,8 +616,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -713,7 +632,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 7
+            "y": 112
           },
           "id": 270,
           "options": {
@@ -729,7 +648,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -797,8 +716,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -814,7 +732,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 12
+            "y": 467
           },
           "id": 62,
           "options": {
@@ -829,7 +747,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -870,8 +788,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "red",
-                    "value": null
+                    "color": "red"
                   },
                   {
                     "color": "#EAB839",
@@ -891,7 +808,7 @@
             "h": 2,
             "w": 9,
             "x": 8,
-            "y": 12
+            "y": 467
           },
           "id": 232,
           "options": {
@@ -912,7 +829,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -980,8 +897,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -997,7 +913,7 @@
             "h": 6,
             "w": 7,
             "x": 17,
-            "y": 12
+            "y": 467
           },
           "id": 74,
           "options": {
@@ -1012,7 +928,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -1054,8 +970,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1071,7 +986,7 @@
             "h": 2,
             "w": 9,
             "x": 8,
-            "y": 14
+            "y": 469
           },
           "id": 118,
           "maxDataPoints": 100,
@@ -1092,7 +1007,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -1134,8 +1049,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1151,7 +1065,7 @@
             "h": 2,
             "w": 9,
             "x": 8,
-            "y": 16
+            "y": 471
           },
           "id": 117,
           "maxDataPoints": 100,
@@ -1172,7 +1086,7 @@
             "textMode": "auto",
             "wideLayout": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -1239,8 +1153,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "transparent",
-                    "value": null
+                    "color": "transparent"
                   },
                   {
                     "color": "red",
@@ -1256,7 +1169,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 18
+            "y": 500
           },
           "id": 39,
           "options": {
@@ -1271,7 +1184,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -1335,8 +1248,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1352,7 +1264,7 @@
             "h": 6,
             "w": 5,
             "x": 8,
-            "y": 18
+            "y": 500
           },
           "id": 190,
           "options": {
@@ -1380,7 +1292,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "9.5.2",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -1422,8 +1334,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "#EAB839",
@@ -1443,7 +1354,7 @@
             "h": 6,
             "w": 4,
             "x": 13,
-            "y": 18
+            "y": 500
           },
           "id": 612,
           "options": {
@@ -1461,7 +1372,7 @@
             "showThresholdMarkers": true,
             "sizing": "auto"
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -1529,8 +1440,7 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green",
-                    "value": null
+                    "color": "green"
                   },
                   {
                     "color": "red",
@@ -1589,7 +1499,7 @@
             "h": 6,
             "w": 7,
             "x": 17,
-            "y": 18
+            "y": 500
           },
           "id": 33,
           "options": {
@@ -1604,7 +1514,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -1706,9 +1616,9 @@
           },
           "gridPos": {
             "h": 11,
-            "w": 8,
+            "w": 24,
             "x": 0,
-            "y": 24
+            "y": 506
           },
           "id": 622,
           "maxPerRow": 3,
@@ -1749,22 +1659,11 @@
           "type": "state-timeline"
         }
       ],
-      "targets": [
-        {
-          "datasource": {
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "General Overview",
       "type": "row"
     },
     {
       "collapsed": true,
-      "datasource": {
-        "uid": "${DS_PROMETHEUS}"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -1841,7 +1740,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 57
+            "y": 1214
           },
           "id": 272,
           "options": {
@@ -1897,7 +1796,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 64
+            "y": 1221
           },
           "id": 418,
           "options": {
@@ -2015,7 +1914,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 64
+            "y": 1221
           },
           "id": 421,
           "options": {
@@ -2113,7 +2012,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 72
+            "y": 1229
           },
           "id": 192,
           "options": {
@@ -2226,7 +2125,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 72
+            "y": 1229
           },
           "id": 602,
           "options": {
@@ -2347,7 +2246,7 @@
             "h": 6,
             "w": 5,
             "x": 0,
-            "y": 80
+            "y": 1237
           },
           "id": 194,
           "options": {
@@ -2479,7 +2378,7 @@
             "h": 6,
             "w": 7,
             "x": 5,
-            "y": 80
+            "y": 1237
           },
           "id": 199,
           "options": {
@@ -2618,7 +2517,7 @@
             "h": 4,
             "w": 7,
             "x": 12,
-            "y": 80
+            "y": 1237
           },
           "id": 196,
           "options": {
@@ -2757,7 +2656,7 @@
             "h": 4,
             "w": 5,
             "x": 19,
-            "y": 80
+            "y": 1237
           },
           "id": 200,
           "options": {
@@ -2896,7 +2795,7 @@
             "h": 8,
             "w": 5,
             "x": 12,
-            "y": 84
+            "y": 1241
           },
           "id": 198,
           "options": {
@@ -3035,7 +2934,7 @@
             "h": 8,
             "w": 7,
             "x": 17,
-            "y": 84
+            "y": 1241
           },
           "id": 268,
           "options": {
@@ -3138,7 +3037,7 @@
             "h": 6,
             "w": 5,
             "x": 0,
-            "y": 86
+            "y": 1243
           },
           "id": 189,
           "options": {
@@ -3272,7 +3171,7 @@
             "h": 6,
             "w": 7,
             "x": 5,
-            "y": 86
+            "y": 1243
           },
           "id": 201,
           "options": {
@@ -3395,7 +3294,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 92
+            "y": 1249
           },
           "id": 604,
           "interval": "1s",
@@ -3524,7 +3423,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 92
+            "y": 1249
           },
           "id": 605,
           "interval": "1s",
@@ -3643,7 +3542,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 98
+            "y": 1255
           },
           "id": 543,
           "options": {
@@ -3737,7 +3636,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 104
+            "y": 1261
           },
           "id": 561,
           "options": {
@@ -3835,7 +3734,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 104
+            "y": 1261
           },
           "id": 594,
           "options": {
@@ -3868,22 +3767,11 @@
           "type": "timeseries"
         }
       ],
-      "targets": [
-        {
-          "datasource": {
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Processing",
       "type": "row"
     },
     {
       "collapsed": true,
-      "datasource": {
-        "uid": "${DS_PROMETHEUS}"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -3902,6 +3790,7 @@
                 "mode": "thresholds"
               },
               "custom": {
+                "align": "auto",
                 "cellOptions": {
                   "type": "auto"
                 },
@@ -3950,9 +3839,8 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 67
+            "y": 3
           },
-          "hideTimeOverride": false,
           "id": 12,
           "options": {
             "cellHeight": "sm",
@@ -3966,7 +3854,7 @@
             },
             "showHeader": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -4002,6 +3890,7 @@
                 "mode": "thresholds"
               },
               "custom": {
+                "align": "auto",
                 "cellOptions": {
                   "type": "auto"
                 },
@@ -4050,9 +3939,8 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 67
+            "y": 3
           },
-          "hideTimeOverride": false,
           "id": 13,
           "options": {
             "cellHeight": "sm",
@@ -4066,7 +3954,7 @@
             },
             "showHeader": true
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -4109,6 +3997,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -4156,7 +4045,7 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 72
+            "y": 147
           },
           "id": 2,
           "options": {
@@ -4171,7 +4060,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -4215,6 +4104,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -4263,7 +4153,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 72
+            "y": 147
           },
           "id": 3,
           "options": {
@@ -4278,7 +4168,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -4322,6 +4212,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -4370,7 +4261,7 @@
             "h": 6,
             "w": 9,
             "x": 0,
-            "y": 78
+            "y": 469
           },
           "id": 4,
           "options": {
@@ -4385,7 +4276,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -4420,6 +4311,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -4468,7 +4360,7 @@
             "h": 6,
             "w": 7,
             "x": 9,
-            "y": 78
+            "y": 469
           },
           "id": 266,
           "options": {
@@ -4483,7 +4375,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -4519,6 +4411,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -4567,7 +4460,7 @@
             "h": 6,
             "w": 8,
             "x": 16,
-            "y": 78
+            "y": 469
           },
           "id": 267,
           "options": {
@@ -4582,7 +4475,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -4619,6 +4512,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -4666,7 +4560,7 @@
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 84
+            "y": 502
           },
           "id": 290,
           "options": {
@@ -4681,7 +4575,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -4715,6 +4609,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -4762,7 +4657,7 @@
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 84
+            "y": 502
           },
           "id": 291,
           "options": {
@@ -4777,7 +4672,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -4811,6 +4706,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -4858,7 +4754,7 @@
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 84
+            "y": 502
           },
           "id": 288,
           "options": {
@@ -4873,7 +4769,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -4907,6 +4803,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -4954,7 +4851,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 84
+            "y": 502
           },
           "id": 289,
           "options": {
@@ -4969,7 +4866,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -4986,22 +4883,11 @@
           "type": "timeseries"
         }
       ],
-      "targets": [
-        {
-          "datasource": {
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Throughput",
       "type": "row"
     },
     {
       "collapsed": true,
-      "datasource": {
-        "uid": "${DS_PROMETHEUS}"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -5027,6 +4913,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -5074,7 +4961,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 68
+            "y": 4
           },
           "id": 102,
           "options": {
@@ -5089,7 +4976,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -5106,15 +4993,6 @@
           "type": "timeseries"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#b4ff00",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateOranges",
-            "exponent": 0.5,
-            "mode": "opacity"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "$DS_PROMETHEUS"
@@ -5139,15 +5017,9 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 68
+            "y": 4
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 112,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -5186,8 +5058,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -5204,20 +5075,7 @@
             }
           ],
           "title": "Snapshot Operation Duration",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
           "datasource": {
@@ -5236,6 +5094,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -5283,7 +5142,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 76
+            "y": 12
           },
           "id": 105,
           "options": {
@@ -5298,7 +5157,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -5314,15 +5173,6 @@
           "type": "timeseries"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#b4ff00",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "uid": "$DS_PROMETHEUS"
           },
@@ -5346,15 +5196,9 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 76
+            "y": 12
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 106,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -5393,8 +5237,7 @@
               "unit": "decmbytes"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -5408,20 +5251,7 @@
             }
           ],
           "title": "Snapshot Files Sizes (1m)",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "decmbytes",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
           "datasource": {
@@ -5440,6 +5270,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -5487,7 +5318,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 84
+            "y": 47
           },
           "id": 182,
           "options": {
@@ -5502,7 +5333,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -5519,22 +5350,11 @@
           "type": "timeseries"
         }
       ],
-      "targets": [
-        {
-          "datasource": {
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Snapshots",
       "type": "row"
     },
     {
       "collapsed": true,
-      "datasource": {
-        "uid": "${DS_PROMETHEUS}"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -5650,7 +5470,7 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 69
+            "y": 1226
           },
           "id": 261,
           "options": {
@@ -5769,7 +5589,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 76
+            "y": 1233
           },
           "id": 98,
           "options": {
@@ -5907,7 +5727,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 76
+            "y": 1233
           },
           "id": 35,
           "options": {
@@ -6012,7 +5832,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 84
+            "y": 1241
           },
           "id": 579,
           "options": {
@@ -6103,7 +5923,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 84
+            "y": 1241
           },
           "id": 580,
           "options": {
@@ -6198,7 +6018,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 92
+            "y": 1249
           },
           "id": 285,
           "options": {
@@ -6307,7 +6127,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 92
+            "y": 1249
           },
           "id": 286,
           "options": {
@@ -6354,22 +6174,11 @@
           "type": "timeseries"
         }
       ],
-      "targets": [
-        {
-          "datasource": {
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Memory",
       "type": "row"
     },
     {
       "collapsed": true,
-      "datasource": {
-        "uid": "${DS_PROMETHEUS}"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -6390,11 +6199,13 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -6441,7 +6252,7 @@
             "h": 9,
             "w": 24,
             "x": 0,
-            "y": 30
+            "y": 57
           },
           "id": 614,
           "options": {
@@ -6461,6 +6272,7 @@
               "sort": "none"
             }
           },
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -6489,11 +6301,13 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "opacity",
@@ -6541,7 +6355,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 39
+            "y": 66
           },
           "id": 64,
           "options": {
@@ -6561,7 +6375,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -6591,11 +6405,13 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "opacity",
@@ -6643,7 +6459,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 39
+            "y": 66
           },
           "id": 294,
           "options": {
@@ -6658,7 +6474,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -6713,22 +6529,11 @@
           "type": "timeseries"
         }
       ],
-      "targets": [
-        {
-          "datasource": {
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "CPU",
       "type": "row"
     },
     {
       "collapsed": true,
-      "datasource": {
-        "uid": "${DS_PROMETHEUS}"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -6754,6 +6559,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -6803,7 +6609,7 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 71
+            "y": 75
           },
           "id": 260,
           "options": {
@@ -6818,7 +6624,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -6849,6 +6655,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -6894,7 +6701,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 76
+            "y": 80
           },
           "id": 379,
           "options": {
@@ -6909,6 +6716,7 @@
               "sort": "desc"
             }
           },
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -6942,6 +6750,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -6987,7 +6796,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 76
+            "y": 80
           },
           "id": 381,
           "options": {
@@ -7002,6 +6811,7 @@
               "sort": "desc"
             }
           },
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -7035,6 +6845,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -7106,7 +6917,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 84
+            "y": 88
           },
           "id": 37,
           "options": {
@@ -7121,7 +6932,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -7165,6 +6976,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -7213,7 +7025,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 84
+            "y": 88
           },
           "id": 40,
           "options": {
@@ -7228,7 +7040,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -7263,6 +7075,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -7310,7 +7123,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 92
+            "y": 96
           },
           "id": 122,
           "options": {
@@ -7325,7 +7138,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "9.5.2",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -7361,6 +7174,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -7408,7 +7222,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 92
+            "y": 96
           },
           "id": 124,
           "options": {
@@ -7423,7 +7237,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "9.5.2",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -7506,7 +7320,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 100
+            "y": 104
           },
           "id": 126,
           "options": {
@@ -7604,7 +7418,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 100
+            "y": 104
           },
           "id": 127,
           "options": {
@@ -7638,14 +7452,6 @@
           "type": "timeseries"
         }
       ],
-      "targets": [
-        {
-          "datasource": {
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "IO",
       "type": "row"
     },
@@ -7660,15 +7466,6 @@
       "id": 337,
       "panels": [
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#ef843c",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "$DS_PROMETHEUS"
@@ -7693,15 +7490,9 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 72
+            "y": 113
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 339,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -7740,8 +7531,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -7771,31 +7561,9 @@
             }
           ],
           "title": " Request response latency",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#ef843c",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
@@ -7820,15 +7588,9 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 72
+            "y": 113
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 341,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -7867,8 +7629,7 @@
               "unit": "deckbytes"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -7897,20 +7658,7 @@
             }
           ],
           "title": "Request size distribution",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
           "datasource": {
@@ -7930,6 +7678,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -7976,7 +7725,7 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 80
+            "y": 121
           },
           "id": 343,
           "options": {
@@ -7991,7 +7740,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -8053,6 +7802,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -8099,7 +7849,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 80
+            "y": 121
           },
           "id": 345,
           "options": {
@@ -8114,7 +7864,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "9.2.5",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -8175,6 +7925,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -8220,7 +7971,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 90
+            "y": 131
           },
           "id": 347,
           "options": {
@@ -8235,6 +7986,7 @@
               "sort": "none"
             }
           },
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -8268,6 +8020,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -8313,7 +8066,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 90
+            "y": 131
           },
           "id": 349,
           "options": {
@@ -8328,6 +8081,7 @@
               "sort": "desc"
             }
           },
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -8361,6 +8115,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -8406,7 +8161,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 98
+            "y": 139
           },
           "id": 353,
           "options": {
@@ -8421,6 +8176,7 @@
               "sort": "none"
             }
           },
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -8455,6 +8211,7 @@
                 "axisPlacement": "auto",
                 "axisSoftMax": 0,
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -8500,7 +8257,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 98
+            "y": 139
           },
           "id": 351,
           "options": {
@@ -8515,6 +8272,7 @@
               "sort": "none"
             }
           },
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -8537,9 +8295,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "uid": "${DS_PROMETHEUS}"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -8549,15 +8304,6 @@
       "id": 46,
       "panels": [
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#ef843c",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "$DS_PROMETHEUS"
@@ -8582,15 +8328,9 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 17
+            "y": 148
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 132,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -8629,8 +8369,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -8663,20 +8402,7 @@
             }
           ],
           "title": "Process Instance Execution Time",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
           "datasource": {
@@ -8696,6 +8422,7 @@
                 "axisLabel": "seconds",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -8743,7 +8470,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 17
+            "y": 148
           },
           "id": 222,
           "options": {
@@ -8758,7 +8485,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -8816,15 +8543,6 @@
           "type": "timeseries"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#ef843c",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "$DS_PROMETHEUS"
@@ -8849,15 +8567,9 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 25
+            "y": 156
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 133,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -8896,8 +8608,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -8929,31 +8640,9 @@
             }
           ],
           "title": "Job Activation Time",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#ef843c",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
@@ -8978,15 +8667,9 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 25
+            "y": 156
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 135,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -9025,8 +8708,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -9057,31 +8739,9 @@
             }
           ],
           "title": "Job Life Time",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#ef843c",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "$DS_PROMETHEUS"
@@ -9106,15 +8766,9 @@
             "h": 7,
             "w": 24,
             "x": 0,
-            "y": 33
+            "y": 164
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 28,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -9153,8 +8807,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -9172,20 +8825,7 @@
             }
           ],
           "title": "Overall Processing Latency",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
           "datasource": {
@@ -9205,6 +8845,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -9250,7 +8891,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 40
+            "y": 171
           },
           "id": 593,
           "options": {
@@ -9265,7 +8906,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "9.5.2",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -9315,15 +8956,6 @@
           "type": "timeseries"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#ef843c",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "$DS_PROMETHEUS"
@@ -9348,15 +8980,9 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 50
+            "y": 181
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 233,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -9395,8 +9021,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -9414,31 +9039,9 @@
             }
           ],
           "title": "Record Processing Duration",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#ef843c",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "uid": "$DS_PROMETHEUS"
           },
@@ -9462,15 +9065,9 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 50
+            "y": 181
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 269,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -9509,8 +9106,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -9526,20 +9122,7 @@
             }
           ],
           "title": "Batch Event Replay Duration",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
           "datasource": {
@@ -9566,7 +9149,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 57
+            "y": 188
           },
           "id": 420,
           "options": {
@@ -9648,7 +9231,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 57
+            "y": 188
           },
           "id": 419,
           "options": {
@@ -9768,7 +9351,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 64
+            "y": 195
           },
           "id": 310,
           "options": {
@@ -9896,7 +9479,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 64
+            "y": 195
           },
           "id": 311,
           "options": {
@@ -9961,15 +9544,6 @@
           "type": "timeseries"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#ef843c",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "uid": "$DS_PROMETHEUS"
           },
@@ -9993,15 +9567,9 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 71
+            "y": 202
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 235,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -10041,7 +9609,6 @@
             }
           },
           "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
           "targets": [
             {
               "datasource": {
@@ -10057,31 +9624,9 @@
             }
           ],
           "title": "Commit latency",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#ef843c",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "uid": "$DS_PROMETHEUS"
           },
@@ -10105,15 +9650,9 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 71
+            "y": 202
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 234,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -10153,7 +9692,6 @@
             }
           },
           "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
           "targets": [
             {
               "datasource": {
@@ -10169,28 +9707,7 @@
             }
           ],
           "title": "Record write latency",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
-        }
-      ],
-      "targets": [
-        {
-          "datasource": {
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "refId": "A"
+          "type": "heatmap"
         }
       ],
       "title": "Latency",
@@ -10198,9 +9715,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "uid": "${DS_PROMETHEUS}"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -10273,7 +9787,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 74
+            "y": 1231
           },
           "id": 26,
           "options": {
@@ -10369,7 +9883,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 74
+            "y": 1231
           },
           "id": 27,
           "options": {
@@ -10413,15 +9927,6 @@
           "type": "timeseries"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#ef843c",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
@@ -10445,15 +9950,9 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 81
+            "y": 1238
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 22,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -10493,7 +9992,6 @@
             }
           },
           "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
           "targets": [
             {
               "datasource": {
@@ -10508,31 +10006,9 @@
             }
           ],
           "title": "Create Process Instance Latency (gRPC)",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#ef843c",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
@@ -10556,15 +10032,9 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 81
+            "y": 1238
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 23,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -10604,7 +10074,6 @@
             }
           },
           "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
           "targets": [
             {
               "datasource": {
@@ -10619,31 +10088,9 @@
             }
           ],
           "title": "Activate Jobs Latency (gRPC)",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#ef843c",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
@@ -10667,15 +10114,9 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 81
+            "y": 1238
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 24,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -10715,7 +10156,6 @@
             }
           },
           "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
           "targets": [
             {
               "datasource": {
@@ -10730,28 +10170,7 @@
             }
           ],
           "title": "Complete Job Latency (gRPC)",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
-        }
-      ],
-      "targets": [
-        {
-          "datasource": {
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "refId": "A"
+          "type": "heatmap"
         }
       ],
       "title": "gRPC",
@@ -10759,9 +10178,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "uid": "${DS_PROMETHEUS}"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -10771,15 +10187,6 @@
       "id": 162,
       "panels": [
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#b4ff00",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
@@ -10804,15 +10211,9 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 75
+            "y": 1232
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 164,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -10852,7 +10253,6 @@
             }
           },
           "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
           "targets": [
             {
               "datasource": {
@@ -10866,20 +10266,7 @@
             }
           ],
           "title": "Gateway Request Latency",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
           "datasource": {
@@ -10969,7 +10356,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 83
+            "y": 1240
           },
           "id": 166,
           "options": {
@@ -11087,7 +10474,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 83
+            "y": 1240
           },
           "id": 168,
           "options": {
@@ -11118,22 +10505,11 @@
           "type": "timeseries"
         }
       ],
-      "targets": [
-        {
-          "datasource": {
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Gateway",
       "type": "row"
     },
     {
       "collapsed": true,
-      "datasource": {
-        "uid": "${DS_PROMETHEUS}"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -11248,7 +10624,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 76
+            "y": 1233
           },
           "id": 278,
           "options": {
@@ -11387,7 +10763,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 76
+            "y": 1233
           },
           "id": 283,
           "options": {
@@ -11483,7 +10859,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 83
+            "y": 1240
           },
           "id": 373,
           "options": {
@@ -11580,7 +10956,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 91
+            "y": 1248
           },
           "id": 363,
           "options": {
@@ -11677,7 +11053,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 91
+            "y": 1248
           },
           "id": 406,
           "options": {
@@ -11774,7 +11150,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 98
+            "y": 1255
           },
           "id": 79,
           "options": {
@@ -11871,7 +11247,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 98
+            "y": 1255
           },
           "id": 114,
           "options": {
@@ -11902,15 +11278,6 @@
           "type": "timeseries"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#b4ff00",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
@@ -11934,15 +11301,9 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 105
+            "y": 1262
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 86,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -11982,7 +11343,6 @@
             }
           },
           "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
           "targets": [
             {
               "datasource": {
@@ -11997,20 +11357,7 @@
             }
           ],
           "title": "Append Entry Latency",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
           "datasource": {
@@ -12075,7 +11422,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 105
+            "y": 1262
           },
           "id": 305,
           "options": {
@@ -12118,15 +11465,6 @@
           "type": "timeseries"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#b4ff00",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "uid": "$DS_PROMETHEUS"
           },
@@ -12149,15 +11487,9 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 112
+            "y": 1269
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 70,
-          "legend": {
-            "show": true
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -12197,7 +11529,6 @@
             }
           },
           "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
           "targets": [
             {
               "datasource": {
@@ -12214,20 +11545,7 @@
             }
           ],
           "title": "Time Between Heartbeats",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
           "datasource": {
@@ -12313,7 +11631,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 112
+            "y": 1269
           },
           "id": 72,
           "options": {
@@ -12412,7 +11730,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 120
+            "y": 1277
           },
           "id": 432,
           "interval": "1s",
@@ -12554,7 +11872,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 120
+            "y": 1277
           },
           "id": 95,
           "interval": "1s",
@@ -12671,9 +11989,9 @@
           },
           "gridPos": {
             "h": 5,
-            "w": 6,
+            "w": 24,
             "x": 0,
-            "y": 128
+            "y": 1285
           },
           "id": 205,
           "options": {
@@ -12798,9 +12116,9 @@
           },
           "gridPos": {
             "h": 5,
-            "w": 6,
+            "w": 24,
             "x": 0,
-            "y": 193
+            "y": 1350
           },
           "id": 209,
           "options": {
@@ -12875,7 +12193,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 248
+            "y": 1405
           },
           "id": 396,
           "options": {
@@ -12895,7 +12213,6 @@
             "text": {}
           },
           "pluginVersion": "10.4.0",
-          "repeatDirection": "h",
           "targets": [
             {
               "datasource": {
@@ -12941,7 +12258,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 258
+            "y": 1415
           },
           "id": 215,
           "options": {
@@ -12979,14 +12296,6 @@
           "type": "gauge"
         }
       ],
-      "targets": [
-        {
-          "datasource": {
-            "uid": "$DS_PROMETHEUS"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Raft",
       "type": "row"
     },
@@ -13018,6 +12327,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -13065,7 +12375,7 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 77
+            "y": 554
           },
           "id": 180,
           "options": {
@@ -13080,7 +12390,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -13114,6 +12424,7 @@
                 "axisLabel": "Entries",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -13161,7 +12472,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 85
+            "y": 618
           },
           "id": 368,
           "options": {
@@ -13176,7 +12487,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -13211,6 +12522,7 @@
                 "axisLabel": "Entries",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -13258,7 +12570,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 85
+            "y": 618
           },
           "id": 411,
           "options": {
@@ -13273,7 +12585,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -13308,6 +12620,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -13354,7 +12667,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 92
+            "y": 625
           },
           "id": 300,
           "options": {
@@ -13369,7 +12682,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -13401,15 +12714,6 @@
           "type": "timeseries"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#b4ff00",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
@@ -13434,15 +12738,9 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 92
+            "y": 625
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 89,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -13481,8 +12779,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -13498,31 +12795,9 @@
             }
           ],
           "title": "Journal Flush Latency",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#b4ff00",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
@@ -13547,15 +12822,9 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 99
+            "y": 714
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 401,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -13594,8 +12863,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -13611,20 +12879,7 @@
             }
           ],
           "title": "Journal append latency",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
           "datasource": {
@@ -13644,6 +12899,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -13690,7 +12946,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 99
+            "y": 714
           },
           "id": 416,
           "options": {
@@ -13705,7 +12961,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -13761,15 +13017,6 @@
           "type": "timeseries"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#b4ff00",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "uid": "$DS_PROMETHEUS"
           },
@@ -13792,15 +13039,9 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 106
+            "y": 721
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 386,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -13839,8 +13080,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -13855,31 +13095,9 @@
             }
           ],
           "title": "Segment Creation Time",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#b4ff00",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "$DS_PROMETHEUS"
@@ -13904,15 +13122,9 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 106
+            "y": 721
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 81,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -13952,8 +13164,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -13970,31 +13181,9 @@
             }
           ],
           "title": "Segment Allocation Time",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#b4ff00",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "uid": "$DS_PROMETHEUS"
           },
@@ -14018,15 +13207,9 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 112
+            "y": 727
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 426,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -14065,8 +13248,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -14081,20 +13263,7 @@
             }
           ],
           "title": "Segment Flush Latency",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
           "datasource": {
@@ -14114,6 +13283,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -14160,7 +13330,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 112
+            "y": 727
           },
           "id": 427,
           "options": {
@@ -14175,7 +13345,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -14203,15 +13373,6 @@
           "type": "timeseries"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#b4ff00",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
@@ -14235,15 +13396,9 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 119
+            "y": 734
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 78,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -14282,8 +13437,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -14297,31 +13451,9 @@
             }
           ],
           "title": "Compacting time",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#b4ff00",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
@@ -14346,15 +13478,9 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 119
+            "y": 734
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 391,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -14393,8 +13519,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -14410,31 +13535,9 @@
             }
           ],
           "title": "Last Written Index Update",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#b4ff00",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
@@ -14459,15 +13562,9 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 125
+            "y": 740
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 559,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -14506,8 +13603,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -14523,20 +13619,7 @@
             }
           ],
           "title": "Segment Seek Latency",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
           "datasource": {
@@ -14556,6 +13639,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -14598,7 +13682,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 125
+            "y": 740
           },
           "id": 560,
           "options": {
@@ -14613,7 +13697,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -14663,6 +13747,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "opacity",
@@ -14707,7 +13792,7 @@
             "h": 6,
             "w": 24,
             "x": 0,
-            "y": 22
+            "y": 469
           },
           "id": 356,
           "options": {
@@ -14723,7 +13808,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -14743,15 +13828,6 @@
           "type": "timeseries"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#ef843c",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
@@ -14776,15 +13852,9 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 28
+            "y": 502
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 357,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -14822,8 +13892,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -14840,31 +13909,9 @@
             }
           ],
           "title": "Sequencer Batch Entry Count",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#ef843c",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
@@ -14889,15 +13936,9 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 28
+            "y": 502
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 358,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -14936,8 +13977,7 @@
               "unit": "kbytes"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -14954,20 +13994,7 @@
             }
           ],
           "title": "Sequencer Batch Size (KB)",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
           "datasource": {
@@ -14981,11 +14008,13 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -15030,7 +14059,7 @@
             "h": 9,
             "w": 8,
             "x": 0,
-            "y": 36
+            "y": 510
           },
           "id": 586,
           "options": {
@@ -15045,7 +14074,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "9.5.2",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -15076,11 +14105,13 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -15125,7 +14156,7 @@
             "h": 9,
             "w": 8,
             "x": 8,
-            "y": 36
+            "y": 510
           },
           "id": 589,
           "options": {
@@ -15140,7 +14171,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "9.5.2",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -15171,11 +14202,13 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -15220,7 +14253,7 @@
             "h": 9,
             "w": 8,
             "x": 16,
-            "y": 36
+            "y": 510
           },
           "id": 590,
           "options": {
@@ -15235,7 +14268,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "9.5.2",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -15265,11 +14298,13 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -15315,7 +14350,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 45
+            "y": 519
           },
           "id": 606,
           "options": {
@@ -15330,6 +14365,7 @@
               "sort": "none"
             }
           },
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -15362,11 +14398,13 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -15412,7 +14450,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 45
+            "y": 519
           },
           "id": 607,
           "options": {
@@ -15427,6 +14465,7 @@
               "sort": "none"
             }
           },
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -15473,11 +14512,13 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -15519,7 +14560,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 53
+            "y": 527
           },
           "id": 608,
           "options": {
@@ -15534,6 +14575,7 @@
               "sort": "desc"
             }
           },
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -15563,11 +14605,13 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -15609,7 +14653,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 53
+            "y": 527
           },
           "id": 609,
           "options": {
@@ -15624,6 +14668,7 @@
               "sort": "desc"
             }
           },
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -15653,11 +14698,13 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -15703,7 +14750,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 61
+            "y": 535
           },
           "id": 610,
           "options": {
@@ -15718,6 +14765,7 @@
               "sort": "desc"
             }
           },
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -15760,12 +14808,14 @@
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "axisSoftMin": 0,
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -15811,7 +14861,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 61
+            "y": 535
           },
           "id": 611,
           "options": {
@@ -15826,6 +14876,7 @@
               "sort": "desc"
             }
           },
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -15872,7 +14923,7 @@
             "h": 9,
             "w": 6,
             "x": 0,
-            "y": 69
+            "y": 543
           },
           "id": 588,
           "options": {
@@ -15894,7 +14945,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "9.5.2",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -15942,7 +14993,7 @@
             "h": 9,
             "w": 6,
             "x": 6,
-            "y": 69
+            "y": 543
           },
           "id": 591,
           "options": {
@@ -15964,7 +15015,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "9.5.2",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -16013,7 +15064,7 @@
             "h": 9,
             "w": 5,
             "x": 12,
-            "y": 69
+            "y": 543
           },
           "id": 592,
           "options": {
@@ -16035,7 +15086,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "9.5.2",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -16090,10 +15141,12 @@
             "h": 9,
             "w": 7,
             "x": 17,
-            "y": 69
+            "y": 543
           },
           "id": 613,
           "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
             "orientation": "auto",
             "reduceOptions": {
               "calcs": [
@@ -16103,9 +15156,10 @@
               "values": false
             },
             "showThresholdLabels": false,
-            "showThresholdMarkers": true
+            "showThresholdMarkers": true,
+            "sizing": "auto"
           },
-          "pluginVersion": "10.1.5",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -16130,9 +15184,6 @@
     },
     {
       "collapsed": true,
-      "datasource": {
-        "uid": "${DS_PROMETHEUS}"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -16207,7 +15258,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 79
+            "y": 1236
           },
           "id": 154,
           "options": {
@@ -16304,7 +15355,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 79
+            "y": 1236
           },
           "id": 144,
           "options": {
@@ -16400,7 +15451,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 85
+            "y": 1242
           },
           "id": 142,
           "options": {
@@ -16497,7 +15548,7 @@
             "h": 12,
             "w": 12,
             "x": 0,
-            "y": 91
+            "y": 1248
           },
           "id": 151,
           "options": {
@@ -16594,7 +15645,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 91
+            "y": 1248
           },
           "id": 152,
           "options": {
@@ -16691,7 +15742,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 97
+            "y": 1254
           },
           "id": 150,
           "options": {
@@ -16788,7 +15839,7 @@
             "h": 13,
             "w": 12,
             "x": 0,
-            "y": 103
+            "y": 1260
           },
           "id": 147,
           "options": {
@@ -16885,7 +15936,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 103
+            "y": 1260
           },
           "id": 149,
           "options": {
@@ -16981,7 +16032,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 110
+            "y": 1267
           },
           "id": 148,
           "options": {
@@ -17077,7 +16128,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 116
+            "y": 1273
           },
           "id": 155,
           "options": {
@@ -17173,7 +16224,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 116
+            "y": 1273
           },
           "id": 156,
           "options": {
@@ -17267,7 +16318,7 @@
             "h": 6,
             "w": 6,
             "x": 0,
-            "y": 124
+            "y": 1281
           },
           "id": 158,
           "options": {
@@ -17364,7 +16415,7 @@
             "h": 6,
             "w": 6,
             "x": 6,
-            "y": 124
+            "y": 1281
           },
           "id": 157,
           "options": {
@@ -17460,7 +16511,7 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 124
+            "y": 1281
           },
           "id": 146,
           "options": {
@@ -17556,7 +16607,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 130
+            "y": 1287
           },
           "id": 159,
           "options": {
@@ -17652,7 +16703,7 @@
             "h": 7,
             "w": 6,
             "x": 6,
-            "y": 130
+            "y": 1287
           },
           "id": 160,
           "options": {
@@ -17749,7 +16800,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 130
+            "y": 1287
           },
           "id": 153,
           "options": {
@@ -17848,7 +16899,7 @@
             "h": 11,
             "w": 24,
             "x": 0,
-            "y": 137
+            "y": 1294
           },
           "id": 603,
           "options": {
@@ -17885,22 +16936,11 @@
           "type": "timeseries"
         }
       ],
-      "targets": [
-        {
-          "datasource": {
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "RocksDB",
       "type": "row"
     },
     {
       "collapsed": true,
-      "datasource": {
-        "uid": "${DS_PROMETHEUS}"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -17910,15 +16950,6 @@
       "id": 50,
       "panels": [
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#ef843c",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
@@ -17942,15 +16973,9 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 24
+            "y": 1075
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 20,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -17989,8 +17014,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -18005,20 +17029,7 @@
             }
           ],
           "title": "Elasticsearch Exporter (Flush Duration)",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
           "datasource": {
@@ -18038,6 +17049,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -18085,7 +17097,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 24
+            "y": 1075
           },
           "id": 255,
           "options": {
@@ -18100,7 +17112,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -18117,15 +17129,6 @@
           "type": "timeseries"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#ef843c",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
@@ -18149,15 +17152,9 @@
             "h": 10,
             "w": 12,
             "x": 0,
-            "y": 34
+            "y": 1085
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 21,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -18196,8 +17193,7 @@
               "unit": "short"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -18212,20 +17208,7 @@
             }
           ],
           "title": "Elasticsearch Exporter (Bulk Size)",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "short",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
           "datasource": {
@@ -18244,6 +17227,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -18291,7 +17275,7 @@
             "h": 10,
             "w": 12,
             "x": 12,
-            "y": 34
+            "y": 1085
           },
           "id": 185,
           "options": {
@@ -18306,7 +17290,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -18340,6 +17324,7 @@
                 "axisLabel": "Disk Usage %",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -18393,7 +17378,7 @@
             "h": 10,
             "w": 24,
             "x": 0,
-            "y": 44
+            "y": 1095
           },
           "id": 52,
           "options": {
@@ -18413,7 +17398,7 @@
               "sort": "desc"
             }
           },
-          "pluginVersion": "10.1.5",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -18430,14 +17415,6 @@
           "type": "timeseries"
         }
       ],
-      "targets": [
-        {
-          "datasource": {
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Elasticsearch Exporter",
       "type": "row"
     },
@@ -18452,15 +17429,6 @@
       "id": 615,
       "panels": [
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#ef843c",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
@@ -18484,15 +17452,9 @@
             "h": 9,
             "w": 10,
             "x": 0,
-            "y": 25
+            "y": 17
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 616,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -18531,8 +17493,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -18549,20 +17510,7 @@
             }
           ],
           "title": "Camunda Exporter (Flush Duration)",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
           "datasource": {
@@ -18581,7 +17529,8 @@
                 "mode": "percentage",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -18597,7 +17546,7 @@
             "h": 9,
             "w": 3,
             "x": 10,
-            "y": 25
+            "y": 17
           },
           "id": 617,
           "options": {
@@ -18615,7 +17564,7 @@
             "showThresholdMarkers": true,
             "sizing": "auto"
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -18651,6 +17600,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -18683,7 +17633,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -18699,7 +17650,7 @@
             "h": 9,
             "w": 11,
             "x": 13,
-            "y": 25
+            "y": 17
           },
           "id": 621,
           "options": {
@@ -18714,7 +17665,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -18733,15 +17684,6 @@
           "type": "timeseries"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#ef843c",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
@@ -18765,15 +17707,9 @@
             "h": 5,
             "w": 24,
             "x": 0,
-            "y": 34
+            "y": 26
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 618,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -18812,8 +17748,7 @@
               "unit": "short"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -18830,20 +17765,7 @@
             }
           ],
           "title": "Camunda Exporter (Bulk Size)",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "short",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
           "datasource": {
@@ -18863,6 +17785,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -18893,7 +17816,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -18908,9 +17832,9 @@
             "h": 7,
             "w": 11,
             "x": 0,
-            "y": 39
+            "y": 31
           },
-          "id": 622,
+          "id": 628,
           "options": {
             "legend": {
               "calcs": [
@@ -18925,6 +17849,7 @@
               "sort": "desc"
             }
           },
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -18974,6 +17899,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -19004,7 +17930,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": null
                   },
                   {
                     "color": "red",
@@ -19019,7 +17946,7 @@
             "h": 7,
             "w": 13,
             "x": 11,
-            "y": 39
+            "y": 31
           },
           "id": 623,
           "options": {
@@ -19034,6 +17961,7 @@
               "sort": "none"
             }
           },
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -19076,7 +18004,7 @@
             "h": 6,
             "w": 11,
             "x": 0,
-            "y": 46
+            "y": 38
           },
           "id": 626,
           "options": {
@@ -19118,7 +18046,7 @@
               "reverse": false
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -19173,6 +18101,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -19218,7 +18147,7 @@
             "h": 6,
             "w": 13,
             "x": 11,
-            "y": 46
+            "y": 38
           },
           "id": 627,
           "options": {
@@ -19233,7 +18162,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -19271,15 +18200,541 @@
       "type": "row"
     },
     {
-      "collapsed": true,
-      "datasource": {
-        "uid": "${DS_PROMETHEUS}"
-      },
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 17
+      },
+      "id": 629,
+      "panels": [],
+      "title": "RDBMS Exporter",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 10,
+        "x": 0,
+        "y": 18
+      },
+      "id": 630,
+      "options": {
+        "calculate": false,
+        "calculation": {},
+        "cellGap": 2,
+        "cellValues": {},
+        "color": {
+          "exponent": 0.5,
+          "fill": "#ef843c",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 128
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": false
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "dtdurations"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(zeebe_rdbms_exporter_flush_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "interval": "30s",
+          "intervalFactor": 1,
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "RDBMS Exporter (Flush Duration)",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "How long an export request is open and collecting new records before flushing.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          },
+          "links": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 11,
+        "x": 10,
+        "y": 18
+      },
+      "id": 636,
+      "options": {
+        "calculate": true,
+        "calculation": {
+          "xBuckets": {
+            "mode": "size",
+            "value": "30s"
+          },
+          "yBuckets": {
+            "scale": {
+              "type": "linear"
+            },
+            "value": "0.01"
+          }
+        },
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 128
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "rate(zeebe_rdbms_exporter_flush_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) / rate(zeebe_rdbms_exporter_flush_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) > 0",
+          "interval": "1",
+          "legendFormat": "{{pod}} Exporter {{partition}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "RDBMS Exporter (Flush Latency)",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "The rate of failure of flush operations, averaged over 15s intervals",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 15
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 3,
+        "x": 21,
+        "y": 18
+      },
+      "id": 631,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "builder",
+          "exemplar": true,
+          "expr": "rate(zeebe_rdbms_exporter_failed_flush_total{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval]) / rate(zeebe_camunda_exporter_flush_duration_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])",
+          "interval": "",
+          "legendFormat": "{{pod}} Exporter {{partition}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "RDBMS Exporter (Flush Failure Rate)",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "type": "linear"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 10,
+        "x": 0,
+        "y": 27
+      },
+      "id": 633,
+      "options": {
+        "calculate": false,
+        "calculation": {},
+        "cellGap": 2,
+        "cellValues": {},
+        "color": {
+          "exponent": 0.5,
+          "fill": "#ef843c",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 128
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": false
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "mode": "single",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "short"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(zeebe_rdbms_exporter_bulk_size_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "interval": "30s",
+          "intervalFactor": 1,
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "RDBMS Exporter (Bulk Size)",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 9,
+        "x": 10,
+        "y": 27
+      },
+      "id": 634,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(zeebe_rdbms_exporter_enqueued_statements_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) / sum(increase(zeebe_rdbms_exporter_executed_statements_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval]))",
+          "format": "time_series",
+          "interval": "30s",
+          "intervalFactor": 1,
+          "legendFormat": "SQL Batch factor",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(increase(zeebe_rdbms_exporter_merged_queue_item_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) / sum(increase(zeebe_rdbms_exporter_enqueued_statements_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "30s",
+          "intervalFactor": 1,
+          "legendFormat": "QueueItem merge factor",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "RDBMS Exporter JDBC Statements Batch factor",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 5,
+        "x": 19,
+        "y": 27
+      },
+      "id": 635,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "pieType": "pie",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$DS_PROMETHEUS"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(zeebe_rdbms_exporter_executed_statements_total{cluster=~\"$cluster\", namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (statementId)",
+          "format": "time_series",
+          "interval": "30s",
+          "intervalFactor": 1,
+          "legendFormat": "{{le}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "RDBMS Exporter Statements",
+      "type": "piechart"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 37
       },
       "id": 176,
       "panels": [
@@ -19315,9 +18770,9 @@
           },
           "gridPos": {
             "h": 6,
-            "w": 8,
+            "w": 24,
             "x": 0,
-            "y": 47
+            "y": 630
           },
           "id": 170,
           "maxPerRow": 6,
@@ -19401,11 +18856,17 @@
             "h": 6,
             "w": 12,
             "x": 0,
-            "y": 53
+            "y": 642
           },
           "id": 174,
           "options": {
             "displayMode": "basic",
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
             "maxVizHeight": 300,
             "minVizHeight": 10,
             "minVizWidth": 0,
@@ -19423,7 +18884,7 @@
             "text": {},
             "valueMode": "color"
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -19471,11 +18932,17 @@
             "h": 6,
             "w": 12,
             "x": 12,
-            "y": 53
+            "y": 642
           },
           "id": 265,
           "options": {
             "displayMode": "basic",
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
             "maxVizHeight": 300,
             "minVizHeight": 10,
             "minVizWidth": 0,
@@ -19493,7 +18960,7 @@
             "text": {},
             "valueMode": "color"
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -19510,27 +18977,16 @@
           "type": "bargauge"
         }
       ],
-      "targets": [
-        {
-          "datasource": {
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Start up",
       "type": "row"
     },
     {
       "collapsed": true,
-      "datasource": {
-        "uid": "${DS_PROMETHEUS}"
-      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 18
+        "y": 38
       },
       "id": 315,
       "panels": [
@@ -19556,7 +19012,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 82
+            "y": 1239
           },
           "id": 329,
           "options": {
@@ -19622,7 +19078,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 82
+            "y": 1239
           },
           "id": 319,
           "options": {
@@ -19659,15 +19115,6 @@
           "type": "stat"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#b4ff00",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateOranges",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
@@ -19691,15 +19138,9 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 90
+            "y": 1247
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 323,
-          "legend": {
-            "show": false
-          },
           "maxDataPoints": 25,
           "options": {
             "calculate": false,
@@ -19740,7 +19181,6 @@
             }
           },
           "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
           "targets": [
             {
               "datasource": {
@@ -19756,20 +19196,7 @@
             }
           ],
           "title": "Status Query Latency",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "s",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
           "datasource": {
@@ -19802,7 +19229,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 90
+            "y": 1247
           },
           "id": 325,
           "options": {
@@ -19900,7 +19327,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 98
+            "y": 1255
           },
           "id": 313,
           "options": {
@@ -19959,7 +19386,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 98
+            "y": 1255
           },
           "id": 321,
           "options": {
@@ -20055,7 +19482,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 106
+            "y": 1263
           },
           "id": 335,
           "options": {
@@ -20113,7 +19540,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 106
+            "y": 1263
           },
           "id": 317,
           "options": {
@@ -20175,7 +19602,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 114
+            "y": 1271
           },
           "id": 327,
           "options": {
@@ -20212,14 +19639,6 @@
           "type": "stat"
         }
       ],
-      "targets": [
-        {
-          "datasource": {
-            "uid": "${DS_PROMETHEUS}"
-          },
-          "refId": "A"
-        }
-      ],
       "title": "Backups",
       "type": "row"
     },
@@ -20229,20 +19648,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 39
       },
       "id": 434,
       "panels": [
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#ef843c",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
@@ -20267,15 +19677,9 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 83
+            "y": 650
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 538,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -20314,8 +19718,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -20332,31 +19735,9 @@
             }
           ],
           "title": "Actor Task Execution Latency",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#ef843c",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
@@ -20381,15 +19762,9 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 83
+            "y": 650
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 540,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -20428,8 +19803,7 @@
               "unit": "dtdurations"
             }
           },
-          "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -20446,20 +19820,7 @@
             }
           ],
           "title": "Actor Job Scheduling Latency",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
           "datasource": {
@@ -20479,6 +19840,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -20526,7 +19888,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 91
+            "y": 674
           },
           "id": 444,
           "options": {
@@ -20541,7 +19903,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -20590,6 +19952,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -20636,7 +19999,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 91
+            "y": 674
           },
           "id": 446,
           "options": {
@@ -20651,7 +20014,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "9.3.6",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -20700,6 +20063,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -20745,7 +20109,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 99
+            "y": 682
           },
           "id": 440,
           "options": {
@@ -20760,6 +20124,7 @@
               "sort": "desc"
             }
           },
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -20794,6 +20159,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -20839,7 +20205,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 99
+            "y": 682
           },
           "id": 442,
           "options": {
@@ -20854,6 +20220,7 @@
               "sort": "desc"
             }
           },
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -20880,20 +20247,11 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 20
+        "y": 40
       },
       "id": 545,
       "panels": [
         {
-          "cards": {},
-          "color": {
-            "cardColor": "#ef843c",
-            "colorScale": "sqrt",
-            "colorScheme": "interpolateSpectral",
-            "exponent": 0.5,
-            "mode": "spectrum"
-          },
-          "dataFormat": "tsbuckets",
           "datasource": {
             "type": "prometheus",
             "uid": "${DS_PROMETHEUS}"
@@ -20918,15 +20276,9 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 84
+            "y": 1241
           },
-          "heatmap": {},
-          "hideZeroBuckets": true,
-          "highlightCards": true,
           "id": 547,
-          "legend": {
-            "show": false
-          },
           "options": {
             "calculate": false,
             "calculation": {},
@@ -20966,7 +20318,6 @@
             }
           },
           "pluginVersion": "10.4.0",
-          "reverseYBuckets": false,
           "targets": [
             {
               "datasource": {
@@ -20983,20 +20334,7 @@
             }
           ],
           "title": "Swim Probe Latency",
-          "tooltip": {
-            "show": true,
-            "showHistogram": false
-          },
-          "type": "heatmap",
-          "xAxis": {
-            "show": true
-          },
-          "yAxis": {
-            "format": "dtdurations",
-            "logBase": 1,
-            "show": true
-          },
-          "yBucketBound": "auto"
+          "type": "heatmap"
         },
         {
           "datasource": {
@@ -21061,7 +20399,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 84
+            "y": 1241
           },
           "id": 549,
           "options": {
@@ -21104,7 +20442,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 41
       },
       "id": 565,
       "panels": [
@@ -21173,7 +20511,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 85
+            "y": 1242
           },
           "id": 562,
           "options": {
@@ -21272,7 +20610,7 @@
             "h": 6,
             "w": 9,
             "x": 8,
-            "y": 85
+            "y": 1242
           },
           "id": 563,
           "options": {
@@ -21371,7 +20709,7 @@
             "h": 6,
             "w": 7,
             "x": 17,
-            "y": 85
+            "y": 1242
           },
           "id": 564,
           "options": {
@@ -21423,7 +20761,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 22
+        "y": 42
       },
       "id": 569,
       "panels": [
@@ -21445,6 +20783,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -21492,7 +20831,7 @@
             "h": 6,
             "w": 8,
             "x": 0,
-            "y": 86
+            "y": 635
           },
           "id": 566,
           "options": {
@@ -21507,7 +20846,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -21543,6 +20882,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -21590,7 +20930,7 @@
             "h": 6,
             "w": 8,
             "x": 8,
-            "y": 86
+            "y": 635
           },
           "id": 567,
           "options": {
@@ -21605,7 +20945,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -21641,6 +20981,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 10,
                 "gradientMode": "none",
@@ -21688,7 +21029,7 @@
             "h": 6,
             "w": 8,
             "x": 16,
-            "y": 86
+            "y": 635
           },
           "id": 568,
           "options": {
@@ -21703,7 +21044,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "10.4.0",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -21731,7 +21072,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 43
       },
       "id": 572,
       "panels": [
@@ -21818,7 +21159,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 87
+            "y": 1244
           },
           "id": 573,
           "options": {
@@ -21944,7 +21285,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 87
+            "y": 1244
           },
           "id": 574,
           "options": {
@@ -22058,7 +21399,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 95
+            "y": 1252
           },
           "id": 600,
           "options": {
@@ -22161,7 +21502,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 95
+            "y": 1252
           },
           "id": 601,
           "options": {
@@ -22257,7 +21598,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 103
+            "y": 1260
           },
           "id": 575,
           "options": {
@@ -22298,7 +21639,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 44
       },
       "id": 576,
       "panels": [
@@ -22320,6 +21661,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -22365,7 +21707,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 88
+            "y": 655
           },
           "id": 570,
           "options": {
@@ -22380,7 +21722,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "9.5.2",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -22425,6 +21767,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -22470,7 +21813,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 88
+            "y": 655
           },
           "id": 577,
           "options": {
@@ -22485,7 +21828,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "9.5.2",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -22529,6 +21872,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -22574,7 +21918,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 96
+            "y": 663
           },
           "id": 578,
           "options": {
@@ -22589,7 +21933,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "9.5.2",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -22624,6 +21968,7 @@
                 "axisLabel": "",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
+                "barWidthFactor": 0.6,
                 "drawStyle": "line",
                 "fillOpacity": 0,
                 "gradientMode": "none",
@@ -22669,7 +22014,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 96
+            "y": 663
           },
           "id": 571,
           "options": {
@@ -22684,7 +22029,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "9.5.2",
+          "pluginVersion": "11.4.0",
           "targets": [
             {
               "datasource": {
@@ -22711,7 +22056,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 45
       },
       "id": 581,
       "panels": [
@@ -22775,7 +22120,7 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 105
+            "y": 1262
           },
           "id": 582,
           "options": {
@@ -22866,7 +22211,7 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 105
+            "y": 1262
           },
           "id": 583,
           "options": {
@@ -22958,7 +22303,7 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 105
+            "y": 1262
           },
           "id": 584,
           "options": {
@@ -23000,7 +22345,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 46
       },
       "id": 595,
       "panels": [
@@ -23063,7 +22408,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 114
+            "y": 1271
           },
           "id": 596,
           "options": {
@@ -23160,7 +22505,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 114
+            "y": 1271
           },
           "id": 597,
           "options": {
@@ -23222,7 +22567,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 122
+            "y": 1279
           },
           "id": 598,
           "options": {
@@ -23347,7 +22692,7 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 122
+            "y": 1279
           },
           "id": 599,
           "options": {
@@ -23395,24 +22740,21 @@
       "type": "row"
     }
   ],
+  "preload": false,
   "refresh": "",
-  "schemaVersion": 39,
+  "schemaVersion": 40,
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {},
-        "hide": 0,
         "includeAll": false,
         "label": "datasource",
-        "multi": false,
         "name": "DS_PROMETHEUS",
         "options": [],
         "query": "prometheus",
-        "queryValue": "",
         "refresh": 1,
         "regex": "",
-        "skipUrlSync": false,
         "type": "datasource"
       },
       {
@@ -23424,9 +22766,7 @@
         },
         "definition": "label_values(atomix_role, cluster)",
         "description": "Kubernetes cluster",
-        "hide": 0,
         "includeAll": true,
-        "multi": false,
         "name": "cluster",
         "options": [],
         "query": {
@@ -23435,12 +22775,8 @@
         },
         "refresh": 2,
         "regex": "",
-        "skipUrlSync": false,
         "sort": 1,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "type": "query"
       },
       {
         "allValue": ".*",
@@ -23450,9 +22786,7 @@
           "uid": "${DS_PROMETHEUS}"
         },
         "definition": "label_values(atomix_role{cluster=~\"$cluster\"}, namespace)",
-        "hide": 0,
         "includeAll": true,
-        "multi": false,
         "name": "namespace",
         "options": [],
         "query": {
@@ -23461,12 +22795,8 @@
         },
         "refresh": 2,
         "regex": "",
-        "skipUrlSync": false,
         "sort": 1,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "type": "query"
       },
       {
         "allValue": ".*",
@@ -23476,7 +22806,6 @@
           "uid": "${DS_PROMETHEUS}"
         },
         "definition": "label_values(atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\"}, pod)",
-        "hide": 0,
         "includeAll": true,
         "multi": true,
         "name": "pod",
@@ -23487,12 +22816,8 @@
         },
         "refresh": 2,
         "regex": "",
-        "skipUrlSync": false,
         "sort": 1,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "type": "query"
       },
       {
         "allValue": ".*",
@@ -23502,7 +22827,6 @@
           "uid": "${DS_PROMETHEUS}"
         },
         "definition": "label_values(atomix_role{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\"}, partition)",
-        "hide": 0,
         "includeAll": true,
         "multi": true,
         "name": "partition",
@@ -23513,12 +22837,8 @@
         },
         "refresh": 2,
         "regex": "",
-        "skipUrlSync": false,
         "sort": 1,
-        "tagValuesQuery": "",
-        "tagsQuery": "",
-        "type": "query",
-        "useTags": false
+        "type": "query"
       }
     ]
   },
@@ -23535,22 +22855,11 @@
       "1h",
       "2h",
       "1d"
-    ],
-    "time_options": [
-      "5m",
-      "15m",
-      "1h",
-      "6h",
-      "12h",
-      "24h",
-      "2d",
-      "7d",
-      "30d"
     ]
   },
   "timezone": "",
   "title": "Zeebe",
   "uid": "zeebe-dashboard",
-  "version": 10,
+  "version": 1,
   "weekStart": ""
 }

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/util/RdbmsTestConfiguration.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/util/RdbmsTestConfiguration.java
@@ -8,7 +8,9 @@
 package io.camunda.it.rdbms.db.util;
 
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
+import io.micrometer.core.instrument.MeterRegistry;
 import javax.sql.DataSource;
+import org.mockito.Mockito;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,5 +26,10 @@ public class RdbmsTestConfiguration {
   @Bean
   public PlatformTransactionManager platformTransactionManager(final DataSource dataSource) {
     return new DataSourceTransactionManager(dataSource);
+  }
+
+  @Bean
+  public MeterRegistry meterRegistry() {
+    return Mockito.mock(MeterRegistry.class, Mockito.RETURNS_DEEP_STUBS);
   }
 }


### PR DESCRIPTION
## Description

Added RDBMS Metrics with prefix `zeebe.rdbms.exporter`:
- `flush.latency`: Max time an element waits in the queue before being flushed
- `flush.duration.seconds`: Duration of the flush execution
- `bulk.size`: Number of flushed elements in a flush execution
- `merged.queue.item`: Counter for when an updated was merged into an existing queueItem
- `enqueued.statements`: Counter for enqueued items
- `executed.statements`: Counter for actually executed SQL statements
- `num.batches`: Number of batched statements into a single SQL statement

![image](https://github.com/user-attachments/assets/78a02bcf-2e78-4eca-85f4-e48eac24f3d8)

## Related issues

closes #26334
