### PR TITLE
Fix failing io.camunda.tasklist.es.SchemaCreationIT

### DIFF
--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticSearchSchemaManagementIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticSearchSchemaManagementIT.java
@@ -35,7 +35,14 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Conditional;
+import org.springframework.test.annotation.DirtiesContext;
 
+/**
+ * ApplicationContext associated with this test gets dirty {@link
+ * #replaceIndexDescriptorsInValidator(Set)} and should therefore be closed and removed from the
+ * context cache.
+ */
+@DirtiesContext
 @Conditional(ElasticSearchCondition.class)
 public class ElasticSearchSchemaManagementIT extends TasklistZeebeIntegrationTest {
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/IndexSchemaValidatorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/IndexSchemaValidatorIT.java
@@ -31,7 +31,14 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
+/**
+ * ApplicationContext associated with this test gets dirty {@link
+ * #replaceIndexDescriptorsInValidator(Set)} and should therefore be closed and removed from the
+ * context cache.
+ */
+@DirtiesContext
 public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
 
   private static final String ORIGINAL_SCHEMA_PATH =

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/IndexSchemaValidatorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/IndexSchemaValidatorIT.java
@@ -29,7 +29,14 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
+/**
+ * ApplicationContext associated with this test gets dirty {@link
+ * #replaceIndexDescriptorsInValidator(Set)} and should therefore be closed and removed from the
+ * context cache.
+ */
+@DirtiesContext
 public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
 
   private static final String ORIGINAL_SCHEMA_PATH_OPENSEARCH =

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchSchemaManagementIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchSchemaManagementIT.java
@@ -32,7 +32,14 @@ import java.util.Set;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
 
+/**
+ * ApplicationContext associated with this test gets dirty {@link
+ * #replaceIndexDescriptorsInValidator(Set)} and should therefore be closed and removed from the
+ * context cache.
+ */
+@DirtiesContext
 public class OpenSearchSchemaManagementIT extends TasklistZeebeIntegrationTest {
 
   private static final String ORIGINAL_SCHEMA_PATH =


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
One Tasklist ES Integration test is failing on `stable/8.6` since 2 weeks (`io.camunda.tasklist.es.SchemaCreationIT`)
https://github.com/camunda/camunda/actions/runs/12435031284/job/34719978871

It is caused by a concurrency situation where another test `ElasticSearchSchemaManagementIT` running in parallel is polluting  the application context of this test by setting an extra `IndexDescriptor` in `IndexSchemaValidator` bean.

When running Spring Boot tests in parallel, it is possible that they share the same autowired beans if the beans are managed by the same Spring ApplicationContext.

So here I marking the Tests updating the autowired beans with `@DirtiesContext` so that it does not get used in other tests.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/camunda/issues/26092
