### PR TITLE
fix: enable process-migration when `tasklist` is enabled

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/migration/MigrationProfilePostProcessor.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/MigrationProfilePostProcessor.java
@@ -22,6 +22,9 @@ public class MigrationProfilePostProcessor implements EnvironmentPostProcessor {
     if (environment.acceptsProfiles(Profiles.of(Profile.MIGRATION.getId()))) {
       environment.addActiveProfile(Profile.PROCESS_MIGRATION.getId());
       environment.addActiveProfile(Profile.IDENTITY_MIGRATION.getId());
+    } else if (environment.acceptsProfiles(Profiles.of(Profile.TASKLIST.getId()))) {
+      /* Enable 'process-migration' when Tasklist is enabled */
+      environment.addActiveProfile(Profile.PROCESS_MIGRATION.getId());
     }
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/migration/MigrationProfilePostProcessor.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/MigrationProfilePostProcessor.java
@@ -22,9 +22,14 @@ public class MigrationProfilePostProcessor implements EnvironmentPostProcessor {
     if (environment.acceptsProfiles(Profiles.of(Profile.MIGRATION.getId()))) {
       environment.addActiveProfile(Profile.PROCESS_MIGRATION.getId());
       environment.addActiveProfile(Profile.IDENTITY_MIGRATION.getId());
-    } else if (environment.acceptsProfiles(Profiles.of(Profile.TASKLIST.getId()))) {
-      /* Enable 'process-migration' when Tasklist is enabled */
+    } else if (shouldEnableProcessMigration(environment)) {
+      /* Enable 'process-migration' when Tasklist is enabled on non Test setups  */
       environment.addActiveProfile(Profile.PROCESS_MIGRATION.getId());
     }
+  }
+
+  private boolean shouldEnableProcessMigration(final ConfigurableEnvironment environment) {
+    return environment.acceptsProfiles(Profiles.of(Profile.TASKLIST.getId()))
+        && !environment.acceptsProfiles(Profiles.of(Profile.TEST.getId()));
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/migration/ProcessMigrationModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/ProcessMigrationModuleConfiguration.java
@@ -15,6 +15,6 @@ import org.springframework.context.annotation.Profile;
 
 @Configuration(proxyBeanMethods = false)
 @ComponentScan(basePackages = {"io.camunda.migration.process"})
-@Profile("process-migration|tasklist")
+@Profile("process-migration")
 @Import({SearchClientDatabaseConfiguration.class})
 public class ProcessMigrationModuleConfiguration {}

--- a/dist/src/test/java/io/camunda/application/CamundaDockerIT.java
+++ b/dist/src/test/java/io/camunda/application/CamundaDockerIT.java
@@ -146,7 +146,9 @@ public class CamundaDockerIT {
         .withEnv("CAMUNDA_TASKLIST_ZEEBE_RESTADDRESS", httpUrl())
         .withEnv("CAMUNDA_OPERATE_ELASTICSEARCH_URL", elasticsearchUrl())
         .withEnv("CAMUNDA_OPERATE_ZEEBEELASTICSEARCH_URL", elasticsearchUrl())
-        .withEnv("CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS", gatewayAddress());
+        .withEnv("CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS", gatewayAddress())
+        .withEnv("CAMUNDA_DATABASE_URL", elasticsearchUrl())
+        .withEnv("ZEEBE_BROKER_GATEWAY_ENABLE", "true");
   }
 
   private static String httpUrl() {

--- a/migration/process-migration/src/main/java/io/camunda/migration/process/util/MigrationUtil.java
+++ b/migration/process-migration/src/main/java/io/camunda/migration/process/util/MigrationUtil.java
@@ -8,8 +8,13 @@
 package io.camunda.migration.process.util;
 
 import io.camunda.webapps.schema.entities.operate.ProcessEntity;
+import java.util.regex.Pattern;
 
 public class MigrationUtil {
+
+  public static final Pattern MIGRATION_REPOSITORY_NOT_EXISTS =
+      Pattern.compile(
+          "no such index \\[[a-zA-Z0-9\\-]+-migration-steps-repository-[0-9]+\\.[0-9]+\\.[0-9]+_]");
 
   public static ProcessEntity migrate(final ProcessEntity entity) {
     final ProcessEntity processEntity = new ProcessEntity();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Always enable `process-migration` profile when `tasklist` is also enabled.
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
