### PR TITLE
feat: remove authorized tenants from REST broker requests

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -533,13 +533,11 @@ public class RequestMapper {
     final List<Long> authenticatedRoleKeys = new ArrayList<>();
     final List<String> authorizedTenants = TenantAttributeHolder.getTenantIds();
 
-    final Map<String, Object> claims = new HashMap<>();
-    claims.put(Authorization.AUTHORIZED_TENANTS, authorizedTenants);
-
     final var requestAuthentication = SecurityContextHolder.getContext().getAuthentication();
 
-    if (requestAuthentication != null) {
+    final Map<String, Object> claims = new HashMap<>();
 
+    if (requestAuthentication != null) {
       if (requestAuthentication.getPrincipal()
           instanceof final CamundaUser authenticatedPrincipal) {
         authenticatedUserKey = authenticatedPrincipal.getUserKey();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Removed the authorized tenants id from the REST request sent to the broker.

## Related issues

closes #26694 
