### PR TITLE
feat: enable webapp functionality only if webappEnabled property is set

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/backup/BackupConfig.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/BackupConfig.java
@@ -9,6 +9,7 @@ package io.camunda.application.commons.backup;
 
 import static io.camunda.application.commons.backup.ConfigValidation.*;
 
+import io.camunda.application.commons.conditions.WebappEnabledCondition;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.optimize.service.metadata.Version;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
@@ -20,11 +21,13 @@ import java.util.LinkedHashMap;
 import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 @Configuration
+@Conditional(WebappEnabledCondition.class)
 public class BackupConfig {
 
   public static String differentRepoNameFormat =

--- a/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
@@ -10,6 +10,7 @@ package io.camunda.application.commons.backup;
 import static io.camunda.application.commons.backup.ConfigValidation.allMatch;
 import static io.camunda.application.commons.backup.ConfigValidation.skipEmptyOptional;
 
+import io.camunda.application.commons.conditions.WebappEnabledCondition;
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.conditions.DatabaseType;
 import io.camunda.operate.property.OperateProperties;
@@ -72,10 +73,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 
 @Configuration
+@Conditional(WebappEnabledCondition.class)
 @ProfileWebApp
 public class BackupPriorityConfiguration {
 

--- a/dist/src/main/java/io/camunda/application/commons/backup/DynamicIndicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/DynamicIndicesConfiguration.java
@@ -7,14 +7,17 @@
  */
 package io.camunda.application.commons.backup;
 
+import io.camunda.application.commons.conditions.WebappEnabledCondition;
 import io.camunda.search.clients.DocumentBasedSearchClient;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.webapps.backup.DynamicIndicesProvider;
 import io.camunda.webapps.profiles.ProfileWebApp;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@Conditional(WebappEnabledCondition.class)
 @ProfileWebApp
 public class DynamicIndicesConfiguration {
 

--- a/dist/src/main/java/io/camunda/application/commons/backup/ElasticsearchBackupRepository.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/ElasticsearchBackupRepository.java
@@ -8,6 +8,7 @@
 package io.camunda.application.commons.backup;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import io.camunda.application.commons.conditions.WebappEnabledCondition;
 import io.camunda.operate.conditions.ElasticsearchCondition;
 import io.camunda.webapps.backup.BackupRepository;
 import io.camunda.webapps.backup.repository.BackupRepositoryProps;
@@ -21,7 +22,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 /** Note that the condition used refers to operate ElasticSearchCondition */
-@Conditional(ElasticsearchCondition.class)
+@Conditional({ElasticsearchCondition.class, WebappEnabledCondition.class})
 @Configuration
 @Profile("operate")
 public class ElasticsearchBackupRepository {

--- a/dist/src/main/java/io/camunda/application/commons/backup/ElasticsearchOptimizeBackupRepository.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/ElasticsearchOptimizeBackupRepository.java
@@ -8,6 +8,7 @@
 package io.camunda.application.commons.backup;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import io.camunda.application.commons.conditions.WebappEnabledCondition;
 import io.camunda.optimize.service.util.configuration.condition.ElasticSearchCondition;
 import io.camunda.webapps.backup.BackupRepository;
 import io.camunda.webapps.backup.repository.BackupRepositoryProps;
@@ -29,7 +30,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
  *
  * <p>Note that the condition used refers to tasklist ElasticSearchCondition
  */
-@Conditional(ElasticSearchCondition.class)
+@Conditional({ElasticSearchCondition.class, WebappEnabledCondition.class})
 @Configuration
 @Profile("optimize")
 @ConditionalOnMissingBean({

--- a/dist/src/main/java/io/camunda/application/commons/backup/ElasticsearchTasklistBackupRepository.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/ElasticsearchTasklistBackupRepository.java
@@ -9,6 +9,7 @@ package io.camunda.application.commons.backup;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.application.commons.conditions.WebappEnabledCondition;
 import io.camunda.tasklist.data.conditionals.ElasticSearchCondition;
 import io.camunda.webapps.backup.BackupRepository;
 import io.camunda.webapps.backup.repository.BackupRepositoryProps;
@@ -31,7 +32,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
  *
  * <p>Note that the condition used refers to tasklist ElasticSearchCondition
  */
-@Conditional(ElasticSearchCondition.class)
+@Conditional({ElasticSearchCondition.class, WebappEnabledCondition.class})
 @Configuration
 @Profile("tasklist")
 @ConditionalOnMissingBean(io.camunda.application.commons.backup.ElasticsearchBackupRepository.class)

--- a/dist/src/main/java/io/camunda/application/commons/backup/HistoryBackupComponent.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/HistoryBackupComponent.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.application.commons.backup;
 
+import io.camunda.application.commons.conditions.WebappEnabledCondition;
 import io.camunda.webapps.backup.BackupRepository;
 import io.camunda.webapps.backup.BackupService;
 import io.camunda.webapps.backup.BackupServiceImpl;
@@ -16,12 +17,14 @@ import io.camunda.webapps.profiles.ProfileWebApp;
 import io.camunda.webapps.schema.descriptors.backup.BackupPriorities;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Component;
 
 @Component
 @Configuration
+@Conditional(WebappEnabledCondition.class)
 @ProfileWebApp
 public class HistoryBackupComponent {
 

--- a/dist/src/main/java/io/camunda/application/commons/backup/OpensearchBackupRepository.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/OpensearchBackupRepository.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.application.commons.backup;
 
+import io.camunda.application.commons.conditions.WebappEnabledCondition;
 import io.camunda.operate.conditions.OpensearchCondition;
 import io.camunda.webapps.backup.repository.BackupRepositoryProps;
 import io.camunda.webapps.backup.repository.WebappsSnapshotNameProvider;
@@ -19,7 +20,7 @@ import org.springframework.context.annotation.Profile;
 /*
  * Note that the condition used refers to operate OpensearchCondition
  */
-@Conditional(OpensearchCondition.class)
+@Conditional({OpensearchCondition.class, WebappEnabledCondition.class})
 @Configuration
 @Profile("operate")
 public class OpensearchBackupRepository

--- a/dist/src/main/java/io/camunda/application/commons/backup/OpensearchOptimizeBackupRepository.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/OpensearchOptimizeBackupRepository.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.application.commons.backup;
 
+import io.camunda.application.commons.conditions.WebappEnabledCondition;
 import io.camunda.optimize.service.util.configuration.condition.OpenSearchCondition;
 import io.camunda.webapps.backup.BackupRepository;
 import io.camunda.webapps.backup.repository.BackupRepositoryProps;
@@ -26,7 +27,7 @@ import org.springframework.context.annotation.Profile;
  *
  * <p>Note that the condition used refers to tasklist OpensearchCondition
  */
-@Conditional(OpenSearchCondition.class)
+@Conditional({OpenSearchCondition.class, WebappEnabledCondition.class})
 @Configuration
 @Profile("optimize")
 @ConditionalOnMissingBean({

--- a/dist/src/main/java/io/camunda/application/commons/backup/OpensearchTasklistBackupRepository.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/OpensearchTasklistBackupRepository.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.application.commons.backup;
 
+import io.camunda.application.commons.conditions.WebappEnabledCondition;
 import io.camunda.tasklist.data.conditionals.OpenSearchCondition;
 import io.camunda.webapps.backup.BackupRepository;
 import io.camunda.webapps.backup.repository.BackupRepositoryProps;
@@ -27,7 +28,7 @@ import org.springframework.context.annotation.Profile;
  *
  * <p>Note that the condition used refers to tasklist OpensearchCondition
  */
-@Conditional(OpenSearchCondition.class)
+@Conditional({OpenSearchCondition.class, WebappEnabledCondition.class})
 @Configuration
 @Profile("tasklist")
 @ConditionalOnMissingBean(OpensearchBackupRepository.class)

--- a/dist/src/main/java/io/camunda/application/commons/conditions/WebappEnabledCondition.java
+++ b/dist/src/main/java/io/camunda/application/commons/conditions/WebappEnabledCondition.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.conditions;
+
+import java.util.List;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+public class WebappEnabledCondition implements Condition {
+
+  @Override
+  public boolean matches(final ConditionContext context, final AnnotatedTypeMetadata metadata) {
+    final var apps = List.of("operate", "tasklist");
+    for (final var app : apps) {
+      if (context.getEnvironment().matchesProfiles(app)) {
+        return webappEnabled(app, context.getEnvironment());
+      }
+    }
+    return context.getEnvironment().matchesProfiles("optimize | identity");
+  }
+
+  private boolean webappEnabled(final String app, final Environment environment) {
+    // Defaults to true if missing, since it's the default in OperateProperties & TasklistProperties
+    return environment.getProperty(
+        String.format("camunda.%s.webappEnabled", app), Boolean.class, Boolean.TRUE);
+  }
+}

--- a/dist/src/main/java/io/camunda/webapps/controllers/BackupController.java
+++ b/dist/src/main/java/io/camunda/webapps/controllers/BackupController.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.webapps.controllers;
 
+import io.camunda.application.commons.conditions.WebappEnabledCondition;
 import io.camunda.management.backups.Error;
 import io.camunda.management.backups.HistoryBackupDetail;
 import io.camunda.management.backups.HistoryBackupInfo;
@@ -34,10 +35,12 @@ import org.springframework.boot.actuate.endpoint.annotation.Selector;
 import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
 @Component
 @WebEndpoint(id = "backupHistory")
+@Conditional(WebappEnabledCondition.class)
 @ProfileWebApp
 public class BackupController {
   private static final Logger LOG = LoggerFactory.getLogger(BackupController.class);

--- a/dist/src/main/java/io/camunda/webapps/controllers/BackupControllerStandalone.java
+++ b/dist/src/main/java/io/camunda/webapps/controllers/BackupControllerStandalone.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.webapps.controllers;
 
+import io.camunda.application.commons.conditions.WebappEnabledCondition;
 import io.camunda.webapps.profiles.ProfileWebAppStandalone;
 import io.micrometer.common.lang.NonNull;
 import org.springframework.boot.actuate.endpoint.annotation.DeleteOperation;
@@ -15,10 +16,12 @@ import org.springframework.boot.actuate.endpoint.annotation.Selector;
 import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
 @Component
 @WebEndpoint(id = "backups")
+@Conditional(WebappEnabledCondition.class)
 @ProfileWebAppStandalone
 public class BackupControllerStandalone {
   private final BackupController backupController;


### PR DESCRIPTION
## Description
To allow running importers, the backup functionality should not be enabled if webappEnabled is set to false for operate or tasklist.

This problem was discovered when releasing 8.7.0-rc3

## Related issues

closes #26489
