### PR TITLE
fix: allow missing indices when archiving for now

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -180,6 +180,22 @@ final class ElasticsearchArchiverRepositoryIT {
     }
   }
 
+  @Test
+  void shouldNotFailSettingILMOnMissingIndex() throws IOException {
+    // given
+    final var repository = createRepository();
+    final var indexName = UUID.randomUUID().toString();
+    retention.setEnabled(true);
+    retention.setPolicyName("operate_delete_archived_indices");
+    putLifecyclePolicy();
+
+    // when
+    final var result = repository.setIndexLifeCycle(indexName);
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+  }
+
   private IndexSettingsLifecycle getLifeCycle(final String indexName) throws IOException {
     return testClient
         .indices()


### PR DESCRIPTION
## Description

This PR allows bulk updates of index settings (specifically setting the ILM policy for them) even if some of the indices are missing. 

This could be optimized by removing indices if we know nothing was reindex instead, and failing, but we can look into that for a proper fix. Right now the goal is to unblock alpha3 :)

> [!Note]
> No OS changes required because OS does not allow bulk updates anyway, and it also doesn't care if the index doesn't exist, as you create a ISM plugin entry instead of updating the index settings.
