### PR TITLE
Resolve junit 5 maven dependency convergence

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -935,6 +935,14 @@
 
       <!-- Third party dependencies -->
       <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>${version.junit}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
         <version>${version.jackson}</version>
@@ -1173,14 +1181,6 @@
         <groupId>org.msgpack</groupId>
         <artifactId>jackson-dataformat-msgpack</artifactId>
         <version>${version.msgpack}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.junit</groupId>
-        <artifactId>junit-bom</artifactId>
-        <version>${version.junit}</version>
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Maven dependencies take precedence by ordering. As the junit-bom was defined below spring-boot-starter-test, spring-boot-starter-test defined what junit version is used in our own maven project.

This caused the effective pom to use 5.10.5 rather than 5.11.4.

This commit moves the declaration of the junit-bom to ensure our declaration takes precedence.

## Related issues

NA

[Discussion in slack](https://camunda.slack.com/archives/C037RS2JHB8/p1736327541102319)

Unblocks #26421 
