### PR TITLE
refactor: lower log level for debugging info

### DIFF
--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitor.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitor.java
@@ -73,6 +73,11 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
   }
 
   @Override
+  public void monitorComponent(final String componentName) {
+    actor.run(() -> componentHealth.put(componentName, HealthReport.unknown(componentName)));
+  }
+
+  @Override
   public void registerComponent(final HealthMonitorable component) {
     actor.run(
         () -> {
@@ -86,7 +91,7 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
           // register graphs
           // it's safe to do it more than once
           graphListener.registerNode(component, Optional.of(name));
-          log.info("Registered component {}:{}", componentName, component.componentName());
+          log.trace("Registered component {}:{}", componentName, component.componentName());
         });
   }
 
@@ -101,14 +106,9 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
             monitoredComponent.component.removeFailureListener(monitoredComponent);
             graphListener.unregisterRelationship(name, componentName);
             graphListener.unregisterNode(monitoredComponent.component);
-            log.info("Unregistered edge {}:{}", name, componentName);
+            log.trace("Unregistered edge {}:{}", name, componentName);
           }
         });
-  }
-
-  @Override
-  public void monitorComponent(final String componentName) {
-    actor.run(() -> componentHealth.put(componentName, HealthReport.unknown(componentName)));
   }
 
   @Override


### PR DESCRIPTION
## Description

This PR lowers the log level when registering a new relationship between components. This is useful debugging information, but not for normal user, and shouldn't be an INFO level log. I've lowered it to trace, as it's really to trace how the registration works.
