### PR TITLE
[Backport release-8.7.0-alpha3] ci: make mvn build Tasklist FE by default

### DIFF
--- a/tasklist/pom.xml
+++ b/tasklist/pom.xml
@@ -37,7 +37,7 @@
     <maven.compiler.target>21</maven.compiler.target>
     <maven.compiler.source>21</maven.compiler.source>
 
-    <skip.fe.build>true</skip.fe.build>
+    <skip.fe.build>false</skip.fe.build>
     <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 


### PR DESCRIPTION
# Description
Backport of #26515 to `release-8.7.0-alpha3`.

relates to 
original author: @houssain-barouni