### PR TITLE
feat: classify some indices as non required that can be skipped if missing

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
@@ -284,6 +284,11 @@ public class BackupPriorityConfiguration {
     public String getFullQualifiedName() {
       return indexService.getOptimizeIndexNameWithVersion(index);
     }
+
+    @Override
+    public boolean required() {
+      return index.required();
+    }
   }
 
   /** Same reasoning as {@link OptimizePrio1Delegate} */
@@ -293,6 +298,11 @@ public class BackupPriorityConfiguration {
     @Override
     public String getFullQualifiedName() {
       return indexService.getOptimizeIndexNameWithVersion(index);
+    }
+
+    @Override
+    public boolean required() {
+      return index.required();
     }
   }
 }

--- a/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
@@ -146,27 +146,27 @@ class BackupPrioritiesTest {
 
     assertThat(indices.size()).isEqualTo(8);
     // PRIO 1
-    assertThat(indices.get(0).indices())
+    assertThat(indices.get(0).allIndices())
         .containsExactlyInAnyOrder(
             "operate-import-position-8.3.0_",
             "tasklist-import-position-8.2.0_",
             "optimize-position-based-import-index_v3",
             "optimize-timestamp-based-import-index_v5");
     // PRIO 2
-    assertThat(indices.get(1).indices())
+    assertThat(indices.get(1).allIndices())
         .containsExactlyInAnyOrder("operate-list-view-8.3.0_", "tasklist-task-8.5.0_");
     // PRIO 2 TEMPLATES
-    assertThat(indices.get(2).indices())
+    assertThat(indices.get(2).allIndices())
         .containsExactlyInAnyOrder(
             "operate-list-view-8.3.0_*",
             "-operate-list-view-8.3.0_",
             "tasklist-task-8.5.0_*",
             "-tasklist-task-8.5.0_");
     // PRIO 3
-    assertThat(indices.get(3).indices())
+    assertThat(indices.get(3).allIndices())
         .containsExactlyInAnyOrder("operate-batch-operation-1.0.0_", "operate-operation-8.4.1_");
     // PRIO 4
-    assertThat(indices.get(4).indices())
+    assertThat(indices.get(4).allIndices())
         .containsExactlyInAnyOrder(
             "operate-decision-8.3.0_",
             "operate-decision-instance-8.3.0_",
@@ -182,7 +182,7 @@ class BackupPrioritiesTest {
             "tasklist-task-variable-8.3.0_");
 
     // PRIO 4 TEMPLATES
-    assertThat(indices.get(5).indices())
+    assertThat(indices.get(5).allIndices())
         .containsExactlyInAnyOrder(
             "operate-event-8.3.0_*",
             "-operate-event-8.3.0_",
@@ -208,7 +208,7 @@ class BackupPrioritiesTest {
             "tasklist-task-variable-8.3.0_*");
 
     // PRIO 5
-    assertThat(indices.get(6).indices())
+    assertThat(indices.get(6).allIndices())
         .containsExactlyInAnyOrder(
             "operate-decision-requirements-8.3.0_",
             "operate-metric-8.3.0_",
@@ -224,7 +224,7 @@ class BackupPrioritiesTest {
             "camunda-user-8.7.0_");
 
     // PRIO6
-    assertThat(indices.get(7).indices())
+    assertThat(indices.get(7).allIndices())
         .containsExactlyInAnyOrder(
             "optimize-single-decision-report_v10",
             "optimize-process-overview_v2",
@@ -246,6 +246,13 @@ class BackupPrioritiesTest {
             "optimize-external-process-variable_v2-000001",
             "optimize-process-definition_v6",
             "optimize-alert_v4");
+
+    for (final var indexList : indices) {
+      assertThat(indexList.skippableIndices())
+          .allSatisfy(i -> assertThat(i).startsWith("optimize"));
+      assertThat(indexList.requiredIndices())
+          .allSatisfy(i -> assertThat(i).doesNotStartWith("optimize"));
+    }
   }
 
   @Test

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/DefaultIndexMappingCreator.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/DefaultIndexMappingCreator.java
@@ -36,6 +36,11 @@ public abstract class DefaultIndexMappingCreator<TBuilder>
       throws IOException;
 
   @Override
+  public boolean required() {
+    return false;
+  }
+
+  @Override
   public TypeMapping getSource() {
     TypeMapping source = null;
     try {

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/BackupRepository.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/BackupRepository.java
@@ -30,7 +30,17 @@ public interface BackupRepository {
   List<GetBackupStateResponseDto> getBackups(String repositoryName);
 
   void executeSnapshotting(
-      BackupService.SnapshotRequest snapshotRequest, Runnable onSuccess, Runnable onFailure);
+      BackupService.SnapshotRequest snapshotRequest,
+      boolean onlyRequired,
+      Runnable onSuccess,
+      Runnable onFailure);
+
+  default void executeSnapshotting(
+      final BackupService.SnapshotRequest snapshotRequest,
+      final Runnable onSuccess,
+      final Runnable onFailure) {
+    executeSnapshotting(snapshotRequest, false, onSuccess, onFailure);
+  }
 
   default boolean isIncompleteCheckTimedOut(
       final long incompleteCheckTimeoutInSeconds, final long lastSnapshotFinishedTime) {

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/BackupService.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/BackupService.java
@@ -24,5 +24,10 @@ public interface BackupService {
       String repositoryName,
       String snapshotName,
       SnapshotIndexCollection indices,
-      Metadata metadata) {}
+      Metadata metadata) {
+
+    public List<String> indices(final boolean onlyRequired) {
+      return onlyRequired ? indices().requiredIndices() : indices().allIndices();
+    }
+  }
 }

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/BackupServiceImpl.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/BackupServiceImpl.java
@@ -99,7 +99,8 @@ public class BackupServiceImpl implements BackupService {
       final String snapshotName = repository.snapshotNameProvider().getSnapshotName(metadata);
       // Add all the dynamic indices in the last step
       if (index == count) {
-        indexCollection = indexCollection.addIndices(dynamicIndicesProvider.getAllDynamicIndices());
+        indexCollection =
+            indexCollection.addSkippableIndices(dynamicIndicesProvider.getAllDynamicIndices());
       }
 
       final SnapshotRequest snapshotRequest =
@@ -120,7 +121,7 @@ public class BackupServiceImpl implements BackupService {
       threadPoolTaskExecutor.execute(
           () ->
               repository.executeSnapshotting(
-                  nextRequest, this::scheduleNextSnapshot, requestsQueue::clear));
+                  nextRequest, false, this::scheduleNextSnapshot, requestsQueue::clear));
       LOGGER.debug("Snapshot picked for execution: {}", nextRequest);
     }
   }

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/BackupServiceImplTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/BackupServiceImplTest.java
@@ -107,7 +107,7 @@ public class BackupServiceImplTest {
     assertThat(backupState.getBackupId()).isEqualTo(1L);
     assertThat(backupState.getState()).isEqualTo(BackupStateDto.COMPLETED);
     final var snapshotRequests = backupRepository.snapshotRequests.get(1L);
-    assertThat(snapshotRequests.stream().map(i -> i.indices().indices()))
+    assertThat(snapshotRequests.stream().map(i -> i.indices().allIndices()))
         .containsExactly(
             List.of("prio1"),
             List.of("prio2"),
@@ -180,7 +180,10 @@ public class BackupServiceImplTest {
 
     @Override
     public void executeSnapshotting(
-        final SnapshotRequest snapshotRequest, final Runnable onSuccess, final Runnable onFailure) {
+        final SnapshotRequest snapshotRequest,
+        final boolean onlyRequired,
+        final Runnable onSuccess,
+        final Runnable onFailure) {
       validateRepositoryExists(snapshotRequest.repositoryName());
       final var id = snapshotNameProvider.extractBackupId(snapshotRequest.snapshotName());
       final var backup = backups.getOrDefault(id, new GetBackupStateResponseDto(id));

--- a/webapps-schema/pom.xml
+++ b/webapps-schema/pom.xml
@@ -40,7 +40,21 @@
       <groupId>io.camunda</groupId>
       <artifactId>camunda-security-core</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/BackupPriorities.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/BackupPriorities.java
@@ -9,6 +9,7 @@ package io.camunda.webapps.schema.descriptors.backup;
 
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -40,8 +41,7 @@ public record BackupPriorities(
 
   private static <A extends BackupPriority> SnapshotIndexCollection fullQualifiedName(
       final Collection<A> backups) {
-    final var indices = backups.stream().map(BackupPriority::getFullQualifiedName).toList();
-    return new SnapshotIndexCollection(indices);
+    return SnapshotIndexCollection.of(backups);
   }
 
   private static <A extends BackupPriority> SnapshotIndexCollection fullQualifiedNameWithMatcher(
@@ -52,6 +52,6 @@ public record BackupPriorities(
             .map(BackupPriority::getFullQualifiedName)
             .flatMap(name -> Stream.of(name + "*", "-" + name))
             .toList();
-    return new SnapshotIndexCollection(indices);
+    return new SnapshotIndexCollection(indices, Collections.emptyList());
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/BackupPriority.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/BackupPriority.java
@@ -9,4 +9,13 @@ package io.camunda.webapps.schema.descriptors.backup;
 
 public interface BackupPriority {
   String getFullQualifiedName();
+
+  /**
+   * Some indices can be skipped if not found, such as optimize indices if optimize is not deployed
+   *
+   * @return if this index can be skipped if it's not created in the DB
+   */
+  default boolean required() {
+    return true;
+  }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/SnapshotIndexCollection.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/SnapshotIndexCollection.java
@@ -7,13 +7,37 @@
  */
 package io.camunda.webapps.schema.descriptors.backup;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public record SnapshotIndexCollection(List<String> indices) {
-  public SnapshotIndexCollection addIndices(final Collection<String> newIndices) {
+public record SnapshotIndexCollection(List<String> requiredIndices, List<String> skippableIndices) {
+
+  public static <A extends BackupPriority> SnapshotIndexCollection of(
+      final Collection<A> backupPriorities) {
+    final var required = new ArrayList<String>(backupPriorities.size());
+    final var skippable = new ArrayList<String>();
+    for (final var priority : backupPriorities) {
+      if (priority.required()) {
+        required.add(priority.getFullQualifiedName());
+      } else {
+        skippable.add(priority.getFullQualifiedName());
+      }
+    }
     return new SnapshotIndexCollection(
-        Stream.concat(indices.stream(), newIndices.stream()).toList());
+        Collections.unmodifiableList(required), Collections.unmodifiableList(skippable));
+  }
+
+  public SnapshotIndexCollection addSkippableIndices(final Collection<String> newIndices) {
+    return new SnapshotIndexCollection(
+        requiredIndices, Stream.concat(skippableIndices.stream(), newIndices.stream()).toList());
+  }
+
+  public List<String> allIndices() {
+    return Stream.concat(requiredIndices.stream(), skippableIndices.stream())
+        .collect(Collectors.toList());
   }
 }

--- a/webapps-schema/src/test/java/io/camunda/webapps/schema/descriptors/backup/SnapshotIndexCollectionTest.java
+++ b/webapps-schema/src/test/java/io/camunda/webapps/schema/descriptors/backup/SnapshotIndexCollectionTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.descriptors.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class SnapshotIndexCollectionTest {
+
+  @Test
+  public void shouldSplitBackupsOnRequired() {
+    final var collection =
+        SnapshotIndexCollection.of(
+            List.of(
+                new Backup("required-1", true),
+                new Backup("skippable-1", false),
+                new Backup("required-2", true)));
+
+    assertThat(collection.requiredIndices()).containsExactly("required-1", "required-2");
+    assertThat(collection.skippableIndices()).containsExactly("skippable-1");
+    assertThat(collection.allIndices()).containsExactly("required-1", "required-2", "skippable-1");
+  }
+
+  private record Backup(String name, boolean required) implements BackupPriority {
+    @Override
+    public String getFullQualifiedName() {
+      return name;
+    }
+  }
+}


### PR DESCRIPTION
## Description

Because optimize may not be deployed in all situations, its indices may not be present in ES/OS. If they are missing, the backup is retried without these indices.

The error type used is "index_not_found_exception:, I tested locally with opensearch by creating a snapshot of a non-existent index (named `missing`):
```
➜  curl localhost:9200/_snapshot/myrepo/mysnapshot -X PUT -d '{"indices": ["missing"]}' -H 'Content-Type:application/json'

{
  "error": {
    "root_cause": [
      {
        "type": "index_not_found_exception",
        "reason": "no such index [missing]",
        "index": "missing",
        "resource.id": "missing",
        "resource.type": "index_or_alias",
        "index_uuid": "_na_"
      }
    ],
    "type": "index_not_found_exception",
    "reason": "no such index [missing]",
    "index": "missing",
    "resource.id": "missing",
    "resource.type": "index_or_alias",
    "index_uuid": "_na_"
  },
  "status": 404
}

```


## Related issues

closes #26120
