### PR TITLE
Fixes Zeebe 8.5 Limiters inFlight concurrent access

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backpressure/CommandRateLimiter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backpressure/CommandRateLimiter.java
@@ -50,11 +50,17 @@ public final class CommandRateLimiter extends AbstractLimiter<Intent>
 
   @Override
   public Optional<Listener> acquire(final Intent intent) {
-    if (getInflight() >= getLimit() && !WHITE_LISTED_COMMANDS.contains(intent)) {
-      return createRejectedListener();
+    if (WHITE_LISTED_COMMANDS.contains(intent)) {
+      return Optional.of(createListener());
     }
-    final Listener listener = createListener();
-    return Optional.of(listener);
+
+    synchronized (this) {
+      if (getInflight() < getLimit()) {
+        return Optional.of(createListener());
+      }
+    }
+
+    return createRejectedListener();
   }
 
   private void registerListener(final int streamId, final long requestId, final Listener listener) {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/AppendLimiter.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/AppendLimiter.java
@@ -26,11 +26,13 @@ final class AppendLimiter extends AbstractLimiter<Void> {
 
   @Override
   public Optional<Listener> acquire(final Void context) {
-    if (getInflight() >= getLimit()) {
-      return createRejectedListener();
-    } else {
-      return Optional.of(createListener());
+    synchronized (this) {
+      if (getInflight() < getLimit()) {
+        return Optional.of(createListener());
+      }
     }
+
+    return createRejectedListener();
   }
 
   @Override

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/AppenderFlowControlTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/AppenderFlowControlTest.java
@@ -7,8 +7,21 @@
  */
 package io.camunda.zeebe.logstreams.impl.flowcontrol;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.netflix.concurrency.limits.Limit;
+import com.netflix.concurrency.limits.Limiter.Listener;
+import com.netflix.concurrency.limits.limit.SettableLimit;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.LinkedList;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -76,5 +89,44 @@ final class AppenderFlowControlTest {
 
     // then
     Awaitility.await("Eventually accepts appends again").until(() -> flow.tryAcquire().isPresent());
+  }
+
+  @Test
+  void shouldNotAllowInFlightHigherThanLimit() throws InterruptedException {
+    // given
+    final int numThreads = 3000;
+    final int poolSize = 300;
+    final int limit = 100;
+    final Limit myLimit = new SettableLimit(limit);
+    final AppenderMetrics appenderMetrics = new AppenderMetrics(1);
+    appenderMetrics.setInflightLimit(limit);
+    final AppendLimiter myRateLimiter =
+        AppendLimiter.builder().limit(myLimit).metrics(appenderMetrics).build();
+    final ExecutorService threadPool = Executors.newFixedThreadPool(poolSize);
+    final Optional<Listener>[] listeners = new Optional[numThreads];
+
+    final Collection<Callable<Object>> tasks =
+        IntStream.range(0, numThreads)
+            .mapToObj(
+                i ->
+                    (Callable<Object>)
+                        () -> {
+                          final int sleepTime = ThreadLocalRandom.current().nextInt(limit);
+                          listeners[i] = myRateLimiter.acquire(null);
+                          Thread.sleep(sleepTime);
+                          assertThat(myRateLimiter.getInflight()).isLessThanOrEqualTo(limit);
+                          listeners[i].get().onSuccess();
+                          return null;
+                        })
+            .collect(Collectors.toList());
+    try {
+      threadPool.invokeAll(tasks);
+    } finally {
+      // when
+      threadPool.shutdown();
+    }
+
+    // then
+    assertThat(myRateLimiter.getInflight()).isEqualTo(0);
   }
 }


### PR DESCRIPTION
## Description
By analyzing the heap dump in #24521, we noticed that the value of `AbstractLimiter.inFlight` was higher than `AbstractLimiter.limit` in some cases. Although this can be valid, even if `inFlight` equals `limit` and the received intents are whitelisted commands, the intent is accepted to be processed and the `inFlight` counter incremented, possibly being assigned a value above `limit`.
We also noticed that the number of `inFlight` requests for some partitions of the analyzed clusters in #26104 when back-pressure was at 100%, could be above the `limit`.
By looking at the code in `CommandRateLimiter.acquire` and `AppendLimiter.acquire`, although `inFlight` is an `AtomicInteger`, we found that the comparison to the value of `limit` was performed without any synchronization mechanism and `inFlight` would be incremented independently afterwards in the call to `AbstractLimiter.createListener`.

With the introduced unit tests for both `CommandRateLimiter` and `AppendLimiter`, we were able to concurrently increment `inFlight` up to 101 with a `limit` of 100.

The changes to these 2 limiters enforces this condition, that `inFlight` < `limit` always, except for the whitelisted commands in the case of `CommandRateLimiter`.
The decision to use a `synchronized` section is a quick fix and also avoids the need to extend or reimplement the `createListener` method, which is inherited from `AbstractListener`, twice.


## Related issues

partially closes #26104 and #24521 
