### PR TITLE
ci: omit commit sha in image tag from branch

### DIFF
--- a/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
+++ b/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
@@ -57,9 +57,8 @@ jobs:
         run: |
           # Replace dots and slashes with dashes
           branch=${BRANCH/[\/\.]/-}
-          branch_git_sha=$(git rev-parse --short=8 HEAD)
           version=$(./mvnw help:evaluate -q -DforceStdout -D"expression=project.version")
-          echo "image-tag=$version-$branch-$branch_git_sha" >> $GITHUB_OUTPUT
+          echo "image-tag=$version-$branch" >> $GITHUB_OUTPUT
         env:
           BRANCH: ${{ inputs.branch }}
       - uses: ./.github/actions/build-zeebe


### PR DESCRIPTION
## Description

We make use of alwaysPull policy in dev anyway. No hash allows easier testing with same generation.
