### PR TITLE
[Backport stable/8.5] ci: use latest compatible benchmark chart version

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -209,6 +209,7 @@ jobs:
       - name: Helm install
         run: >
           helm upgrade --install ${{ inputs.name }} zeebe-benchmark/zeebe-benchmark
+          --version zeebe-benchmark-0.3.7 
           --namespace ${{ inputs.name }}
           --create-namespace
           --reuse-values


### PR DESCRIPTION
# Description
Backport of #26591 to `stable/8.5`.

relates to 
original author: @megglos