### PR TITLE
feat: add process identifiers to document metadata

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateDocumentBatchCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateDocumentBatchCommandStep1.java
@@ -34,6 +34,20 @@ public interface CreateDocumentBatchCommandStep1
    */
   CreateDocumentBatchCommandStep1 storeId(String storeId);
 
+  /**
+   * Sets the process definition that the document is associated with.
+   *
+   * @param processDefinitionId the process definition ID
+   */
+  CreateDocumentBatchCommandStep1 processDefinitionId(String processDefinitionId);
+
+  /**
+   * Sets the process instance key that the document is associated with.
+   *
+   * @param processInstanceKey the process instance key
+   */
+  CreateDocumentBatchCommandStep1 processInstanceKey(long processInstanceKey);
+
   /** Starts the creation of a new document in a batch. */
   CreateDocumentBatchCommandStep2 addDocument();
 

--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateDocumentCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateDocumentCommandStep1.java
@@ -103,6 +103,20 @@ public interface CreateDocumentCommandStep1 extends DocumentBuilderStep1 {
     CreateDocumentCommandStep2 timeToLive(Duration timeToLive);
 
     /**
+     * Sets the process definition that the document is associated with.
+     *
+     * @param processDefinitionId the process definition ID
+     */
+    CreateDocumentCommandStep2 processDefinitionId(String processDefinitionId);
+
+    /**
+     * Sets the process instance key that the document is associated with.
+     *
+     * @param processInstanceKey the process instance key
+     */
+    CreateDocumentCommandStep2 processInstanceKey(long processInstanceKey);
+
+    /**
      * Adds a custom key-value pair to the document metadata.
      *
      * @param key custom metadata key

--- a/clients/java/src/main/java/io/camunda/client/api/response/DocumentMetadata.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/DocumentMetadata.java
@@ -43,6 +43,16 @@ public interface DocumentMetadata {
   String getFileName();
 
   /**
+   * @return the process definition ID, if present in the metadata
+   */
+  String getProcessDefinitionId();
+
+  /**
+   * @return the process definition key, if present in the metadata
+   */
+  Long getProcessInstanceKey();
+
+  /**
    * @return the custom properties of the document, if present in the metadata
    */
   Map<String, Object> getCustomProperties();

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateDocumentBatchCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateDocumentBatchCommandImpl.java
@@ -55,6 +55,8 @@ public class CreateDocumentBatchCommandImpl implements CreateDocumentBatchComman
   private final RequestConfig.Builder httpRequestConfig;
 
   private final Map<String, String> queryParams = new HashMap<>();
+  private String processDefinitionId;
+  private Long processInstanceKey;
 
   public CreateDocumentBatchCommandImpl(
       final JsonMapper jsonMapper,
@@ -85,6 +87,12 @@ public class CreateDocumentBatchCommandImpl implements CreateDocumentBatchComman
         ensureNotNull("fileName", fileName);
         final InputStreamBody body =
             new InputStreamBody(document.getContent(), ContentType.DEFAULT_BINARY, fileName);
+        if (processDefinitionId != null) {
+          document.getMetadata().setProcessDefinitionId(processDefinitionId);
+        }
+        if (processInstanceKey != null) {
+          document.getMetadata().setProcessInstanceKey(processInstanceKey);
+        }
         final String metadataString = jsonMapper.toJson(document.getMetadata());
         final MultipartPart part =
             MultipartPartBuilder.create()
@@ -126,6 +134,19 @@ public class CreateDocumentBatchCommandImpl implements CreateDocumentBatchComman
   public CreateDocumentBatchCommandStep1 storeId(final String storeId) {
     ensureNotNull("storeId", storeId);
     queryParams.put("storeId", storeId);
+    return this;
+  }
+
+  @Override
+  public CreateDocumentBatchCommandStep1 processDefinitionId(final String processDefinitionId) {
+    ensureNotNull("processDefinitionId", processDefinitionId);
+    this.processDefinitionId = processDefinitionId;
+    return this;
+  }
+
+  @Override
+  public CreateDocumentBatchCommandStep1 processInstanceKey(final long processInstanceKey) {
+    this.processInstanceKey = processInstanceKey;
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateDocumentCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateDocumentCommandImpl.java
@@ -168,4 +168,16 @@ public class CreateDocumentCommandImpl extends DocumentBuilder
     this.storeId = storeId;
     return this;
   }
+
+  @Override
+  public CreateDocumentCommandStep2 processDefinitionId(final String processDefinitionId) {
+    super.getMetadata().setProcessDefinitionId(processDefinitionId);
+    return this;
+  }
+
+  @Override
+  public CreateDocumentCommandStep2 processInstanceKey(final long processInstanceKey) {
+    super.getMetadata().setProcessInstanceKey(processInstanceKey);
+    return this;
+  }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/DocumentMetadataImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/DocumentMetadataImpl.java
@@ -57,6 +57,16 @@ public class DocumentMetadataImpl implements DocumentMetadata {
   }
 
   @Override
+  public String getProcessDefinitionId() {
+    return response.getProcessDefinitionId();
+  }
+
+  @Override
+  public Long getProcessInstanceKey() {
+    return response.getProcessInstanceKey();
+  }
+
+  @Override
   public Map<String, Object> getCustomProperties() {
     return response.getCustomProperties();
   }

--- a/document/api/src/main/java/io/camunda/document/api/DocumentMetadataModel.java
+++ b/document/api/src/main/java/io/camunda/document/api/DocumentMetadataModel.java
@@ -15,4 +15,6 @@ public record DocumentMetadataModel(
     String fileName,
     OffsetDateTime expiresAt,
     Long size,
+    String processDefinitionId,
+    Long processInstanceKey,
     Map<String, Object> customProperties) {}

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
@@ -53,6 +53,9 @@ public class AwsDocumentStore implements DocumentStore {
   private static final Tag NO_AUTO_DELETE_TAG =
       Tag.builder().key("NoAutoDelete").value("true").build();
 
+  private static final String METADATA_PROCESS_DEFINITION_ID = "camunda.processDefinitionId";
+  private static final String METADATA_PROCESS_INSTANCE_KEY = "camunda.processInstanceKey";
+
   private final String bucketName;
   private final S3Client client;
   private final ExecutorService executor;
@@ -237,6 +240,8 @@ public class AwsDocumentStore implements DocumentStore {
             resolveFileName(request.metadata(), documentId),
             request.metadata().expiresAt(),
             request.metadata().size(),
+            request.metadata().processDefinitionId(),
+            request.metadata().processInstanceKey(),
             request.metadata().customProperties());
     return Either.right(new DocumentReference(documentId, updatedMetadata));
   }
@@ -259,6 +264,9 @@ public class AwsDocumentStore implements DocumentStore {
           .customProperties()
           .forEach((key, value) -> metadataMap.put(key, String.valueOf(value)));
     }
+
+    putIfPresent(METADATA_PROCESS_DEFINITION_ID, metadata.processDefinitionId(), metadataMap);
+    putIfPresent(METADATA_PROCESS_INSTANCE_KEY, metadata.processInstanceKey(), metadataMap);
 
     return metadataMap;
   }

--- a/document/store/src/main/java/io/camunda/document/store/inmemory/InMemoryDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/inmemory/InMemoryDocumentStore.java
@@ -68,6 +68,8 @@ public class InMemoryDocumentStore implements DocumentStore {
             fileName,
             request.metadata().expiresAt(),
             request.metadata().size(),
+            request.metadata().processDefinitionId(),
+            request.metadata().processInstanceKey(),
             request.metadata().customProperties());
     return CompletableFuture.completedFuture(
         Either.right(new DocumentReference(id, updatedMetadata)));

--- a/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreTest.java
@@ -70,7 +70,13 @@ class AwsDocumentStoreTest {
 
     final var metadata =
         new DocumentMetadataModel(
-            "text/plain", "test-file.txt", null, (long) content.length, Collections.emptyMap());
+            "text/plain",
+            "test-file.txt",
+            null,
+            (long) content.length,
+            null,
+            null,
+            Collections.emptyMap());
 
     final var request = new DocumentCreationRequest(documentId, inputStream, metadata);
 
@@ -120,6 +126,8 @@ class AwsDocumentStoreTest {
             "given-test-document.jpeg",
             expiryTime,
             10000L,
+            null,
+            null,
             Collections.emptyMap());
 
     final var request = new DocumentCreationRequest(documentId, inputStream, metadata);

--- a/document/store/src/test/java/io/camunda/document/store/inmemory/InMemoryDocumentStoreTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/inmemory/InMemoryDocumentStoreTest.java
@@ -41,6 +41,8 @@ public class InMemoryDocumentStoreTest {
                 "hello.json",
                 OffsetDateTime.now(),
                 10L,
+                "myProcessDefinition",
+                123L,
                 Map.of("key", "value")));
     final var result = store.createDocument(request).join();
 
