### PR TITLE
ci: adapt to breaking changes of slackapi/slack-github-action

### DIFF
--- a/.github/workflows/camunda-helm-integration.yml
+++ b/.github/workflows/camunda-helm-integration.yml
@@ -38,15 +38,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [helm-deploy]
     if: ${{ always() }}
-    env:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:
       - id: slack-notify-failure
         name: Send failure slack notification
         uses: slackapi/slack-github-action@v2.0.0
         if: ${{ always() && needs.helm-deploy.result != 'success' }}
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
             {

--- a/.github/workflows/camunda-platform-release-main-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-main-dry-run.yml
@@ -36,15 +36,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ dry-run-release ]
     if: ${{ github.event_name == 'schedule' }}
-    env:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:
       - id: slack-notify-failure
         name: Send failure slack notification
         uses: slackapi/slack-github-action@v2.0.0
         if: ${{ always() && needs.dry-run-release.result != 'success' }}
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
             {
@@ -70,6 +69,8 @@ jobs:
         uses: slackapi/slack-github-action@v2.0.0
         if: ${{ always() && needs.dry-run-release.result == 'success' }}
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
             {

--- a/.github/workflows/camunda-platform-release-manual.yml
+++ b/.github/workflows/camunda-platform-release-manual.yml
@@ -54,6 +54,8 @@ jobs:
         name: Send slack notification
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
             {
@@ -75,6 +77,3 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/critical-issue.yml
+++ b/.github/workflows/critical-issue.yml
@@ -19,6 +19,8 @@ jobs:
         name: Send slack notification
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
             {
@@ -39,6 +41,3 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/dispatch-release-8-3.yaml
+++ b/.github/workflows/dispatch-release-8-3.yaml
@@ -27,6 +27,8 @@ jobs:
         name: Send slack notification
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
             {
@@ -41,9 +43,6 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
   notify-if-failed:
     name: Send slack notification on failure
     runs-on: ubuntu-latest
@@ -56,6 +55,8 @@ jobs:
         name: Send slack notification
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
             {
@@ -77,6 +78,3 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/dispatch-release-8-4.yaml
+++ b/.github/workflows/dispatch-release-8-4.yaml
@@ -27,6 +27,8 @@ jobs:
         name: Send slack notification
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
             {
@@ -41,9 +43,6 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
   notify-if-failed:
     name: Send slack notification on failure
     runs-on: ubuntu-latest
@@ -56,6 +55,8 @@ jobs:
         name: Send slack notification
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
             {
@@ -77,6 +78,3 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/dispatch-release-8-5.yaml
+++ b/.github/workflows/dispatch-release-8-5.yaml
@@ -27,6 +27,8 @@ jobs:
         name: Send slack notification
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
             {
@@ -41,9 +43,6 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
   notify-if-failed:
     name: Send slack notification on failure
     runs-on: ubuntu-latest
@@ -56,6 +55,8 @@ jobs:
         name: Send slack notification
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
             {
@@ -77,6 +78,3 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/dispatch-release-8-6.yaml
+++ b/.github/workflows/dispatch-release-8-6.yaml
@@ -28,6 +28,8 @@ jobs:
         name: Send slack notification
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
             {
@@ -42,9 +44,6 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
   notify-if-failed:
     name: Send slack notification on failure
     runs-on: ubuntu-latest
@@ -57,6 +56,8 @@ jobs:
         name: Send slack notification
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
             {
@@ -78,6 +79,3 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/dispatch-release-8-7.yaml
+++ b/.github/workflows/dispatch-release-8-7.yaml
@@ -28,6 +28,8 @@ jobs:
         name: Send slack notification
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
             {
@@ -42,9 +44,6 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
   notify-if-failed:
     name: Send slack notification on failure
     runs-on: ubuntu-latest
@@ -57,6 +56,8 @@ jobs:
         name: Send slack notification
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
             {
@@ -78,6 +79,3 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/java-client-issue.yaml
+++ b/.github/workflows/java-client-issue.yaml
@@ -14,6 +14,8 @@ jobs:
         name: Send slack notification to DevEx
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_DEVEX_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
             {
@@ -34,6 +36,3 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEVEX_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/operate-ci-test-reusable.yml
+++ b/.github/workflows/operate-ci-test-reusable.yml
@@ -108,9 +108,9 @@ jobs:
       - name: Send Slack notification on failure
         if: failure()
         uses: slackapi/slack-github-action@v2.0.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.OPERATE_CI_ALERT_WEBHOOK_URL }}
         with:
+          webhook: ${{ steps.secrets.outputs.OPERATE_CI_ALERT_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "workflow_name": "${{ github.workflow }}",

--- a/.github/workflows/operate-release-reusable.yml
+++ b/.github/workflows/operate-release-reusable.yml
@@ -283,9 +283,9 @@ jobs:
       - name: Send Slack notification on failure
         if: failure()
         uses: slackapi/slack-github-action@v2.0.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.OPERATE_CI_ALERT_WEBHOOK_URL }}
         with:
+          webhook: ${{ steps.secrets.outputs.OPERATE_CI_ALERT_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "workflow_name": "${{ github.workflow }}",

--- a/.github/workflows/operate-run-tests.yml
+++ b/.github/workflows/operate-run-tests.yml
@@ -58,9 +58,9 @@ jobs:
       - name: Send Slack notification on failure
         if: failure()
         uses: slackapi/slack-github-action@v2.0.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.OPERATE_CI_ALERT_WEBHOOK_URL }}
         with:
+          webhook: ${{ steps.secrets.outputs.OPERATE_CI_ALERT_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "workflow_name": "${{ github.workflow }}",

--- a/.github/workflows/optimize-health-status-report.yml
+++ b/.github/workflows/optimize-health-status-report.yml
@@ -48,7 +48,8 @@ jobs:
       - name: Send report to slack channel
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
-          channel-id: "#optimize-status"
-          slack-message: ${{ steps.get-report.outputs.infra_report }}
-        env:
-          SLACK_BOT_TOKEN: ${{ steps.secrets.outputs.SLACK_API_KEY }}
+          method: chat.postMessage
+          token: ${{ steps.secrets.outputs.SLACK_API_KEY }}
+          payload: |
+            channel: "#optimize-status"
+            text: ${{ steps.get-report.outputs.infra_report }}

--- a/.github/workflows/tasklist-backup-restore-tests-reusable.yml
+++ b/.github/workflows/tasklist-backup-restore-tests-reusable.yml
@@ -83,9 +83,9 @@ jobs:
       - name: Send Slack notification on failure
         if: failure()
         uses: slackapi/slack-github-action@v2.0.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.TASKLIST_CI_ALERT_WEBHOOK_URL }}
         with:
+          webhook: ${{ steps.secrets.outputs.TASKLIST_CI_ALERT_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "workflow_name": "Backup and restore tests",

--- a/.github/workflows/update-identity.yml
+++ b/.github/workflows/update-identity.yml
@@ -62,14 +62,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ update-identity ]
     if: ${{ failure() && inputs.dryRun == false }}
-    env:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:
       - id: slack-notify-failure
         name: Send failure slack notification
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
             {

--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -59,15 +59,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ dry-run-release-83, dry-run-release-84, dry-run-release-85, dry-run-release-86 ]
     if: ${{ always() }}
-    env:
-      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:
       - id: slack-notify-failure
         name: Send failure slack notification
         uses: slackapi/slack-github-action@v2.0.0
         if: ${{ always() && (needs.dry-run-release-83.result != 'success' || needs.dry-run-release-84.result != 'success' || needs.dry-run-release-85.result != 'success' || needs.dry-run-release-86.result != 'success') }}
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
             {
@@ -93,6 +92,8 @@ jobs:
         uses: slackapi/slack-github-action@v2.0.0
         if: ${{ always() && needs.dry-run-release-83.result == 'success' && needs.dry-run-release-84.result == 'success' && needs.dry-run-release-85.result == 'success' && needs.dry-run-release-86.result == 'success' }}
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
             {

--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -130,6 +130,8 @@ jobs:
       - id: slack-notify
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
             {
@@ -150,6 +152,3 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
## Description

After https://github.com/camunda/camunda/pull/26554 got merged all slack-github-action calls broke.

See breaking changes https://github.com/slackapi/slack-github-action/releases/tag/v2.0.0
and this thread https://camunda.slack.com/archives/C071KP5BTHB/p1736268841614739
