### PR TITLE
Add BackupRestore E2E test with ES 

### DIFF
--- a/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
@@ -249,8 +249,6 @@ class BackupPrioritiesTest {
             "optimize-alert_v4");
 
     for (final var indexList : indices) {
-      assertThat(indexList.skippableIndices())
-          .allSatisfy(i -> assertThat(i).startsWith("optimize"));
       assertThat(indexList.requiredIndices())
           .allSatisfy(i -> assertThat(i).doesNotStartWith("optimize"));
     }

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -32,6 +32,11 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>webapps-backup</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>camunda-search-client-query-transformer</artifactId>
       <scope>test</scope>
     </dependency>
@@ -267,6 +272,11 @@
       <artifactId>elasticsearch</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>elasticsearch-rest-client</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.testcontainers</groupId>
@@ -391,6 +401,12 @@
     <dependency>
       <groupId>org.agrona</groupId>
       <artifactId>agrona</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <version>4.4.16</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.ExpandWildcard;
+import co.elastic.clients.elasticsearch.indices.DeleteIndexRequest;
+import co.elastic.clients.elasticsearch.snapshot.Repository;
+import co.elastic.clients.elasticsearch.snapshot.RestoreRequest;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import io.camunda.client.CamundaClient;
+import io.camunda.it.utils.MultiDbConfigurator;
+import io.camunda.management.backups.TakeBackupHistoryResponse;
+import io.camunda.qa.util.cluster.TestRestManagementClient;
+import io.camunda.qa.util.cluster.TestSimpleCamundaApplication;
+import io.camunda.search.connect.configuration.DatabaseType;
+import io.camunda.webapps.backup.BackupStateDto;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+import org.agrona.CloseHelper;
+import org.apache.http.HttpHost;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.awaitility.Awaitility;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+@ZeebeIntegration
+public class BackupRestoreIT {
+  private static final String REPOSITORY_NAME = "test-repository";
+  private static final String INDEX_PREFIX = "backup-restore";
+  @TempDir public Path repositoryDir;
+  protected CamundaClient camundaClient;
+
+  @TestZeebe(autoStart = false)
+  protected TestStandaloneApplication<?> testStandaloneCamunda;
+
+  private GenericContainer<?> searchContainer;
+
+  private RestClient restClient;
+  private ElasticsearchClient esClient;
+  private BackupRestoreTestConfig config;
+  private TestRestManagementClient backupClient;
+
+  @AfterEach
+  public void tearDown() {
+    CloseHelper.quietCloseAll(restClient, camundaClient, searchContainer);
+  }
+
+  private void setup(final BackupRestoreTestConfig config) throws IOException {
+    final String dbUrl;
+    testStandaloneCamunda = new TestSimpleCamundaApplication();
+    final var configurator = new MultiDbConfigurator(testStandaloneCamunda);
+    searchContainer =
+        switch (config.databaseType) {
+          case ELASTICSEARCH -> {
+            final var container =
+                TestSearchContainers.createDefeaultElasticsearchContainer()
+                    .withStartupTimeout(Duration.ofMinutes(5))
+                    // location of the repository that will be used for snapshots
+                    .withEnv("path.repo", "~/");
+            // container.addFileSystemBind(
+            // repositoryDir.toString(), "~/", BindMode.READ_WRITE, SelinuxContext.SHARED);
+            container.start();
+            dbUrl = "http://" + container.getHttpHostAddress();
+
+            // configure the app
+            configurator.configureElasticsearchSupport(dbUrl, INDEX_PREFIX);
+            yield container;
+          }
+
+          default ->
+              throw new IllegalArgumentException(
+                  "Unsupported database type: " + config.databaseType);
+        };
+    configurator.getOperateProperties().getBackup().setRepositoryName(REPOSITORY_NAME);
+    configurator.getTasklistProperties().getBackup().setRepositoryName(REPOSITORY_NAME);
+
+    this.config = config;
+    testStandaloneCamunda.start().awaitCompleteTopology();
+    backupClient = TestRestManagementClient.of(testStandaloneCamunda);
+    createSearchClient();
+    createRepository();
+  }
+
+  public static Stream<BackupRestoreTestConfig> sources() {
+    final var backupRestoreConfigs = new ArrayList<BackupRestoreTestConfig>();
+    for (final var db : List.of(DatabaseType.ELASTICSEARCH)) {
+      backupRestoreConfigs.add(new BackupRestoreTestConfig(db, "bucket"));
+    }
+    return backupRestoreConfigs.stream();
+  }
+
+  @ParameterizedTest
+  @MethodSource(value = {"sources"})
+  public void shouldBackupAndRestoreToPreviousState(final BackupRestoreTestConfig config)
+      throws IOException, InterruptedException {
+    // given
+    setup(config);
+
+    final var takeResponse = backupClient.takeBackup(1L);
+    assertThat(takeResponse)
+        .extracting(TakeBackupHistoryResponse::getScheduledSnapshots)
+        .asInstanceOf(InstanceOfAssertFactories.LIST)
+        .isNotEmpty();
+    final var snapshots = takeResponse.getScheduledSnapshots();
+
+    Awaitility.await("Backup completed")
+        .atMost(Duration.ofSeconds(600))
+        .untilAsserted(
+            () -> {
+              final var backupResponse = backupClient.getBackup(1L);
+              assertThat(backupResponse.getState()).isEqualTo(BackupStateDto.COMPLETED);
+              assertThat(backupResponse.getDetails()).allMatch(d -> d.getState().equals("SUCCESS"));
+            });
+
+    // then
+    // if we stop all apps and restart elasticsearch
+    testStandaloneCamunda.stop();
+
+    // then
+    deleteAllIndices();
+
+    // restore with a new client is successful
+    restore(snapshots);
+  }
+
+  private void deleteAllIndices() throws IOException {
+    switch (config.databaseType) {
+      case ELASTICSEARCH -> {
+        esClient
+            .indices()
+            .delete(
+                DeleteIndexRequest.of(
+                    b -> b.index(INDEX_PREFIX + "*").expandWildcards(ExpandWildcard.All)));
+      }
+      case OPENSEARCH -> {
+        throw new UnsupportedOperationException("Opensearch is not yet supported");
+      }
+    }
+  }
+
+  public void createSearchClient() {
+    switch (config.databaseType) {
+      case ELASTICSEARCH:
+        final var esContainer = (ElasticsearchContainer) searchContainer;
+        CloseHelper.quietClose(restClient);
+        restClient = RestClient.builder(HttpHost.create(esContainer.getHttpHostAddress())).build();
+
+        esClient =
+            new ElasticsearchClient(new RestClientTransport(restClient, new JacksonJsonpMapper()));
+        break;
+      case OPENSEARCH:
+    }
+  }
+
+  private void createRepository() throws IOException {
+    switch (config.databaseType) {
+      case ELASTICSEARCH -> {
+        final var repository =
+            Repository.of(r -> r.fs(rb -> rb.settings(s -> s.location(REPOSITORY_NAME))));
+        final var response =
+            esClient
+                .snapshot()
+                .createRepository(b -> b.repository(repository).name(REPOSITORY_NAME));
+        assertThat(response.acknowledged()).isTrue();
+      }
+    }
+  }
+
+  private void restore(final Collection<String> snapshots) throws IOException {
+    for (final var snapshot : snapshots) {
+      switch (config.databaseType) {
+        case ELASTICSEARCH -> {
+          final var request =
+              RestoreRequest.of(
+                  rb ->
+                      rb.repository(REPOSITORY_NAME)
+                          .snapshot(snapshot)
+                          .indices("*")
+                          .ignoreUnavailable(true)
+                          .waitForCompletion(true));
+          final var response = esClient.snapshot().restore(request);
+          assertThat(response.snapshot().snapshot()).isEqualTo(snapshot);
+        }
+      }
+    }
+  }
+
+  public record BackupRestoreTestConfig(DatabaseType databaseType, String bucket) {}
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfigurator.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfigurator.java
@@ -139,4 +139,12 @@ public class MultiDbConfigurator {
           cfg.setArgs(Map.of("flushInterval", "0"));
         });
   }
