### PR TITLE
docs: Improve JavaDocs for `JobResult` API

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobCommandStep1.java
@@ -291,11 +291,26 @@ public interface CompleteJobCommandStep1
     CompleteJobCommandStep2 correctPriority(Integer priority);
 
     /**
-     * Indicates that you are done setting up the result of the job. Allows to call methods
-     * unrelated to the job result like {@link #variables(Object)}. This method can be called
-     * optionally, it has no effect on the command.
+     * Marks the completion of configuring the result of the job.
      *
-     * @return the builder for this command.
+     * <p>This method is optional and can be used to indicate that the result configuration (such as
+     * corrections or denial) is complete. It allows calling methods unrelated to the job result.
+     *
+     * <p>Calling this method has no effect on the final command sent to the broker. It is provided
+     * for readability and organizational clarity in method chaining.
+     *
+     * <p>Example usage:
+     *
+     * <pre>{@code
+     * client.newCompleteJobCommand(jobKey)
+     *     .withResult()
+     *     .correctAssignee("john_doe")
+     *     .resultDone() // explicitly marks the end of result configuration
+     *     .send();
+     * }</pre>
+     *
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
      */
     CompleteJobCommandStep1 resultDone();
   }

--- a/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobCommandStep1.java
@@ -159,34 +159,80 @@ public interface CompleteJobCommandStep1
 
     /**
      * Indicates whether the worker denies the work, i.e. explicitly doesn't approve it. For
-     * example, a Task Listener can deny the completion of a task by setting this flag to true. In
-     * this example, the completion of a task is represented by a job that the worker can complete
-     * as denied. As a result, the completion request is rejected and the task remains active.
-     * Defaults to false.
+     * example, a user task listener can deny the completion of a task by setting this flag to true.
+     * In this example, the completion of a task is represented by a job that the worker can
+     * complete as denied. As a result, the completion request is rejected and the task remains
+     * active. Defaults to {@code false}.
+     *
+     * <p>Example usage:
+     *
+     * <pre>{@code
+     * client.newCompleteJobCommand(jobKey)
+     *     .withResult()
+     *     .deny(true)
+     *     .send();
+     * }</pre>
      *
      * @param isDenied indicates if the worker has denied the reason for the job
-     * @return the builder for this command.
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
      */
     CompleteJobCommandStep2 deny(boolean isDenied);
 
     /**
-     * Correct the task.
+     * Applies corrections to the user task attributes.
      *
-     * @param corrections corrections to apply
-     * @return this job result
+     * <p>This method allows the worker to modify key attributes of the user task (such as {@code
+     * assignee}, {@code candidateGroups}, and so on)
+     *
+     * <p>Example usage:
+     *
+     * <pre>{@code
+     * final JobResultCorrections corrections = new JobResultCorrections()
+     *     .assignee("john_doe")               // reassigns the task to 'john_doe'
+     *     .priority(80)                       // sets a high priority
+     *     .dueDate("2024-01-01T12:00:00Z")    // updates the due date
+     *     .candidateGroups(List.of("sales"))  // assigns the task to the 'sales' group
+     *     .candidateUsers(List.of("alice"));  // allows 'alice' to claim the task
+     *
+     * client.newCompleteJobCommand(jobKey)
+     *     .withResult()
+     *     .correct(corrections)
+     *     .send();
+     * }</pre>
+     *
+     * @param corrections the corrections to apply to the user task.
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
      */
     CompleteJobCommandStep2 correct(JobResultCorrections corrections);
 
     /**
-     * Correct the task.
+     * Dynamically applies corrections to the user task attributes using a lambda expression.
      *
-     * <p>This is a convenience method for {@link #correct(JobResultCorrections)} that allows you to
-     * apply corrections using a lambda expression. It provides the current corrections as input, so
-     * you can easily modify them. If no corrections have been set yet, it provides the default
-     * corrections as input.
+     * <p>This method is a functional alternative to {@link #correct(JobResultCorrections)}. It
+     * allows the worker to modify key user task attributes (such as {@code assignee}, {@code
+     * dueDate}, {@code priority}, and so on) directly via a lambda expression. The lambda receives
+     * the current {@link JobResultCorrections} instance, which can be updated as needed. If no
+     * corrections have been set yet, a default {@link JobResultCorrections} instance is provided.
      *
-     * @param corrections function to modify the corrections
-     * @return this job result
+     * <p>Example usage:
+     *
+     * <pre>{@code
+     * client.newCompleteJobCommand(jobKey)
+     *     .withResult()
+     *     .correct(corrections -> corrections
+     *         .assignee("john_doe")               // dynamically reassigns the task to 'john_doe'
+     *         .priority(80)                       // adjusts the priority of the task
+     *         .dueDate("2024-01-01T12:00:00Z")    // updates the due date
+     *         .candidateGroups(List.of("sales"))  // assigns the task to the 'sales' group
+     *         .candidateUsers(List.of("alice")))  // allows 'alice' to claim the task
+     *     .send();
+     * }</pre>
+     *
+     * @param corrections a lambda expression to modify the {@link JobResultCorrections}.
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
      */
     CompleteJobCommandStep2 correct(UnaryOperator<JobResultCorrections> corrections);
 

