### PR TITLE
[Backport main] fix: fix optimize image wait-for-it.sh permissions

### DIFF
--- a/optimize.Dockerfile
+++ b/optimize.Dockerfile
@@ -78,6 +78,7 @@ RUN addgroup --gid 1001 camunda && \
     apk add --no-cache bash curl tini openjdk21-jre tzdata && \
     apk -U upgrade && \
     curl "https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh" --output /usr/local/bin/wait-for-it.sh && \
+    chmod +x /usr/local/bin/wait-for-it.sh && \
     # These directories are to be mounted by users, eagerly creating them and setting ownership
     # helps to avoid potential permission issues due to default volume ownership.
     mkdir ${OPTIMIZE_HOME}/logs && \


### PR DESCRIPTION
# Description
Backport of #26487 to `main`.

relates to 
original author: @megglos