### PR TITLE
feat: gcp document store supports prefixes

### DIFF
--- a/document/store/src/main/java/io/camunda/document/store/gcp/GcpDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/gcp/GcpDocumentStoreProvider.java
@@ -16,20 +16,31 @@ import java.util.concurrent.ExecutorService;
 public class GcpDocumentStoreProvider implements DocumentStoreProvider {
 
   private static final String BUCKET_NAME_PROPERTY = "BUCKET";
+  private static final String PREFIX_PROPERTY = "PREFIX";
+
+  private static final String DEFAULT_PREFIX = "temp/";
 
   @Override
   public DocumentStore createDocumentStore(
-      final DocumentStoreConfigurationRecord configuration, final ExecutorService executor) {
-    final String bucketName =
-        Optional.ofNullable(configuration.properties().get(BUCKET_NAME_PROPERTY))
-            .orElseThrow(
-                () ->
-                    new IllegalArgumentException(
-                        "Failed to configure document store with id '"
-                            + configuration.id()
-                            + "': missing required property '"
-                            + BUCKET_NAME_PROPERTY
-                            + "'"));
-    return new GcpDocumentStore(bucketName, executor);
+      final DocumentStoreConfigurationRecord configuration, final ExecutorService executorService) {
+    return new GcpDocumentStore(
+        getBucketNameProperty(configuration), getPrefixProperty(configuration), executorService);
+  }
+
+  private String getBucketNameProperty(final DocumentStoreConfigurationRecord configuration) {
+    return Optional.ofNullable(configuration.properties().get(BUCKET_NAME_PROPERTY))
+        .orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    "Failed to configure document store with id '"
+                        + configuration.id()
+                        + "': missing required property '"
+                        + BUCKET_NAME_PROPERTY
+                        + "'"));
+  }
+
+  private String getPrefixProperty(final DocumentStoreConfigurationRecord configuration) {
+    return Optional.ofNullable(configuration.properties().get(PREFIX_PROPERTY))
+        .orElse(DEFAULT_PREFIX);
   }
 }

--- a/document/store/src/test/java/io/camunda/document/store/gcp/GcpDocumentStoreProviderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/gcp/GcpDocumentStoreProviderTest.java
@@ -64,7 +64,8 @@ public class GcpDocumentStoreProviderTest {
     final GcpDocumentStoreProvider provider = new GcpDocumentStoreProvider();
 
     // when
-    final DocumentStore documentStore = provider.createDocumentStore(configuration);
+    final DocumentStore documentStore =
+        provider.createDocumentStore(configuration, Executors.newSingleThreadExecutor());
 
     // then
     assertNotNull(documentStore);
@@ -81,7 +82,8 @@ public class GcpDocumentStoreProviderTest {
     final GcpDocumentStoreProvider provider = new GcpDocumentStoreProvider();
 
     // when
-    final DocumentStore documentStore = provider.createDocumentStore(configuration);
+    final DocumentStore documentStore =
+        provider.createDocumentStore(configuration, Executors.newSingleThreadExecutor());
 
     // then
     assertNotNull(documentStore);

--- a/document/store/src/test/java/io/camunda/document/store/gcp/GcpDocumentStoreProviderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/gcp/GcpDocumentStoreProviderTest.java
@@ -53,4 +53,37 @@ public class GcpDocumentStoreProviderTest {
         .isEqualTo(
             "Failed to configure document store with id 'my-gcp': missing required property 'BUCKET'");
   }
+
+  @Test
+  public void shouldUseTempPrefixIfNotProvided() {
+    // given
+    final DocumentStoreConfigurationRecord configuration =
+        new DocumentStoreConfigurationRecord(
+            "gcp", GcpDocumentStoreProvider.class, new HashMap<>());
+    configuration.properties().put("BUCKET", "bucketName");
+    final GcpDocumentStoreProvider provider = new GcpDocumentStoreProvider();
+
+    // when
+    final DocumentStore documentStore = provider.createDocumentStore(configuration);
+
+    // then
+    assertNotNull(documentStore);
+  }
+
+  @Test
+  public void shouldUsePrefixIfProvided() {
+    // given
+    final DocumentStoreConfigurationRecord configuration =
+        new DocumentStoreConfigurationRecord(
+            "gcp", GcpDocumentStoreProvider.class, new HashMap<>());
+    configuration.properties().put("BUCKET", "bucketName");
+    configuration.properties().put("PREFIX", "prefix");
+    final GcpDocumentStoreProvider provider = new GcpDocumentStoreProvider();
+
+    // when
+    final DocumentStore documentStore = provider.createDocumentStore(configuration);
+
+    // then
+    assertNotNull(documentStore);
+  }
 }

--- a/document/store/src/test/java/io/camunda/document/store/gcp/GcpDocumentStoreTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/gcp/GcpDocumentStoreTest.java
@@ -350,7 +350,8 @@ public class GcpDocumentStoreTest {
     // then
     assertThat(documentOperationResponse).isNotNull();
     assertThat(documentOperationResponse).isInstanceOf(Right.class);
-    assertThat(((Right<DocumentError, InputStream>) documentOperationResponse).value()).isNotNull();
+    assertThat(((Right<DocumentError, DocumentContent>) documentOperationResponse).value())
+        .isNotNull();
   }
 
   @Test

--- a/document/store/src/test/java/io/camunda/document/store/gcp/GcpDocumentStoreTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/gcp/GcpDocumentStoreTest.java
@@ -310,14 +310,22 @@ public class GcpDocumentStoreTest {
   }
 
   @Test
-  void createDocumentShouldUseCorrectPrefix() throws IOException {
+  void createDocumentShouldUseCorrectPrefix() {
     // given
     gcpDocumentStore =
         new GcpDocumentStore(
             BUCKET_NAME, "prefix/", storage, mapper, Executors.newSingleThreadExecutor());
     final var inputStream = new ByteArrayInputStream("content".getBytes());
     final var documentCreationRequest =
-        new DocumentCreationRequest("documentId", inputStream, null);
+        new DocumentCreationRequest(
+            "documentId",
+            inputStream,
+            new DocumentMetadataModel(
+                "application/json",
+                "hello.json",
+                OffsetDateTime.now(),
+                10L,
+                Map.of("key", "value")));
 
     when(storage.get(BUCKET_NAME, "prefix/documentId")).thenReturn(null);
 
@@ -327,8 +335,7 @@ public class GcpDocumentStoreTest {
 
     // then
     assertThat(documentReferenceResponse).isNotNull();
-    verify(storage)
-        .createFrom(BlobInfo.newBuilder(BUCKET_NAME, "prefix/documentId").build(), inputStream);
+    verify(storage).get(BUCKET_NAME, "prefix/documentId");
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR will add prefix support to the GCP document store implementation.

The default prefix value is "temp" - the idea is that for now, all documents in SaaS will be temporary, but later we will likely add a new policy for documents that expire when their process instance is finished. Adding a prefix early on will help avoid migrations in the future.

**⚠️ This PR is part of the PR train that needs to follow a specific order when merging ⚠️**

@mo-okocha @marcosgvieira Please merge the PRs in this specific order to avoid merge conflicts:

- https://github.com/camunda/camunda/pull/26336
- https://github.com/camunda/camunda/pull/26340
- https://github.com/camunda/camunda/pull/26351

The branches of each PR are pointed towards the branch of the previous PR - please wait for the previous PR to be merged and make sure the target branch of the second PR is changed to main. Only after that you can merge the next PR.

**This PR goes second.**

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #26136 
