### PR TITLE
[Backport stable/8.4] test: use lowercase GCS bucketname

### DIFF
--- a/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigIT.java
+++ b/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigIT.java
@@ -22,7 +22,8 @@ public class ConfigIT {
   @Test
   void shouldSuccessfullyValidateConfiguration() throws Exception {
     // given
-    final var bucketName = RandomStringUtils.randomAlphabetic(12);
+    // bucketname must be lowercase, see https://cloud.google.com/storage/docs/buckets
+    final var bucketName = RandomStringUtils.randomAlphanumeric(12).toLowerCase();
     final var config =
         new GcsBackupConfig.Builder()
             .withHost(GCS.externalEndpoint())
@@ -42,7 +43,8 @@ public class ConfigIT {
   @Test
   void shouldNotFailValidationIfBucketDoesNotExist() {
     // given
-    final var bucketName = RandomStringUtils.randomAlphabetic(12);
+    // bucketname must be lowercase, see https://cloud.google.com/storage/docs/buckets
+    final var bucketName = RandomStringUtils.randomAlphanumeric(12).toLowerCase();
     final var config =
         new GcsBackupConfig.Builder()
             .withHost(GCS.externalEndpoint())


### PR DESCRIPTION
# Description
Backport of #26538 to `stable/8.4`.

relates to 
original author: @megglos