### PR TITLE
ci: yarn install mutex on all yarn 1.x usages

### DIFF
--- a/operate/client/pom.xml
+++ b/operate/client/pom.xml
@@ -63,6 +63,7 @@
             <configuration>
               <failOnError>false</failOnError>
               <skip>${skip.fe.build}</skip>
+              <arguments>install --mutex file:/tmp/.yarn-mutex</arguments>
             </configuration>
           </execution>
 

--- a/optimize/client/pom.xml
+++ b/optimize/client/pom.xml
@@ -42,6 +42,7 @@
             <configuration>
               <failOnError>false</failOnError>
               <skip>${skip.fe.build}</skip>
+              <arguments>install --mutex file:/tmp/.yarn-mutex</arguments>
             </configuration>
           </execution>
 

--- a/tasklist/client/pom.xml
+++ b/tasklist/client/pom.xml
@@ -57,6 +57,7 @@
             <configuration>
               <failOnError>false</failOnError>
               <skip>${skip.fe.build}</skip>
+              <arguments>install --mutex file:/tmp/.yarn-mutex</arguments>
             </configuration>
           </execution>
 


### PR DESCRIPTION
## Description

Yarn 1.x doesn't seem to play well with concurrent processes accessing the same cache. See https://github.com/yarnpkg/yarn/issues/2629#issuecomment-480535595 .

I didn't touch the identity frontend as this uses the new yarn >2.x, which according to https://yarnpkg.com/configuration/yarnrc  doesn't have concurrency issues "The cache is deemed to be relatively safe to be shared by multiple projects, even when multiple Yarn instances run at the same time on different projects. "

With now having 4 frontend modules with yarn 1.x which potentially build in parallel on multi-threaded maven builds, I noticed cache file issues e.g. here https://github.com/camunda/camunda/actions/runs/12480775858/job/34832175681 or here 
https://github.com/camunda/camunda/actions/runs/12475426337/job/34818808394

Effectively the QA workflow fails since last week because of such issues https://github.com/camunda/camunda/actions/workflows/zeebe-qa-testbench.yaml?query=branch%3Amain

```
[INFO] error Error: ENOTEMPTY: directory not empty, rmdir '/home/runner/.cache/yarn/v6/npm-lodash-4.17.21-679591c564c3bffaae8454cf0b3df370c3d6911c-integrity/node_modules/lodash'
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
