### PR TITLE
feat: update operation entity only if operation with the specified operation reference exist

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/exceptions/PersistenceException.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/exceptions/PersistenceException.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.exporter.exceptions;
 
-public class PersistenceException extends Exception {
+public class PersistenceException extends RuntimeException {
 
   private static final long serialVersionUID = 1L;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ExportHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ExportHandler.java
@@ -80,4 +80,19 @@ public interface ExportHandler<T extends ExporterEntity<T>, R extends RecordValu
    * @return the index name that the handler entities are flushed to.
    */
   String getIndexName();
+
+  /**
+   * Adds a custom error handling behavior to the BatchRequest, in case of failing to execute the
+   * flushed requests from this handler. By default, if not overridden, a {@link
+   * PersistenceException} is thrown.
+   *
+   * @param batchRequest the batch request to add the error handler to.
+   */
+  default void onError(final BatchRequest batchRequest) {
+    batchRequest.onError(
+        getIndexName(),
+        (cause) -> {
+          throw new PersistenceException(cause);
+        });
+  }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/operation/AbstractOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/operation/AbstractOperationHandler.java
@@ -66,7 +66,7 @@ public abstract class AbstractOperationHandler<R extends RecordValue>
     updateFields.put(OperationTemplate.LOCK_OWNER, entity.getLockOwner());
     updateFields.put(OperationTemplate.LOCK_EXPIRATION_TIME, entity.getLockExpirationTime());
 
-    batchRequest.updateWithScript(indexName, entity.getId(), getScript(), updateFields);
+    batchRequest.update(indexName, entity.getId(), updateFields);
   }
 
   @Override
@@ -74,21 +74,8 @@ public abstract class AbstractOperationHandler<R extends RecordValue>
     return indexName;
   }
 
