### PR TITLE
fix: prevent focus trap on Tasklist native OS notifications dialog

### DIFF
--- a/tasklist/client/src/Tasks/Task/Details/TurnOnNotificationPermission.test.tsx
+++ b/tasklist/client/src/Tasks/Task/Details/TurnOnNotificationPermission.test.tsx
@@ -16,7 +16,7 @@ describe('<TurnOnNotificationPermission/>', () => {
 
     render(<TurnOnNotificationPermission />);
 
-    const dialog = screen.getByRole('alertdialog', {
+    const dialog = screen.getByRole('status', {
       name: /^Don't miss new assignments$/i,
     });
 
@@ -37,7 +37,7 @@ describe('<TurnOnNotificationPermission/>', () => {
     render(<TurnOnNotificationPermission />);
 
     expect(
-      screen.queryByRole('alertdialog', {
+      screen.queryByRole('status', {
         name: /^Don't miss new assignments$/i,
       }),
     ).not.toBeInTheDocument();
@@ -49,7 +49,7 @@ describe('<TurnOnNotificationPermission/>', () => {
     render(<TurnOnNotificationPermission />);
 
     expect(
-      screen.queryByRole('alertdialog', {
+      screen.queryByRole('status', {
         name: /^Don't miss new assignments$/i,
       }),
     ).not.toBeInTheDocument();
@@ -61,7 +61,7 @@ describe('<TurnOnNotificationPermission/>', () => {
     const {user} = render(<TurnOnNotificationPermission />);
 
     expect(
-      screen.getByRole('alertdialog', {
+      screen.getByRole('status', {
         name: /^Don't miss new assignments$/i,
       }),
     ).toBeInTheDocument();
@@ -69,7 +69,7 @@ describe('<TurnOnNotificationPermission/>', () => {
     await user.click(screen.getByRole('button', {name: /close notification/i}));
 
     expect(
-      screen.queryByRole('alertdialog', {
+      screen.queryByRole('status', {
         name: /^Don't miss new assignments$/i,
       }),
     ).not.toBeInTheDocument();
@@ -83,9 +83,43 @@ describe('<TurnOnNotificationPermission/>', () => {
     render(<TurnOnNotificationPermission />);
 
     expect(
-      screen.queryByRole('alertdialog', {
+      screen.queryByRole('status', {
         name: /^Don't miss new assignments$/i,
       }),
     ).not.toBeInTheDocument();
+  });
+
+  it('should disable the focus trap when the dialog is open', async () => {
+    vi.stubGlobal('Notification', {permission: 'default'});
+
+    const {unmount} = render(
+      <>
+        <TurnOnNotificationPermission />
+        <input type="text" aria-label="Mock input" />
+      </>,
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: /turn on notifications/i,
+      }),
+    ).toHaveFocus();
+    expect(screen.getByLabelText(/mock input/i)).not.toHaveFocus();
+
+    unmount();
+
+    render(
+      <>
+        <TurnOnNotificationPermission />
+        <input type="text" aria-label="Mock input" autoFocus />
+      </>,
+    );
+
+    expect(
+      screen.getByRole('button', {
+        name: /turn on notifications/i,
+      }),
+    ).not.toHaveFocus();
+    expect(screen.getByLabelText(/mock input/i)).toHaveFocus();
   });
 });

--- a/tasklist/client/src/Tasks/Task/Details/TurnOnNotificationPermission.tsx
+++ b/tasklist/client/src/Tasks/Task/Details/TurnOnNotificationPermission.tsx
@@ -6,7 +6,10 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {ActionableNotification} from '@carbon/react';
+import {
+  ActionableNotification,
+  unstable_FeatureFlags as FeatureFlags,
+} from '@carbon/react';
 import {requestPermission} from 'modules/os-notifications/requestPermission';
 import {getStateLocally, storeStateLocally} from 'modules/utils/localStorage';
 import {useState} from 'react';
@@ -30,25 +33,34 @@ const TurnOnNotificationPermission: React.FC = () => {
 
   return (
     <div>
-      <ActionableNotification
-        inline
-        kind="info"
-        title={t('turnOnNotificationTitle')}
-        subtitle={t('turnOnNotificationSubtitle')}
-        actionButtonLabel={t('turnOnNotificationsActionButton')}
-        onActionButtonClick={async () => {
-          const result = await requestPermission();
-          if (result !== 'default') {
+      {/* This is a temporary fix, it should be removed once this feature is implemented on Carbon: https://github.com/camunda/camunda/issues/26648 */}
+      <FeatureFlags
+        flags={{
+          'enable-experimental-focus-wrap-without-sentinels': true,
+        }}
+      >
+        <ActionableNotification
+          inline
+          kind="info"
+          role="status"
+          aria-live="polite"
+          title={t('turnOnNotificationTitle')}
+          subtitle={t('turnOnNotificationSubtitle')}
+          actionButtonLabel={t('turnOnNotificationsActionButton')}
+          onActionButtonClick={async () => {
+            const result = await requestPermission();
+            if (result !== 'default') {
+              setIsEnabled(false);
+            }
+          }}
+          onClose={() => {
             setIsEnabled(false);
-          }
-        }}
-        onClose={() => {
-          setIsEnabled(false);
-          storeStateLocally('areNativeNotificationsEnabled', false);
-        }}
-        className={styles.actionableNotification}
-        lowContrast
-      />
+            storeStateLocally('areNativeNotificationsEnabled', false);
+          }}
+          className={styles.actionableNotification}
+          lowContrast
+        />
+      </FeatureFlags>
     </div>
   );
 };


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The Carbon component `ActionableNotification` has a built-in focus trap for a11y reasons. For our use this is not ideal because it prevents users from editing tasks forms/variables.
I temporarily used a Carbon feature flag to disable this feature but this should be removed as soon as Carbon implements this on main because the behavior might not be stable

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #26522
