### PR TITLE
Minor clean up for messaging related logging

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/discovery/BootstrapDiscoveryProvider.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/discovery/BootstrapDiscoveryProvider.java
@@ -95,13 +95,13 @@ public final class BootstrapDiscoveryProvider
 
   @Override
   public CompletableFuture<Void> join(final BootstrapService bootstrap, final Node localNode) {
-    LOGGER.info("Local node {} joined the bootstrap service", localNode);
+    LOGGER.debug("Local node {} joined the bootstrap service", localNode);
     return CompletableFuture.completedFuture(null);
   }
 
   @Override
   public CompletableFuture<Void> leave(final Node localNode) {
-    LOGGER.info("Local node {} left the bootstrap servide", localNode);
+    LOGGER.debug("Local node {} left the bootstrap servide", localNode);
     return CompletableFuture.completedFuture(null);
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -910,7 +910,6 @@ public final class NettyMessagingService implements ManagedMessagingService {
               (ChannelFutureListener)
                   f -> {
                     if (f.isSuccess()) {
-                      log.info("TCP server listening for connections on {}", address);
                       serverChannel = f.channel();
                       bind(bootstrap, addressIterator, future);
                     } else {


### PR DESCRIPTION
## Description

This PR cleans up some minor logs from the startup/transitions related to messaging. We're already logging all the bind addresses when the messaging service starts, so logging it before is just redundant. 

And logging that the local node joins the discovery group to INFO is also redundant, because we'll later log the initial members of the group (which is _only_ the local node anyway).
