### PR TITLE
[Backport release-8.7.0-alpha3] build: add curl fetch for wait-for-it.sh script for optimize dockerfile

### DIFF
--- a/optimize.Dockerfile
+++ b/optimize.Dockerfile
@@ -75,6 +75,7 @@ VOLUME ${OPTIMIZE_HOME}/logs
 
 RUN addgroup --gid 1001 camunda && \
     adduser -D -h ${OPTIMIZE_HOME} -G camunda -u 1001 camunda && \
+    curl "https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh" --output /usr/local/bin/wait-for-it.sh && \
     # These directories are to be mounted by users, eagerly creating them and setting ownership
     # helps to avoid potential permission issues due to default volume ownership.
     mkdir ${OPTIMIZE_HOME}/logs && \


### PR DESCRIPTION
# Description
Backport of #26454 to `release-8.7.0-alpha3`.

relates to 
original author: @matthewBearCamunda