### PR TITLE
feat: more flexible filters for mappings, groups and tenants

### DIFF
--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
@@ -118,6 +118,12 @@ public class SearchClients
   }
 
   @Override
+  public List<MappingEntity> findAllMappings(final MappingQuery query) {
+    return getSearchExecutor()
+        .findAll(query, io.camunda.webapps.schema.entities.usermanagement.MappingEntity.class);
+  }
+
+  @Override
   public SearchQueryResult<DecisionDefinitionEntity> searchDecisionDefinitions(
       final DecisionDefinitionQuery filter) {
     return getSearchExecutor()
@@ -200,13 +206,21 @@ public class SearchClients
   }
 
   @Override
-  public SearchQueryResult<GroupEntity> searchGroups(final GroupQuery filter) {
-    return new SearchClientBasedQueryExecutor(
-            searchClient,
-            transformers,
-            new DocumentAuthorizationQueryStrategy(this),
-            securityContext)
-        .search(filter, io.camunda.webapps.schema.entities.usermanagement.GroupEntity.class);
+  public List<TenantEntity> findAllTenants(final TenantQuery query) {
+    return getSearchExecutor()
+        .findAll(query, io.camunda.webapps.schema.entities.usermanagement.TenantEntity.class);
+  }
+
+  @Override
+  public SearchQueryResult<GroupEntity> searchGroups(final GroupQuery query) {
+    return getSearchExecutor()
+        .search(query, io.camunda.webapps.schema.entities.usermanagement.GroupEntity.class);
+  }
+
+  @Override
+  public List<GroupEntity> findAllGroups(final GroupQuery query) {
+    return getSearchExecutor()
+        .findAll(query, io.camunda.webapps.schema.entities.usermanagement.GroupEntity.class);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformer.java
@@ -9,6 +9,8 @@ package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.hasChildQuery;
+import static io.camunda.search.clients.query.SearchQueryBuilders.longTerms;
+import static io.camunda.search.clients.query.SearchQueryBuilders.matchNone;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.webapps.schema.descriptors.usermanagement.index.GroupIndex.KEY;
 import static io.camunda.webapps.schema.descriptors.usermanagement.index.GroupIndex.MEMBER_KEY;
@@ -32,10 +34,12 @@ public class GroupFilterTransformer extends IndexFilterTransformer<GroupFilter> 
         term(GroupIndex.JOIN, IdentityJoinRelationshipType.GROUP.getType()),
         filter.groupKey() == null ? null : term(KEY, filter.groupKey()),
         filter.name() == null ? null : term(NAME, filter.name()),
-        filter.memberKey() == null
+        filter.memberKeys() == null
             ? null
-            : hasChildQuery(
-                IdentityJoinRelationshipType.MEMBER.getType(),
-                term(MEMBER_KEY, filter.memberKey())));
+            : filter.memberKeys().isEmpty()
+                ? matchNone()
+                : hasChildQuery(
+                    IdentityJoinRelationshipType.MEMBER.getType(),
+                    longTerms(MEMBER_KEY, filter.memberKeys())));
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/MappingFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/MappingFilterTransformer.java
@@ -8,6 +8,7 @@
 package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.or;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.webapps.schema.descriptors.usermanagement.index.MappingIndex.CLAIM_NAME;
@@ -30,6 +31,14 @@ public class MappingFilterTransformer extends IndexFilterTransformer<MappingFilt
         stringTerms(CLAIM_NAME, filter.claimNames()),
         filter.claimName() == null ? null : term(CLAIM_NAME, filter.claimName()),
         filter.claimValue() == null ? null : term(CLAIM_VALUE, filter.claimValue()),
-        filter.name() == null ? null : term(NAME, filter.name()));
+        filter.name() == null ? null : term(NAME, filter.name()),
+        filter.claims() == null
+            ? null
+            : or(
+                filter.claims().stream()
+                    .map(
+                        claim ->
+                            and(term(CLAIM_NAME, claim.name()), term(CLAIM_VALUE, claim.value())))
+                    .toList()));
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformer.java
@@ -9,6 +9,8 @@ package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.hasChildQuery;
+import static io.camunda.search.clients.query.SearchQueryBuilders.longTerms;
+import static io.camunda.search.clients.query.SearchQueryBuilders.matchNone;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 
 import io.camunda.search.clients.query.SearchQuery;
