### PR TITLE
feat: return specific content type from the document content endpoint

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/http/DocumentDataConsumer.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/DocumentDataConsumer.java
@@ -83,12 +83,10 @@ public class DocumentDataConsumer<T>
         entityDetails != null ? ContentType.parse(entityDetails.getContentType()) : null;
     if (ContentType.APPLICATION_PROBLEM_JSON.isSameMimeType(contentType)) {
       problemDetail = true;
-    } else if (ContentType.APPLICATION_OCTET_STREAM.isSameMimeType(contentType)) {
+    } else {
       problemDetail = false;
       inputStream.setCapacityCallback(this);
       resultCallback.completed((ApiEntity<T>) ApiEntity.of(inputStream));
-    } else {
-      resultCallback.failed(new IOException("Unexpected content type: " + contentType));
     }
   }
 

--- a/document/api/src/main/java/io/camunda/document/api/DocumentContent.java
+++ b/document/api/src/main/java/io/camunda/document/api/DocumentContent.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.document.api;
+
+import java.io.InputStream;
+
+public record DocumentContent(InputStream inputStream, String contentType) {}

--- a/document/api/src/main/java/io/camunda/document/api/DocumentStore.java
+++ b/document/api/src/main/java/io/camunda/document/api/DocumentStore.java
@@ -8,7 +8,6 @@
 package io.camunda.document.api;
 
 import io.camunda.zeebe.util.Either;
