### PR TITLE
refactor: make shouldCreateData check zeebe deployment index

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/zeebe/ZeebeESConstants.java
+++ b/operate/common/src/main/java/io/camunda/operate/zeebe/ZeebeESConstants.java
@@ -23,4 +23,5 @@ public interface ZeebeESConstants {
   String VARIABLE_DOCUMENT_INDEX_NAME = "variable-document";
   String PROCESS_MESSAGE_SUBSCRIPTION_INDEX_NAME = "process-message-subscription";
   String USER_TASK_INDEX_NAME = "user-task";
+  String DEPLOYMENT = "deployment";
 }

--- a/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
@@ -13,8 +13,8 @@ import static io.camunda.webapps.schema.entities.AbstractExporterEntity.DEFAULT_
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.worker.JobWorker;
 import io.camunda.operate.data.usertest.UserTestDataGenerator;
-import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.store.ZeebeStore;
+import io.camunda.operate.zeebe.ZeebeESConstants;
 import io.camunda.security.configuration.SecurityConfiguration;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -38,7 +38,6 @@ public abstract class AbstractDataGenerator implements DataGenerator {
   @Qualifier("camundaClient")
   protected CamundaClient client;
 
-  @Autowired protected OperateProperties operateProperties;
   protected boolean manuallyCalled = false;
   protected ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(3);
   @Autowired private SecurityConfiguration securityConfiguration;
@@ -107,9 +106,9 @@ public abstract class AbstractDataGenerator implements DataGenerator {
 
   public boolean shouldCreateData(final boolean manuallyCalled) {
     if (!manuallyCalled) { // when called manually, always create the data
+      final String zeebeIndexPrefix = zeebeStore.getZeebeIndexPrefix();
       final boolean exists =
-          zeebeStore.zeebeIndicesExists(
-              operateProperties.getZeebeElasticsearch().getPrefix() + "*");
+          zeebeStore.zeebeIndicesExists(zeebeIndexPrefix + "*" + ZeebeESConstants.DEPLOYMENT + "*");
       if (exists) {
         // data already exists
         LOGGER.debug("Data already exists in Zeebe.");

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportJob.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportJob.java
@@ -216,9 +216,7 @@ public class ImportJob implements Callable<Boolean> {
 
   public void refreshZeebeIndices() {
     final String indexPattern =
-        importBatch
-            .getImportValueType()
-            .getIndicesPattern(operateProperties.getZeebeElasticsearch().getPrefix());
+        importBatch.getImportValueType().getIndicesPattern(zeebeStore.getZeebeIndexPrefix());
     zeebeStore.refreshIndex(indexPattern);
   }
 

--- a/operate/schema/src/main/java/io/camunda/operate/store/ZeebeStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/ZeebeStore.java
@@ -11,4 +11,6 @@ public interface ZeebeStore {
   void refreshIndex(String indexPattern);
 
   boolean zeebeIndicesExists(String indexPattern);
+
+  String getZeebeIndexPrefix();
 }

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchZeebeStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchZeebeStore.java
@@ -37,7 +37,7 @@ public class ElasticsearchZeebeStore implements ZeebeStore {
   @Autowired private OperateProperties operateProperties;
 
   @Override
-  public void refreshIndex(String indexPattern) {
+  public void refreshIndex(final String indexPattern) {
     final RefreshRequest refreshRequest = new RefreshRequest(indexPattern);
     try {
       final RefreshResponse refresh =
@@ -45,13 +45,13 @@ public class ElasticsearchZeebeStore implements ZeebeStore {
       if (refresh.getFailedShards() > 0) {
         LOGGER.warn("Unable to refresh indices: {}", indexPattern);
       }
-    } catch (Exception ex) {
+    } catch (final Exception ex) {
       LOGGER.warn(String.format("Unable to refresh indices: %s", indexPattern), ex);
     }
   }
 
   @Override
-  public boolean zeebeIndicesExists(String indexPattern) {
+  public boolean zeebeIndicesExists(final String indexPattern) {
     try {
       final GetIndexRequest request = new GetIndexRequest(indexPattern);
       request.indicesOptions(IndicesOptions.fromOptions(true, false, true, false));
@@ -60,11 +60,16 @@ public class ElasticsearchZeebeStore implements ZeebeStore {
         LOGGER.debug("Data already exists in Zeebe.");
       }
       return exists;
-    } catch (IOException io) {
+    } catch (final IOException io) {
       LOGGER.debug(
           "Error occurred while checking existence of data in Zeebe: {}. Demo data won't be created.",
           io.getMessage());
       return false;
     }
+  }
+
+  @Override
+  public String getZeebeIndexPrefix() {
+    return operateProperties.getZeebeElasticsearch().getPrefix();
   }
 }

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchZeebeStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchZeebeStore.java
@@ -8,6 +8,7 @@
 package io.camunda.operate.store.opensearch;
 
 import io.camunda.operate.conditions.OpensearchCondition;
+import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.store.ZeebeStore;
 import java.io.IOException;
 import org.opensearch.client.opensearch.OpenSearchClient;
@@ -28,20 +29,22 @@ public class OpensearchZeebeStore implements ZeebeStore {
   @Qualifier("zeebeOpensearchClient")
   private OpenSearchClient openSearchClient;
 
+  @Autowired private OperateProperties operateProperties;
+
   @Override
-  public void refreshIndex(String indexPattern) {
+  public void refreshIndex(final String indexPattern) {
     try {
       final var response = openSearchClient.indices().refresh(r -> r.index(indexPattern));
       if (!response.shards().failures().isEmpty()) {
         LOGGER.warn("Unable to refresh indices: {}", indexPattern);
       }
-    } catch (Exception ex) {
+    } catch (final Exception ex) {
       LOGGER.warn(String.format("Unable to refresh indices: %s", indexPattern), ex);
     }
   }
 
   @Override
-  public boolean zeebeIndicesExists(String indexPattern) {
+  public boolean zeebeIndicesExists(final String indexPattern) {
     try {
       final var exists =
           openSearchClient
@@ -52,11 +55,16 @@ public class OpensearchZeebeStore implements ZeebeStore {
         LOGGER.debug("Data already exists in Zeebe.");
       }
       return exists;
-    } catch (IOException io) {
+    } catch (final IOException io) {
       LOGGER.debug(
           "Error occurred while checking existence of data in Zeebe: {}. Demo data won't be created.",
           io.getMessage());
       return false;
     }
+  }
+
+  @Override
+  public String getZeebeIndexPrefix() {
+    return operateProperties.getZeebeOpensearch().getPrefix();
   }
 }

--- a/tasklist/common/src/main/java/io/camunda/tasklist/zeebe/ZeebeESConstants.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/zeebe/ZeebeESConstants.java
@@ -18,4 +18,5 @@ public interface ZeebeESConstants {
   String VARIABLE_INDEX_NAME = "variable";
   String FORM_INDEX_NAME = "form";
   String USER_TASK_INDEX_NAME = "user-task";
+  String DEPLOYMENT = "deployment";
 }

--- a/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/es/DevDataGeneratorElasticSearch.java
+++ b/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/es/DevDataGeneratorElasticSearch.java
@@ -14,6 +14,7 @@ import io.camunda.tasklist.data.DataGenerator;
 import io.camunda.tasklist.data.DevDataGeneratorAbstract;
 import io.camunda.tasklist.data.conditionals.ElasticSearchCondition;
 import io.camunda.tasklist.entities.UserEntity;
+import io.camunda.tasklist.zeebe.ZeebeESConstants;
 import java.io.IOException;
 import java.util.List;
 import org.elasticsearch.action.index.IndexRequest;
@@ -46,7 +47,7 @@ public class DevDataGeneratorElasticSearch extends DevDataGeneratorAbstract
   private RestHighLevelClient esClient;
 
   @Override
-  public void createUser(String username, String firstname, String lastname) {
+  public void createUser(final String username, final String firstname, final String lastname) {
     final String password = username;
     final String passwordEncoded = passwordEncoder.encode(password);
     final UserEntity user =
@@ -59,7 +60,7 @@ public class DevDataGeneratorElasticSearch extends DevDataGeneratorAbstract
               .id(user.getId())
               .source(userEntityToJSONString(user), XContentType.JSON);
       esClient.index(request, RequestOptions.DEFAULT);
-    } catch (Exception t) {
+    } catch (final Exception t) {
       LOGGER.error("Could not create demo user with user id {}", user.getUserId(), t);
     }
     LOGGER.info("Created demo user {} with password {}", username, password);
@@ -69,7 +70,11 @@ public class DevDataGeneratorElasticSearch extends DevDataGeneratorAbstract
   public boolean shouldCreateData() {
     try {
       final GetIndexRequest request =
-          new GetIndexRequest(tasklistProperties.getZeebeElasticsearch().getPrefix() + "*");
+          new GetIndexRequest(
+              tasklistProperties.getZeebeElasticsearch().getPrefix()
+                  + "*"
+                  + ZeebeESConstants.DEPLOYMENT
+                  + "*");
       request.indicesOptions(LENIENT_EXPAND_OPEN_FORBID_NO_INDICES_IGNORE_THROTTLED);
       final boolean exists = zeebeEsClient.indices().exists(request, RequestOptions.DEFAULT);
       if (exists) {
@@ -77,7 +82,7 @@ public class DevDataGeneratorElasticSearch extends DevDataGeneratorAbstract
         LOGGER.debug("Data already exists in Zeebe.");
         return false;
       }
-    } catch (IOException io) {
+    } catch (final IOException io) {
       LOGGER.debug(
           "Error occurred while checking existance of data in Zeebe: {}. Demo data won't be created.",
           io.getMessage());

--- a/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/os/DevDataGeneratorOpenSearch.java
+++ b/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/os/DevDataGeneratorOpenSearch.java
@@ -13,6 +13,7 @@ import io.camunda.tasklist.data.DataGenerator;
 import io.camunda.tasklist.data.DevDataGeneratorAbstract;
 import io.camunda.tasklist.data.conditionals.OpenSearchCondition;
 import io.camunda.tasklist.entities.UserEntity;
+import io.camunda.tasklist.zeebe.ZeebeESConstants;
 import java.io.IOException;
 import java.util.List;
 import org.opensearch.client.opensearch.OpenSearchClient;
@@ -41,7 +42,7 @@ public class DevDataGeneratorOpenSearch extends DevDataGeneratorAbstract impleme
   private OpenSearchClient osClient;
 
   @Override
-  public void createUser(String username, String firstname, String lastname) {
+  public void createUser(final String username, final String firstname, final String lastname) {
     final String password = username;
     final String passwordEncoded = passwordEncoder.encode(password);
     final UserEntity user =
@@ -57,7 +58,7 @@ public class DevDataGeneratorOpenSearch extends DevDataGeneratorAbstract impleme
               .build();
       osClient.index(request);
 
-    } catch (Exception t) {
+    } catch (final Exception t) {
       LOGGER.error("Could not create demo user with user id {}", user.getUserId(), t);
     }
     LOGGER.info("Created demo user {} with password {}", username, password);
@@ -72,7 +73,12 @@ public class DevDataGeneratorOpenSearch extends DevDataGeneratorAbstract impleme
               .indices()
               .exists(
                   e ->
-                      e.index(List.of(tasklistProperties.getZeebeOpenSearch().getPrefix() + "*"))
+                      e.index(
+                              List.of(
+                                  tasklistProperties.getZeebeOpenSearch().getPrefix()
+                                      + "*"
+                                      + ZeebeESConstants.DEPLOYMENT
+                                      + "*"))
                           .allowNoIndices(false)
                           .ignoreUnavailable(true))
               .value();
@@ -82,7 +88,7 @@ public class DevDataGeneratorOpenSearch extends DevDataGeneratorAbstract impleme
         LOGGER.debug("Data already exists in Zeebe.");
         return false;
       }
-    } catch (IOException io) {
+    } catch (final IOException io) {
       LOGGER.debug(
           "Error occurred while checking existance of data in Zeebe: {}. Demo data won't be created.",
           io.getMessage());


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
[Slack discussion](https://camunda.slack.com/archives/C06UWQNCU7M/p1735893954509739?thread_ts=1735656326.026989&cid=C06UWQNCU7M)
zeebe export indices may be created before the Dev Data creation in Operate and Tasklist (due to the creation of default user), this prevents the creation of dev data.
In this pull request, we make the check on the zeebe deployment index.
Also, I fixed Operate not using the right zeebe index prefix properties (ES was always used)


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
