### PR TITLE
fix: fixing something in Camunda client

### DIFF
--- a/clients/java-new/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java-new/src/main/java/io/camunda/client/CamundaClient.java
@@ -95,6 +95,8 @@ import io.camunda.client.impl.CamundaClientImpl;
 /** The client to communicate with a Camunda broker/cluster. */
 public interface CamundaClient extends AutoCloseable, JobClient {
 
+  /** Fixing something in Camunda Client */
+
   /**
    * @return a new Camunda client with default configuration values. In order to customize
    *     configuration, use the methods {@link #newClientBuilder()} or {@link


### PR DESCRIPTION
## Description

The following outlines a solution to mitigate the double maintenance effort described in [Option 1](https://github.com/camunda/camunda/issues/19479#issuecomment-2578019210).

This should add some automation to avoid forgetting applying the camunda client changes on the deprecated zeebe client module.

_For experimentation, I used branches prefixed with `tmp/`._
1. Created a `tmp/main` branch containing the zeebe-java-client module (brought from stable/8.6).
2. Submitted a "fix" pull request to `tmp/main`, fixing an issue in `CamundaClient` ([current PR](https://github.com/camunda/camunda/pull/26689)). As the fix needs to be backported to 8.6, I labeled the pull request with `backport tmp/stable/8.6` (`tmp/stable/8.6` is a branch created from `stable/8.6`).
3. After merging the PR, the backport action automatically created a backport PR to `tmp/stable/8.6`(https://github.com/camunda/camunda/pull/26690). This PR contained merge conflicts, as expected: Git tracks ZeebeClient in 8.6 but does not recognize `CamundaClient` due to reintroducing `ZeebeClient` in `main`. These conflicts need to be resolved manually.
4. After resolving the conflicts, I labeled the backport PR with `backport tmp/main`. The idea is to automatically add this label when detecting changes in the `zeebe-java-client` module for PRs targeting stable/8.6. We can use the [labeler](https://github.com/camunda/camunda/blob/main/.github/labeler.yml) workflow that we already have.
5. The backport action then created a backport PR to `tmp/main` without conflicts (https://github.com/camunda/camunda/pull/26691). In some cases, the developer has to undo of the changes that do not apply to the `main` or `stable/8.7` branch

**This procedure does not apply anymore after we stop the support of stable/8.6. If we remove ZeebeClient in 8.8, this will be the case during the last 6 months of 8.7 where we don't backport to 8.6 anymore.**

