### PR TITLE
feat: rework batch operation update to be run asynchronously

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SearchEngineClient.java
@@ -17,6 +17,11 @@ import java.util.Map;
 public interface SearchEngineClient {
   void createIndex(final IndexDescriptor indexDescriptor, final IndexSettings settings);
 
+  /**
+   * @param indexDescriptor indexDescriptor
+   * @param settings settings
+   * @param create If true, this request cannot replace or update existing index templates.
+   */
   void createIndexTemplate(
       final IndexTemplateDescriptor indexDescriptor,
       final IndexSettings settings,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -133,7 +133,7 @@ public final class BackgroundTaskManagerFactory {
 
   private ReschedulingTask buildBatchOperationUpdateTask() {
     return new ReschedulingTask(
-        new BatchOperationUpdateTask(batchOperationUpdateRepository, logger),
+        new BatchOperationUpdateTask(batchOperationUpdateRepository, logger, executor),
         config.getArchiver().getRolloverBatchSize(),
         config.getArchiver().getDelayBetweenRuns(),
         executor,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepository.java
@@ -9,6 +9,8 @@ package io.camunda.exporter.tasks.batchoperations;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 public interface BatchOperationUpdateRepository extends AutoCloseable {
 
@@ -16,7 +18,7 @@ public interface BatchOperationUpdateRepository extends AutoCloseable {
    * Returns the list of not finished batch operations. We can use endDate field to distinguish
    * finished from running.
    */
-  Collection<String> getNotFinishedBatchOperations();
+  CompletionStage<Collection<String>> getNotFinishedBatchOperations();
 
   /**
    * Counts amount of single operations that are finished (COMPLETED or FAILED state) that are
@@ -26,7 +28,8 @@ public interface BatchOperationUpdateRepository extends AutoCloseable {
    *
    * @param batchOperationIds list of batch operation ids
    */
-  List<OperationsAggData> getFinishedOperationsCount(Collection<String> batchOperationIds);
+  CompletionStage<List<OperationsAggData>> getFinishedOperationsCount(
+      Collection<String> batchOperationIds);
 
   /**
    * Updates the batch operations with the amount of finished operations. Update method additionally
@@ -36,7 +39,7 @@ public interface BatchOperationUpdateRepository extends AutoCloseable {
    * @param documentUpdates
    * @return
    */
-  Integer bulkUpdate(List<DocumentUpdate> documentUpdates);
+  CompletionStage<Integer> bulkUpdate(List<DocumentUpdate> documentUpdates);
 
   /**
    * Represents a specific document store agnostic update to execute.
@@ -50,19 +53,19 @@ public interface BatchOperationUpdateRepository extends AutoCloseable {
   class NoopBatchOperationUpdateRepository implements BatchOperationUpdateRepository {
 
     @Override
-    public Collection<String> getNotFinishedBatchOperations() {
-      return List.of();
+    public CompletionStage<Collection<String>> getNotFinishedBatchOperations() {
+      return CompletableFuture.completedFuture(List.of());
     }
 
     @Override
-    public List<OperationsAggData> getFinishedOperationsCount(
+    public CompletionStage<List<OperationsAggData>> getFinishedOperationsCount(
         final Collection<String> batchOperationIds) {
-      return List.of();
+      return CompletableFuture.completedFuture(List.of());
     }
 
     @Override
-    public Integer bulkUpdate(final List<DocumentUpdate> documentUpdates) {
-      return 0;
+    public CompletionStage<Integer> bulkUpdate(final List<DocumentUpdate> documentUpdates) {
+      return CompletableFuture.completedFuture(0);
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateTask.java
@@ -10,9 +10,12 @@ package io.camunda.exporter.tasks.batchoperations;
 import io.camunda.exporter.tasks.BackgroundTask;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.DocumentUpdate;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.OperationsAggData;
+import io.camunda.zeebe.util.FunctionUtil;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
 import org.slf4j.Logger;
 
 public class BatchOperationUpdateTask implements BackgroundTask {
@@ -21,39 +24,43 @@ public class BatchOperationUpdateTask implements BackgroundTask {
   private final BatchOperationUpdateRepository batchOperationUpdateRepository;
 
   private final Logger logger;
+  private final Executor executor;
 
   public BatchOperationUpdateTask(
-      final BatchOperationUpdateRepository batchOperationUpdateRepository, final Logger logger) {
+      final BatchOperationUpdateRepository batchOperationUpdateRepository,
+      final Logger logger,
+      final Executor executor) {
     this.batchOperationUpdateRepository = batchOperationUpdateRepository;
     this.logger = logger;
+    this.executor = executor;
   }
 
   @Override
   public CompletionStage<Integer> execute() {
+    return batchOperationUpdateRepository
+        .getNotFinishedBatchOperations()
+        .thenComposeAsync(this::updateBatchOperations, executor);
+  }
 
-    final var batchOperationIds = batchOperationUpdateRepository.getNotFinishedBatchOperations();
-
+  private CompletionStage<Integer> updateBatchOperations(
+      final Collection<String> batchOperationIds) {
     if (batchOperationIds.isEmpty()) {
       return CompletableFuture.completedFuture(NO_UPDATES);
     }
 
-    final List<OperationsAggData> finishedSingleOperationsCount =
-        batchOperationUpdateRepository.getFinishedOperationsCount(batchOperationIds);
+    return batchOperationUpdateRepository
+        .getFinishedOperationsCount(batchOperationIds)
+        .thenApplyAsync(this::collectDocumentUpdates, executor)
+        .thenComposeAsync(batchOperationUpdateRepository::bulkUpdate, executor)
+        .thenApplyAsync(
+            FunctionUtil.peek(
+                (updatesCount) -> logger.trace("Updated {} batch operations", updatesCount)));
+  }
 
-    final var documentUpdates =
-        finishedSingleOperationsCount.stream()
-            .map(d -> new DocumentUpdate(d.batchOperationId(), d.finishedOperationsCount()))
-            .toList();
-
-    if (documentUpdates.isEmpty()) {
-      return CompletableFuture.completedFuture(NO_UPDATES);
-    }
-
-    final Integer updatesCount = batchOperationUpdateRepository.bulkUpdate(documentUpdates);
-    logger.trace(
-        "Updated {} batch operations with the following completedOperationsCount {}",
-        updatesCount,
-        documentUpdates);
-    return CompletableFuture.completedFuture(updatesCount);
+  private List<DocumentUpdate> collectDocumentUpdates(
+      final List<OperationsAggData> finishedSingleOperationsCount) {
+    return finishedSingleOperationsCount.stream()
+        .map(d -> new DocumentUpdate(d.batchOperationId(), d.finishedOperationsCount()))
+        .toList();
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/util/ElasticsearchUtil.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/util/ElasticsearchUtil.java
@@ -58,7 +58,6 @@ public class ElasticsearchUtil {
     final var request =
         requestBuilder
             .allowNoIndices(true)
-            .ignoreUnavailable(true)
             .scroll(SCROLL_KEEP_ALIVE)
             .size(SCROLL_PAGE_SIZE)
             .build();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerTest.java
@@ -123,6 +123,7 @@ final class BackgroundTaskManagerTest {
       // then
       assertThat(archiverRepository.isClosed).isTrue();
       assertThat(incidentRepository.isClosed).isTrue();
+      assertThat(batchOperationUpdateRepository.isClosed).isTrue();
     }
 
     @Test
@@ -138,6 +139,15 @@ final class BackgroundTaskManagerTest {
     void shouldNotThrowOnIncidentRepositoryCloseError() {
       // given
       incidentRepository.exception = new RuntimeException("foo");
+
+      // when
+      assertThatCode(taskManager::close).doesNotThrowAnyException();
+    }
+
+    @Test
+    void shouldNotThrowOnBatchOperationUpdateRepositoryCloseError() {
+      // given
+      batchOperationUpdateRepository.exception = new RuntimeException("foo");
 
       // when
       assertThatCode(taskManager::close).doesNotThrowAnyException();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepositoryIT.java
@@ -75,7 +75,11 @@ abstract sealed class BatchOperationUpdateRepositoryIT {
   @BeforeEach
   void beforeEach() {
     Stream.of(batchOperationTemplate, operationTemplate)
-        .forEach(template -> engineClient.createIndexTemplate(template, new IndexSettings(), true));
+        .forEach(
+            template -> {
+              engineClient.createIndexTemplate(template, new IndexSettings(), true);
+              engineClient.createIndex(template, new IndexSettings());
+            });
   }
 
   protected abstract BatchOperationUpdateRepository createRepository();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepositoryIT.java
@@ -28,6 +28,7 @@ import io.camunda.webapps.schema.entities.operation.OperationState;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -50,6 +51,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 abstract sealed class BatchOperationUpdateRepositoryIT {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(BatchOperationUpdateRepositoryIT.class);
+  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
   protected final BatchOperationTemplate batchOperationTemplate;
   protected final OperationTemplate operationTemplate;
   @AutoCloseResource protected final ClientAdapter clientAdapter;
@@ -152,7 +154,10 @@ abstract sealed class BatchOperationUpdateRepositoryIT {
       final var documents = repository.getNotFinishedBatchOperations();
 
       // then
-      assertThat(documents).asInstanceOf(InstanceOfAssertFactories.list(String.class)).isEmpty();
+      assertThat(documents)
+          .succeedsWithin(REQUEST_TIMEOUT)
+          .asInstanceOf(InstanceOfAssertFactories.list(String.class))
+          .isEmpty();
     }
 
     @Test
@@ -168,6 +173,7 @@ abstract sealed class BatchOperationUpdateRepositoryIT {
 
       // then
       assertThat(documents)
+          .succeedsWithin(REQUEST_TIMEOUT)
           .asInstanceOf(InstanceOfAssertFactories.list(String.class))
           .hasSize(1)
           .contains(expected.getId());
@@ -192,6 +198,7 @@ abstract sealed class BatchOperationUpdateRepositoryIT {
       var operationsAggData = repository.getFinishedOperationsCount(List.of());
       // then
       assertThat(operationsAggData)
+          .succeedsWithin(REQUEST_TIMEOUT)
           .asInstanceOf(InstanceOfAssertFactories.list(OperationsAggData.class))
           .isEmpty();
 
@@ -199,6 +206,7 @@ abstract sealed class BatchOperationUpdateRepositoryIT {
       operationsAggData = repository.getFinishedOperationsCount(null);
       // then
       assertThat(operationsAggData)
+          .succeedsWithin(REQUEST_TIMEOUT)
           .asInstanceOf(InstanceOfAssertFactories.list(OperationsAggData.class))
           .isEmpty();
     }
@@ -221,6 +229,7 @@ abstract sealed class BatchOperationUpdateRepositoryIT {
 
       // then
       assertThat(documents)
+          .succeedsWithin(REQUEST_TIMEOUT)
           .asInstanceOf(InstanceOfAssertFactories.list(OperationsAggData.class))
           .hasSize(2)
           .isEqualTo(expected);
@@ -258,7 +267,10 @@ abstract sealed class BatchOperationUpdateRepositoryIT {
           repository.bulkUpdate(List.of(new DocumentUpdate("1", 2), new DocumentUpdate("2", 50)));
 
       // then
-      assertThat(updated).isEqualTo(2);
+      assertThat(updated)
+          .succeedsWithin(REQUEST_TIMEOUT)
+          .asInstanceOf(InstanceOfAssertFactories.type(Integer.class))
+          .isEqualTo(2);
 
       final BatchOperationEntity batchOperationEntity1 = getBatchOperationEntity("1");
       assertThat(batchOperationEntity1.getEndDate()).isNotNull();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateTaskTest.java
@@ -37,7 +37,7 @@ public class BatchOperationUpdateTaskTest {
 
     // then
     assertThat(result)
-        .succeedsWithin(Duration.ZERO)
+        .succeedsWithin(REQUEST_TIMEOUT)
         .asInstanceOf(InstanceOfAssertFactories.type(Integer.class))
         .isEqualTo(0);
   }
@@ -50,7 +50,7 @@ public class BatchOperationUpdateTaskTest {
 
     // then
     assertThat(result)
-        .succeedsWithin(Duration.ZERO)
+        .succeedsWithin(REQUEST_TIMEOUT)
         .asInstanceOf(InstanceOfAssertFactories.type(Integer.class))
         .isEqualTo(0);
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateTaskTest.java
@@ -15,6 +15,9 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
@@ -22,8 +25,10 @@ import org.slf4j.LoggerFactory;
 
 public class BatchOperationUpdateTaskTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(BatchOperationUpdateTaskTest.class);
+  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
   private final TestRepository repository = Mockito.spy(new TestRepository());
-  private final BatchOperationUpdateTask task = new BatchOperationUpdateTask(repository, LOGGER);
+  private final BatchOperationUpdateTask task =
+      new BatchOperationUpdateTask(repository, LOGGER, Runnable::run);
 
   @Test
   void shouldReturnZeroIfNoBatchOperationsFound() {
@@ -31,7 +36,10 @@ public class BatchOperationUpdateTaskTest {
     final var result = task.execute();
 
     // then
-    assertThat(result).succeedsWithin(Duration.ZERO).isEqualTo(0);
+    assertThat(result)
+        .succeedsWithin(Duration.ZERO)
+        .asInstanceOf(InstanceOfAssertFactories.type(Integer.class))
+        .isEqualTo(0);
   }
 
   @Test
@@ -41,7 +49,10 @@ public class BatchOperationUpdateTaskTest {
     final var result = task.execute();
 
     // then
-    assertThat(result).succeedsWithin(Duration.ZERO).isEqualTo(0);
+    assertThat(result)
+        .succeedsWithin(Duration.ZERO)
+        .asInstanceOf(InstanceOfAssertFactories.type(Integer.class))
+        .isEqualTo(0);
   }
 
   @Test
@@ -55,7 +66,10 @@ public class BatchOperationUpdateTaskTest {
     final var result = task.execute();
 
     // then
-    assertThat(result).succeedsWithin(Duration.ZERO).isEqualTo(2);
+    assertThat(result)
+        .succeedsWithin(REQUEST_TIMEOUT)
+        .asInstanceOf(InstanceOfAssertFactories.type(Integer.class))
+        .isEqualTo(2);
     assertThat(repository.documentUpdates).hasSize(2);
     assertThat(repository.documentUpdates)
         .contains(new DocumentUpdate("1", 5L), new DocumentUpdate("2", 6L));
@@ -67,20 +81,20 @@ public class BatchOperationUpdateTaskTest {
     private List<DocumentUpdate> documentUpdates = new ArrayList<>();
 
     @Override
-    public List<String> getNotFinishedBatchOperations() {
-      return batchOperationIds;
+    public CompletionStage<Collection<String>> getNotFinishedBatchOperations() {
+      return CompletableFuture.completedFuture(batchOperationIds);
     }
 
     @Override
-    public List<OperationsAggData> getFinishedOperationsCount(
+    public CompletionStage<List<OperationsAggData>> getFinishedOperationsCount(
         final Collection<String> batchOperationIds) {
-      return finishedOperationsCount;
+      return CompletableFuture.completedFuture(finishedOperationsCount);
     }
 
     @Override
-    public Integer bulkUpdate(final List<DocumentUpdate> documentUpdates) {
+    public CompletionStage<Integer> bulkUpdate(final List<DocumentUpdate> documentUpdates) {
       this.documentUpdates = documentUpdates;
-      return documentUpdates.size();
+      return CompletableFuture.completedFuture(documentUpdates.size());
     }
 
     @Override


### PR DESCRIPTION
## Description

* Reworked batch operation update task to run steps asynchronously
* small fix: when reading data from indices we're failing now, when shards/indices are unavailable. We're keeping `allowNoIndices(true)` as we don't want to get failures on first schema creation.

## Related issues

related with #24084
