### PR TITLE
ci: generate javadoc for migration modules

### DIFF
--- a/migration/pom.xml
+++ b/migration/pom.xml
@@ -32,7 +32,7 @@
     <maven.compiler.target>21</maven.compiler.target>
     <maven.compiler.source>21</maven.compiler.source>
 
-    <maven.javadoc.skip>true</maven.javadoc.skip>
+    <maven.javadoc.skip>false</maven.javadoc.skip>
   </properties>
 
 </project>


### PR DESCRIPTION
## Description

Lack of javadocs violates nexus staging rules on release.

See thread https://camunda.slack.com/archives/C071KP5BTHB/p1735644619860209

Verified this fixes the release job on the [8.7.0-alpha3 branch](https://github.com/camunda/camunda/commits/release-8.7.0-alpha3/).

