### PR TITLE
refactor: use debug to log each individual transition steps

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
@@ -89,7 +89,7 @@ final class PartitionTransitionProcess {
           final var nextStep = pendingSteps.remove(0);
           currentStep = nextStep;
           stepStartedAtMs = ActorClock.currentTimeMillis();
-          LOG.info(
+          LOG.debug(
               "Transition to {} on term {} - transitioning {}", role, term, nextStep.getName());
           nextStep
               .transitionTo(context, term, role)
@@ -139,7 +139,7 @@ final class PartitionTransitionProcess {
         () -> {
           final var nextPrepareStep = stepsToPrepare.pop();
 
-          LOG.info(
+          LOG.debug(
               MSG_PREPARE_TRANSITION_STEP,
               context.getCurrentRole(),
               context.getCurrentTerm(),

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -65,7 +65,7 @@ public final class LogStreamImpl implements LogStream, CommitListener {
   @Override
   public void close() {
     closed = true;
-    LOG.info("Closing {} with {} readers", logName, readers.size());
+    LOG.debug("Closing {} with {} readers", logName, readers.size());
     readers.forEach(LogStreamReader::close);
     logStorage.removeCommitListener(this);
     logStreamMetrics.remove();


### PR DESCRIPTION
## Description

This PR lowers the log level of each individual transition steps to debug. We still log the overall transition at INFO level, as it's useful information for the user, but the individual steps are not (and only useful for debugging).

This is the previous logs on INFO:

```
17:14:51.973 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Transition to FOLLOWER on term 1 requested.
17:14:51.973 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Prepare transition from LEADER[term: 1] -> FOLLOWER[term: 1]
17:14:51.973 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Prepare transition from LEADER[term: 1] -> FOLLOWER[term: 1] - preparing Admin API
17:14:51.973 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Prepare transition from LEADER[term: 1] -> FOLLOWER[term: 1] - preparing BackupApiRequestHandler
17:14:51.973 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Prepare transition from LEADER[term: 1] -> FOLLOWER[term: 1] - preparing ExporterDirector
17:14:51.973 [Broker-0] [ZeebePartition-1] [zb-actors-0] WARN  io.camunda.zeebe.broker.system.monitoring.HealthTreeMetrics - Tried to remove invalid relationship: child=Partition-1, parent=Exporter-1
17:14:51.973 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Unregistered edge Partition-1:Exporter-1
17:14:51.973 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Prepare transition from LEADER[term: 1] -> FOLLOWER[term: 1] - preparing SnapshotDirector
17:14:51.973 [Broker-0] [ZeebePartition-1] [zb-actors-0] WARN  io.camunda.zeebe.broker.system.monitoring.HealthTreeMetrics - Tried to remove invalid relationship: child=Partition-1, parent=SnapshotDirector-1
17:14:51.973 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Unregistered edge Partition-1:SnapshotDirector-1
17:14:51.973 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Prepare transition from LEADER[term: 1] -> FOLLOWER[term: 1] - preparing CommandApiService
17:14:51.973 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Prepare transition from LEADER[term: 1] -> FOLLOWER[term: 1] - preparing StreamProcessor
17:14:51.973 [Broker-0] [ZeebePartition-1] [zb-actors-0] WARN  io.camunda.zeebe.broker.system.monitoring.HealthTreeMetrics - Tried to remove invalid relationship: child=Partition-1, parent=StreamProcessor-1
17:14:51.973 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Unregistered edge Partition-1:StreamProcessor-1
17:14:51.973 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Prepare transition from LEADER[term: 1] -> FOLLOWER[term: 1] - preparing InterPartitionCommandService
17:14:51.974 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Prepare transition from LEADER[term: 1] -> FOLLOWER[term: 1] - preparing BackupManager
17:14:51.974 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Prepare transition from LEADER[term: 1] -> FOLLOWER[term: 1] - preparing BackupStore
17:14:51.974 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Prepare transition from LEADER[term: 1] -> FOLLOWER[term: 1] - preparing QueryService
17:14:51.974 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Prepare transition from LEADER[term: 1] -> FOLLOWER[term: 1] - preparing Migration
17:14:51.974 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Prepare transition from LEADER[term: 1] -> FOLLOWER[term: 1] - preparing ZeebeDb
17:14:51.974 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Prepare transition from LEADER[term: 1] -> FOLLOWER[term: 1] - preparing LogStream
17:14:51.974 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.logstreams - Closing logStream-raft-partition-partition-1 with 2 readers
17:14:51.974 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Prepare transition from LEADER[term: 1] -> FOLLOWER[term: 1] - preparing LogStorage
17:14:51.974 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Prepare transition from LEADER[term: 1] -> FOLLOWER[term: 1] - preparing Metrics
17:14:51.974 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Prepare transition from LEADER[term: 1] -> FOLLOWER[term: 1] completed
17:14:51.974 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Transition to FOLLOWER on term 1 starting
17:14:51.974 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Transition to FOLLOWER on term 1 - transitioning Metrics
17:14:51.974 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Transition to FOLLOWER on term 1 - transitioning LogStorage
17:14:51.974 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Transition to FOLLOWER on term 1 - transitioning LogStream
17:14:51.974 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system
17:14:52.042 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.broker.system - Transition to FOLLOWER on term 1 - transitioning Migration
17:14:52.042 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  org.camunda.feel.FeelEngine - Engine created. [value-mapper: CompositeValueMapper(List(io.camunda.zeebe.feel.impl.MessagePackValueMapper@7ce4564d)), function-provider: io.camunda.zeebe.feel.impl.FeelFunctionProvider@6969edd8, clock: io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock@16427ab4, configuration: {externalFunctionsEnabled: false}]
17:14:52.044 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  org.camunda.dmn.DmnEngine - DMN-Engine created. [value-mapper: CompositeValueMapper(List(io.camunda.zeebe.feel.impl.MessagePackValueMapper@30e8cf4)), function-provider: org.camunda.feel.context.FunctionProvider$EmptyFunctionProvider$@7be06e40, audit-loggers: List(), configuration: Configuration(false,false,false)]
17:14:52.044 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  org.camunda.feel.FeelEngine - Engine created. [value-mapper: CompositeValueMapper(List(org.camunda.dmn.NoUnpackValueMapper@50218258)), function-provider: org.camunda.feel.context.FunctionProvider$EmptyFunctionProvider$@7be06e40, clock: SystemClock, configuration: {externalFunctionsEnabled: false}]
17:14:52.044 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  org.camunda.dmn.DmnEngine - DMN-Engine created. [value-mapper: CompositeValueMapper(List(io.camunda.zeebe.feel.impl.MessagePackValueMapper@7bbfcdbd)), function-provider: org.camunda.feel.context.FunctionProvider$EmptyFunctionProvider$@7be06e40, audit-loggers: List(), configuration: Configuration(false,false,false)]
17:14:52.044 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  org.camunda.feel.FeelEngine - Engine created. [value-mapper: CompositeValueMapper(List(org.camunda.dmn.NoUnpackValueMapper@24166f6f)), function-provider: org.camunda.feel.context.FunctionProvider$EmptyFunctionProvider$@7be06e40, clock: SystemClock, configuration: {externalFunctionsEnabled: false}]
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Starting processing of migration tasks (use LogLevel.DEBUG for more details) ... 
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Skipping ProcessMessageSubscriptionSentTimeMigration migration (1/21).  It was determined it does not need to run right now.
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Skipping MessageSubscriptionSentTimeMigration migration (2/21).  It was determined it does not need to run right now.
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Skipping TemporaryVariableMigration migration (3/21).  It was determined it does not need to run right now.
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Skipping DecisionMigration migration (4/21).  It was determined it does not need to run right now.
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Skipping DecisionRequirementsMigration migration (5/21).  It was determined it does not need to run right now.
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Starting ProcessInstanceByProcessDefinitionMigration migration (6/21)
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Finished ProcessInstanceByProcessDefinitionMigration migration (6/21)
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Starting JobTimeoutCleanupMigration migration (7/21)
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Finished JobTimeoutCleanupMigration migration (7/21)
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Starting JobBackoffCleanupMigration migration (8/21)
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Finished JobBackoffCleanupMigration migration (8/21)
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Skipping MultiTenancyProcessStateMigration migration (9/21).  It was determined it does not need to run right now.
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Skipping MultiTenancyDecisionStateMigration migration (10/21).  It was determined it does not need to run right now.
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Skipping MultiTenancyMessageStateMigration migration (11/21).  It was determined it does not need to run right now.
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Skipping MultiTenancyMessageStartEventSubscriptionStateMigration migration (12/21).  It was determined it does not need to run right now.
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Skipping MultiTenancyMessageSubscriptionStateMigration migration (13/21).  It was determined it does not need to run right now.
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Skipping MultiTenancyProcessMessageSubscriptionStateMigration migration (14/21).  It was determined it does not need to run right now.
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Skipping MultiTenancyJobStateMigration migration (15/21).  It was determined it does not need to run right now.
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Starting ColumnFamilyPrefixCorrectionMigration migration (16/21)
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Finished ColumnFamilyPrefixCorrectionMigration migration (16/21)
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Skipping MultiTenancySignalSubscriptionStateMigration migration (17/21).  It was determined it does not need to run right now.
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Starting JobBackoffRestoreMigration migration (18/21)
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Finished JobBackoffRestoreMigration migration (18/21)
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Starting RoutingInfoMigration migration (19/21)
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Finished RoutingInfoMigration migration (19/21)
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Skipping OrderedCommandDistributionMigration migration (20/21).  It was determined it does not need to run right now.
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Skipping IdempotentCommandDistributionMigration migration (21/21).  It was determined it does not need to run right now.
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.engine.state.migration - Completed processing of migration tasks (use LogLevel.DEBUG for more details) ... 
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.broker.system - Transition to FOLLOWER on term 1 - transitioning QueryService
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.broker.system - Transition to FOLLOWER on term 1 - transitioning BackupStore
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.broker.system - Transition to FOLLOWER on term 1 - transitioning BackupManager
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.broker.system - Transition to FOLLOWER on term 1 - transitioning InterPartitionCommandService
17:14:52.045 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.broker.system - Transition to FOLLOWER on term 1 - transitioning StreamProcessor
17:14:52.046 [Broker-0] [StreamProcessor-1] [zb-actors-1] INFO  io.camunda.zeebe.logstreams - Recovered state of partition 1 from snapshot at position -1
17:14:52.046 [Broker-0] [StreamProcessor-1] [zb-actors-1] INFO  org.camunda.feel.FeelEngine - Engine created. [value-mapper: CompositeValueMapper(List(io.camunda.zeebe.feel.impl.MessagePackValueMapper@6d0f5cf5)), function-provider: io.camunda.zeebe.feel.impl.FeelFunctionProvider@7a753b2c, clock: io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock@6aecf5b2, configuration: {externalFunctionsEnabled: false}]
17:14:52.047 [Broker-0] [StreamProcessor-1] [zb-actors-1] INFO  org.camunda.dmn.DmnEngine - DMN-Engine created. [value-mapper: CompositeValueMapper(List(io.camunda.zeebe.feel.impl.MessagePackValueMapper@61d1b616)), function-provider: org.camunda.feel.context.FunctionProvider$EmptyFunctionProvider$@7be06e40, audit-loggers: List(), configuration: Configuration(false,false,false)]
17:14:52.047 [Broker-0] [StreamProcessor-1] [zb-actors-1] INFO  org.camunda.feel.FeelEngine - Engine created. [value-mapper: CompositeValueMapper(List(org.camunda.dmn.NoUnpackValueMapper@35cb3866)), function-provider: org.camunda.feel.context.FunctionProvider$EmptyFunctionProvider$@7be06e40, clock: SystemClock, configuration: {externalFunctionsEnabled: false}]
17:14:52.047 [Broker-0] [StreamProcessor-1] [zb-actors-1] INFO  org.camunda.dmn.DmnEngine - DMN-Engine created. [value-mapper: CompositeValueMapper(List(io.camunda.zeebe.feel.impl.MessagePackValueMapper@1082dfa6)), function-provider: org.camunda.feel.context.FunctionProvider$EmptyFunctionProvider$@7be06e40, audit-loggers: List(), configuration: Configuration(false,false,false)]
17:14:52.047 [Broker-0] [StreamProcessor-1] [zb-actors-1] INFO  org.camunda.feel.FeelEngine - Engine created. [value-mapper: CompositeValueMapper(List(org.camunda.dmn.NoUnpackValueMapper@2037c3ca)), function-provider: org.camunda.feel.context.FunctionProvider$EmptyFunctionProvider$@7be06e40, clock: SystemClock, configuration: {externalFunctionsEnabled: false}]
17:14:52.048 [Broker-0] [StreamProcessor-1] [zb-actors-1] INFO  org.camunda.dmn.DmnEngine - DMN-Engine created. [value-mapper: CompositeValueMapper(List(io.camunda.zeebe.feel.impl.MessagePackValueMapper@411ce270)), function-provider: org.camunda.feel.context.FunctionProvider$EmptyFunctionProvider$@7be06e40, audit-loggers: List(), configuration: Configuration(false,false,false)]
17:14:52.048 [Broker-0] [StreamProcessor-1] [zb-actors-1] INFO  org.camunda.feel.FeelEngine - Engine created. [value-mapper: CompositeValueMapper(List(org.camunda.dmn.NoUnpackValueMapper@7435353a)), function-provider: org.camunda.feel.context.FunctionProvider$EmptyFunctionProvider$@7be06e40, clock: SystemClock, configuration: {externalFunctionsEnabled: false}]
17:14:52.048 [Broker-0] [StreamProcessor-1] [zb-actors-1] INFO  org.camunda.feel.FeelEngine - Engine created. [value-mapper: CompositeValueMapper(List(io.camunda.zeebe.feel.impl.MessagePackValueMapper@62674959)), function-provider: io.camunda.zeebe.feel.impl.FeelFunctionProvider@22f6216f, clock: io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock@4df4823, configuration: {externalFunctionsEnabled: false}]
17:14:52.048 [Broker-0] [StreamProcessor-1] [zb-actors-1] INFO  org.camunda.feel.FeelEngine - Engine created. [value-mapper: CompositeValueMapper(List(io.camunda.zeebe.feel.impl.MessagePackValueMapper@591e3167)), function-provider: io.camunda.zeebe.feel.impl.FeelFunctionProvider@16b969c, clock: io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock@12053287, configuration: {externalFunctionsEnabled: false}]
17:14:52.048 [Broker-0] [StreamProcessor-1] [zb-actors-1] INFO  org.camunda.feel.FeelEngine - Engine created. [value-mapper: CompositeValueMapper(List(io.camunda.zeebe.feel.impl.MessagePackValueMapper@6c65eeb4)), function-provider: io.camunda.zeebe.feel.impl.FeelFunctionProvider@44587f56, clock: io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock@19dace37, configuration: {externalFunctionsEnabled: false}]
17:14:52.049 [Broker-0] [StreamProcessor-1] [zb-actors-1] INFO  org.camunda.dmn.DmnEngine - DMN-Engine created. [value-mapper: CompositeValueMapper(List(io.camunda.zeebe.feel.impl.MessagePackValueMapper@70bd44db)), function-provider: org.camunda.feel.context.FunctionProvider$EmptyFunctionProvider$@7be06e40, audit-loggers: List(), configuration: Configuration(false,false,false)]
17:14:52.049 [Broker-0] [StreamProcessor-1] [zb-actors-1] INFO  org.camunda.feel.FeelEngine - Engine created. [value-mapper: CompositeValueMapper(List(org.camunda.dmn.NoUnpackValueMapper@25028d79)), function-provider: org.camunda.feel.context.FunctionProvider$EmptyFunctionProvider$@7be06e40, clock: SystemClock, configuration: {externalFunctionsEnabled: false}]
17:14:52.050 [Broker-0] [StreamProcessor-1] [zb-actors-1] INFO  io.camunda.zeebe.processor - Processor starts replay of events. [snapshot-position: -1, replay-mode: REPLAY]
17:14:52.050 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.broker.system - Registered component StreamProcessor-1:StreamProcessor-1
17:14:52.050 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.broker.system - Transition to FOLLOWER on term 1 - transitioning CommandApiService
17:14:52.050 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.broker.system - Transition to FOLLOWER on term 1 - transitioning SnapshotDirector
17:14:52.058 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.broker.system - Registered component SnapshotDirector-1:SnapshotDirector-1
17:14:52.058 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.broker.system - Transition to FOLLOWER on term 1 - transitioning ExporterDirector
17:14:52.058 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.broker.exporter - Use default exporter factory to create instance of class io.camunda.zeebe.test.util.record.RecordingExporter
17:14:52.059 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.broker.system - Registered component Exporter-1:Exporter-1
17:14:52.059 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.broker.system - Transition to FOLLOWER on term 1 - transitioning BackupApiRequestHandler
17:14:52.059 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.broker.system - Transition to FOLLOWER on term 1 - transitioning Admin API
17:14:52.059 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.broker.system - Transition to FOLLOWER on term 1 completed
```

And with this PR (and the other 3 pending PRs in other places):

> [!Note]
> I've opened issues on the FEEL and DMN scala projects to lower the log level of the relevant statements.

```
2024-12-23 19:46:53.593 [Broker-0] [zb-actors-1] [ZeebePartition-1] INFO 
      io.camunda.zeebe.broker.system - Transition to LEADER on term 17 starting
2024-12-23 19:46:53.620 [Broker-0] [zb-actors-1] [HealthCheckService] WARN 
      io.camunda.zeebe.broker.system - Partition-1 failed, marking it as unhealthy: HealthReport[componentName=Partition-1, status=UNHEALTHY, issue=HealthIssue[message=Services not installed, throwable=null, cause=null, since=2024-12-23T18:46:53.588556604Z], children={ZeebePartitionHealth-1=HealthReport[componentName=ZeebePartitionHealth-1, status=UNHEALTHY, issue=HealthIssue[message=Services not installed, throwable=null, cause=null, since=2024-12-23T18:46:53.588556604Z], children={}], RaftPartition-1=HealthReport[componentName=RaftPartition-1, status=HEALTHY, issue=null, children={}]}]
2024-12-23 19:46:53.899 [Broker-0] [zb-actors-0] [ZeebePartition-1] INFO 
      io.camunda.zeebe.engine.state.migration - No migrations to run, snapshot is the same as current version
2024-12-23 19:46:53.959 [Broker-0] [zb-actors-0] [StreamProcessor-1] INFO 
      io.camunda.zeebe.logstreams - Recovered state of partition 1 from snapshot at position 1
2024-12-23 19:46:54.141 [Broker-0] [zb-actors-0] [StreamProcessor-1] INFO 
      io.camunda.zeebe.processor - Processor starts replay of events. [snapshot-position: 1, replay-mode: PROCESSING]
2024-12-23 19:46:54.156 [Broker-0] [zb-actors-0] [StreamProcessor-1] INFO 
      io.camunda.zeebe.processor - Processor finished replay, with [lastProcessedPosition: 5, lastWrittenPosition: 6]
2024-12-23 19:46:54.158 [Broker-0] [zb-actors-1] [ZeebePartition-1] INFO 
      io.camunda.zeebe.broker.system - Transition to LEADER on term 17 completed
```