+
+  public OperateProperties getOperateProperties() {
+    return operateProperties;
+  }
+
+  public TasklistProperties getTasklistProperties() {
+    return tasklistProperties;
+  }
 }

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -55,6 +55,10 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>io.camunda</groupId>
@@ -135,6 +139,10 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>webapps-backup</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-elasticsearch-exporter</artifactId>
     </dependency>
     <dependency>
@@ -148,6 +156,18 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.github.openfeign</groupId>
+      <artifactId>feign-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.github.openfeign</groupId>
+      <artifactId>feign-jackson</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/HistoryBackupClient.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/HistoryBackupClient.java
@@ -23,7 +23,7 @@ import io.camunda.webapps.backup.GetBackupStateResponseDto;
 import io.camunda.zeebe.qa.util.cluster.TestApplication;
 import java.util.List;
 
-public interface TestRestManagementClient {
+public interface HistoryBackupClient {
 
   @RequestLine("POST")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
@@ -35,25 +35,25 @@ public interface TestRestManagementClient {
   GetBackupStateResponseDto getBackup(@Param final long id);
 
   /**
-   * Returns a {@link TestRestManagementClient} instance using the given node as upstream.
+   * Returns a {@link HistoryBackupClient} instance using the given node as upstream.
    *
    * @param node the node to connect to
-   * @return a new instance of {@link TestRestManagementClient}
+   * @return a new instance of {@link HistoryBackupClient}
    */
-  static TestRestManagementClient of(final TestApplication<?> node) {
+  static HistoryBackupClient of(final TestApplication<?> node) {
     return of(node.actuatorUri("backupHistory").toString());
   }
 
   /**
-   * Returns a {@link TestRestManagementClient} instance using the given endpoint as upstream. The
+   * Returns a {@link HistoryBackupClient} instance using the given endpoint as upstream. The
    * endpoint is expected to be a complete absolute URL, e.g.
    * "http://localhost:9600/actuator/backups".
    *
    * @param endpoint the actuator URL to connect to
-   * @return a new instance of {@link TestRestManagementClient}
+   * @return a new instance of {@link HistoryBackupClient}
    */
-  static TestRestManagementClient of(final String endpoint) {
-    final var target = new HardCodedTarget<>(TestRestManagementClient.class, endpoint);
+  static HistoryBackupClient of(final String endpoint) {
+    final var target = new HardCodedTarget<>(HistoryBackupClient.class, endpoint);
     final var decoder = new JacksonDecoder(List.of(new Jdk8Module(), new JavaTimeModule()));
 
     return Feign.builder()

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestOperateOpenSearchSchemaManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestOperateOpenSearchSchemaManager.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.cluster;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.operate.conditions.OpensearchCondition;
+import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.schema.opensearch.OpensearchSchemaManager;
+import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component("schemaManager")
+@Conditional(OpensearchCondition.class)
+@Profile("test")
+public class TestOperateOpenSearchSchemaManager extends OpensearchSchemaManager {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(TestOperateOpenSearchSchemaManager.class);
+
+  public TestOperateOpenSearchSchemaManager(
+      final OperateProperties operateProperties,
+      final RichOpenSearchClient richOpenSearchClient,
+      final List<IndexTemplateDescriptor> templateDescriptors,
+      final List<IndexDescriptor> indexDescriptors,
+      final ObjectMapper objectMapper) {
+    super(
+        operateProperties,
+        richOpenSearchClient,
+        templateDescriptors,
+        indexDescriptors,
+        objectMapper);
+  }
+
+  public void deleteSchema() {
+    final String prefix = operateProperties.getElasticsearch().getIndexPrefix();
+    LOGGER.info("Removing indices {}*", prefix);
+    richOpenSearchClient.index().deleteIndicesWithRetries(prefix + "*");
+    LOGGER.info("Removing templates {}*", prefix);
+    richOpenSearchClient.template().deleteTemplatesWithRetries(prefix + "*");
+  }
+
+  public void setCreateSchema(final boolean createSchema) {
+    operateProperties.getOpensearch().setCreateSchema(createSchema);
+  }
+
+  public void setIndexPrefix(final String indexPrefix) {
+    operateProperties.getOpensearch().setIndexPrefix(indexPrefix);
+  }
+
+  public void setDefaultIndexPrefix() {
+    operateProperties.getOpensearch().setDefaultIndexPrefix();
+  }
+}

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestRestManagementClient.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestRestManagementClient.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.cluster;
+
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import feign.Body;
+import feign.Feign;
+import feign.Headers;
+import feign.Param;
+import feign.RequestLine;
+import feign.Retryer;
+import feign.Target.HardCodedTarget;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import io.camunda.management.backups.TakeBackupHistoryResponse;
+import io.camunda.webapps.backup.GetBackupStateResponseDto;
+import io.camunda.zeebe.qa.util.cluster.TestApplication;
+import java.util.List;
+
+public interface TestRestManagementClient {
+
+  @RequestLine("POST")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  @Body("%7B\"backupId\": \"{backupId}\"%7D")
+  TakeBackupHistoryResponse takeBackup(@Param final long backupId);
+
+  @RequestLine("GET /{id}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  GetBackupStateResponseDto getBackup(@Param final long id);
+
+  /**
+   * Returns a {@link TestRestManagementClient} instance using the given node as upstream.
+   *
+   * @param node the node to connect to
+   * @return a new instance of {@link TestRestManagementClient}
+   */
+  static TestRestManagementClient of(final TestApplication<?> node) {
+    return of(node.actuatorUri("backupHistory").toString());
+  }
+
+  /**
+   * Returns a {@link TestRestManagementClient} instance using the given endpoint as upstream. The
+   * endpoint is expected to be a complete absolute URL, e.g.
+   * "http://localhost:9600/actuator/backups".
+   *
+   * @param endpoint the actuator URL to connect to
+   * @return a new instance of {@link TestRestManagementClient}
+   */
+  static TestRestManagementClient of(final String endpoint) {
+    final var target = new HardCodedTarget<>(TestRestManagementClient.class, endpoint);
+    final var decoder = new JacksonDecoder(List.of(new Jdk8Module(), new JavaTimeModule()));
+
+    return Feign.builder()
+        .encoder(new JacksonEncoder())
+        .decoder(decoder)
+        .retryer(Retryer.NEVER_RETRY)
+        .target(target);
+  }
+}

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneCamunda.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneCamunda.java
@@ -316,6 +316,12 @@ public final class TestStandaloneCamunda extends TestSpringApplication<TestStand
     return this;
   }
 
+  public TestStandaloneCamunda withBackupRepository(final String repositoryName) {
+    operateProperties.getBackup().setRepositoryName(repositoryName);
+    tasklistProperties.getBackup().setRepositoryName(repositoryName);
+    return this;
+  }
+
   /**
    * Registers or replaces a new exporter with the given ID. If it was already registered, the
    * existing configuration is passed to the modifier.

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/BackupServiceImpl.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/BackupServiceImpl.java
@@ -8,6 +8,7 @@
 package io.camunda.webapps.backup;
 
 import io.camunda.webapps.backup.BackupException.*;
+import io.camunda.webapps.backup.BackupService.SnapshotRequest;
 import io.camunda.webapps.backup.repository.BackupRepositoryProps;
 import io.camunda.webapps.schema.descriptors.backup.BackupPriorities;
 import io.camunda.webapps.schema.descriptors.backup.SnapshotIndexCollection;
@@ -110,6 +111,8 @@ public class BackupServiceImpl implements BackupService {
       final SnapshotRequest snapshotRequest =
           new SnapshotRequest(repositoryName, snapshotName, indexCollection, metadata);
 
+      LOGGER.debug(
+          "Snapshot part {} contains indices {}", metadata.partNo(), indexCollection.allIndices());
       requestsQueue.offer(snapshotRequest);
       LOGGER.debug("Snapshot scheduled: {}", snapshotName);
       snapshotNames.add(snapshotName);
@@ -142,6 +145,10 @@ public class BackupServiceImpl implements BackupService {
           indices.requiredIndices().stream().filter(idx -> !foundIndices.contains(idx)).toList();
       if (!missingRequiredIndices.isEmpty()) {
         missingIndicesList.addAll(missingRequiredIndices);
+        LOGGER.warn(
+            "Missing required indices:{}. All indices found are {}",
+            missingRequiredIndices,
+            foundIndices);
       }
       // skip this part if there is no index, but they are not required
       if (!foundIndices.isEmpty()) {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/BackupPriorities.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/BackupPriorities.java
@@ -49,9 +49,10 @@ public record BackupPriorities(
     final var indices =
         backups.stream()
             .filter(IndexTemplateDescriptor.class::isInstance)
-            .map(BackupPriority::getFullQualifiedName)
+            .map(IndexTemplateDescriptor.class::cast)
+            .map(IndexTemplateDescriptor::getFullQualifiedName)
             .flatMap(name -> Stream.of(name + "*", "-" + name))
             .toList();
-    return new SnapshotIndexCollection(indices, Collections.emptyList());
+    return new SnapshotIndexCollection(Collections.emptyList(), indices);
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/SnapshotIndexCollection.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/SnapshotIndexCollection.java
@@ -16,6 +16,10 @@ import java.util.stream.Stream;
 
 public record SnapshotIndexCollection(List<String> requiredIndices, List<String> skippableIndices) {
 
+  public boolean isEmpty() {
+    return requiredIndices.isEmpty() && skippableIndices.isEmpty();
+  }
+
   public static <A extends BackupPriority> SnapshotIndexCollection of(
       final Collection<A> backupPriorities) {
     final var required = new ArrayList<String>(backupPriorities.size());


### PR DESCRIPTION
## Description
Add a draft of Backup & Restore tests for standalone camunda, using TestStandaloneCamunda class. Currently no data is being generated yet.

- basic test with ES has been added 
- [bug](https://github.com/camunda/camunda/issues/26618) was fixed when optimize is not deployed: all the optimize indices are not present, hence they are skipped. However, when a snapshot is request with no indices specified, ES/OS interpret it as a request to make a snapshot of all the indices.
This create a "double" backup, which is impossible to restore, since open indices cannot be restored.
As a *temporary* fix, if the indices *required* indices are empty, all indices are requested with the flag `allowUnavailable`. 
However, I don't like this "quick solution", but I'll try to think of something more robust.
- Fix `DatabaseInfo` class to be able to re-initializedd after the `SpringContext` is closed 



## Checklist
- [X] Add complete process instances
- [X] Add user tasks in the process definition
- [x] Depends on #27292 for the tests to pass


## Related issues
relates #25935 #26618
