### PR TITLE
feat: Opensearch implementation for batch operation update

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManager.java
@@ -44,12 +44,9 @@ public final class BackgroundTaskManager implements CloseableSilently {
         Objects.requireNonNull(archiverRepository, "must specify an archiver repository");
     this.incidentRepository =
         Objects.requireNonNull(incidentRepository, "must specify an incident repository");
-    // TODO enable null check when Opensearch is implemented
-    this.batchOperationUpdateRepository = batchOperationUpdateRepository;
-    //    this.batchOperationUpdateRepository =
-    //        Objects.requireNonNull(
-    //            batchOperationUpdateRepository, "must specify a batch operation update
-    // repository");
+    this.batchOperationUpdateRepository =
+        Objects.requireNonNull(
+            batchOperationUpdateRepository, "must specify a batch operation update repository");
     this.logger = Objects.requireNonNull(logger, "must specify a logger");
     this.executor = Objects.requireNonNull(executor, "must specify an executor");
     this.tasks = Objects.requireNonNull(tasks, "must specify tasks");

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -23,6 +23,7 @@ import io.camunda.exporter.tasks.archiver.ProcessInstancesArchiverJob;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateTask;
 import io.camunda.exporter.tasks.batchoperations.ElasticsearchBatchOperationUpdateRepository;
+import io.camunda.exporter.tasks.batchoperations.OpensearchBatchOperationUpdateRepository;
 import io.camunda.exporter.tasks.incident.ElasticsearchIncidentUpdateRepository;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository;
 import io.camunda.exporter.tasks.incident.IncidentUpdateTask;
@@ -293,8 +294,13 @@ public final class BackgroundTaskManagerFactory {
             logger);
       }
       case OPENSEARCH -> {
-        // TODO
-        yield null;
+        final var connector = new OpensearchConnector(config.getConnect());
+        yield new OpensearchBatchOperationUpdateRepository(
+            connector.createAsyncClient(),
+            executor,
+            batchOperationTemplate.getFullQualifiedName(),
+            operationTemplate.getFullQualifiedName(),
+            logger);
       }
     };
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -65,10 +65,7 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
   private final String indexPrefix;
   private final String processInstanceIndex;
   private final String batchOperationIndex;
-  private final ElasticsearchAsyncClient client;
-  private final Executor executor;
   private final CamundaExporterMetrics metrics;
-  private final Logger logger;
 
   private final CalendarInterval rolloverInterval;
 
