### PR TITLE
refactor: change OpenAPI string & long key object names

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/response/FlowNodeInstanceState.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/FlowNodeInstanceState.java
@@ -17,7 +17,7 @@ package io.camunda.client.api.search.response;
 
 import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.protocol.rest.FlowNodeInstanceFilterRequest;
-import io.camunda.client.protocol.rest.FlowNodeInstanceItem;
+import io.camunda.client.protocol.rest.FlowNodeInstanceResult;
 
 public enum FlowNodeInstanceState {
   ACTIVE,
@@ -31,7 +31,7 @@ public enum FlowNodeInstanceState {
   }
 
   public static FlowNodeInstanceState fromProtocolState(
-      final FlowNodeInstanceItem.StateEnum value) {
+      final FlowNodeInstanceResult.StateEnum value) {
     if (value == null) {
       return null;
     }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/FlowNodeInstanceType.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/FlowNodeInstanceType.java
@@ -17,7 +17,7 @@ package io.camunda.client.api.search.response;
 
 import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.protocol.rest.FlowNodeInstanceFilterRequest;
-import io.camunda.client.protocol.rest.FlowNodeInstanceItem;
+import io.camunda.client.protocol.rest.FlowNodeInstanceResult;
 
 public enum FlowNodeInstanceType {
   UNSPECIFIED,
@@ -52,7 +52,7 @@ public enum FlowNodeInstanceType {
     return (value == null) ? null : FlowNodeInstanceFilterRequest.TypeEnum.fromValue(value.name());
   }
 
-  public static FlowNodeInstanceType fromProtocolType(final FlowNodeInstanceItem.TypeEnum value) {
+  public static FlowNodeInstanceType fromProtocolType(final FlowNodeInstanceResult.TypeEnum value) {
     if (value == null) {
       return null;
     }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ActivateJobsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ActivateJobsCommandImpl.java
@@ -29,7 +29,7 @@ import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.ActivateJobsResponseImpl;
 import io.camunda.client.protocol.rest.JobActivationRequest;
-import io.camunda.client.protocol.rest.JobActivationResponse;
+import io.camunda.client.protocol.rest.JobActivationResult;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
@@ -172,7 +172,7 @@ public final class ActivateJobsCommandImpl
         "/jobs/activation",
         jsonMapper.toJson(httpRequestObject),
         httpRequestConfig.build(),
-        JobActivationResponse.class,
+        JobActivationResult.class,
         response::addResponse,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/command/BroadcastSignalCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/BroadcastSignalCommandImpl.java
@@ -28,7 +28,7 @@ import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.BroadcastSignalResponseImpl;
 import io.camunda.client.protocol.rest.SignalBroadcastRequest;
-import io.camunda.client.protocol.rest.SignalBroadcastResponse;
+import io.camunda.client.protocol.rest.SignalBroadcastResult;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalRequest;
@@ -121,7 +121,7 @@ public final class BroadcastSignalCommandImpl
         "/signals/broadcast",
         objectMapper.toJson(httpRequestObject),
         httpRequestConfig.build(),
-        SignalBroadcastResponse.class,
+        SignalBroadcastResult.class,
         BroadcastSignalResponseImpl::new,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CorrelateMessageCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CorrelateMessageCommandImpl.java
@@ -26,7 +26,7 @@ import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.CorrelateMessageResponseImpl;
 import io.camunda.client.protocol.rest.MessageCorrelationRequest;
-import io.camunda.client.protocol.rest.MessageCorrelationResponse;
+import io.camunda.client.protocol.rest.MessageCorrelationResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -85,7 +85,7 @@ public class CorrelateMessageCommandImpl extends CommandWithVariables<CorrelateM
         "/messages/correlation",
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
-        MessageCorrelationResponse.class,
+        MessageCorrelationResult.class,
         response::setResponse,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateGroupCommandImpl.java
@@ -24,7 +24,7 @@ import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.CreateGroupResponseImpl;
 import io.camunda.client.protocol.rest.GroupCreateRequest;
-import io.camunda.client.protocol.rest.GroupCreateResponse;
+import io.camunda.client.protocol.rest.GroupCreateResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -64,7 +64,7 @@ public class CreateGroupCommandImpl implements CreateGroupCommandStep1 {
         "/groups",
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
-        GroupCreateResponse.class,
+        GroupCreateResult.class,
         response::setResponse,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateMappingCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateMappingCommandImpl.java
@@ -24,7 +24,7 @@ import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.CreateMappingResponseImpl;
 import io.camunda.client.protocol.rest.MappingRuleCreateRequest;
-import io.camunda.client.protocol.rest.MappingRuleCreateResponse;
+import io.camunda.client.protocol.rest.MappingRuleCreateResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -78,7 +78,7 @@ public class CreateMappingCommandImpl implements CreateMappingCommandStep1 {
         "/mapping-rules",
         jsonMapper.toJson(mappingRequest),
         httpRequestConfig.build(),
-        MappingRuleCreateResponse.class,
+        MappingRuleCreateResult.class,
         response::setResponse,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceCommandImpl.java
@@ -29,6 +29,7 @@ import io.camunda.client.impl.RetriableClientFutureImpl;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.CreateProcessInstanceResponseImpl;
+import io.camunda.client.protocol.rest.CreateProcessInstanceResult;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
@@ -86,8 +87,8 @@ public final class CreateProcessInstanceCommandImpl
    * backwards compatibility in tests.
    *
    * @deprecated since 8.3.0, use {@link
-   *     CreateProcessInstanceCommandImpl#CreateProcessInstanceCommandImpl(GatewayStub asyncStub,
-   *     JsonMapper jsonMapper, CamundaClientConfiguration config, Predicate retryPredicate)}
+   *     CreateProcessInstanceCommandImpl#CreateProcessInstanceCommandImpl(GatewayStub, JsonMapper,
+   *     CamundaClientConfiguration, Predicate, HttpClient, boolean)}
    */
   public CreateProcessInstanceCommandImpl(
       final GatewayStub asyncStub,
@@ -190,7 +191,7 @@ public final class CreateProcessInstanceCommandImpl
         "/process-instances",
         jsonMapper.toJson(httpRequestObject),
         httpRequestConfig.build(),
-        io.camunda.client.protocol.rest.CreateProcessInstanceResponse.class,
+        CreateProcessInstanceResult.class,
         CreateProcessInstanceResponseImpl::new,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceWithResultCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateProcessInstanceWithResultCommandImpl.java
@@ -25,6 +25,7 @@ import io.camunda.client.impl.RetriableClientFutureImpl;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.CreateProcessInstanceWithResultResponseImpl;
+import io.camunda.client.protocol.rest.CreateProcessInstanceResult;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
@@ -99,7 +100,7 @@ public final class CreateProcessInstanceWithResultCommandImpl
         "/process-instances",
         jsonMapper.toJson(httpRequestObject),
         httpRequestConfig.build(),
-        io.camunda.client.protocol.rest.CreateProcessInstanceResponse.class,
+        CreateProcessInstanceResult.class,
         response -> new CreateProcessInstanceWithResultResponseImpl(jsonMapper, response),
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateRoleCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateRoleCommandImpl.java
@@ -24,7 +24,7 @@ import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.CreateRoleResponseImpl;
 import io.camunda.client.protocol.rest.RoleCreateRequest;
-import io.camunda.client.protocol.rest.RoleCreateResponse;
+import io.camunda.client.protocol.rest.RoleCreateResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -64,7 +64,7 @@ public final class CreateRoleCommandImpl implements CreateRoleCommandStep1 {
         "/roles",
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
-        RoleCreateResponse.class,
+        RoleCreateResult.class,
         response::setResponse,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateTenantCommandImpl.java
@@ -24,7 +24,7 @@ import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.CreateTenantResponseImpl;
 import io.camunda.client.protocol.rest.TenantCreateRequest;
-import io.camunda.client.protocol.rest.TenantCreateResponse;
+import io.camunda.client.protocol.rest.TenantCreateResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -69,7 +69,7 @@ public final class CreateTenantCommandImpl implements CreateTenantCommandStep1 {
         "/tenants",
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
-        TenantCreateResponse.class,
+        TenantCreateResult.class,
         response::setResponse,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateUserCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateUserCommandImpl.java
@@ -23,7 +23,7 @@ import io.camunda.client.api.response.CreateUserResponse;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.CreateUserResponseImpl;
-import io.camunda.client.protocol.rest.UserCreateResponse;
+import io.camunda.client.protocol.rest.UserCreateResult;
 import io.camunda.client.protocol.rest.UserRequest;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -61,7 +61,7 @@ public final class CreateUserCommandImpl implements CreateUserCommandStep1 {
         "/users",
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
-        UserCreateResponse.class,
+        UserCreateResult.class,
         response::setResponse,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeployResourceCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeployResourceCommandImpl.java
@@ -32,7 +32,7 @@ import io.camunda.client.impl.RetriableClientFutureImpl;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.DeploymentEventImpl;
-import io.camunda.client.protocol.rest.DeploymentResponse;
+import io.camunda.client.protocol.rest.DeploymentResult;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceResponse;
@@ -251,7 +251,7 @@ public final class DeployResourceCommandImpl
         "/deployments",
         multipartEntityBuilder,
         httpRequestConfig.build(),
-        DeploymentResponse.class,
+        DeploymentResult.class,
         DeploymentEventImpl::new,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/command/EvaluateDecisionCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/EvaluateDecisionCommandImpl.java
@@ -28,6 +28,7 @@ import io.camunda.client.impl.RetriableClientFutureImpl;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.EvaluateDecisionResponseImpl;
+import io.camunda.client.protocol.rest.EvaluateDecisionResult;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateDecisionRequest;
@@ -79,8 +80,8 @@ public class EvaluateDecisionCommandImpl extends CommandWithVariables<EvaluateDe
    * backwards compatibility in tests.
    *
    * @deprecated since 8.3.0, use {@link
-   *     EvaluateDecisionCommandImpl#EvaluateDecisionCommandImpl(GatewayStub asyncStub, JsonMapper
-   *     jsonMapper, CamundaClientConfiguration config, Predicate retryPredicate)}
+   *     EvaluateDecisionCommandImpl#EvaluateDecisionCommandImpl(GatewayStub, JsonMapper,
+   *     CamundaClientConfiguration, Predicate, HttpClient)}
    */
   public EvaluateDecisionCommandImpl(
       final GatewayStub asyncStub,
@@ -153,7 +154,7 @@ public class EvaluateDecisionCommandImpl extends CommandWithVariables<EvaluateDe
         "/decision-definitions/evaluation",
         jsonMapper.toJson(httpRequestObject),
         httpRequestConfig.build(),
-        io.camunda.client.protocol.rest.EvaluateDecisionResponse.class,
+        EvaluateDecisionResult.class,
         response -> new EvaluateDecisionResponseImpl(response, jsonMapper),
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/command/PublishMessageCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/PublishMessageCommandImpl.java
@@ -29,7 +29,7 @@ import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.PublishMessageResponseImpl;
 import io.camunda.client.protocol.rest.MessagePublicationRequest;
-import io.camunda.client.protocol.rest.MessagePublicationResponse;
+import io.camunda.client.protocol.rest.MessagePublicationResult;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.PublishMessageRequest;
@@ -148,7 +148,7 @@ public final class PublishMessageCommandImpl extends CommandWithVariables<Publis
         "/messages/publication",
         objectMapper.toJson(httpRequestObject),
         httpRequestConfig.build(),
-        MessagePublicationResponse.class,
+        MessagePublicationResult.class,
         PublishMessageResponseImpl::new,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateTenantCommandImpl.java
@@ -24,7 +24,7 @@ import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.UpdateTenantResponseImpl;
 import io.camunda.client.protocol.rest.TenantUpdateRequest;
-import io.camunda.client.protocol.rest.TenantUpdateResponse;
+import io.camunda.client.protocol.rest.TenantUpdateResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -67,7 +67,7 @@ public final class UpdateTenantCommandImpl implements UpdateTenantCommandStep1 {
         "/tenants/" + tenantKey,
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
-        TenantUpdateResponse.class,
+        TenantUpdateResult.class,
         response::setResponse,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/DecisionDefinitionGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/DecisionDefinitionGetRequestImpl.java
@@ -21,7 +21,7 @@ import io.camunda.client.api.search.response.DecisionDefinition;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.search.response.DecisionDefinitionImpl;
-import io.camunda.client.protocol.rest.DecisionDefinitionItem;
+import io.camunda.client.protocol.rest.DecisionDefinitionResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -51,7 +51,7 @@ public class DecisionDefinitionGetRequestImpl implements DecisionDefinitionGetRe
     httpClient.get(
         String.format("/decision-definitions/%d", decisionDefinitionKey),
         httpRequestConfig.build(),
-        DecisionDefinitionItem.class,
+        DecisionDefinitionResult.class,
         DecisionDefinitionImpl::new,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/DecisionInstanceGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/DecisionInstanceGetRequestImpl.java
@@ -23,7 +23,7 @@ import io.camunda.client.api.search.response.DecisionInstance;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.search.response.DecisionInstanceImpl;
-import io.camunda.client.protocol.rest.DecisionInstanceGetQueryResponse;
+import io.camunda.client.protocol.rest.DecisionInstanceGetQueryResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -55,7 +55,7 @@ public class DecisionInstanceGetRequestImpl implements DecisionInstanceGetReques
     httpClient.get(
         String.format("/decision-instances/%s", decisionInstanceId),
         httpRequestConfig.build(),
-        DecisionInstanceGetQueryResponse.class,
+        DecisionInstanceGetQueryResult.class,
         resp -> new DecisionInstanceImpl(resp, jsonMapper),
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/DecisionRequirementsGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/DecisionRequirementsGetRequestImpl.java
@@ -21,7 +21,7 @@ import io.camunda.client.api.search.response.DecisionRequirements;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.search.response.DecisionRequirementsImpl;
-import io.camunda.client.protocol.rest.DecisionRequirementsItem;
+import io.camunda.client.protocol.rest.DecisionRequirementsResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -51,7 +51,7 @@ public class DecisionRequirementsGetRequestImpl implements DecisionRequirementsG
     httpClient.get(
         String.format("/decision-requirements/%d", decisionRequirementsKey),
         httpRequestConfig.build(),
-        DecisionRequirementsItem.class,
+        DecisionRequirementsResult.class,
         DecisionRequirementsImpl::new,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/FlowNodeInstanceGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/FlowNodeInstanceGetRequestImpl.java
@@ -22,7 +22,7 @@ import io.camunda.client.api.search.response.FlowNodeInstance;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.search.SearchResponseMapper;
-import io.camunda.client.protocol.rest.FlowNodeInstanceItem;
+import io.camunda.client.protocol.rest.FlowNodeInstanceResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -52,7 +52,7 @@ public class FlowNodeInstanceGetRequestImpl implements FlowNodeInstanceGetReques
     httpClient.get(
         String.format("/flownode-instances/%d", flowNodeInstanceKey),
         httpRequestConfig.build(),
-        FlowNodeInstanceItem.class,
+        FlowNodeInstanceResult.class,
         SearchResponseMapper::toFlowNodeInstanceGetResponse,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/IncidentGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/IncidentGetRequestImpl.java
@@ -22,7 +22,7 @@ import io.camunda.client.api.search.response.Incident;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.search.SearchResponseMapper;
-import io.camunda.client.protocol.rest.IncidentItem;
+import io.camunda.client.protocol.rest.IncidentResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -51,7 +51,7 @@ public class IncidentGetRequestImpl implements IncidentGetRequest {
     httpClient.get(
         String.format("/incidents/%d", incidentKey),
         httpRequestConfig.build(),
-        IncidentItem.class,
+        IncidentResult.class,
         SearchResponseMapper::toIncidentGetResponse,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/ProcessDefinitionGetFormRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/ProcessDefinitionGetFormRequestImpl.java
@@ -22,7 +22,7 @@ import io.camunda.client.api.search.response.Form;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.search.response.FormImpl;
-import io.camunda.client.protocol.rest.FormItem;
+import io.camunda.client.protocol.rest.FormResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -52,7 +52,7 @@ public class ProcessDefinitionGetFormRequestImpl implements ProcessDefinitionGet
     httpClient.get(
         String.format("/process-definitions/%d/form", processDefinitionKey),
         httpRequestConfig.build(),
-        FormItem.class,
+        FormResult.class,
         FormImpl::new,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/ProcessDefinitionGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/ProcessDefinitionGetRequestImpl.java
@@ -22,7 +22,7 @@ import io.camunda.client.api.search.response.ProcessDefinition;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.search.SearchResponseMapper;
-import io.camunda.client.protocol.rest.ProcessDefinitionItem;
+import io.camunda.client.protocol.rest.ProcessDefinitionResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -52,7 +52,7 @@ public class ProcessDefinitionGetRequestImpl implements ProcessDefinitionGetRequ
     httpClient.get(
         String.format("/process-definitions/%d", processDefinitionKey),
         httpRequestConfig.build(),
-        ProcessDefinitionItem.class,
+        ProcessDefinitionResult.class,
         SearchResponseMapper::toProcessDefinitionGetResponse,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/ProcessInstanceGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/ProcessInstanceGetRequestImpl.java
@@ -21,7 +21,7 @@ import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.search.SearchResponseMapper;
-import io.camunda.client.protocol.rest.ProcessInstanceItem;
+import io.camunda.client.protocol.rest.ProcessInstanceResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -50,7 +50,7 @@ public class ProcessInstanceGetRequestImpl implements ProcessInstanceGetRequest 
     httpClient.get(
         String.format("/process-instances/%d", processInstanceKey),
         httpRequestConfig.build(),
-        ProcessInstanceItem.class,
+        ProcessInstanceResult.class,
         SearchResponseMapper::toProcessInstanceGetResponse,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/UserTaskGetFormRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/UserTaskGetFormRequestImpl.java
@@ -21,7 +21,7 @@ import io.camunda.client.api.search.response.Form;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.search.response.FormImpl;
-import io.camunda.client.protocol.rest.FormItem;
+import io.camunda.client.protocol.rest.FormResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -49,7 +49,7 @@ public class UserTaskGetFormRequestImpl implements UserTaskGetFormRequest {
     httpClient.get(
         String.format("/user-tasks/%d/form", userTaskKey),
         httpRequestConfig.build(),
-        FormItem.class,
+        FormResult.class,
         FormImpl::new,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/UserTaskGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/UserTaskGetRequestImpl.java
@@ -21,7 +21,7 @@ import io.camunda.client.api.search.response.UserTask;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.search.response.UserTaskImpl;
-import io.camunda.client.protocol.rest.UserTaskItem;
+import io.camunda.client.protocol.rest.UserTaskResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -50,7 +50,7 @@ public class UserTaskGetRequestImpl implements UserTaskGetRequest {
     httpClient.get(
         String.format("/user-tasks/%d", userTaskKey),
         httpRequestConfig.build(),
-        UserTaskItem.class,
+        UserTaskResult.class,
         UserTaskImpl::new,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/fetch/VariableGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/fetch/VariableGetRequestImpl.java
@@ -21,7 +21,7 @@ import io.camunda.client.api.search.response.Variable;
 import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.search.response.VariableImpl;
-import io.camunda.client.protocol.rest.VariableItem;
+import io.camunda.client.protocol.rest.VariableResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -50,7 +50,7 @@ public class VariableGetRequestImpl implements VariableGetRequest {
     httpClient.get(
         String.format("/variables/%d", variableKey),
         httpRequestConfig.build(),
-        VariableItem.class,
+        VariableResult.class,
         VariableImpl::new,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/response/ActivateJobsResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/ActivateJobsResponseImpl.java
@@ -18,7 +18,7 @@ package io.camunda.client.impl.response;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.response.ActivateJobsResponse;
 import io.camunda.client.api.response.ActivatedJob;
-import io.camunda.client.protocol.rest.JobActivationResponse;
+import io.camunda.client.protocol.rest.JobActivationResult;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -39,8 +39,8 @@ public final class ActivateJobsResponseImpl implements ActivateJobsResponse {
         .forEach(jobs::add);
   }
 
-  public ActivateJobsResponseImpl addResponse(final JobActivationResponse activateJobsResponse) {
-    final List<io.camunda.client.protocol.rest.ActivatedJob> activatedJobs =
+  public ActivateJobsResponseImpl addResponse(final JobActivationResult activateJobsResponse) {
+    final List<io.camunda.client.protocol.rest.ActivatedJobResult> activatedJobs =
         activateJobsResponse.getJobs();
     if (activatedJobs != null) {
       activatedJobs.stream().map(r -> new ActivatedJobImpl(jsonMapper, r)).forEach(jobs::add);

--- a/clients/java/src/main/java/io/camunda/client/impl/response/ActivatedJobImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/ActivatedJobImpl.java
@@ -71,7 +71,7 @@ public final class ActivatedJobImpl implements ActivatedJob {
   }
 
   public ActivatedJobImpl(
-      final JsonMapper jsonMapper, final io.camunda.client.protocol.rest.ActivatedJob job) {
+      final JsonMapper jsonMapper, final io.camunda.client.protocol.rest.ActivatedJobResult job) {
     this.jsonMapper = jsonMapper;
 
     key = parseLongOrEmpty(job.getJobKey());

--- a/clients/java/src/main/java/io/camunda/client/impl/response/BroadcastSignalResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/BroadcastSignalResponseImpl.java
@@ -16,7 +16,7 @@
 package io.camunda.client.impl.response;
 
 import io.camunda.client.api.response.BroadcastSignalResponse;
-import io.camunda.client.protocol.rest.SignalBroadcastResponse;
+import io.camunda.client.protocol.rest.SignalBroadcastResult;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 
 public final class BroadcastSignalResponseImpl implements BroadcastSignalResponse {
@@ -29,7 +29,7 @@ public final class BroadcastSignalResponseImpl implements BroadcastSignalRespons
     tenantId = response.getTenantId();
   }
 
-  public BroadcastSignalResponseImpl(final SignalBroadcastResponse response) {
+  public BroadcastSignalResponseImpl(final SignalBroadcastResult response) {
     key = Long.parseLong(response.getSignalKey());
     tenantId = response.getTenantId();
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CorrelateMessageResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CorrelateMessageResponseImpl.java
@@ -17,7 +17,7 @@ package io.camunda.client.impl.response;
 
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.response.CorrelateMessageResponse;
-import io.camunda.client.protocol.rest.MessageCorrelationResponse;
+import io.camunda.client.protocol.rest.MessageCorrelationResult;
 
 public final class CorrelateMessageResponseImpl implements CorrelateMessageResponse {
 
@@ -45,7 +45,7 @@ public final class CorrelateMessageResponseImpl implements CorrelateMessageRespo
     return processInstanceKey;
   }
 
-  public CorrelateMessageResponseImpl setResponse(final MessageCorrelationResponse response) {
+  public CorrelateMessageResponseImpl setResponse(final MessageCorrelationResult response) {
     key = Long.parseLong(response.getMessageKey());
     tenantId = response.getTenantId();
     processInstanceKey = Long.parseLong(response.getProcessInstanceKey());

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateGroupResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateGroupResponseImpl.java
@@ -16,7 +16,7 @@
 package io.camunda.client.impl.response;
 
 import io.camunda.client.api.response.CreateGroupResponse;
-import io.camunda.client.protocol.rest.GroupCreateResponse;
+import io.camunda.client.protocol.rest.GroupCreateResult;
 
 public class CreateGroupResponseImpl implements CreateGroupResponse {
 
@@ -27,7 +27,7 @@ public class CreateGroupResponseImpl implements CreateGroupResponse {
     return groupKey;
   }
 
-  public CreateGroupResponseImpl setResponse(final GroupCreateResponse response) {
+  public CreateGroupResponseImpl setResponse(final GroupCreateResult response) {
     groupKey = Long.parseLong(response.getGroupKey());
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateMappingResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateMappingResponseImpl.java
@@ -16,7 +16,7 @@
 package io.camunda.client.impl.response;
 
 import io.camunda.client.api.response.CreateMappingResponse;
-import io.camunda.client.protocol.rest.MappingRuleCreateResponse;
+import io.camunda.client.protocol.rest.MappingRuleCreateResult;
 
 public class CreateMappingResponseImpl implements CreateMappingResponse {
 
@@ -27,7 +27,7 @@ public class CreateMappingResponseImpl implements CreateMappingResponse {
     return mappingKey;
   }
 
-  public CreateMappingResponseImpl setResponse(final MappingRuleCreateResponse response) {
+  public CreateMappingResponseImpl setResponse(final MappingRuleCreateResult response) {
     mappingKey = Long.parseLong(response.getMappingKey());
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateProcessInstanceResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateProcessInstanceResponseImpl.java
@@ -16,7 +16,7 @@
 package io.camunda.client.impl.response;
 
 import io.camunda.client.api.response.ProcessInstanceEvent;
-import io.camunda.client.protocol.rest.CreateProcessInstanceResponse;
+import io.camunda.client.protocol.rest.CreateProcessInstanceResult;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 
 public final class CreateProcessInstanceResponseImpl implements ProcessInstanceEvent {
@@ -36,7 +36,7 @@ public final class CreateProcessInstanceResponseImpl implements ProcessInstanceE
     tenantId = response.getTenantId();
   }
 
-  public CreateProcessInstanceResponseImpl(final CreateProcessInstanceResponse response) {
+  public CreateProcessInstanceResponseImpl(final CreateProcessInstanceResult response) {
     processDefinitionKey = Long.parseLong(response.getProcessDefinitionKey());
     bpmnProcessId = response.getProcessDefinitionId();
     version = response.getProcessDefinitionVersion();

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateProcessInstanceWithResultResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateProcessInstanceWithResultResponseImpl.java
@@ -18,7 +18,7 @@ package io.camunda.client.impl.response;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.ClientException;
 import io.camunda.client.api.response.ProcessInstanceResult;
-import io.camunda.client.protocol.rest.CreateProcessInstanceResponse;
+import io.camunda.client.protocol.rest.CreateProcessInstanceResult;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceWithResultResponse;
 import java.util.Map;
 
@@ -35,7 +35,7 @@ public final class CreateProcessInstanceWithResultResponseImpl implements Proces
   private Map<String, Object> variablesAsMap;
 
   public CreateProcessInstanceWithResultResponseImpl(
-      final JsonMapper jsonMapper, final CreateProcessInstanceResponse response) {
+      final JsonMapper jsonMapper, final CreateProcessInstanceResult response) {
     this.jsonMapper = jsonMapper;
     processDefinitionKey = Long.parseLong(response.getProcessDefinitionKey());
     bpmnProcessId = response.getProcessDefinitionId();

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateRoleResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateRoleResponseImpl.java
@@ -16,7 +16,7 @@
 package io.camunda.client.impl.response;
 
 import io.camunda.client.api.response.CreateRoleResponse;
-import io.camunda.client.protocol.rest.RoleCreateResponse;
+import io.camunda.client.protocol.rest.RoleCreateResult;
 
 public class CreateRoleResponseImpl implements CreateRoleResponse {
   private long roleKey;
@@ -26,7 +26,7 @@ public class CreateRoleResponseImpl implements CreateRoleResponse {
     return roleKey;
   }
 
-  public CreateRoleResponseImpl setResponse(final RoleCreateResponse response) {
+  public CreateRoleResponseImpl setResponse(final RoleCreateResult response) {
     roleKey = Long.parseLong(response.getRoleKey());
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateTenantResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateTenantResponseImpl.java
@@ -16,7 +16,7 @@
 package io.camunda.client.impl.response;
 
 import io.camunda.client.api.response.CreateTenantResponse;
-import io.camunda.client.protocol.rest.TenantCreateResponse;
+import io.camunda.client.protocol.rest.TenantCreateResult;
 
 public class CreateTenantResponseImpl implements CreateTenantResponse {
   private long tenantKey;
@@ -26,7 +26,7 @@ public class CreateTenantResponseImpl implements CreateTenantResponse {
     return tenantKey;
   }
 
-  public CreateTenantResponseImpl setResponse(final TenantCreateResponse response) {
+  public CreateTenantResponseImpl setResponse(final TenantCreateResult response) {
     tenantKey = Long.parseLong(response.getTenantKey());
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateUserResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateUserResponseImpl.java
@@ -17,7 +17,7 @@ package io.camunda.client.impl.response;
 
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.response.CreateUserResponse;
-import io.camunda.client.protocol.rest.UserCreateResponse;
+import io.camunda.client.protocol.rest.UserCreateResult;
 
 public class CreateUserResponseImpl implements CreateUserResponse {
 
@@ -33,7 +33,7 @@ public class CreateUserResponseImpl implements CreateUserResponse {
     return userKey;
   }
 
-  public CreateUserResponseImpl setResponse(final UserCreateResponse response) {
+  public CreateUserResponseImpl setResponse(final UserCreateResult response) {
     userKey = Long.parseLong(response.getUserKey());
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/DeploymentEventImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/DeploymentEventImpl.java
@@ -22,12 +22,12 @@ import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.client.api.response.Form;
 import io.camunda.client.api.response.Process;
 import io.camunda.client.impl.Loggers;
-import io.camunda.client.protocol.rest.DeploymentDecision;
-import io.camunda.client.protocol.rest.DeploymentDecisionRequirements;
-import io.camunda.client.protocol.rest.DeploymentForm;
-import io.camunda.client.protocol.rest.DeploymentMetadata;
-import io.camunda.client.protocol.rest.DeploymentProcess;
-import io.camunda.client.protocol.rest.DeploymentResponse;
+import io.camunda.client.protocol.rest.DeploymentDecisionRequirementsResult;
+import io.camunda.client.protocol.rest.DeploymentDecisionResult;
+import io.camunda.client.protocol.rest.DeploymentFormResult;
+import io.camunda.client.protocol.rest.DeploymentMetadataResult;
+import io.camunda.client.protocol.rest.DeploymentProcessResult;
+import io.camunda.client.protocol.rest.DeploymentResult;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployProcessResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.Deployment;
@@ -83,11 +83,11 @@ public final class DeploymentEventImpl implements DeploymentEvent {
     }
   }
 
-  public DeploymentEventImpl(final DeploymentResponse response) {
+  public DeploymentEventImpl(final DeploymentResult response) {
     key = Long.parseLong(response.getDeploymentKey());
     tenantId = response.getTenantId();
 
-    for (final DeploymentMetadata deployment : response.getDeployments()) {
+    for (final DeploymentMetadataResult deployment : response.getDeployments()) {
       addDeployedForm(deployment.getForm());
       addDeployedProcess(deployment.getProcessDefinition());
       addDeployedDecision(deployment.getDecisionDefinition());
@@ -95,7 +95,7 @@ public final class DeploymentEventImpl implements DeploymentEvent {
     }
   }
 
-  private void addDeployedForm(final DeploymentForm form) {
+  private void addDeployedForm(final DeploymentFormResult form) {
     Optional.ofNullable(form)
         .ifPresent(
             f ->
@@ -109,7 +109,7 @@ public final class DeploymentEventImpl implements DeploymentEvent {
   }
 
   private void addDeployedDecisionRequirements(
-      final DeploymentDecisionRequirements decisionRequirement) {
+      final DeploymentDecisionRequirementsResult decisionRequirement) {
     Optional.ofNullable(decisionRequirement)
         .ifPresent(
             dr ->
@@ -123,7 +123,7 @@ public final class DeploymentEventImpl implements DeploymentEvent {
                         dr.getTenantId())));
   }
 
-  private void addDeployedDecision(final DeploymentDecision decision) {
+  private void addDeployedDecision(final DeploymentDecisionResult decision) {
     Optional.ofNullable(decision)
         .ifPresent(
             d ->
@@ -138,7 +138,7 @@ public final class DeploymentEventImpl implements DeploymentEvent {
                         d.getTenantId())));
   }
 
-  private void addDeployedProcess(final DeploymentProcess process) {
+  private void addDeployedProcess(final DeploymentProcessResult process) {
     Optional.ofNullable(process)
         .ifPresent(
             p ->

--- a/clients/java/src/main/java/io/camunda/client/impl/response/EvaluateDecisionResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/EvaluateDecisionResponseImpl.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.response.EvaluateDecisionResponse;
 import io.camunda.client.api.response.EvaluatedDecision;
+import io.camunda.client.protocol.rest.EvaluateDecisionResult;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,8 +42,7 @@ public class EvaluateDecisionResponseImpl implements EvaluateDecisionResponse {
   private final long decisionInstanceKey;
 
   public EvaluateDecisionResponseImpl(
-      final io.camunda.client.protocol.rest.EvaluateDecisionResponse response,
-      final JsonMapper jsonMapper) {
+      final EvaluateDecisionResult response, final JsonMapper jsonMapper) {
     this.jsonMapper = jsonMapper;
     decisionId = response.getDecisionDefinitionId();
     decisionKey = Long.parseLong(response.getDecisionDefinitionKey());
@@ -79,8 +79,7 @@ public class EvaluateDecisionResponseImpl implements EvaluateDecisionResponse {
         .forEach(evaluatedDecisions::add);
   }
 
-  private void buildEvaluatedDecisions(
-      final io.camunda.client.protocol.rest.EvaluateDecisionResponse response) {
+  private void buildEvaluatedDecisions(final EvaluateDecisionResult response) {
     if (response.getEvaluatedDecisions() == null) {
       return;
     }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/EvaluatedDecisionImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/EvaluatedDecisionImpl.java
@@ -20,7 +20,7 @@ import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.response.EvaluatedDecision;
 import io.camunda.client.api.response.EvaluatedDecisionInput;
 import io.camunda.client.api.response.MatchedDecisionRule;
-import io.camunda.client.protocol.rest.EvaluatedDecisionItem;
+import io.camunda.client.protocol.rest.EvaluatedDecisionResult;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,10 +40,10 @@ public class EvaluatedDecisionImpl implements EvaluatedDecision {
   private final String tenantId;
 
   public EvaluatedDecisionImpl(
-      final EvaluatedDecisionItem evaluatedDecisionItem, final JsonMapper jsonMapper) {
+      final EvaluatedDecisionResult evaluatedDecisionItem, final JsonMapper jsonMapper) {
     this.jsonMapper = jsonMapper;
     decisionId = evaluatedDecisionItem.getDecisionDefinitionId();
-    decisionKey = evaluatedDecisionItem.getDecisionDefinitionKey();
+    decisionKey = Long.parseLong(evaluatedDecisionItem.getDecisionDefinitionKey());
     decisionVersion = evaluatedDecisionItem.getDecisionDefinitionVersion();
     decisionName = evaluatedDecisionItem.getDecisionDefinitionName();
     decisionType = evaluatedDecisionItem.getDecisionDefinitionType();
@@ -74,7 +74,7 @@ public class EvaluatedDecisionImpl implements EvaluatedDecision {
         .forEach(matchedRules::add);
   }
 
-  private void buildEvaluatedDecisionInput(final EvaluatedDecisionItem evaluatedDecisionItem) {
+  private void buildEvaluatedDecisionInput(final EvaluatedDecisionResult evaluatedDecisionItem) {
     if (evaluatedDecisionItem.getEvaluatedInputs() == null) {
       return;
     }
@@ -84,7 +84,7 @@ public class EvaluatedDecisionImpl implements EvaluatedDecision {
             .collect(Collectors.toList()));
   }
 
-  private void buildMatchedRules(final EvaluatedDecisionItem evaluatedDecisionItem) {
+  private void buildMatchedRules(final EvaluatedDecisionResult evaluatedDecisionItem) {
     if (evaluatedDecisionItem.getMatchedRules() == null) {
       return;
     }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/PublishMessageResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/PublishMessageResponseImpl.java
@@ -16,7 +16,7 @@
 package io.camunda.client.impl.response;
 
 import io.camunda.client.api.response.PublishMessageResponse;
-import io.camunda.client.protocol.rest.MessagePublicationResponse;
+import io.camunda.client.protocol.rest.MessagePublicationResult;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 
 public final class PublishMessageResponseImpl implements PublishMessageResponse {
@@ -29,7 +29,7 @@ public final class PublishMessageResponseImpl implements PublishMessageResponse 
     tenantId = response.getTenantId();
   }
 
-  public PublishMessageResponseImpl(final MessagePublicationResponse response) {
+  public PublishMessageResponseImpl(final MessagePublicationResult response) {
     key = Long.parseLong(response.getMessageKey());
     tenantId = response.getTenantId();
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UpdateTenantResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UpdateTenantResponseImpl.java
@@ -16,7 +16,7 @@
 package io.camunda.client.impl.response;
 
 import io.camunda.client.api.response.UpdateTenantResponse;
-import io.camunda.client.protocol.rest.TenantUpdateResponse;
+import io.camunda.client.protocol.rest.TenantUpdateResult;
 
 public final class UpdateTenantResponseImpl implements UpdateTenantResponse {
   private long tenantKey;
@@ -38,7 +38,7 @@ public final class UpdateTenantResponseImpl implements UpdateTenantResponse {
     return name;
   }
 
-  public UpdateTenantResponseImpl setResponse(final TenantUpdateResponse response) {
+  public UpdateTenantResponseImpl setResponse(final TenantUpdateResult response) {
     tenantKey = Long.parseLong(response.getTenantKey());
     tenantId = response.getTenantId();
     name = response.getName();

--- a/clients/java/src/main/java/io/camunda/client/impl/search/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/SearchResponseMapper.java
@@ -50,7 +50,7 @@ public final class SearchResponseMapper {
   private SearchResponseMapper() {}
 
   public static SearchQueryResponse<ProcessDefinition> toProcessDefinitionSearchResponse(
-      final ProcessDefinitionSearchQueryResponse response) {
+      final ProcessDefinitionSearchQueryResult response) {
     final SearchResponsePage page = toSearchResponsePage(response.getPage());
     final List<ProcessDefinition> instances =
         toSearchResponseInstances(response.getItems(), ProcessDefinitionImpl::new);
@@ -59,16 +59,16 @@ public final class SearchResponseMapper {
   }
 
   public static ProcessDefinition toProcessDefinitionGetResponse(
-      final ProcessDefinitionItem response) {
+      final ProcessDefinitionResult response) {
     return new ProcessDefinitionImpl(response);
   }
 
-  public static ProcessInstance toProcessInstanceGetResponse(final ProcessInstanceItem response) {
+  public static ProcessInstance toProcessInstanceGetResponse(final ProcessInstanceResult response) {
     return new ProcessInstanceImpl(response);
   }
 
   public static SearchQueryResponse<ProcessInstance> toProcessInstanceSearchResponse(
-      final ProcessInstanceSearchQueryResponse response) {
+      final ProcessInstanceSearchQueryResult response) {
     final SearchResponsePage page = toSearchResponsePage(response.getPage());
     final List<ProcessInstance> instances =
         toSearchResponseInstances(response.getItems(), ProcessInstanceImpl::new);
@@ -77,7 +77,7 @@ public final class SearchResponseMapper {
   }
 
   public static SearchQueryResponse<UserTask> toUserTaskSearchResponse(
-      final UserTaskSearchQueryResponse response) {
+      final UserTaskSearchQueryResult response) {
     final SearchResponsePage page = toSearchResponsePage(response.getPage());
     final List<UserTask> instances =
         toSearchResponseInstances(response.getItems(), UserTaskImpl::new);
@@ -85,7 +85,7 @@ public final class SearchResponseMapper {
   }
 
   public static SearchQueryResponse<Variable> toVariableSearchResponse(
-      final VariableSearchQueryResponse response) {
+      final VariableSearchQueryResult response) {
     final SearchResponsePage page = toSearchResponsePage(response.getPage());
     final List<Variable> instances =
         toSearchResponseInstances(response.getItems(), VariableImpl::new);
@@ -93,7 +93,7 @@ public final class SearchResponseMapper {
   }
 
   public static SearchQueryResponse<DecisionDefinition> toDecisionDefinitionSearchResponse(
-      final DecisionDefinitionSearchQueryResponse response) {
+      final DecisionDefinitionSearchQueryResult response) {
     final SearchResponsePage page = toSearchResponsePage(response.getPage());
     final List<DecisionDefinition> instances =
         toSearchResponseInstances(response.getItems(), DecisionDefinitionImpl::new);
@@ -101,7 +101,7 @@ public final class SearchResponseMapper {
   }
 
   public static SearchQueryResponse<FlowNodeInstance> toFlowNodeInstanceSearchResponse(
-      final FlowNodeInstanceSearchQueryResponse response) {
+      final FlowNodeInstanceSearchQueryResult response) {
     final SearchResponsePage page = toSearchResponsePage(response.getPage());
     final List<FlowNodeInstance> instances =
         toSearchResponseInstances(response.getItems(), FlowNodeInstanceImpl::new);
@@ -109,19 +109,19 @@ public final class SearchResponseMapper {
   }
 
   public static FlowNodeInstance toFlowNodeInstanceGetResponse(
-      final FlowNodeInstanceItem response) {
+      final FlowNodeInstanceResult response) {
     return new FlowNodeInstanceImpl(response);
   }
 
   public static SearchQueryResponse<Incident> toIncidentSearchResponse(
-      final IncidentSearchQueryResponse response) {
+      final IncidentSearchQueryResult response) {
     final SearchResponsePage page = toSearchResponsePage(response.getPage());
     final List<Incident> incidents =
         toSearchResponseInstances(response.getItems(), IncidentImpl::new);
     return new SearchQueryResponseImpl<>(incidents, page);
   }
 
-  public static Incident toIncidentGetResponse(final IncidentItem response) {
+  public static Incident toIncidentGetResponse(final IncidentResult response) {
     return new IncidentImpl(response);
   }
 
@@ -134,7 +134,7 @@ public final class SearchResponseMapper {
   }
 
   public static SearchQueryResponse<DecisionRequirements> toDecisionRequirementsSearchResponse(
-      final DecisionRequirementsSearchQueryResponse response) {
+      final DecisionRequirementsSearchQueryResult response) {
     final SearchResponsePage page = toSearchResponsePage(response.getPage());
     final List<DecisionRequirements> instances =
         toSearchResponseInstances(response.getItems(), DecisionRequirementsImpl::new);
@@ -142,7 +142,7 @@ public final class SearchResponseMapper {
   }
 
   public static SearchQueryResponse<DecisionInstance> toDecisionInstanceSearchResponse(
-      final DecisionInstanceSearchQueryResponse response, final JsonMapper jsonMapper) {
+      final DecisionInstanceSearchQueryResult response, final JsonMapper jsonMapper) {
     final SearchResponsePage page = toSearchResponsePage(response.getPage());
     final List<DecisionInstance> instances =
         toSearchResponseInstances(

--- a/clients/java/src/main/java/io/camunda/client/impl/search/query/DecisionDefinitionQueryImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/query/DecisionDefinitionQueryImpl.java
@@ -34,7 +34,7 @@ import io.camunda.client.impl.search.SearchResponseMapper;
 import io.camunda.client.impl.search.TypedSearchRequestPropertyProvider;
 import io.camunda.client.protocol.rest.DecisionDefinitionFilterRequest;
 import io.camunda.client.protocol.rest.DecisionDefinitionSearchQueryRequest;
-import io.camunda.client.protocol.rest.DecisionDefinitionSearchQueryResponse;
+import io.camunda.client.protocol.rest.DecisionDefinitionSearchQueryResult;
 import io.camunda.client.protocol.rest.SearchQueryPageRequest;
 import io.camunda.client.protocol.rest.SearchQuerySortRequest;
 import java.time.Duration;
@@ -114,7 +114,7 @@ public class DecisionDefinitionQueryImpl
         "/decision-definitions/search",
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
-        DecisionDefinitionSearchQueryResponse.class,
+        DecisionDefinitionSearchQueryResult.class,
         SearchResponseMapper::toDecisionDefinitionSearchResponse,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/search/query/DecisionInstanceQueryImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/query/DecisionInstanceQueryImpl.java
@@ -34,7 +34,7 @@ import io.camunda.client.impl.search.SearchResponseMapper;
 import io.camunda.client.impl.search.TypedSearchRequestPropertyProvider;
 import io.camunda.client.protocol.rest.DecisionInstanceFilterRequest;
 import io.camunda.client.protocol.rest.DecisionInstanceSearchQueryRequest;
-import io.camunda.client.protocol.rest.DecisionInstanceSearchQueryResponse;
+import io.camunda.client.protocol.rest.DecisionInstanceSearchQueryResult;
 import io.camunda.client.protocol.rest.SearchQueryPageRequest;
 import io.camunda.client.protocol.rest.SearchQuerySortRequest;
 import java.time.Duration;
@@ -114,7 +114,7 @@ public class DecisionInstanceQueryImpl
         "/decision-instances/search",
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
-        DecisionInstanceSearchQueryResponse.class,
+        DecisionInstanceSearchQueryResult.class,
         resp -> SearchResponseMapper.toDecisionInstanceSearchResponse(resp, jsonMapper),
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/search/query/DecisionRequirementsQueryImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/query/DecisionRequirementsQueryImpl.java
@@ -35,7 +35,7 @@ import io.camunda.client.impl.search.TypedSearchRequestPropertyProvider;
 import io.camunda.client.impl.search.sort.DecisionRequirementsSortImpl;
 import io.camunda.client.protocol.rest.DecisionRequirementsFilterRequest;
 import io.camunda.client.protocol.rest.DecisionRequirementsSearchQueryRequest;
-import io.camunda.client.protocol.rest.DecisionRequirementsSearchQueryResponse;
+import io.camunda.client.protocol.rest.DecisionRequirementsSearchQueryResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -71,7 +71,7 @@ public class DecisionRequirementsQueryImpl
         "/decision-requirements/search",
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
-        DecisionRequirementsSearchQueryResponse.class,
+        DecisionRequirementsSearchQueryResult.class,
         SearchResponseMapper::toDecisionRequirementsSearchResponse,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/search/query/FlowNodeInstanceQueryImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/query/FlowNodeInstanceQueryImpl.java
@@ -36,7 +36,7 @@ import io.camunda.client.impl.search.TypedSearchRequestPropertyProvider;
 import io.camunda.client.impl.search.sort.FlownodeInstanceSortImpl;
 import io.camunda.client.protocol.rest.FlowNodeInstanceFilterRequest;
 import io.camunda.client.protocol.rest.FlowNodeInstanceSearchQueryRequest;
-import io.camunda.client.protocol.rest.FlowNodeInstanceSearchQueryResponse;
+import io.camunda.client.protocol.rest.FlowNodeInstanceSearchQueryResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -72,7 +72,7 @@ public class FlowNodeInstanceQueryImpl
         "/flownode-instances/search",
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
-        FlowNodeInstanceSearchQueryResponse.class,
+        FlowNodeInstanceSearchQueryResult.class,
         SearchResponseMapper::toFlowNodeInstanceSearchResponse,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/search/query/IncidentQueryImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/query/IncidentQueryImpl.java
@@ -35,7 +35,7 @@ import io.camunda.client.impl.search.SearchResponseMapper;
 import io.camunda.client.impl.search.TypedSearchRequestPropertyProvider;
 import io.camunda.client.protocol.rest.IncidentFilterRequest;
 import io.camunda.client.protocol.rest.IncidentSearchQueryRequest;
-import io.camunda.client.protocol.rest.IncidentSearchQueryResponse;
+import io.camunda.client.protocol.rest.IncidentSearchQueryResult;
 import io.camunda.client.protocol.rest.SearchQuerySortRequest;
 import java.time.Duration;
 import java.util.List;
@@ -72,7 +72,7 @@ public class IncidentQueryImpl
         "/incidents/search",
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
-        IncidentSearchQueryResponse.class,
+        IncidentSearchQueryResult.class,
         SearchResponseMapper::toIncidentSearchResponse,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/search/query/ProcessDefinitionQueryImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/query/ProcessDefinitionQueryImpl.java
@@ -34,7 +34,7 @@ import io.camunda.client.impl.search.SearchResponseMapper;
 import io.camunda.client.impl.search.TypedSearchRequestPropertyProvider;
 import io.camunda.client.protocol.rest.ProcessDefinitionFilterRequest;
 import io.camunda.client.protocol.rest.ProcessDefinitionSearchQueryRequest;
-import io.camunda.client.protocol.rest.ProcessDefinitionSearchQueryResponse;
+import io.camunda.client.protocol.rest.ProcessDefinitionSearchQueryResult;
 import io.camunda.client.protocol.rest.SearchQueryPageRequest;
 import io.camunda.client.protocol.rest.SearchQuerySortRequest;
 import java.time.Duration;
@@ -73,7 +73,7 @@ public class ProcessDefinitionQueryImpl
         "/process-definitions/search",
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
-        ProcessDefinitionSearchQueryResponse.class,
+        ProcessDefinitionSearchQueryResult.class,
         SearchResponseMapper::toProcessDefinitionSearchResponse,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/search/query/ProcessInstanceQueryImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/query/ProcessInstanceQueryImpl.java
@@ -34,7 +34,7 @@ import io.camunda.client.impl.search.SearchResponseMapper;
 import io.camunda.client.impl.search.TypedSearchRequestPropertyProvider;
 import io.camunda.client.protocol.rest.ProcessInstanceFilterRequest;
 import io.camunda.client.protocol.rest.ProcessInstanceSearchQueryRequest;
-import io.camunda.client.protocol.rest.ProcessInstanceSearchQueryResponse;
+import io.camunda.client.protocol.rest.ProcessInstanceSearchQueryResult;
 import io.camunda.client.protocol.rest.SearchQueryPageRequest;
 import io.camunda.client.protocol.rest.SearchQuerySortRequest;
 import java.time.Duration;
@@ -73,7 +73,7 @@ public class ProcessInstanceQueryImpl
         "/process-instances/search",
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
-        ProcessInstanceSearchQueryResponse.class,
+        ProcessInstanceSearchQueryResult.class,
         SearchResponseMapper::toProcessInstanceSearchResponse,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/search/query/UserTaskQueryImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/query/UserTaskQueryImpl.java
@@ -35,7 +35,7 @@ import io.camunda.client.impl.search.TypedSearchRequestPropertyProvider;
 import io.camunda.client.impl.search.sort.UserTaskSortImpl;
 import io.camunda.client.protocol.rest.UserTaskFilterRequest;
 import io.camunda.client.protocol.rest.UserTaskSearchQueryRequest;
-import io.camunda.client.protocol.rest.UserTaskSearchQueryResponse;
+import io.camunda.client.protocol.rest.UserTaskSearchQueryResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -70,7 +70,7 @@ public class UserTaskQueryImpl
         "/user-tasks/search",
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
-        UserTaskSearchQueryResponse.class,
+        UserTaskSearchQueryResult.class,
         SearchResponseMapper::toUserTaskSearchResponse,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/search/query/UserTaskVariableQueryImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/query/UserTaskVariableQueryImpl.java
@@ -34,7 +34,7 @@ import io.camunda.client.impl.search.SearchResponseMapper;
 import io.camunda.client.impl.search.TypedSearchRequestPropertyProvider;
 import io.camunda.client.impl.search.sort.VariableSortImpl;
 import io.camunda.client.protocol.rest.UserTaskVariableSearchQueryRequest;
-import io.camunda.client.protocol.rest.VariableSearchQueryResponse;
+import io.camunda.client.protocol.rest.VariableSearchQueryResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -72,7 +72,7 @@ public class UserTaskVariableQueryImpl
         String.format("/user-tasks/%d/variables/search", userTaskKey),
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
-        VariableSearchQueryResponse.class,
+        VariableSearchQueryResult.class,
         SearchResponseMapper::toVariableSearchResponse,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/search/query/VariableQueryImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/query/VariableQueryImpl.java
@@ -36,7 +36,7 @@ import io.camunda.client.impl.search.TypedSearchRequestPropertyProvider;
 import io.camunda.client.impl.search.sort.VariableSortImpl;
 import io.camunda.client.protocol.rest.VariableFilterRequest;
 import io.camunda.client.protocol.rest.VariableSearchQueryRequest;
-import io.camunda.client.protocol.rest.VariableSearchQueryResponse;
+import io.camunda.client.protocol.rest.VariableSearchQueryResult;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -71,7 +71,7 @@ public class VariableQueryImpl
         "/variables/search",
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
-        VariableSearchQueryResponse.class,
+        VariableSearchQueryResult.class,
         SearchResponseMapper::toVariableSearchResponse,
         result);
     return result;

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/DecisionDefinitionImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/DecisionDefinitionImpl.java
@@ -16,7 +16,7 @@
 package io.camunda.client.impl.search.response;
 
 import io.camunda.client.api.search.response.DecisionDefinition;
-import io.camunda.client.protocol.rest.DecisionDefinitionItem;
+import io.camunda.client.protocol.rest.DecisionDefinitionResult;
 import java.util.Objects;
 
 public final class DecisionDefinitionImpl implements DecisionDefinition {
@@ -29,7 +29,7 @@ public final class DecisionDefinitionImpl implements DecisionDefinition {
   private final long decisionRequirementsKey;
   private final String tenantId;
 
-  public DecisionDefinitionImpl(final DecisionDefinitionItem item) {
+  public DecisionDefinitionImpl(final DecisionDefinitionResult item) {
     this(
         item.getDecisionDefinitionId(),
         item.getName(),

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/DecisionInstanceImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/DecisionInstanceImpl.java
@@ -26,8 +26,8 @@ import io.camunda.client.impl.response.EvaluatedDecisionInputImpl;
 import io.camunda.client.impl.response.MatchedDecisionRuleImpl;
 import io.camunda.client.impl.util.EnumUtil;
 import io.camunda.client.protocol.rest.DecisionDefinitionTypeEnum;
-import io.camunda.client.protocol.rest.DecisionInstanceGetQueryResponse;
-import io.camunda.client.protocol.rest.DecisionInstanceItem;
+import io.camunda.client.protocol.rest.DecisionInstanceGetQueryResult;
+import io.camunda.client.protocol.rest.DecisionInstanceResult;
 import io.camunda.client.protocol.rest.DecisionInstanceStateEnum;
 import java.util.List;
 import java.util.Objects;
@@ -52,7 +52,7 @@ public class DecisionInstanceImpl implements DecisionInstance {
   private final List<EvaluatedDecisionInput> evaluatedInputs;
   private final List<MatchedDecisionRule> matchedRules;
 
-  public DecisionInstanceImpl(final DecisionInstanceItem item, final JsonMapper jsonMapper) {
+  public DecisionInstanceImpl(final DecisionInstanceResult item, final JsonMapper jsonMapper) {
     this(
         jsonMapper,
         Long.parseLong(item.getDecisionInstanceKey()),
@@ -73,7 +73,7 @@ public class DecisionInstanceImpl implements DecisionInstance {
   }
 
   public DecisionInstanceImpl(
-      final DecisionInstanceGetQueryResponse item, final JsonMapper jsonMapper) {
+      final DecisionInstanceGetQueryResult item, final JsonMapper jsonMapper) {
     this(
         jsonMapper,
         Long.parseLong(item.getDecisionInstanceKey()),

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/DecisionRequirementsImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/DecisionRequirementsImpl.java
@@ -17,7 +17,7 @@ package io.camunda.client.impl.search.response;
 
 import io.camunda.client.api.search.response.DecisionRequirements;
 import io.camunda.client.impl.util.ParseUtil;
-import io.camunda.client.protocol.rest.DecisionRequirementsItem;
+import io.camunda.client.protocol.rest.DecisionRequirementsResult;
 
 public class DecisionRequirementsImpl implements DecisionRequirements {
   private final Long decisionRequirementsKey;
@@ -27,7 +27,7 @@ public class DecisionRequirementsImpl implements DecisionRequirements {
   private final String dmnDecisionRequirementsName;
   private final Integer version;
 
-  public DecisionRequirementsImpl(final DecisionRequirementsItem item) {
+  public DecisionRequirementsImpl(final DecisionRequirementsResult item) {
     decisionRequirementsKey = ParseUtil.parseLongOrNull(item.getDecisionRequirementsKey());
     resourceName = item.getResourceName();
     tenantId = item.getTenantId();

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/FlowNodeInstanceImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/FlowNodeInstanceImpl.java
@@ -19,7 +19,7 @@ import io.camunda.client.api.search.response.FlowNodeInstance;
 import io.camunda.client.api.search.response.FlowNodeInstanceState;
 import io.camunda.client.api.search.response.FlowNodeInstanceType;
 import io.camunda.client.impl.util.ParseUtil;
-import io.camunda.client.protocol.rest.FlowNodeInstanceItem;
+import io.camunda.client.protocol.rest.FlowNodeInstanceResult;
 import java.util.Objects;
 
 public final class FlowNodeInstanceImpl implements FlowNodeInstance {
@@ -38,7 +38,7 @@ public final class FlowNodeInstanceImpl implements FlowNodeInstance {
   private final String tenantId;
   private final FlowNodeInstanceType type;
 
-  public FlowNodeInstanceImpl(final FlowNodeInstanceItem item) {
+  public FlowNodeInstanceImpl(final FlowNodeInstanceResult item) {
     flowNodeInstanceKey = ParseUtil.parseLongOrNull(item.getFlowNodeInstanceKey());
     processDefinitionKey = ParseUtil.parseLongOrNull(item.getProcessDefinitionKey());
     processDefinitionId = item.getProcessDefinitionId();

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/FormImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/FormImpl.java
@@ -16,7 +16,7 @@
 package io.camunda.client.impl.search.response;
 
 import io.camunda.client.api.search.response.Form;
-import io.camunda.client.protocol.rest.FormItem;
+import io.camunda.client.protocol.rest.FormResult;
 
 public class FormImpl implements Form {
   private final String formId;
@@ -25,7 +25,7 @@ public class FormImpl implements Form {
   private final Object schema;
   private final String tenantId;
 
-  public FormImpl(final FormItem item) {
+  public FormImpl(final FormResult item) {
     formId = item.getBpmnId();
     version = item.getVersion();
     formKey = Long.parseLong(item.getFormKey());

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/IncidentImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/IncidentImpl.java
@@ -17,9 +17,9 @@ package io.camunda.client.impl.search.response;
 
 import io.camunda.client.api.search.response.Incident;
 import io.camunda.client.impl.util.ParseUtil;
-import io.camunda.client.protocol.rest.IncidentItem;
-import io.camunda.client.protocol.rest.IncidentItem.ErrorTypeEnum;
-import io.camunda.client.protocol.rest.IncidentItem.StateEnum;
+import io.camunda.client.protocol.rest.IncidentResult;
+import io.camunda.client.protocol.rest.IncidentResult.ErrorTypeEnum;
+import io.camunda.client.protocol.rest.IncidentResult.StateEnum;
 import java.util.Objects;
 
 public class IncidentImpl implements Incident {
@@ -37,7 +37,7 @@ public class IncidentImpl implements Incident {
   private final Long jobKey;
   private final String tenantId;
 
-  public IncidentImpl(final IncidentItem item) {
+  public IncidentImpl(final IncidentResult item) {
     incidentKey = ParseUtil.parseLongOrNull(item.getIncidentKey());
     processDefinitionKey = ParseUtil.parseLongOrNull(item.getProcessDefinitionKey());
     processDefinitionId = item.getProcessDefinitionId();

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/ProcessDefinitionImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/ProcessDefinitionImpl.java
@@ -18,7 +18,7 @@ package io.camunda.client.impl.search.response;
 import io.camunda.client.api.response.Process;
 import io.camunda.client.api.search.response.ProcessDefinition;
 import io.camunda.client.impl.util.ParseUtil;
-import io.camunda.client.protocol.rest.ProcessDefinitionItem;
+import io.camunda.client.protocol.rest.ProcessDefinitionResult;
 import java.util.Objects;
 
 public class ProcessDefinitionImpl implements ProcessDefinition, Process {
@@ -31,7 +31,7 @@ public class ProcessDefinitionImpl implements ProcessDefinition, Process {
   private final String processDefinitionId;
   private final String tenantId;
 
-  public ProcessDefinitionImpl(final ProcessDefinitionItem item) {
+  public ProcessDefinitionImpl(final ProcessDefinitionResult item) {
     processDefinitionKey = ParseUtil.parseLongOrNull(item.getProcessDefinitionKey());
     name = item.getName();
     resourceName = item.getResourceName();

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/ProcessInstanceImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/ProcessInstanceImpl.java
@@ -17,7 +17,7 @@ package io.camunda.client.impl.search.response;
 
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.impl.util.ParseUtil;
-import io.camunda.client.protocol.rest.ProcessInstanceItem;
+import io.camunda.client.protocol.rest.ProcessInstanceResult;
 import java.util.Optional;
 
 public class ProcessInstanceImpl implements ProcessInstance {
@@ -36,7 +36,7 @@ public class ProcessInstanceImpl implements ProcessInstance {
   private final Boolean hasIncident;
   private final String tenantId;
 
-  public ProcessInstanceImpl(final ProcessInstanceItem item) {
+  public ProcessInstanceImpl(final ProcessInstanceResult item) {
     processInstanceKey = ParseUtil.parseLongOrNull(item.getProcessInstanceKey());
     processDefinitionId = item.getProcessDefinitionId();
     processDefinitionName = item.getProcessDefinitionName();

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/UserTaskImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/UserTaskImpl.java
@@ -17,7 +17,7 @@ package io.camunda.client.impl.search.response;
 
 import io.camunda.client.api.search.response.UserTask;
 import io.camunda.client.impl.util.ParseUtil;
-import io.camunda.client.protocol.rest.UserTaskItem;
+import io.camunda.client.protocol.rest.UserTaskResult;
 import java.util.List;
 import java.util.Map;
 
@@ -45,7 +45,7 @@ public class UserTaskImpl implements UserTask {
   private final Map<String, String> customHeaders;
   private final Integer priority;
 
-  public UserTaskImpl(final UserTaskItem item) {
+  public UserTaskImpl(final UserTaskResult item) {
     userTaskKey = ParseUtil.parseLongOrNull(item.getUserTaskKey());
     name = item.getName();
     state = item.getState().getValue();

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/VariableImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/VariableImpl.java
@@ -17,7 +17,7 @@ package io.camunda.client.impl.search.response;
 
 import io.camunda.client.api.search.response.Variable;
 import io.camunda.client.impl.util.ParseUtil;
-import io.camunda.client.protocol.rest.VariableItem;
+import io.camunda.client.protocol.rest.VariableResult;
 
 public class VariableImpl implements Variable {
 
@@ -30,7 +30,7 @@ public class VariableImpl implements Variable {
   private final String tenantId;
   private final Boolean isTruncated;
 
-  public VariableImpl(final VariableItem item) {
+  public VariableImpl(final VariableResult item) {
     variableKey = ParseUtil.parseLongOrNull(item.getVariableKey());
     name = item.getName();
     value = item.getValue();

--- a/clients/java/src/test/java/io/camunda/client/decision/rest/DecisionEvaluationRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/decision/rest/DecisionEvaluationRestTest.java
@@ -26,9 +26,10 @@ import io.camunda.client.api.response.EvaluatedDecisionInput;
 import io.camunda.client.api.response.EvaluatedDecisionOutput;
 import io.camunda.client.api.response.MatchedDecisionRule;
 import io.camunda.client.protocol.rest.EvaluateDecisionRequest;
+import io.camunda.client.protocol.rest.EvaluateDecisionResult;
 import io.camunda.client.protocol.rest.EvaluatedDecisionInputItem;
-import io.camunda.client.protocol.rest.EvaluatedDecisionItem;
 import io.camunda.client.protocol.rest.EvaluatedDecisionOutputItem;
+import io.camunda.client.protocol.rest.EvaluatedDecisionResult;
 import io.camunda.client.protocol.rest.MatchedDecisionRuleItem;
 import io.camunda.client.protocol.rest.ProblemDetail;
 import io.camunda.client.util.ClientRestTest;
@@ -60,10 +61,10 @@ public class DecisionEvaluationRestTest extends ClientRestTest {
           .ruleId("rule-id")
           .ruleIndex(1)
           .addEvaluatedOutputsItem(EVALUATED_OUTPUT);
-  private static final EvaluatedDecisionItem EVALUATED_DECISION =
-      new EvaluatedDecisionItem()
+  private static final EvaluatedDecisionResult EVALUATED_DECISION =
+      new EvaluatedDecisionResult()
           .decisionDefinitionId("my-decision")
-          .decisionDefinitionKey(DECISION_KEY)
+          .decisionDefinitionKey(String.valueOf(DECISION_KEY))
           .decisionDefinitionName("My Decision")
           .decisionDefinitionVersion(1)
           .decisionDefinitionType("TABLE")
@@ -71,21 +72,20 @@ public class DecisionEvaluationRestTest extends ClientRestTest {
           .tenantId(TENANT_ID)
           .addEvaluatedInputsItem(EVALUATED_INPUT)
           .addMatchedRulesItem(MATCHED_RULE);
-  private static final io.camunda.client.protocol.rest.EvaluateDecisionResponse
-      EVALUATE_DECISION_RESPONSE =
-          new io.camunda.client.protocol.rest.EvaluateDecisionResponse()
-              .decisionDefinitionKey(String.valueOf(DECISION_KEY))
-              .decisionDefinitionId("my-decision")
-              .decisionDefinitionName("My Decision")
-              .decisionDefinitionVersion(1)
-              .output("testOutput")
-              .decisionRequirementsId("decision-requirements-id")
-              .decisionRequirementsKey("124")
-              .failedDecisionDefinitionId("my-decision")
-              .failureMessage("decision-evaluation-failure")
-              .tenantId(TENANT_ID)
-              .decisionInstanceKey(String.valueOf(DECISION_INSTANCE_KEY))
-              .addEvaluatedDecisionsItem(EVALUATED_DECISION);
+  private static final EvaluateDecisionResult EVALUATE_DECISION_RESPONSE =
+      new EvaluateDecisionResult()
+          .decisionDefinitionKey(String.valueOf(DECISION_KEY))
+          .decisionDefinitionId("my-decision")
+          .decisionDefinitionName("My Decision")
+          .decisionDefinitionVersion(1)
+          .output("testOutput")
+          .decisionRequirementsId("decision-requirements-id")
+          .decisionRequirementsKey("124")
+          .failedDecisionDefinitionId("my-decision")
+          .failureMessage("decision-evaluation-failure")
+          .tenantId(TENANT_ID)
+          .decisionInstanceKey(String.valueOf(DECISION_INSTANCE_KEY))
+          .addEvaluatedDecisionsItem(EVALUATED_DECISION);
 
   @Test
   public void shouldEvaluateStandaloneDecisionWithDecisionKey() {
@@ -292,7 +292,7 @@ public class DecisionEvaluationRestTest extends ClientRestTest {
     final EvaluatedDecision evaluatedDecisionResponse = response.getEvaluatedDecisions().get(0);
     assertThat(evaluatedDecisionResponse.getDecisionId())
         .isEqualTo(EVALUATED_DECISION.getDecisionDefinitionId());
-    assertThat(evaluatedDecisionResponse.getDecisionKey())
+    assertThat(String.valueOf(evaluatedDecisionResponse.getDecisionKey()))
         .isEqualTo(EVALUATED_DECISION.getDecisionDefinitionKey());
     assertThat(evaluatedDecisionResponse.getDecisionName())
         .isEqualTo(EVALUATED_DECISION.getDecisionDefinitionName());

--- a/clients/java/src/test/java/io/camunda/client/flownodeinstance/FlownodeInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/flownodeinstance/FlownodeInstanceTest.java
@@ -148,11 +148,11 @@ public class FlownodeInstanceTest extends ClientRestTest {
       }
     }
 
-    for (final FlowNodeInstanceItem.TypeEnum protocolValue :
-        FlowNodeInstanceItem.TypeEnum.values()) {
+    for (final FlowNodeInstanceResult.TypeEnum protocolValue :
+        FlowNodeInstanceResult.TypeEnum.values()) {
       final FlowNodeInstanceType value = FlowNodeInstanceType.fromProtocolType(protocolValue);
       assertThat(value).isNotNull();
-      if (protocolValue == FlowNodeInstanceItem.TypeEnum.UNKNOWN_DEFAULT_OPEN_API) {
+      if (protocolValue == FlowNodeInstanceResult.TypeEnum.UNKNOWN_DEFAULT_OPEN_API) {
         assertThat(value).isEqualTo(FlowNodeInstanceType.UNKNOWN_ENUM_VALUE);
       } else {
         assertThat(value.name()).isEqualTo(protocolValue.name());
@@ -175,11 +175,11 @@ public class FlownodeInstanceTest extends ClientRestTest {
       }
     }
 
-    for (final FlowNodeInstanceItem.StateEnum protocolValue :
-        FlowNodeInstanceItem.StateEnum.values()) {
+    for (final FlowNodeInstanceResult.StateEnum protocolValue :
+        FlowNodeInstanceResult.StateEnum.values()) {
       final FlowNodeInstanceState value = FlowNodeInstanceState.fromProtocolState(protocolValue);
       assertThat(value).isNotNull();
-      if (protocolValue == FlowNodeInstanceItem.StateEnum.UNKNOWN_DEFAULT_OPEN_API) {
+      if (protocolValue == FlowNodeInstanceResult.StateEnum.UNKNOWN_DEFAULT_OPEN_API) {
         assertThat(value).isEqualTo(FlowNodeInstanceState.UNKNOWN_ENUM_VALUE);
       } else {
         assertThat(value.name()).isEqualTo(protocolValue.name());

--- a/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/ActivateJobsRestTest.java
@@ -26,9 +26,9 @@ import io.camunda.client.api.response.ActivateJobsResponse;
 import io.camunda.client.impl.CamundaClientBuilderImpl;
 import io.camunda.client.impl.CamundaObjectMapper;
 import io.camunda.client.impl.response.ActivatedJobImpl;
-import io.camunda.client.protocol.rest.ActivatedJob;
+import io.camunda.client.protocol.rest.ActivatedJobResult;
 import io.camunda.client.protocol.rest.JobActivationRequest;
-import io.camunda.client.protocol.rest.JobActivationResponse;
+import io.camunda.client.protocol.rest.JobActivationResult;
 import io.camunda.client.protocol.rest.ProblemDetail;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayPaths;
@@ -44,8 +44,8 @@ public final class ActivateJobsRestTest extends ClientRestTest {
   @Test
   void shouldActivateJobs() {
     // given
-    final ActivatedJob activatedJob1 =
-        new ActivatedJob()
+    final ActivatedJobResult activatedJob1 =
+        new ActivatedJobResult()
             .jobKey("12")
             .type("foo")
             .processInstanceKey("123")
@@ -61,8 +61,8 @@ public final class ActivateJobsRestTest extends ClientRestTest {
             .variables(singletonMap("key", "val"))
             .tenantId("test-tenant-1");
 
-    final ActivatedJob activatedJob2 =
-        new ActivatedJob()
+    final ActivatedJobResult activatedJob2 =
+        new ActivatedJobResult()
             .jobKey("42")
             .type("foo")
             .processInstanceKey("333")
@@ -79,7 +79,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
             .tenantId("test-tenant-2");
 
     gatewayService.onActivateJobsRequest(
-        new JobActivationResponse().addJobsItem(activatedJob1).addJobsItem(activatedJob2));
+        new JobActivationResult().addJobsItem(activatedJob1).addJobsItem(activatedJob2));
 
     // when
     final ActivateJobsResponse response =
@@ -258,7 +258,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
     final ActivatedJobImpl activatedJob =
         new ActivatedJobImpl(
             new CamundaObjectMapper(),
-            new ActivatedJob().customHeaders(new HashMap<>()).variables(variables));
+            new ActivatedJobResult().customHeaders(new HashMap<>()).variables(variables));
 
     // when
     final VariablesPojo variablesPojo = activatedJob.getVariablesAsType(VariablesPojo.class);
@@ -357,11 +357,11 @@ public final class ActivateJobsRestTest extends ClientRestTest {
     variablesJob2.put("foo", "bar2");
     variablesJob2.put("joe", "doe2");
 
-    final ActivatedJob activatedJob1 = new ActivatedJob().variables(variablesJob1);
-    final ActivatedJob activatedJob2 = new ActivatedJob().variables(variablesJob2);
+    final ActivatedJobResult activatedJob1 = new ActivatedJobResult().variables(variablesJob1);
+    final ActivatedJobResult activatedJob2 = new ActivatedJobResult().variables(variablesJob2);
 
     gatewayService.onActivateJobsRequest(
-        new JobActivationResponse().addJobsItem(activatedJob1).addJobsItem(activatedJob2));
+        new JobActivationResult().addJobsItem(activatedJob1).addJobsItem(activatedJob2));
 
     // when
     final ActivateJobsResponse response =
@@ -387,9 +387,9 @@ public final class ActivateJobsRestTest extends ClientRestTest {
     variables.put("key", "val");
     variables.put("foo", "bar");
     variables.put("joe", "doe");
-    final ActivatedJob activatedJob1 = new ActivatedJob().variables(variables);
+    final ActivatedJobResult activatedJob1 = new ActivatedJobResult().variables(variables);
 
-    gatewayService.onActivateJobsRequest(new JobActivationResponse().addJobsItem(activatedJob1));
+    gatewayService.onActivateJobsRequest(new JobActivationResult().addJobsItem(activatedJob1));
 
     // when
     final ActivateJobsResponse response =
@@ -405,9 +405,9 @@ public final class ActivateJobsRestTest extends ClientRestTest {
   void shouldReturnNullIfVariableValueIsNull() {
     final Map<String, Object> variables = singletonMap("key", null);
     // given
-    final ActivatedJob activatedJob1 = new ActivatedJob().variables(variables);
+    final ActivatedJobResult activatedJob1 = new ActivatedJobResult().variables(variables);
 
-    gatewayService.onActivateJobsRequest(new JobActivationResponse().addJobsItem(activatedJob1));
+    gatewayService.onActivateJobsRequest(new JobActivationResult().addJobsItem(activatedJob1));
 
     // when
     final ActivateJobsResponse response =

--- a/clients/java/src/test/java/io/camunda/client/resource/rest/DeployResourceRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/resource/rest/DeployResourceRestTest.java
@@ -25,12 +25,12 @@ import io.camunda.client.impl.response.DecisionImpl;
 import io.camunda.client.impl.response.DecisionRequirementsImpl;
 import io.camunda.client.impl.response.FormImpl;
 import io.camunda.client.impl.response.ProcessImpl;
-import io.camunda.client.protocol.rest.DeploymentDecision;
-import io.camunda.client.protocol.rest.DeploymentDecisionRequirements;
-import io.camunda.client.protocol.rest.DeploymentForm;
-import io.camunda.client.protocol.rest.DeploymentMetadata;
-import io.camunda.client.protocol.rest.DeploymentProcess;
-import io.camunda.client.protocol.rest.DeploymentResponse;
+import io.camunda.client.protocol.rest.DeploymentDecisionRequirementsResult;
+import io.camunda.client.protocol.rest.DeploymentDecisionResult;
+import io.camunda.client.protocol.rest.DeploymentFormResult;
+import io.camunda.client.protocol.rest.DeploymentMetadataResult;
+import io.camunda.client.protocol.rest.DeploymentProcessResult;
+import io.camunda.client.protocol.rest.DeploymentResult;
 import io.camunda.client.protocol.rest.ProblemDetail;
 import io.camunda.client.resource.DeployResourceTest;
 import io.camunda.client.util.ClientRestTest;
@@ -205,13 +205,13 @@ public class DeployResourceRestTest extends ClientRestTest {
     final String tenantId = "test-tenant";
     final String filename = DeployResourceTest.class.getResource(BPMN_1_FILENAME).getPath();
     gatewayService.onDeploymentsRequest(
-        new DeploymentResponse()
+        new DeploymentResult()
             .deploymentKey(key)
             .tenantId(tenantId)
             .addDeploymentsItem(
-                new DeploymentMetadata()
+                new DeploymentMetadataResult()
                     .processDefinition(
-                        new DeploymentProcess()
+                        new DeploymentProcessResult()
                             .processDefinitionId(BPMN_1_PROCESS_ID)
                             .processDefinitionVersion(12)
                             .processDefinitionKey("423")
@@ -242,22 +242,22 @@ public class DeployResourceRestTest extends ClientRestTest {
     final String filename1 = BPMN_1_FILENAME.substring(1);
     final String filename2 = BPMN_2_FILENAME.substring(1);
     gatewayService.onDeploymentsRequest(
-        new DeploymentResponse()
+        new DeploymentResult()
             .deploymentKey(key)
             .tenantId(tenantId)
             .addDeploymentsItem(
-                new DeploymentMetadata()
+                new DeploymentMetadataResult()
                     .processDefinition(
-                        new DeploymentProcess()
+                        new DeploymentProcessResult()
                             .processDefinitionId(BPMN_1_PROCESS_ID)
                             .processDefinitionVersion(1)
                             .processDefinitionKey("1")
                             .tenantId(tenantId)
                             .resourceName(filename1)))
             .addDeploymentsItem(
-                new DeploymentMetadata()
+                new DeploymentMetadataResult()
                     .processDefinition(
-                        new DeploymentProcess()
+                        new DeploymentProcessResult()
                             .processDefinitionId(BPMN_2_PROCESS_ID)
                             .processDefinitionVersion(1)
                             .processDefinitionKey("2")
@@ -293,13 +293,13 @@ public class DeployResourceRestTest extends ClientRestTest {
     final long decisionKey1 = 345L;
     final long decisionKey2 = 456L;
     gatewayService.onDeploymentsRequest(
-        new DeploymentResponse()
+        new DeploymentResult()
             .deploymentKey(deploymentKey)
             .tenantId(tenantId)
             .addDeploymentsItem(
-                new DeploymentMetadata()
+                new DeploymentMetadataResult()
                     .decisionDefinition(
-                        new DeploymentDecision()
+                        new DeploymentDecisionResult()
                             .decisionDefinitionId(DMN_DECISION_ID_1)
                             .name(DMN_DECISION_NAME_1)
                             .version(version)
@@ -308,9 +308,9 @@ public class DeployResourceRestTest extends ClientRestTest {
                             .decisionRequirementsKey(String.valueOf(decisionRequirementsKey))
                             .tenantId(tenantId)))
             .addDeploymentsItem(
-                new DeploymentMetadata()
+                new DeploymentMetadataResult()
                     .decisionDefinition(
-                        new DeploymentDecision()
+                        new DeploymentDecisionResult()
                             .decisionDefinitionId(DMN_DECISION_ID_2)
                             .name(DMN_DECISION_NAME_2)
                             .version(version)
@@ -319,9 +319,9 @@ public class DeployResourceRestTest extends ClientRestTest {
                             .decisionRequirementsKey(String.valueOf(decisionRequirementsKey))
                             .tenantId(tenantId)))
             .addDeploymentsItem(
-                new DeploymentMetadata()
+                new DeploymentMetadataResult()
                     .decisionRequirements(
-                        new DeploymentDecisionRequirements()
+                        new DeploymentDecisionRequirementsResult()
                             .decisionRequirementsId(DMN_DECISION_REQUIREMENTS_ID)
                             .name(DMN_DECISION_REQUIREMENTS_NAME)
                             .version(version)
@@ -391,13 +391,13 @@ public class DeployResourceRestTest extends ClientRestTest {
     final long formKey = 234L;
     final String formId = "formId";
     gatewayService.onDeploymentsRequest(
-        new DeploymentResponse()
+        new DeploymentResult()
             .deploymentKey(deploymentKey)
             .tenantId(DEFAULT_TENANT)
             .addDeploymentsItem(
-                new DeploymentMetadata()
+                new DeploymentMetadataResult()
                     .form(
-                        new DeploymentForm()
+                        new DeploymentFormResult()
                             .formId(formId)
                             .version(version)
                             .formKey(String.valueOf(formKey))
@@ -423,22 +423,22 @@ public class DeployResourceRestTest extends ClientRestTest {
     final String formId1 = "formId1";
     final String formId2 = "formId2";
     gatewayService.onDeploymentsRequest(
-        new DeploymentResponse()
+        new DeploymentResult()
             .deploymentKey(key)
             .tenantId(DEFAULT_TENANT)
             .addDeploymentsItem(
-                new DeploymentMetadata()
+                new DeploymentMetadataResult()
                     .form(
-                        new DeploymentForm()
+                        new DeploymentFormResult()
                             .formId(formId1)
                             .version(1)
                             .formKey("1")
                             .resourceName(filename1)
                             .tenantId(DEFAULT_TENANT)))
             .addDeploymentsItem(
-                new DeploymentMetadata()
+                new DeploymentMetadataResult()
                     .form(
-                        new DeploymentForm()
+                        new DeploymentFormResult()
                             .formId(formId2)
                             .version(1)
                             .formKey("2")

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -20,9 +20,9 @@ import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.impl.CamundaObjectMapper;
-import io.camunda.client.protocol.rest.DeploymentResponse;
-import io.camunda.client.protocol.rest.EvaluateDecisionResponse;
-import io.camunda.client.protocol.rest.JobActivationResponse;
+import io.camunda.client.protocol.rest.DeploymentResult;
+import io.camunda.client.protocol.rest.EvaluateDecisionResult;
+import io.camunda.client.protocol.rest.JobActivationResult;
 import io.camunda.client.protocol.rest.ProblemDetail;
 import io.camunda.client.protocol.rest.TopologyResponse;
 import java.util.List;
@@ -50,7 +50,7 @@ public class RestGatewayService {
    *
    * @param jobActivationResponse the response to provide upon a job activation request
    */
-  public void onActivateJobsRequest(final JobActivationResponse jobActivationResponse) {
+  public void onActivateJobsRequest(final JobActivationResult jobActivationResponse) {
     mockInfo
         .getWireMock()
         .register(
@@ -71,7 +71,7 @@ public class RestGatewayService {
                 .willReturn(WireMock.okJson(JSON_MAPPER.toJson(topologyResponse))));
   }
 
-  public void onEvaluateDecisionRequest(final EvaluateDecisionResponse response) {
+  public void onEvaluateDecisionRequest(final EvaluateDecisionResult response) {
     mockInfo
         .getWireMock()
         .register(
@@ -79,7 +79,7 @@ public class RestGatewayService {
                 .willReturn(WireMock.okJson(JSON_MAPPER.toJson(response))));
   }
 
-  public void onDeploymentsRequest(final DeploymentResponse response) {
+  public void onDeploymentsRequest(final DeploymentResult response) {
     mockInfo
         .getWireMock()
         .register(

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -98,13 +98,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CamundaUser"
+                $ref: "#/components/schemas/CamundaUserResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/CamundaUserNumberKeys"
+                $ref: "#/components/schemas/CamundaUser"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/CamundaUser"
+                $ref: "#/components/schemas/CamundaUserResult"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "500":
@@ -130,13 +130,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/JobActivationResponse"
+                $ref: "#/components/schemas/JobActivationResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/JobActivationResponseNumberKeys"
+                $ref: "#/components/schemas/JobActivationResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/JobActivationResponse"
+                $ref: "#/components/schemas/JobActivationResult"
         "400":
           description: >
             The provided data is not valid.
@@ -395,13 +395,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TenantCreateResponse"
+                $ref: "#/components/schemas/TenantCreateResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/TenantCreateResponseNumberKeys"
+                $ref: "#/components/schemas/TenantCreateResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/TenantCreateResponse"
+                $ref: "#/components/schemas/TenantCreateResult"
         "400":
           description: The provided data is not valid.
           content:
@@ -446,13 +446,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TenantUpdateResponse"
+                $ref: "#/components/schemas/TenantUpdateResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/TenantUpdateResponseNumberKeys"
+                $ref: "#/components/schemas/TenantUpdateResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/TenantUpdateResponse"
+                $ref: "#/components/schemas/TenantUpdateResult"
         "400":
           description: The provided data is not valid.
           content:
@@ -490,13 +490,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TenantItem"
+                $ref: "#/components/schemas/TenantResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/TenantItemNumberKeys"
+                $ref: "#/components/schemas/TenantItem"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/TenantItem"
+                $ref: "#/components/schemas/TenantResult"
         "400":
           description: The provided data is not valid.
           content:
@@ -818,13 +818,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TenantSearchQueryResponse"
+                $ref: "#/components/schemas/TenantSearchQueryResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/TenantSearchQueryResponseNumberKeys"
+                $ref: "#/components/schemas/TenantSearchQueryResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/TenantSearchQueryResponse"
+                $ref: "#/components/schemas/TenantSearchQueryResult"
         "400":
           description: The provided data is not valid.
           content:
@@ -966,13 +966,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UserTaskItem"
+                $ref: "#/components/schemas/UserTaskResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/UserTaskItemNumberKeys"
+                $ref: "#/components/schemas/UserTaskItem"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/UserTaskItem"
+                $ref: "#/components/schemas/UserTaskResult"
         "400":
           description: >
             The provided data is not valid.
@@ -1067,13 +1067,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/FormItem"
+                $ref: "#/components/schemas/FormResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/FormItemNumberKeys"
+                $ref: "#/components/schemas/FormItem"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/FormItem"
+                $ref: "#/components/schemas/FormResult"
         "204":
           description: >
             The user task was found, but no form is associated with it.
@@ -1159,13 +1159,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UserTaskSearchQueryResponse"
+                $ref: "#/components/schemas/UserTaskSearchQueryResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/UserTaskSearchQueryResponseNumberKeys"
+                $ref: "#/components/schemas/UserTaskSearchQueryResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/UserTaskSearchQueryResponse"
+                $ref: "#/components/schemas/UserTaskSearchQueryResult"
         "400":
           description: >
             The user task search query failed.
@@ -1210,13 +1210,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/VariableSearchQueryResponse"
+                $ref: "#/components/schemas/VariableSearchQueryResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/VariableSearchQueryResponseNumberKeys"
+                $ref: "#/components/schemas/VariableSearchQueryResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/VariableSearchQueryResponse"
+                $ref: "#/components/schemas/VariableSearchQueryResult"
         "400":
           description: >
             The user task variables search query failed.
@@ -1249,13 +1249,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/VariableSearchQueryResponse"
+                $ref: "#/components/schemas/VariableSearchQueryResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/VariableSearchQueryResponseNumberKeys"
+                $ref: "#/components/schemas/VariableSearchQueryResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/VariableSearchQueryResponse"
+                $ref: "#/components/schemas/VariableSearchQueryResult"
         "400":
           description: >
             The user task search query failed.
@@ -1294,13 +1294,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/VariableItem"
+                $ref: "#/components/schemas/VariableResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/VariableItemNumberKeys"
+                $ref: "#/components/schemas/VariableItem"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/VariableItem"
+                $ref: "#/components/schemas/VariableResult"
         "400":
           description: "Bad request"
           content:
@@ -1392,13 +1392,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProcessDefinitionSearchQueryResponse"
+                $ref: "#/components/schemas/ProcessDefinitionSearchQueryResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/ProcessDefinitionSearchQueryResponseNumberKeys"
+                $ref: "#/components/schemas/ProcessDefinitionSearchQueryResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/ProcessDefinitionSearchQueryResponse"
+                $ref: "#/components/schemas/ProcessDefinitionSearchQueryResult"
         "400":
           description: >
             The process definition search query failed.
@@ -1437,13 +1437,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProcessDefinitionItem"
+                $ref: "#/components/schemas/ProcessDefinitionResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/ProcessDefinitionItemNumberKeys"
+                $ref: "#/components/schemas/ProcessDefinitionItem"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/ProcessDefinitionItem"
+                $ref: "#/components/schemas/ProcessDefinitionResult"
         "400":
           description: >
             The process definition request failed.
@@ -1546,13 +1546,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/FormItem"
+                $ref: "#/components/schemas/FormResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/FormItemNumberKeys"
+                $ref: "#/components/schemas/FormItem"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/FormItem"
+                $ref: "#/components/schemas/FormResult"
         "204":
           description: >
             The process was found, but no form is associated with it.
@@ -1612,13 +1612,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/CreateProcessInstanceResponse"
+                $ref: "#/components/schemas/CreateProcessInstanceResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/CreateProcessInstanceResponseNumberKeys"
+                $ref: "#/components/schemas/CreateProcessInstanceResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/CreateProcessInstanceResponse"
+                $ref: "#/components/schemas/CreateProcessInstanceResult"
         "400":
           description: The provided data is not valid.
         "500":
@@ -1646,13 +1646,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProcessInstanceItem"
+                $ref: "#/components/schemas/ProcessInstanceResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/ProcessInstanceItemNumberKeys"
+                $ref: "#/components/schemas/ProcessInstanceItem"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/ProcessInstanceItem"
+                $ref: "#/components/schemas/ProcessInstanceResult"
         "400":
           description: The provided data is not valid.
           content:
@@ -1692,13 +1692,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProcessInstanceSearchQueryResponse"
+                $ref: "#/components/schemas/ProcessInstanceSearchQueryResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/ProcessInstanceSearchQueryResponseNumberKeys"
+                $ref: "#/components/schemas/ProcessInstanceSearchQueryResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/ProcessInstanceSearchQueryResponse"
+                $ref: "#/components/schemas/ProcessInstanceSearchQueryResult"
         "400":
           description: >
             The process instance search query failed.
@@ -1865,13 +1865,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/FlowNodeInstanceSearchQueryResponse"
+                $ref: "#/components/schemas/FlowNodeInstanceSearchQueryResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/FlowNodeInstanceSearchQueryResponseNumberKeys"
+                $ref: "#/components/schemas/FlowNodeInstanceSearchQueryResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/FlowNodeInstanceSearchQueryResponse"
+                $ref: "#/components/schemas/FlowNodeInstanceSearchQueryResult"
         "400":
           description: >
             The Flow node instance search query failed.
@@ -1910,13 +1910,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/FlowNodeInstanceItem"
+                $ref: "#/components/schemas/FlowNodeInstanceResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/FlowNodeInstanceItemNumberKeys"
+                $ref: "#/components/schemas/FlowNodeInstanceItem"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/FlowNodeInstanceItem"
+                $ref: "#/components/schemas/FlowNodeInstanceResult"
         "400":
           description: >
             The flow node instance request failed.
@@ -1961,13 +1961,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DecisionDefinitionSearchQueryResponse"
+                $ref: "#/components/schemas/DecisionDefinitionSearchQueryResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/DecisionDefinitionSearchQueryResponseNumberKeys"
+                $ref: "#/components/schemas/DecisionDefinitionSearchQueryResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/DecisionDefinitionSearchQueryResponse"
+                $ref: "#/components/schemas/DecisionDefinitionSearchQueryResult"
         "400":
           description: >
             The decision definition search query failed.
@@ -2006,13 +2006,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DecisionDefinitionItem"
+                $ref: "#/components/schemas/DecisionDefinitionResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/DecisionDefinitionItemNumberKeys"
+                $ref: "#/components/schemas/DecisionDefinitionItem"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/DecisionDefinitionItem"
+                $ref: "#/components/schemas/DecisionDefinitionResult"
         "400":
           description: >
             The decision definition request failed.
@@ -2104,13 +2104,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DecisionRequirementsSearchQueryResponse"
+                $ref: "#/components/schemas/DecisionRequirementsSearchQueryResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/DecisionRequirementsSearchQueryResponseNumberKeys"
+                $ref: "#/components/schemas/DecisionRequirementsSearchQueryResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/DecisionRequirementsSearchQueryResponse"
+                $ref: "#/components/schemas/DecisionRequirementsSearchQueryResult"
         "400":
           description: >
             The search query failed.
@@ -2149,13 +2149,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DecisionRequirementsItem"
+                $ref: "#/components/schemas/DecisionRequirementsResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/DecisionRequirementsItemNumberKeys"
+                $ref: "#/components/schemas/DecisionRequirementsItem"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/DecisionRequirementsItem"
+                $ref: "#/components/schemas/DecisionRequirementsResult"
         "400":
           description: >
             The decision requirements request failed.
@@ -2247,13 +2247,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DecisionInstanceSearchQueryResponse"
+                $ref: "#/components/schemas/DecisionInstanceSearchQueryResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/DecisionInstanceSearchQueryResponseNumberKeys"
+                $ref: "#/components/schemas/DecisionInstanceSearchQueryResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/DecisionInstanceSearchQueryResponse"
+                $ref: "#/components/schemas/DecisionInstanceSearchQueryResult"
         "400":
           description: >
             The decision instance search query failed.
@@ -2291,7 +2291,13 @@ paths:
           content:
             application/json:
               schema:
+                $ref: "#/components/schemas/DecisionInstanceGetQueryResult"
+            application/vnd.camunda.api.keys.number+json:
+              schema:
                 $ref: "#/components/schemas/DecisionInstanceGetQueryResponse"
+            application/vnd.camunda.api.keys.string+json:
+              schema:
+                $ref: "#/components/schemas/DecisionInstanceGetQueryResult"
         "400":
           description: >
             The decision instance request failed.
@@ -2349,13 +2355,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/EvaluateDecisionResponse"
+                $ref: "#/components/schemas/EvaluateDecisionResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/EvaluateDecisionResponseNumberKeys"
+                $ref: "#/components/schemas/EvaluateDecisionResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/EvaluateDecisionResponse"
+                $ref: "#/components/schemas/EvaluateDecisionResult"
         "400":
           description: The provided data is not valid.
           content:
@@ -2441,13 +2447,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AuthorizationSearchResponse"
+                $ref: "#/components/schemas/AuthorizationSearchResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/AuthorizationSearchResponseNumberKeys"
+                $ref: "#/components/schemas/AuthorizationSearchResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/AuthorizationSearchResponse"
+                $ref: "#/components/schemas/AuthorizationSearchResult"
         "400":
           description: >
             The authorization search query failed.
@@ -2483,13 +2489,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/RoleCreateResponse"
+                $ref: "#/components/schemas/RoleCreateResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/RoleCreateResponseNumberKeys"
+                $ref: "#/components/schemas/RoleCreateResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/RoleCreateResponse"
+                $ref: "#/components/schemas/RoleCreateResult"
         "400":
           description: |
             The role could not be created.
@@ -2526,13 +2532,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/RoleItem"
+                $ref: "#/components/schemas/RoleResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/RoleItemNumberKeys"
+                $ref: "#/components/schemas/RoleItem"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/RoleItem"
+                $ref: "#/components/schemas/RoleResult"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
@@ -2632,13 +2638,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/RoleSearchQueryResponse"
+                $ref: "#/components/schemas/RoleSearchQueryResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/RoleSearchQueryResponseNumberKeys"
+                $ref: "#/components/schemas/RoleSearchQueryResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/RoleSearchQueryResponse"
+                $ref: "#/components/schemas/RoleSearchQueryResult"
         "400":
           description: >
             The role search query failed.
@@ -2675,13 +2681,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GroupCreateResponse"
+                $ref: "#/components/schemas/GroupCreateResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/GroupCreateResponseNumberKeys"
+                $ref: "#/components/schemas/GroupCreateResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/GroupCreateResponse"
+                $ref: "#/components/schemas/GroupCreateResult"
         "400":
           description: |
             The group could not be created.
@@ -2718,13 +2724,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GroupItem"
+                $ref: "#/components/schemas/GroupResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/GroupItemNumberKeys"
+                $ref: "#/components/schemas/GroupItem"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/GroupItem"
+                $ref: "#/components/schemas/GroupResult"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
@@ -2917,13 +2923,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/GroupSearchQueryResponse"
+                $ref: "#/components/schemas/GroupSearchQueryResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/GroupSearchQueryResponseNumberKeys"
+                $ref: "#/components/schemas/GroupSearchQueryResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/GroupSearchQueryResponse"
+                $ref: "#/components/schemas/GroupSearchQueryResult"
         "400":
           description: >
             The group search query failed.
@@ -2962,13 +2968,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MappingRuleCreateResponse"
+                $ref: "#/components/schemas/MappingRuleCreateResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/MappingRuleCreateResponseNumberKeys"
+                $ref: "#/components/schemas/MappingRuleCreateResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/MappingRuleCreateResponse"
+                $ref: "#/components/schemas/MappingRuleCreateResult"
         "400":
           description: The mapping rule could not be created.
           content:
@@ -3040,13 +3046,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MappingSearchQueryResponse"
+                $ref: "#/components/schemas/MappingSearchQueryResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/MappingSearchQueryResponseNumberKeys"
+                $ref: "#/components/schemas/MappingSearchQueryResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/MappingSearchQueryResponse"
+                $ref: "#/components/schemas/MappingSearchQueryResult"
         "400":
           description: >
             The mapping rule search query failed.
@@ -3086,13 +3092,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MessagePublicationResponse"
+                $ref: "#/components/schemas/MessagePublicationResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/MessagePublicationResponseNumberKeys"
+                $ref: "#/components/schemas/MessagePublicationResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/MessagePublicationResponse"
+                $ref: "#/components/schemas/MessagePublicationResult"
         "400":
           description: The provided data is not valid.
           content:
@@ -3125,13 +3131,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/MessageCorrelationResponse"
+                $ref: "#/components/schemas/MessageCorrelationResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/MessageCorrelationResponseNumberKeys"
+                $ref: "#/components/schemas/MessageCorrelationResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/MessageCorrelationResponse"
+                $ref: "#/components/schemas/MessageCorrelationResult"
         "400":
           description: The provided data is not valid
           content:
@@ -3454,13 +3460,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UserCreateResponse"
+                $ref: "#/components/schemas/UserCreateResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/UserCreateResponseNumberKeys"
+                $ref: "#/components/schemas/UserCreateResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/UserCreateResponse"
+                $ref: "#/components/schemas/UserCreateResult"
         "400":
           description: |
             Unable to create the user.
@@ -3503,13 +3509,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UserSearchResponse"
+                $ref: "#/components/schemas/UserSearchResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/UserSearchResponseNumberKeys"
+                $ref: "#/components/schemas/UserSearchResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/UserSearchResponse"
+                $ref: "#/components/schemas/UserSearchResult"
         "400":
           description: >
             The user search query failed.
@@ -3553,13 +3559,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/AuthorizationSearchResponse"
+                $ref: "#/components/schemas/AuthorizationSearchResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/AuthorizationSearchResponseNumberKeys"
+                $ref: "#/components/schemas/AuthorizationSearchResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/AuthorizationSearchResponse"
+                $ref: "#/components/schemas/AuthorizationSearchResult"
         "400":
           description: >
             The user authorization search query failed.
@@ -3630,13 +3636,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/IncidentSearchQueryResponse"
+                $ref: "#/components/schemas/IncidentSearchQueryResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/IncidentSearchQueryResponseNumberKeys"
+                $ref: "#/components/schemas/IncidentSearchQueryResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/IncidentSearchQueryResponse"
+                $ref: "#/components/schemas/IncidentSearchQueryResult"
         "400":
           description: >
             The incident search query failed.
@@ -3671,13 +3677,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/IncidentItem"
+                $ref: "#/components/schemas/IncidentResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/IncidentItemNumberKeys"
+                $ref: "#/components/schemas/IncidentItem"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/IncidentItem"
+                $ref: "#/components/schemas/IncidentResult"
         "400":
           description: >
             The incident request failed.
@@ -3778,13 +3784,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/DeploymentResponse"
+                $ref: "#/components/schemas/DeploymentResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/DeploymentResponseNumberKeys"
+                $ref: "#/components/schemas/DeploymentResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/DeploymentResponse"
+                $ref: "#/components/schemas/DeploymentResult"
         "400":
           description: >
             The document upload failed. More details are provided in the response body.
@@ -3894,13 +3900,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SignalBroadcastResponse"
+                $ref: "#/components/schemas/SignalBroadcastResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/SignalBroadcastResponseNumberKeys"
+                $ref: "#/components/schemas/SignalBroadcastResponse"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/SignalBroadcastResponse"
+                $ref: "#/components/schemas/SignalBroadcastResult"
         "400":
           description: The provided data is not valid.
           content:
@@ -3930,7 +3936,7 @@ components:
       required:
         - tenantId
 
-    TenantCreateResponseNumberKeys:
+    TenantCreateResponse:
       deprecated: true
       type: object
       properties:
@@ -3938,7 +3944,7 @@ components:
           description: The external key of the created tenant
           type: integer
           format: int64
-    TenantCreateResponse:
+    TenantCreateResult:
       type: object
       properties:
         tenantKey:
@@ -3964,7 +3970,7 @@ components:
         name:
           type: string
           description: The name of the tenant.
-    TenantUpdateResponseNumberKeys:
+    TenantUpdateResponse:
       deprecated: true
       type: object
       allOf:
@@ -3974,7 +3980,7 @@ components:
           type: integer
           description: The unique system-generated internal tenant ID.
           format: int64
-    TenantUpdateResponse:
+    TenantUpdateResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/TenantUpdateResponseBase"
@@ -3993,7 +3999,7 @@ components:
         tenantId:
           type: string
           description: The unique external tenant ID.
-    TenantItemNumberKeys:
+    TenantItem:
       description: Tenant search response item. Key attributes as numeric values.
       deprecated: true
       type: object
@@ -4010,7 +4016,7 @@ components:
           items:
             type: integer
             format: int64
-    TenantItem:
+    TenantResult:
       description: Tenant search response item.
       type: object
       allOf:
@@ -4047,7 +4053,7 @@ components:
           type: string
           description: The name of the tenant.
 
-    TenantSearchQueryResponseNumberKeys:
+    TenantSearchQueryResponse:
       description: Tenant search response. Key attributes as numeric values.
       deprecated: true
       type: object
@@ -4058,8 +4064,8 @@ components:
           description: The matching tenants.
           type: array
           items:
-            $ref: "#/components/schemas/TenantItemNumberKeys"
-    TenantSearchQueryResponse:
+            $ref: "#/components/schemas/TenantItem"
+    TenantSearchQueryResult:
       description: Tenant search response.
       type: object
       allOf:
@@ -4069,7 +4075,7 @@ components:
           description: The matching tenants.
           type: array
           items:
-            $ref: "#/components/schemas/TenantItem"
+            $ref: "#/components/schemas/TenantResult"
 
     UserTaskSearchQueryRequest:
       allOf:
@@ -4086,7 +4092,7 @@ components:
         - $ref: "#/components/schemas/SearchQueryRequest"
       description: User task search query request.
       type: object
-    UserTaskSearchQueryResponseNumberKeys:
+    UserTaskSearchQueryResponse:
       description: User task search query response. Key attributes as numeric values.
       deprecated: true
       type: object
@@ -4097,8 +4103,8 @@ components:
           description: The matching user tasks.
           type: array
           items:
-            $ref: "#/components/schemas/UserTaskItemNumberKeys"
-    UserTaskSearchQueryResponse:
+            $ref: "#/components/schemas/UserTaskItem"
+    UserTaskSearchQueryResult:
       description: User task search query response.
       type: object
       allOf:
@@ -4108,7 +4114,7 @@ components:
           description: The matching user tasks.
           type: array
           items:
-            $ref: "#/components/schemas/UserTaskItem"
+            $ref: "#/components/schemas/UserTaskResult"
     UserTaskFilterRequest:
       description: User task filter request.
       type: object
@@ -4252,7 +4258,7 @@ components:
           minimum: 0
           maximum: 100
           default: 50
-    UserTaskItemNumberKeys:
+    UserTaskItem:
       deprecated: true
       type: object
       allOf:
@@ -4278,7 +4284,7 @@ components:
           type: integer
           description: The key of the form.
           format: int64
-    UserTaskItem:
+    UserTaskResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/UserTaskItemBase"
@@ -4338,7 +4344,7 @@ components:
         isTruncated:
           description: Whether the value is truncated or not.
           type: boolean
-    VariableSearchQueryResponseNumberKeys:
+    VariableSearchQueryResponse:
       description: Variable search query response. Key attributes as numeric values.
       deprecated: true
       type: object
@@ -4349,8 +4355,8 @@ components:
           description: The matching variables.
           type: array
           items:
-            $ref: "#/components/schemas/VariableItemNumberKeys"
-    VariableSearchQueryResponse:
+            $ref: "#/components/schemas/VariableItem"
+    VariableSearchQueryResult:
       description: Variable search query response.
       type: object
       allOf:
@@ -4360,7 +4366,7 @@ components:
           description: The matching variables.
           type: array
           items:
-            $ref: "#/components/schemas/VariableItem"
+            $ref: "#/components/schemas/VariableResult"
     VariableItemBase:
       description: Base properties for VariableItem.
       type: object
@@ -4380,7 +4386,7 @@ components:
         isTruncated:
           description: Whether the value is truncated or not.
           type: boolean
-    VariableItemNumberKeys:
+    VariableItem:
       description: Variable search response item. Key attributes as numeric values.
       deprecated: true
       type: object
@@ -4399,7 +4405,7 @@ components:
           description: The key of the process instance of this variable.
           type: integer
           format: int64
-    VariableItem:
+    VariableResult:
       description: Variable search response item.
       type: object
       allOf:
@@ -4450,7 +4456,7 @@ components:
         tenantId:
           description: Tenant ID of this process definition.
           type: string
-    ProcessDefinitionSearchQueryResponseNumberKeys:
+    ProcessDefinitionSearchQueryResponse:
       deprecated: true
       type: object
       allOf:
@@ -4460,8 +4466,8 @@ components:
           description: The matching process definitions.
           type: array
           items:
-            $ref: "#/components/schemas/ProcessDefinitionItemNumberKeys"
-    ProcessDefinitionSearchQueryResponse:
+            $ref: "#/components/schemas/ProcessDefinitionItem"
+    ProcessDefinitionSearchQueryResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/SearchQueryResponse"
@@ -4470,7 +4476,7 @@ components:
           description: The matching process definitions.
           type: array
           items:
-            $ref: "#/components/schemas/ProcessDefinitionItem"
+            $ref: "#/components/schemas/ProcessDefinitionResult"
     ProcessDefinitionItemBase:
       description: Base properties for ProcessDefinitionItem.
       type: object
@@ -4494,7 +4500,7 @@ components:
         tenantId:
           description: Tenant ID of this process definition.
           type: string
-    ProcessDefinitionItemNumberKeys:
+    ProcessDefinitionItem:
       deprecated: true
       type: object
       allOf:
@@ -4504,7 +4510,7 @@ components:
           description: The key for this process definition.
           type: integer
           format: int64
-    ProcessDefinitionItem:
+    ProcessDefinitionResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/ProcessDefinitionItemBase"
@@ -4797,7 +4803,7 @@ components:
         value:
           description: The value of the variable.
           type: string
-    ProcessInstanceSearchQueryResponseNumberKeys:
+    ProcessInstanceSearchQueryResponse:
       description: Process instance search response. Key attributes as numeric values.
       deprecated: true
       type: object
@@ -4808,8 +4814,8 @@ components:
           description: The matching process instances.
           type: array
           items:
-            $ref: "#/components/schemas/ProcessInstanceItemNumberKeys"
-    ProcessInstanceSearchQueryResponse:
+            $ref: "#/components/schemas/ProcessInstanceItem"
+    ProcessInstanceSearchQueryResult:
       description: Process instance search response.
       type: object
       allOf:
@@ -4819,7 +4825,7 @@ components:
           description: The matching process instances.
           type: array
           items:
-            $ref: "#/components/schemas/ProcessInstanceItem"
+            $ref: "#/components/schemas/ProcessInstanceResult"
     ProcessInstanceItemBase:
       description: Base properties for ProcessInstanceItem.
       type: object
@@ -4853,7 +4859,7 @@ components:
         tenantId:
           type: string
           description: The tenant ID.
-    ProcessInstanceItemNumberKeys:
+    ProcessInstanceItem:
       description: Process instance search response item. Key attributes as numeric values.
       deprecated: true
       type: object
@@ -4876,7 +4882,7 @@ components:
           type: integer
           description: The parent flow node instance key.
           format: int64
-    ProcessInstanceItem:
+    ProcessInstanceResult:
       description: Process instance search response item.
       type: object
       allOf:
@@ -4993,7 +4999,7 @@ components:
         tenantId:
           description: The tenant ID.
           type: string
-    FlowNodeInstanceSearchQueryResponseNumberKeys:
+    FlowNodeInstanceSearchQueryResponse:
       deprecated: true
       type: object
       allOf:
@@ -5003,8 +5009,8 @@ components:
           description: The matching flow node instances.
           type: array
           items:
-            $ref: "#/components/schemas/FlowNodeInstanceItemNumberKeys"
-    FlowNodeInstanceSearchQueryResponse:
+            $ref: "#/components/schemas/FlowNodeInstanceItem"
+    FlowNodeInstanceSearchQueryResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/SearchQueryResponse"
@@ -5013,7 +5019,7 @@ components:
           description: The matching flow node instances.
           type: array
           items:
-            $ref: "#/components/schemas/FlowNodeInstanceItem"
+            $ref: "#/components/schemas/FlowNodeInstanceResult"
     FlowNodeInstanceItemBase:
       description: Base properties for FlowNodeInstanceItem.
       type: object
@@ -5077,7 +5083,7 @@ components:
         tenantId:
           description: The tenant ID of the incident.
           type: string
-    FlowNodeInstanceItemNumberKeys:
+    FlowNodeInstanceItem:
       deprecated: true
       type: object
       allOf:
@@ -5099,7 +5105,7 @@ components:
           description: Incident key associated with this flow node instance.
           type: integer
           format: int64
-    FlowNodeInstanceItem:
+    FlowNodeInstanceResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/FlowNodeInstanceItemBase"
@@ -5226,7 +5232,7 @@ components:
         tenantId:
           description: The tenant ID of the incident.
           type: string
-    IncidentSearchQueryResponseNumberKeys:
+    IncidentSearchQueryResponse:
       deprecated: true
       type: object
       allOf:
@@ -5236,8 +5242,8 @@ components:
           description: The matching incidents.
           type: array
           items:
-            $ref: "#/components/schemas/IncidentItemNumberKeys"
-    IncidentSearchQueryResponse:
+            $ref: "#/components/schemas/IncidentItem"
+    IncidentSearchQueryResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/SearchQueryResponse"
@@ -5246,7 +5252,7 @@ components:
           description: The matching incidents.
           type: array
           items:
-            $ref: "#/components/schemas/IncidentItem"
+            $ref: "#/components/schemas/IncidentResult"
     IncidentItemBase:
       description: Base properties for IncidentItem.
       type: object
@@ -5292,33 +5298,33 @@ components:
         tenantId:
           description: The tenant ID of the incident.
           type: string
-    IncidentItemNumberKeys:
-      deprecated: true
-      type: object
-      allOf:
-        - $ref: "#/components/schemas/IncidentItemBase"
-      properties:
-        incidentKey:
-          type: integer
-          format: int64
-          description: The assigned key, which acts as a unique identifier for this incident.
-        processDefinitionKey:
-          type: integer
-          format: int64
-          description: The process definition key associated to this incident.
-        processInstanceKey:
-          type: integer
-          format: int64
-          description: The process instance key associated to this incident.
-        flowNodeInstanceKey:
-          type: integer
-          format: int64
-          description: The flow node instance key associated to this incident.
-        jobKey:
-          type: integer
-          description: The job key, if exists, associated with this incident.
-          format: int64
     IncidentItem:
+      deprecated: true
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/IncidentItemBase"
+      properties:
+        incidentKey:
+          type: integer
+          format: int64
+          description: The assigned key, which acts as a unique identifier for this incident.
+        processDefinitionKey:
+          type: integer
+          format: int64
+          description: The process definition key associated to this incident.
+        processInstanceKey:
+          type: integer
+          format: int64
+          description: The process instance key associated to this incident.
+        flowNodeInstanceKey:
+          type: integer
+          format: int64
+          description: The flow node instance key associated to this incident.
+        jobKey:
+          type: integer
+          description: The job key, if exists, associated with this incident.
+          format: int64
+    IncidentResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/IncidentItemBase"
@@ -5338,18 +5344,8 @@ components:
         jobKey:
           type: string
           description: The job key, if exists, associated with this incident.
-    DecisionDefinitionSearchQueryResponseNumberKeys:
-      deprecated: true
-      type: object
-      allOf:
-        - $ref: "#/components/schemas/SearchQueryResponse"
-      properties:
-        items:
-          description: The matching decision definitions.
-          type: array
-          items:
-            $ref: "#/components/schemas/DecisionDefinitionItemNumberKeys"
     DecisionDefinitionSearchQueryResponse:
+      deprecated: true
       type: object
       allOf:
         - $ref: "#/components/schemas/SearchQueryResponse"
@@ -5359,6 +5355,16 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/DecisionDefinitionItem"
+    DecisionDefinitionSearchQueryResult:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryResponse"
+      properties:
+        items:
+          description: The matching decision definitions.
+          type: array
+          items:
+            $ref: "#/components/schemas/DecisionDefinitionResult"
     DecisionDefinitionItemBase:
       description: Base properties for DecisionDefinitionItem.
       type: object
@@ -5379,7 +5385,7 @@ components:
         tenantId:
           type: string
           description: The tenant ID of the decision definition.
-    DecisionDefinitionItemNumberKeys:
+    DecisionDefinitionItem:
       deprecated: true
       type: object
       allOf:
@@ -5393,7 +5399,7 @@ components:
           type: integer
           format: int64
           description: The assigned key of the decision requirements graph that the decision definition is part of.
-    DecisionDefinitionItem:
+    DecisionDefinitionResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/DecisionDefinitionItemBase"
@@ -5536,7 +5542,7 @@ components:
           description: The permissions.
           items:
             $ref: "#/components/schemas/PermissionDTO"
-    AuthorizationResponseNumberKeys:
+    AuthorizationResponse:
       type: "object"
       allOf:
         - $ref: "#/components/schemas/AuthorizationResponseBase"
@@ -5545,7 +5551,7 @@ components:
           description: The id of the owner of permissions.
           type: integer
           format: int64
-    AuthorizationResponse:
+    AuthorizationResult:
       type: "object"
       allOf:
         - $ref: "#/components/schemas/AuthorizationResponseBase"
@@ -5553,7 +5559,7 @@ components:
         ownerKey:
           description: The id of the owner of permissions.
           type: string
-    AuthorizationSearchResponseNumberKeys:
+    AuthorizationSearchResponse:
       deprecated: true
       type: object
       allOf:
@@ -5563,8 +5569,8 @@ components:
           description: The matching authorizations.
           type: array
           items:
-            $ref: "#/components/schemas/AuthorizationResponseNumberKeys"
-    AuthorizationSearchResponse:
+            $ref: "#/components/schemas/AuthorizationResponse"
+    AuthorizationSearchResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/SearchQueryResponse"
@@ -5573,7 +5579,7 @@ components:
           description: The matching authorizations.
           type: array
           items:
-            $ref: "#/components/schemas/AuthorizationResponse"
+            $ref: "#/components/schemas/AuthorizationResult"
     UserRequest:
       type: "object"
       properties:
@@ -5589,7 +5595,7 @@ components:
         email:
           description: The email of the user.
           type: "string"
-    UserCreateResponseNumberKeys:
+    UserCreateResponse:
       deprecated: true
       type: object
       properties:
@@ -5597,7 +5603,7 @@ components:
           description: The key of the created user
           type: integer
           format: int64
-    UserCreateResponse:
+    UserCreateResult:
       type: object
       properties:
         userKey:
@@ -5705,7 +5711,7 @@ components:
         apiUser:
           description: Flag for understanding if the user is an API user.
           type: boolean
-    CamundaUserNumberKeys:
+    CamundaUser:
       deprecated: true
       type: object
       allOf:
@@ -5715,7 +5721,7 @@ components:
           description: The system generated key of the user.
           type: integer
           format: int64
-    CamundaUser:
+    CamundaUserResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/CamundaUserBase"
@@ -5739,7 +5745,7 @@ components:
         email:
           description: The email of the user.
           type: "string"
-    UserResponseNumberKeys:
+    UserResponse:
       type: "object"
       allOf:
         - $ref: "#/components/schemas/UserResponseBase"
@@ -5748,7 +5754,7 @@ components:
           description: The key of the user.
           type: "integer"
           format: "int64"
-    UserResponse:
+    UserResult:
       type: "object"
       allOf:
         - $ref: "#/components/schemas/UserResponseBase"
@@ -5756,7 +5762,7 @@ components:
         key:
           description: The key of the user.
           type: "string"
-    UserSearchResponseNumberKeys:
+    UserSearchResponse:
       deprecated: true
       type: object
       allOf:
@@ -5766,8 +5772,8 @@ components:
           description: The matching users.
           type: array
           items:
-            $ref: "#/components/schemas/UserResponseNumberKeys"
-    UserSearchResponse:
+            $ref: "#/components/schemas/UserResponse"
+    UserSearchResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/SearchQueryResponse"
@@ -5776,7 +5782,7 @@ components:
           description: The matching users.
           type: array
           items:
-            $ref: "#/components/schemas/UserResponse"
+            $ref: "#/components/schemas/UserResult"
     UserUpdateRequest:
       type: object
       properties:
@@ -5802,7 +5808,7 @@ components:
         name:
           type: "string"
           description: The display name of the new role.
-    RoleCreateResponseNumberKeys:
+    RoleCreateResponse:
       deprecated: true
       type: object
       properties:
@@ -5810,7 +5816,7 @@ components:
           description: The key of the created role.
           type: integer
           format: int64
-    RoleCreateResponse:
+    RoleCreateResult:
       type: object
       properties:
         roleKey:
@@ -5839,7 +5845,7 @@ components:
         name:
           type: string
           description: The role name.
-    RoleItemNumberKeys:
+    RoleItem:
       description: Role search response item. Key attributes as numeric values.
       deprecated: true
       type: object
@@ -5856,7 +5862,7 @@ components:
           items:
             type: integer
             format: int64
-    RoleItem:
+    RoleResult:
       description: Role search response item.
       type: object
       allOf:
@@ -5875,7 +5881,7 @@ components:
       allOf:
         - $ref: "#/components/schemas/SearchQueryRequest"
       type: object
-    RoleSearchQueryResponseNumberKeys:
+    RoleSearchQueryResponse:
       description: Role search response. Key attributes as numeric values.
       deprecated: true
       type: object
@@ -5886,8 +5892,8 @@ components:
           description: The matching roles.
           type: array
           items:
-            $ref: "#/components/schemas/RoleItemNumberKeys"
-    RoleSearchQueryResponse:
+            $ref: "#/components/schemas/RoleItem"
+    RoleSearchQueryResult:
       description: Role search response.
       type: object
       allOf:
@@ -5897,7 +5903,7 @@ components:
           description: The matching roles.
           type: array
           items:
-            $ref: "#/components/schemas/RoleItem"
+            $ref: "#/components/schemas/RoleResult"
 
     GroupCreateRequest:
       type: "object"
@@ -5905,7 +5911,7 @@ components:
         name:
           type: "string"
           description: The display name of the new group.
-    GroupCreateResponseNumberKeys:
+    GroupCreateResponse:
       deprecated: true
       type: object
       properties:
@@ -5913,7 +5919,7 @@ components:
           description: The key of the created group.
           type: integer
           format: int64
-    GroupCreateResponse:
+    GroupCreateResult:
       type: object
       properties:
         groupKey:
@@ -5942,7 +5948,7 @@ components:
         name:
           type: string
           description: The group name.
-    GroupItemNumberKeys:
+    GroupItem:
       description: Group search response item. Key attributes as numeric values.
       deprecated: true
       type: object
@@ -5959,7 +5965,7 @@ components:
           items:
             type: integer
             format: int64
-    GroupItem:
+    GroupResult:
       description: Group search response item.
       type: object
       allOf:
@@ -5990,7 +5996,7 @@ components:
         name:
           type: string
           description: The name of the group.
-    GroupSearchQueryResponseNumberKeys:
+    GroupSearchQueryResponse:
       description: Group search response. Key attributes as numeric values.
       deprecated: true
       type: object
@@ -6001,8 +6007,8 @@ components:
           description: The matching groups.
           type: array
           items:
-            $ref: "#/components/schemas/GroupItemNumberKeys"
-    GroupSearchQueryResponse:
+            $ref: "#/components/schemas/GroupItem"
+    GroupSearchQueryResult:
       description: Group search response.
       type: object
       allOf:
@@ -6012,7 +6018,7 @@ components:
           description: The matching groups.
           type: array
           items:
-            $ref: "#/components/schemas/GroupItem"
+            $ref: "#/components/schemas/GroupResult"
 
     MappingRuleCreateRequest:
       type: object
@@ -6042,7 +6048,7 @@ components:
         name:
           type: string
           description: The name of the mapping.
-    MappingRuleCreateResponseNumberKeys:
+    MappingRuleCreateResponse:
       type: object
       allOf:
         - $ref: "#/components/schemas/MappingRuleCreateResponseBase"
@@ -6051,7 +6057,7 @@ components:
           description: The key of the created mapping rule.
           type: integer
           format: int64
-    MappingRuleCreateResponse:
+    MappingRuleCreateResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/MappingRuleCreateResponseBase"
@@ -6059,7 +6065,7 @@ components:
         mappingKey:
           description: The key of the created mapping rule.
           type: string
-    MappingSearchQueryResponseNumberKeys:
+    MappingSearchQueryResponse:
       deprecated: true
       type: object
       allOf:
@@ -6069,8 +6075,8 @@ components:
           description: The matching mapping rules.
           type: array
           items:
-            $ref: "#/components/schemas/MappingItemNumberKeys"
-    MappingSearchQueryResponse:
+            $ref: "#/components/schemas/MappingItem"
+    MappingSearchQueryResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/SearchQueryResponse"
@@ -6079,7 +6085,7 @@ components:
           description: The matching mapping rules.
           type: array
           items:
-            $ref: "#/components/schemas/MappingItem"
+            $ref: "#/components/schemas/MappingResult"
     MappingItemBase:
       type: "object"
       properties:
@@ -6092,7 +6098,7 @@ components:
         name:
           type: string
           description: The name of the mapping.
-    MappingItemNumberKeys:
+    MappingItem:
       type: "object"
       allOf:
         - $ref: "#/components/schemas/MappingItemBase"
@@ -6101,7 +6107,7 @@ components:
           description: The key of the created mapping rule.
           type: integer
           format: int64
-    MappingItem:
+    MappingResult:
       type: "object"
       allOf:
         - $ref: "#/components/schemas/MappingItemBase"
@@ -6360,15 +6366,6 @@ components:
         - type
         - timeout
         - maxJobsToActivate
-    JobActivationResponseNumberKeys:
-      description: The list of activated jobs
-      type: object
-      properties:
-        jobs:
-          description: The activated jobs.
-          type: array
-          items:
-            $ref: "#/components/schemas/ActivatedJobNumberKeys"
     JobActivationResponse:
       description: The list of activated jobs
       type: object
@@ -6378,6 +6375,15 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ActivatedJob"
+    JobActivationResult:
+      description: The list of activated jobs
+      type: object
+      properties:
+        jobs:
+          description: The activated jobs.
+          type: array
+          items:
+            $ref: "#/components/schemas/ActivatedJobResult"
     ActivatedJobBase:
       type: object
       properties:
@@ -6416,7 +6422,7 @@ components:
         tenantId:
           description: The ID of the tenant that owns the job.
           type: string
-    ActivatedJobNumberKeys:
+    ActivatedJob:
       type: object
       allOf:
         - $ref: "#/components/schemas/ActivatedJobBase"
@@ -6439,7 +6445,7 @@ components:
             process instance.
           type: integer
           format: int64
-    ActivatedJob:
+    ActivatedJobResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/ActivatedJobBase"
@@ -6744,7 +6750,7 @@ components:
         tenantId:
           type: string
           description: The tenant ID of the decision requirements.
-    DecisionRequirementsSearchQueryResponseNumberKeys:
+    DecisionRequirementsSearchQueryResponse:
       deprecated: true
       type: object
       allOf:
@@ -6754,8 +6760,8 @@ components:
           description: The matching decision requirements.
           type: array
           items:
-            $ref: "#/components/schemas/DecisionRequirementsItemNumberKeys"
-    DecisionRequirementsSearchQueryResponse:
+            $ref: "#/components/schemas/DecisionRequirementsItem"
+    DecisionRequirementsSearchQueryResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/SearchQueryResponse"
@@ -6764,7 +6770,7 @@ components:
           description: The matching decision requirements.
           type: array
           items:
-            $ref: "#/components/schemas/DecisionRequirementsItem"
+            $ref: "#/components/schemas/DecisionRequirementsResult"
     DecisionRequirementsItemBase:
       description: Base properties for DecisionRequirementsItem.
       type: object
@@ -6785,7 +6791,7 @@ components:
         tenantId:
           type: string
           description: The tenant ID of the decision requirements.
-    DecisionRequirementsItemNumberKeys:
+    DecisionRequirementsItem:
       deprecated: true
       type: object
       allOf:
@@ -6795,7 +6801,7 @@ components:
           type: integer
           format: int64
           description: The assigned key, which acts as a unique identifier for this decision requirements.
-    DecisionRequirementsItem:
+    DecisionRequirementsResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/DecisionRequirementsItemBase"
@@ -6855,12 +6861,7 @@ components:
         tenantId:
           description: The tenant ID of the evaluated decision.
           type: string
-        evaluatedDecisions:
-          description: Decisions that were evaluated within the requested decision evaluation.
-          type: array
-          items:
-            $ref: "#/components/schemas/EvaluatedDecisionItem"
-    EvaluateDecisionResponseNumberKeys:
+    EvaluateDecisionResponse:
       deprecated: true
       type: object
       allOf:
@@ -6878,7 +6879,12 @@ components:
           description: The unique key identifying this decision evaluation.
           type: integer
           format: int64
-    EvaluateDecisionResponse:
+        evaluatedDecisions:
+          description: Decisions that were evaluated within the requested decision evaluation.
+          type: array
+          items:
+            $ref: "#/components/schemas/EvaluatedDecisionItem"
+    EvaluateDecisionResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/EvaluateDecisionResponseBase"
@@ -6892,14 +6898,15 @@ components:
         decisionInstanceKey:
           description: The unique key identifying this decision evaluation.
           type: string
-    EvaluatedDecisionItem:
+        evaluatedDecisions:
+          description: Decisions that were evaluated within the requested decision evaluation.
+          type: array
+          items:
+            $ref: "#/components/schemas/EvaluatedDecisionResult"
+    EvaluatedDecisionItemBase:
       type: object
-      description: A decision that was evaluated.
+      description: Base properties for EvaluatedDecisionItem.
       properties:
-        decisionDefinitionKey:
-          description: The unique key identifying the decision which was evaluate.
-          type: integer
-          format: int64
         decisionDefinitionId:
           description: The ID of the decision which was evaluated.
           type: string
@@ -6930,6 +6937,25 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/EvaluatedDecisionInputItem"
+    EvaluatedDecisionItem:
+      type: object
+      description: A decision that was evaluated. Key attributes as numeric values.
+      allOf:
+        - $ref: "#/components/schemas/EvaluatedDecisionItemBase"
+      properties:
+        decisionDefinitionKey:
+          description: The unique key identifying the decision which was evaluate.
+          type: integer
+          format: int64
+    EvaluatedDecisionResult:
+      type: object
+      description: A decision that was evaluated.
+      allOf:
+        - $ref: "#/components/schemas/EvaluatedDecisionItemBase"
+      properties:
+        decisionDefinitionKey:
+          description: The unique key identifying the decision which was evaluate.
+          type: string
     MatchedDecisionRuleItem:
       type: object
       description: A decision rule that matched within this decision evaluation.
@@ -7029,7 +7055,7 @@ components:
         tenantId:
           type: string
           description: The tenant ID of the decision instance.
-    DecisionInstanceSearchQueryResponseNumberKeys:
+    DecisionInstanceSearchQueryResponse:
       deprecated: true
       type: object
       allOf:
@@ -7039,8 +7065,8 @@ components:
           description: The matching decision instances.
           type: array
           items:
-            $ref: "#/components/schemas/DecisionInstanceItemNumberKeys"
-    DecisionInstanceSearchQueryResponse:
+            $ref: "#/components/schemas/DecisionInstanceItem"
+    DecisionInstanceSearchQueryResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/SearchQueryResponse"
@@ -7049,7 +7075,7 @@ components:
           description: The matching decision instances.
           type: array
           items:
-            $ref: "#/components/schemas/DecisionInstanceItem"
+            $ref: "#/components/schemas/DecisionInstanceResult"
 
     DecisionInstanceItemBase:
       type: object
@@ -7084,33 +7110,33 @@ components:
         tenantId:
           type: string
           description: The tenant ID of the decision instance.
-    DecisionInstanceItemNumberKeys:
-      type: object
-      allOf:
-        - $ref: "#/components/schemas/DecisionInstanceItemBase"
-      properties:
-        decisionInstanceKey:
-          type: integer
-          format: int64
-          description: The key of the decision instance. Note that this is not the unique identifier of the entity itself; the `decisionInstanceId` serves as the primary identifier.
-        processDefinitionKey:
-          type: integer
-          format: int64
-          description: The key of the process definition.
-        processInstanceKey:
-          type: integer
-          format: int64
-          description: The key of the process instance.
-        decisionDefinitionKey:
-          type: integer
-          format: int64
-          description: The key of the decision.
     DecisionInstanceItem:
       type: object
       allOf:
         - $ref: "#/components/schemas/DecisionInstanceItemBase"
       properties:
         decisionInstanceKey:
+          type: integer
+          format: int64
+          description: The key of the decision instance. Note that this is not the unique identifier of the entity itself; the `decisionInstanceId` serves as the primary identifier.
+        processDefinitionKey:
+          type: integer
+          format: int64
+          description: The key of the process definition.
+        processInstanceKey:
+          type: integer
+          format: int64
+          description: The key of the process instance.
+        decisionDefinitionKey:
+          type: integer
+          format: int64
+          description: The key of the decision.
+    DecisionInstanceResult:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/DecisionInstanceItemBase"
+      properties:
+        decisionInstanceKey:
           type: string
           description: The key of the decision instance. Note that this is not the unique identifier of the entity itself; the `decisionInstanceId` serves as the primary identifier.
         processDefinitionKey:
@@ -7123,10 +7149,26 @@ components:
           type: string
           description: The key of the decision.
 
-
     DecisionInstanceGetQueryResponse:
       allOf:
         - $ref: "#/components/schemas/DecisionInstanceItem"
+        - type: object
+          properties:
+            evaluatedInputs:
+              type: array
+              items:
+                $ref: "#/components/schemas/EvaluatedDecisionInputItem"
+              description: |
+                The evaluated inputs of the decision instance.
+            matchedRules:
+              type: array
+              items:
+                $ref: "#/components/schemas/MatchedDecisionRuleItem"
+              description: |
+                The matched rules of the decision instance.
+    DecisionInstanceGetQueryResult:
+      allOf:
+        - $ref: "#/components/schemas/DecisionInstanceResult"
         - type: object
           properties:
             evaluatedInputs:
@@ -7190,7 +7232,7 @@ components:
         tenantId:
           description: The tenant ID of the correlated message
           type: string
-    MessageCorrelationResponseNumberKeys:
+    MessageCorrelationResponse:
       description: |
         The message key of the correlated message, as well as the first process instance key it
         correlated with. Key attributes as numeric values.
@@ -7207,7 +7249,7 @@ components:
           description: The key of the first process instance the message correlated with
           type: integer
           format: int64
-    MessageCorrelationResponse:
+    MessageCorrelationResult:
       description: |
         The message key of the correlated message, as well as the first process instance key it
         correlated with.
@@ -7261,7 +7303,7 @@ components:
         tenantId:
           description: The tenant ID of the message.
           type: string
-    MessagePublicationResponseNumberKeys:
+    MessagePublicationResponse:
       description: The message key of the published message. Key attributes as numeric values.
       deprecated: true
       type: object
@@ -7272,7 +7314,7 @@ components:
           description: The key of the message
           type: integer
           format: int64
-    MessagePublicationResponse:
+    MessagePublicationResult:
       description: The message key of the published message.
       type: object
       allOf:
@@ -7381,7 +7423,7 @@ components:
         tenantId:
           description: The tenant ID associated with the deployment.
           type: string
-    DeploymentResponseNumberKeys:
+    DeploymentResponse:
       deprecated: true
       type: object
       allOf:
@@ -7395,8 +7437,8 @@ components:
           description: Items deployed by the request.
           type: array
           items:
-            $ref: "#/components/schemas/DeploymentMetadataNumberKeys"
-    DeploymentResponse:
+            $ref: "#/components/schemas/DeploymentMetadata"
+    DeploymentResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/DeploymentResponseBase"
@@ -7408,7 +7450,18 @@ components:
           description: Items deployed by the request.
           type: array
           items:
-            $ref: "#/components/schemas/DeploymentMetadata"
+            $ref: "#/components/schemas/DeploymentMetadataResult"
+    DeploymentMetadataResult:
+      type: object
+      properties:
+        processDefinition:
+          $ref: "#/components/schemas/DeploymentProcessResult"
+        decisionDefinition:
+          $ref: "#/components/schemas/DeploymentDecisionResult"
+        decisionRequirements:
+          $ref: "#/components/schemas/DeploymentDecisionRequirementsResult"
+        form:
+          $ref: "#/components/schemas/DeploymentFormResult"
     DeploymentMetadata:
       type: object
       properties:
@@ -7420,17 +7473,6 @@ components:
           $ref: "#/components/schemas/DeploymentDecisionRequirements"
         form:
           $ref: "#/components/schemas/DeploymentForm"
-    DeploymentMetadataNumberKeys:
-      type: object
-      properties:
-        processDefinition:
-          $ref: "#/components/schemas/DeploymentProcessNumberKeys"
-        decisionDefinition:
-          $ref: "#/components/schemas/DeploymentDecisionNumberKeys"
-        decisionRequirements:
-          $ref: "#/components/schemas/DeploymentDecisionRequirementsNumberKeys"
-        form:
-          $ref: "#/components/schemas/DeploymentFormNumberKeys"
     DeploymentProcessBase:
       description: Base properties for DeploymentProcess.
       type: object
@@ -7450,7 +7492,7 @@ components:
         tenantId:
           type: string
           description: The tenant ID of the deployed process.
-    DeploymentProcessNumberKeys:
+    DeploymentProcess:
       description: A deployed process.
       type: object
       allOf:
@@ -7460,7 +7502,7 @@ components:
           type: integer
           format: int64
           description: The assigned key, which acts as a unique identifier for this process.
-    DeploymentProcess:
+    DeploymentProcessResult:
       description: A deployed process.
       type: object
       allOf:
@@ -7492,7 +7534,7 @@ components:
           type: string
           description: |
             The dmn ID of the decision requirements graph that this decision is part of, as parsed during deployment.
-    DeploymentDecisionNumberKeys:
+    DeploymentDecision:
       description: A deployed decision.
       type: object
       allOf:
@@ -7508,7 +7550,7 @@ components:
           format: int64
           description: |
             The assigned key of the decision requirements graph that this decision is part of.
-    DeploymentDecision:
+    DeploymentDecisionResult:
       description: A deployed decision.
       type: object
       allOf:
@@ -7543,7 +7585,7 @@ components:
         resourceName:
           type: string
           description: The resource name from which this decision requirements was parsed.
-    DeploymentDecisionRequirementsNumberKeys:
+    DeploymentDecisionRequirements:
       description: Deployed decision requirements.
       type: object
       allOf:
@@ -7554,7 +7596,7 @@ components:
           format: int64
           description: |
             The assigned decision requirements key, which acts as a unique identifier for this decision requirements.
-    DeploymentDecisionRequirements:
+    DeploymentDecisionRequirementsResult:
       description: Deployed decision requirements.
       type: object
       allOf:
@@ -7583,7 +7625,7 @@ components:
         tenantId:
           type: string
           description: The tenant ID of the deployed form.
-    DeploymentFormNumberKeys:
+    DeploymentForm:
       description: A deployed form.
       type: object
       allOf:
@@ -7593,7 +7635,7 @@ components:
           type: integer
           format: int64
           description: The assigned key, which acts as a unique identifier for this form.
-    DeploymentForm:
+    DeploymentFormResult:
       description: A deployed form.
       type: object
       allOf:
@@ -7699,7 +7741,7 @@ components:
           additionalProperties: true
           description: All the variables visible in the root scope.
           type: object
-    CreateProcessInstanceResponseNumberKeys:
+    CreateProcessInstanceResponse:
       deprecated: true
       type: object
       allOf:
@@ -7716,7 +7758,7 @@ components:
             needs a process instance key (e.g. CancelProcessInstanceRequest).
           type: integer
           format: int64
-    CreateProcessInstanceResponse:
+    CreateProcessInstanceResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/CreateProcessInstanceResponseBase"
@@ -7908,7 +7950,7 @@ components:
         tenantId:
           description: The tenant ID of the signal that was broadcast.
           type: string
-    SignalBroadcastResponseNumberKeys:
+    SignalBroadcastResponse:
       deprecated: true
       type: object
       allOf:
@@ -7918,7 +7960,7 @@ components:
           description: The unique ID of the signal that was broadcast.
           type: integer
           format: int64
-    SignalBroadcastResponse:
+    SignalBroadcastResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/SignalBroadcastResponseBase"
@@ -7943,7 +7985,7 @@ components:
           description: The version of the form.
           type: integer
           format: int64
-    FormItemNumberKeys:
+    FormItem:
       deprecated: true
       type: object
       allOf:
@@ -7953,7 +7995,7 @@ components:
           description: The key of the form.
           type: integer
           format: int64
-    FormItem:
+    FormResult:
       type: object
       allOf:
         - $ref: "#/components/schemas/FormItemBase"

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -124,6 +124,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -131,6 +132,17 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.web.multipart.MultipartFile;
 
 public class RequestMapper {
+
+  public static final String VND_CAMUNDA_API_KEYS_STRING_JSON = "vnd.camunda.api.keys.string+json";
+  public static final String VND_CAMUNDA_API_KEYS_NUMBER_JSON = "vnd.camunda.api.keys.number+json";
+  public static final MediaType MEDIA_TYPE_KEYS_STRING =
+      new MediaType("application", VND_CAMUNDA_API_KEYS_STRING_JSON);
+  public static final MediaType MEDIA_TYPE_KEYS_NUMBER =
+      new MediaType("application", VND_CAMUNDA_API_KEYS_NUMBER_JSON);
+  public static final String MEDIA_TYPE_KEYS_STRING_VALUE =
+      "application/" + VND_CAMUNDA_API_KEYS_STRING_JSON;
+  public static final String MEDIA_TYPE_KEYS_NUMBER_VALUE =
+      "application/" + VND_CAMUNDA_API_KEYS_NUMBER_JSON;
 
   public static CompleteUserTaskRequest toUserTaskCompletionRequest(
       final UserTaskCompletionRequest completionRequest, final long userTaskKey) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -160,14 +160,14 @@ public final class ResponseMapper {
 
   private static ActivatedJob toActivatedJob(final long jobKey, final JobRecord job) {
     return new ActivatedJob()
-        .jobKey(String.valueOf(jobKey))
+        .jobKey(jobKey)
         .type(job.getType())
         .processDefinitionId(job.getBpmnProcessId())
         .elementId(job.getElementId())
-        .processInstanceKey(String.valueOf(job.getProcessInstanceKey()))
+        .processInstanceKey(job.getProcessInstanceKey())
         .processDefinitionVersion(job.getProcessDefinitionVersion())
-        .processDefinitionKey(String.valueOf(job.getProcessDefinitionKey()))
-        .elementInstanceKey(String.valueOf(job.getElementInstanceKey()))
+        .processDefinitionKey(job.getProcessDefinitionKey())
+        .elementInstanceKey(job.getElementInstanceKey())
         .worker(bufferAsString(job.getWorkerBuffer()))
         .retries(job.getRetries())
         .deadline(job.getDeadline())
@@ -180,9 +180,9 @@ public final class ResponseMapper {
       final MessageCorrelationRecord brokerResponse) {
     final var response =
         new MessageCorrelationResponse()
-            .messageKey(String.valueOf(brokerResponse.getMessageKey()))
+            .messageKey(brokerResponse.getMessageKey())
             .tenantId(brokerResponse.getTenantId())
-            .processInstanceKey(String.valueOf(brokerResponse.getProcessInstanceKey()));
+            .processInstanceKey(brokerResponse.getProcessInstanceKey());
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
@@ -297,7 +297,7 @@ public final class ResponseMapper {
       final DeploymentRecord brokerResponse) {
     final var response =
         new DeploymentResponse()
-            .deploymentKey(String.valueOf(brokerResponse.getDeploymentKey()))
+            .deploymentKey(brokerResponse.getDeploymentKey())
             .tenantId(brokerResponse.getTenantId());
     addDeployedProcess(response, brokerResponse.getProcessesMetadata());
     addDeployedDecision(response, brokerResponse.decisionsMetadata());
@@ -311,7 +311,7 @@ public final class ResponseMapper {
 
     final var response =
         new MessagePublicationResponse()
-            .messageKey(String.valueOf(brokerResponse.getKey()))
+            .messageKey(brokerResponse.getKey())
             .tenantId(brokerResponse.getResponse().getTenantId());
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
@@ -324,7 +324,7 @@ public final class ResponseMapper {
                 new DeploymentForm()
                     .formId(form.getFormId())
                     .version(form.getVersion())
-                    .formKey(String.valueOf(form.getFormKey()))
+                    .formKey(form.getFormKey())
                     .resourceName(form.getResourceName())
                     .tenantId(form.getTenantId()))
         .map(deploymentForm -> new DeploymentMetadata().form(deploymentForm))
@@ -342,8 +342,7 @@ public final class ResponseMapper {
                     .version(decisionRequirement.getDecisionRequirementsVersion())
                     .name(decisionRequirement.getDecisionRequirementsName())
                     .tenantId(decisionRequirement.getTenantId())
-                    .decisionRequirementsKey(
-                        String.valueOf(decisionRequirement.getDecisionRequirementsKey()))
+                    .decisionRequirementsKey(decisionRequirement.getDecisionRequirementsKey())
                     .resourceName(decisionRequirement.getResourceName()))
         .map(
             deploymentDecisionRequirement ->
@@ -359,11 +358,11 @@ public final class ResponseMapper {
                 new DeploymentDecision()
                     .decisionDefinitionId(decision.getDecisionId())
                     .version(decision.getVersion())
-                    .decisionDefinitionKey(String.valueOf(decision.getDecisionKey()))
+                    .decisionDefinitionKey(decision.getDecisionKey())
                     .name(decision.getDecisionName())
                     .tenantId(decision.getTenantId())
                     .decisionRequirementsId(decision.getDecisionRequirementsId())
-                    .decisionRequirementsKey(String.valueOf(decision.getDecisionRequirementsKey())))
+                    .decisionRequirementsKey(decision.getDecisionRequirementsKey()))
         .map(deploymentDecision -> new DeploymentMetadata().decisionDefinition(deploymentDecision))
         .forEach(response::addDeploymentsItem);
   }
@@ -376,7 +375,7 @@ public final class ResponseMapper {
                 new DeploymentProcess()
                     .processDefinitionId(process.getBpmnProcessId())
                     .processDefinitionVersion(process.getVersion())
-                    .processDefinitionKey(String.valueOf(process.getProcessDefinitionKey()))
+                    .processDefinitionKey(process.getProcessDefinitionKey())
                     .tenantId(process.getTenantId())
                     .resourceName(process.getResourceName()))
         .map(deploymentProcess -> new DeploymentMetadata().processDefinition(deploymentProcess))
@@ -414,10 +413,10 @@ public final class ResponseMapper {
       final Map<String, Object> variables) {
     final var response =
         new CreateProcessInstanceResponse()
-            .processDefinitionKey(String.valueOf(processDefinitionKey))
+            .processDefinitionKey(processDefinitionKey)
             .processDefinitionId(bpmnProcessId)
             .processDefinitionVersion(version)
-            .processInstanceKey(String.valueOf(processInstanceKey))
+            .processInstanceKey(processInstanceKey)
             .tenantId(tenantId);
     if (variables != null) {
       response.variables(variables);
@@ -430,37 +429,35 @@ public final class ResponseMapper {
       final BrokerResponse<SignalRecord> brokerResponse) {
     final var response =
         new SignalBroadcastResponse()
-            .signalKey(String.valueOf(brokerResponse.getKey()))
+            .signalKey(brokerResponse.getKey())
             .tenantId(brokerResponse.getResponse().getTenantId());
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
   public static ResponseEntity<Object> toUserCreateResponse(final UserRecord userRecord) {
-    final var response = new UserCreateResponse().userKey(String.valueOf(userRecord.getUserKey()));
+    final var response = new UserCreateResponse().userKey(userRecord.getUserKey());
     return new ResponseEntity<>(response, HttpStatus.CREATED);
   }
 
   public static ResponseEntity<Object> toRoleCreateResponse(final RoleRecord roleRecord) {
-    final var response = new RoleCreateResponse().roleKey(String.valueOf(roleRecord.getRoleKey()));
+    final var response = new RoleCreateResponse().roleKey(roleRecord.getRoleKey());
     return new ResponseEntity<>(response, HttpStatus.CREATED);
   }
 
   public static ResponseEntity<Object> toGroupCreateResponse(final GroupRecord groupRecord) {
-    final var response =
-        new GroupCreateResponse().groupKey(String.valueOf(groupRecord.getGroupKey()));
+    final var response = new GroupCreateResponse().groupKey(groupRecord.getGroupKey());
     return new ResponseEntity<>(response, HttpStatus.CREATED);
   }
 
   public static ResponseEntity<Object> toTenantCreateResponse(final TenantRecord record) {
-    final var response =
-        new TenantCreateResponse().tenantKey(String.valueOf(record.getTenantKey()));
+    final var response = new TenantCreateResponse().tenantKey(record.getTenantKey());
     return new ResponseEntity<>(response, HttpStatus.CREATED);
   }
 
   public static ResponseEntity<Object> toTenantUpdateResponse(final TenantRecord record) {
     final var response =
         new TenantUpdateResponse()
-            .tenantKey(String.valueOf(record.getTenantKey()))
+            .tenantKey(record.getTenantKey())
             .tenantId(record.getTenantId())
             .name(record.getName());
     return new ResponseEntity<>(response, HttpStatus.OK);
@@ -469,7 +466,7 @@ public final class ResponseMapper {
   public static ResponseEntity<Object> toMappingCreateResponse(final MappingRecord record) {
     final var response =
         new MappingRuleCreateResponse()
-            .mappingKey(String.valueOf(record.getMappingKey()))
+            .mappingKey(record.getMappingKey())
             .claimName(record.getClaimName())
             .claimValue(record.getClaimValue());
     return new ResponseEntity<>(response, HttpStatus.CREATED);
@@ -481,17 +478,16 @@ public final class ResponseMapper {
     final var response =
         new EvaluateDecisionResponse()
             .decisionDefinitionId(decisionEvaluationRecord.getDecisionId())
-            .decisionDefinitionKey(String.valueOf(decisionEvaluationRecord.getDecisionKey()))
+            .decisionDefinitionKey(decisionEvaluationRecord.getDecisionKey())
             .decisionDefinitionName(decisionEvaluationRecord.getDecisionName())
             .decisionDefinitionVersion(decisionEvaluationRecord.getDecisionVersion())
             .decisionRequirementsId(decisionEvaluationRecord.getDecisionRequirementsId())
-            .decisionRequirementsKey(
-                String.valueOf(decisionEvaluationRecord.getDecisionRequirementsKey()))
+            .decisionRequirementsKey(decisionEvaluationRecord.getDecisionRequirementsKey())
             .output(decisionEvaluationRecord.getDecisionOutput())
             .failedDecisionDefinitionId(decisionEvaluationRecord.getFailedDecisionId())
             .failureMessage(decisionEvaluationRecord.getEvaluationFailureMessage())
             .tenantId(decisionEvaluationRecord.getTenantId())
-            .decisionInstanceKey(String.valueOf(brokerResponse.getKey()));
+            .decisionInstanceKey(brokerResponse.getKey());
 
     buildEvaluatedDecisions(decisionEvaluationRecord, response);
     return new ResponseEntity<>(response, HttpStatus.OK);
@@ -572,7 +568,7 @@ public final class ResponseMapper {
     @Override
     public List<ActivatedJob> getJobs() {
       return response.getJobs().stream()
-          .map(j -> new ActivatedJob(Long.parseLong(j.getJobKey()), j.getRetries()))
+          .map(j -> new ActivatedJob(j.getJobKey(), j.getRetries()))
           .toList();
     }
 
@@ -586,7 +582,7 @@ public final class ResponseMapper {
       final var result = new ArrayList<ActivatedJob>(sizeExceedingJobs.size());
       for (final var job : sizeExceedingJobs) {
         try {
-          final var key = Long.parseLong(job.getJobKey());
+          final var key = job.getJobKey();
           result.add(new ActivatedJob(key, job.getRetries()));
         } catch (final NumberFormatException ignored) {
           // could happen

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -259,7 +259,7 @@ public final class SearchQueryResponseMapper {
 
   public static ProcessDefinitionItem toProcessDefinition(final ProcessDefinitionEntity entity) {
     return new ProcessDefinitionItem()
-        .processDefinitionKey(keyToString(entity.processDefinitionKey()))
+        .processDefinitionKey(entity.processDefinitionKey())
         .name(entity.name())
         .resourceName(entity.resourceName())
         .version(entity.version())
@@ -275,14 +275,14 @@ public final class SearchQueryResponseMapper {
 
   public static ProcessInstanceItem toProcessInstance(final ProcessInstanceEntity p) {
     return new ProcessInstanceItem()
-        .processInstanceKey(keyToString(p.processInstanceKey()))
+        .processInstanceKey(p.processInstanceKey())
         .processDefinitionId(p.processDefinitionId())
         .processDefinitionName(p.processDefinitionName())
         .processDefinitionVersion(p.processDefinitionVersion())
         .processDefinitionVersionTag(p.processDefinitionVersionTag())
-        .processDefinitionKey(keyToString(p.processDefinitionKey()))
-        .parentProcessInstanceKey(keyToString(p.parentProcessInstanceKey()))
-        .parentFlowNodeInstanceKey(keyToString(p.parentFlowNodeInstanceKey()))
+        .processDefinitionKey(p.processDefinitionKey())
+        .parentProcessInstanceKey(p.parentProcessInstanceKey())
+        .parentFlowNodeInstanceKey(p.parentFlowNodeInstanceKey())
         .startDate(formatDate(p.startDate()))
         .endDate(formatDate(p.endDate()))
         .state((p.state() == null) ? null : ProcessInstanceStateEnum.fromValue(p.state().name()))
@@ -295,7 +295,7 @@ public final class SearchQueryResponseMapper {
   }
 
   public static RoleItem toRole(final RoleEntity roleEntity) {
-    return new RoleItem().key(keyToString(roleEntity.roleKey())).name(roleEntity.name());
+    return new RoleItem().key(roleEntity.roleKey()).name(roleEntity.name());
   }
 
   private static List<GroupItem> toGroups(final List<GroupEntity> groups) {
@@ -303,7 +303,7 @@ public final class SearchQueryResponseMapper {
   }
 
   public static GroupItem toGroup(final GroupEntity groupEntity) {
-    return new GroupItem().groupKey(keyToString(groupEntity.groupKey())).name(groupEntity.name());
+    return new GroupItem().groupKey(groupEntity.groupKey()).name(groupEntity.name());
   }
 
   private static List<TenantItem> toTenants(final List<TenantEntity> tenants) {
@@ -312,16 +312,13 @@ public final class SearchQueryResponseMapper {
 
   public static TenantItem toTenant(final TenantEntity tenantEntity) {
     return new TenantItem()
-        .tenantKey(keyToString(tenantEntity.key()))
+        .tenantKey(tenantEntity.key())
         .name(tenantEntity.name())
         .tenantId(tenantEntity.tenantId())
         .assignedMemberKeys(
             tenantEntity.assignedMemberKeys() == null
                 ? null
-                : tenantEntity.assignedMemberKeys().stream()
-                    .map(SearchQueryResponseMapper::keyToString)
-                    .sorted()
-                    .toList());
+                : tenantEntity.assignedMemberKeys().stream().sorted().toList());
   }
 
   private static List<MappingItem> toMappings(final List<MappingEntity> mappings) {
@@ -330,7 +327,7 @@ public final class SearchQueryResponseMapper {
 
   public static MappingItem toMapping(final MappingEntity mappingEntity) {
     return new MappingItem()
-        .mappingKey(keyToString(mappingEntity.mappingKey()))
+        .mappingKey(mappingEntity.mappingKey())
         .claimName(mappingEntity.claimName())
         .claimValue(mappingEntity.claimValue())
         .name(mappingEntity.name());
@@ -364,13 +361,13 @@ public final class SearchQueryResponseMapper {
   public static FlowNodeInstanceItem toFlowNodeInstance(
       final FlowNodeInstanceEntity instance, final String name) {
     return new FlowNodeInstanceItem()
-        .flowNodeInstanceKey(keyToString(instance.flowNodeInstanceKey()))
+        .flowNodeInstanceKey(instance.flowNodeInstanceKey())
         .flowNodeId(instance.flowNodeId())
         .flowNodeName(name)
-        .processDefinitionKey(keyToString(instance.processDefinitionKey()))
+        .processDefinitionKey(instance.processDefinitionKey())
         .processDefinitionId(instance.processDefinitionId())
-        .processInstanceKey(keyToString(instance.processInstanceKey()))
-        .incidentKey(keyToString(instance.incidentKey()))
+        .processInstanceKey(instance.processInstanceKey())
+        .incidentKey(instance.incidentKey())
         .hasIncident(instance.hasIncident())
         .startDate(formatDate(instance.startDate()))
         .endDate(formatDate(instance.endDate()))
@@ -382,11 +379,11 @@ public final class SearchQueryResponseMapper {
   public static DecisionDefinitionItem toDecisionDefinition(final DecisionDefinitionEntity d) {
     return new DecisionDefinitionItem()
         .tenantId(d.tenantId())
-        .decisionDefinitionKey(keyToString(d.decisionDefinitionKey()))
+        .decisionDefinitionKey(d.decisionDefinitionKey())
         .name(d.name())
         .version(d.version())
         .decisionDefinitionId(d.decisionDefinitionId())
-        .decisionRequirementsKey(keyToString(d.decisionRequirementsKey()))
+        .decisionRequirementsKey(d.decisionRequirementsKey())
         .decisionRequirementsId(d.decisionRequirementsId());
   }
 
@@ -394,7 +391,7 @@ public final class SearchQueryResponseMapper {
       final DecisionRequirementsEntity d) {
     return new DecisionRequirementsItem()
         .tenantId(d.tenantId())
-        .decisionRequirementsKey(keyToString(d.decisionRequirementsKey()))
+        .decisionRequirementsKey(d.decisionRequirementsKey())
         .name(d.name())
         .version(d.version())
         .resourceName(d.resourceName())
@@ -421,34 +418,34 @@ public final class SearchQueryResponseMapper {
 
   public static IncidentItem toIncident(final IncidentEntity t) {
     return new IncidentItem()
-        .incidentKey(keyToString(t.incidentKey()))
-        .processDefinitionKey(keyToString(t.processDefinitionKey()))
+        .incidentKey(t.incidentKey())
+        .processDefinitionKey(t.processDefinitionKey())
         .processDefinitionId(t.processDefinitionId())
-        .processInstanceKey(keyToString(t.processInstanceKey()))
+        .processInstanceKey(t.processInstanceKey())
         .errorType(IncidentItem.ErrorTypeEnum.fromValue(t.errorType().name()))
         .errorMessage(t.errorMessage())
         .flowNodeId(t.flowNodeId())
-        .flowNodeInstanceKey(keyToString(t.flowNodeInstanceKey()))
+        .flowNodeInstanceKey(t.flowNodeInstanceKey())
         .creationTime(formatDate(t.creationTime()))
         .state(IncidentItem.StateEnum.fromValue(t.state().name()))
-        .jobKey(keyToString(t.jobKey()))
+        .jobKey(t.jobKey())
         .tenantId(t.tenantId());
   }
 
   public static UserTaskItem toUserTask(final UserTaskEntity t, final String name) {
     return new UserTaskItem()
         .tenantId(t.tenantId())
-        .userTaskKey(keyToString(t.userTaskKey()))
+        .userTaskKey(t.userTaskKey())
         .name(name)
-        .processInstanceKey(keyToString(t.processInstanceKey()))
-        .processDefinitionKey(keyToString(t.processDefinitionKey()))
-        .elementInstanceKey(keyToString(t.elementInstanceKey()))
+        .processInstanceKey(t.processInstanceKey())
+        .processDefinitionKey(t.processDefinitionKey())
+        .elementInstanceKey(t.elementInstanceKey())
         .processDefinitionId(t.processDefinitionId())
         .state(UserTaskItem.StateEnum.fromValue(t.state().name()))
         .assignee(t.assignee())
         .candidateUsers(t.candidateUsers())
         .candidateGroups(t.candidateGroups())
-        .formKey(keyToString(t.formKey()))
+        .formKey(t.formKey())
         .elementId(t.elementId())
         .creationDate(formatDate(t.creationDate()))
         .completionDate(formatDate(t.completionDate()))
@@ -462,7 +459,7 @@ public final class SearchQueryResponseMapper {
 
   public static FormItem toFormItem(final FormEntity f) {
     return new FormItem()
-        .formKey(keyToString(f.formKey()))
+        .formKey(f.formKey())
         .bpmnId(f.formId())
         .version(f.version())
         .schema(f.schema())
@@ -475,7 +472,7 @@ public final class SearchQueryResponseMapper {
 
   public static UserResponse toUser(final UserEntity user) {
     return new UserResponse()
-        .key(keyToString(user.userKey()))
+        .key(user.userKey())
         .username(user.username())
         .email(user.email())
         .name(user.name());
@@ -488,14 +485,14 @@ public final class SearchQueryResponseMapper {
 
   public static DecisionInstanceItem toDecisionInstance(final DecisionInstanceEntity entity) {
     return new DecisionInstanceItem()
-        .decisionInstanceKey(keyToString(entity.decisionInstanceKey()))
+        .decisionInstanceKey(entity.decisionInstanceKey())
         .decisionInstanceId(entity.decisionInstanceId())
         .state(toDecisionInstanceStateEnum(entity.state()))
         .evaluationDate(formatDate(entity.evaluationDate()))
         .evaluationFailure(entity.evaluationFailure())
-        .processDefinitionKey(keyToString(entity.processDefinitionKey()))
-        .processInstanceKey(keyToString(entity.processInstanceKey()))
-        .decisionDefinitionKey(keyToString(entity.decisionDefinitionKey()))
+        .processDefinitionKey(entity.processDefinitionKey())
+        .processInstanceKey(entity.processInstanceKey())
+        .decisionDefinitionKey(entity.decisionDefinitionKey())
         .decisionDefinitionId(entity.decisionDefinitionId())
         .decisionDefinitionName(entity.decisionDefinitionName())
         .decisionDefinitionVersion(entity.decisionDefinitionVersion())
@@ -506,14 +503,14 @@ public final class SearchQueryResponseMapper {
   public static DecisionInstanceGetQueryResponse toDecisionInstanceGetQueryResponse(
       final DecisionInstanceEntity entity) {
     return new DecisionInstanceGetQueryResponse()
-        .decisionInstanceKey(keyToString(entity.decisionInstanceKey()))
+        .decisionInstanceKey(entity.decisionInstanceKey())
         .decisionInstanceId(entity.decisionInstanceId())
         .state(toDecisionInstanceStateEnum(entity.state()))
         .evaluationDate(formatDate(entity.evaluationDate()))
         .evaluationFailure(entity.evaluationFailure())
-        .processDefinitionKey(keyToString(entity.processDefinitionKey()))
-        .processInstanceKey(keyToString(entity.processInstanceKey()))
-        .decisionDefinitionKey(keyToString(entity.decisionDefinitionKey()))
+        .processDefinitionKey(entity.processDefinitionKey())
+        .processInstanceKey(entity.processInstanceKey())
+        .decisionDefinitionKey(entity.decisionDefinitionKey())
         .decisionDefinitionId(entity.decisionDefinitionId())
         .decisionDefinitionName(entity.decisionDefinitionName())
         .decisionDefinitionVersion(entity.decisionDefinitionVersion())
@@ -610,14 +607,14 @@ public final class SearchQueryResponseMapper {
 
   public static VariableItem toVariable(final VariableEntity variableEntity) {
     return new VariableItem()
-        .variableKey(keyToString(variableEntity.variableKey()))
+        .variableKey(variableEntity.variableKey())
         .name(variableEntity.name())
         .value(variableEntity.value())
         .fullValue(variableEntity.fullValue())
-        .processInstanceKey(keyToString(variableEntity.processInstanceKey()))
+        .processInstanceKey(variableEntity.processInstanceKey())
         .tenantId(variableEntity.tenantId())
         .isTruncated(variableEntity.isPreview())
-        .scopeKey(keyToString(variableEntity.scopeKey()));
+        .scopeKey(variableEntity.scopeKey());
   }
 
   public static AuthorizationSearchResponse toAuthorizationSearchQueryResponse(
@@ -638,7 +635,7 @@ public final class SearchQueryResponseMapper {
   public static AuthorizationResponse toAuthorization(final AuthorizationEntity authorization) {
     return new AuthorizationResponse()
         .ownerType(OwnerTypeEnum.fromValue(authorization.ownerType()))
-        .ownerKey(keyToString(authorization.ownerKey()))
+        .ownerKey(authorization.ownerKey())
         .resourceType(ResourceTypeEnum.valueOf(authorization.resourceType()))
         .permissions(
             authorization.permissions().stream()
@@ -648,10 +645,6 @@ public final class SearchQueryResponseMapper {
                             .permissionType(PermissionTypeEnum.fromValue(p.type().name()))
                             .resourceIds(p.resourceIds()))
                 .toList());
-  }
-
-  private static String keyToString(final Long key) {
-    return key == null ? null : key.toString();
   }
 
   private record RuleIdentifier(String ruleId, int ruleIndex) {}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/annotation/CamundaDeleteMapping.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/annotation/CamundaDeleteMapping.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.annotation;
+
+import io.camunda.zeebe.gateway.rest.RequestMapper;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@RequestMapping(method = RequestMethod.DELETE)
+public @interface CamundaDeleteMapping {
+  /** Alias for {@link RequestMapping#path}. */
+  @AliasFor(annotation = RequestMapping.class)
+  String[] path() default {};
+
+  /** Alias for {@link RequestMapping#produces}. */
+  @AliasFor(annotation = RequestMapping.class)
+  String[] produces() default {
+    MediaType.APPLICATION_JSON_VALUE,
+    RequestMapper.MEDIA_TYPE_KEYS_NUMBER_VALUE,
+    RequestMapper.MEDIA_TYPE_KEYS_STRING_VALUE,
+    MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+  };
+
+  /** Alias for {@link RequestMapping#consumes}. */
+  @AliasFor(annotation = RequestMapping.class)
+  String[] consumes() default {};
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/annotation/CamundaGetMapping.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/annotation/CamundaGetMapping.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.annotation;
+
+import io.camunda.zeebe.gateway.rest.RequestMapper;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@RequestMapping(method = RequestMethod.GET)
+public @interface CamundaGetMapping {
+  /** Alias for {@link RequestMapping#path}. */
+  @AliasFor(annotation = RequestMapping.class)
+  String[] path() default {};
+
+  /** Alias for {@link RequestMapping#produces}. */
+  @AliasFor(annotation = RequestMapping.class)
+  String[] produces() default {
+    MediaType.APPLICATION_JSON_VALUE,
+    RequestMapper.MEDIA_TYPE_KEYS_NUMBER_VALUE,
+    RequestMapper.MEDIA_TYPE_KEYS_STRING_VALUE,
+    MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+  };
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/annotation/CamundaPatchMapping.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/annotation/CamundaPatchMapping.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.annotation;
+
+import io.camunda.zeebe.gateway.rest.RequestMapper;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@RequestMapping(method = RequestMethod.PATCH)
+public @interface CamundaPatchMapping {
+  /** Alias for {@link RequestMapping#path}. */
+  @AliasFor(annotation = RequestMapping.class)
+  String[] path() default {};
+
+  /** Alias for {@link RequestMapping#produces}. */
+  @AliasFor(annotation = RequestMapping.class)
+  String[] produces() default {
+    MediaType.APPLICATION_JSON_VALUE,
+    RequestMapper.MEDIA_TYPE_KEYS_NUMBER_VALUE,
+    RequestMapper.MEDIA_TYPE_KEYS_STRING_VALUE,
+    MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+  };
+
+  /** Alias for {@link RequestMapping#consumes}. */
+  @AliasFor(annotation = RequestMapping.class)
+  String[] consumes() default {MediaType.APPLICATION_JSON_VALUE};
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/annotation/CamundaPostMapping.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/annotation/CamundaPostMapping.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.annotation;
+
+import io.camunda.zeebe.gateway.rest.RequestMapper;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@RequestMapping(method = RequestMethod.POST)
+public @interface CamundaPostMapping {
+  /** Alias for {@link RequestMapping#path}. */
+  @AliasFor(annotation = RequestMapping.class)
+  String[] path() default {};
+
+  /** Alias for {@link RequestMapping#produces}. */
+  @AliasFor(annotation = RequestMapping.class)
+  String[] produces() default {
+    MediaType.APPLICATION_JSON_VALUE,
+    RequestMapper.MEDIA_TYPE_KEYS_NUMBER_VALUE,
+    RequestMapper.MEDIA_TYPE_KEYS_STRING_VALUE,
+    MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+  };
+
+  /** Alias for {@link RequestMapping#consumes}. */
+  @AliasFor(annotation = RequestMapping.class)
+  String[] consumes() default {MediaType.APPLICATION_JSON_VALUE};
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/annotation/CamundaPutMapping.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/annotation/CamundaPutMapping.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.annotation;
+
+import io.camunda.zeebe.gateway.rest.RequestMapper;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@RequestMapping(method = RequestMethod.PUT)
+public @interface CamundaPutMapping {
+  /** Alias for {@link RequestMapping#path}. */
+  @AliasFor(annotation = RequestMapping.class)
+  String[] path() default {};
+
+  /** Alias for {@link RequestMapping#produces}. */
+  @AliasFor(annotation = RequestMapping.class)
+  String[] produces() default {
+    MediaType.APPLICATION_JSON_VALUE,
+    RequestMapper.MEDIA_TYPE_KEYS_NUMBER_VALUE,
+    RequestMapper.MEDIA_TYPE_KEYS_STRING_VALUE,
+    MediaType.APPLICATION_PROBLEM_JSON_VALUE,
+  };
+
+  /** Alias for {@link RequestMapping#consumes}. */
+  @AliasFor(annotation = RequestMapping.class)
+  String[] consumes() default {};
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/config/JacksonConfig.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.gateway.rest.deserializer.IntegerFilterPropertyDeseriali
 import io.camunda.zeebe.gateway.rest.deserializer.LongFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.ProcessInstanceStateFilterPropertyDeserializer;
 import io.camunda.zeebe.gateway.rest.deserializer.StringFilterPropertyDeserializer;
+import io.camunda.zeebe.gateway.rest.serializer.LongSerializer;
 import java.util.function.Consumer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -41,6 +42,7 @@ public class JacksonConfig {
     module.addDeserializer(
         ProcessInstanceStateFilterProperty.class,
         new ProcessInstanceStateFilterPropertyDeserializer());
+    module.addSerializer(Long.class, new LongSerializer());
     return builder -> builder.modulesToInstall(modules -> modules.add(module));
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AuthenticationController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AuthenticationController.java
@@ -9,9 +9,8 @@ package io.camunda.zeebe.gateway.rest.controller;
 
 import io.camunda.authentication.entity.CamundaUserDTO;
 import io.camunda.authentication.service.CamundaUserService;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import org.springframework.context.annotation.Profile;
-import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Profile("auth-basic")
@@ -24,9 +23,7 @@ public class AuthenticationController {
     this.camundaUserService = camundaUserService;
   }
 
-  @GetMapping(
-      path = "/me",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaGetMapping(path = "/me")
   public CamundaUserDTO getCurrentUser() {
     return camundaUserService.getCurrentUser();
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClockController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClockController.java
@@ -11,11 +11,11 @@ import io.camunda.service.ClockServices;
 import io.camunda.zeebe.gateway.protocol.rest.ClockPinRequest;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPutMapping;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -29,9 +29,7 @@ public class ClockController {
     this.clockServices = clockServices;
   }
 
-  @PutMapping(
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPutMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
   public CompletableFuture<ResponseEntity<Object>> pinClock(
       @RequestBody final ClockPinRequest pinRequest) {
 
@@ -39,9 +37,9 @@ public class ClockController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::pinClock);
   }
 
-  @PostMapping(
+  @CamundaPostMapping(
       path = "/reset",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+      consumes = {})
   public CompletableFuture<ResponseEntity<Object>> resetClock() {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () -> clockServices.withAuthentication(RequestMapper.getAuthentication()).resetClock());

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionController.java
@@ -22,13 +22,13 @@ import io.camunda.zeebe.gateway.rest.ResponseMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -46,10 +46,7 @@ public class DecisionDefinitionController {
     this.multiTenancyCfg = multiTenancyCfg;
   }
 
-  @PostMapping(
-      path = "/evaluation",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/evaluation")
   public CompletableFuture<ResponseEntity<Object>> evaluateDecision(
       @RequestBody final EvaluateDecisionRequest evaluateDecisionRequest) {
     return RequestMapper.toEvaluateDecisionRequest(
@@ -57,19 +54,14 @@ public class DecisionDefinitionController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::evaluateDecision);
   }
 
-  @PostMapping(
-      path = "/search",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/search")
   public ResponseEntity<DecisionDefinitionSearchQueryResponse> searchDecisionDefinitions(
       @RequestBody(required = false) final DecisionDefinitionSearchQueryRequest query) {
     return SearchQueryRequestMapper.toDecisionDefinitionQuery(query)
         .fold(RestErrorMapper::mapProblemToResponse, this::search);
   }
 
-  @GetMapping(
-      path = "/{decisionDefinitionKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaGetMapping(path = "/{decisionDefinitionKey}")
   public ResponseEntity<DecisionDefinitionItem> getDecisionDefinitionByKey(
       @PathVariable("decisionDefinitionKey") final long decisionDefinitionKey) {
     try {
@@ -83,7 +75,7 @@ public class DecisionDefinitionController {
     }
   }
 
-  @GetMapping(
+  @CamundaGetMapping(
       path = "/{decisionDefinitionKey}/xml",
       produces = {MediaType.TEXT_XML_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
   public ResponseEntity<String> getDecisionDefinitionXml(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceController.java
@@ -16,12 +16,11 @@ import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -31,19 +30,14 @@ public class DecisionInstanceController {
 
   @Autowired private DecisionInstanceServices decisionInstanceServices;
 
-  @PostMapping(
-      path = "/search",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/search")
   public ResponseEntity<DecisionInstanceSearchQueryResponse> searchDecisionInstances(
       @RequestBody(required = false) final DecisionInstanceSearchQueryRequest query) {
     return SearchQueryRequestMapper.toDecisionInstanceQuery(query)
         .fold(RestErrorMapper::mapProblemToResponse, this::search);
   }
 
-  @GetMapping(
-      path = "/{decisionInstanceKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaGetMapping(path = "/{decisionInstanceKey}")
   public ResponseEntity<DecisionInstanceGetQueryResponse> getDecisionInstanceById(
       @PathVariable("decisionInstanceKey") final String decisionInstanceId) {
     try {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsController.java
@@ -17,12 +17,12 @@ import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import java.nio.charset.StandardCharsets;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -37,10 +37,7 @@ public class DecisionRequirementsController {
     this.decisionRequirementsServices = decisionRequirementsServices;
   }
 
-  @PostMapping(
-      path = "/search",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/search")
   public ResponseEntity<Object> searchUserTasks(
       @RequestBody(required = false) final DecisionRequirementsSearchQueryRequest query) {
     return SearchQueryRequestMapper.toDecisionRequirementsQuery(query)
@@ -60,9 +57,7 @@ public class DecisionRequirementsController {
     }
   }
 
-  @GetMapping(
-      path = "/{decisionRequirementsKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaGetMapping(path = "/{decisionRequirementsKey}")
   public ResponseEntity<DecisionRequirementsItem> getByKey(
       @PathVariable("decisionRequirementsKey") final Long decisionRequirementsKey) {
     try {
@@ -77,7 +72,7 @@ public class DecisionRequirementsController {
     }
   }
 
-  @GetMapping(
+  @CamundaGetMapping(
       path = "/{decisionRequirementsKey}/xml",
       produces = {MediaType.TEXT_XML_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
   public ResponseEntity<String> getDecisionRequirementsXml(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DocumentController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DocumentController.java
@@ -17,6 +17,9 @@ import io.camunda.zeebe.gateway.protocol.rest.DocumentMetadata;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.ResponseMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaDeleteMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import jakarta.servlet.http.Part;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -25,11 +28,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.InvalidMediaTypeException;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -49,9 +49,7 @@ public class DocumentController {
     this.objectMapper = objectMapper;
   }
 
-  @PostMapping(
-      consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaPostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public CompletableFuture<ResponseEntity<Object>> createDocument(
       @RequestParam(required = false) final String documentId,
       @RequestParam(required = false) final String storeId,
@@ -62,10 +60,7 @@ public class DocumentController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createDocument);
   }
 
-  @PostMapping(
-      path = "/batch",
-      consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaPostMapping(path = "/batch", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public CompletableFuture<ResponseEntity<Object>> createDocuments(
       @RequestPart(value = "files") final List<Part> files,
       @RequestParam(required = false) final String storeId) {
@@ -96,7 +91,9 @@ public class DocumentController {
         ResponseMapper::toDocumentReferenceBatch);
   }
 
-  @GetMapping(path = "/{documentId}") // produces arbitrary content type
+  @CamundaGetMapping(
+      path = "/{documentId}",
+      produces = {}) // produces arbitrary content type
   public ResponseEntity<StreamingResponseBody> getDocumentContent(
       @PathVariable final String documentId,
       @RequestParam(required = false) final String storeId,
@@ -156,9 +153,7 @@ public class DocumentController {
         .getDocumentContent(documentId, storeId, contentHash);
   }
 
-  @DeleteMapping(
-      path = "/{documentId}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaDeleteMapping(path = "/{documentId}")
   public CompletableFuture<ResponseEntity<Object>> deleteDocument(
       @PathVariable final String documentId, @RequestParam(required = false) final String storeId) {
 
@@ -169,10 +164,7 @@ public class DocumentController {
                 .deleteDocument(documentId, storeId));
   }
 
-  @PostMapping(
-      path = "/{documentId}/links",
-      consumes = MediaType.APPLICATION_JSON_VALUE,
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaPostMapping(path = "/{documentId}/links")
   public CompletableFuture<ResponseEntity<Object>> createDocumentLink(
       @PathVariable final String documentId,
       @RequestParam(required = false) final String storeId,

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ElementInstanceController.java
@@ -12,11 +12,11 @@ import io.camunda.service.ElementInstanceServices.SetVariablesRequest;
 import io.camunda.zeebe.gateway.protocol.rest.SetVariableRequest;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPutMapping;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -30,9 +30,8 @@ public class ElementInstanceController {
     this.elementInstanceServices = elementInstanceServices;
   }
 
-  @PutMapping(
+  @CamundaPutMapping(
       path = "/{elementInstanceKey}/variables",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
       consumes = MediaType.APPLICATION_JSON_VALUE)
   public CompletableFuture<ResponseEntity<Object>> setVariables(
       @PathVariable final long elementInstanceKey,

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/FlowNodeInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/FlowNodeInstanceController.java
@@ -19,12 +19,11 @@ import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.cache.ProcessCache;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -41,19 +40,14 @@ public class FlowNodeInstanceController {
     this.processCache = processCache;
   }
 
-  @PostMapping(
-      path = "/search",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/search")
   public ResponseEntity<FlowNodeInstanceSearchQueryResponse> searchFlownodeInstances(
       @RequestBody(required = false) final FlowNodeInstanceSearchQueryRequest query) {
     return SearchQueryRequestMapper.toFlownodeInstanceQuery(query)
         .fold(RestErrorMapper::mapProblemToResponse, this::search);
   }
 
-  @GetMapping(
-      path = "/{flowNodeInstanceKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaGetMapping(path = "/{flowNodeInstanceKey}")
   public ResponseEntity<FlowNodeInstanceItem> getByKey(
       @PathVariable("flowNodeInstanceKey") final Long flowNodeInstanceKey) {
     try {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/IncidentController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/IncidentController.java
@@ -18,14 +18,13 @@ import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import jakarta.validation.ValidationException;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -39,10 +38,7 @@ public class IncidentController {
     this.incidentServices = incidentServices;
   }
 
-  @PostMapping(
-      path = "/{incidentKey}/resolution",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/{incidentKey}/resolution")
   public CompletableFuture<ResponseEntity<Object>> incidentResolution(
       @PathVariable final long incidentKey) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
@@ -52,19 +48,14 @@ public class IncidentController {
                 .resolveIncident(incidentKey));
   }
 
-  @PostMapping(
-      path = "/search",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/search")
   public ResponseEntity<IncidentSearchQueryResponse> searchIncidents(
       @RequestBody(required = false) final IncidentSearchQueryRequest query) {
     return SearchQueryRequestMapper.toIncidentQuery(query)
         .fold(RestErrorMapper::mapProblemToResponse, this::search);
   }
 
-  @GetMapping(
-      path = "/{incidentKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaGetMapping(path = "/{incidentKey}")
   public ResponseEntity<IncidentItem> getByKey(
       @PathVariable("incidentKey") final Long incidentKey) {
     try {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
@@ -21,12 +21,11 @@ import io.camunda.zeebe.gateway.rest.RequestMapper.ErrorJobRequest;
 import io.camunda.zeebe.gateway.rest.RequestMapper.FailJobRequest;
 import io.camunda.zeebe.gateway.rest.RequestMapper.UpdateJobRequest;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import java.util.concurrent.CompletableFuture;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -44,50 +43,35 @@ public class JobController {
     this.responseObserverProvider = responseObserverProvider;
   }
 
-  @PostMapping(
-      path = "/activation",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/activation")
   public CompletableFuture<ResponseEntity<Object>> activateJobs(
       @RequestBody final JobActivationRequest activationRequest) {
     return RequestMapper.toJobsActivationRequest(activationRequest)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::activateJobs);
   }
 
-  @PostMapping(
-      path = "/{jobKey}/failure",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/{jobKey}/failure")
   public CompletableFuture<ResponseEntity<Object>> failureJob(
       @PathVariable final long jobKey,
       @RequestBody(required = false) final JobFailRequest failureRequest) {
     return failJob(RequestMapper.toJobFailRequest(failureRequest, jobKey));
   }
 
-  @PostMapping(
-      path = "/{jobKey}/error",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/{jobKey}/error")
   public CompletableFuture<ResponseEntity<Object>> errorJob(
       @PathVariable final long jobKey, @RequestBody final JobErrorRequest errorRequest) {
     return RequestMapper.toJobErrorRequest(errorRequest, jobKey)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::errorJob);
   }
 
-  @PostMapping(
-      path = "/{jobKey}/completion",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/{jobKey}/completion")
   public CompletableFuture<ResponseEntity<Object>> completeJob(
       @PathVariable final long jobKey,
       @RequestBody(required = false) final JobCompletionRequest completionRequest) {
     return completeJob(RequestMapper.toJobCompletionRequest(completionRequest, jobKey));
   }
 
-  @PatchMapping(
-      path = "/{jobKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPatchMapping(path = "/{jobKey}")
   public CompletableFuture<ResponseEntity<Object>> updateJob(
       @PathVariable final long jobKey, @RequestBody final JobUpdateRequest jobUpdateRequest) {
     return RequestMapper.toJobUpdateRequest(jobUpdateRequest, jobKey)

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/LicenseController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/LicenseController.java
@@ -9,12 +9,11 @@ package io.camunda.zeebe.gateway.rest.controller;
 
 import io.camunda.service.ManagementServices;
 import io.camunda.zeebe.gateway.protocol.rest.LicenseResponse;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @CamundaRestController
@@ -31,7 +30,7 @@ public class LicenseController {
     this.managementServices = managementServices;
   }
 
-  @GetMapping(path = "/license", produces = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaGetMapping(path = "/license")
   public LicenseResponse get() {
     final LicenseResponse response = new LicenseResponse();
     response.setValidLicense(managementServices.isCamundaLicenseValid());

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/MessageController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/MessageController.java
@@ -16,10 +16,9 @@ import io.camunda.zeebe.gateway.protocol.rest.MessagePublicationRequest;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.ResponseMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import java.util.concurrent.CompletableFuture;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -36,10 +35,7 @@ public class MessageController {
     this.multiTenancyCfg = multiTenancyCfg;
   }
 
-  @PostMapping(
-      path = "/publication",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/publication")
   public CompletableFuture<ResponseEntity<Object>> publishMessage(
       @RequestBody final MessagePublicationRequest publicationRequest) {
     return RequestMapper.toMessagePublicationRequest(
@@ -47,10 +43,7 @@ public class MessageController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::publishMessage);
   }
 
-  @PostMapping(
-      path = "/correlation",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/correlation")
   public CompletableFuture<ResponseEntity<Object>> correlateMessage(
       @RequestBody final MessageCorrelationRequest correlationRequest) {
     return RequestMapper.toMessageCorrelationRequest(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionController.java
@@ -20,13 +20,13 @@ import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import java.nio.charset.StandardCharsets;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -43,10 +43,7 @@ public class ProcessDefinitionController {
     this.formServices = formServices;
   }
 
-  @PostMapping(
-      path = "/search",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/search")
   public ResponseEntity<ProcessDefinitionSearchQueryResponse> searchProcessDefinitions(
       @RequestBody(required = false) final ProcessDefinitionSearchQueryRequest query) {
     return SearchQueryRequestMapper.toProcessDefinitionQuery(query)
@@ -67,9 +64,7 @@ public class ProcessDefinitionController {
     }
   }
 
-  @GetMapping(
-      path = "/{processDefinitionKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaGetMapping(path = "/{processDefinitionKey}")
   public ResponseEntity<Object> getByKey(
       @PathVariable("processDefinitionKey") final Long processDefinitionKey) {
     try {
@@ -86,7 +81,7 @@ public class ProcessDefinitionController {
     }
   }
 
-  @GetMapping(
+  @CamundaGetMapping(
       path = "/{processDefinitionKey}/xml",
       produces = {MediaType.TEXT_XML_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
   public ResponseEntity<String> getProcessDefinitionXml(
@@ -106,9 +101,7 @@ public class ProcessDefinitionController {
     }
   }
 
-  @GetMapping(
-      path = "/{processDefinitionKey}/form",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaGetMapping(path = "/{processDefinitionKey}/form")
   public ResponseEntity<FormItem> getStartProcessForm(
       @PathVariable("processDefinitionKey") final long processDefinitionKey) {
     try {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -27,12 +27,11 @@ import io.camunda.zeebe.gateway.rest.ResponseMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import java.util.concurrent.CompletableFuture;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -50,19 +49,14 @@ public class ProcessInstanceController {
     this.multiTenancyCfg = multiTenancyCfg;
   }
 
-  @PostMapping(
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping
   public CompletableFuture<ResponseEntity<Object>> createProcessInstance(
       @RequestBody final CreateProcessInstanceRequest request) {
     return RequestMapper.toCreateProcessInstance(request, multiTenancyCfg.isEnabled())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createProcessInstance);
   }
 
-  @PostMapping(
-      path = "/{processInstanceKey}/cancellation",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/{processInstanceKey}/cancellation")
   public CompletableFuture<ResponseEntity<Object>> cancelProcessInstance(
       @PathVariable final long processInstanceKey,
       @RequestBody(required = false) final CancelProcessInstanceRequest cancelRequest) {
@@ -70,10 +64,7 @@ public class ProcessInstanceController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::cancelProcessInstance);
   }
 
-  @PostMapping(
-      path = "/{processInstanceKey}/migration",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/{processInstanceKey}/migration")
   public CompletableFuture<ResponseEntity<Object>> migrateProcessInstance(
       @PathVariable final long processInstanceKey,
       @RequestBody final MigrateProcessInstanceRequest migrationRequest) {
@@ -81,10 +72,7 @@ public class ProcessInstanceController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::migrateProcessInstance);
   }
 
-  @PostMapping(
-      path = "/{processInstanceKey}/modification",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/{processInstanceKey}/modification")
   public CompletableFuture<ResponseEntity<Object>> modifyProcessInstance(
       @PathVariable final long processInstanceKey,
       @RequestBody final ModifyProcessInstanceRequest modifyRequest) {
@@ -92,19 +80,14 @@ public class ProcessInstanceController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::modifyProcessInstance);
   }
 
-  @PostMapping(
-      path = "/search",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/search")
   public ResponseEntity<ProcessInstanceSearchQueryResponse> searchProcessInstances(
       @RequestBody(required = false) final ProcessInstanceSearchQueryRequest query) {
     return SearchQueryRequestMapper.toProcessInstanceQuery(query)
         .fold(RestErrorMapper::mapProblemToResponse, this::search);
   }
 
-  @GetMapping(
-      path = "/{processInstanceKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaGetMapping(path = "/{processInstanceKey}")
   public ResponseEntity<Object> getByKey(
       @PathVariable("processInstanceKey") final Long processInstanceKey) {
     try {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ResourceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ResourceController.java
@@ -15,12 +15,12 @@ import io.camunda.zeebe.gateway.protocol.rest.DeleteResourceRequest;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.ResponseMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -39,10 +39,7 @@ public class ResourceController {
     this.multiTenancyCfg = multiTenancyCfg;
   }
 
-  @PostMapping(
-      path = "/deployments",
-      consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaPostMapping(path = "/deployments", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public CompletableFuture<ResponseEntity<Object>> deployResources(
       @RequestPart("resources") final List<MultipartFile> resources,
       @RequestPart(value = "tenantId", required = false) final String tenantId) {
@@ -51,10 +48,7 @@ public class ResourceController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::deployResources);
   }
 
-  @PostMapping(
-      path = "/resources/{resourceKey}/deletion",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/resources/{resourceKey}/deletion")
   public CompletableFuture<ResponseEntity<Object>> deleteResource(
       @PathVariable final long resourceKey,
       @RequestBody(required = false) final DeleteResourceRequest deleteRequest) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/SignalController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/SignalController.java
@@ -14,11 +14,10 @@ import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RequestMapper.BroadcastSignalRequest;
 import io.camunda.zeebe.gateway.rest.ResponseMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -36,10 +35,7 @@ public class SignalController {
     this.multiTenancyCfg = multiTenancyCfg;
   }
 
-  @PostMapping(
-      path = "/broadcast",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/broadcast")
   public CompletableFuture<ResponseEntity<Object>> broadcastSignal(
       @RequestBody final SignalBroadcastRequest request) {
     return RequestMapper.toBroadcastSignalRequest(request, multiTenancyCfg.isEnabled())

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/TopologyController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/TopologyController.java
@@ -16,10 +16,9 @@ import io.camunda.zeebe.gateway.protocol.rest.Partition.HealthEnum;
 import io.camunda.zeebe.gateway.protocol.rest.Partition.RoleEnum;
 import io.camunda.zeebe.gateway.protocol.rest.TopologyResponse;
 import io.camunda.zeebe.gateway.rest.Loggers;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.util.VersionUtil;
 import java.util.Set;
-import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @CamundaRestController
@@ -32,7 +31,7 @@ public final class TopologyController {
     this.client = client;
   }
 
-  @GetMapping(path = "/topology", produces = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaGetMapping(path = "/topology")
   public TopologyResponse get() {
 
     final var response = new TopologyResponse();

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsController.java
@@ -16,9 +16,8 @@ import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
-import org.springframework.http.MediaType;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -32,8 +31,7 @@ public class UsageMetricsController {
     this.usageMetricsServices = usageMetricsServices;
   }
 
-  @GetMapping(
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaGetMapping
   public ResponseEntity<UsageMetricsResponse> getUsageMetrics(
       @RequestParam(required = false) final String startTime,
       @RequestParam(required = false) final String endTime) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskController.java
@@ -29,16 +29,15 @@ import io.camunda.zeebe.gateway.rest.RequestMapper.UpdateUserTaskRequest;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaDeleteMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.cache.ProcessCache;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -55,10 +54,7 @@ public class UserTaskController {
     this.processCache = processCache;
   }
 
-  @PostMapping(
-      path = "/{userTaskKey}/completion",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/{userTaskKey}/completion")
   public CompletableFuture<ResponseEntity<Object>> completeUserTask(
       @PathVariable final long userTaskKey,
       @RequestBody(required = false) final UserTaskCompletionRequest completionRequest) {
@@ -67,10 +63,7 @@ public class UserTaskController {
         RequestMapper.toUserTaskCompletionRequest(completionRequest, userTaskKey));
   }
 
-  @PostMapping(
-      path = "/{userTaskKey}/assignment",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/{userTaskKey}/assignment")
   public CompletableFuture<ResponseEntity<Object>> assignUserTask(
       @PathVariable final long userTaskKey,
       @RequestBody final UserTaskAssignmentRequest assignmentRequest) {
@@ -79,17 +72,14 @@ public class UserTaskController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::assignUserTask);
   }
 
-  @DeleteMapping(path = "/{userTaskKey}/assignee")
+  @CamundaDeleteMapping(path = "/{userTaskKey}/assignee")
   public CompletableFuture<ResponseEntity<Object>> unassignUserTask(
       @PathVariable final long userTaskKey) {
 
     return unassignUserTask(RequestMapper.toUserTaskUnassignmentRequest(userTaskKey));
   }
 
-  @PatchMapping(
-      path = "/{userTaskKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPatchMapping(path = "/{userTaskKey}")
   public CompletableFuture<ResponseEntity<Object>> updateUserTask(
       @PathVariable final long userTaskKey,
       @RequestBody(required = false) final UserTaskUpdateRequest updateRequest) {
@@ -98,19 +88,14 @@ public class UserTaskController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::updateUserTask);
   }
 
-  @PostMapping(
-      path = "/search",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/search")
   public ResponseEntity<UserTaskSearchQueryResponse> searchUserTasks(
       @RequestBody(required = false) final UserTaskSearchQueryRequest query) {
     return SearchQueryRequestMapper.toUserTaskQuery(query)
         .fold(RestErrorMapper::mapProblemToResponse, this::search);
   }
 
-  @GetMapping(
-      path = "/{userTaskKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaGetMapping(path = "/{userTaskKey}")
   public ResponseEntity<UserTaskItem> getByKey(
       @PathVariable("userTaskKey") final Long userTaskKey) {
     try {
@@ -125,9 +110,7 @@ public class UserTaskController {
     }
   }
 
-  @GetMapping(
-      path = "/{userTaskKey}/form",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaGetMapping(path = "/{userTaskKey}/form")
   public ResponseEntity<FormItem> getFormByUserTaskKey(
       @PathVariable("userTaskKey") final long userTaskKey) {
     try {
@@ -143,10 +126,7 @@ public class UserTaskController {
     }
   }
 
-  @PostMapping(
-      path = "/{userTaskKey}/variables/search",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/{userTaskKey}/variables/search")
   public ResponseEntity<VariableSearchQueryResponse> searchVariables(
       @PathVariable("userTaskKey") final long userTaskKey,
       @RequestBody(required = false)

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/VariableController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/VariableController.java
@@ -16,11 +16,10 @@ import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
-import org.springframework.http.MediaType;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -34,10 +33,7 @@ public class VariableController {
     this.variableServices = variableServices;
   }
 
-  @PostMapping(
-      path = "/search",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/search")
   public ResponseEntity<Object> searchVariables(
       @RequestBody(required = false) final VariableSearchQueryRequest query) {
     return SearchQueryRequestMapper.toVariableQuery(query)
@@ -54,9 +50,7 @@ public class VariableController {
     }
   }
 
-  @GetMapping(
-      path = "/{variableKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaGetMapping(path = "/{variableKey}")
   public ResponseEntity<Object> getByKey(@PathVariable("variableKey") final Long variableKey) {
     try {
       // Success case: Return the left side with the VariableItem wrapped in ResponseEntity

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -22,10 +22,14 @@ import io.camunda.zeebe.gateway.rest.ResponseMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaDeleteMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPutMapping;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.concurrent.CompletableFuture;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -38,9 +42,7 @@ public class TenantController {
     this.tenantServices = tenantServices;
   }
 
-  @PostMapping(
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping
   public CompletableFuture<ResponseEntity<Object>> createTenant(
       @RequestBody final TenantCreateRequest createTenantRequest) {
     return RequestMapper.toTenantCreateDto(createTenantRequest)
@@ -56,10 +58,7 @@ public class TenantController {
         ResponseMapper::toTenantCreateResponse);
   }
 
-  @PatchMapping(
-      path = "/{tenantKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPatchMapping(path = "/{tenantKey}")
   public CompletableFuture<ResponseEntity<Object>> updateTenant(
       @PathVariable final long tenantKey,
       @RequestBody final TenantUpdateRequest tenantUpdateRequest) {
@@ -67,9 +66,7 @@ public class TenantController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::updateTenant);
   }
 
-  @DeleteMapping(
-      path = "/{tenantKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaDeleteMapping(path = "/{tenantKey}")
   public CompletableFuture<ResponseEntity<Object>> deleteTenant(
       @PathVariable final long tenantKey) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
@@ -88,9 +85,7 @@ public class TenantController {
         ResponseMapper::toTenantUpdateResponse);
   }
 
-  @PutMapping(
-      path = "/{tenantKey}/users/{userKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaPutMapping(path = "/{tenantKey}/users/{userKey}")
   public CompletableFuture<ResponseEntity<Object>> assignUsersToTenant(
       @PathVariable final long tenantKey, @PathVariable final long userKey) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
@@ -100,9 +95,7 @@ public class TenantController {
                 .addMember(tenantKey, EntityType.USER, userKey));
   }
 
-  @DeleteMapping(
-      path = "/{tenantKey}/users/{userKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaDeleteMapping(path = "/{tenantKey}/users/{userKey}")
   public CompletableFuture<ResponseEntity<Object>> removeUserFromTenant(
       @PathVariable final long tenantKey, @PathVariable final long userKey) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
@@ -112,9 +105,7 @@ public class TenantController {
                 .removeMember(tenantKey, EntityType.USER, userKey));
   }
 
-  @PutMapping(
-      path = "/{tenantKey}/mapping-rules/{mappingKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaPutMapping(path = "/{tenantKey}/mapping-rules/{mappingKey}")
   public CompletableFuture<ResponseEntity<Object>> assignMappingToTenant(
       @PathVariable final long tenantKey, @PathVariable final long mappingKey) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
@@ -124,9 +115,7 @@ public class TenantController {
                 .addMember(tenantKey, EntityType.MAPPING, mappingKey));
   }
 
-  @DeleteMapping(
-      path = "/{tenantKey}/mapping-rules/{mappingKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaDeleteMapping(path = "/{tenantKey}/mapping-rules/{mappingKey}")
   public CompletableFuture<ResponseEntity<Object>> removeMappingFromTenant(
       @PathVariable final long tenantKey, @PathVariable final long mappingKey) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
@@ -136,9 +125,7 @@ public class TenantController {
                 .removeMember(tenantKey, EntityType.MAPPING, mappingKey));
   }
 
-  @PutMapping(
-      path = "/{tenantKey}/groups/{groupKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaPutMapping(path = "/{tenantKey}/groups/{groupKey}")
   public CompletableFuture<ResponseEntity<Object>> assignGroupToTenant(
       @PathVariable final long tenantKey, @PathVariable final long groupKey) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
@@ -148,9 +135,7 @@ public class TenantController {
                 .addMember(tenantKey, EntityType.GROUP, groupKey));
   }
 
-  @DeleteMapping(
-      path = "/{tenantKey}/groups/{groupKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaDeleteMapping(path = "/{tenantKey}/groups/{groupKey}")
   public CompletableFuture<ResponseEntity<Object>> removeGroupFromTenant(
       @PathVariable final long tenantKey, @PathVariable final long groupKey) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
@@ -160,9 +145,7 @@ public class TenantController {
                 .removeMember(tenantKey, EntityType.GROUP, groupKey));
   }
 
-  @GetMapping(
-      path = "/{tenantKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaGetMapping(path = "/{tenantKey}")
   public ResponseEntity<TenantItem> getTenant(@PathVariable final long tenantKey) {
     try {
       return ResponseEntity.ok()
@@ -172,10 +155,7 @@ public class TenantController {
     }
   }
 
-  @PostMapping(
-      path = "/search",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/search")
   public ResponseEntity<TenantSearchQueryResponse> searchTenants(
       @RequestBody(required = false) final TenantSearchQueryRequest query) {
     return SearchQueryRequestMapper.toTenantQuery(query)

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationController.java
@@ -21,13 +21,12 @@ import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import java.util.concurrent.CompletableFuture;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -40,10 +39,7 @@ public class AuthorizationController {
     this.authorizationServices = authorizationServices;
   }
 
-  @PatchMapping(
-      path = "/authorizations/{ownerKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPatchMapping(path = "/authorizations/{ownerKey}")
   public CompletableFuture<ResponseEntity<Object>> patchAuthorization(
       @PathVariable final long ownerKey,
       @RequestBody final AuthorizationPatchRequest authorizationPatchRequest) {
@@ -51,20 +47,14 @@ public class AuthorizationController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::patchAuthorization);
   }
 
-  @PostMapping(
-      path = "/authorizations/search",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/authorizations/search")
   public ResponseEntity<AuthorizationSearchResponse> searchAuthorizations(
       @RequestBody(required = false) final AuthorizationSearchQueryRequest query) {
     return SearchQueryRequestMapper.toAuthorizationQuery(query)
         .fold(RestErrorMapper::mapProblemToResponse, this::search);
   }
 
-  @PostMapping(
-      path = "/users/{userKey}/authorizations/search",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/users/{userKey}/authorizations/search")
   public ResponseEntity<AuthorizationSearchResponse> searchUserAuthorizations(
       @PathVariable("userKey") final long userKey,
       @RequestBody(required = false) final AuthorizationSearchQueryRequest query) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
@@ -20,16 +20,15 @@ import io.camunda.zeebe.gateway.rest.ResponseMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaDeleteMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.concurrent.CompletableFuture;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -43,28 +42,21 @@ public class GroupController {
     this.groupServices = groupServices;
   }
 
-  @PostMapping(
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping
   public CompletableFuture<ResponseEntity<Object>> createGroup(
       @RequestBody final GroupCreateRequest createGroupRequest) {
     return RequestMapper.toGroupCreateRequest(createGroupRequest)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createGroup);
   }
 
-  @PatchMapping(
-      path = "/{groupKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPatchMapping(path = "/{groupKey}")
   public CompletableFuture<ResponseEntity<Object>> updateGroup(
       @PathVariable final long groupKey, @RequestBody final GroupUpdateRequest groupUpdateRequest) {
     return RequestMapper.toGroupUpdateRequest(groupUpdateRequest, groupKey)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::updateGroup);
   }
 
-  @DeleteMapping(
-      path = "/{groupKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaDeleteMapping(path = "/{groupKey}")
   public CompletableFuture<ResponseEntity<Object>> deleteGroup(@PathVariable final long groupKey) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
@@ -73,9 +65,9 @@ public class GroupController {
                 .deleteGroup(groupKey));
   }
 
-  @PostMapping(
+  @CamundaPostMapping(
       path = "/{groupKey}/users/{userKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+      consumes = {})
   public CompletableFuture<ResponseEntity<Object>> assignUserToGroup(
       @PathVariable final long groupKey, @PathVariable final long userKey) {
     return RequestMapper.executeServiceMethodWithAcceptedResult(
@@ -85,9 +77,7 @@ public class GroupController {
                 .assignMember(groupKey, userKey, EntityType.USER));
   }
 
-  @DeleteMapping(
-      path = "/{groupKey}/users/{userKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaDeleteMapping(path = "/{groupKey}/users/{userKey}")
   public CompletableFuture<ResponseEntity<Object>> unassignUserFromGroup(
       @PathVariable final long groupKey, @PathVariable final long userKey) {
     return RequestMapper.executeServiceMethodWithAcceptedResult(
@@ -97,9 +87,7 @@ public class GroupController {
                 .removeMember(groupKey, userKey, EntityType.USER));
   }
 
-  @GetMapping(
-      path = "/{groupKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaGetMapping(path = "/{groupKey}")
   public ResponseEntity<Object> getGroup(@PathVariable final long groupKey) {
     try {
       return ResponseEntity.ok()
@@ -109,10 +97,7 @@ public class GroupController {
     }
   }
 
-  @PostMapping(
-      path = "/search",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/search")
   public ResponseEntity<GroupSearchQueryResponse> searchGroups(
       @RequestBody(required = false) final GroupSearchQueryRequest query) {
     return SearchQueryRequestMapper.toGroupQuery(query)

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingController.java
@@ -21,14 +21,13 @@ import io.camunda.zeebe.gateway.rest.ResponseMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaDeleteMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import java.util.concurrent.CompletableFuture;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -41,9 +40,7 @@ public class MappingController {
     this.mappingServices = mappingServices;
   }
 
-  @PostMapping(
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping
   public CompletableFuture<ResponseEntity<Object>> create(
       @RequestBody final MappingRuleCreateRequest mappingRequest) {
     return RequestMapper.toMappingDTO(mappingRequest)
@@ -59,9 +56,7 @@ public class MappingController {
         ResponseMapper::toMappingCreateResponse);
   }
 
-  @DeleteMapping(
-      path = "/{mappingKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaDeleteMapping(path = "/{mappingKey}")
   public CompletableFuture<ResponseEntity<Object>> deleteMapping(
       @PathVariable final long mappingKey) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
@@ -71,9 +66,7 @@ public class MappingController {
                 .deleteMapping(mappingKey));
   }
 
-  @GetMapping(
-      path = "/{mappingKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaGetMapping(path = "/{mappingKey}")
   public ResponseEntity<MappingItem> getMapping(@PathVariable final long mappingKey) {
     try {
       return ResponseEntity.ok()
@@ -83,10 +76,7 @@ public class MappingController {
     }
   }
 
-  @PostMapping(
-      path = "/search",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/search")
   public ResponseEntity<MappingSearchQueryResponse> searchMappings(
       @RequestBody(required = false) final MappingSearchQueryRequest query) {
     return SearchQueryRequestMapper.toMappingQuery(query)

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -20,15 +20,14 @@ import io.camunda.zeebe.gateway.rest.ResponseMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaDeleteMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import java.util.concurrent.CompletableFuture;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -41,9 +40,7 @@ public class RoleController {
     this.roleServices = roleServices;
   }
 
-  @PostMapping(
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping
   public CompletableFuture<ResponseEntity<Object>> createRole(
       @RequestBody final RoleCreateRequest createRoleRequest) {
     return RequestMapper.toRoleCreateRequest(createRoleRequest)
@@ -60,10 +57,7 @@ public class RoleController {
         ResponseMapper::toRoleCreateResponse);
   }
 
-  @PatchMapping(
-      path = "/{roleKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPatchMapping(path = "/{roleKey}")
   public CompletableFuture<ResponseEntity<Object>> updateRole(
       @PathVariable final long roleKey, @RequestBody final RoleUpdateRequest roleUpdateRequest) {
     return RequestMapper.toRoleUpdateRequest(roleUpdateRequest, roleKey)
@@ -79,18 +73,14 @@ public class RoleController {
                 .updateRole(updateRoleRequest.roleKey(), updateRoleRequest.name()));
   }
 
-  @DeleteMapping(
-      path = "/{roleKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaDeleteMapping(path = "/{roleKey}")
   public CompletableFuture<ResponseEntity<Object>> deleteRole(@PathVariable final long roleKey) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             roleServices.withAuthentication(RequestMapper.getAuthentication()).deleteRole(roleKey));
   }
 
-  @GetMapping(
-      path = "/{roleKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaGetMapping(path = "/{roleKey}")
   public ResponseEntity<Object> getRole(@PathVariable final long roleKey) {
     try {
       return ResponseEntity.ok()
@@ -100,10 +90,7 @@ public class RoleController {
     }
   }
 
-  @PostMapping(
-      path = "/search",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/search")
   public ResponseEntity<RoleSearchQueryResponse> searchRoles(
       @RequestBody(required = false) final RoleSearchQueryRequest query) {
     return SearchQueryRequestMapper.toRoleQuery(query)

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
@@ -23,16 +23,16 @@ import io.camunda.zeebe.gateway.rest.ResponseMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaDeleteMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPatchMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPutMapping;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -47,18 +47,14 @@ public class UserController {
     this.roleServices = roleServices;
   }
 
-  @PostMapping(
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping
   public CompletableFuture<ResponseEntity<Object>> createUser(
       @RequestBody final UserRequest userRequest) {
     return RequestMapper.toUserDTO(null, userRequest)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createUser);
   }
 
-  @DeleteMapping(
-      path = "/{key}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  @CamundaDeleteMapping(path = "/{key}")
   public CompletableFuture<ResponseEntity<Object>> deleteUser(@PathVariable final long key) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () -> userServices.withAuthentication(RequestMapper.getAuthentication()).deleteUser(key));
@@ -71,10 +67,7 @@ public class UserController {
         ResponseMapper::toUserCreateResponse);
   }
 
-  @PatchMapping(
-      path = "/{userKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPatchMapping(path = "/{userKey}")
   public CompletableFuture<ResponseEntity<Object>> updateUser(
       @PathVariable final long userKey, @RequestBody final UserUpdateRequest userUpdateRequest) {
     return RequestMapper.toUserUpdateRequest(userUpdateRequest, userKey)
@@ -95,9 +88,8 @@ public class UserController {
                         request.password())));
   }
 
-  @PutMapping(
+  @CamundaPutMapping(
       path = "/{userKey}/roles/{roleKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
       consumes = MediaType.APPLICATION_JSON_VALUE)
   public CompletableFuture<ResponseEntity<Object>> addRole(
       @PathVariable final long userKey, @PathVariable final long roleKey) {
@@ -108,10 +100,7 @@ public class UserController {
                 .addMember(roleKey, EntityType.USER, userKey));
   }
 
-  @DeleteMapping(
-      path = "/{userKey}/roles/{roleKey}",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaDeleteMapping(path = "/{userKey}/roles/{roleKey}")
   public CompletableFuture<ResponseEntity<Object>> removeRole(
       @PathVariable final long userKey, @PathVariable final long roleKey) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
@@ -121,10 +110,7 @@ public class UserController {
                 .removeMember(roleKey, EntityType.USER, userKey));
   }
 
-  @PostMapping(
-      path = "/search",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/search")
   public ResponseEntity<UserSearchResponse> searchUsers(
       @RequestBody(required = false) final UserSearchQueryRequest query) {
     return SearchQueryRequestMapper.toUserQuery(query)

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserRolesController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserRolesController.java
@@ -14,11 +14,10 @@ import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryResponse;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -32,10 +31,7 @@ public class UserRolesController {
     this.roleServices = roleServices;
   }
 
-  @PostMapping(
-      path = "/search",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+  @CamundaPostMapping(path = "/search")
   public ResponseEntity<RoleSearchQueryResponse> searchRoles(
       @PathVariable("userKey") final long userKey,
       @RequestBody(required = false) final RoleSearchQueryRequest queryRequest) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/serializer/LongSerializer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/serializer/LongSerializer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import io.camunda.zeebe.gateway.rest.RequestMapper;
+import java.io.IOException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+public class LongSerializer extends JsonSerializer<Long> {
+
+  public static final String PACKAGE_GATEWAY_REST = "io.camunda.zeebe.gateway.protocol.rest";
+  public static final String KEY = "Key";
+  public static final String KEYS = "Keys";
+
+  private void writeDefault(final Long value, final JsonGenerator gen) throws IOException {
+    writeString(value, gen);
+  }
+
+  private void writeString(final Long value, final JsonGenerator gen) throws IOException {
+    gen.writeString(String.valueOf(value));
+  }
+
+  private void writeNumber(final Long value, final JsonGenerator gen) throws IOException {
+    gen.writeNumber(value);
+  }
+
+  private boolean gatewayRestPackage(final Object value) {
+    return value != null && value.getClass().getPackageName().startsWith(PACKAGE_GATEWAY_REST);
+  }
+
+  private boolean gatewayRestPackage(final JsonGenerator gen) {
+    return gatewayRestPackage(gen.getOutputContext().getCurrentValue())
+        || gatewayRestPackage(gen.getOutputContext().getParent().getCurrentValue());
+  }
+
+  private boolean fieldNameEndsWithKey(final JsonGenerator gen) {
+    final var currentName = gen.getOutputContext().getCurrentName();
+    final var parentName = gen.getOutputContext().getParent().getCurrentName();
+    return currentName != null && (currentName.equals("key") || currentName.endsWith(KEY))
+        || parentName != null && parentName.endsWith(KEYS);
+  }
+
+  @Override
+  public void serialize(
+      final Long value, final JsonGenerator gen, final SerializerProvider serializers)
+      throws IOException {
+
+    if (!gatewayRestPackage(gen) || !fieldNameEndsWithKey(gen)) {
+      writeNumber(value, gen);
+      return;
+    }
+
+    final RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+    if (requestAttributes instanceof final ServletRequestAttributes r) {
+      final var acceptHeader = r.getRequest().getHeader(HttpHeaders.ACCEPT);
+
+      if (acceptHeader != null && acceptHeader.equals(RequestMapper.MEDIA_TYPE_KEYS_NUMBER_VALUE)) {
+        writeNumber(value, gen);
+        return;
+      }
+      if (acceptHeader != null && acceptHeader.equals(RequestMapper.MEDIA_TYPE_KEYS_STRING_VALUE)) {
+        writeString(value, gen);
+        return;
+      }
+    }
+
+    writeDefault(value, gen);
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsRestTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsRestTest.java
@@ -999,7 +999,7 @@ public class LongPollingActivateJobsRestTest {
     final var brokerRequestValue = failRequest.getRequestWriter();
     final var activatedJob = activatedJobRef.get();
 
-    assertThat(String.valueOf(failRequest.getKey())).isEqualTo(activatedJob.getJobKey());
+    assertThat(failRequest.getKey()).isEqualTo(activatedJob.getJobKey());
     assertThat(brokerRequestValue.getRetries()).isEqualTo(activatedJob.getRetries());
     assertThat(brokerRequestValue.getRetryBackoff()).isEqualTo(0);
     assertThat(brokerRequestValue.getErrorMessageBuffer()).isNotNull();

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionControllerTest.java
@@ -17,6 +17,7 @@ import io.camunda.security.auth.Authentication;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.DecisionDefinitionServices;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
+import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
@@ -51,6 +52,22 @@ public class DecisionDefinitionControllerTest extends RestControllerTest {
              "decisionInstanceKey":"123",
              "evaluatedDecisions":[]
           }""";
+  private static final String EXPECTED_EVALUATION_RESPONSE_NUMBER_KEYS =
+      """
+      {
+         "decisionDefinitionKey":123456,
+         "decisionDefinitionId":"decisionId",
+         "decisionDefinitionName":"decisionName",
+         "decisionDefinitionVersion":1,
+         "decisionRequirementsId":"decisionRequirementsId",
+         "decisionRequirementsKey":123456,
+         "output":"null",
+         "failedDecisionDefinitionId":"",
+         "failureMessage":"",
+         "tenantId":"tenantId",
+         "decisionInstanceKey":123,
+         "evaluatedDecisions":[]
+      }""";
 
   @MockBean MultiTenancyConfiguration multiTenancyCfg;
   @MockBean private DecisionDefinitionServices decisionServices;
@@ -94,6 +111,43 @@ public class DecisionDefinitionControllerTest extends RestControllerTest {
                     .isOk());
 
     response.expectBody().json(EXPECTED_EVALUATION_RESPONSE);
+    Mockito.verify(decisionServices)
+        .evaluateDecision("", 123456L, Map.of("key", "value"), "tenantId");
+  }
+
+  @Test
+  void shouldEvaluateDecisionWithDecisionNumberKeys() {
+    // given
+    when(multiTenancyCfg.isEnabled()).thenReturn(true);
+    when(decisionServices.evaluateDecision(anyString(), anyLong(), anyMap(), anyString()))
+        .thenReturn((buildResponse("tenantId")));
+
+    final var request =
+        """
+            {
+              "decisionDefinitionKey": 123456,
+              "variables": {
+                "key": "value"
+              },
+              "tenantId": "tenantId"
+            }""";
+
+    // when/then
+    final ResponseSpec response =
+        withMultiTenancy(
+            "tenantId",
+            client ->
+                client
+                    .post()
+                    .uri(EVALUATION_URL)
+                    .accept(RequestMapper.MEDIA_TYPE_KEYS_NUMBER)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(request)
+                    .exchange()
+                    .expectStatus()
+                    .isOk());
+
+    response.expectBody().json(EXPECTED_EVALUATION_RESPONSE_NUMBER_KEYS);
     Mockito.verify(decisionServices)
         .evaluateDecision("", 123456L, Map.of("key", "value"), "tenantId");
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
 import io.camunda.zeebe.gateway.protocol.rest.JobActivationResponse;
+import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.ResponseMapper;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.gateway.rest.controller.util.ResettableJobActivationRequestResponseObserver;
@@ -83,7 +84,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
         {
           "jobs": [
             {
-              "jobKey": "2251799813685248",
+              "jobKey": "4503599627370496",
               "type": "TEST",
               "processInstanceKey": "123",
               "processDefinitionKey": "4532",
@@ -99,7 +100,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
               "worker": "bar"
             },
             {
-              "jobKey": "2251799813685249",
+              "jobKey": "4503599627370497",
               "type": "TEST",
               "processInstanceKey": "123",
               "processDefinitionKey": "4532",
@@ -128,6 +129,81 @@ public class JobControllerLongPollingTest extends RestControllerTest {
         .isOk()
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(expectedBody);
+
+    Mockito.verify(responseObserver, Mockito.times(1)).onNext(any());
+    Mockito.verify(responseObserver).onCompleted();
+  }
+
+  @Test
+  void shouldActivateJobsImmediatelyIfAvailableNumberKeys() {
+    // given
+    final ActivateJobsStub stub = new ActivateJobsStub();
+    stub.addAvailableJobs("TEST", 2);
+    stub.registerWith(stubbedBrokerClient);
+
+    final var request =
+        """
+        {
+          "type": "TEST",
+          "maxJobsToActivate": 2,
+          "requestTimeout": 100,
+          "timeout": 100,
+          "fetchVariable": [],
+          "tenantIds": ["default"],
+          "worker": "bar"
+        }""";
+    final var expectedBody =
+        """
+        {
+          "jobs": [
+            {
+              "jobKey": 2251799813685248,
+              "type": "TEST",
+              "processInstanceKey": 123,
+              "processDefinitionKey": 4532,
+              "processDefinitionVersion": 23,
+              "elementInstanceKey": 459,
+              "retries": 12,
+              "deadline": 123123123,
+              "tenantId": "default",
+              "variables": {"bar": "world", "foo": 13},
+              "customHeaders": {"bar": "val", "foo": 12},
+              "processDefinitionId": "stubProcess",
+              "elementId": "stubActivity",
+              "worker": "bar"
+            },
+            {
+              "jobKey": 2251799813685249,
+              "type": "TEST",
+              "processInstanceKey": 123,
+              "processDefinitionKey": 4532,
+              "processDefinitionVersion": 23,
+              "elementInstanceKey": 459,
+              "retries": 12,
+              "deadline": 123123123,
+              "tenantId": "default",
+              "variables": {"bar": "world", "foo": 13},
+              "customHeaders": {"bar": "val", "foo": 12},
+              "processDefinitionId": "stubProcess",
+              "elementId": "stubActivity",
+              "worker": "bar"
+            }
+          ]
+        }""";
+    // when / then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/activation")
+        .accept(RequestMapper.MEDIA_TYPE_KEYS_NUMBER)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(RequestMapper.MEDIA_TYPE_KEYS_NUMBER)
         .expectBody()
         .json(expectedBody);
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -19,6 +19,7 @@ import io.camunda.service.ProcessInstanceServices.ProcessInstanceCancelRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceCreateRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyRequest;
+import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
@@ -48,6 +49,15 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
              "processInstanceKey":"123",
              "tenantId":"tenantId"
           }""";
+  static final String EXPECTED_START_RESPONSE_NUMBER_KEYS =
+      """
+      {
+         "processDefinitionKey":123,
+         "processDefinitionId":"bpmnProcessId",
+         "processDefinitionVersion":-1,
+         "processInstanceKey":123,
+         "tenantId":"tenantId"
+      }""";
   static final String PROCESS_INSTANCES_START_URL = "/v2/process-instances";
   static final String CANCEL_PROCESS_URL = PROCESS_INSTANCES_START_URL + "/%s/cancellation";
   static final String MIGRATE_PROCESS_URL = PROCESS_INSTANCES_START_URL + "/%s/migration";
@@ -107,6 +117,54 @@ public class ProcessInstanceControllerTest extends RestControllerTest {
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
         .json(EXPECTED_START_RESPONSE);
+
+    verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture());
+    final var capturedRequest = createRequestCaptor.getValue();
+    assertThat(capturedRequest.processDefinitionKey()).isEqualTo(123L);
+    assertThat(capturedRequest.tenantId()).isEqualTo("tenantId");
+  }
+
+  @Test
+  void shouldCreateProcessInstancesWithProcessDefinitionNumberKeys() {
+    // given
+    when(multiTenancyCfg.isEnabled()).thenReturn(true);
+    final var mockResponse =
+        new ProcessInstanceCreationRecord()
+            .setProcessDefinitionKey(123L)
+            .setBpmnProcessId("bpmnProcessId")
+            .setProcessInstanceKey(123L)
+            .setTenantId("tenantId");
+
+    when(processInstanceServices.createProcessInstance(any(ProcessInstanceCreateRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(mockResponse));
+
+    final var request =
+        """
+        {
+            "processDefinitionKey": 123,
+            "tenantId": "tenantId"
+        }""";
+
+    // when / then
+    final ResponseSpec response =
+        withMultiTenancy(
+            "tenantId",
+            client ->
+                client
+                    .post()
+                    .uri(PROCESS_INSTANCES_START_URL)
+                    .accept(RequestMapper.MEDIA_TYPE_KEYS_NUMBER)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(request)
+                    .exchange()
+                    .expectStatus()
+                    .isOk());
+
+    response
+        .expectHeader()
+        .contentType(RequestMapper.MEDIA_TYPE_KEYS_NUMBER)
+        .expectBody()
+        .json(EXPECTED_START_RESPONSE_NUMBER_KEYS);
 
     verify(processInstanceServices).createProcessInstance(createRequestCaptor.capture());
     final var capturedRequest = createRequestCaptor.getValue();

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
@@ -17,6 +17,7 @@ import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.service.ResourceServices;
 import io.camunda.service.ResourceServices.DeployResourcesRequest;
 import io.camunda.service.ResourceServices.ResourceDeletionRequest;
+import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
@@ -102,6 +103,68 @@ public class ResourceControllerTest extends RestControllerTest {
                              "processDefinitionId":"processId",
                              "processDefinitionVersion":1,
                              "processDefinitionKey":"123456",
+                             "resourceName":"process.bpmn",
+                             "tenantId":"<default>"
+                          }
+                       }
+                    ],
+                    "tenantId":"<default>"
+                 }
+                """);
+  }
+
+  @Test
+  void shouldDeployASingleResourceNumberKeys() {
+    // given
+    final var filename = "process.bpmn";
+    final var contentType = MediaType.APPLICATION_OCTET_STREAM;
+    final var content = new byte[] {1, 2, 3};
+
+    final var mockedResponse = new DeploymentRecord().setDeploymentKey(123);
+    mockedResponse
+        .processesMetadata()
+        .add()
+        .setResourceName(filename)
+        .setBpmnProcessId("processId")
+        .setDeploymentKey(123L)
+        .setVersion(1)
+        .setKey(123456L)
+        .setChecksum(BufferUtil.wrapString("checksum"));
+    when(resourceServices.deployResources(any()))
+        .thenReturn(CompletableFuture.completedFuture(mockedResponse));
+
+    final var multipartBodyBuilder = new MultipartBodyBuilder();
+    multipartBodyBuilder.part("resources", content).contentType(contentType).filename(filename);
+
+    // when/then
+    final var response =
+        webClient
+            .post()
+            .uri(DEPLOY_RESOURCES_ENDPOINT)
+            .contentType(MediaType.MULTIPART_FORM_DATA)
+            .bodyValue(multipartBodyBuilder.build())
+            .accept(RequestMapper.MEDIA_TYPE_KEYS_NUMBER)
+            .exchange()
+            .expectStatus()
+            .isOk();
+
+    verify(resourceServices).deployResources(deployRequestCaptor.capture());
+    final var capturedRequest = deployRequestCaptor.getValue();
+    assertThat(capturedRequest.resources()).isNotEmpty();
+    assertThat(capturedRequest.resources()).size().isEqualTo(1);
+
+    response
+        .expectBody()
+        .json(
+            """
+                 {
+                    "deploymentKey":123,
+                    "deployments":[
+                       {
+                          "processDefinition":{
+                             "processDefinitionId":"processId",
+                             "processDefinitionVersion":1,
+                             "processDefinitionKey":123456,
                              "resourceName":"process.bpmn",
                              "tenantId":"<default>"
                           }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/serializer/LongSerializerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/serializer/LongSerializerTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.serializer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonStreamContext;
+import io.camunda.zeebe.gateway.protocol.rest.UserTaskItem;
+import io.camunda.zeebe.gateway.protocol.rest.UserTaskSearchQueryResponse;
+import io.camunda.zeebe.gateway.rest.RequestMapper;
+import io.camunda.zeebe.util.Either.Left;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+class LongSerializerTest {
+
+  private LongSerializer longSerializer;
+  private JsonGenerator jsonGenerator;
+  private JsonStreamContext context;
+  private JsonStreamContext parentContext;
+  private HttpServletRequest httpServletRequest;
+
+  @BeforeEach
+  void setUp() {
+    longSerializer = new LongSerializer();
+    jsonGenerator = mock(JsonGenerator.class);
+    context = mock(JsonStreamContext.class);
+    parentContext = mock(JsonStreamContext.class);
+    doReturn(context).when(jsonGenerator).getOutputContext();
+    doReturn(parentContext).when(context).getParent();
+
+    httpServletRequest = mock(HttpServletRequest.class);
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(httpServletRequest));
+  }
+
+  @Test
+  void shouldSerializeNonRestClassAsNumber() throws IOException {
+    // given
+    doReturn(new Left<>(false)).when(context).getCurrentValue();
+    // when
+    longSerializer.serialize(1L, jsonGenerator, null);
+    // then
+    verify(jsonGenerator).writeNumber(1L);
+    verify(httpServletRequest, never()).getHeader(any());
+  }
+
+  @Test
+  void shouldSerializeRestClassWithoutKeyNameAsNumber() throws IOException {
+    // given
+    doReturn(new UserTaskItem()).when(context).getCurrentValue();
+    doReturn("field").when(context).getCurrentName();
+    // when
+    longSerializer.serialize(1L, jsonGenerator, null);
+    // then
+    verify(jsonGenerator).writeNumber(1L);
+    verify(httpServletRequest, never()).getHeader(HttpHeaders.ACCEPT);
+  }
+
+  @Test
+  void shouldSerializeRestClassWithDefaultStringIfNoHeaderAvailable() throws IOException {
+    // given
+    doReturn(new UserTaskItem()).when(context).getCurrentValue();
+    doReturn("elementInstanceKey").when(context).getCurrentName();
+    // when
+    longSerializer.serialize(1L, jsonGenerator, null);
+    // then
+    verify(jsonGenerator).writeString("1");
+    verify(httpServletRequest).getHeader(HttpHeaders.ACCEPT);
+  }
+
+  @Test
+  void shouldSerializeRestClassWithNumberIfHeaderSent() throws IOException {
+    // given
+    doReturn(new UserTaskItem()).when(context).getCurrentValue();
+    doReturn("elementInstanceKey").when(context).getCurrentName();
+    doReturn(RequestMapper.MEDIA_TYPE_KEYS_NUMBER_VALUE)
+        .when(httpServletRequest)
+        .getHeader(HttpHeaders.ACCEPT);
+    // when
+    longSerializer.serialize(1L, jsonGenerator, null);
+    // then
+    verify(jsonGenerator).writeNumber(1L);
+    verify(httpServletRequest).getHeader(HttpHeaders.ACCEPT);
+  }
+
+  @Test
+  void shouldSerializeRestClassWithStringIfHeaderSent() throws IOException {
+    // given
+    doReturn(new UserTaskItem()).when(context).getCurrentValue();
+    doReturn("elementInstanceKey").when(context).getCurrentName();
+    doReturn(RequestMapper.MEDIA_TYPE_KEYS_STRING_VALUE)
+        .when(httpServletRequest)
+        .getHeader(HttpHeaders.ACCEPT);
+    // when
+    longSerializer.serialize(1L, jsonGenerator, null);
+    // then
+    verify(jsonGenerator).writeString(String.valueOf(1L));
+    verify(httpServletRequest).getHeader(HttpHeaders.ACCEPT);
+  }
+
+  @Test
+  void shouldSerializeArrayField() throws IOException {
+    // given
+    doReturn(1L).when(context).getCurrentValue();
+    doReturn(null).when(context).getCurrentName();
+    doReturn(new UserTaskSearchQueryResponse()).when(parentContext).getCurrentValue();
+    doReturn("assignedMemberKeys").when(parentContext).getCurrentName();
+    // when
+    longSerializer.serialize(1L, jsonGenerator, null);
+    // then
+    verify(jsonGenerator).writeString("1");
+    verify(httpServletRequest).getHeader(HttpHeaders.ACCEPT);
+  }
+}


### PR DESCRIPTION
## Description

- Revert Long key objects
- Rename String key objects to *Result
- Adjust mapper classes
- Update Java Client to String key objects

## Related issues

closes https://github.com/camunda/camunda/issues/26465
