### PR TITLE
build: compile as Java 8 module due to transitive inclusion

### DIFF
--- a/security/security-core/pom.xml
+++ b/security/security-core/pom.xml
@@ -14,9 +14,13 @@
     <version>8.7.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>io.camunda</groupId>
   <artifactId>camunda-security-core</artifactId>
   <name>Camunda Security Core</name>
+
+  <properties>
+    <!-- must match the zeebe-protocol lowest support JDK version -->
+    <version.java>8</version.java>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/security/security-core/src/main/java/io/camunda/security/auth/Authentication.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authentication.java
@@ -10,15 +10,30 @@ package io.camunda.security.auth;
 import static java.util.Collections.unmodifiableList;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 
-public record Authentication(
-    Long authenticatedUserKey,
-    List<Long> authenticatedGroupKeys,
-    List<Long> authenticatedRoleKeys,
-    List<String> authenticatedTenantIds,
-    String token) {
+public final class Authentication {
+  private final Long authenticatedUserKey;
+  private final List<Long> authenticatedGroupKeys;
+  private final List<Long> authenticatedRoleKeys;
+  private final List<String> authenticatedTenantIds;
+  private final String token;
+
+  public Authentication(
+      final Long authenticatedUserKey,
+      final List<Long> authenticatedGroupKeys,
+      final List<Long> authenticatedRoleKeys,
+      final List<String> authenticatedTenantIds,
+      final String token) {
+    this.authenticatedUserKey = authenticatedUserKey;
+    this.authenticatedGroupKeys = authenticatedGroupKeys;
+    this.authenticatedRoleKeys = authenticatedRoleKeys;
+    this.authenticatedTenantIds = authenticatedTenantIds;
+    this.token = token;
+  }
 
   public static Authentication none() {
     return new Builder().build();
@@ -26,6 +41,72 @@ public record Authentication(
 
   public static Authentication of(final Function<Builder, Builder> builderFunction) {
     return builderFunction.apply(new Builder()).build();
+  }
+
+  public Long authenticatedUserKey() {
+    return authenticatedUserKey;
+  }
+
+  public List<Long> authenticatedGroupKeys() {
+    return authenticatedGroupKeys;
+  }
+
+  public List<Long> authenticatedRoleKeys() {
+    return authenticatedRoleKeys;
+  }
+
+  public List<String> authenticatedTenantIds() {
+    return authenticatedTenantIds;
+  }
+
+  public String token() {
+    return token;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        authenticatedUserKey,
+        authenticatedGroupKeys,
+        authenticatedRoleKeys,
+        authenticatedTenantIds,
+        token);
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj == null || obj.getClass() != getClass()) {
+      return false;
+    }
+    final Authentication that = (Authentication) obj;
+    return Objects.equals(authenticatedUserKey, that.authenticatedUserKey)
+        && Objects.equals(authenticatedGroupKeys, that.authenticatedGroupKeys)
+        && Objects.equals(authenticatedRoleKeys, that.authenticatedRoleKeys)
+        && Objects.equals(authenticatedTenantIds, that.authenticatedTenantIds)
+        && Objects.equals(token, that.token);
+  }
+
+  @Override
+  public String toString() {
+    return "Authentication["
+        + "authenticatedUserKey="
+        + authenticatedUserKey
+        + ", "
+        + "authenticatedGroupKeys="
+        + authenticatedGroupKeys
+        + ", "
+        + "authenticatedRoleKeys="
+        + authenticatedRoleKeys
+        + ", "
+        + "authenticatedTenantIds="
+        + authenticatedTenantIds
+        + ", "
+        + "token="
+        + token
+        + ']';
   }
 
   public static final class Builder {
@@ -42,7 +123,7 @@ public record Authentication(
     }
 
     public Builder group(final Long value) {
-      return groupKeys(List.of(value));
+      return groupKeys(Collections.singletonList(value));
     }
 
     public Builder groupKeys(final List<Long> values) {
@@ -53,7 +134,7 @@ public record Authentication(
     }
 
     public Builder role(final Long value) {
-      return roleKeys(java.util.List.of(value));
+      return roleKeys(Collections.singletonList(value));
     }
 
     public Builder roleKeys(final List<Long> values) {
@@ -64,7 +145,7 @@ public record Authentication(
     }
 
     public Builder tenant(final String tenant) {
-      return tenants(List.of(tenant));
+      return tenants(Collections.singletonList(tenant));
     }
 
     public Builder tenants(final List<String> values) {

--- a/security/security-core/src/main/java/io/camunda/security/auth/Authentication.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authentication.java
@@ -9,12 +9,16 @@ package io.camunda.security.auth;
 
 import static java.util.Collections.unmodifiableList;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public final class Authentication {
   private final Long authenticatedUserKey;
   private final List<Long> authenticatedGroupKeys;
@@ -22,12 +26,13 @@ public final class Authentication {
   private final List<String> authenticatedTenantIds;
   private final String token;
 
+  @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
   public Authentication(
-      final Long authenticatedUserKey,
-      final List<Long> authenticatedGroupKeys,
-      final List<Long> authenticatedRoleKeys,
-      final List<String> authenticatedTenantIds,
-      final String token) {
+      final @JsonProperty("authenticated_user_key") Long authenticatedUserKey,
+      final @JsonProperty("authenticated_group_keys") List<Long> authenticatedGroupKeys,
+      final @JsonProperty("authenticated_role_keys") List<Long> authenticatedRoleKeys,
+      final @JsonProperty("authenticated_tenant_ids") List<String> authenticatedTenantIds,
+      final @JsonProperty("token") String token) {
     this.authenticatedUserKey = authenticatedUserKey;
     this.authenticatedGroupKeys = authenticatedGroupKeys;
     this.authenticatedRoleKeys = authenticatedRoleKeys;

--- a/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
@@ -35,7 +35,8 @@ public final class Authorization {
   private final AuthorizationResourceType resourceType;
   private final PermissionType permissionType;
 
-  public Authorization(final AuthorizationResourceType resourceType, final PermissionType permissionType) {
+  public Authorization(
+      final AuthorizationResourceType resourceType, final PermissionType permissionType) {
     this.resourceType = resourceType;
     this.permissionType = permissionType;
   }

--- a/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
@@ -26,14 +26,59 @@ import static io.camunda.zeebe.protocol.record.value.PermissionType.UPDATE_USER_
 
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
+import java.util.Objects;
 import java.util.function.Function;
 
-public record Authorization(AuthorizationResourceType resourceType, PermissionType permissionType) {
+public final class Authorization {
 
   public static final String WILDCARD = "*";
+  private final AuthorizationResourceType resourceType;
+  private final PermissionType permissionType;
+
+  public Authorization(final AuthorizationResourceType resourceType, final PermissionType permissionType) {
+    this.resourceType = resourceType;
+    this.permissionType = permissionType;
+  }
 
   public static Authorization of(final Function<Builder, Builder> builderFunction) {
     return builderFunction.apply(new Builder()).build();
+  }
+
+  public AuthorizationResourceType resourceType() {
+    return resourceType;
+  }
+
+  public PermissionType permissionType() {
+    return permissionType;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(resourceType, permissionType);
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj == null || obj.getClass() != getClass()) {
+      return false;
+    }
+    final Authorization that = (Authorization) obj;
+    return Objects.equals(resourceType, that.resourceType)
+        && Objects.equals(permissionType, that.permissionType);
+  }
+
+  @Override
+  public String toString() {
+    return "Authorization["
+        + "resourceType="
+        + resourceType
+        + ", "
+        + "permissionType="
+        + permissionType
+        + ']';
   }
 
   public static class Builder {

--- a/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
@@ -24,19 +24,25 @@ import static io.camunda.zeebe.protocol.record.value.PermissionType.READ_USER_TA
 import static io.camunda.zeebe.protocol.record.value.PermissionType.UPDATE_PROCESS_INSTANCE;
 import static io.camunda.zeebe.protocol.record.value.PermissionType.UPDATE_USER_TASK;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.Objects;
 import java.util.function.Function;
 
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public final class Authorization {
 
   public static final String WILDCARD = "*";
   private final AuthorizationResourceType resourceType;
   private final PermissionType permissionType;
 
+  @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
   public Authorization(
-      final AuthorizationResourceType resourceType, final PermissionType permissionType) {
+      final @JsonProperty("resource_type") AuthorizationResourceType resourceType,
+      final @JsonProperty("permission_type") PermissionType permissionType) {
     this.resourceType = resourceType;
     this.permissionType = permissionType;
   }

--- a/security/security-core/src/main/java/io/camunda/security/auth/SecurityContext.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/SecurityContext.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.security.auth;
 
+import java.util.Objects;
 import java.util.function.Function;
 
 /**
@@ -17,7 +18,15 @@ import java.util.function.Function;
  * <p><strong>Note:</strong> For now, we only support a single authorization check. This will be
  * later extended to more than one authorization (for composite permissions checks).
  */
-public record SecurityContext(Authentication authentication, Authorization authorization) {
+public final class SecurityContext {
+  private final Authentication authentication;
+  private final Authorization authorization;
+
+  /** */
+  public SecurityContext(final Authentication authentication, final Authorization authorization) {
+    this.authentication = authentication;
+    this.authorization = authorization;
+  }
 
   public boolean requiresAuthorizationChecks() {
     return authentication != null && authorization != null;
@@ -29,6 +38,43 @@ public record SecurityContext(Authentication authentication, Authorization autho
 
   public static SecurityContext withoutAuthentication() {
     return new Builder().build();
+  }
+
+  public Authentication authentication() {
+    return authentication;
+  }
+
+  public Authorization authorization() {
+    return authorization;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(authentication, authorization);
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj == null || obj.getClass() != getClass()) {
+      return false;
+    }
+    final SecurityContext that = (SecurityContext) obj;
+    return Objects.equals(authentication, that.authentication)
+        && Objects.equals(authorization, that.authorization);
+  }
+
+  @Override
+  public String toString() {
+    return "SecurityContext["
+        + "authentication="
+        + authentication
+        + ", "
+        + "authorization="
+        + authorization
+        + ']';
   }
 
   public static class Builder {

--- a/security/security-core/src/main/java/io/camunda/security/auth/SecurityContext.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/SecurityContext.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.security.auth;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -18,12 +21,16 @@ import java.util.function.Function;
  * <p><strong>Note:</strong> For now, we only support a single authorization check. This will be
  * later extended to more than one authorization (for composite permissions checks).
  */
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public final class SecurityContext {
   private final Authentication authentication;
   private final Authorization authorization;
 
   /** */
-  public SecurityContext(final Authentication authentication, final Authorization authorization) {
+  @JsonCreator
+  public SecurityContext(
+      final @JsonProperty("authentication") Authentication authentication,
+      final @JsonProperty("authorization") Authorization authorization) {
     this.authentication = authentication;
     this.authorization = authorization;
   }

--- a/security/security-core/src/main/java/io/camunda/security/entity/ClusterMetadata.java
+++ b/security/security-core/src/main/java/io/camunda/security/entity/ClusterMetadata.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.security.entity;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.HashMap;
@@ -78,11 +80,14 @@ public class ClusterMetadata implements Serializable {
     return String.format("ClusterMetadata{uuid='%s', name='%s', urls='%s'}", uuid, name, urls);
   }
 
+  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
   public static final class C8AppLink {
     private final String name;
     private final String link;
 
-    public C8AppLink(final String name, final String link) {
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public C8AppLink(
+        final @JsonProperty("name") String name, final @JsonProperty("link") String link) {
       this.name = name;
       this.link = link;
     }

--- a/security/security-core/src/main/java/io/camunda/security/entity/ClusterMetadata.java
+++ b/security/security-core/src/main/java/io/camunda/security/entity/ClusterMetadata.java
@@ -75,10 +75,48 @@ public class ClusterMetadata implements Serializable {
 
   @Override
   public String toString() {
-    return "ClusterMetadata{uuid='%s', name='%s', urls='%s'}".formatted(uuid, name, urls);
+    return String.format("ClusterMetadata{uuid='%s', name='%s', urls='%s'}", uuid, name, urls);
   }
 
-  public record C8AppLink(String name, String link) {}
+  public static final class C8AppLink {
+    private final String name;
+    private final String link;
+
+    public C8AppLink(final String name, final String link) {
+      this.name = name;
+      this.link = link;
+    }
+
+    public String name() {
+      return name;
+    }
+
+    public String link() {
+      return link;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(name, link);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      if (obj == null || obj.getClass() != getClass()) {
+        return false;
+      }
+      final C8AppLink that = (C8AppLink) obj;
+      return Objects.equals(name, that.name) && Objects.equals(link, that.link);
+    }
+
+    @Override
+    public String toString() {
+      return "C8AppLink[" + "name=" + name + ", " + "link=" + link + ']';
+    }
+  }
 
   public enum AppName {
     @JsonProperty("console")

--- a/security/security-core/src/main/java/io/camunda/security/entity/Permission.java
+++ b/security/security-core/src/main/java/io/camunda/security/entity/Permission.java
@@ -42,8 +42,7 @@ public final class Permission {
       return false;
     }
     final Permission that = (Permission) obj;
-    return Objects.equals(type, that.type)
-        && Objects.equals(resourceIds, that.resourceIds);
+    return Objects.equals(type, that.type) && Objects.equals(resourceIds, that.resourceIds);
   }
 
   @Override

--- a/security/security-core/src/main/java/io/camunda/security/entity/Permission.java
+++ b/security/security-core/src/main/java/io/camunda/security/entity/Permission.java
@@ -7,15 +7,22 @@
  */
 package io.camunda.security.entity;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.Objects;
 import java.util.Set;
 
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public final class Permission {
   private final PermissionType type;
   private final Set<String> resourceIds;
 
-  public Permission(final PermissionType type, final Set<String> resourceIds) {
+  @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+  public Permission(
+      final @JsonProperty("type") PermissionType type,
+      final @JsonProperty("resource_ids") Set<String> resourceIds) {
     this.type = type;
     this.resourceIds = resourceIds;
   }

--- a/security/security-core/src/main/java/io/camunda/security/entity/Permission.java
+++ b/security/security-core/src/main/java/io/camunda/security/entity/Permission.java
@@ -8,6 +8,46 @@
 package io.camunda.security.entity;
 
 import io.camunda.zeebe.protocol.record.value.PermissionType;
+import java.util.Objects;
 import java.util.Set;
 
-public record Permission(PermissionType type, Set<String> resourceIds) {}
+public final class Permission {
+  private final PermissionType type;
+  private final Set<String> resourceIds;
+
+  public Permission(final PermissionType type, final Set<String> resourceIds) {
+    this.type = type;
+    this.resourceIds = resourceIds;
+  }
+
+  public PermissionType type() {
+    return type;
+  }
+
+  public Set<String> resourceIds() {
+    return resourceIds;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, resourceIds);
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj == null || obj.getClass() != getClass()) {
+      return false;
+    }
+    final Permission that = (Permission) obj;
+    return Objects.equals(type, that.type)
+        && Objects.equals(resourceIds, that.resourceIds);
+  }
+
+  @Override
+  public String toString() {
+    return "Permission[" + "type=" + type + ", " + "resourceIds=" + resourceIds + ']';
+  }
+}


### PR DESCRIPTION
## Description

The new `camunda-security-core` module is pulled in the `zeebe-protocol` module, which is fixed to Java version 8 (as it may be included in older modules directly). 

> [!Note]
> I consider it out of scope here to start a debate about `zeebe-protocol` being on Java 8, but we can do that elsewhere.

To make sure anyone using `zeebe-protocol` on Java 8 (e.g. `zeebe-process-test`), we also need to make sure this module is compiled and released with the same version.