### PR TITLE
[Backport stable/8.4] fix: do not throw Exception when GCS store is not accessible on startup

### DIFF
--- a/backup-stores/gcs/pom.xml
+++ b/backup-stores/gcs/pom.xml
@@ -78,6 +78,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-backup-testkit</artifactId>
       <scope>test</scope>

--- a/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
+++ b/backup-stores/gcs/src/main/java/io/camunda/zeebe/backup/gcs/GcsBackupStore.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
-import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.ConfigurationException.CouldNotAccessBucketException;
+import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.ConfigurationException;
 import io.camunda.zeebe.backup.gcs.manifest.Manifest;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -28,15 +28,19 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class GcsBackupStore implements BackupStore {
   public static final String ERROR_MSG_BACKUP_NOT_FOUND =
       "Expected to restore from backup with id '%s', but does not exist.";
   public static final String ERROR_MSG_BACKUP_WRONG_STATE_TO_RESTORE =
       "Expected to restore from completed backup with id '%s', but was in state '%s'";
-  public static final String ERROR_MSG_ACCESS_FAILED = "Expected to access bucket '%s', but failed";
+  public static final String ERROR_VALIDATION_FAILED =
+      "Invalid configuration for GcsBackupStore: %s";
   public static final String SNAPSHOT_FILESET_NAME = "snapshot";
   public static final String SEGMENTS_FILESET_NAME = "segments";
+  private static final Logger LOG = LoggerFactory.getLogger(GcsBackupStore.class);
   private final ExecutorService executor;
   private final ManifestManager manifestManager;
   private final FileSetManager fileSetManager;
@@ -194,10 +198,16 @@ public final class GcsBackupStore implements BackupStore {
 
   public static void validateConfig(final GcsBackupConfig config) {
     try (final var storage = buildClient(config)) {
-      storage.list(config.bucketName(), BlobListOption.pageSize(1));
+      try {
+        storage.list(config.bucketName(), BlobListOption.pageSize(1));
+      } catch (final Exception e) {
+        LOG.warn(
+            "Unable to verify that the bucket %s exists, initialization will continue as it can be a transient network issue"
+                .formatted(config.bucketName()),
+            e);
+      }
     } catch (final Exception e) {
-      throw new CouldNotAccessBucketException(
-          ERROR_MSG_ACCESS_FAILED.formatted(config.bucketName()), e);
+      throw new ConfigurationException(ERROR_VALIDATION_FAILED.formatted(config), e);
     }
   }
 }

--- a/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigIT.java
+++ b/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigIT.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.backup.gcs;
 
 import com.google.cloud.storage.BucketInfo;
-import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.ConfigurationException.CouldNotAccessBucketException;
 import io.camunda.zeebe.backup.gcs.util.GcsContainer;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.assertj.core.api.Assertions;
@@ -41,7 +40,7 @@ public class ConfigIT {
   }
 
   @Test
-  void shouldFailValidationIfBucketDoesNotExist() {
+  void shouldNotFailValidationIfBucketDoesNotExist() {
     // given
     final var bucketName = RandomStringUtils.randomAlphabetic(12);
     final var config =
@@ -52,8 +51,7 @@ public class ConfigIT {
             .build();
 
     // then
-    Assertions.assertThatThrownBy(() -> GcsBackupStore.validateConfig(config))
-        .isInstanceOf(CouldNotAccessBucketException.class)
-        .hasMessageContaining(config.bucketName());
+    Assertions.assertThatCode(() -> GcsBackupStore.validateConfig(config))
+        .doesNotThrowAnyException();
   }
 }


### PR DESCRIPTION
# Description
Backport of #23057 to `stable/8.4`.

relates to #14593
original author: @entangled90