--- a/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobCommandStep1.java
@@ -72,36 +72,75 @@ public interface CompleteJobCommandStep1
   CompleteJobCommandStep1 variable(String key, Object value);
 
   /**
-   * The result of the completed job as determined by the worker.
+   * Initializes the job result to allow corrections or a denial to be configured.
+   *
+   * <p>This method is used to apply changes to user task attributes (such as {@code assignee},
+   * {@code priority}, {@code dueDate}, and so on) or explicitly deny a user task operation.
+   *
+   * <p>Example usage:
+   *
+   * <pre>{@code
+   * client.newCompleteJobCommand(jobKey)
+   *     .withResult()
+   *     .correctAssignee("john_doe")                 // dynamically reassigns the task to 'john_doe'
+   *     .correctPriority(84)                         // adjusts the priority of the task
+   *     .correctDueDate("2024-11-22T11:44:55.0000Z") // sets a new due date
+   *     .send();
+   * }</pre>
    *
    * @return the builder for this command.
+   * @apiNote Currently, this API is relevant only for user task listeners.
    */
   CompleteJobCommandStep2 withResult();
 
   /**
-   * The result of the completed job as determined by the worker.
+   * Sets the result of the completed job, allowing the worker to apply corrections to user task
+   * attributes or explicitly deny the user task operation.
+   *
+   * <p>The {@link CompleteJobResult} object provides a flexible way to:
+   *
+   * <ul>
+   *   <li>Correct user task attributes such as {@code assignee}, {@code dueDate}, {@code priority},
+   *       and more.
+   *   <li>Deny the operation associated with the user task, preventing its lifecycle transition.
+   * </ul>
    *
    * <pre>{@code
-   * CompleteJobResult jobResult =
+   * final CompleteJobResult jobResult =
    *     new CompleteJobResult()
-   *         .correctAssignee("newAssignee")
-   *         .correctPriority(42);
+   *         .correctAssignee("newAssignee") // dynamically assigns the task
+   *         .correctPriority(42);           // updates the task priority
+   *
    * client.newCompleteJobCommand(jobKey)
    *     .withResult(jobResult)
    *     .send();
    * }</pre>
    *
-   * @param jobResult the result of the job
-   * @return the builder for this command.
+   * @param jobResult the result of the job, containing corrections and/or a denial flag.
+   * @return the builder for this command. Call {@link #send()} to finalize the command and send it
+   *     to the broker.
+   * @apiNote This API is currently relevant only for user task listeners.
    */
   CompleteJobCommandStep1 withResult(CompleteJobResult jobResult);
 
   /**
-   * The result of the completed job as determined by the worker.
+   * Modifies the result of the completed job using a lambda expression, allowing the worker to
+   * dynamically apply corrections to user task attributes or explicitly deny the user task
+   * operation.
    *
-   * <p>This is a convenience method for {@link #withResult(CompleteJobResult)} that allows you to
-   * set the result using a lambda expression. It provides the current job result as input, so you
-   * can easily modify it. If the job result has not been changed yet, it provides the default.
+   * <p>This is a convenience method for {@link #withResult(CompleteJobResult)}, allowing
+   * modifications to be applied directly via a functional interface rather than constructing the
+   * {@link CompleteJobResult} manually, enabling:
+   *
+   * <ul>
+   *   <li>Correcting user task attributes such as {@code assignee}, {@code dueDate}, {@code
+   *       priority}, and more.
+   *   <li>Denying the operation associated with the user task, preventing its lifecycle transition.
+   * </ul>
+   *
+   * <p>The lambda expression receives the current {@link CompleteJobResult}, which can be modified
+   * as needed. If no result has been set yet, a default {@link CompleteJobResult} is provided for
+   * modification.
    *
    * <pre>{@code
    * client.newCompleteJobCommand(jobKey)
@@ -109,8 +148,10 @@ public interface CompleteJobCommandStep1
    *     .send();
    * }</pre>
    *
-   * @param jobResultModifier function to modify the job result
-   * @return the builder for this command.
+   * @param jobResultModifier a function to modify the {@link CompleteJobResult}.
+   * @return the builder for this command. Call {@link #send()} to finalize the command and send it
+   *     to the broker.
+   * @apiNote This API is currently relevant only for user task listeners.
    */
   CompleteJobCommandStep1 withResult(UnaryOperator<CompleteJobResult> jobResultModifier);
 