@@ -28,10 +30,12 @@ public class RoleFilterTransformer extends IndexFilterTransformer<RoleFilter> {
         term(RoleIndex.JOIN, IdentityJoinRelationshipType.ROLE.getType()),
         filter.roleKey() == null ? null : term(RoleIndex.KEY, filter.roleKey()),
         filter.name() == null ? null : term(RoleIndex.NAME, filter.name()),
-        filter.memberKey() == null
+        filter.memberKeys() == null
             ? null
-            : hasChildQuery(
-                IdentityJoinRelationshipType.MEMBER.getType(),
-                term(RoleIndex.MEMBER_KEY, filter.memberKey())));
+            : filter.memberKeys().isEmpty()
+                ? matchNone()
+                : hasChildQuery(
+                    IdentityJoinRelationshipType.MEMBER.getType(),
+                    longTerms(RoleIndex.MEMBER_KEY, filter.memberKeys())));
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantFilterTransformer.java
@@ -10,6 +10,7 @@ package io.camunda.search.clients.transformers.filter;
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.hasChildQuery;
 import static io.camunda.search.clients.query.SearchQueryBuilders.longTerms;
+import static io.camunda.search.clients.query.SearchQueryBuilders.matchNone;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex.KEY;
 import static io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex.NAME;
@@ -36,8 +37,10 @@ public class TenantFilterTransformer extends IndexFilterTransformer<TenantFilter
         filter.name() == null ? null : term(NAME, filter.name()),
         filter.memberKeys() == null
             ? null
-            : hasChildQuery(
-                IdentityJoinRelationshipType.MEMBER.getType(),
-                longTerms(TenantIndex.MEMBER_KEY, filter.memberKeys())));
+            : filter.memberKeys().isEmpty()
+                ? matchNone()
+                : hasChildQuery(
+                    IdentityJoinRelationshipType.MEMBER.getType(),
+                    longTerms(TenantIndex.MEMBER_KEY, filter.memberKeys())));
   }
 }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/MappingQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/MappingQueryTransformerTest.java
@@ -10,10 +10,13 @@ package io.camunda.search.clients.transformers.filter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.query.SearchQueryBuilders;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.MappingFilter;
 import io.camunda.search.filter.MappingFilter.Builder;
+import io.camunda.search.filter.MappingFilter.Claim;
 import io.camunda.util.ObjectBuilder;
+import io.camunda.webapps.schema.descriptors.usermanagement.index.MappingIndex;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -50,6 +53,19 @@ public class MappingQueryTransformerTest extends AbstractTransformerTest {
             SearchQuery.of(q -> q.term(t -> t.field("claimValue").value("foobar")))),
         Arguments.of(
             (Function<Builder, ObjectBuilder<MappingFilter>>) f -> f.name("foobar"),
-            SearchQuery.of(q -> q.term(t -> t.field("name").value("foobar")))));
+            SearchQuery.of(q -> q.term(t -> t.field("name").value("foobar")))),
+        Arguments.of(
+            (Function<Builder, ObjectBuilder<MappingFilter>>)
+                f -> f.claims(List.of(new Claim("c1", "v1"), new Claim("c2", "v2"))),
+            SearchQueryBuilders.or(
+                List.of(
+                    SearchQueryBuilders.and(
+                        List.of(
+                            SearchQueryBuilders.term(MappingIndex.CLAIM_NAME, "c1"),
+                            SearchQueryBuilders.term(MappingIndex.CLAIM_VALUE, "v1"))),
+                    SearchQueryBuilders.and(
+                        List.of(
+                            SearchQueryBuilders.term(MappingIndex.CLAIM_NAME, "c2"),
+                            SearchQueryBuilders.term(MappingIndex.CLAIM_VALUE, "v2")))))));
   }
 }

--- a/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
+++ b/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
@@ -155,6 +155,22 @@ public class RdbmsSearchClient
   }
 
   @Override
