### PR TITLE
ci: use correct latest benchmark version

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Helm install
         run: >
           helm upgrade --install ${{ inputs.name }} zeebe-benchmark/zeebe-benchmark
-          --version zeebe-benchmark-0.3.7 
+          --version 0.3.7
           --namespace ${{ inputs.name }}
           --create-namespace
           --set global.image.tag=${{ needs.build-benchmark-images.outputs.image-tag }}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

In https://github.com/camunda/camunda/pull/26591 we use `zeebe-benchmark-0.3.7` as the zeebe-benchmark version however the correct usage should be just the version number `0.3.7`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
