### PR TITLE
fix: load dev data from classpath

### DIFF
--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/CamundaClientBasedAdapter.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/CamundaClientBasedAdapter.java
@@ -119,7 +119,7 @@ public class CamundaClientBasedAdapter implements TasklistServicesAdapter {
   public void deployResourceWithoutAuthentication(
       final String classpathResource, final String tenantId) {
     final DeployResourceCommandStep2 deployResourceCommandStep2 =
-        camundaClient.newDeployResourceCommand().addResourceFile(classpathResource);
+        camundaClient.newDeployResourceCommand().addResourceFromClasspath(classpathResource);
     if (tenantService.isMultiTenancyEnabled()) {
       deployResourceCommandStep2.tenantId(tenantId);
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Since https://github.com/camunda/camunda/pull/26464
Dev data is not automatically created in **local setup (when zeebe compatibility mode is enabled)** because we are not loading the resource files from the classpath 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