--- a/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobCommandStep1.java
@@ -75,7 +75,8 @@ public interface CompleteJobCommandStep1
    * Initializes the job result to allow corrections or a denial to be configured.
    *
    * <p>This method is used to apply changes to user task attributes (such as {@code assignee},
-   * {@code priority}, {@code dueDate}, and so on) or explicitly deny a user task operation.
+   * {@code priority}, {@code dueDate}, and so on) or explicitly deny a user task lifecycle
+   * transition.
    *
    * <p>Example usage:
    *
@@ -95,14 +96,14 @@ public interface CompleteJobCommandStep1
 
   /**
    * Sets the result of the completed job, allowing the worker to apply corrections to user task
-   * attributes or explicitly deny the user task operation.
+   * attributes or explicitly deny the user task lifecycle transition.
    *
    * <p>The {@link CompleteJobResult} object provides a flexible way to:
    *
    * <ul>
    *   <li>Correct user task attributes such as {@code assignee}, {@code dueDate}, {@code priority},
    *       and more.
-   *   <li>Deny the operation associated with the user task, preventing its lifecycle transition.
+   *   <li>Deny the lifecycle transition associated with the user task.
    * </ul>
    *
    * <pre>{@code
@@ -126,7 +127,7 @@ public interface CompleteJobCommandStep1
   /**
    * Modifies the result of the completed job using a lambda expression, allowing the worker to
    * dynamically apply corrections to user task attributes or explicitly deny the user task
-   * operation.
+   * lifecycle transition.
    *
    * <p>This is a convenience method for {@link #withResult(CompleteJobResult)}, allowing
    * modifications to be applied directly via a functional interface rather than constructing the
@@ -135,7 +136,7 @@ public interface CompleteJobCommandStep1
    * <ul>
    *   <li>Correcting user task attributes such as {@code assignee}, {@code dueDate}, {@code
    *       priority}, and more.
-   *   <li>Denying the operation associated with the user task, preventing its lifecycle transition.
+   *   <li>Denying the lifecycle transition associated with the user task.
    * </ul>
    *
    * <p>The lambda expression receives the current {@link CompleteJobResult}, which can be modified
@@ -192,7 +193,7 @@ public interface CompleteJobCommandStep1
      *     .assignee("john_doe")               // reassigns the task to 'john_doe'
      *     .priority(80)                       // sets a high priority
      *     .dueDate("2024-01-01T12:00:00Z")    // updates the due date
-     *     .candidateGroups(List.of("sales"))  // assigns the task to the 'sales' group
+     *     .candidateGroups(List.of("sales"))  // allows the 'sales' group to claim the task
      *     .candidateUsers(List.of("alice"));  // allows 'alice' to claim the task
      *
      * client.newCompleteJobCommand(jobKey)
@@ -225,7 +226,7 @@ public interface CompleteJobCommandStep1
      *         .assignee("john_doe")               // dynamically reassigns the task to 'john_doe'
      *         .priority(80)                       // adjusts the priority of the task
      *         .dueDate("2024-01-01T12:00:00Z")    // updates the due date
-     *         .candidateGroups(List.of("sales"))  // assigns the task to the 'sales' group
+     *         .candidateGroups(List.of("sales"))  // allows the 'sales' group to claim the task
      *         .candidateUsers(List.of("alice")))  // allows 'alice' to claim the task
      *     .send();
      * }</pre>
@@ -306,6 +307,7 @@ public interface CompleteJobCommandStep1
      *     .withResult()
      *     .correctAssignee("john_doe")
      *     .resultDone() // explicitly marks the end of result configuration
+     *     .variable("we_can", "still_set_vars")
      *     .send();
      * }</pre>
      *

--- a/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobResult.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobResult.java
@@ -29,12 +29,12 @@ public class CompleteJobResult {
 
   /**
    * Indicates whether the worker denies the work, i.e. explicitly doesn't approve it. For example,
-   * a Task Listener can deny the completion of a task by setting this flag to true. In this
+   * a user task listener can deny the completion of a task by setting this flag to true. In this
    * example, the completion of a task is represented by a job that the worker can complete as
    * denied. As a result, the completion request is rejected and the task remains active. Defaults
-   * to false.
+   * to {@code false}.
    *
-   * @param isDenied true if the work must be denied, false otherwise
+   * @param isDenied indicates if the worker has denied the reason for the job
    * @return this job result
    */
   public CompleteJobResult deny(final boolean isDenied) {
@@ -43,9 +43,12 @@ public class CompleteJobResult {
   }
 
   /**
-   * Correct the task.
+   * Applies corrections to the user task attributes.
    *
-   * @param corrections corrections to apply
+   * <p>This method allows the worker to modify key attributes of the user task (such as {@code
+   * assignee}, {@code candidateGroups}, and so on).
+   *
+   * @param corrections the corrections to apply to the user task.
    * @return this job result
    */
   public CompleteJobResult correct(final JobResultCorrections corrections) {
@@ -58,14 +61,15 @@ public class CompleteJobResult {
   }
 
   /**
-   * Correct the task.
+   * Dynamically applies corrections to the user task attributes using a lambda expression.
    *
-   * <p>This is a convenience method for {@link #correct(JobResultCorrections)} that allows you to
-   * apply corrections using a lambda expression. It provides the current corrections as input, so
-   * you can easily modify them. If no corrections have been set yet, it provides the default
-   * corrections as input.
+   * <p>This method is a functional alternative to {@link #correct(JobResultCorrections)}. It allows
+   * the worker to modify key user task attributes (such as {@code assignee}, {@code dueDate},
+   * {@code priority}, and so on) directly via a lambda expression. The lambda receives the current
+   * {@link JobResultCorrections} instance, which can be updated as needed. If no corrections have
+   * been set yet, a default {@link JobResultCorrections} instance is provided.
    *
-   * @param corrections function to modify the corrections
+   * @param corrections a lambda expression to modify the {@link JobResultCorrections}.
    * @return this job result
    */
   public CompleteJobResult correct(final UnaryOperator<JobResultCorrections> corrections) {

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6520,13 +6520,15 @@ components:
     JobResult:
       type: object
       nullable: true
-      description: The result of the completed job as determined by the worker.
+      description: >
+        The result of the completed job as determined by the worker.
+        This functionality is currently supported only by user task listeners.
       properties:
         denied:
           type: boolean
           description: >
             Indicates whether the worker denies the work, i.e. explicitly doesn't approve it.
-            For example, a Task Listener can deny the completion of a task by setting this flag to true.
+            For example, a user task listener can deny the completion of a task by setting this flag to true.
             In this example, the completion of a task is represented by a job that the worker can complete as denied.
             As a result, the completion request is rejected and the task remains active.
             Defaults to false.


### PR DESCRIPTION
## Description

This pull request enhances the JavaDocs for the `JobResult` API, focusing on providing clear, comprehensive, and practical examples for developers working with user task listener jobs. The updates include improvements across several key methods to ensure better usability and understanding of the API.

## Contributors:
- @ce-dmelnych
- @ana-vinogradova-camunda

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #26346 
