### PR TITLE
ci: submit detailed test statistics on JUnit flaky tests

### DIFF
--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -21,6 +21,10 @@ inputs:
   job_name:
     description: 'Optional string, the job whose status is being observed; defaults to $GITHUB_JOB when omitted'
     required: false
+  detailed_junit_flaky_tests:
+    description: 'Optional boolean, if true search for TEST-*-FLAKY.xml files and submit their details to dedicated analytics endpoint'
+    required: false
+    default: 'false'
   secret_vault_address:
     description: 'Secret vault url'
     required: false
@@ -68,6 +72,28 @@ runs:
         else
           echo "result=" >> $GITHUB_OUTPUT
         fi
+
+    ####################### DETAILED FLAKY JUNIT TESTS #########################
+    - name: Get detailed info on flaky JUnit tests
+      id: get-detailed-flaky-junit-tests
+      if: ${{ inputs.detailed_junit_flaky_tests == 'true' && steps.secrets.outputs.gcloud_sa_key != '' }}
+      shell: bash
+      # To support multi-line string in output we have to work with EOF delimiter
+      # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
+      run: |
+        {
+          echo 'result<<EOF'
+          find . -iname 'TEST-*-FLAKY.xml' | xargs -d '\n' --no-run-if-empty -n1 python3 .github/actions/observe-build-status/junit-flaky-to-jsonl.py
+          echo EOF
+        } >> $GITHUB_OUTPUT
+
+    - uses: camunda/infra-global-github-actions/submit-test-status@main
+      if: ${{ inputs.detailed_junit_flaky_tests == 'true' && steps.secrets.outputs.gcloud_sa_key != '' }}
+      with:
+        test_event_record: "${{ steps.get-detailed-flaky-junit-tests.outputs.result }}"  # TODO: what is the size limit?
+        job_name_override: "${{ inputs.job_name }}"
+        gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"
+    ############################################################################
 
     - uses: camunda/infra-global-github-actions/submit-build-status@main
       if: ${{ always() && steps.secrets.outputs.gcloud_sa_key != '' }}

--- a/.github/actions/observe-build-status/junit-flaky-to-jsonl.py
+++ b/.github/actions/observe-build-status/junit-flaky-to-jsonl.py
@@ -1,0 +1,34 @@
+
+import sys
+import xml.etree.ElementTree
+
+def parse_junit_xml(file_path):
+    tree = xml.etree.ElementTree.parse(file_path)
+    root = tree.getroot()
+
+    if root.tag == 'testsuite':
+        parse_testsuite(root)
+    elif root.tag == 'testsuites':
+        for testsuite in root:
+            parse_testsuite(testsuite)
+
+def parse_testsuite(testsuite):
+    for testcase in testsuite.findall('testcase'):
+        test_class_name = testcase.get('classname')
+        test_class_duration_milliseconds = int(float(testsuite.get('time'))*1000)
+        test_name = testcase.get('name').removesuffix(' (Flaky Test)')
+        test_duration_milliseconds = int(float(testcase.get('time'))*1000)
+        print((
+            f'{{"test_class_name": "{test_class_name}", '
+            f'"test_class_duration_milliseconds": {test_class_duration_milliseconds}, '
+            f'"test_name": "{test_name}", '
+            f'"test_status": "flaky", '
+            f'"test_duration_milliseconds": {test_duration_milliseconds}}}'
+        ))
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python3 junit-flaky-to-jsonl.py path/to/TEST-sometestname-FLAKY.xml")
+        sys.exit(1)
+
+    parse_junit_xml(sys.argv[1])

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,7 @@ jobs:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
           user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
+          detailed_junit_flaky_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -326,6 +327,7 @@ jobs:
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
           user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
+          detailed_junit_flaky_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -197,6 +197,9 @@ jobs:
         uses: ./.github/actions/observe-build-status
         with:
           build_status: ${{ job.status }}
+          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
+          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
+          detailed_junit_flaky_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -250,6 +253,9 @@ jobs:
         uses: ./.github/actions/observe-build-status
         with:
           build_status: ${{ job.status }}
+          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
+          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
+          detailed_junit_flaky_tests: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}


### PR DESCRIPTION
## Description

This PR uses the new feature from https://github.com/camunda/team-infrastructure/issues/608 to submit detailed test statistics on flaky tests from JUnit.

That feature is implemented by the existing `observe-build-status` composite action local in this repo which gains a new input specifying whether it should search for and submit JUnit flaky test stats in addition. This composite action already is invoked at the end of every job and has access to the relevant secrets.

The submission is implemented via a `find ... | xargs python3 conversion-script.py` expression that uses Unix/Bash capabilities to find all relevant JUnit flaky test result files and then leverages a custom Python3 script to convert those XML files to JSONL output required by https://github.com/camunda/infra-global-github-actions/tree/main/submit-test-status

You can see example data in a new work-in-progess section at the top of this [Grafana](https://dashboard.int.camunda.com/d/ae2j69npxh3b4f/flaky-tests-camunda-camunda-monorepo) dashboard.

You can also see example data in `dev` BigQuery via:

```sql
SELECT test_class_name,test_name,a.build_id,b.*
FROM `ci-30-162810.dev_ci_analytics.test_status_v1` a LEFT OUTER JOIN `ci-30-162810.dev_ci_analytics.build_status_v2` b ON a.ci_url=b.ci_url AND a.build_id=b.build_id AND a.job_name=b.job_name
WHERE a.ci_url="https://github.com/camunda/camunda"
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Related to https://github.com/camunda/camunda/issues/26930