### PR TITLE
ci: use path-filters GHA in Tasklist CI

### DIFF
--- a/.github/workflows/tasklist-ci-test-reusable.yml
+++ b/.github/workflows/tasklist-ci-test-reusable.yml
@@ -41,7 +41,6 @@ jobs:
   integration-tests:
     name: Test
     runs-on: gcp-perf-core-16-default
-    if: ${{ !startsWith(inputs.branch, 'fe-') && !startsWith(inputs.branch, 'renovate/') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tasklist-ci.yml
+++ b/.github/workflows/tasklist-ci.yml
@@ -8,23 +8,7 @@ on:
     branches:
       - "main"
       - "stable/**"
-    paths:
-      - ".github/actions/**"
-      - ".github/workflows/tasklist-*"
-      - "bom/*"
-      - "parent/*"
-      - "pom.xml"
-      - "tasklist/**"
-      - "tasklist.Dockerfile"
   pull_request:
-    paths:
-      - ".github/actions/**"
-      - ".github/workflows/tasklist-*"
-      - "bom/*"
-      - "parent/*"
-      - "pom.xml"
-      - "tasklist/**"
-      - "tasklist.Dockerfile"
 
 # Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
 # Exception for main branch: complete builds for every commit needed for confidenence
@@ -33,16 +17,34 @@ concurrency:
   group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
+  detect-changes:
+    outputs:
+      tasklist-backend-changes: ${{ steps.filter.outputs.tasklist-backend-changes }}
+      tasklist-frontend-changes: ${{ steps.filter.outputs.tasklist-frontend-changes }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+      # Detect changes against the base branch
+      - name: Detect changes
+        uses: ./.github/actions/paths-filter
+        id: filter
   run-build:
     name: run-build
+    needs: [detect-changes]
     uses: ./.github/workflows/tasklist-ci-build-reusable.yml
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }} # head_ref = branch name on PR, ref_name = `main` or `stable/**`
+    if: ${{ needs.detect-changes.outputs.tasklist-backend-changes == 'true' || needs.detect-changes.outputs.tasklist-frontend-changes == 'true' }}
 
   run-tests:
     name: run-tests
+    needs: [detect-changes]
     uses: ./.github/workflows/tasklist-ci-test-reusable.yml
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
+    if: ${{ needs.detect-changes.outputs.tasklist-backend-changes == 'true' }}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Tasklist CI is not triggered when changes that could affect Tasklist integration tests are made. For example, the pull request https://github.com/camunda/camunda/pull/26276 did not trigger the Tasklist CI, yet it caused Tasklist integration tests to fail on the main branch.

To address this, I’m using the common path-filters GitHub Action to detect changes that impact Tasklist.

![image](https://github.com/user-attachments/assets/262807d3-a11a-4f6d-889d-ab4ca194afe2)


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
