### PR TITLE
fix: $exist filter on query builder for dates

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceQueryTest.java
@@ -370,6 +370,36 @@ public class ProcessInstanceAndFlowNodeInstanceQueryTest {
   }
 
   @Test
+  void shouldRetrieveProcessInstancesByExistEndDates() {
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceQuery()
+            .filter(f -> f.endDate(b -> b.exists(true)))
+            .send()
+            .join();
+
+    // then
+    // validate all end dates are not null
+    assertThat(result.items()).allMatch(p -> p.getEndDate() != null);
+  }
+
+  @Test
+  void shouldRetrieveProcessInstancesByNotExistEndDates() {
+    // when
+    final var result =
+        camundaClient
+            .newProcessInstanceQuery()
+            .filter(f -> f.endDate(b -> b.exists(false)))
+            .send()
+            .join();
+
+    // then
+    // validate all end dates are not null
+    assertThat(result.items()).allMatch(p -> p.getEndDate() == null);
+  }
+
+  @Test
   void shouldRetrieveProcessInstancesByEndDateFilterGteLte() {
     // given
     final var pi =

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
@@ -431,20 +431,23 @@ public final class SearchQueryBuilders {
       final var queries = new ArrayList<SearchQuery>();
       SearchRangeQuery.Builder rangeQueryBuilder = null;
       for (final Operation<OffsetDateTime> op : operations) {
-        final var formatted = formatDate(op.value());
         switch (op.operator()) {
-          case EQUALS -> queries.add(term(field, formatted));
-          case NOT_EQUALS -> queries.add(mustNot(term(field, formatted)));
+          case EQUALS -> queries.add(term(field, formatDate(op.value())));
+          case NOT_EQUALS -> queries.add(mustNot(term(field, formatDate(op.value()))));
           case EXISTS -> queries.add(exists(field));
           case NOT_EXISTS -> queries.add(mustNot(exists(field)));
           case GREATER_THAN ->
-              rangeQueryBuilder = buildRangeQuery(rangeQueryBuilder, field, b -> b.gt(formatted));
+              rangeQueryBuilder =
+                  buildRangeQuery(rangeQueryBuilder, field, b -> b.gt(formatDate(op.value())));
           case GREATER_THAN_EQUALS ->
-              rangeQueryBuilder = buildRangeQuery(rangeQueryBuilder, field, b -> b.gte(formatted));
+              rangeQueryBuilder =
+                  buildRangeQuery(rangeQueryBuilder, field, b -> b.gte(formatDate(op.value())));
           case LOWER_THAN ->
-              rangeQueryBuilder = buildRangeQuery(rangeQueryBuilder, field, b -> b.lt(formatted));
+              rangeQueryBuilder =
+                  buildRangeQuery(rangeQueryBuilder, field, b -> b.lt(formatDate(op.value())));
           case LOWER_THAN_EQUALS ->
-              rangeQueryBuilder = buildRangeQuery(rangeQueryBuilder, field, b -> b.lte(formatted));
+              rangeQueryBuilder =
+                  buildRangeQuery(rangeQueryBuilder, field, b -> b.lte(formatDate(op.value())));
           default -> throw unexpectedOperation("Date", op.operator());
         }
       }


### PR DESCRIPTION
## Description

- Previously the date was formatting the Date independent of Filter Option Output,
- If I send exist(true) it has Parse Date Error, once it is a Boolean

Action: 
I just moved the format inside the conditions in order to format only when it is necessary 
- Implement integration tests

## Related issues

closes #26566
