### PR TITLE
deps: bump tomcat out of band to resolve a CVE

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1031,6 +1031,26 @@
         <version>${version.spring-boot}</version>
       </dependency>
 
+      <!-- TODO: remove when https://github.com/camunda/camunda/pull/25062 is merged -->
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>10.1.34</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>10.1.34</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-el</artifactId>
+        <version>10.1.34</version>
+      </dependency>
+      <!-- TODO: remove when https://github.com/camunda/camunda/pull/25062 is merged -->
+
       <!--
            In order resolve dependency issues with wiremock and spring-boot-dependencies
            make sure this is declared before spring boot dependencies.


### PR DESCRIPTION
## Description

This PR bumps Tomcat to resolve a CVE: CVE-2024-50379. While it does not affect C8, I've opened the PR in case not fixing it increases support load. I seriously doubt we would ever start using JSP, but who knows.

Preference would be getting #25062 merged, but it's blocked by a breaking Apache HTTP update (see https://github.com/camunda/camunda/pull/22241).

So if those are merged before, then we can close this. But in case they aren't, we can go ahead and merge this one.