-import java.io.InputStream;
 import java.util.concurrent.CompletableFuture;
 
 public interface DocumentStore {
@@ -16,7 +15,7 @@ public interface DocumentStore {
   CompletableFuture<Either<DocumentError, DocumentReference>> createDocument(
       DocumentCreationRequest request);
 
-  CompletableFuture<Either<DocumentError, InputStream>> getDocument(String documentId);
+  CompletableFuture<Either<DocumentError, DocumentContent>> getDocument(String documentId);
 
   CompletableFuture<Either<DocumentError, Void>> deleteDocument(String documentId);
 

--- a/document/store/src/main/java/io/camunda/document/store/inmemory/InMemoryDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/inmemory/InMemoryDocumentStore.java
@@ -50,6 +50,10 @@ public class InMemoryDocumentStore implements DocumentStore {
     final var fileName = Optional.ofNullable(request.metadata().fileName()).orElse(id);
     final var contentInputStream = request.contentInputStream();
     final byte[] content;
+    final var contentType =
+        Optional.ofNullable(request.metadata())
+            .map(DocumentMetadataModel::contentType)
+            .orElse(null);
     try {
       content = contentInputStream.readAllBytes();
       contentInputStream.close();
@@ -57,7 +61,7 @@ public class InMemoryDocumentStore implements DocumentStore {
       return CompletableFuture.completedFuture(
           Either.left(new DocumentError.InvalidInput("Failed to read content")));
     }
-    documents.put(id, new InMemoryDocumentContent(content, request.metadata().contentType()));
+    documents.put(id, new InMemoryDocumentContent(content, contentType));
     final var updatedMetadata =
         new DocumentMetadataModel(
             request.metadata().contentType(),

--- a/document/store/src/main/java/io/camunda/document/store/inmemory/InMemoryDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/inmemory/InMemoryDocumentStore.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.document.store.inmemory;
 
+import io.camunda.document.api.DocumentContent;
 import io.camunda.document.api.DocumentCreationRequest;
 import io.camunda.document.api.DocumentError;
 import io.camunda.document.api.DocumentError.OperationNotSupported;
@@ -17,7 +18,6 @@ import io.camunda.document.api.DocumentStore;
 import io.camunda.zeebe.util.Either;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -31,7 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class InMemoryDocumentStore implements DocumentStore {
 
-  private final Map<String, byte[]> documents;
+  private final Map<String, InMemoryDocumentContent> documents;
 
   public InMemoryDocumentStore() {
     documents = new ConcurrentHashMap<>();
@@ -57,7 +57,7 @@ public class InMemoryDocumentStore implements DocumentStore {
       return CompletableFuture.completedFuture(
           Either.left(new DocumentError.InvalidInput("Failed to read content")));
     }
-    documents.put(id, content);
+    documents.put(id, new InMemoryDocumentContent(content, request.metadata().contentType()));
     final var updatedMetadata =
         new DocumentMetadataModel(
             request.metadata().contentType(),
@@ -70,14 +70,16 @@ public class InMemoryDocumentStore implements DocumentStore {
   }
 
   @Override
-  public CompletableFuture<Either<DocumentError, InputStream>> getDocument(
+  public CompletableFuture<Either<DocumentError, DocumentContent>> getDocument(
       final String documentId) {
     final var content = documents.get(documentId);
     if (content == null) {
       return CompletableFuture.completedFuture(
           Either.left(new DocumentError.DocumentNotFound(documentId)));
     }
-    return CompletableFuture.completedFuture(Either.right(new ByteArrayInputStream(content)));
+    final var stream = new ByteArrayInputStream(content.content);
+    return CompletableFuture.completedFuture(
+        Either.right(new DocumentContent(stream, content.contentType)));
   }
 
   @Override
@@ -98,4 +100,6 @@ public class InMemoryDocumentStore implements DocumentStore {
             new OperationNotSupported(
                 "The in-memory document store does not support creating links")));
   }
+
+  private record InMemoryDocumentContent(byte[] content, String contentType) {}
 }

--- a/document/store/src/test/java/io/camunda/document/store/TestDocumentStoreProvider.java
+++ b/document/store/src/test/java/io/camunda/document/store/TestDocumentStoreProvider.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.document.store;
 
+import io.camunda.document.api.DocumentContent;
 import io.camunda.document.api.DocumentCreationRequest;
 import io.camunda.document.api.DocumentError;
 import io.camunda.document.api.DocumentLink;
@@ -15,7 +16,6 @@ import io.camunda.document.api.DocumentStore;
 import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
 import io.camunda.document.api.DocumentStoreProvider;
 import io.camunda.zeebe.util.Either;
-import java.io.InputStream;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 
@@ -42,7 +42,7 @@ public class TestDocumentStoreProvider implements DocumentStoreProvider {
     }
 
     @Override
-    public CompletableFuture<Either<DocumentError, InputStream>> getDocument(
+    public CompletableFuture<Either<DocumentError, DocumentContent>> getDocument(
         final String documentId) {
       throw new UnsupportedOperationException("Not implemented");
     }

--- a/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreTest.java
@@ -160,7 +160,7 @@ class AwsDocumentStoreTest {
     final var inputStream = new ByteArrayInputStream(new byte[0]);
     final var responseInputStream =
         new ResponseInputStream<>(GetObjectResponse.builder().build(), inputStream);
-    final var expectedResponse = new DocumentContent(inputStream, null);
+    final var expectedResponse = new DocumentContent(responseInputStream, null);
 
     when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(responseInputStream);
 

--- a/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreTest.java
@@ -160,6 +160,7 @@ class AwsDocumentStoreTest {
     final var inputStream = new ByteArrayInputStream(new byte[0]);
     final var responseInputStream =
         new ResponseInputStream<>(GetObjectResponse.builder().build(), inputStream);
+    final var expectedResponse = new DocumentContent(inputStream, null);
 
     when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(responseInputStream);
 
@@ -168,7 +169,7 @@ class AwsDocumentStoreTest {
 
     // then
     assertTrue(result.isRight());
-    assertEquals(responseInputStream, result.get());
+    assertEquals(expectedResponse, result.get());
   }
 
   @Test

--- a/document/store/src/test/java/io/camunda/document/store/gcp/GcpDocumentStoreTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/gcp/GcpDocumentStoreTest.java
@@ -16,6 +16,7 @@ import com.google.cloud.ReadChannel;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
+import io.camunda.document.api.DocumentContent;
 import io.camunda.document.api.DocumentCreationRequest;
 import io.camunda.document.api.DocumentError;
 import io.camunda.document.api.DocumentError.UnknownDocumentError;
@@ -27,7 +28,6 @@ import io.camunda.zeebe.util.Either.Left;
 import io.camunda.zeebe.util.Either.Right;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.time.OffsetDateTime;
@@ -153,7 +153,7 @@ public class GcpDocumentStoreTest {
     // then
     assertThat(documentOperationResponse).isNotNull();
     assertThat(documentOperationResponse).isInstanceOf(Left.class);
-    assertThat(((Left<DocumentError, InputStream>) documentOperationResponse).value())
+    assertThat(((Left<DocumentError, DocumentContent>) documentOperationResponse).value())
         .isInstanceOf(DocumentError.DocumentNotFound.class);
   }
 
@@ -171,7 +171,7 @@ public class GcpDocumentStoreTest {
     // then
     assertThat(documentOperationResponse).isNotNull();
     assertThat(documentOperationResponse).isInstanceOf(Left.class);
-    assertThat(((Left<DocumentError, InputStream>) documentOperationResponse).value())
+    assertThat(((Left<DocumentError, DocumentContent>) documentOperationResponse).value())
         .isInstanceOf(UnknownDocumentError.class);
   }
 
@@ -191,7 +191,8 @@ public class GcpDocumentStoreTest {
     // then
     assertThat(documentOperationResponse).isNotNull();
     assertThat(documentOperationResponse).isInstanceOf(Right.class);
-    assertThat(((Right<DocumentError, InputStream>) documentOperationResponse).value()).isNotNull();
+    assertThat(((Right<DocumentError, DocumentContent>) documentOperationResponse).value())
+        .isNotNull();
   }
 
   @Test

--- a/service/src/main/java/io/camunda/service/DocumentServices.java
+++ b/service/src/main/java/io/camunda/service/DocumentServices.java
@@ -90,11 +90,15 @@ public class DocumentServices extends ApiServices<DocumentServices> {
         .thenApply((ignoredRes) -> results);
   }
 
-  public InputStream getDocumentContent(final String documentId, final String storeId) {
+  public DocumentContentResponse getDocumentContent(final String documentId, final String storeId) {
 
     return getDocumentStore(storeId)
         .thenCompose(storeRecord -> storeRecord.instance().getDocument(documentId))
         .thenApply(this::requireRightOrThrow)
+        .thenApply(
+            documentContent ->
+                new DocumentContentResponse(
+                    documentContent.inputStream(), documentContent.contentType()))
         .join();
   }
 
@@ -165,6 +169,8 @@ public class DocumentServices extends ApiServices<DocumentServices> {
 
   public record DocumentReferenceResponse(
       String documentId, String storeId, DocumentMetadataModel metadata) {}
+
+  public record DocumentContentResponse(InputStream content, String contentType) {}
 
   public record DocumentLinkParams(Duration timeToLive) {}
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DocumentController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DocumentController.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.rest.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.service.DocumentServices;
+import io.camunda.service.DocumentServices.DocumentContentResponse;
 import io.camunda.service.DocumentServices.DocumentException;
 import io.camunda.service.DocumentServices.DocumentLinkParams;
 import io.camunda.zeebe.gateway.protocol.rest.DocumentLinkRequest;
@@ -22,6 +23,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.InvalidMediaTypeException;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -95,20 +97,17 @@ public class DocumentController {
         ResponseMapper::toDocumentReferenceBatch);
   }
 
-  @GetMapping(
-      path = "/{documentId}",
-      produces = {
-        MediaType.APPLICATION_OCTET_STREAM_VALUE,
-        MediaType.APPLICATION_PROBLEM_JSON_VALUE
-      })
+  @GetMapping(path = "/{documentId}") // produces arbitrary content type
   public ResponseEntity<StreamingResponseBody> getDocumentContent(
       @PathVariable final String documentId, @RequestParam(required = false) final String storeId) {
 
     try {
-      final InputStream contentInputStream = getDocumentContentStream(documentId, storeId);
-      return ResponseEntity.ok()
-          .contentType(MediaType.APPLICATION_OCTET_STREAM)
-          .body(contentInputStream::transferTo);
+      final DocumentContentResponse contentResponse =
+          getDocumentContentResponse(documentId, storeId);
+      final MediaType mediaType = resolveMediaType(contentResponse);
+      try (final InputStream contentInputStream = contentResponse.content()) {
+        return ResponseEntity.ok().contentType(mediaType).body(contentInputStream::transferTo);
+      }
     } catch (final Exception e) {
       // we can't return a generic Object type when streaming a response due to Spring MVC
       // limitations
@@ -117,6 +116,18 @@ public class DocumentController {
         throw new DocumentContentFetchException("Failed to get document content", ce.getCause());
       }
       throw new DocumentContentFetchException("Failed to get document content", e);
+    }
+  }
+
+  private MediaType resolveMediaType(final DocumentContentResponse contentResponse) {
+    try {
+      final var contentType = contentResponse.contentType();
+      if (contentType == null) {
+        return MediaType.APPLICATION_OCTET_STREAM;
+      }
+      return MediaType.parseMediaType(contentResponse.contentType());
+    } catch (final InvalidMediaTypeException e) {
+      return MediaType.APPLICATION_OCTET_STREAM;
     }
   }
 
@@ -132,7 +143,8 @@ public class DocumentController {
     }
   }
 
-  private InputStream getDocumentContentStream(final String documentId, final String storeId) {
+  private DocumentContentResponse getDocumentContentResponse(
+      final String documentId, final String storeId) {
     return documentServices
         .withAuthentication(RequestMapper.getAuthentication())
         .getDocumentContent(documentId, storeId);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.document.api.DocumentMetadataModel;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.DocumentServices;
+import io.camunda.service.DocumentServices.DocumentContentResponse;
 import io.camunda.service.DocumentServices.DocumentCreateRequest;
 import io.camunda.service.DocumentServices.DocumentReferenceResponse;
 import io.camunda.zeebe.gateway.protocol.rest.DocumentMetadata;
@@ -192,13 +193,14 @@ public class DocumentControllerTest extends RestControllerTest {
     final var content = new byte[] {1, 2, 3};
 
     when(documentServices.getDocumentContent("documentId", null))
-        .thenReturn(new ByteArrayInputStream(content));
+        .thenReturn(
+            new DocumentContentResponse(new ByteArrayInputStream(content), "application/pdf"));
 
     // when/then
     webClient
         .get()
         .uri(DOCUMENTS_BASE_URL + "/documentId")
-        .accept(MediaType.APPLICATION_OCTET_STREAM)
+        .accept(MediaType.APPLICATION_PDF)
         .exchange()
         .expectStatus()
         .isOk()
@@ -219,6 +221,26 @@ public class DocumentControllerTest extends RestControllerTest {
         .exchange()
         .expectStatus()
         .isNoContent();
+  }
+
+  @Test
+  void testNullContentTypeShouldReturnOctetStream() {
+    // given
+    final var content = new byte[] {1, 2, 3};
+
+    when(documentServices.getDocumentContent("documentId", null))
+        .thenReturn(new DocumentContentResponse(new ByteArrayInputStream(content), null));
+
+    // when/then
+    webClient
+        .get()
+        .uri(DOCUMENTS_BASE_URL + "/documentId")
+        .accept(MediaType.APPLICATION_OCTET_STREAM)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(byte[].class)
+        .isEqualTo(content);
   }
 
   // TODO: test error cases


### PR DESCRIPTION
## Description

This PR adds the functionality of keeping track of content type in every document store and allows returning the specific content type from the document content get endpoint, if it's present in the metadata.

**⚠️ This PR is part of the PR train that needs to follow a specific order when merging ⚠️**

@mo-okocha @marcosgvieira Please merge the PRs in this specific order to avoid merge conflicts:

- https://github.com/camunda/camunda/pull/26336
- https://github.com/camunda/camunda/pull/26340
- https://github.com/camunda/camunda/pull/26351

The branches of each PR are pointed towards the branch of the previous PR - please wait for the previous PR to be merged and make sure the target branch of the second PR is changed to main. Only after that you can merge the next PR.

**This PR goes first.**

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #26137 
