### PR TITLE
feat: add more trusted algorithms to Operate JWT decoder [Backport 8.5]

### DIFF
--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -87,6 +87,7 @@
     <zeebe-test-container.version>3.6.3</zeebe-test-container.version>
     <elasticsearch-test-container.version>1.19.8</elasticsearch-test-container.version>
     <postgres-test-container.version>1.17.6</postgres-test-container.version>
+    <wiremock.version>3.9.2</wiremock.version>
     <version.docker-java-api>3.3.6</version.docker-java-api>
     <version.httpclient>4.5.14</version.httpclient>
     <version.elasticsearch7>7.17.26</version.elasticsearch7>
@@ -482,6 +483,12 @@
         <groupId>org.testcontainers</groupId>
         <artifactId>postgresql</artifactId>
         <version>${postgres-test-container.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.wiremock</groupId>
+        <artifactId>wiremock-standalone</artifactId>
+        <version>${wiremock.version}</version>
       </dependency>
 
       <dependency>

--- a/operate/qa/integration-tests/pom.xml
+++ b/operate/qa/integration-tests/pom.xml
@@ -364,6 +364,16 @@
       <artifactId>jakarta.json</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/oauth2/JwtDecoderIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/oauth2/JwtDecoderIT.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright Camunda Services GmbH
+ *
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
+ * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
+ *
+ * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
+ * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
+ * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
+ * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
+ *
+ * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
+ *
+ * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
+ */
+package io.camunda.operate.webapp.security.oauth2;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import io.camunda.identity.sdk.IdentityConfiguration;
+import java.util.Date;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@WireMockTest
+public class JwtDecoderIT {
+
+  private final MockEnvironment environment = new MockEnvironment();
+  @Mock private IdentityJwt2AuthenticationTokenConverter jwtConverter;
+  private final WireMockRuntimeInfo wireMockInfo;
+  private final String authServerMockUrl;
+  private JwtDecoder decoder;
+
+  public JwtDecoderIT(final WireMockRuntimeInfo wireMockInfo) {
+    this.wireMockInfo = wireMockInfo;
+    authServerMockUrl = wireMockInfo.getHttpBaseUrl();
+  }
+
+  @BeforeEach
+  public void setup() {
+    final IdentityConfiguration identityConfiguration =
+        new IdentityConfiguration(null, authServerMockUrl, null, null, null);
+    final IdentityOAuth2WebConfigurer identityOAuth2WebConfigurer =
+        new IdentityOAuth2WebConfigurer(environment, identityConfiguration, jwtConverter);
+
+    decoder = ReflectionTestUtils.invokeMethod(identityOAuth2WebConfigurer, "jwtDecoder");
+  }
+
+  @Test
+  public void testDecodeRs256JwtWithNoAlgFieldInJwkResponse() throws JOSEException {
+    // given
+    final RSAKey rsaJWK = getRsaJWK(JWSAlgorithm.RS256);
+    final String serializedJwt = signAndSerialize(rsaJWK, JWSAlgorithm.RS256);
+    final String publicKey = rsaJWK.toPublicJWK().toJSONString();
+
+    // remove alg field from mocked server response and assert it was removed to cover this use case
+    final String withoutAlg = publicKey.replaceFirst("\"alg\":\".*\",", "");
+    final String authServerResponseBody = "{\"keys\":[" + withoutAlg + "]}";
+    System.out.println("authServerResponse=" + authServerResponseBody);
+    assertFalse(authServerResponseBody.contains("alg:"));
+
+    wireMockInfo
+        .getWireMock()
+        .register(
+            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
+                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
+
+    // when - then
+    assertDoesNotThrow(() -> decoder.decode(serializedJwt));
+    wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+  }
+
+  @Test
+  public void testDecodeES256JwtWithNoAlgFieldInJwkResponse() throws JOSEException {
+    // given
+    final ECKey ecJWK = getEcJWK(JWSAlgorithm.ES256, Curve.P_256);
+    final String ecSerializedJwt = signAndSerialize(ecJWK, JWSAlgorithm.ES256);
+    final String publicKey = ecJWK.toPublicJWK().toJSONString();
+    System.out.println("publicKey=" + publicKey);
+
+    // remove alg field from mocked server response and assert it was removed to cover this use case
+    final String withoutAlg = publicKey.replaceFirst(",\"alg\":\".*\"", "");
+    final String authServerResponseBody = "{\"keys\":[" + withoutAlg + "]}";
+    System.out.println("authServerResponse=" + authServerResponseBody);
+    assertFalse(authServerResponseBody.contains("alg:"));
+
+    wireMockInfo
+        .getWireMock()
+        .register(
+            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
+                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
+
+    // when - then
+    assertDoesNotThrow(() -> decoder.decode(ecSerializedJwt));
+    wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+  }
+
+  @Test
+  public void testDecodeRS384Jwt() throws JOSEException {
+    // given
+    final RSAKey rsaJWK = getRsaJWK(JWSAlgorithm.RS384);
+    final String serializedJwt = signAndSerialize(rsaJWK, JWSAlgorithm.RS384);
+    final String publicKey = rsaJWK.toPublicJWK().toJSONString();
+
+    final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
+    System.out.println("authServerResponse=" + authServerResponseBody);
+    assertFalse(authServerResponseBody.contains("alg:"));
+
+    wireMockInfo
+        .getWireMock()
+        .register(
+            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
+                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
+
+    // when - then
+    assertDoesNotThrow(() -> decoder.decode(serializedJwt));
+    wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+  }
+
+  @Test
+  public void testDecodeRS512Jwt() throws JOSEException {
+    // given
+    final RSAKey rsaJWK = getRsaJWK(JWSAlgorithm.RS512);
+    final String serializedJwt = signAndSerialize(rsaJWK, JWSAlgorithm.RS512);
+    final String publicKey = rsaJWK.toPublicJWK().toJSONString();
+
+    final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
+    System.out.println("authServerResponse=" + authServerResponseBody);
+    assertFalse(authServerResponseBody.contains("alg:"));
+
+    wireMockInfo
+        .getWireMock()
+        .register(
+            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
+                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
+
+    // when - then
+    assertDoesNotThrow(() -> decoder.decode(serializedJwt));
+    wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+  }
+
+  @Test
+  public void testDecodeES384Jwt() throws JOSEException {
+    // given
+    final ECKey ecJWK = getEcJWK(JWSAlgorithm.ES384, Curve.P_384);
+    final String ecSerializedJwt = signAndSerialize(ecJWK, JWSAlgorithm.ES384);
+    final String publicKey = ecJWK.toPublicJWK().toJSONString();
+    System.out.println("publicKey=" + publicKey);
+
+    final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
+    System.out.println("authServerResponse=" + authServerResponseBody);
+    assertFalse(authServerResponseBody.contains("alg:"));
+
+    wireMockInfo
+        .getWireMock()
+        .register(
+            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
+                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
+
+    // when - then
+    assertDoesNotThrow(() -> decoder.decode(ecSerializedJwt));
+    wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+  }
+
+  @Test
+  public void testDecodeES512Jwt() throws JOSEException {
+    // given
+    final ECKey ecJWK = getEcJWK(JWSAlgorithm.ES512, Curve.P_521);
+    final String ecSerializedJwt = signAndSerialize(ecJWK, JWSAlgorithm.ES512);
+    final String publicKey = ecJWK.toPublicJWK().toJSONString();
+    System.out.println("publicKey=" + publicKey);
+
+    final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
+    System.out.println("authServerResponse=" + authServerResponseBody);
+    assertFalse(authServerResponseBody.contains("alg:"));
+
+    wireMockInfo
+        .getWireMock()
+        .register(
+            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
+                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
+
+    // when - then
+    assertDoesNotThrow(() -> decoder.decode(ecSerializedJwt));
+    wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+  }
+
+  private RSAKey getRsaJWK(final JWSAlgorithm alg) throws JOSEException {
+    return new RSAKeyGenerator(2048)
+        .keyID("123")
+        .keyUse(KeyUse.SIGNATURE)
+        .algorithm(alg)
+        .generate();
+  }
+
+  private ECKey getEcJWK(final JWSAlgorithm alg, final Curve curve) throws JOSEException {
+    return new ECKeyGenerator(curve)
+        .algorithm(alg)
+        .keyUse(KeyUse.SIGNATURE)
+        .keyID("345")
+        .generate();
+  }
+
+  private String signAndSerialize(final RSAKey rsaKey, final JWSAlgorithm alg)
+      throws JOSEException {
+    // Create RSA-signer with the private key
+    final JWSSigner rsaSigner = new RSASSASigner(rsaKey);
+
+    final SignedJWT rsaSignedJWT =
+        new SignedJWT(
+            new JWSHeader.Builder(alg).type(JOSEObjectType.JWT).keyID(rsaKey.getKeyID()).build(),
+            getClaimsSet());
+
+    rsaSignedJWT.sign(rsaSigner);
+    final String serializedJwt = rsaSignedJWT.serialize();
+    System.out.println("JWT serialized=" + serializedJwt);
+    return serializedJwt;
+  }
+
+  private String signAndSerialize(final ECKey ecKey, final JWSAlgorithm alg) throws JOSEException {
+    // Create EC-signer with the private key
+    final ECDSASigner ecSigner = new ECDSASigner(ecKey);
+
+    final SignedJWT ecSignedJWT =
+        new SignedJWT(
+            new JWSHeader.Builder(alg).type(JOSEObjectType.JWT).keyID(ecKey.getKeyID()).build(),
+            getClaimsSet());
+
+    ecSignedJWT.sign(ecSigner);
+    final String ecSerializedJwt = ecSignedJWT.serialize();
+    System.out.println("JWT serialized=" + ecSerializedJwt);
+    return ecSerializedJwt;
+  }
+
+  private JWTClaimsSet getClaimsSet() {
+    // prepare default JWT claims set
+    return new JWTClaimsSet.Builder()
+        .subject("alice")
+        .issuer("http://localhost")
+        .expirationTime(new Date(new Date().getTime() + 60 * 1000))
+        .build();
+  }
+}

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/oauth2/IdentityOAuth2WebConfigurer.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/oauth2/IdentityOAuth2WebConfigurer.java
@@ -19,6 +19,12 @@ package io.camunda.operate.webapp.security.oauth2;
 import static com.nimbusds.jose.JOSEObjectType.JWT;
 import static io.camunda.operate.OperateProfileService.IDENTITY_AUTH_PROFILE;
 import static io.camunda.operate.webapp.security.BaseWebConfigurer.sendJSONErrorMessage;
+import static org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.ES256;
+import static org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.ES384;
+import static org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.ES512;
+import static org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.RS256;
+import static org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.RS384;
+import static org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.RS512;
 
 import com.nimbusds.jose.JOSEObjectType;
 import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier;
@@ -87,10 +93,20 @@ public class IdentityOAuth2WebConfigurer {
    */
   private JwtDecoder jwtDecoder() {
     return NimbusJwtDecoder.withJwkSetUri(getJwkSetUriProperty())
+        .jwsAlgorithms(
+            algorithms -> {
+              algorithms.add(RS256);
+              algorithms.add(RS384);
+              algorithms.add(RS512);
+              algorithms.add(ES256);
+              algorithms.add(ES384);
+              algorithms.add(ES512);
+            })
         .jwtProcessorCustomizer(
-            processor ->
-                processor.setJWSTypeVerifier(
-                    new DefaultJOSEObjectTypeVerifier<>(JWT, new JOSEObjectType("at+jwt"))))
+            processor -> {
+              processor.setJWSTypeVerifier(
+                  new DefaultJOSEObjectTypeVerifier<>(JWT, new JOSEObjectType("at+jwt")));
+            })
         .build();
   }
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/oauth2/IdentityOAuth2WebConfigurer.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/oauth2/IdentityOAuth2WebConfigurer.java
@@ -28,7 +28,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -52,11 +51,20 @@ public class IdentityOAuth2WebConfigurer {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IdentityOAuth2WebConfigurer.class);
 
-  @Autowired private Environment env;
+  private final Environment env;
 
-  @Autowired private IdentityConfiguration identityConfiguration;
+  private final IdentityConfiguration identityConfiguration;
 
-  @Autowired private IdentityJwt2AuthenticationTokenConverter jwtConverter;
+  private final IdentityJwt2AuthenticationTokenConverter jwtConverter;
+
+  public IdentityOAuth2WebConfigurer(
+      final Environment env,
+      final IdentityConfiguration identityConfiguration,
+      final IdentityJwt2AuthenticationTokenConverter jwtConverter) {
+    this.env = env;
+    this.identityConfiguration = identityConfiguration;
+    this.jwtConverter = jwtConverter;
+  }
 
   public void configure(final HttpSecurity http) throws Exception {
     if (isJWTEnabled()) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Backport of https://github.com/camunda/camunda/pull/26231

Had to manually add wiremock-standalone dependency to operate parent.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates to https://github.com/camunda/camunda/issues/23727
