### PR TITLE
feat: support context path in identity client

### DIFF
--- a/identity/client/src/App.tsx
+++ b/identity/client/src/App.tsx
@@ -1,11 +1,11 @@
 import { FC, StrictMode } from "react";
 import { BrowserRouter } from "react-router-dom";
-import { baseUrl } from "./configuration";
+import { getBaseUrl } from "./configuration";
 import AppRoot from "./components/global/AppRoot";
 import GlobalRoutes from "src/components/global/GlobalRoutes";
 
 const App: FC = () => (
-  <BrowserRouter basename={baseUrl}>
+  <BrowserRouter basename={getBaseUrl()}>
     <StrictMode>
       <AppRoot>
         <GlobalRoutes />

--- a/identity/client/src/components/global/GlobalRoutes.tsx
+++ b/identity/client/src/components/global/GlobalRoutes.tsx
@@ -7,7 +7,7 @@
  */
 
 import { FC } from "react";
-import { Route, Routes as RouterRoutes } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 import { useGlobalRoutes } from "src/components/global/useGlobalRoutes";
 import Redirect from "src/components/router/Redirect";
 
@@ -16,13 +16,13 @@ const GlobalRoutes: FC = () => {
   const indexRoute = routes[0].key;
 
   return (
-    <RouterRoutes>
+    <Routes>
       <Route index element={<Redirect to={indexRoute} />} />
       {routes.map(({ path, element }) => {
         return <Route key={path} path={path} element={element} />;
       })}
       <Route path="*" element={<Redirect to="/" />} />
-    </RouterRoutes>
+    </Routes>
   );
 };
 

--- a/identity/client/src/configuration/index.ts
+++ b/identity/client/src/configuration/index.ts
@@ -1,5 +1,15 @@
-export const baseUrl = "/identity";
+const baseUrl = "/identity";
 
-export const apiBaseUrl = "/v2";
+const apiBaseUrl = "/v2";
 
 export const docsUrl = "https://docs.camunda.io";
+
+export function getApiBaseUrl() {
+  return getBaseUrl(apiBaseUrl);
+}
+
+export function getBaseUrl(path = baseUrl) {
+  const uiPath = window.location.pathname;
+  const endIndex = uiPath.indexOf(baseUrl);
+  return uiPath.substring(0, endIndex) + path;
+}

--- a/identity/client/src/utility/api/hooks/useApiCall.ts
+++ b/identity/client/src/utility/api/hooks/useApiCall.ts
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import { ApiCall, ApiDefinition, namedErrorsReducer } from "../request";
 import useTranslate from "../../localization";
 import { useNotifications } from "src/components/notifications";
-import { apiBaseUrl } from "src/configuration";
+import { getApiBaseUrl } from "src/configuration";
 import { useAuth } from "src/utility/auth";
 
 export type NamedErrors<R> = Partial<Record<keyof R, string[]>> | null;
@@ -71,7 +71,7 @@ const useApiCall: UseApiCall = <R, P>(
         status: apiStatus,
         errors: apiErrors,
         success: apiSuccess,
-      } = await apiDefinition(params as P)(apiBaseUrl, authHeaders);
+      } = await apiDefinition(params as P)(getApiBaseUrl(), authHeaders);
 
       if (apiStatus >= 400) {
         switch (apiStatus) {

--- a/identity/client/vite.config.ts
+++ b/identity/client/vite.config.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import sbom from "@vzeta/rollup-plugin-sbom";
 
 const outDir = "dist";
+const contextPath = process.env.CONTEXT_PATH ?? "";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
@@ -34,7 +35,7 @@ export default defineConfig(({ mode }) => ({
   },
   server: {
     proxy: {
-      "/v2": {
+      [contextPath + "/v2"]: {
         target: "http://localhost:8080",
         changeOrigin: true,
       },


### PR DESCRIPTION
## Description

Support a non-empty context path (`SERVER_SERVLET_CONTEXT_PATH`) in identity client. This is necessary for SaaS.
