### PR TITLE
fix: c8run version bumps for 8.7.0-alpha3-rc5

### DIFF
--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -85,7 +85,7 @@ jobs:
         working-directory: ./c8run/e2e_tests
 
       - name: Wait for camunda process to start
-        run: bash -c 'while ! curl -s -f "http://localhost:8080/operate/login"; do sleep 5; done'
+        run: bash -c 'while ! curl -s -f "http://localhost:9600/actuator/health"; do sleep 5; done'
         timeout-minutes: 5
 
       - name: Run Playwright tests

--- a/c8run/e2e_tests/api_tests.sh
+++ b/c8run/e2e_tests/api_tests.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-printf "\nTest: Authenticate\n"
-curl -f --request POST 'http://localhost:8080/api/login?username=demo&password=demo' \
-   --cookie-jar cookie.txt
-
-returnCode=$?
-
-if [[ "$returnCode" != 0 ]]; then
-   echo "test failed"
-   exit 1
-fi
+# printf "\nTest: Authenticate\n"
+# curl -udemo:demo -f --request POST 'http://localhost:8080/api/login?username=demo&password=demo' \
+#    --cookie-jar cookie.txt
+#
+# returnCode=$?
+#
+# if [[ "$returnCode" != 0 ]]; then
+#    echo "test failed"
+#    exit 1
+# fi
 
 
 # printf "\nTest: Operate process instance api\n"
@@ -33,7 +33,7 @@ fi
 
 
 printf "\nTest: Tasklist user task\n"
-curl -f -L -X POST 'http://localhost:8080/v2/user-tasks/search' --cookie cookie.txt \
+curl -udemo:demo -f -L -X POST 'http://localhost:8080/v2/user-tasks/search' --cookie cookie.txt \
 -H 'Content-Type: application/json' \
 -H 'Accept: application/json' \
 --data-raw '{}'
@@ -47,7 +47,7 @@ fi
 
 
 printf "\nTest: Zeebe topology endpoint\n"
-curl -f --cookie  cookie.txt  localhost:8080/v2/topology
+curl -udemo:demo -f --cookie  cookie.txt  localhost:8080/v2/topology
 
 returnCode=$?
 if [[ "$returnCode" != 0 ]]; then

