### PR TITLE
fix: fixing tasklist startup for StandaloneCamunda and StandaloneTask…

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/backup/ElasticsearchOptimizeBackupRepository.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/ElasticsearchOptimizeBackupRepository.java
@@ -32,7 +32,10 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 @Conditional(ElasticSearchCondition.class)
 @Configuration
 @Profile("optimize")
-@ConditionalOnMissingBean({ElasticsearchBackupRepository.class, ElasticsearchTasklistBackupRepository.class})
+@ConditionalOnMissingBean({
+  ElasticsearchBackupRepository.class,
+  ElasticsearchTasklistBackupRepository.class
+})
 // only active if standalone, otherwise the operate one is used
 public class ElasticsearchOptimizeBackupRepository {
 

--- a/dist/src/main/java/io/camunda/application/commons/backup/ElasticsearchOptimizeBackupRepository.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/ElasticsearchOptimizeBackupRepository.java
@@ -14,6 +14,7 @@ import io.camunda.webapps.backup.repository.BackupRepositoryProps;
 import io.camunda.webapps.backup.repository.WebappsSnapshotNameProvider;
 import io.camunda.webapps.backup.repository.elasticsearch.ElasticsearchBackupRepository;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -30,7 +31,8 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
  */
 @Conditional(ElasticSearchCondition.class)
 @Configuration
-@Profile("optimize & !operate & standalone")
+@Profile("optimize")
+@ConditionalOnMissingBean({ElasticsearchBackupRepository.class, ElasticsearchTasklistBackupRepository.class})
 // only active if standalone, otherwise the operate one is used
 public class ElasticsearchOptimizeBackupRepository {
 

--- a/dist/src/main/java/io/camunda/application/commons/backup/ElasticsearchTasklistBackupRepository.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/ElasticsearchTasklistBackupRepository.java
@@ -16,6 +16,7 @@ import io.camunda.webapps.backup.repository.WebappsSnapshotNameProvider;
 import io.camunda.webapps.backup.repository.elasticsearch.ElasticsearchBackupRepository;
 import java.util.concurrent.Executor;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -32,7 +33,8 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
  */
 @Conditional(ElasticSearchCondition.class)
 @Configuration
-@Profile("tasklist & !operate & standalone")
+@Profile("tasklist")
+@ConditionalOnMissingBean(io.camunda.application.commons.backup.ElasticsearchBackupRepository.class)
 // only active if standalone, otherwise the operate one is used
 public class ElasticsearchTasklistBackupRepository {
 

--- a/dist/src/main/java/io/camunda/application/commons/backup/OpensearchOptimizeBackupRepository.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/OpensearchOptimizeBackupRepository.java
@@ -12,6 +12,7 @@ import io.camunda.webapps.backup.BackupRepository;
 import io.camunda.webapps.backup.repository.BackupRepositoryProps;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -27,7 +28,8 @@ import org.springframework.context.annotation.Profile;
  */
 @Conditional(OpenSearchCondition.class)
 @Configuration
-@Profile("optimize & !operate & standalone")
+@Profile("optimize")
+@ConditionalOnMissingBean({OpensearchBackupRepository.class, OpensearchTasklistBackupRepository.class})
 // only active if standalone, otherwise the operate one is used
 public class OpensearchOptimizeBackupRepository {
 

--- a/dist/src/main/java/io/camunda/application/commons/backup/OpensearchOptimizeBackupRepository.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/OpensearchOptimizeBackupRepository.java
@@ -29,7 +29,10 @@ import org.springframework.context.annotation.Profile;
 @Conditional(OpenSearchCondition.class)
 @Configuration
 @Profile("optimize")
-@ConditionalOnMissingBean({OpensearchBackupRepository.class, OpensearchTasklistBackupRepository.class})
+@ConditionalOnMissingBean({
+  OpensearchBackupRepository.class,
+  OpensearchTasklistBackupRepository.class
+})
 // only active if standalone, otherwise the operate one is used
 public class OpensearchOptimizeBackupRepository {
 

--- a/dist/src/main/java/io/camunda/application/commons/backup/OpensearchTasklistBackupRepository.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/OpensearchTasklistBackupRepository.java
@@ -13,6 +13,7 @@ import io.camunda.webapps.backup.repository.BackupRepositoryProps;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -28,7 +29,8 @@ import org.springframework.context.annotation.Profile;
  */
 @Conditional(OpenSearchCondition.class)
 @Configuration
-@Profile("tasklist & !operate & standalone")
+@Profile("tasklist")
+@ConditionalOnMissingBean(OpensearchBackupRepository.class)
 // only active if standalone, otherwise the operate one is used
 public class OpensearchTasklistBackupRepository {
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Tasklist wasn't starting properly using StandaloneCamunda with tasklist, broker profiles (what is a valid scenario) - unless when using operate together (as the classes were being loaded from there).
I applied a similar fix for Optimize, making it the "last" option when no other beans are loaded.

This can bring some configuration issues and should be revisited (example: when having different configurations for ES or OS in Optimize, Tasklist, Operate - what I consider not usual but still possible - the backups are going to take the first one)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
