### PR TITLE
build: allow differences based on semantic versions

### DIFF
--- a/build-tools/src/main/resources/revapi/revapi.json
+++ b/build-tools/src/main/resources/revapi/revapi.json
@@ -39,6 +39,15 @@
             "OTHER": "BREAKING"
           }
         }
+      },
+      "onAllowed": {
+        "classification": {
+          "BINARY": "EQUIVALENT",
+          "SOURCE": "EQUIVALENT",
+          "SEMANTIC": "EQUIVALENT",
+          "OTHER": "EQUIVALENT"
+        },
+        "justification": "Allowed due to semantic versioning rules"
       }
     }
   },


### PR DESCRIPTION
## Description

This PR updates the revapi configuration to correctly allow differences based on semantic versioning rules. This was previously working, but it seems at some point, an update of `revapi` introduced a new `onAllowed` configuration section, and without it the semantic version extension simply does not ignore anything.

> [!Note]
> Randomly discovered while updating `zeebe-test-container`

On another note, it seems we currently allow source breaking changes for patch updates. I would recommend we also enforce source compatibility (not just binary) for patches, but did not include it here yet.
