### PR TITLE
[Backport stable/8.5] ci: update zeebe-performance-test link

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -161,7 +161,7 @@ jobs:
     needs:
       - build-zeebe-image
       - build-benchmark-images
-    uses: zeebe-io/zeebe-performance-test/.github/workflows/measure.yaml@main
+    uses: camunda/zeebe-performance-test/.github/workflows/measure.yaml@main
     secrets: inherit
     if: inputs.measure
     with:


### PR DESCRIPTION
# Description
Backport of #26128 to `stable/8.5`.

relates to 
original author: @vthiery