### PR TITLE
build: add curl fetch for wait-for-it.sh script for optimize dockerfile

### DIFF
--- a/optimize.Dockerfile
+++ b/optimize.Dockerfile
@@ -75,6 +75,7 @@ VOLUME ${OPTIMIZE_HOME}/logs
 
 RUN addgroup --gid 1001 camunda && \
     adduser -D -h ${OPTIMIZE_HOME} -G camunda -u 1001 camunda && \
+    curl "https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh" --output /usr/local/bin/wait-for-it.sh && \
     # These directories are to be mounted by users, eagerly creating them and setting ownership
     # helps to avoid potential permission issues due to default volume ownership.
     mkdir ${OPTIMIZE_HOME}/logs && \


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The Optimize image is failing to come up for the image generated for `alpha3`

https://camunda.slack.com/archives/C06UWQNCU7M/p1735656326026989

`failed to create containerd task: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "wait-for-it.sh": executable file not found in $PATH: unknown`

Add the `curl` fetch for `wait-for-it.sh` back to Optimize's dockerfile

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
