### PR TITLE
ci: make mvn build Tasklist FE by default

### DIFF
--- a/tasklist/pom.xml
+++ b/tasklist/pom.xml
@@ -37,7 +37,7 @@
     <maven.compiler.target>21</maven.compiler.target>
     <maven.compiler.source>21</maven.compiler.source>
 
-    <skip.fe.build>true</skip.fe.build>
+    <skip.fe.build>false</skip.fe.build>
     <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
With the changes introduced in https://github.com/camunda/camunda/pull/26409, we now support building the entire project, including the frontend, with maven build concurrency enabled. 
The Tasklist frontend build is re-enabled by default, ensuring it is automatically included when packaging the project with Maven.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
