### PR TITLE
feat: add more trusted algorithms to Operate JWT decoder

### DIFF
--- a/operate/qa/integration-tests/pom.xml
+++ b/operate/qa/integration-tests/pom.xml
@@ -431,6 +431,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/oauth2/JwtDecoderIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/oauth2/JwtDecoderIT.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.security.oauth2;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import io.camunda.identity.sdk.IdentityConfiguration;
+import java.util.Date;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@WireMockTest
+public class JwtDecoderIT {
+
+  private final MockEnvironment environment = new MockEnvironment();
+  @Mock private IdentityJwt2AuthenticationTokenConverter jwtConverter;
+  private final WireMockRuntimeInfo wireMockInfo;
+  private final String authServerMockUrl;
+  private JwtDecoder decoder;
+
+  public JwtDecoderIT(final WireMockRuntimeInfo wireMockInfo) {
+    this.wireMockInfo = wireMockInfo;
+    authServerMockUrl = wireMockInfo.getHttpBaseUrl();
+  }
+
+  @BeforeEach
+  public void setup() {
+    final IdentityConfiguration identityConfiguration =
+        new IdentityConfiguration(null, authServerMockUrl, null, null, null);
+    final IdentityOAuth2WebConfigurer identityOAuth2WebConfigurer =
+        new IdentityOAuth2WebConfigurer(environment, identityConfiguration, jwtConverter);
+
+    decoder = ReflectionTestUtils.invokeMethod(identityOAuth2WebConfigurer, "jwtDecoder");
+  }
+
+  @Test
+  public void testDecodeRs256JwtWithNoAlgFieldInJwkResponse() throws JOSEException {
+    // given
+    final RSAKey rsaJWK = getRsaJWK(JWSAlgorithm.RS256);
+    final String serializedJwt = signAndSerialize(rsaJWK, JWSAlgorithm.RS256);
+    final String publicKey = rsaJWK.toPublicJWK().toJSONString();
+
+    // remove alg field from mocked server response and assert it was removed to cover this use case
+    final String withoutAlg = publicKey.replaceFirst("\"alg\":\".*\",", "");
+    final String authServerResponseBody = "{\"keys\":[" + withoutAlg + "]}";
+    System.out.println("authServerResponse=" + authServerResponseBody);
+    assertFalse(authServerResponseBody.contains("alg:"));
+
+    wireMockInfo
+        .getWireMock()
+        .register(
+            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
+                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
+
+    // when - then
+    assertDoesNotThrow(() -> decoder.decode(serializedJwt));
+    wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+  }
+
+  @Test
+  public void testDecodeES256JwtWithNoAlgFieldInJwkResponse() throws JOSEException {
+    // given
+    final ECKey ecJWK = getEcJWK(JWSAlgorithm.ES256, Curve.P_256);
+    final String ecSerializedJwt = signAndSerialize(ecJWK, JWSAlgorithm.ES256);
+    final String publicKey = ecJWK.toPublicJWK().toJSONString();
+    System.out.println("publicKey=" + publicKey);
+
+    // remove alg field from mocked server response and assert it was removed to cover this use case
+    final String withoutAlg = publicKey.replaceFirst(",\"alg\":\".*\"", "");
+    final String authServerResponseBody = "{\"keys\":[" + withoutAlg + "]}";
+    System.out.println("authServerResponse=" + authServerResponseBody);
+    assertFalse(authServerResponseBody.contains("alg:"));
+
+    wireMockInfo
+        .getWireMock()
+        .register(
+            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
+                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
+
+    // when - then
+    assertDoesNotThrow(() -> decoder.decode(ecSerializedJwt));
+    wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+  }
+
+  @Test
+  public void testDecodeRS384Jwt() throws JOSEException {
+    // given
+    final RSAKey rsaJWK = getRsaJWK(JWSAlgorithm.RS384);
+    final String serializedJwt = signAndSerialize(rsaJWK, JWSAlgorithm.RS384);
+    final String publicKey = rsaJWK.toPublicJWK().toJSONString();
+
+    final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
+    System.out.println("authServerResponse=" + authServerResponseBody);
+    assertFalse(authServerResponseBody.contains("alg:"));
+
+    wireMockInfo
+        .getWireMock()
+        .register(
+            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
+                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
+
+    // when - then
+    assertDoesNotThrow(() -> decoder.decode(serializedJwt));
+    wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+  }
+
+  @Test
+  public void testDecodeRS512Jwt() throws JOSEException {
+    // given
+    final RSAKey rsaJWK = getRsaJWK(JWSAlgorithm.RS512);
+    final String serializedJwt = signAndSerialize(rsaJWK, JWSAlgorithm.RS512);
+    final String publicKey = rsaJWK.toPublicJWK().toJSONString();
+
+    final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
+    System.out.println("authServerResponse=" + authServerResponseBody);
+    assertFalse(authServerResponseBody.contains("alg:"));
+
+    wireMockInfo
+        .getWireMock()
+        .register(
+            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
+                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
+
+    // when - then
+    assertDoesNotThrow(() -> decoder.decode(serializedJwt));
+    wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+  }
+
+  @Test
+  public void testDecodeES384Jwt() throws JOSEException {
+    // given
+    final ECKey ecJWK = getEcJWK(JWSAlgorithm.ES384, Curve.P_384);
+    final String ecSerializedJwt = signAndSerialize(ecJWK, JWSAlgorithm.ES384);
+    final String publicKey = ecJWK.toPublicJWK().toJSONString();
+    System.out.println("publicKey=" + publicKey);
+
+    final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
+    System.out.println("authServerResponse=" + authServerResponseBody);
+    assertFalse(authServerResponseBody.contains("alg:"));
+
+    wireMockInfo
+        .getWireMock()
+        .register(
+            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
+                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
+
+    // when - then
+    assertDoesNotThrow(() -> decoder.decode(ecSerializedJwt));
+    wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+  }
+
+  @Test
+  public void testDecodeES512Jwt() throws JOSEException {
+    // given
+    final ECKey ecJWK = getEcJWK(JWSAlgorithm.ES512, Curve.P_521);
+    final String ecSerializedJwt = signAndSerialize(ecJWK, JWSAlgorithm.ES512);
+    final String publicKey = ecJWK.toPublicJWK().toJSONString();
+    System.out.println("publicKey=" + publicKey);
+
+    final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
+    System.out.println("authServerResponse=" + authServerResponseBody);
+    assertFalse(authServerResponseBody.contains("alg:"));
+
+    wireMockInfo
+        .getWireMock()
+        .register(
+            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
+                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
+
+    // when - then
+    assertDoesNotThrow(() -> decoder.decode(ecSerializedJwt));
+    wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+  }
+
+  private RSAKey getRsaJWK(final JWSAlgorithm alg) throws JOSEException {
+    return new RSAKeyGenerator(2048)
+        .keyID("123")
+        .keyUse(KeyUse.SIGNATURE)
+        .algorithm(alg)
+        .generate();
+  }
+
+  private ECKey getEcJWK(final JWSAlgorithm alg, final Curve curve) throws JOSEException {
+    return new ECKeyGenerator(curve)
+        .algorithm(alg)
+        .keyUse(KeyUse.SIGNATURE)
+        .keyID("345")
+        .generate();
+  }
+
+  private String signAndSerialize(final RSAKey rsaKey, final JWSAlgorithm alg)
+      throws JOSEException {
+    // Create RSA-signer with the private key
+    final JWSSigner rsaSigner = new RSASSASigner(rsaKey);
+
+    final SignedJWT rsaSignedJWT =
+        new SignedJWT(
+            new JWSHeader.Builder(alg).type(JOSEObjectType.JWT).keyID(rsaKey.getKeyID()).build(),
+            getClaimsSet());
+
+    rsaSignedJWT.sign(rsaSigner);
+    final String serializedJwt = rsaSignedJWT.serialize();
+    System.out.println("JWT serialized=" + serializedJwt);
+    return serializedJwt;
+  }
+
+  private String signAndSerialize(final ECKey ecKey, final JWSAlgorithm alg) throws JOSEException {
+    // Create EC-signer with the private key
+    final ECDSASigner ecSigner = new ECDSASigner(ecKey);
+
+    final SignedJWT ecSignedJWT =
+        new SignedJWT(
+            new JWSHeader.Builder(alg).type(JOSEObjectType.JWT).keyID(ecKey.getKeyID()).build(),
+            getClaimsSet());
+
+    ecSignedJWT.sign(ecSigner);
+    final String ecSerializedJwt = ecSignedJWT.serialize();
+    System.out.println("JWT serialized=" + ecSerializedJwt);
+    return ecSerializedJwt;
+  }
+
+  private JWTClaimsSet getClaimsSet() {
+    // prepare default JWT claims set
+    return new JWTClaimsSet.Builder()
+        .subject("alice")
+        .issuer("http://localhost")
+        .expirationTime(new Date(new Date().getTime() + 60 * 1000))
+        .build();
+  }
+}

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/oauth2/IdentityOAuth2WebConfigurer.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/oauth2/IdentityOAuth2WebConfigurer.java
@@ -19,7 +19,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -43,11 +42,20 @@ public class IdentityOAuth2WebConfigurer {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IdentityOAuth2WebConfigurer.class);
 
-  @Autowired private Environment env;
+  private final Environment env;
 
-  @Autowired private IdentityConfiguration identityConfiguration;
+  private final IdentityConfiguration identityConfiguration;
 
-  @Autowired private IdentityJwt2AuthenticationTokenConverter jwtConverter;
+  private final IdentityJwt2AuthenticationTokenConverter jwtConverter;
+
+  public IdentityOAuth2WebConfigurer(
+      final Environment env,
+      final IdentityConfiguration identityConfiguration,
+      final IdentityJwt2AuthenticationTokenConverter jwtConverter) {
+    this.env = env;
+    this.identityConfiguration = identityConfiguration;
+    this.jwtConverter = jwtConverter;
+  }
 
   public void configure(final HttpSecurity http) throws Exception {
     if (isJWTEnabled()) {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/oauth2/IdentityOAuth2WebConfigurer.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/oauth2/IdentityOAuth2WebConfigurer.java
@@ -10,6 +10,12 @@ package io.camunda.operate.webapp.security.oauth2;
 import static com.nimbusds.jose.JOSEObjectType.JWT;
 import static io.camunda.operate.OperateProfileService.IDENTITY_AUTH_PROFILE;
 import static io.camunda.operate.webapp.security.BaseWebConfigurer.sendJSONErrorMessage;
+import static org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.ES256;
+import static org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.ES384;
+import static org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.ES512;
+import static org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.RS256;
+import static org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.RS384;
+import static org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.RS512;
 
 import com.nimbusds.jose.JOSEObjectType;
 import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier;
@@ -78,10 +84,20 @@ public class IdentityOAuth2WebConfigurer {
    */
   private JwtDecoder jwtDecoder() {
     return NimbusJwtDecoder.withJwkSetUri(getJwkSetUriProperty())
+        .jwsAlgorithms(
+            algorithms -> {
+              algorithms.add(RS256);
+              algorithms.add(RS384);
+              algorithms.add(RS512);
+              algorithms.add(ES256);
+              algorithms.add(ES384);
+              algorithms.add(ES512);
+            })
         .jwtProcessorCustomizer(
-            processor ->
-                processor.setJWSTypeVerifier(
-                    new DefaultJOSEObjectTypeVerifier<>(JWT, new JOSEObjectType("at+jwt"))))
+            processor -> {
+              processor.setJWSTypeVerifier(
+                  new DefaultJOSEObjectTypeVerifier<>(JWT, new JOSEObjectType("at+jwt")));
+            })
         .build();
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Port of https://github.com/camunda/camunda/pull/26231

Added all algorithms that are supported by Identity to the Operate decoder and wrote unit tests to verify they work, including tests that remove the alg field from mocked JWK responses to cover an edge case that was brought up through a support case and triggered the investigation into the decoder functionality.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates to https://github.com/camunda/camunda/issues/23727
