### PR TITLE
deps: remove unused Jetty dependency

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -213,7 +213,7 @@
 
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/operate/common/pom.xml
+++ b/operate/common/pom.xml
@@ -49,7 +49,7 @@
 
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/operate/qa/integration-tests/pom.xml
+++ b/operate/qa/integration-tests/pom.xml
@@ -432,7 +432,7 @@
 
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/optimize/backend/README.md
+++ b/optimize/backend/README.md
@@ -72,7 +72,7 @@ info("TEST")
         ┌───────────┐      ┌───────────┐    ┌─────────────────┐       │                  │
         │ Import    │ <──> │ Import    │    │ Import handlers │──────>│                  │
         │ scheduler │      │ mediator  │    │ (state storage) │       │                  │
-        └───────────┘      └───────────┘    └─────────────────┘       │                  │       
+        └───────────┘      └───────────┘    └─────────────────┘       │                  │
                                             ┌─────────────────┐       │                  │
                                             │ Import fetchers │       │                  │
                                             │ (data fetching) │       │                  │
@@ -162,7 +162,7 @@ In order to run API you have to run
 io.camunda.optimize.Main
 ```
 
-class as a normal class, which will start up embedded Jetty server with listener on port 8080 and
+class as a normal class, which will start up embedded Tomcat server with listener on port 8080 and
 endpoints providing basic operations
 
 to run from command line please execute following from root folder of the project
@@ -198,7 +198,6 @@ which will reply with something like
 <pre>    Unauthorized</pre>
 </p>
 <hr/>
-<i><small>Powered by Jetty://</small></i>
 </body>
 </html>
 ```

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -170,7 +170,6 @@
     <version.hdr-histogram>2.2.2</version.hdr-histogram>
     <version.joda-time>2.13.0</version.joda-time>
     <version.commons-collections4>4.4</version.commons-collections4>
-    <version.jetty>11.0.24</version.jetty>
     <version.xmlunit-core>2.10.0</version.xmlunit-core>
 
     <!-- Auth0 Dependencies -->
@@ -1022,14 +1021,6 @@
            In order resolve dependency issues with wiremock and spring-boot-dependencies
            make sure this is declared before spring boot dependencies.
       -->
-
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-bom</artifactId>
-        <version>${version.jetty}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
 
       <dependency>
         <!-- Import dependency management from Spring Boot -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1522,12 +1522,6 @@
 
       <dependency>
         <groupId>org.wiremock</groupId>
-        <artifactId>wiremock</artifactId>
-        <version>${version.wiremock}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.wiremock</groupId>
         <artifactId>wiremock-standalone</artifactId>
         <version>${version.wiremock}</version>
       </dependency>

--- a/search/search-client-connect/pom.xml
+++ b/search/search-client-connect/pom.xml
@@ -181,9 +181,10 @@
 
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>

--- a/tasklist/common/pom.xml
+++ b/tasklist/common/pom.xml
@@ -44,7 +44,7 @@
 
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/tasklist/qa/integration-tests/pom.xml
+++ b/tasklist/qa/integration-tests/pom.xml
@@ -421,7 +421,7 @@
 
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/zeebe/exporters/elasticsearch-exporter/pom.xml
+++ b/zeebe/exporters/elasticsearch-exporter/pom.xml
@@ -180,7 +180,7 @@
 
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/zeebe/exporters/opensearch-exporter/pom.xml
+++ b/zeebe/exporters/opensearch-exporter/pom.xml
@@ -200,7 +200,7 @@
 
     <dependency>
       <groupId>org.wiremock</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
## Description

Removes Jetty from our dependencies. This was previously used by Optimize, but the application was since migrated to use Tomcat with the rest of the stack.

However, by leaving the dependency, we still have Renovate trying to update it (causing unnecessary CI runs), and we also have to deal with potential dependency convergence unnecessarily.
