### PR TITLE
[Backport stable/8.3] ci: use correct latest benchmark version

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -205,6 +205,7 @@ jobs:
       - name: Helm install
         run: >
           helm upgrade --install ${{ inputs.name }} zeebe-benchmark/zeebe-benchmark
+          --version 0.3.7
           --namespace ${{ inputs.name }}
           --create-namespace
           --set global.image.tag=${{ needs.build-benchmark-images.outputs.image-tag }}


### PR DESCRIPTION
# Description
Backport of #26674 to `stable/8.3`.

relates to 
original author: @berkaycanbc