### PR TITLE
Remove 8.7 Importer leftovers

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -606,12 +606,6 @@
 
       <dependency>
         <groupId>io.camunda</groupId>
-        <artifactId>operate-importer-8_7</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
         <artifactId>operate-data-generator</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -731,12 +725,6 @@
       <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>tasklist-importer-860</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.camunda</groupId>
-        <artifactId>tasklist-importer-870</artifactId>
         <version>${project.version}</version>
       </dependency>
 

--- a/tasklist/importer/pom.xml
+++ b/tasklist/importer/pom.xml
@@ -40,12 +40,6 @@
       <scope>runtime</scope>
     </dependency>
 
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>tasklist-importer-870</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
     <!-- ZEEBE -->
 
     <dependency>
@@ -188,7 +182,6 @@
         <configuration>
           <usedDependencies>
             <dependency>io.camunda:tasklist-importer-860</dependency>
-            <dependency>io.camunda:tasklist-importer-870</dependency>
           </usedDependencies>
         </configuration>
       </plugin>

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/ImportJobAbstract.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/ImportJobAbstract.java
@@ -85,15 +85,17 @@ public abstract class ImportJobAbstract implements ImportJob {
   private boolean processOneIndexBatch(final ImportBatch subBatch) {
     try {
       final String version = extractZeebeVersionFromIndexName(subBatch.getLastRecordIndexName());
-      final ImportBatchProcessor importBatchProcessor =
-          importBatchProcessorFactory.getImportBatchProcessor(version);
-      importBatchProcessor.performImport(subBatch);
 
       final var batchVersion = SemanticVersion.fromVersion(version);
 
       if (batchVersion.getMajor() == 8 && batchVersion.getMinor() == 7) {
         recordsReaderHolder.addPartitionCompletedImporting(subBatch.getPartitionId());
+        return true;
       }
+
+      final ImportBatchProcessor importBatchProcessor =
+          importBatchProcessorFactory.getImportBatchProcessor(version);
+      importBatchProcessor.performImport(subBatch);
 
       return true;
     } catch (final Exception ex) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- Fix order of processing 8.7 records
- Remove 8.7 Importer references for Tasklist & Operate

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