@@ -62,7 +64,13 @@ public class InMemoryDocumentStoreTest {
     final String key = "key";
     final var metadata =
         new DocumentMetadataModel(
-            "application/json", "hello.json", OffsetDateTime.now(), 10L, Map.of("key", "value"));
+            "application/json",
+            "hello.json",
+            OffsetDateTime.now(),
+            10L,
+            null,
+            null,
+            Map.of("key", "value"));
 
     // when
     final var request =
@@ -93,6 +101,8 @@ public class InMemoryDocumentStoreTest {
                 "hello.json",
                 OffsetDateTime.now(),
                 10L,
+                null,
+                null,
                 Map.of("key", "value")));
     final var result = store.createDocument(request).join();
 
@@ -130,6 +140,8 @@ public class InMemoryDocumentStoreTest {
                 "hello.json",
                 OffsetDateTime.now(),
                 10L,
+                null,
+                null,
                 Map.of("key", "value")));
 
     final var result = store.createDocument(request).join();
@@ -178,7 +190,7 @@ public class InMemoryDocumentStoreTest {
     final InMemoryDocumentStore store = new InMemoryDocumentStore();
     final String id = "key";
     final DocumentMetadataModel metadata =
-        new DocumentMetadataModel("application/json", null, null, null, null);
+        new DocumentMetadataModel("application/json", null, null, null, null, null, null);
 
     // when
     final var request =

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/CreateDocumentTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/CreateDocumentTest.java
@@ -262,4 +262,48 @@ public class CreateDocumentTest {
     assertThat(documentReference.getMetadata().getCustomProperties().get("key2"))
         .isEqualTo("value2");
   }
+
+  @Test
+  public void shouldAddProcessDefinitionId() {
+    // given
+    camundaClient = testStandaloneCamunda.newClientBuilder().build();
+    final var documentContent = "test";
+    final String processDefinitionId = "test";
+
+    // when
+    final var documentReference =
+        camundaClient
+            .newCreateDocumentCommand()
+            .content(documentContent)
+            .processDefinitionId(processDefinitionId)
+            .send()
+            .join();
+
+    // then
+    assertThat(documentReference).isNotNull();
+    assertThat(documentReference.getMetadata().getProcessDefinitionId())
+        .isEqualTo(processDefinitionId);
+  }
+
+  @Test
+  public void shouldAddProcessInstanceKey() {
+    // given
+    camundaClient = testStandaloneCamunda.newClientBuilder().build();
+    final var documentContent = "test";
+    final long processInstanceKey = 1;
+
+    // when
+    final var documentReference =
+        camundaClient
+            .newCreateDocumentCommand()
+            .content(documentContent)
+            .processInstanceKey(processInstanceKey)
+            .send()
+            .join();
+
+    // then
+    assertThat(documentReference).isNotNull();
+    assertThat(documentReference.getMetadata().getProcessInstanceKey())
+        .isEqualTo(processInstanceKey);
+  }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3112,7 +3112,7 @@ paths:
         Publishes a message and correlates it to a subscription.
         If correlation is successful it will return the first process instance key the message correlated with.
         The message is not buffered.
-        Use the publish message endpoint to send messages that can be buffered. 
+        Use the publish message endpoint to send messages that can be buffered.
       requestBody:
         required: true
         content:
@@ -7320,6 +7320,13 @@ components:
           type: integer
           format: int64
           description: The size of the document in bytes.
+        processDefinitionId:
+          type: string
+          description: The ID of the process definition that created the document.
+        processInstanceKey:
+          type: integer
+          format: int64
+          description: The key of the process instance that created the document.
         customProperties:
           type: object
           description: Custom properties of the document.

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -607,7 +607,13 @@ public class RequestMapper {
 
     if (metadata == null) {
       return new DocumentMetadataModel(
-          file.getContentType(), file.getSubmittedFileName(), null, file.getSize(), Map.of());
+          file.getContentType(),
+          file.getSubmittedFileName(),
+          null,
+          file.getSize(),
+          null,
+          null,
+          Map.of());
     }
     final OffsetDateTime expiresAt;
     if (metadata.getExpiresAt() == null || metadata.getExpiresAt().isBlank()) {
@@ -621,7 +627,13 @@ public class RequestMapper {
         Optional.ofNullable(metadata.getContentType()).orElse(file.getContentType());
 
     return new DocumentMetadataModel(
-        contentType, fileName, expiresAt, file.getSize(), metadata.getCustomProperties());
+        contentType,
+        fileName,
+        expiresAt,
+        file.getSize(),
+        metadata.getProcessDefinitionId(),
+        metadata.getProcessInstanceKey(),
+        metadata.getCustomProperties());
   }
 
   private static DeployResourcesRequest createDeployResourceRequest(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -256,7 +256,9 @@ public final class ResponseMapper {
                     .orElse(null))
             .fileName(internalMetadata.fileName())
             .size(internalMetadata.size())
-            .contentType(internalMetadata.contentType());
+            .contentType(internalMetadata.contentType())
+            .processDefinitionId(internalMetadata.processDefinitionId())
+            .processInstanceKey(internalMetadata.processInstanceKey());
     Optional.ofNullable(internalMetadata.customProperties())
         .ifPresent(map -> map.forEach(externalMetadata::putCustomPropertiesItem));
     return new DocumentReference()

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
@@ -63,7 +63,7 @@ public class DocumentControllerTest extends RestControllerTest {
                     "documentId",
                     "default",
                     new DocumentMetadataModel(
-                        contentType.toString(), filename, timestamp, 0L, Map.of()))));
+                        contentType.toString(), filename, timestamp, 0L, null, null, Map.of()))));
 
     final var multipartBodyBuilder = new MultipartBodyBuilder();
     multipartBodyBuilder.part("file", content).contentType(contentType).filename(filename);
@@ -131,7 +131,7 @@ public class DocumentControllerTest extends RestControllerTest {
                     "documentId",
                     "default",
                     new DocumentMetadataModel(
-                        contentType.toString(), filename, timestamp, 0L, Map.of()))));
+                        contentType.toString(), filename, timestamp, 0L, null, null, Map.of()))));
 
     final var metadataToSend = new DocumentMetadata();
     metadataToSend.setContentType(contentType.toString());


### PR DESCRIPTION
## Description

This PR will add process definition ID and process instance key as optional identifiers to the document metadata.

Adding these values will allow to use them for authorization checks in the future.

**⚠️ This PR is part of the PR train that needs to follow a specific order when merging ⚠️**

@mo-okocha @marcosgvieira Please merge the PRs in this specific order to avoid merge conflicts:

- https://github.com/camunda/camunda/pull/26336
- https://github.com/camunda/camunda/pull/26340
- https://github.com/camunda/camunda/pull/26351

The branches of each PR are pointed towards the branch of the previous PR - please wait for the previous PR to be merged and make sure the target branch of the second PR is changed to main. Only after that you can merge the next PR.

**This PR goes third.**

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes: #24847 
