### PR TITLE
feat: extend sbom workflow to manual dispatch and draft releases

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -8,8 +8,12 @@ name: Generate and Attach SBOM
 
 on:
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag to attach SBOMs"
+        required: true
   release:
-    types: [published]
+    types: [published,created]
   schedule:
     - cron: "0 9 * * MON"
 
@@ -91,7 +95,7 @@ jobs:
   attach_artifacts_to_release:
     runs-on: ubuntu-latest
     needs: [ frontend_sbom, generate_backend_sbom ]
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Check out repository code
@@ -132,6 +136,8 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" == "release" ]; then
             echo "RELEASE_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ -n "${{ github.event.inputs.release_tag }}" ]; then
+            echo "RELEASE_TAG=${{ github.event.inputs.release_tag }}" >> $GITHUB_ENV
           else
             latest_release=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
               "https://api.github.com/repos/${{ github.repository }}/releases?per_page=1" | jq -r '.[0].tag_name')
@@ -145,7 +151,7 @@ jobs:
           for artifact in ./sboms/*/*; do
             base_name=$(basename "$artifact")
             dir_name=$(basename "$(dirname "$artifact")")
-            unique_name="${dir_name}-${base_name}"
+            unique_name="${dir_name}-${base_name}-${RELEASE_TAG}"
             gh release upload "$RELEASE_TAG" "$artifact" \
               --repo "camunda/camunda" \
               --clobber \

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -149,13 +149,38 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           for artifact in ./sboms/*/*; do
+            # Debug: Print the artifact being processed
+            echo "Processing artifact: $artifact"
+
+            # Extract the file and directory names
             base_name=$(basename "$artifact")
             dir_name=$(basename "$(dirname "$artifact")")
             unique_name="${dir_name}-${base_name}-${RELEASE_TAG}"
-            gh release upload "$RELEASE_TAG" "$artifact" \
-              --repo "camunda/camunda" \
-              --clobber \
-              --name "$unique_name"
+
+            # Debug: Print the unique name being generated
+            echo "Generated unique name for upload: $unique_name"
+
+            # Temporarily rename the artifact with the unique name
+            mv "$artifact" "./sboms/$unique_name"
+            echo "Renamed $artifact to ./sboms/$unique_name"
+
+            # Upload the artifact
+            echo "Uploading ./sboms/$unique_name to release $RELEASE_TAG"
+            gh release upload "$RELEASE_TAG" "./sboms/$unique_name" \
+            --repo "camunda/camunda" \
+            --clobber
+
+            # Check the exit code of the upload command
+            if [ $? -eq 0 ]; then
+              echo "Successfully uploaded: $unique_name"
+            else
+              echo "Failed to upload: $unique_name"
+            exit 1
+            fi
+
+            # Restore the original artifact name
+            mv "./sboms/$unique_name" "$artifact"
+            echo "Restored ./sboms/$unique_name back to $artifact"
           done
 
 

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -149,16 +149,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           for artifact in ./sboms/*/*; do
-            # Debug: Print the artifact being processed
-            echo "Processing artifact: $artifact"
-
             # Extract the file and directory names
             base_name=$(basename "$artifact")
             dir_name=$(basename "$(dirname "$artifact")")
             unique_name="${dir_name}-${base_name}-${RELEASE_TAG}"
-
-            # Debug: Print the unique name being generated
-            echo "Generated unique name for upload: $unique_name"
 
             # Temporarily rename the artifact with the unique name
             mv "$artifact" "./sboms/$unique_name"

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -161,15 +161,15 @@ jobs:
             # Upload the artifact
             echo "Uploading ./sboms/$unique_name to release $RELEASE_TAG"
             gh release upload "$RELEASE_TAG" "./sboms/$unique_name" \
-            --repo "camunda/camunda" \
-            --clobber
+              --repo "camunda/camunda" \
+              --clobber
 
             # Check the exit code of the upload command
             if [ $? -eq 0 ]; then
               echo "Successfully uploaded: $unique_name"
             else
               echo "Failed to upload: $unique_name"
-            exit 1
+              exit 1
             fi
 
             # Restore the original artifact name


### PR DESCRIPTION
## Description

Enhance the SBOM workflow with the follow resources
- Manual dispatch (In order to set the release tag for testing)
- Created releases, apply SBOM for Draft release for test proposals
- Bug fix over release name publish

Tested at:
https://github.com/camunda/camunda/actions/runs/12690445894