@@ -83,16 +80,14 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
       final Executor executor,
       final CamundaExporterMetrics metrics,
       final Logger logger) {
+    super(client, executor, logger);
     this.partitionId = partitionId;
     this.config = config;
     this.retention = retention;
     this.indexPrefix = indexPrefix;
     this.processInstanceIndex = processInstanceIndex;
     this.batchOperationIndex = batchOperationIndex;
-    this.client = client;
-    this.executor = executor;
     this.metrics = metrics;
-    this.logger = logger;
 
     rolloverInterval = mapCalendarInterval(config.getRolloverInterval());
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -34,6 +34,7 @@ import co.elastic.clients.json.JsonData;
 import io.camunda.exporter.config.ExporterConfiguration.ArchiverConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.RetentionConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.util.ElasticsearchRepository;
 import io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
@@ -46,7 +47,8 @@ import java.util.regex.Pattern;
 import javax.annotation.WillCloseWhenClosed;
 import org.slf4j.Logger;
 
-public final class ElasticsearchArchiverRepository implements ArchiverRepository {
+public final class ElasticsearchArchiverRepository extends ElasticsearchRepository
+    implements ArchiverRepository {
   private static final String DATES_AGG = "datesAgg";
   private static final String INSTANCES_AGG = "instancesAgg";
   private static final String DATES_SORTED_AGG = "datesSortedAgg";

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.exporter.config.ExporterConfiguration.ArchiverConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.RetentionConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.util.OpensearchRepository;
 import io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
@@ -49,7 +50,8 @@ import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
 import org.opensearch.client.opensearch.generic.Requests;
 import org.slf4j.Logger;
 
-public final class OpenSearchArchiverRepository implements ArchiverRepository {
+public final class OpenSearchArchiverRepository extends OpensearchRepository
+    implements ArchiverRepository {
   private static final String DATES_AGG = "datesAgg";
   private static final String INSTANCES_AGG = "instancesAgg";
   private static final String DATES_SORTED_AGG = "datesSortedAgg";

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -65,10 +65,7 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
   private final String indexPrefix;
   private final String processInstanceIndex;
   private final String batchOperationIndex;
-  private final OpenSearchAsyncClient client;
-  private final Executor executor;
   private final CamundaExporterMetrics metrics;
-  private final Logger logger;
   private final OpenSearchGenericClient genericClient;
   private final CalendarInterval rolloverInterval;
 
@@ -83,16 +80,14 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
       final Executor executor,
       final CamundaExporterMetrics metrics,
       final Logger logger) {
+    super(client, executor, logger);
     this.partitionId = partitionId;
     this.config = config;
     this.retention = retention;
     this.indexPrefix = indexPrefix;
     this.processInstanceIndex = processInstanceIndex;
     this.batchOperationIndex = batchOperationIndex;
-    this.client = client;
-    this.executor = executor;
     this.metrics = metrics;
-    this.logger = logger;
 
     genericClient = new OpenSearchGenericClient(client._transport(), client._transportOptions());
     rolloverInterval = mapCalendarInterval(config.getRolloverInterval());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/ElasticsearchBatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/ElasticsearchBatchOperationUpdateRepository.java
@@ -43,11 +43,9 @@ public class ElasticsearchBatchOperationUpdateRepository extends ElasticsearchRe
 
   private static final String BATCH_OPERATION_IDAGG_NAME = "batchOperationId";
   private static final Integer RETRY_COUNT = 3;
-  private final ElasticsearchAsyncClient client;
-  private final Executor executor;
+
   private final String batchOperationIndex;
   private final String operationIndex;
-  private final Logger logger;
 
   public ElasticsearchBatchOperationUpdateRepository(
       final ElasticsearchAsyncClient client,
@@ -55,11 +53,10 @@ public class ElasticsearchBatchOperationUpdateRepository extends ElasticsearchRe
       final String batchOperationIndex,
       final String operationIndex,
       final Logger logger) {
-    this.client = client;
-    this.executor = executor;
+
+    super(client, executor, logger);
     this.batchOperationIndex = batchOperationIndex;
     this.operationIndex = operationIndex;
-    this.logger = logger;
   }
 
   @Override
@@ -68,8 +65,7 @@ public class ElasticsearchBatchOperationUpdateRepository extends ElasticsearchRe
         new SearchRequest.Builder()
             .index(batchOperationIndex)
             .query(q -> q.bool(b -> b.mustNot(m -> m.exists(e -> e.field(END_DATE)))));
-    return fetchUnboundedDocumentCollection(
-        client, executor, logger, request, BatchOperationEntity.class, Hit::id);
+    return fetchUnboundedDocumentCollection(request, BatchOperationEntity.class, Hit::id);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/ElasticsearchBatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/ElasticsearchBatchOperationUpdateRepository.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.exporter.tasks.batchoperations;
 
-import static io.camunda.exporter.tasks.util.ElasticsearchUtil.collectBulkErrors;
 import static io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate.END_DATE;
 import static io.camunda.webapps.schema.descriptors.operate.template.OperationTemplate.BATCH_OPERATION_ID;
 import static io.camunda.webapps.schema.entities.operation.OperationState.COMPLETED;
@@ -25,7 +24,7 @@ import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
 import co.elastic.clients.elasticsearch.core.bulk.UpdateOperation;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.json.JsonData;
-import io.camunda.exporter.tasks.util.ElasticsearchUtil;
+import io.camunda.exporter.tasks.util.ElasticsearchRepository;
 import io.camunda.webapps.schema.descriptors.operate.template.OperationTemplate;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
 import java.time.OffsetDateTime;
@@ -39,7 +38,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
 
-public class ElasticsearchBatchOperationUpdateRepository implements BatchOperationUpdateRepository {
+public class ElasticsearchBatchOperationUpdateRepository extends ElasticsearchRepository
+    implements BatchOperationUpdateRepository {
 
   private static final String BATCH_OPERATION_IDAGG_NAME = "batchOperationId";
   private static final Integer RETRY_COUNT = 3;
@@ -68,7 +68,7 @@ public class ElasticsearchBatchOperationUpdateRepository implements BatchOperati
         new SearchRequest.Builder()
             .index(batchOperationIndex)
             .query(q -> q.bool(b -> b.mustNot(m -> m.exists(e -> e.field(END_DATE)))));
-    return ElasticsearchUtil.fetchUnboundedDocumentCollection(
+    return fetchUnboundedDocumentCollection(
         client, executor, logger, request, BatchOperationEntity.class, Hit::id);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/OpensearchBatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/OpensearchBatchOperationUpdateRepository.java
@@ -7,13 +7,12 @@
  */
 package io.camunda.exporter.tasks.batchoperations;
 
-import static io.camunda.exporter.tasks.util.OpensearchUtil.collectBulkErrors;
-import static io.camunda.exporter.tasks.util.OpensearchUtil.fetchUnboundedDocumentCollection;
 import static io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate.END_DATE;
 import static io.camunda.webapps.schema.descriptors.operate.template.OperationTemplate.BATCH_OPERATION_ID;
 import static io.camunda.webapps.schema.entities.operation.OperationState.COMPLETED;
 import static io.camunda.webapps.schema.entities.operation.OperationState.FAILED;
 
+import io.camunda.exporter.tasks.util.OpensearchRepository;
 import io.camunda.webapps.schema.descriptors.operate.template.OperationTemplate;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
 import java.io.IOException;
@@ -40,7 +39,8 @@ import org.opensearch.client.opensearch.core.bulk.UpdateOperation;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.slf4j.Logger;
 
-public class OpensearchBatchOperationUpdateRepository implements BatchOperationUpdateRepository {
+public class OpensearchBatchOperationUpdateRepository extends OpensearchRepository
+    implements BatchOperationUpdateRepository {
 
   private static final String BATCH_OPERATION_IDAGG_NAME = "batchOperationId";
   private static final Integer RETRY_COUNT = 3;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/OpensearchBatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/OpensearchBatchOperationUpdateRepository.java
@@ -44,11 +44,8 @@ public class OpensearchBatchOperationUpdateRepository extends OpensearchReposito
 
   private static final String BATCH_OPERATION_IDAGG_NAME = "batchOperationId";
   private static final Integer RETRY_COUNT = 3;
-  private final OpenSearchAsyncClient client;
-  private final Executor executor;
   private final String batchOperationIndex;
   private final String operationIndex;
-  private final Logger logger;
 
   public OpensearchBatchOperationUpdateRepository(
       final OpenSearchAsyncClient client,
@@ -56,11 +53,9 @@ public class OpensearchBatchOperationUpdateRepository extends OpensearchReposito
       final String batchOperationIndex,
       final String operationIndex,
       final Logger logger) {
-    this.client = client;
-    this.executor = executor;
+    super(client, executor, logger);
     this.batchOperationIndex = batchOperationIndex;
     this.operationIndex = operationIndex;
-    this.logger = logger;
   }
 
   @Override
@@ -69,8 +64,7 @@ public class OpensearchBatchOperationUpdateRepository extends OpensearchReposito
         new SearchRequest.Builder()
             .index(batchOperationIndex)
             .query(q -> q.bool(b -> b.mustNot(m -> m.exists(e -> e.field(END_DATE)))));
-    return fetchUnboundedDocumentCollection(
-        client, executor, logger, request, BatchOperationEntity.class, Hit::id);
+    return fetchUnboundedDocumentCollection(request, BatchOperationEntity.class, Hit::id);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/OpensearchBatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/OpensearchBatchOperationUpdateRepository.java
@@ -75,7 +75,7 @@ public class OpensearchBatchOperationUpdateRepository implements BatchOperationU
 
   @Override
   public CompletionStage<List<OperationsAggData>> getFinishedOperationsCount(
-      final List<String> batchOperationIds) {
+      final Collection<String> batchOperationIds) {
     if (batchOperationIds == null || batchOperationIds.isEmpty()) {
       return CompletableFuture.completedFuture(List.of());
     }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/OpensearchBatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/OpensearchBatchOperationUpdateRepository.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.batchoperations;
+
+import static io.camunda.exporter.tasks.util.OpensearchUtil.collectBulkErrors;
+import static io.camunda.exporter.tasks.util.OpensearchUtil.fetchUnboundedDocumentCollection;
+import static io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate.END_DATE;
+import static io.camunda.webapps.schema.descriptors.operate.template.OperationTemplate.BATCH_OPERATION_ID;
+import static io.camunda.webapps.schema.entities.operation.OperationState.COMPLETED;
+import static io.camunda.webapps.schema.entities.operation.OperationState.FAILED;
+
+import io.camunda.webapps.schema.descriptors.operate.template.OperationTemplate;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.Script;
+import org.opensearch.client.opensearch._types.aggregations.Aggregation;
+import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
+import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.bulk.BulkOperation;
+import org.opensearch.client.opensearch.core.bulk.UpdateOperation;
+import org.opensearch.client.opensearch.core.search.Hit;
+import org.slf4j.Logger;
+
+public class OpensearchBatchOperationUpdateRepository implements BatchOperationUpdateRepository {
+
+  private static final String BATCH_OPERATION_IDAGG_NAME = "batchOperationId";
+  private static final Integer RETRY_COUNT = 3;
+  private final OpenSearchAsyncClient client;
+  private final Executor executor;
+  private final String batchOperationIndex;
+  private final String operationIndex;
+  private final Logger logger;
+
+  public OpensearchBatchOperationUpdateRepository(
+      final OpenSearchAsyncClient client,
+      final Executor executor,
+      final String batchOperationIndex,
+      final String operationIndex,
+      final Logger logger) {
+    this.client = client;
+    this.executor = executor;
+    this.batchOperationIndex = batchOperationIndex;
+    this.operationIndex = operationIndex;
+    this.logger = logger;
+  }
+
+  @Override
+  public CompletionStage<Collection<String>> getNotFinishedBatchOperations() {
+    final var request =
+        new SearchRequest.Builder()
+            .index(batchOperationIndex)
+            .query(q -> q.bool(b -> b.mustNot(m -> m.exists(e -> e.field(END_DATE)))));
+    return fetchUnboundedDocumentCollection(
+        client, executor, logger, request, BatchOperationEntity.class, Hit::id);
+  }
+
+  @Override
+  public CompletionStage<List<OperationsAggData>> getFinishedOperationsCount(
+      final List<String> batchOperationIds) {
+    if (batchOperationIds == null || batchOperationIds.isEmpty()) {
+      return CompletableFuture.completedFuture(List.of());
+    }
+    final var batchOperationIdsValues = batchOperationIds.stream().map(FieldValue::of).toList();
+    final var completedStatesValues =
+        Stream.of(COMPLETED.name(), FAILED.name()).map(FieldValue::of).toList();
+
+    final var batchOperationIdsQ =
+        QueryBuilders.terms()
+            .field(BATCH_OPERATION_ID)
+            .terms(v -> v.value(batchOperationIdsValues))
+            .build()
+            .toQuery();
+
+    final var statesQ =
+        QueryBuilders.terms()
+            .field(OperationTemplate.STATE)
+            .terms(v -> v.value(completedStatesValues))
+            .build()
+            .toQuery();
+
+    final var operationsQ =
+        QueryBuilders.bool().must(batchOperationIdsQ, statesQ).build().toQuery();
+
+    final var aggregation =
+        Aggregation.of(
+            a -> a.terms(t -> t.field(BATCH_OPERATION_ID).size(batchOperationIds.size())));
+
+    final var request =
+        new SearchRequest.Builder()
+            .index(operationIndex)
+            .query(operationsQ)
+            .size(0)
+            .aggregations(BATCH_OPERATION_IDAGG_NAME, aggregation)
+            .build();
+    try {
+      return client.search(request, Void.class).thenApply(this::processAggregations);
+    } catch (final IOException e) {
+      return CompletableFuture.failedFuture(e);
+    }
+  }
+
+  @Override
+  public CompletionStage<Integer> bulkUpdate(final List<DocumentUpdate> documentUpdates) {
+    if (documentUpdates == null || documentUpdates.isEmpty()) {
+      return CompletableFuture.completedFuture(0);
+    }
+    final var updates = documentUpdates.stream().map(this::createUpdateOperation).toList();
+    final var request =
+        new BulkRequest.Builder().operations(updates).source(s -> s.fetch(false)).build();
+    try {
+      return client
+          .bulk(request)
+          .thenCompose(
+              r -> {
+                if (r.errors()) {
+                  return CompletableFuture.failedFuture(collectBulkErrors(r.items()));
+                }
+                return CompletableFuture.completedFuture(r.items().size());
+              });
+    } catch (final IOException e) {
+      return CompletableFuture.failedFuture(e);
+    }
+  }
+
+  private BulkOperation createUpdateOperation(final DocumentUpdate update) {
+    final Map<String, Object> params =
+        Map.of(
+            "operationsFinishedCount",
+            update.finishedOperationsCount(),
+            "endDate",
+            OffsetDateTime.now());
+    return new UpdateOperation.Builder<>()
+        .index(batchOperationIndex)
+        .id(update.id())
+        .retryOnConflict(RETRY_COUNT)
+        .script(getBatchOperationUpdateScript(params))
+        .build()
+        ._toBulkOperation();
+  }
+
+  private Script getBatchOperationUpdateScript(final Map<String, Object> params) {
+    final Map<String, JsonData> parameters =
+        params.entrySet().stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> JsonData.of(e.getValue())));
+    return new Script.Builder()
+        .inline(
+            s ->
+                s.source(
+                        "if (ctx._source.operationsTotalCount <= params.operationsFinishedCount) { "
+                            + "   ctx._source.endDate = params.endDate; "
+                            + "} "
+                            + "ctx._source.operationsFinishedCount = params.operationsFinishedCount;")
+                    .lang("painless")
+                    .params(parameters))
+        .build();
+  }
+
+  private List<OperationsAggData> processAggregations(final SearchResponse<Void> response) {
+    return response
+        .aggregations()
+        .get(BATCH_OPERATION_IDAGG_NAME)
+        .sterms()
+        .buckets()
+        .array()
+        .stream()
+        .map(b -> new OperationsAggData(b.key(), b.docCount()))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public void close() throws Exception {}
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/util/ElasticsearchRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/util/ElasticsearchRepository.java
@@ -27,7 +27,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 
-public class ElasticsearchUtil {
+public class ElasticsearchRepository {
 
   public static final Time SCROLL_KEEP_ALIVE = Time.of(t -> t.time("1m"));
   public static final int SCROLL_PAGE_SIZE = 100;
@@ -37,7 +37,7 @@ public class ElasticsearchUtil {
    * Builder, Class, Function)} to use when you don't care about the source document, meaning you
    * won't be using any deserialization functionality.
    */
-  public static <T> CompletionStage<Collection<T>> fetchUnboundedDocumentCollection(
+  public <T> CompletionStage<Collection<T>> fetchUnboundedDocumentCollection(
       final ElasticsearchAsyncClient client,
       final Executor executor,
       final Logger logger,
@@ -47,14 +47,13 @@ public class ElasticsearchUtil {
         client, executor, logger, requestBuilder, Object.class, transformer);
   }
 
-  public static <TDocument, TResult>
-      CompletionStage<Collection<TResult>> fetchUnboundedDocumentCollection(
-          final ElasticsearchAsyncClient client,
-          final Executor executor,
-          final Logger logger,
-          final SearchRequest.Builder requestBuilder,
-          final Class<TDocument> type,
-          final Function<Hit<TDocument>, TResult> transformer) {
+  public <TDocument, TResult> CompletionStage<Collection<TResult>> fetchUnboundedDocumentCollection(
+      final ElasticsearchAsyncClient client,
+      final Executor executor,
+      final Logger logger,
+      final SearchRequest.Builder requestBuilder,
+      final Class<TDocument> type,
+      final Function<Hit<TDocument>, TResult> transformer) {
     final var request =
         requestBuilder
             .allowNoIndices(true)
@@ -89,7 +88,7 @@ public class ElasticsearchUtil {
             executor);
   }
 
-  private static <TResult, TDocument> CompletionStage<Collection<TDocument>> scrollDocuments(
+  private <TResult, TDocument> CompletionStage<Collection<TDocument>> scrollDocuments(
       final ElasticsearchAsyncClient client,
       final List<Hit<TResult>> hits,
       final String scrollId,
@@ -112,7 +111,7 @@ public class ElasticsearchUtil {
                     client, r.hits().hits(), r.scrollId(), accumulator, transformer, type));
   }
 
-  private static <T> CompletionStage<T> clearScrollOnComplete(
+  private <T> CompletionStage<T> clearScrollOnComplete(
       final ElasticsearchAsyncClient client,
       final Executor executor,
       final Logger logger,
@@ -127,7 +126,7 @@ public class ElasticsearchUtil {
         .thenComposeAsync(Function.identity(), executor);
   }
 
-  private static <T> CompletableFuture<T> clearScroll(
+  private <T> CompletableFuture<T> clearScroll(
       final ElasticsearchAsyncClient client,
       final Executor executor,
       final Logger logger,
@@ -155,7 +154,7 @@ public class ElasticsearchUtil {
         .thenComposeAsync(ignored -> endResult);
   }
 
-  public static Throwable collectBulkErrors(final List<BulkResponseItem> items) {
+  public Throwable collectBulkErrors(final List<BulkResponseItem> items) {
     final var collectedErrors = new ArrayList<String>();
     items.stream()
         .flatMap(item -> Optional.ofNullable(item.error()).stream())

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/util/OpensearchRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/util/OpensearchRepository.java
@@ -26,17 +26,17 @@ import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.slf4j.Logger;
 
-public class OpensearchUtil {
+public class OpensearchRepository {
 
-  private static final Time SCROLL_KEEP_ALIVE = Time.of(t -> t.time("1m"));
-  private static final int SCROLL_PAGE_SIZE = 100;
+  private final Time SCROLL_KEEP_ALIVE = Time.of(t -> t.time("1m"));
+  private final int SCROLL_PAGE_SIZE = 100;
 
   /**
    * Variant of {@link #fetchUnboundedDocumentCollection(OpenSearchAsyncClient, Executor, Logger,
    * SearchRequest.Builder, Class, Function)} to use when you don't care about the source document,
    * meaning you won't be using any deserialization functionality.
    */
-  public static <T> CompletionStage<Collection<T>> fetchUnboundedDocumentCollection(
+  public <T> CompletionStage<Collection<T>> fetchUnboundedDocumentCollection(
       final OpenSearchAsyncClient client,
       final Executor executor,
       final Logger logger,
@@ -46,14 +46,13 @@ public class OpensearchUtil {
         client, executor, logger, requestBuilder, Object.class, transformer);
   }
 
-  public static <TDocument, TResult>
-      CompletionStage<Collection<TResult>> fetchUnboundedDocumentCollection(
-          final OpenSearchAsyncClient client,
-          final Executor executor,
-          final Logger logger,
-          final SearchRequest.Builder requestBuilder,
-          final Class<TDocument> type,
-          final Function<Hit<TDocument>, TResult> transformer) {
+  public <TDocument, TResult> CompletionStage<Collection<TResult>> fetchUnboundedDocumentCollection(
+      final OpenSearchAsyncClient client,
+      final Executor executor,
+      final Logger logger,
+      final SearchRequest.Builder requestBuilder,
+      final Class<TDocument> type,
+      final Function<Hit<TDocument>, TResult> transformer) {
     final var request =
         requestBuilder
             .allowNoIndices(true)
@@ -94,7 +93,7 @@ public class OpensearchUtil {
     }
   }
 
-  private static <T> CompletionStage<T> clearScrollOnComplete(
+  private <T> CompletionStage<T> clearScrollOnComplete(
       final OpenSearchAsyncClient client,
       final Executor executor,
       final Logger logger,
@@ -109,7 +108,7 @@ public class OpensearchUtil {
         .thenComposeAsync(Function.identity(), executor);
   }
 
-  private static <T> CompletableFuture<T> clearScroll(
+  private <T> CompletableFuture<T> clearScroll(
       final OpenSearchAsyncClient client,
       final Executor executor,
       final Logger logger,
@@ -141,7 +140,7 @@ public class OpensearchUtil {
     }
   }
 
-  private static <TResult, TDocument> CompletionStage<Collection<TDocument>> scrollDocuments(
+  private <TResult, TDocument> CompletionStage<Collection<TDocument>> scrollDocuments(
       final OpenSearchAsyncClient client,
       final List<Hit<TResult>> hits,
       final String scrollId,
@@ -168,7 +167,7 @@ public class OpensearchUtil {
     }
   }
 
-  public static Throwable collectBulkErrors(final List<BulkResponseItem> items) {
+  public Throwable collectBulkErrors(final List<BulkResponseItem> items) {
     final var collectedErrors = new ArrayList<String>();
     items.stream()
         .flatMap(item -> Optional.ofNullable(item.error()).stream())

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/util/OpensearchUtil.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/util/OpensearchUtil.java
@@ -57,7 +57,6 @@ public class OpensearchUtil {
     final var request =
         requestBuilder
             .allowNoIndices(true)
-            .ignoreUnavailable(true)
             .scroll(SCROLL_KEEP_ALIVE)
             .size(SCROLL_PAGE_SIZE)
             .build();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/util/OpensearchUtil.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/util/OpensearchUtil.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.util;
+
+import io.camunda.zeebe.exporter.api.ExporterException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch._types.ErrorCause;
+import org.opensearch.client.opensearch._types.Time;
+import org.opensearch.client.opensearch.core.ClearScrollRequest;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
+import org.opensearch.client.opensearch.core.search.Hit;
+import org.slf4j.Logger;
+
+public class OpensearchUtil {
+
+  private static final Time SCROLL_KEEP_ALIVE = Time.of(t -> t.time("1m"));
+  private static final int SCROLL_PAGE_SIZE = 100;
+
+  /**
+   * Variant of {@link #fetchUnboundedDocumentCollection(OpenSearchAsyncClient, Executor, Logger,
+   * SearchRequest.Builder, Class, Function)} to use when you don't care about the source document,
+   * meaning you won't be using any deserialization functionality.
+   */
+  public static <T> CompletionStage<Collection<T>> fetchUnboundedDocumentCollection(
+      final OpenSearchAsyncClient client,
+      final Executor executor,
+      final Logger logger,
+      final SearchRequest.Builder requestBuilder,
+      final Function<Hit<Object>, T> transformer) {
+    return fetchUnboundedDocumentCollection(
+        client, executor, logger, requestBuilder, Object.class, transformer);
+  }
+
+  public static <TDocument, TResult>
+      CompletionStage<Collection<TResult>> fetchUnboundedDocumentCollection(
+          final OpenSearchAsyncClient client,
+          final Executor executor,
+          final Logger logger,
+          final SearchRequest.Builder requestBuilder,
+          final Class<TDocument> type,
+          final Function<Hit<TDocument>, TResult> transformer) {
+    final var request =
+        requestBuilder
+            .allowNoIndices(true)
+            .ignoreUnavailable(true)
+            .scroll(SCROLL_KEEP_ALIVE)
+            .size(SCROLL_PAGE_SIZE)
+            .build();
+
+    try {
+      return client
+          .search(request, type)
+          .thenComposeAsync(
+              r -> {
+                try {
+                  return clearScrollOnComplete(
+                      client,
+                      executor,
+                      logger,
+                      r.scrollId(),
+                      scrollDocuments(
+                          client,
+                          r.hits().hits(),
+                          r.scrollId(),
+                          new ArrayList<>(),
+                          transformer,
+                          type));
+                } catch (final Exception e) {
+                  // scrollDocuments may fail, in which case we still want to clear the scroll
+                  // anyway
+                  // we don't need to do this later on however, since at this point our async
+                  // pipeline
+                  // is set up already to clear it
+                  return clearScroll(client, executor, logger, r.scrollId(), null, e);
+                }
+              },
+              executor);
+    } catch (final Exception e) {
+      return CompletableFuture.failedFuture(e);
+    }
+  }
+
+  private static <T> CompletionStage<T> clearScrollOnComplete(
+      final OpenSearchAsyncClient client,
+      final Executor executor,
+      final Logger logger,
+      final String scrollId,
+      final CompletionStage<T> scrollOperation) {
+    return scrollOperation
+        // we combine `handleAsync` and `thenComposeAsync` to emulate the behavior of a try/finally
+        // so we always clear the scroll even if the future is already failed
+        .handleAsync(
+            (result, error) -> clearScroll(client, executor, logger, scrollId, result, error),
+            executor)
+        .thenComposeAsync(Function.identity(), executor);
+  }
+
+  private static <T> CompletableFuture<T> clearScroll(
+      final OpenSearchAsyncClient client,
+      final Executor executor,
+      final Logger logger,
+      final String scrollId,
+      final T result,
+      final Throwable error) {
+    final var request = new ClearScrollRequest.Builder().scrollId(scrollId).build();
+    final CompletionStage<T> endResult =
+        error != null
+            ? CompletableFuture.failedFuture(error)
+            : CompletableFuture.completedFuture(result);
+    try {
+      return client
+          .clearScroll(request)
+          .exceptionallyAsync(
+              clearError -> {
+                logger.warn(
+                    """
+                        Failed to clear scroll context; this could eventually lead to \
+                        increased resource usage in Elastic""",
+                    clearError);
+
+                return null;
+              },
+              executor)
+          .thenComposeAsync(ignored -> endResult);
+    } catch (final Exception e) {
+      return CompletableFuture.failedFuture(e);
+    }
+  }
+
+  private static <TResult, TDocument> CompletionStage<Collection<TDocument>> scrollDocuments(
+      final OpenSearchAsyncClient client,
+      final List<Hit<TResult>> hits,
+      final String scrollId,
+      final List<TDocument> accumulator,
+      final Function<Hit<TResult>, TDocument> transformer,
+      final Class<TResult> type) {
+    if (hits.isEmpty()) {
+      return CompletableFuture.completedFuture(accumulator);
+    }
+
+    for (final var hit : hits) {
+      accumulator.add(transformer.apply(hit));
+    }
+
+    try {
+      return client
+          .scroll(r -> r.scrollId(scrollId).scroll(SCROLL_KEEP_ALIVE), type)
+          .thenComposeAsync(
+              r ->
+                  scrollDocuments(
+                      client, r.hits().hits(), r.scrollId(), accumulator, transformer, type));
+    } catch (final Exception e) {
+      return CompletableFuture.failedFuture(e);
+    }
+  }
+
+  public static Throwable collectBulkErrors(final List<BulkResponseItem> items) {
+    final var collectedErrors = new ArrayList<String>();
+    items.stream()
+        .flatMap(item -> Optional.ofNullable(item.error()).stream())
+        .collect(Collectors.groupingBy(ErrorCause::type))
+        .forEach(
+            (type, errors) ->
+                collectedErrors.add(
+                    String.format(
+                        "Failed to update %d item(s) of bulk update [type: %s, reason: %s]",
+                        errors.size(), type, errors.getFirst().reason())));
+
+    return new ExporterException("Failed to flush bulk request: " + collectedErrors);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepositoryIT.java
@@ -48,7 +48,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 @AutoCloseResources
-abstract sealed class BatchOperationUpdateRepositoryIT {
+abstract class BatchOperationUpdateRepositoryIT {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(BatchOperationUpdateRepositoryIT.class);
   private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
@@ -80,8 +80,12 @@ abstract sealed class BatchOperationUpdateRepositoryIT {
 
   protected abstract BatchOperationUpdateRepository createRepository();
 
-  protected abstract void indexBatchOperation(BatchOperationEntity batchOperationEntity)
-      throws PersistenceException;
+  protected void indexBatchOperation(final BatchOperationEntity batchOperationEntity)
+      throws PersistenceException {
+    final var batchRequest = clientAdapter.createBatchRequest();
+    batchRequest.add(batchOperationTemplate.getFullQualifiedName(), batchOperationEntity);
+    batchRequest.executeWithRefresh();
+  }
 
   protected abstract BatchOperationEntity getBatchOperationEntity(final String id);
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepositoryIT.java
@@ -145,8 +145,6 @@ abstract class BatchOperationUpdateRepositoryIT {
     }
   }
 
-  // TODO OpenSearchIT
-
   @Nested
   final class GetNotFinishedBatchOperationsTest {
     @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/ElasticsearchBatchOperationUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/ElasticsearchBatchOperationUpdateRepositoryIT.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.batchoperations;
+
+import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import io.camunda.search.connect.es.ElasticsearchConnector;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.util.concurrent.ExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+
+final class ElasticsearchBatchOperationUpdateRepositoryIT extends BatchOperationUpdateRepositoryIT {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ElasticsearchBatchOperationUpdateRepositoryIT.class);
+
+  @Container
+  private static final ElasticsearchContainer CONTAINER =
+      TestSearchContainers.createDefeaultElasticsearchContainer();
+
+  private final ElasticsearchAsyncClient client;
+
+  public ElasticsearchBatchOperationUpdateRepositoryIT() {
+    super("http://" + CONTAINER.getHttpHostAddress(), true);
+    final var connector = new ElasticsearchConnector(config.getConnect());
+    client = connector.createAsyncClient();
+  }
+
+  @Override
+  protected ElasticsearchBatchOperationUpdateRepository createRepository() {
+    return new ElasticsearchBatchOperationUpdateRepository(
+        client,
+        Runnable::run,
+        batchOperationTemplate.getFullQualifiedName(),
+        operationTemplate.getFullQualifiedName(),
+        LOGGER);
+  }
+
+  @Override
+  protected BatchOperationEntity getBatchOperationEntity(final String id) {
+    try {
+      return client
+          .get(
+              r -> r.index(batchOperationTemplate.getFullQualifiedName()).id(id),
+              BatchOperationEntity.class)
+          .get()
+          .source();
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    } catch (final ExecutionException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/OpensearchBatchOperationUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/OpensearchBatchOperationUpdateRepositoryIT.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.batchoperations;
+
+import io.camunda.search.connect.os.OpensearchConnector;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.testcontainers.OpensearchContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.junit.jupiter.Container;
+
+final class OpensearchBatchOperationUpdateRepositoryIT extends BatchOperationUpdateRepositoryIT {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(OpensearchBatchOperationUpdateRepositoryIT.class);
+
+  @Container
+  private static final OpensearchContainer<?> CONTAINER =
+      TestSearchContainers.createDefaultOpensearchContainer();
+
+  private final OpenSearchAsyncClient client;
+
+  public OpensearchBatchOperationUpdateRepositoryIT() {
+    super(CONTAINER.getHttpHostAddress(), false);
+    final var connector = new OpensearchConnector(config.getConnect());
+    client = connector.createAsyncClient();
+  }
+
+  @Override
+  protected OpensearchBatchOperationUpdateRepository createRepository() {
+    return new OpensearchBatchOperationUpdateRepository(
+        client,
+        Runnable::run,
+        batchOperationTemplate.getFullQualifiedName(),
+        operationTemplate.getFullQualifiedName(),
+        LOGGER);
+  }
+
+  @Override
+  protected BatchOperationEntity getBatchOperationEntity(final String id) {
+    try {
+      return client
+          .get(
+              r -> r.index(batchOperationTemplate.getFullQualifiedName()).id(id),
+              BatchOperationEntity.class)
+          .get()
+          .source();
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    } catch (final ExecutionException | IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
* implement batch operation update task for Opensearch
* create `OpensearchUtil` class for reusable code
* refactor [ElasticsearchBatchOperationUpdateRepositoryIT.java](https://github.com/camunda/camunda/compare/sd-batch-operations-finished-count-3...sd-batch-operations-finished-count-4?expand=1#diff-a012648004449d5dd1e3165862bba31be979636acaad87ea41ac9ae1004ac615) to extract Opensearch and Elasticsearch static inner classes, similar to commit 718960d7f1333797fce5fe10b08a3fc973079473

## Related issues

closes #24084
