### PR TITLE
[POC] Introduce intermediate variable handling for User Task Listeners

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -127,6 +127,10 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
           commandWriter.appendFollowUpCommand(
               userTask.getUserTaskKey(), UserTaskIntent.DENY_TASK_LISTENER, userTask);
         } else {
+          if (hasVariables(value)) {
+            userTask.mergeVariables(value.getVariables());
+          }
+
           userTask.correctAttributes(
               value.getResult().getCorrectedAttributes(), value.getResult().getCorrections());
           commandWriter.appendFollowUpCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -68,7 +68,6 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
             this::acceptCommand,
             authCheckBehavior,
             List.of(
-                this::checkTaskListenerJobForProvidingVariables,
                 this::checkTaskListenerJobForDenyingWithCorrections,
                 this::checkTaskListenerJobForUnknownPropertyCorrections));
     this.jobMetrics = jobMetrics;
@@ -149,23 +148,8 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
     }
   }
 
-  /** We currently don't support completing task listener jobs with variables. */
-  private Either<Rejection, JobRecord> checkTaskListenerJobForProvidingVariables(
-      final TypedRecord<JobRecord> command, final JobRecord job) {
-
-    if (job.getJobKind() == JobKind.TASK_LISTENER && hasVariables(command)) {
-      return Either.left(
-          new Rejection(
-              RejectionType.INVALID_ARGUMENT,
-              TL_JOB_COMPLETION_WITH_VARS_NOT_SUPPORTED_MESSAGE.formatted(
-                  command.getKey(), job.getType(), job.getProcessInstanceKey())));
-    }
-
-    return Either.right(job);
-  }
-
-  private boolean hasVariables(final TypedRecord<JobRecord> command) {
-    return !DocumentValue.EMPTY_DOCUMENT.equals(command.getValue().getVariablesBuffer());
+  private boolean hasVariables(final JobRecord jobRecord) {
+    return !DocumentValue.EMPTY_DOCUMENT.equals(jobRecord.getVariablesBuffer());
   }
 
   private Either<Rejection, JobRecord> checkTaskListenerJobForDenyingWithCorrections(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandProcessors.java
@@ -48,10 +48,10 @@ public final class UserTaskCommandProcessors {
             Map.of(
                 UserTaskIntent.ASSIGN,
                 new UserTaskAssignProcessor(
-                    processingState, eventHandle, writers, authCheckBehavior),
+                    processingState, writers, bpmnBehaviors, authCheckBehavior),
                 UserTaskIntent.CLAIM,
                 new UserTaskClaimProcessor(
-                    processingState, eventHandle, writers, authCheckBehavior),
+                    processingState, writers, bpmnBehaviors, authCheckBehavior),
                 UserTaskIntent.UPDATE,
                 new UserTaskUpdateProcessor(processingState, writers, authCheckBehavior),
                 UserTaskIntent.COMPLETE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandProcessors.java
@@ -50,7 +50,8 @@ public final class UserTaskCommandProcessors {
                 new UserTaskAssignProcessor(
                     processingState, eventHandle, writers, authCheckBehavior),
                 UserTaskIntent.CLAIM,
-                new UserTaskClaimProcessor(processingState, writers, authCheckBehavior),
+                new UserTaskClaimProcessor(
+                    processingState, eventHandle, writers, authCheckBehavior),
                 UserTaskIntent.UPDATE,
                 new UserTaskUpdateProcessor(processingState, writers, authCheckBehavior),
                 UserTaskIntent.COMPLETE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandProcessors.java
@@ -47,7 +47,8 @@ public final class UserTaskCommandProcessors {
         new EnumMap<>(
             Map.of(
                 UserTaskIntent.ASSIGN,
-                new UserTaskAssignProcessor(processingState, writers, authCheckBehavior),
+                new UserTaskAssignProcessor(
+                    processingState, eventHandle, writers, authCheckBehavior),
                 UserTaskIntent.CLAIM,
                 new UserTaskClaimProcessor(processingState, writers, authCheckBehavior),
                 UserTaskIntent.UPDATE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.usertask.processors;
 
 import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -33,15 +34,18 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
       "Expected to claim user task with key '%d', but provided assignee is empty";
 
   private final UserTaskState userTaskState;
+  private final EventHandle eventHandle;
   private final StateWriter stateWriter;
   private final TypedResponseWriter responseWriter;
   private final UserTaskCommandPreconditionChecker preconditionChecker;
 
   public UserTaskClaimProcessor(
       final ProcessingState state,
+      final EventHandle eventHandle,
       final Writers writers,
       final AuthorizationCheckBehavior authCheckBehavior) {
     userTaskState = state.getUserTaskState();
+    this.eventHandle = eventHandle;
     stateWriter = writers.state();
     responseWriter = writers.response();
     preconditionChecker =
@@ -86,9 +90,11 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
       stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord);
       responseWriter.writeEventOnCommand(
           userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord, command);
+      eventHandle.triggeringProcessEvent(userTaskRecord);
     } else {
       final var recordRequestMetadata = userTaskState.findRecordRequestMetadata(userTaskKey);
       stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord);
+      eventHandle.triggeringProcessEvent(userTaskRecord);
 
       recordRequestMetadata.ifPresent(
           metadata ->

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
@@ -8,11 +8,12 @@
 package io.camunda.zeebe.engine.processing.usertask.processors;
 
 import io.camunda.zeebe.engine.processing.Rejection;
-import io.camunda.zeebe.engine.processing.common.EventHandle;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
@@ -34,18 +35,18 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
       "Expected to claim user task with key '%d', but provided assignee is empty";
 
   private final UserTaskState userTaskState;
-  private final EventHandle eventHandle;
   private final StateWriter stateWriter;
   private final TypedResponseWriter responseWriter;
+  private final VariableBehavior variableBehavior;
   private final UserTaskCommandPreconditionChecker preconditionChecker;
 
   public UserTaskClaimProcessor(
       final ProcessingState state,
-      final EventHandle eventHandle,
       final Writers writers,
+      final BpmnBehaviors bpmnBehaviors,
       final AuthorizationCheckBehavior authCheckBehavior) {
     userTaskState = state.getUserTaskState();
-    this.eventHandle = eventHandle;
+    variableBehavior = bpmnBehaviors.variableBehavior();
     stateWriter = writers.state();
     responseWriter = writers.response();
     preconditionChecker =
@@ -90,11 +91,23 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
       stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord);
       responseWriter.writeEventOnCommand(
           userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord, command);
-      eventHandle.triggeringProcessEvent(userTaskRecord);
+      variableBehavior.mergeLocalDocument(
+          command.getKey(),
+          command.getValue().getProcessDefinitionKey(),
+          command.getValue().getProcessInstanceKey(),
+          command.getValue().getBpmnProcessIdBuffer(),
+          command.getValue().getTenantId(),
+          command.getValue().getVariablesBuffer());
     } else {
       final var recordRequestMetadata = userTaskState.findRecordRequestMetadata(userTaskKey);
       stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord);
-      eventHandle.triggeringProcessEvent(userTaskRecord);
+      variableBehavior.mergeLocalDocument(
+          command.getKey(),
+          command.getValue().getProcessDefinitionKey(),
+          command.getValue().getProcessInstanceKey(),
+          command.getValue().getBpmnProcessIdBuffer(),
+          command.getValue().getTenantId(),
+          command.getValue().getVariablesBuffer());
 
       recordRequestMetadata.ifPresent(
           metadata ->

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -429,6 +429,7 @@ public final class EventAppliers implements EventApplier {
     register(UserTaskIntent.CORRECTED, new UserTaskCorrectedApplier(state));
     register(UserTaskIntent.COMPLETION_DENIED, new UserTaskCompletionDeniedApplier(state));
     register(UserTaskIntent.ASSIGNMENT_DENIED, new UserTaskAssignmentDeniedApplier(state));
+    register(UserTaskIntent.VARIABLES_UPDATED, new UserTaskVariablesUpdatedApplier(state));
   }
 
   private void registerCompensationSubscriptionApplier(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskVariablesUpdatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskVariablesUpdatedApplier.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+
+public final class UserTaskVariablesUpdatedApplier
+    implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
+
+  private final MutableUserTaskState userTaskState;
+
+  public UserTaskVariablesUpdatedApplier(final MutableProcessingState state) {
+    userTaskState = state.getUserTaskState();
+  }
+
+  @Override
+  public void applyState(final long key, final UserTaskRecord value) {
+    userTaskState.updateIntermediateState(
+        key,
+        intermediateStateValue ->
+            intermediateStateValue.getRecord().setVariables(value.getVariablesBuffer()));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -703,9 +703,8 @@ public class TaskListenerTest {
   }
 
   @Test
-  @Ignore(
-      "Ignored due to task listener job completion rejection when variables payload is provided (issue #24056). Re-enable after implementing issue #23702.")
-  public void shouldMakeVariablesFromPreviousTaskListenersAvailableToSubsequentListeners() {
+  public void
+  shouldMakeVariablesFromPreviousCompletingTaskListenersAvailableToSubsequentListeners() {
     final long processInstanceKey =
         createProcessInstance(
             createProcessWithCompletingTaskListeners(listenerType, listenerType + "_2"));
@@ -727,8 +726,8 @@ public class TaskListenerTest {
 
   @Test
   @Ignore(
-      "Ignored due to task listener job completion rejection when variables payload is provided (issue #24056). Re-enable after implementing issue #23702.")
-  public void shouldNotExposeTaskListenerVariablesOutsideUserTaskScope() {
+      "This behaviour might change, so the variables provided while completing user task listener jobs will be merged to the process instance local scope")
+  public void shouldNotExposeCompletingTaskListenerVariablesOutsideUserTaskScope() {
     // given: deploy a process with a user task having complete TL and service task following it
     final long processInstanceKey =
         createProcessInstance(
@@ -761,8 +760,6 @@ public class TaskListenerTest {
   }
 
   @Test
-  @Ignore(
-      "Ignored due to task listener job completion rejection when variables payload is provided (issue #24056). Re-enable after implementing issue #23702.")
   public void shouldAllowTaskListenerVariablesInUserTaskOutputMappings() {
     // given: deploy a process with a user task having complete TL and service task following it
     final long processInstanceKey =
@@ -1070,7 +1067,9 @@ public class TaskListenerTest {
   }
 
   @Test
-  public void shouldRejectCompleteTaskListenerJobCompletionWhenVariablesAreSet() {
+  @Ignore(
+      "This case would not be relevant after enabling user task listener job completion with provided variables")
+  public void shouldRejectCompletingTaskListenerJobCompletionWhenVariablesAreSet() {
     // given
     final long processInstanceKey =
         createProcessInstance(createProcessWithCompletingTaskListeners(listenerType));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -704,7 +704,7 @@ public class TaskListenerTest {
 
   @Test
   public void
-  shouldMakeVariablesFromPreviousCompletingTaskListenersAvailableToSubsequentListeners() {
+      shouldMakeVariablesFromPreviousCompletingTaskListenersAvailableToSubsequentListeners() {
     final long processInstanceKey =
         createProcessInstance(
             createProcessWithCompletingTaskListeners(listenerType, listenerType + "_2"));
@@ -726,7 +726,7 @@ public class TaskListenerTest {
 
   @Test
   public void
-  shouldMakeVariablesFromPreviousAssigningTaskListenersAvailableToSubsequentListeners() {
+      shouldMakeVariablesFromPreviousAssigningTaskListenersAvailableToSubsequentListeners() {
     final long processInstanceKey =
         createProcessInstance(
             createUserTaskWithTaskListeners(

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.PackedProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.spec.MsgPackHelper;
+import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -307,6 +308,18 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
           }
           addChangedAttribute(attribute);
         });
+  }
+
+  public void mergeVariables(final Map<String, Object> variables) {
+
+    final Map<String, Object> taskVariables = getVariables();
+    taskVariables.putAll(variables);
+
+    setVariables(BufferUtil.wrapArray(MsgPackConverter.convertToMsgPack(taskVariables)));
+  }
+
+  public boolean hasVariables() {
+    return !DocumentValue.EMPTY_DOCUMENT.equals(variableProp.getValue());
   }
 
   @Override

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserTaskIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserTaskIntent.java
@@ -91,7 +91,9 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
    * This intent is written during the processing of a CLAIM command and marks the User Task with
    * the `CLAIMING` lifecycle state.
    */
-  CLAIMING(20);
+  CLAIMING(20),
+
+  VARIABLES_UPDATED(21);
 
   private final short value;
   private final boolean shouldBanInstance;
@@ -153,6 +155,8 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
         return ASSIGNMENT_DENIED;
       case 20:
         return CLAIMING;
+      case 21:
+        return VARIABLES_UPDATED;
       default:
         return UNKNOWN;
     }
@@ -181,6 +185,7 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
       case CORRECTED:
       case ASSIGNMENT_DENIED:
       case CLAIMING:
+      case VARIABLES_UPDATED:
         return true;
       default:
         return false;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
@@ -45,6 +45,7 @@ import org.apache.hc.core5.http.HttpStatus;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @ZeebeIntegration
@@ -151,6 +152,7 @@ public class UserTaskListenersTest {
    * </ul>
    */
   @Test
+  @Disabled("As this POC enables UTL job completion with variables")
   void shouldRejectCompleteTaskListenerJobCompletionWhenVariablesAreSet() {
     // given
     final int jobRetries = 2;


### PR DESCRIPTION
## Description

This POC introduces intermediate handling for variables provided by user task listener jobs, following the approach used in the `corrections` feature. Variables are managed within the `intermediateUserTaskRecord` and applied to the process instance's local scope only after all task listeners complete successfully.

#### Key Changes:
1. **Intermediate Variable Handling:**
   - Introduced the `VARIABLES_UPDATED` intent and `UserTaskVariablesUpdatedApplier` for updating variables in user task intermediate states.
   - Ensured variables are merged into the local scope upon successful completion of user task lifecycle transitions (`COMPLETE`, `ASSIGN`, `CLAIM`).

2. **Test updates:**
   - Re-enabled some of previously ignored tests related to variable handling.
   - Added new tests to verify variable visibility and correct behaviour.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates to #23702 