-  private String getScript() {
-    return """
-    if (ctx._source != null) {
-        ctx._source.%1$s = params.%1$s;
-        ctx._source.%2$s = params.%2$s;
-        ctx._source.%3$s = params.%3$s;
-        ctx._source.%4$s = params.%4$s;
-    } else {
-        ctx.op = 'noop';
-    }
-  """
-        .formatted(
-            OperationTemplate.STATE,
-            OperationTemplate.COMPLETED_DATE,
-            OperationTemplate.LOCK_OWNER,
-            OperationTemplate.LOCK_EXPIRATION_TIME);
+  @Override
+  public void onError(final BatchRequest batchRequest) throws PersistenceException {
+    // do nothing
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/operation/AbstractOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/operation/AbstractOperationHandler.java
@@ -19,12 +19,12 @@ import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
+import java.util.function.Consumer;
 
 public abstract class AbstractOperationHandler<R extends RecordValue>
     implements ExportHandler<OperationEntity, R> {
 
-  protected static final Function<String, Void> NOOP_ERROR_HANDLER = error -> null;
+  protected static final Consumer<String> NOOP_ERROR_HANDLER = error -> {};
   protected final String indexName;
 
   public AbstractOperationHandler(final String indexName) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/operation/AbstractOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/operation/AbstractOperationHandler.java
@@ -66,11 +66,29 @@ public abstract class AbstractOperationHandler<R extends RecordValue>
     updateFields.put(OperationTemplate.LOCK_OWNER, entity.getLockOwner());
     updateFields.put(OperationTemplate.LOCK_EXPIRATION_TIME, entity.getLockExpirationTime());
 
-    batchRequest.update(indexName, entity.getId(), updateFields);
+    batchRequest.updateWithScript(indexName, entity.getId(), getScript(), updateFields);
   }
 
   @Override
   public String getIndexName() {
     return indexName;
+  }
+
+  private String getScript() {
+    return """
+    if (ctx._source != null) {
+        ctx._source.%1$s = params.%1$s;
+        ctx._source.%2$s = params.%2$s;
+        ctx._source.%3$s = params.%3$s;
+        ctx._source.%4$s = params.%4$s;
+    } else {
+        ctx.op = 'noop';
+    }
+  """
+        .formatted(
+            OperationTemplate.STATE,
+            OperationTemplate.COMPLETED_DATE,
+            OperationTemplate.LOCK_OWNER,
+            OperationTemplate.LOCK_EXPIRATION_TIME);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/operation/AbstractOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/operation/AbstractOperationHandler.java
@@ -19,10 +19,12 @@ import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 public abstract class AbstractOperationHandler<R extends RecordValue>
     implements ExportHandler<OperationEntity, R> {
 
+  protected static final Function<String, Void> NOOP_ERROR_HANDLER = error -> null;
   protected final String indexName;
 
   public AbstractOperationHandler(final String indexName) {
@@ -76,6 +78,6 @@ public abstract class AbstractOperationHandler<R extends RecordValue>
 
   @Override
   public void onError(final BatchRequest batchRequest) throws PersistenceException {
-    // do nothing
+    batchRequest.onError(indexName, NOOP_ERROR_HANDLER);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/BatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/BatchRequest.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.store;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import java.util.Map;
+import java.util.function.Function;
 
 /** A {@link BatchRequest} contains updates to one or more {@link ExporterEntity} */
 @SuppressWarnings("rawtypes")
@@ -65,4 +66,13 @@ public interface BatchRequest {
   void execute() throws PersistenceException;
 
   void executeWithRefresh() throws PersistenceException;
+
+  /**
+   * Adds an error handler to the batch request. The error handler is called when an error occurs
+   *
+   * @param index the index name that this specific error handler should be used to handle errors
+   *     for.
+   * @param errorHandler the error handler to call when an error occurs
+   */
+  void onError(String index, Function<String, Void> errorHandler);
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/BatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/BatchRequest.java
@@ -10,7 +10,7 @@ package io.camunda.exporter.store;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import java.util.Map;
-import java.util.function.Function;
+import java.util.function.Consumer;
 
 /** A {@link BatchRequest} contains updates to one or more {@link ExporterEntity} */
 @SuppressWarnings("rawtypes")
@@ -74,5 +74,5 @@ public interface BatchRequest {
    *     for.
    * @param errorHandler the error handler to call when an error occurs
    */
-  void onError(String index, Function<String, Void> errorHandler);
+  void onError(String index, Consumer<String> errorHandler);
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
@@ -73,6 +73,7 @@ public class ExporterBatchWriter {
       final ExporterEntity entity = entityAndHandler.entity();
       for (final var handler : entityAndHandler.handlers()) {
         handler.flush(entity, batchRequest);
+        handler.onError(batchRequest);
       }
     }
     batchRequest.execute();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/OpensearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/OpensearchBatchRequest.java
@@ -256,7 +256,7 @@ public class OpensearchBatchRequest implements BatchRequest {
     }
   }
 
-  private void validateNoErrors(final List<BulkResponseItem> items) throws PersistenceException {
+  private void validateNoErrors(final List<BulkResponseItem> items) {
     final var errorItems = items.stream().filter(item -> item.error() != null).toList();
     if (errorItems.isEmpty()) {
       return;
@@ -275,11 +275,14 @@ public class OpensearchBatchRequest implements BatchRequest {
     errorItems.forEach(
         item -> {
           final Function<String, Void> errorHandler = errorHandlers.get(item.index());
+          final String message =
+              String.format(
+                  "%s failed for type [%s] and id [%s]: %s",
+                  item.operationType(), item.index(), item.id(), item.error().reason());
           if (errorHandler != null) {
-            errorHandler.apply(
-                String.format(
-                    "%s failed for type [%s] and id [%s]: %s",
-                    item.operationType(), item.index(), item.id(), item.error().reason()));
+            errorHandler.apply(message);
+          } else {
+            throw new PersistenceException(message);
           }
         });
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/operation/AbstractOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/operation/AbstractOperationHandlerTest.java
@@ -7,13 +7,12 @@
  */
 package io.camunda.exporter.handlers.operation;
 
+import static io.camunda.exporter.handlers.operation.AbstractOperationHandler.NOOP_ERROR_HANDLER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
@@ -135,7 +134,7 @@ abstract class AbstractOperationHandlerTest<R extends RecordValue> {
     // when
     underTest.onError(mockRequest);
     // then
-    verify(mockRequest, never()).onError(anyString(), any());
+    verify(mockRequest).onError(anyString(), eq(NOOP_ERROR_HANDLER));
   }
 
   protected Record<R> generateRecord(final Intent intent) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/operation/AbstractOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/operation/AbstractOperationHandlerTest.java
@@ -9,9 +9,11 @@ package io.camunda.exporter.handlers.operation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
@@ -123,8 +125,17 @@ abstract class AbstractOperationHandlerTest<R extends RecordValue> {
     underTest.flush(entity, mockRequest);
 
     // then
-    verify(mockRequest)
-        .updateWithScript(eq(indexName), eq(entity.getId()), anyString(), eq(expectedUpdateFields));
+    verify(mockRequest).update(eq(indexName), eq(entity.getId()), eq(expectedUpdateFields));
+  }
+
+  @Test
+  void shouldSwallowErrors() {
+    // given
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+    // when
+    underTest.onError(mockRequest);
+    // then
+    verify(mockRequest, never()).onError(anyString(), any());
   }
 
   protected Record<R> generateRecord(final Intent intent) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/operation/AbstractOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/operation/AbstractOperationHandlerTest.java
@@ -9,6 +9,8 @@ package io.camunda.exporter.handlers.operation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -121,7 +123,8 @@ abstract class AbstractOperationHandlerTest<R extends RecordValue> {
     underTest.flush(entity, mockRequest);
 
     // then
-    verify(mockRequest).update(indexName, entity.getId(), expectedUpdateFields);
+    verify(mockRequest)
+        .updateWithScript(eq(indexName), eq(entity.getId()), anyString(), eq(expectedUpdateFields));
   }
 
   protected Record<R> generateRecord(final Intent intent) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ElasticsearchBatchRequestTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ElasticsearchBatchRequestTest.java
@@ -31,6 +31,7 @@ import io.camunda.exporter.utils.ElasticsearchScriptBuilder;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,6 +43,7 @@ class ElasticsearchBatchRequestTest {
 
   private static final String ID = "id";
   private static final String INDEX = "index";
+  private static final String INDEX_WITH_HANDLER = "indexWithHandler";
   private ElasticsearchBatchRequest batchRequest;
   private ElasticsearchClient elasticsearchClient;
   private Builder requestBuilder;
@@ -439,5 +441,30 @@ class ElasticsearchBatchRequestTest {
     // Then
     assertThatThrownBy(callable).isInstanceOf(PersistenceException.class);
     verify(elasticsearchClient).bulk(any(BulkRequest.class));
+  }
+
+  @Test
+  void shouldUseCustomErrorHandlerIfProvided() throws IOException {
+    // Given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+
+    final Function<String, Void> errorHandler = mock(Function.class);
+    batchRequest.onError(INDEX_WITH_HANDLER, errorHandler);
+
+    final BulkResponseItem item = mock(BulkResponseItem.class);
+    when(item.error()).thenReturn(new ErrorCause.Builder().reason("error").build());
+    when(item.index()).thenReturn(INDEX_WITH_HANDLER);
+
+    final BulkResponse bulkResponse = mock(BulkResponse.class);
+    when(bulkResponse.items()).thenReturn(List.of(item));
+
+    when(elasticsearchClient.bulk(any(BulkRequest.class))).thenReturn(bulkResponse);
+
+    // When
+    batchRequest.add(INDEX_WITH_HANDLER, entity);
+    batchRequest.execute();
+
+    // Then
+    verify(errorHandler).apply(any());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ElasticsearchBatchRequestTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ElasticsearchBatchRequestTest.java
@@ -31,7 +31,7 @@ import io.camunda.exporter.utils.ElasticsearchScriptBuilder;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
+import java.util.function.Consumer;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -448,7 +448,7 @@ class ElasticsearchBatchRequestTest {
     // Given
     final TestExporterEntity entity = new TestExporterEntity().setId(ID);
 
-    final Function<String, Void> errorHandler = mock(Function.class);
+    final Consumer<String> errorHandler = mock(Consumer.class);
     batchRequest.onError(INDEX_WITH_HANDLER, errorHandler);
 
     final BulkResponseItem item = mock(BulkResponseItem.class);
@@ -465,6 +465,6 @@ class ElasticsearchBatchRequestTest {
     batchRequest.execute();
 
     // Then
-    verify(errorHandler).apply(any());
+    verify(errorHandler).accept(any());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/OpensearchBatchRequestTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/OpensearchBatchRequestTest.java
@@ -20,6 +20,7 @@ import io.camunda.exporter.utils.OpensearchScriptBuilder;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,6 +43,7 @@ class OpensearchBatchRequestTest {
 
   private static final String ID = "id";
   private static final String INDEX = "index";
+  private static final String INDEX_WITH_HANDLER = "indexWithHandler";
   private OpensearchBatchRequest batchRequest;
   private OpenSearchClient osClient;
   private Builder requestBuilder;
@@ -433,5 +435,32 @@ class OpensearchBatchRequestTest {
     // Then
     assertThatThrownBy(callable).isInstanceOf(PersistenceException.class);
     verify(osClient).bulk(any(BulkRequest.class));
+  }
+
+  @Test
+  void shouldUseCustomErrorHandlerIfProvided() throws IOException {
+    // Given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+
+    final Function<String, Void> errorHandler = mock(Function.class);
+    batchRequest.onError(INDEX_WITH_HANDLER, errorHandler);
+
+    final BulkResponseItem item = mock(BulkResponseItem.class);
+    when(item.id()).thenReturn("1");
+    when(item.error())
+        .thenReturn(new ErrorCause.Builder().type("string_error").reason("error").build());
+    when(item.index()).thenReturn(INDEX_WITH_HANDLER);
+
+    final BulkResponse bulkResponse = mock(BulkResponse.class);
+    when(bulkResponse.items()).thenReturn(List.of(item));
+
+    when(osClient.bulk(any(BulkRequest.class))).thenReturn(bulkResponse);
+
+    // When
+    batchRequest.add(INDEX_WITH_HANDLER, entity);
+    batchRequest.execute();
+
+    // Then
+    verify(errorHandler).apply(any());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/OpensearchBatchRequestTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/OpensearchBatchRequestTest.java
@@ -20,7 +20,7 @@ import io.camunda.exporter.utils.OpensearchScriptBuilder;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
+import java.util.function.Consumer;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -442,7 +442,7 @@ class OpensearchBatchRequestTest {
     // Given
     final TestExporterEntity entity = new TestExporterEntity().setId(ID);
 
-    final Function<String, Void> errorHandler = mock(Function.class);
+    final Consumer<String> errorHandler = mock(Consumer.class);
     batchRequest.onError(INDEX_WITH_HANDLER, errorHandler);
 
     final BulkResponseItem item = mock(BulkResponseItem.class);
@@ -461,6 +461,6 @@ class OpensearchBatchRequestTest {
     batchRequest.execute();
 
     // Then
-    verify(errorHandler).apply(any());
+    verify(errorHandler).accept(any());
   }
 }


### PR DESCRIPTION
## Description

Currently if a wrong operation reference is specified the update operation will fail and the exporter will retry it

~~With this change, we are using an update script the first checks if the document exists then update.
Otherwise, it will set the batch operation as `noop`, meaning no operation will be performed~~

### Current Implementation
- Provided an API for A `BatchRequest` to keep track of different error handling behavior per index.
- Allowed `ExporterHandler`s to set their own error handling behavior
- Thrown Errors by default for all handlers
- Swallowed errors for Operation Index.

### Improvments:
- [ ] Is it worth it to make the `key` in the BatchRequest error handlers map a combination of `operation type + index name` or `index + document Id` (i.e `update-custom-prefox-operation-8.4.3` instead of `custom-prefox-operation-8.4.3`)?

## Related issues

closes #26093
