### PR TITLE
test: fix tasklist docker tests

### DIFF
--- a/migration/process-migration/src/main/java/io/camunda/migration/process/MigrationRunner.java
+++ b/migration/process-migration/src/main/java/io/camunda/migration/process/MigrationRunner.java
@@ -28,6 +28,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -181,6 +182,9 @@ public class MigrationRunner implements Migrator {
    */
   private boolean shouldThrowException(final Exception exception) {
     if (exception.getCause() instanceof final ElasticsearchException ex) {
+      return ex.error().reason() != null
+          && !MigrationUtil.MIGRATION_REPOSITORY_NOT_EXISTS.matcher(ex.error().reason()).find();
+    } else if (exception.getCause() instanceof final OpenSearchException ex) {
       return ex.error().reason() != null
           && !MigrationUtil.MIGRATION_REPOSITORY_NOT_EXISTS.matcher(ex.error().reason()).find();
     }

--- a/qa/integration-tests/src/test/java/io/camunda/it/migration/MigrationUserTaskUpdateIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/migration/MigrationUserTaskUpdateIT.java
@@ -35,7 +35,7 @@ public class MigrationUserTaskUpdateIT {
   @RegisterExtension
   static final MigrationITInvocationProvider PROVIDER =
       new MigrationITInvocationProvider()
-          .withDatabaseTypes(DatabaseType.ELASTICSEARCH, DatabaseType.OPENSEARCH)
+          .withDatabaseTypes(DatabaseType.ELASTICSEARCH)
           .withRunBefore(MigrationUserTaskUpdateIT::generateData)
           .withRunAfter(MigrationUserTaskUpdateIT::generate87Data);
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/migration/util/TasklistMigrationHelper.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/migration/util/TasklistMigrationHelper.java
@@ -240,8 +240,7 @@ public class TasklistMigrationHelper {
     return new HashMap<>() {
       {
         put("CAMUNDA_TASKLIST_ELASTICSEARCH_URL", "http://elasticsearch:9200");
-        put("CAMUNDA_TASKLIST_ELASTICSEARCH_HOST", "elasticsearch");
-        put("CAMUNDA_TASKLIST_ELASTICSEARCH_PORT", "9200");
+        put("CAMUNDA_DATABASE_URL", "http://elasticsearch:9200");
         put("CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_URL", "http://elasticsearch:9200");
         put("CAMUNDA_TASKLIST_ZEEBE_GATEWAYADDRESS", zeebe.getZeebeGatewayAddress());
         put("CAMUNDA_TASKLIST_ZEEBE_REST_ADDRESS", zeebe.getZeebeRestAddress());
@@ -254,9 +253,9 @@ public class TasklistMigrationHelper {
     return new HashMap<>() {
       {
         put("CAMUNDA_TASKLIST_DATABASE", "opensearch");
+        put("CAMUNDA_DATABASE_TYPE", "opensearch");
         put("CAMUNDA_TASKLIST_OPENSEARCH_URL", "http://opensearch:9200");
-        put("CAMUNDA_TASKLIST_OPENSEARCH_HOST", "opensearch");
-        put("CAMUNDA_TASKLIST_OPENSEARCH_PORT", "9200");
+        put("CAMUNDA_DATABASE_URL", "http://opensearch:9200");
         put("CAMUNDA_TASKLIST_ZEEBEOPENSEARCH_URL", "http://opensearch:9200");
         put("CAMUNDA_TASKLIST_ZEEBE_GATEWAYADDRESS", zeebe.getZeebeGatewayAddress());
         put("CAMUNDA_TASKLIST_ZEEBE_REST_ADDRESS", zeebe.getZeebeRestAddress());

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/StartupIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/StartupIT.java
@@ -63,16 +63,11 @@ public class StartupIT {
     final String elsHost = testContext.getInternalElsHost();
     final Integer elsPort = testContext.getInternalElsPort();
 
+    final String elasticSearchUrl = String.format("http://%s:%s", elsHost, elsPort);
     tasklistContainer
-        .withEnv(
-            "CAMUNDA_TASKLIST_ELASTICSEARCH_URL", String.format("http://%s:%s", elsHost, elsPort))
-        .withEnv("CAMUNDA_TASKLIST_ELASTICSEARCH_HOST", elsHost)
-        .withEnv("CAMUNDA_TASKLIST_ELASTICSEARCH_PORT", String.valueOf(elsPort))
-        .withEnv(
-            "CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_URL",
-            String.format("http://%s:%s", elsHost, elsPort))
-        .withEnv("CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_HOST", elsHost)
-        .withEnv("CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_PORT", String.valueOf(elsPort))
+        .withEnv("CAMUNDA_TASKLIST_ELASTICSEARCH_URL", elasticSearchUrl)
+        .withEnv("CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_URL", elasticSearchUrl)
+        .withEnv("CAMUNDA_DATABASE_URL", elasticSearchUrl)
         .withEnv("CAMUNDA_TASKLIST_ZEEBE_COMPATIBILITY_ENABLED", "true");
 
     testContainerUtil.startTasklistContainer(tasklistContainer, VERSION, testContext);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Since https://github.com/camunda/camunda/commit/a5aa922c6404e8444fb02a1b8e6dc6e3729237ba, Tasklist container in the test does not start with this error (it is missing the `CAMUNDA_DATABASE_URL` parameter)
```
2024-12-24 15:17:58.470 [] [main] [] ERROR
      io.camunda.application - Failed to start application with message: Failed to execute ApplicationRunner
java.lang.IllegalStateException: Failed to execute ApplicationRunner
        at org.springframework.boot.SpringApplication.lambda$callRunner$6(SpringApplication.java:797) ~[spring-boot-3.3.7.jar:3.3.7]
        at org.springframework.util.function.ThrowingConsumer.accept(ThrowingConsumer.java:66) ~[spring-core-6.1.14.jar:6.1.14]
        at org.springframework.util.function.ThrowingConsumer$1.accept(ThrowingConsumer.java:88) ~[spring-core-6.1.14.jar:6.1.14]
        at org.springframework.boot.SpringApplication.callRunner(SpringApplication.java:798) ~[spring-boot-3.3.7.jar:3.3.7]
        at org.springframework.boot.SpringApplication.callRunner(SpringApplication.java:786) ~[spring-boot-3.3.7.jar:3.3.7]
        at org.springframework.boot.SpringApplication.lambda$callRunners$3(SpringApplication.java:774) ~[spring-boot-3.3.7.jar:3.3.7]
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184) ~[?:?]
        at java.base/java.util.stream.SortedOps$SizedRefSortingSink.end(SortedOps.java:357) ~[?:?]
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:510) ~[?:?]
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499) ~[?:?]
        at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151) ~[?:?]
        at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174) ~[?:?]
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
        at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596) ~[?:?]
        at org.springframework.boot.SpringApplication.callRunners(SpringApplication.java:774) [spring-boot-3.3.7.jar:3.3.7]
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:342) [spring-boot-3.3.7.jar:3.3.7]
        at io.camunda.application.StandaloneTasklist.main(StandaloneTasklist.java:48) [camunda-zeebe-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
Caused by: java.util.concurrent.ExecutionException: io.camunda.migration.api.MigrationException: Failed to fetch last migrated process
        at java.base/java.util.concurrent.FutureTask.report(FutureTask.java:122) ~[?:?]
        at java.base/java.util.concurrent.FutureTask.get(FutureTask.java:191) ~[?:?]
        at io.camunda.application.commons.migration.MigrationsRunner.run(MigrationsRunner.java:41) ~[camunda-zeebe-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
        at org.springframework.boot.SpringApplication.lambda$callRunner$4(SpringApplication.java:786) ~[spring-boot-3.3.7.jar:3.3.7]
        at org.springframework.util.function.ThrowingConsumer$1.acceptWithException(ThrowingConsumer.java:83) ~[spring-core-6.1.14.jar:6.1.14]
        at org.springframework.util.function.ThrowingConsumer.accept(ThrowingConsumer.java:60) ~[spring-core-6.1.14.jar:6.1.14]
        ... 15 more
Caused by: io.camunda.migration.api.MigrationException: Failed to fetch last migrated process
        at io.camunda.migration.process.MigrationRunner.call(MigrationRunner.java:86) ~[process-migration-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
        at io.camunda.migration.process.MigrationRunner.call(MigrationRunner.java:36) ~[process-migration-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
Caused by: io.camunda.migration.api.MigrationException: Failed to fetch last migrated process
        at io.camunda.migration.process.adapter.es.ElasticsearchAdapter.readLastMigratedEntity(ElasticsearchAdapter.java:144) ~[process-migration-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
        at io.camunda.migration.process.MigrationRunner.call(MigrationRunner.java:66) ~[process-migration-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
        at io.camunda.migration.process.MigrationRunner.call(MigrationRunner.java:36) ~[process-migration-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
Caused by: java.net.ConnectException: Connection refused
        at org.elasticsearch.client.RestClient.extractAndWrapCause(RestClient.java:934) ~[elasticsearch-rest-client-8.13.4.jar:8.13.4]
        at org.elasticsearch.client.RestClient.performRequest(RestClient.java:304) ~[elasticsearch-rest-client-8.13.4.jar:8.13.4]
        at org.elasticsearch.client.RestClient.performRequest(RestClient.java:292) ~[elasticsearch-rest-client-8.13.4.jar:8.13.4]
        at co.elastic.clients.transport.rest_client.RestClientHttpClient.performRequest(RestClientHttpClient.java:91) ~[elasticsearch-java-8.13.4.jar:?]
        at co.elastic.clients.transport.ElasticsearchTransportBase.performRequest(ElasticsearchTransportBase.java:144) ~[elasticsearch-java-8.13.4.jar:?]
        at co.elastic.clients.elasticsearch.ElasticsearchClient.search(ElasticsearchClient.java:1923) ~[elasticsearch-java-8.13.4.jar:?]
        at io.camunda.migration.process.adapter.es.ElasticsearchAdapter.lambda$readLastMigratedEntity$15(ElasticsearchAdapter.java:141) ~[process-migration-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
        at io.github.resilience4j.retry.Retry.lambda$decorateCallable$5(Retry.java:237) ~[resilience4j-retry-2.2.0.jar:2.2.0]
        at io.camunda.migration.process.util.AdapterRetryDecorator.decorate(AdapterRetryDecorator.java:40) ~[process-migration-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
        at io.camunda.migration.process.adapter.es.ElasticsearchAdapter.readLastMigratedEntity(ElasticsearchAdapter.java:139) ~[process-migration-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
        at io.camunda.migration.process.MigrationRunner.call(MigrationRunner.java:66) ~[process-migration-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
        at io.camunda.migration.process.MigrationRunner.call(MigrationRunner.java:36) ~[process-migration-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[?:?]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[?:?]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
Caused by: java.net.ConnectException: Connection refused
        at java.base/sun.nio.ch.Net.pollConnect(Native Method) ~[?:?]
        at java.base/sun.nio.ch.Net.pollConnectNow(Net.java:682) ~[?:?]
        at java.base/sun.nio.ch.SocketChannelImpl.finishConnect(SocketChannelImpl.java:973) ~[?:?]
        at org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor.processEvent(DefaultConnectingIOReactor.java:174) ~[httpcore-nio-4.4.16.jar:4.4.16]
        at org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor.processEvents(DefaultConnectingIOReactor.java:148) ~[httpcore-nio-4.4.16.jar:4.4.16]
        at org.apache.http.impl.nio.reactor.AbstractMultiworkerIOReactor.execute(AbstractMultiworkerIOReactor.java:351) ~[httpcore-nio-4.4.16.jar:4.4.16]
        at org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager.execute(PoolingNHttpClientConnectionManager.java:221) ~[httpasyncclient-4.1.5.jar:4.1.5]
        at org.apache.http.impl.nio.client.CloseableHttpAsyncClientBase$1.run(CloseableHttpAsyncClientBase.java:64) ~[httpasyncclient-4.1.5.jar:4.1.5]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
