### PR TITLE
ci: workflow to deploy all dedicated images from a branch

### DIFF
--- a/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
+++ b/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
@@ -1,5 +1,5 @@
 ---
-name: Deploy Camunda Docker Image to SaaS registry
+name: Deploy Camunda Docker Images to SaaS registry
 
 on:
   workflow_dispatch:
@@ -57,8 +57,9 @@ jobs:
         run: |
           # Replace dots and slashes with dashes
           branch=${BRANCH/[\/\.]/-}
+          branch_git_sha=$(git rev-parse --short=8 HEAD)
           version=$(./mvnw help:evaluate -q -DforceStdout -D"expression=project.version")
-          echo "image-tag=$version-$branch-${GITHUB_SHA::8}" >> $GITHUB_OUTPUT
+          echo "image-tag=$version-$branch-$branch_git_sha" >> $GITHUB_OUTPUT
         env:
           BRANCH: ${{ inputs.branch }}
       - uses: ./.github/actions/build-zeebe
@@ -72,4 +73,39 @@ jobs:
           platforms: ${{ env.DOCKER_PLATFORMS }}
           dockerfile: camunda.Dockerfile
           push: true
-
+      - uses: ./.github/actions/build-platform-docker
+        id: build-push-zeebe-docker
+        with:
+          repository: europe-docker.pkg.dev/camunda-saas-registry/zeebe-io/zeebe
+          version: ${{ steps.image-tag.outputs.image-tag }}
+          distball: ${{ steps.build-camunda.outputs.distball }}
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          dockerfile: Dockerfile
+          push: true
+      - uses: ./.github/actions/build-platform-docker
+        id: build-push-operate-docker
+        with:
+          repository: europe-docker.pkg.dev/camunda-saas-registry/zeebe-io/operate
+          version: ${{ steps.image-tag.outputs.image-tag }}
+          distball: ${{ steps.build-camunda.outputs.distball }}
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          dockerfile: operate.Dockerfile
+          push: true
+      - uses: ./.github/actions/build-platform-docker
+        id: build-push-tasklist-docker
+        with:
+          repository: europe-docker.pkg.dev/camunda-saas-registry/zeebe-io/tasklist
+          version: ${{ steps.image-tag.outputs.image-tag }}
+          distball: ${{ steps.build-camunda.outputs.distball }}
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          dockerfile: tasklist.Dockerfile
+          push: true
+      - uses: ./.github/actions/build-platform-docker
+        id: build-push-optimize-docker
+        with:
+          repository: europe-docker.pkg.dev/camunda-saas-registry/zeebe-io/optimize
+          version: ${{ steps.image-tag.outputs.image-tag }}
+          distball: ${{ steps.build-camunda.outputs.distball }}
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          dockerfile: optimize.Dockerfile
+          push: true

--- a/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
+++ b/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
@@ -1,0 +1,75 @@
+---
+name: Deploy Camunda Docker Image to SaaS registry
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to deploy an image for'
+        required: true
+        type: string
+
+defaults:
+  run:
+    # use bash shell by default to ensure pipefail behavior is the default
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+env:
+  DOCKER_PLATFORMS: "linux/amd64"
+
+jobs:
+  deploy-camunda-docker-saas:
+    name: Deploy Camunda Docker image
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+      - name: Authenticate for saas image registry
+        id: auth-saas
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: 'projects/618877442292/locations/global/workloadIdentityPools/github/providers/camunda'
+          service_account: 'github-actions-zeebe-io@camunda-saas-registry.iam.gserviceaccount.com'
+      - name: Login to SaaS image registry
+        uses: docker/login-action@v3
+        with:
+          registry: europe-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth-saas.outputs.access_token }}
+      - name: Setup BuildKit
+        uses: docker/setup-buildx-action@v3
+      - uses: ./.github/actions/setup-build
+        with:
+          dockerhub-readonly: true
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - id: image-tag
+        name: Calculate image tag
+        shell: bash
+        run: |
+          # Replace dots and slashes with dashes
+          branch=${BRANCH/[\/\.]/-}
+          version=$(./mvnw help:evaluate -q -DforceStdout -D"expression=project.version")
+          echo "image-tag=$version-$branch-${GITHUB_SHA::8}" >> $GITHUB_OUTPUT
+        env:
+          BRANCH: ${{ inputs.branch }}
+      - uses: ./.github/actions/build-zeebe
+        id: build-camunda
+      - uses: ./.github/actions/build-platform-docker
+        id: build-push-camunda-docker
+        with:
+          repository: europe-docker.pkg.dev/camunda-saas-registry/zeebe-io/camunda
+          version: ${{ steps.image-tag.outputs.image-tag }}
+          distball: ${{ steps.build-camunda.outputs.distball }}
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          dockerfile: camunda.Dockerfile
+          push: true
+


### PR DESCRIPTION
## Description

When wanting to test some identity changes from branches in SaaS dev, I figured we seem to lack a workflow to deploy all camunda images from a branch to the SaaS registry. I thus created this wf to unblock manual integration testing of changes.

For now it needs to be run manually which is suffice for some testing we currently do, I didn't go further into adding labeling as trigger, curious if you think that would be generally useful to do already.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
