### PR TITLE
Opensearch handle 404 for GET by document ID

### DIFF
--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/FormStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/FormStoreOpenSearch.java
@@ -21,6 +21,7 @@ import io.camunda.webapps.schema.descriptors.tasklist.index.FormIndex;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
 import io.camunda.webapps.schema.entities.tasklist.FormEntity;
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -101,12 +102,16 @@ public class FormStoreOpenSearch implements FormStore {
       final GetResponse<FormIdView> response = osClient.get(request, FormIdView.class);
       if (response.found() && response.source() != null) {
         return Optional.of(response.source());
-      } else {
+      }
+    } catch (final OpenSearchException e) {
+      if (e.response().status() == HttpURLConnection.HTTP_NOT_FOUND) {
         return Optional.empty();
       }
+      throw new TasklistRuntimeException(e);
     } catch (final IOException e) {
       throw new TasklistRuntimeException(e);
     }
+    return Optional.empty();
   }
 
   private Boolean isFormAssociatedToTask(final String formId, final String processDefinitionId) {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/FormStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/FormStoreOpenSearch.java
@@ -33,6 +33,8 @@ import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.GetRequest;
 import org.opensearch.client.opensearch.core.GetResponse;
 import org.opensearch.client.opensearch.core.SearchRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
@@ -41,6 +43,8 @@ import org.springframework.stereotype.Component;
 @Component
 @Conditional(OpenSearchCondition.class)
 public class FormStoreOpenSearch implements FormStore {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FormStoreOpenSearch.class);
 
   @Autowired private FormIndex formIndex;
 
@@ -105,6 +109,7 @@ public class FormStoreOpenSearch implements FormStore {
       }
     } catch (final OpenSearchException e) {
       if (e.response().status() == HttpURLConnection.HTTP_NOT_FOUND) {
+        LOG.debug("Form with key {} not found, opensearch related exception {}", formKey, e);
         return Optional.empty();
       }
       throw new TasklistRuntimeException(e);

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/FormStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/FormStoreOpenSearch.java
@@ -109,7 +109,7 @@ public class FormStoreOpenSearch implements FormStore {
       }
     } catch (final OpenSearchException e) {
       if (e.response().status() == HttpURLConnection.HTTP_NOT_FOUND) {
-        LOG.debug("Form with key {} not found, opensearch related exception {}", formKey, e);
+        LOG.debug("Form with key {} not found.", formKey, e);
         return Optional.empty();
       }
       throw new TasklistRuntimeException(e);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Opensearch throws an exception when requesting documents by ID that are not present ( `GET <index>/_doc/<_id>` ). Spotted only on AWS managed Opensearch.

Manually handle this `404` as not present regarding User Task forms.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Ref Slack thread: https://camunda.slack.com/archives/C046XS3GGCR/p1735037743082099