--- a/c8run/e2e_tests/playwright.config.ts
+++ b/c8run/e2e_tests/playwright.config.ts
@@ -28,6 +28,10 @@ export default defineConfig({
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
+    httpCredentials: {
+      username: 'demo',
+      password: 'demo',
+    }
   },
 
   /* Configure projects for major browsers */

--- a/c8run/e2e_tests/tests/operate_login.spec.ts
+++ b/c8run/e2e_tests/tests/operate_login.spec.ts
@@ -3,11 +3,6 @@ const playwright = require('playwright');
 
 test('test', async ({ page }) => {
   test.setTimeout(60000);
-  await page.goto('http://localhost:8080/operate/login');
-  await page.getByPlaceholder('Username').click();
-  await page.getByPlaceholder('Username').fill('demo');
-  await page.getByPlaceholder('Username').press('Tab');
-  await page.getByPlaceholder('Password').fill('demo');
-  await page.getByRole('button', { name: 'Login' }).click();
+  await page.goto('http://localhost:8080/operate');
   await page.getByRole('link', { name: 'Processes' }).click();
 });

--- a/c8run/e2e_tests/tests/tasklist_login.spec.ts
+++ b/c8run/e2e_tests/tests/tasklist_login.spec.ts
@@ -3,12 +3,7 @@ const playwright = require('playwright');
 
 test('test', async ({ page }) => {
   test.setTimeout(60000);
-  await page.goto('http://localhost:8080/tasklist/login');
-  await page.getByPlaceholder('Username').click();
-  await page.getByPlaceholder('Username').fill('demo');
-  await page.getByPlaceholder('Username').press('Tab');
-  await page.getByPlaceholder('Password').fill('demo');
-  await page.getByRole('button', { name: 'Login' }).click();
+  await page.goto('http://localhost:8080/tasklist');
   await page.getByLabel('Expand to show filters', { exact: true }).click();
   await page.getByRole('link', { name: 'Assigned to me' }).click();
 });

--- a/c8run/internal/archive/archive.go
+++ b/c8run/internal/archive/archive.go
@@ -17,7 +17,7 @@ import (
 const OpenFlagsForWriting = os.O_RDWR | os.O_CREATE | os.O_TRUNC
 const ReadWriteMode = 0755
 
-func DownloadFile(filepath string, url string) error {
+func DownloadFile(filepath string, url string, authToken string) error {
 	// if the file already exists locally, don't download a new copy
 	_, err := os.Stat(filepath)
 	if !errors.Is(err, os.ErrNotExist) {
@@ -30,7 +30,16 @@ func DownloadFile(filepath string, url string) error {
 	}
 	defer out.Close()
 
-	resp, err := http.Get(url)
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("DownloadFile: failed to create request for url: %s\n%w\n%s", url)
+	}
+	if authToken != "" {
+		req.Header.Add("Authorization", "Bearer "+authToken)
+	}
+
+	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("DownloadFile: failed to download from url: %s\n%w\n%s", url, err, debug.Stack())
 	}

--- a/c8run/main.go
+++ b/c8run/main.go
@@ -197,7 +197,7 @@ func main() {
 	baseDir, _ := os.Getwd()
 	parentDir := baseDir
 	elasticsearchVersion := "8.13.4"
-	camundaVersion := "8.7.0-alpha2"
+	camundaVersion := "8.7.0-alpha3-rc4"
 	connectorsVersion := "8.7.0-alpha2.1"
 	composeTag := "8.7-alpha2"
 	composeExtractedFolder := "camunda-platform-8.7-alpha2"

--- a/c8run/main.go
+++ b/c8run/main.go
@@ -197,10 +197,10 @@ func main() {
 	baseDir, _ := os.Getwd()
 	parentDir := baseDir
 	elasticsearchVersion := "8.13.4"
-	camundaVersion := "8.7.0-alpha3"
-	connectorsVersion := "8.7.0-alpha3"
-	composeTag := "8.7-alpha3"
-	composeExtractedFolder := "camunda-platform-8.7-alpha3"
+	camundaVersion := "8.7.0-alpha2"
+	connectorsVersion := "8.7.0-alpha2.1"
+	composeTag := "8.7-alpha2"
+	composeExtractedFolder := "camunda-platform-8.7-alpha2"
 
 	if os.Getenv("CAMUNDA_VERSION") != "" {
 		camundaVersion = os.Getenv("CAMUNDA_VERSION")

--- a/c8run/main.go
+++ b/c8run/main.go
@@ -197,8 +197,8 @@ func main() {
 	baseDir, _ := os.Getwd()
 	parentDir := baseDir
 	elasticsearchVersion := "8.13.4"
-	camundaVersion := "8.7.0-alpha3-rc4"
-	connectorsVersion := "8.7.0-alpha2.1"
+	camundaVersion := "8.7.0-alpha3-rc5"
+	connectorsVersion := "8.7.0-alpha3"
 	composeTag := "8.7-alpha2"
 	composeExtractedFolder := "camunda-platform-8.7-alpha2"
 

--- a/c8run/main.go
+++ b/c8run/main.go
@@ -197,8 +197,8 @@ func main() {
 	baseDir, _ := os.Getwd()
 	parentDir := baseDir
 	elasticsearchVersion := "8.13.4"
-	camundaVersion := "8.7.0-alpha3-rc5"
-	connectorsVersion := "8.7.0-alpha3"
+	camundaVersion := "8.7.0-alpha2"
+	connectorsVersion := "8.7.0-alpha2"
 	composeTag := "8.7-alpha2"
 	composeExtractedFolder := "camunda-platform-8.7-alpha2"
 

--- a/c8run/main.go
+++ b/c8run/main.go
@@ -199,7 +199,7 @@ func main() {
 	elasticsearchVersion := "8.13.4"
 	camundaReleaseTag := "untagged-6aae82d948631897ab68"
 	camundaVersion := "8.7.0-alpha3-rc5"
-	connectorsVersion := "8.7.0-alpha3.1"
+	connectorsVersion := "8.7.0-alpha3.2"
 	composeTag := "8.7-alpha2"
 	composeExtractedFolder := "camunda-platform-8.7-alpha2"
 

--- a/c8run/main.go
+++ b/c8run/main.go
@@ -197,8 +197,9 @@ func main() {
 	baseDir, _ := os.Getwd()
 	parentDir := baseDir
 	elasticsearchVersion := "8.13.4"
-	camundaVersion := "8.7.0-alpha2"
-	connectorsVersion := "8.7.0-alpha2"
+	camundaReleaseTag := "untagged-6aae82d948631897ab68"
+	camundaVersion := "8.7.0-alpha3-rc5"
+	connectorsVersion := "8.7.0-alpha3.1"
 	composeTag := "8.7-alpha2"
 	composeExtractedFolder := "camunda-platform-8.7-alpha2"
 
@@ -477,13 +478,13 @@ func main() {
 
 	if baseCommand == "package" {
 		if runtime.GOOS == "windows" {
-			err := PackageWindows(camundaVersion, elasticsearchVersion, connectorsVersion, composeTag)
+			err := PackageWindows(camundaVersion, elasticsearchVersion, connectorsVersion, camundaReleaseTag, composeTag)
 			if err != nil {
 				fmt.Printf("%+v", err)
 				os.Exit(1)
 			}
 		} else if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
-			err := PackageUnix(camundaVersion, elasticsearchVersion, connectorsVersion, composeTag)
+			err := PackageUnix(camundaVersion, elasticsearchVersion, connectorsVersion, camundaReleaseTag, composeTag)
 			if err != nil {
 				fmt.Printf("%+v", err)
 				os.Exit(1)

--- a/c8run/package.go
+++ b/c8run/package.go
@@ -23,8 +23,8 @@ func Clean(camundaVersion string, elasticsearchVersion string) {
 	}
 }
 
-func downloadAndExtract(filePath, url, extractDir string, extractFunc func(string, string) error) error {
-	err := archive.DownloadFile(filePath, url)
+func downloadAndExtract(filePath, url, extractDir string, authToken string, extractFunc func(string, string) error) error {
+	err := archive.DownloadFile(filePath, url, authToken)
 	if err != nil {
 		return fmt.Errorf("downloadAndExtract: failed to download file at url %s\n%w\n%s", url, err, debug.Stack())
 	}
@@ -49,25 +49,26 @@ func PackageWindows(camundaVersion string, elasticsearchVersion string, connecto
 	composeUrl := "https://github.com/camunda/camunda-platform/archive/refs/tags/" + composeTag + ".zip"
 	composeFilePath := composeTag + ".zip"
 	composeExtractionPath := "camunda-platform-" + composeTag
+	authToken := os.Getenv("GITHUB_TOKEN")
 
 	Clean(camundaVersion, elasticsearchVersion)
 
-	err := downloadAndExtract(elasticsearchFilePath, elasticsearchUrl, "elasticsearch-"+elasticsearchVersion, archive.UnzipSource)
+	err := downloadAndExtract(elasticsearchFilePath, elasticsearchUrl, "elasticsearch-"+elasticsearchVersion, "", archive.UnzipSource)
 	if err != nil {
 		return fmt.Errorf("PackageWindows: failed to fetch elasticsearch: %w\n%s", err, debug.Stack())
 	}
 
-	err = downloadAndExtract(camundaFilePath, camundaUrl, "camunda-zeebe-"+camundaVersion, archive.UnzipSource)
+	err = downloadAndExtract(camundaFilePath, camundaUrl, "camunda-zeebe-"+camundaVersion, authToken, archive.UnzipSource)
 	if err != nil {
 		return fmt.Errorf("PackageWindows: failed to fetch camunda: %w\n%s", err, debug.Stack())
 	}
 
-	err = downloadAndExtract(connectorsFilePath, connectorsUrl, connectorsFilePath, func(_, _ string) error { return nil })
+	err = downloadAndExtract(connectorsFilePath, connectorsUrl, connectorsFilePath, authToken, func(_, _ string) error { return nil })
 	if err != nil {
 		return fmt.Errorf("PackageWindows: failed to fetch connectors: %w\n%s", err, debug.Stack())
 	}
 
-	err = downloadAndExtract(composeFilePath, composeUrl, composeExtractionPath, archive.UnzipSource)
+	err = downloadAndExtract(composeFilePath, composeUrl, composeExtractionPath, authToken, archive.UnzipSource)
 	if err != nil {
 		return fmt.Errorf("PackageWindows: failed to fetch compose release %w\n%s", err, debug.Stack())
 	}
@@ -113,25 +114,26 @@ func PackageUnix(camundaVersion string, elasticsearchVersion string, connectorsV
 	composeUrl := "https://github.com/camunda/camunda-platform/archive/refs/tags/" + composeTag + ".tar.gz"
 	composeFilePath := composeTag + ".tar.gz"
 	composeExtractionPath := "camunda-platform-" + composeTag
+	authToken := os.Getenv("GITHUB_TOKEN")
 
 	Clean(camundaVersion, elasticsearchVersion)
 
-	err := downloadAndExtract(elasticsearchFilePath, elasticsearchUrl, "elasticsearch-"+elasticsearchVersion, archive.ExtractTarGzArchive)
+	err := downloadAndExtract(elasticsearchFilePath, elasticsearchUrl, "elasticsearch-"+elasticsearchVersion, "", archive.ExtractTarGzArchive)
 	if err != nil {
 		return fmt.Errorf("PackageUnix: failed to fetch elasticsearch %w\n%s", err, debug.Stack())
 	}
 
-	err = downloadAndExtract(camundaFilePath, camundaUrl, "camunda-zeebe-"+camundaVersion, archive.ExtractTarGzArchive)
+	err = downloadAndExtract(camundaFilePath, camundaUrl, "camunda-zeebe-"+camundaVersion, authToken, archive.ExtractTarGzArchive)
 	if err != nil {
 		return fmt.Errorf("PackageUnix: failed to fetch camunda %w\n%s", err, debug.Stack())
 	}
 
-	err = downloadAndExtract(connectorsFilePath, connectorsUrl, connectorsFilePath, func(_, _ string) error { return nil })
+	err = downloadAndExtract(connectorsFilePath, connectorsUrl, connectorsFilePath, authToken, func(_, _ string) error { return nil })
 	if err != nil {
 		return fmt.Errorf("PackageUnix: failed to fetch connectors %w\n%s", err, debug.Stack())
 	}
 
-	err = downloadAndExtract(composeFilePath, composeUrl, composeExtractionPath, archive.ExtractTarGzArchive)
+	err = downloadAndExtract(composeFilePath, composeUrl, composeExtractionPath, authToken, archive.ExtractTarGzArchive)
 	if err != nil {
 		return fmt.Errorf("PackageUnix: failed to fetch compose release %w\n%s", err, debug.Stack())
 	}

--- a/c8run/package.go
+++ b/c8run/package.go
@@ -41,8 +41,13 @@ func downloadAndExtract(filePath, url, extractDir string, authToken string, extr
 }
 
 func downloadGHArtifact(camundaVersion string, camundaFilePath string) error {
+        _, err := exec.LookPath("gh")
+        if err != nil {
+                // This is not an error because there is another way to download camunda releases
+                return nil
+        }
 	cmd := exec.Command("gh", "release", "download", "--repo", "camunda/camunda", camundaVersion, "-p", camundaFilePath)
-	err := cmd.Run()
+	err = cmd.Run()
 	if err != nil {
 		return fmt.Errorf("downloadGHArtifact: failed to download artifact %w\n%s", err, debug.Stack())
 	}

--- a/c8run/package.go
+++ b/c8run/package.go
@@ -83,7 +83,7 @@ func PackageWindows(camundaVersion string, elasticsearchVersion string, connecto
 		return fmt.Errorf("PackageWindows: failed to fetch camunda: %w\n%s", err, debug.Stack())
 	}
 
-	err = downloadAndExtract(connectorsFilePath, connectorsUrl, connectorsFilePath, authToken, func(_, _ string) error { return nil })
+	err = downloadAndExtract(connectorsFilePath, connectorsUrl, connectorsFilePath, "", func(_, _ string) error { return nil })
 	if err != nil {
 		return fmt.Errorf("PackageWindows: failed to fetch connectors: %w\n%s", err, debug.Stack())
 	}
@@ -153,7 +153,7 @@ func PackageUnix(camundaVersion string, elasticsearchVersion string, connectorsV
 		return fmt.Errorf("PackageUnix: failed to fetch camunda %w\n%s", err, debug.Stack())
 	}
 
-	err = downloadAndExtract(connectorsFilePath, connectorsUrl, connectorsFilePath, authToken, func(_, _ string) error { return nil })
+	err = downloadAndExtract(connectorsFilePath, connectorsUrl, connectorsFilePath, "", func(_, _ string) error { return nil })
 	if err != nil {
 		return fmt.Errorf("PackageUnix: failed to fetch connectors %w\n%s", err, debug.Stack())
 	}

--- a/c8run/package.go
+++ b/c8run/package.go
@@ -49,7 +49,7 @@ func PackageWindows(camundaVersion string, elasticsearchVersion string, connecto
 	composeUrl := "https://github.com/camunda/camunda-platform/archive/refs/tags/" + composeTag + ".zip"
 	composeFilePath := composeTag + ".zip"
 	composeExtractionPath := "camunda-platform-" + composeTag
-	authToken := os.Getenv("GITHUB_TOKEN")
+	authToken := os.Getenv("GH_TOKEN")
 
 	Clean(camundaVersion, elasticsearchVersion)
 
@@ -114,7 +114,7 @@ func PackageUnix(camundaVersion string, elasticsearchVersion string, connectorsV
 	composeUrl := "https://github.com/camunda/camunda-platform/archive/refs/tags/" + composeTag + ".tar.gz"
 	composeFilePath := composeTag + ".tar.gz"
 	composeExtractionPath := "camunda-platform-" + composeTag
-	authToken := os.Getenv("GITHUB_TOKEN")
+	authToken := os.Getenv("GH_TOKEN")
 
 	Clean(camundaVersion, elasticsearchVersion)
 

--- a/c8run/package.go
+++ b/c8run/package.go
@@ -39,11 +39,11 @@ func downloadAndExtract(filePath, url, extractDir string, authToken string, extr
 	return nil
 }
 
-func PackageWindows(camundaVersion string, elasticsearchVersion string, connectorsVersion string, composeTag string) error {
+func PackageWindows(camundaVersion string, elasticsearchVersion string, connectorsVersion string, camundaReleaseTag string, composeTag string) error {
 	elasticsearchUrl := "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-" + elasticsearchVersion + "-windows-x86_64.zip"
 	elasticsearchFilePath := "elasticsearch-" + elasticsearchVersion + ".zip"
 	camundaFilePath := "camunda-zeebe-" + camundaVersion + ".zip"
-	camundaUrl := "https://github.com/camunda/camunda/releases/download/" + camundaVersion + "/" + camundaFilePath
+	camundaUrl := "https://github.com/camunda/camunda/releases/download/" + camundaReleaseTag + "/" + camundaFilePath
 	connectorsFilePath := "connector-runtime-bundle-" + connectorsVersion + "-with-dependencies.jar"
 	connectorsUrl := "https://artifacts.camunda.com/artifactory/connectors/io/camunda/connector/connector-runtime-bundle/" + connectorsVersion + "/" + connectorsFilePath
 	composeUrl := "https://github.com/camunda/camunda-platform/archive/refs/tags/" + composeTag + ".zip"
@@ -96,7 +96,7 @@ func PackageWindows(camundaVersion string, elasticsearchVersion string, connecto
 	return nil
 }
 
-func PackageUnix(camundaVersion string, elasticsearchVersion string, connectorsVersion string, composeTag string) error {
+func PackageUnix(camundaVersion string, elasticsearchVersion string, connectorsVersion string, camundaReleaseTag string, composeTag string) error {
 	var architecture string
 	if runtime.GOARCH == "amd64" {
 		architecture = "x86_64"
@@ -107,7 +107,7 @@ func PackageUnix(camundaVersion string, elasticsearchVersion string, connectorsV
 	elasticsearchUrl := "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-" + elasticsearchVersion + "-" + runtime.GOOS + "-" + architecture + ".tar.gz"
 	elasticsearchFilePath := "elasticsearch-" + elasticsearchVersion + ".tar.gz"
 	camundaFilePath := "camunda-zeebe-" + camundaVersion + ".tar.gz"
-	camundaUrl := "https://github.com/camunda/camunda/releases/download/" + camundaVersion + "/" + camundaFilePath
+	camundaUrl := "https://github.com/camunda/camunda/releases/download/" + camundaReleaseTag + "/" + camundaFilePath
 	connectorsFilePath := "connector-runtime-bundle-" + connectorsVersion + "-with-dependencies.jar"
 	connectorsUrl := "https://artifacts.camunda.com/artifactory/connectors/io/camunda/connector/connector-runtime-bundle/" + connectorsVersion + "/" + connectorsFilePath
 


### PR DESCRIPTION
## Description

My recent PR introduced unintended version bumps for tags that don't exist yet. This PR is to prevent other ci from failing until the tags are in place.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
