### PR TITLE
Prefix migration changes

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -30,6 +30,7 @@
     <dependency>
       <groupId>co.elastic.clients</groupId>
       <artifactId>elasticsearch-java</artifactId>
+      <version>8.14.2</version>
     </dependency>
 
     <dependency>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -15,6 +15,16 @@
 
   <name>Zeebe Distribution</name>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>co.elastic.clients</groupId>
+        <artifactId>elasticsearch-java</artifactId>
+        <version>8.14.2</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
 
     <dependency>
@@ -30,7 +40,6 @@
     <dependency>
       <groupId>co.elastic.clients</groupId>
       <artifactId>elasticsearch-java</artifactId>
-      <version>8.14.2</version>
     </dependency>
 
     <dependency>

--- a/dist/src/main/java/io/camunda/application/StandaloneSchemaManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneSchemaManager.java
@@ -91,6 +91,7 @@ public class StandaloneSchemaManager {
 
     final ExporterConfiguration exporterConfig = new ExporterConfiguration();
     exporterConfig.setConnect(connectConfiguration);
+    exporterConfig.getIndex().setPrefix(connectConfiguration.getIndexPrefix());
 
     final IndexDescriptors indexDescriptors =
         new IndexDescriptors(connectConfiguration.getIndexPrefix(), IS_ELASTICSEARCH);

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -53,6 +53,12 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-search-client-connect</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>co.elastic.clients</groupId>
+          <artifactId>elasticsearch-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -73,6 +73,7 @@
     <dependency>
       <groupId>co.elastic.clients</groupId>
       <artifactId>elasticsearch-java</artifactId>
+      <version>8.14.2</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Description

When migrating the prefix the https://github.com/elastic/elasticsearch-java/issues/696 `Property 'type' was not found` bug was encountered this was fixed locally here https://github.com/camunda/camunda/commit/8ea3885067638df255acab3e1c2e93f293c25410 where the `type:custom` was manually added.

For legacy index templates from 8.6 this default type field does not exist so it causes issues with deserialisation, this bug was fixed in a later version of the client which this PR updates it to. This version change is not propagated widely as there are some breaking API usages in the client in other modules.

Also add the ability to pass in a prefix when running the standalone schema manager to make prefix migration simpler on the user 

## Related issues

relates to  https://github.com/camunda/camunda-docs/issues/4498
