### PR TITLE
[Backport stable/8.3] ci: use latest compatible benchmark chart version

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -205,6 +205,7 @@ jobs:
       - name: Helm install
         run: >
           helm upgrade --install ${{ inputs.name }} zeebe-benchmark/zeebe-benchmark
+          --version zeebe-benchmark-0.3.7 
           --namespace ${{ inputs.name }}
           --create-namespace
           --set global.image.tag=${{ needs.build-benchmark-images.outputs.image-tag }}


### PR DESCRIPTION
# Description
Backport of #26591 to `stable/8.3`.

relates to 
original author: @megglos