### PR TITLE
fix: make CommandWrapper response type agnostic

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/jobhandling/CommandWrapper.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/jobhandling/CommandWrapper.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 
 public class CommandWrapper {
 
-  private final FinalCommandStep<Void> command;
+  private final FinalCommandStep<?> command;
   private final ActivatedJob job;
   private final CommandExceptionHandlingStrategy commandExceptionHandlingStrategy;
   private final MetricsRecorder metricsRecorder;
@@ -35,7 +35,7 @@ public class CommandWrapper {
   private final int maxRetries;
 
   public CommandWrapper(
-      final FinalCommandStep<Void> command,
+      final FinalCommandStep<?> command,
       final ActivatedJob job,
       final CommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
       final MetricsRecorder metricsRecorder,

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobHandlerInvokingSpringBeans.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobHandlerInvokingSpringBeans.java
@@ -19,6 +19,7 @@ import io.camunda.client.api.command.CompleteJobCommandStep1;
 import io.camunda.client.api.command.FinalCommandStep;
 import io.camunda.client.api.command.ThrowErrorCommandStep1.ThrowErrorCommandStep2;
 import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.response.CompleteJobResponse;
 import io.camunda.client.api.worker.JobClient;
 import io.camunda.client.api.worker.JobHandler;
 import io.camunda.client.impl.Loggers;
@@ -116,7 +117,7 @@ public class JobHandlerInvokingSpringBeans implements JobHandler {
     return parameterResolvers.stream().map(resolver -> resolver.resolve(jobClient, job)).toList();
   }
 
-  private FinalCommandStep createCompleteCommand(
+  private FinalCommandStep<CompleteJobResponse> createCompleteCommand(
       final JobClient jobClient, final ActivatedJob job, final Object result) {
     CompleteJobCommandStep1 completeCommand = jobClient.newCompleteCommand(job.getKey());
     if (result != null) {


### PR DESCRIPTION
## Description

Previously Void was used statically, which wasn't a problem as the response wasn't consumed in the wrapper. Since the introduction of [executeAsyncWithMetrics](https://github.com/camunda/camunda/blob/7975ade4b85293ce24da1e1424a5f442f6751d83/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/jobhandling/CommandWrapper.java#L67) it is consumed though.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #26418 