+  public List<MappingEntity> findAllMappings(final MappingQuery query) {
+    LOG.debug("[RDBMS Search Client] Search for all mappings: {}", query);
+
+    // search without size boundary to find all items
+    return rdbmsService
+        .getMappingReader()
+        .search(
+            MappingQuery.of(
+                b ->
+                    b.filter(query.filter())
+                        .sort(query.sort())
+                        .page(p -> p.size(Integer.MAX_VALUE))))
+        .items();
+  }
+
+  @Override
   public SearchQueryResult<DecisionDefinitionEntity> searchDecisionDefinitions(
       final DecisionDefinitionQuery query) {
     LOG.debug("[RDBMS Search Client] Search for decisionDefinition: {}", query);
@@ -209,6 +225,22 @@ public class RdbmsSearchClient
   }
 
   @Override
+  public List<GroupEntity> findAllGroups(final GroupQuery query) {
+    LOG.debug("[RDBMS Search Client] Search for all groups: {}", query);
+
+    // search without size boundary to find all items
+    return rdbmsService
+        .getGroupReader()
+        .search(
+            GroupQuery.of(
+                b ->
+                    b.filter(query.filter())
+                        .sort(query.sort())
+                        .page(p -> p.size(Integer.MAX_VALUE))))
+        .items();
+  }
+
+  @Override
   public SearchQueryResult<UserTaskEntity> searchUserTasks(final UserTaskQuery query) {
     final var searchResult =
         rdbmsService
@@ -244,6 +276,22 @@ public class RdbmsSearchClient
     LOG.debug("[RDBMS Search Client] Search for tenants: {}", query);
 
     return rdbmsService.getTenantReader().search(query);
+  }
+
+  @Override
+  public List<TenantEntity> findAllTenants(final TenantQuery query) {
+    LOG.debug("[RDBMS Search Client] Search for all tenants: {}", query);
+
+    // search without size boundary to find all items
+    return rdbmsService
+        .getTenantReader()
+        .search(
+            TenantQuery.of(
+                b ->
+                    b.filter(query.filter())
+                        .sort(query.sort())
+                        .page(p -> p.size(Integer.MAX_VALUE))))
+        .items();
   }
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/GroupSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/GroupSearchClient.java
@@ -11,10 +11,13 @@ import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.SecurityContext;
+import java.util.List;
 
 public interface GroupSearchClient {
 
-  SearchQueryResult<GroupEntity> searchGroups(final GroupQuery filter);
+  SearchQueryResult<GroupEntity> searchGroups(final GroupQuery query);
+
+  List<GroupEntity> findAllGroups(final GroupQuery query);
 
   GroupSearchClient withSecurityContext(SecurityContext securityContext);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/MappingSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/MappingSearchClient.java
@@ -11,10 +11,13 @@ import io.camunda.search.entities.MappingEntity;
 import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.SecurityContext;
+import java.util.List;
 
 public interface MappingSearchClient {
 
   SearchQueryResult<MappingEntity> searchMappings(MappingQuery filter);
+
+  List<MappingEntity> findAllMappings(MappingQuery query);
 
   MappingSearchClient withSecurityContext(SecurityContext securityContext);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/TenantSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/TenantSearchClient.java
@@ -11,9 +11,12 @@ import io.camunda.search.entities.TenantEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.TenantQuery;
 import io.camunda.security.auth.SecurityContext;
+import java.util.List;
 
 public interface TenantSearchClient {
   SearchQueryResult<TenantEntity> searchTenants(TenantQuery filter);
+
+  List<TenantEntity> findAllTenants(TenantQuery query);
 
   TenantSearchClient withSecurityContext(SecurityContext securityContext);
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/GroupFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/GroupFilter.java
@@ -8,13 +8,14 @@
 package io.camunda.search.filter;
 
 import io.camunda.util.ObjectBuilder;
+import java.util.Set;
 
-public record GroupFilter(Long groupKey, String name, Long memberKey) implements FilterBase {
+public record GroupFilter(Long groupKey, String name, Set<Long> memberKeys) implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<GroupFilter> {
     private Long groupKey;
     private String name;
-    private Long memberKey;
+    private Set<Long> memberKeys;
 
     public Builder groupKey(final Long value) {
       groupKey = value;
@@ -27,13 +28,17 @@ public record GroupFilter(Long groupKey, String name, Long memberKey) implements
     }
 
     public Builder memberKey(final Long value) {
-      memberKey = value;
+      return memberKeys(Set.of(value));
+    }
+
+    public Builder memberKeys(final Set<Long> value) {
+      memberKeys = value;
       return this;
     }
 
     @Override
     public GroupFilter build() {
-      return new GroupFilter(groupKey, name, memberKey);
+      return new GroupFilter(groupKey, name, memberKeys);
     }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/MappingFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/MappingFilter.java
@@ -13,7 +13,12 @@ import io.camunda.util.ObjectBuilder;
 import java.util.List;
 
 public record MappingFilter(
-    Long mappingKey, String claimName, List<String> claimNames, String claimValue, String name)
+    Long mappingKey,
+    String claimName,
+    List<String> claimNames,
+    String claimValue,
+    String name,
+    List<Claim> claims)
     implements FilterBase {
   public static final class Builder implements ObjectBuilder<MappingFilter> {
     private Long mappingKey;
@@ -21,6 +26,7 @@ public record MappingFilter(
     private List<String> claimNames;
     private String claimValue;
     private String name;
+    private List<Claim> claims;
 
     public Builder mappingKey(final Long value) {
       mappingKey = value;
@@ -47,9 +53,16 @@ public record MappingFilter(
       return this;
     }
 
+    public Builder claims(final List<Claim> claims) {
+      this.claims = claims;
+      return this;
+    }
+
     @Override
     public MappingFilter build() {
-      return new MappingFilter(mappingKey, claimName, claimNames, claimValue, name);
+      return new MappingFilter(mappingKey, claimName, claimNames, claimValue, name, claims);
     }
   }
+
+  public record Claim(String name, String value) {}
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/RoleFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/RoleFilter.java
@@ -8,16 +8,17 @@
 package io.camunda.search.filter;
 
 import io.camunda.util.ObjectBuilder;
+import java.util.Set;
 
-public record RoleFilter(Long roleKey, String name, Long memberKey) implements FilterBase {
+public record RoleFilter(Long roleKey, String name, Set<Long> memberKeys) implements FilterBase {
   public Builder toBuilder() {
-    return new Builder().roleKey(roleKey).name(name).memberKey(memberKey);
+    return new Builder().roleKey(roleKey).name(name).memberKeys(memberKeys);
   }
 
   public static final class Builder implements ObjectBuilder<RoleFilter> {
     private Long roleKey;
     private String name;
-    private Long memberKey;
+    private Set<Long> memberKeys;
 
     public Builder roleKey(final Long value) {
       roleKey = value;
@@ -29,14 +30,18 @@ public record RoleFilter(Long roleKey, String name, Long memberKey) implements F
       return this;
     }
 
-    public Builder memberKey(final Long value) {
-      memberKey = value;
+    public Builder memberKeys(final Set<Long> value) {
+      memberKeys = value;
       return this;
+    }
+
+    public Builder memberKey(final Long... values) {
+      return memberKeys(Set.of(values));
     }
 
     @Override
     public RoleFilter build() {
-      return new RoleFilter(roleKey, name, memberKey);
+      return new RoleFilter(roleKey, name, memberKeys);
     }
   }
 }

--- a/service/src/main/java/io/camunda/service/GroupServices.java
+++ b/service/src/main/java/io/camunda/service/GroupServices.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 public class GroupServices extends SearchQueryService<GroupServices, GroupQuery, GroupEntity> {
@@ -51,6 +52,14 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
         .searchGroups(query);
   }
 
+  public List<GroupEntity> findAll(final GroupQuery query) {
+    return groupSearchClient
+        .withSecurityContext(
+            securityContextProvider.provideSecurityContext(
+                authentication, Authorization.of(a -> a.group().read())))
+        .findAllGroups(query);
+  }
+
   @Override
   public GroupServices withAuthentication(final Authentication authentication) {
     return new GroupServices(
@@ -72,6 +81,11 @@ public class GroupServices extends SearchQueryService<GroupServices, GroupQuery,
         .items()
         .stream()
         .toList();
+  }
+
+  public List<GroupEntity> getGroupsByMemberKeys(final Set<Long> memberKeys) {
+    return findAll(
+        SearchQueryBuilders.groupSearchQuery().filter(f -> f.memberKeys(memberKeys)).build());
   }
 
   public Optional<GroupEntity> findGroup(final Long groupKey) {

--- a/service/src/main/java/io/camunda/service/MappingServices.java
+++ b/service/src/main/java/io/camunda/service/MappingServices.java
@@ -10,6 +10,7 @@ package io.camunda.service;
 import io.camunda.search.clients.MappingSearchClient;
 import io.camunda.search.entities.MappingEntity;
 import io.camunda.search.exception.NotFoundException;
+import io.camunda.search.filter.MappingFilter.Claim;
 import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
@@ -21,8 +22,12 @@ import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerMappingCreateRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerMappingDeleteRequest;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 
 public class MappingServices
     extends SearchQueryService<MappingServices, MappingQuery, MappingEntity> {
@@ -45,6 +50,14 @@ public class MappingServices
             securityContextProvider.provideSecurityContext(
                 authentication, Authorization.of(a -> a.mapping().read())))
         .searchMappings(query);
+  }
+
+  public List<MappingEntity> findAll(final MappingQuery query) {
+    return mappingSearchClient
+        .withSecurityContext(
+            securityContextProvider.provideSecurityContext(
+                authentication, Authorization.of(a -> a.mapping().read())))
+        .findAllMappings(query);
   }
 
   @Override
@@ -90,6 +103,27 @@ public class MappingServices
 
   public CompletableFuture<MappingRecord> deleteMapping(final long mappingKey) {
     return sendBrokerRequest(new BrokerMappingDeleteRequest().setMappingKey(mappingKey));
+  }
+
+  public List<MappingEntity> getMatchingMappings(final Map<String, Object> claims) {
+    final List<Claim> claimFilters =
+        claims.entrySet().stream()
+            .flatMap(
+                claimEntry ->
+                    flattenClaimValue(claimEntry.getValue())
+                        .map(value -> new Claim(claimEntry.getKey(), value)))
+            .toList();
+    return findAll(MappingQuery.of(q -> q.filter(f -> f.claims(claimFilters))));
+  }
+
+  private static Stream<String> flattenClaimValue(final Object value) {
+    if (value == null) {
+      return Stream.of();
+    }
+    if (value instanceof final Collection<?> collection) {
+      return collection.stream().flatMap(MappingServices::flattenClaimValue);
+    }
+    return Stream.of(String.valueOf(value));
   }
 
   public record MappingDTO(String claimName, String claimValue, String name) {}

--- a/service/src/main/java/io/camunda/service/RoleServices.java
+++ b/service/src/main/java/io/camunda/service/RoleServices.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, RoleEntity> {
@@ -53,6 +54,10 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
   public SearchQueryResult<RoleEntity> getMemberRoles(final long memberKey, final RoleQuery query) {
     return search(
         query.toBuilder().filter(query.filter().toBuilder().memberKey(memberKey).build()).build());
+  }
+
+  public List<RoleEntity> getRolesByMemberKeys(final Set<Long> memberKeys) {
+    return findAll(RoleQuery.of(q -> q.filter(f -> f.memberKeys(memberKeys))));
   }
 
   public List<RoleEntity> findAll(final RoleQuery query) {

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -11,7 +11,6 @@ import io.camunda.search.clients.TenantSearchClient;
 import io.camunda.search.entities.TenantEntity;
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.exception.NotFoundException;
-import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.TenantQuery;
 import io.camunda.security.auth.Authentication;
@@ -27,6 +26,8 @@ import io.camunda.zeebe.gateway.impl.broker.request.tenant.BrokerTenantUpdateReq
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 public class TenantServices extends SearchQueryService<TenantServices, TenantQuery, TenantEntity> {
@@ -49,6 +50,14 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
             securityContextProvider.provideSecurityContext(
                 authentication, Authorization.of(a -> a.tenant().read())))
         .searchTenants(query);
+  }
+
+  public List<TenantEntity> findAll(final TenantQuery query) {
+    return tenantSearchClient
+        .withSecurityContext(
+            securityContextProvider.provideSecurityContext(
+                authentication, Authorization.of(a -> a.tenant().read())))
+        .findAllTenants(query);
   }
 
   @Override
@@ -91,15 +100,11 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
   }
 
   public Collection<TenantEntity> getTenantsByMemberKey(final long memberKey) {
-    return search(
-            TenantQuery.of(
-                queryBuilder ->
-                    queryBuilder
-                        .filter(filterBuilder -> filterBuilder.memberKey(memberKey))
-                        // FIXME: we don't have an easy way to fetch all results, so we use a large
-                        //        limit – 10k tenants ought to be enough for anybody …
-                        .page(SearchQueryPage.of(b -> b.size(10_000)))))
-        .items();
+    return getTenantsByMemberKeys(Set.of(memberKey));
+  }
+
+  public List<TenantEntity> getTenantsByMemberKeys(final Set<Long> memberKeys) {
+    return findAll(TenantQuery.of(q -> q.filter(b -> b.memberKeys(memberKeys))));
   }
 
   public TenantEntity getById(final String tenantId) {
@@ -126,5 +131,9 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
     return tenantEntity;
   }
 
-  public record TenantDTO(Long key, String tenantId, String name) {}
+  public record TenantDTO(Long key, String tenantId, String name) {
+    public static TenantDTO fromEntity(final TenantEntity entity) {
+      return new TenantDTO(entity.key(), entity.tenantId(), entity.name());
+    }
+  }
 }

--- a/service/src/test/java/io/camunda/service/MappingServicesTest.java
+++ b/service/src/test/java/io/camunda/service/MappingServicesTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -18,6 +19,8 @@ import io.camunda.search.clients.MappingSearchClient;
 import io.camunda.search.entities.MappingEntity;
 import io.camunda.search.exception.NotFoundException;
 import io.camunda.search.filter.MappingFilter;
+import io.camunda.search.filter.MappingFilter.Claim;
+import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
@@ -32,6 +35,7 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.MappingIntent;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.assertj.core.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
@@ -155,5 +159,28 @@ public class MappingServicesTest {
     verify(mockBrokerClient).sendRequest(mappingDeleteRequestArgumentCaptor.capture());
     final var request = mappingDeleteRequestArgumentCaptor.getValue();
     assertThat(request.getRequestWriter().getMappingKey()).isEqualTo(1234L);
+  }
+
+  @Test
+  public void getMatchingMappings() {
+    // given
+    final Map<String, Object> claims =
+        Map.of("c1", "v1", "c2", List.of("v2.1", "v2.2"), "c3", 300, "c4", true);
+    // when
+    services.getMatchingMappings(claims);
+    // then
+    final ArgumentCaptor<MappingQuery> queryCaptor = ArgumentCaptor.forClass(MappingQuery.class);
+    verify(client, times(1)).findAllMappings(queryCaptor.capture());
+    final MappingQuery query = queryCaptor.getValue();
+    assertThat(query.filter().claimName()).isNull();
+    assertThat(query.filter().claimValue()).isNull();
+    assertThat(query.filter().name()).isNull();
+    assertThat(query.filter().claims())
+        .containsExactlyInAnyOrder(
+            new Claim("c1", "v1"),
+            new Claim("c2", "v2.1"),
+            new Claim("c2", "v2.2"),
+            new Claim("c3", "300"),
+            new Claim("c4", "true"));
   }
 }


### PR DESCRIPTION
## Description

This PR introduces filters that we're going to use for mapping OAuth tokens.

* search client methods for returning unpaginated results: `findAllMappings()`,  `findAllGroups()`, `findAllTenants()`
* filtering groups and roles by multiple member keys
* filtering mappings by key-value pairs

