### PR TITLE
refactor: apply SO_SNDBUF to child channels

### DIFF
--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -263,7 +263,7 @@ public final class Gateway implements CloseableSilently {
         .permitKeepAliveTime(minKeepAliveInterval.toMillis(), TimeUnit.MILLISECONDS)
         .permitKeepAliveWithoutCalls(false)
         .withOption(ChannelOption.SO_RCVBUF, (int) cfg.getSocketReceiveBuffer().toBytes())
-        .withOption(ChannelOption.SO_SNDBUF, (int) cfg.getSocketSendBuffer().toBytes());
+        .withChildOption(ChannelOption.SO_SNDBUF, (int) cfg.getSocketSendBuffer().toBytes());
   }
 
   private void setSecurityConfig(


### PR DESCRIPTION
## Description

This PR applies the `SO_SNDBUF` channel configuration as a child option for gRPC channels. It's invalid to apply it to the main server channel, since it's used _only_ to receive requests. Whenever it receives one, it will spawn an ephemeral so-called "child" channel to handle it, and only there will it send anything.

Previously, this resulted in a warning at startup, saying we were applying an unknown option, resulting in the configuration option not being used at all.

> [!Note]
> I'm not marking this as closing the issue, as I'd like to challenge if we really want to overwrite gRPC defaults.

## Related issues

related to #26396 
