### PR TITLE
[POC] Support incident notification with camunda exporter

### DIFF
--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -128,7 +128,16 @@
     <dependency>
       <groupId>com.auth0</groupId>
       <artifactId>java-jwt</artifactId>
-      <version>4.4.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
 
     <dependency>

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -126,6 +126,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.auth0</groupId>
+      <artifactId>java-jwt</artifactId>
+      <version>4.4.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -226,6 +226,11 @@
       <artifactId>httpcore</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -241,12 +241,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -137,6 +137,8 @@ public class CamundaExporter implements Exporter {
 
   @Override
   public void close() {
+    provider.close();
+
     if (writer != null) {
       try {
         flush();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -94,6 +94,7 @@ import io.camunda.webapps.schema.descriptors.usermanagement.index.RoleIndex;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.UserIndex;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.net.http.HttpClient;
 import java.util.Collection;
 import java.util.Set;
 
@@ -135,9 +136,11 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(FormIndex.class).getFullQualifiedName()),
             new ExporterCacheMetrics("form", meterRegistry));
 
-    final M2mTokenManager m2mTokenManager = new M2mTokenManager(configuration.getNotifier());
+    final M2mTokenManager m2mTokenManager =
+        new M2mTokenManager(configuration.getNotifier(), HttpClient.newHttpClient());
     final IncidentNotifier incidentNotifier =
-        new IncidentNotifier(m2mTokenManager, processCache, configuration.getNotifier());
+        new IncidentNotifier(
+            m2mTokenManager, processCache, configuration.getNotifier(), HttpClient.newHttpClient());
     exportHandlers =
         Set.of(
             new RoleCreateUpdateHandler(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -64,6 +64,8 @@ import io.camunda.exporter.handlers.VariableHandler;
 import io.camunda.exporter.handlers.operation.OperationFromIncidentHandler;
 import io.camunda.exporter.handlers.operation.OperationFromProcessInstanceHandler;
 import io.camunda.exporter.handlers.operation.OperationFromVariableDocumentHandler;
+import io.camunda.exporter.notifier.IncidentNotifier;
+import io.camunda.exporter.notifier.M2mTokenManager;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
@@ -133,6 +135,9 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(FormIndex.class).getFullQualifiedName()),
             new ExporterCacheMetrics("form", meterRegistry));
 
+    final M2mTokenManager m2mTokenManager = new M2mTokenManager(configuration.getNotifier());
+    final IncidentNotifier incidentNotifier =
+        new IncidentNotifier(m2mTokenManager, processCache, configuration.getNotifier());
     exportHandlers =
         Set.of(
             new RoleCreateUpdateHandler(
@@ -186,7 +191,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new FlowNodeInstanceFromProcessInstanceHandler(
                 indexDescriptors.get(FlowNodeInstanceTemplate.class).getFullQualifiedName()),
             new IncidentHandler(
-                indexDescriptors.get(IncidentTemplate.class).getFullQualifiedName(), processCache),
+                indexDescriptors.get(IncidentTemplate.class).getFullQualifiedName(), processCache,
+                incidentNotifier),
             new SequenceFlowHandler(
                 indexDescriptors.get(SequenceFlowTemplate.class).getFullQualifiedName()),
             new DecisionEvaluationHandler(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
@@ -24,6 +24,8 @@ public interface ExporterResourceProvider {
       final MeterRegistry meterRegistry,
       final ExporterMetadata exporterMetadata);
 
+  void close();
+
   /**
    * This should return descriptors describing the desired state of all indices provided.
    *

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -21,6 +21,7 @@ public class ExporterConfiguration {
   private CacheConfiguration processCache = new CacheConfiguration();
   private CacheConfiguration formCache = new CacheConfiguration();
   private PostExportConfiguration postExport = new PostExportConfiguration();
+  private IncidentNotifierConfiguration notifier = new IncidentNotifierConfiguration();
   private boolean createSchema = true;
 
   public ConnectConfiguration getConnect() {
@@ -93,6 +94,14 @@ public class ExporterConfiguration {
 
   public void setPostExport(final PostExportConfiguration postExport) {
     this.postExport = postExport;
+  }
+
+  public IncidentNotifierConfiguration getNotifier() {
+    return notifier;
+  }
+
+  public void setNotifier(final IncidentNotifierConfiguration notifier) {
+    this.notifier = notifier;
   }
 
   @Override
@@ -441,6 +450,60 @@ public class ExporterConfiguration {
           + ", ignoreMissingData="
           + ignoreMissingData
           + '}';
+    }
+  }
+
+  public static final class IncidentNotifierConfiguration {
+
+    private String webhook;
+
+    /** Defines the domain which the user always sees */
+    private String domain;
+
+    private String m2mClientId;
+
+    private String m2mClientSecret;
+
+    private String m2mAudience;
+
+    public String getWebhook() {
+      return webhook;
+    }
+
+    public void setWebhook(final String webhook) {
+      this.webhook = webhook;
+    }
+
+    public String getDomain() {
+      return domain;
+    }
+
+    public void setDomain(final String domain) {
+      this.domain = domain;
+    }
+
+    public String getM2mClientId() {
+      return m2mClientId;
+    }
+
+    public void setM2mClientId(final String m2mClientId) {
+      this.m2mClientId = m2mClientId;
+    }
+
+    public String getM2mClientSecret() {
+      return m2mClientSecret;
+    }
+
+    public void setM2mClientSecret(final String m2mClientSecret) {
+      this.m2mClientSecret = m2mClientSecret;
+    }
+
+    public String getM2mAudience() {
+      return m2mAudience;
+    }
+
+    public void setM2mAudience(final String m2mAudience) {
+      this.m2mAudience = m2mAudience;
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -458,7 +458,7 @@ public class ExporterConfiguration {
     private String webhook;
 
     /** Defines the domain which the user always sees */
-    private String domain;
+    private String auth0Domain;
 
     private String m2mClientId;
 
@@ -474,12 +474,12 @@ public class ExporterConfiguration {
       this.webhook = webhook;
     }
 
-    public String getDomain() {
-      return domain;
+    public String getAuth0Domain() {
+      return auth0Domain;
     }
 
-    public void setDomain(final String domain) {
-      this.domain = domain;
+    public void setAuth0Domain(final String auth0Domain) {
+      this.auth0Domain = auth0Domain;
     }
 
     public String getM2mClientId() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/exceptions/IncidentNotifierException.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/exceptions/IncidentNotifierException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.exceptions;
+
+public class IncidentNotifierException extends RuntimeException {
+
+  public IncidentNotifierException(final String message) {
+    super(message);
+  }
+
+  public IncidentNotifierException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -129,7 +130,7 @@ public class IncidentHandler implements ExportHandler<IncidentEntity, IncidentRe
     batchRequest.upsert(indexName, String.valueOf(entity.getKey()), entity, updateFields);
 
     if (Objects.equals(intent, IncidentIntent.CREATED)) {
-      incidentNotifier.notifyOnIncidents(List.of(entity));
+      CompletableFuture.runAsync(() -> incidentNotifier.notifyOnIncidents(List.of(entity)));
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
@@ -31,7 +31,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,7 +43,8 @@ public class IncidentHandler implements ExportHandler<IncidentEntity, IncidentRe
   private final IncidentNotifier incidentNotifier;
 
   public IncidentHandler(
-      final String indexName, final ExporterEntityCache<Long, CachedProcessEntity> processCache,
+      final String indexName,
+      final ExporterEntityCache<Long, CachedProcessEntity> processCache,
       final IncidentNotifier incidentNotifier) {
     this.indexName = indexName;
     this.processCache = processCache;
@@ -130,7 +130,7 @@ public class IncidentHandler implements ExportHandler<IncidentEntity, IncidentRe
     batchRequest.upsert(indexName, String.valueOf(entity.getKey()), entity, updateFields);
 
     if (Objects.equals(intent, IncidentIntent.CREATED)) {
-      CompletableFuture.runAsync(() -> incidentNotifier.notifyOnIncidents(List.of(entity)));
+      incidentNotifier.notifyAsync(List.of(entity));
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
@@ -11,6 +11,7 @@ import static io.camunda.webapps.schema.descriptors.operate.template.IncidentTem
 
 import io.camunda.exporter.cache.ExporterEntityCache;
 import io.camunda.exporter.cache.process.CachedProcessEntity;
+import io.camunda.exporter.notifier.IncidentNotifier;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.exporter.utils.ProcessCacheUtil;
@@ -21,6 +22,7 @@ import io.camunda.webapps.schema.entities.operate.IncidentState;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -38,11 +40,14 @@ public class IncidentHandler implements ExportHandler<IncidentEntity, IncidentRe
   private final Map<String, Record<IncidentRecordValue>> recordsMap = new HashMap<>();
   private final String indexName;
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
+  private final IncidentNotifier incidentNotifier;
 
   public IncidentHandler(
-      final String indexName, final ExporterEntityCache<Long, CachedProcessEntity> processCache) {
+      final String indexName, final ExporterEntityCache<Long, CachedProcessEntity> processCache,
+      final IncidentNotifier incidentNotifier) {
     this.indexName = indexName;
     this.processCache = processCache;
+    this.incidentNotifier = incidentNotifier;
   }
 
   @Override
@@ -115,13 +120,17 @@ public class IncidentHandler implements ExportHandler<IncidentEntity, IncidentRe
   public void flush(final IncidentEntity entity, final BatchRequest batchRequest) {
     final String id = entity.getId();
     final Record<IncidentRecordValue> record = recordsMap.get(id);
-    final String intentStr = (record == null) ? null : record.getIntent().name();
-    if (intentStr == null) {
+    final Intent intent = (record == null) ? null : record.getIntent();
+    if (intent == null) {
       LOGGER.warn("Intent is null for incident: id {}", id);
     }
-    final Map<String, Object> updateFields = getUpdateFieldsMapByIntent(intentStr, entity);
+    final Map<String, Object> updateFields = getUpdateFieldsMapByIntent(intent, entity);
     updateFields.put(POSITION, entity.getPosition());
     batchRequest.upsert(indexName, String.valueOf(entity.getKey()), entity, updateFields);
+
+    if (Objects.equals(intent, IncidentIntent.CREATED)) {
+      incidentNotifier.notifyOnIncidents(List.of(entity));
+    }
   }
 
   @Override
@@ -175,9 +184,9 @@ public class IncidentHandler implements ExportHandler<IncidentEntity, IncidentRe
   }
 
   private static Map<String, Object> getUpdateFieldsMapByIntent(
-      final String intent, final IncidentEntity incidentEntity) {
+      final Intent intent, final IncidentEntity incidentEntity) {
     final Map<String, Object> updateFields = new HashMap<>();
-    if (Objects.equals(intent, IncidentIntent.MIGRATED.name())) {
+    if (Objects.equals(intent, IncidentIntent.MIGRATED)) {
       updateFields.put(BPMN_PROCESS_ID, incidentEntity.getBpmnProcessId());
       updateFields.put(PROCESS_DEFINITION_KEY, incidentEntity.getProcessDefinitionKey());
       updateFields.put(FLOW_NODE_ID, incidentEntity.getFlowNodeId());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
@@ -212,16 +212,14 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
   }
 
   private String getProcessName(final Long processDefinitionKey, final String bpmnProcessId) {
+    // If the cache does not contain the process definition then the process has been
+    // deleted from the backend. This is a special case which can happen only if there was a
+    // data loss in the backend. In that case, inorder to not block the exporter, we can
+    // return the bpmnProcessId as the process name.
     return processCache
         .get(processDefinitionKey)
         .map(CachedProcessEntity::name)
-        .map(
-            processName ->
-                processName == null || processName.isBlank() ? bpmnProcessId : processName)
-        // If the cache does not contain the process definition then the process has been
-        // deleted from the backend. This is a special case which can happen only if there was a
-        // data loss in the backend. In that case, inorder to not block the exporter, we can
-        // return the bpmnProcessId as the process name.
+        .filter(processName -> !processName.isBlank())
         .orElse(bpmnProcessId);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/IncidentNotifier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/IncidentNotifier.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.notifier;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.cache.ExporterEntityCache;
+import io.camunda.exporter.cache.process.CachedProcessEntity;
+import io.camunda.exporter.config.ExporterConfiguration.IncidentNotifierConfiguration;
+import io.camunda.webapps.schema.entities.operate.IncidentEntity;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Class that sends notifications about the created incidents on configured URL. */
+public class IncidentNotifier {
+
+  protected static final String FIELD_NAME_ALERTS = "alerts";
+  protected static final String FIELD_NAME_MESSAGE = "message";
+  protected static final String MESSAGE = "Incident created";
+  protected static final String FIELD_NAME_ID = "id";
+  protected static final String FIELD_NAME_PROCESS_INSTANCE_ID = "processInstanceId";
+  protected static final String FIELD_NAME_CREATION_TIME = "creationTime";
+  protected static final String FIELD_NAME_STATE = "state";
+  protected static final String FIELD_NAME_ERROR_MESSAGE = "errorMessage";
+  protected static final String FIELD_NAME_ERROR_TYPE = "errorType";
+  protected static final String FIELD_NAME_FLOW_NODE_ID = "flowNodeId";
+  protected static final String FIELD_NAME_FLOW_NODE_INSTANCE_KEY = "flowNodeInstanceKey";
+  protected static final String FIELD_NAME_JOB_KEY = "jobKey";
+  protected static final String FIELD_NAME_PROCESS_KEY = "processDefinitionKey";
+  protected static final String FIELD_NAME_BPMN_PROCESS_ID = "bpmnProcessId";
+  protected static final String FIELD_NAME_PROCESS_NAME = "processName";
+  protected static final String FIELD_NAME_PROCESS_VERSION = "processVersion";
+  private static final Logger LOGGER = LoggerFactory.getLogger(IncidentNotifier.class);
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final M2mTokenManager m2mTokenManager;
+
+  private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
+  private final IncidentNotifierConfiguration configuration;
+  private final HttpClient httpClient;
+
+  public IncidentNotifier(
+      final M2mTokenManager m2mTokenManager,
+      final ExporterEntityCache<Long, CachedProcessEntity> processCache,
+      final IncidentNotifierConfiguration configuration) {
+    this.m2mTokenManager = m2mTokenManager;
+    this.processCache = processCache;
+    this.configuration = configuration;
+    httpClient = HttpClient.newHttpClient();
+  }
+
+  public void notifyOnIncidents(final List<IncidentEntity> incidents) {
+    if (StringUtils.isBlank(configuration.getWebhook())) {
+      LOGGER.debug("Incident notification is disabled");
+      return;
+    }
+
+    try {
+      int status = notifyOnIncidents(incidents, m2mTokenManager.getToken());
+
+      if (status / 100 == 2) {
+        LOGGER.debug("Incident notification is sent");
+      } else if (status == 401) {
+        LOGGER.debug("Incident notification recieved 401 response");
+        // retry
+        status = notifyOnIncidents(incidents, m2mTokenManager.getToken(true));
+        if (status / 100 == 2) {
+          LOGGER.debug("Incident notification is sent");
+        } else {
+          LOGGER.error("Failed to send incident notification. Response status: " + status);
+        }
+      } else {
+        LOGGER.error("Failed to send incident notification. Response status: " + status);
+      }
+    } catch (final JsonProcessingException e) {
+      LOGGER.error("Failed to create incident notification request: " + e.getMessage(), e);
+    } catch (final Exception e) {
+      LOGGER.error("Failed to notify on incidents: " + e.getMessage(), e);
+    }
+  }
+
+  private int notifyOnIncidents(final List<IncidentEntity> incidents, final String m2mToken)
+      throws IOException, InterruptedException {
+    final String payload = getIncidentsAsJSON(incidents);
+    final HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(URI.create(configuration.getWebhook()))
+            .header("Content-Type", "application/json")
+            .header("Authorization", "Bearer " + m2mToken)
+            .POST(HttpRequest.BodyPublishers.ofString(payload))
+            .build();
+
+    final HttpResponse<String> response =
+        httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+    return response.statusCode();
+  }
+
+  private String getIncidentsAsJSON(final List<IncidentEntity> incidents)
+      throws JsonProcessingException {
+    final List<Map<String, Object>> incidentList = new ArrayList<>();
+    for (final IncidentEntity inc : incidents) {
+      final Map<String, Object> incidentFields = new HashMap<>();
+      incidentFields.put(FIELD_NAME_MESSAGE, MESSAGE);
+      incidentFields.put(FIELD_NAME_ID, inc.getId());
+      incidentFields.put(
+          FIELD_NAME_PROCESS_INSTANCE_ID, String.valueOf(inc.getProcessInstanceKey()));
+      incidentFields.put(FIELD_NAME_CREATION_TIME, inc.getCreationTime());
+      incidentFields.put(FIELD_NAME_STATE, inc.getState());
+      incidentFields.put(FIELD_NAME_ERROR_MESSAGE, inc.getErrorMessage());
+      incidentFields.put(FIELD_NAME_ERROR_TYPE, inc.getErrorType());
+      incidentFields.put(FIELD_NAME_FLOW_NODE_ID, inc.getFlowNodeId());
+      incidentFields.put(FIELD_NAME_FLOW_NODE_INSTANCE_KEY, inc.getFlowNodeInstanceKey());
+      incidentFields.put(FIELD_NAME_JOB_KEY, inc.getJobKey());
+      incidentFields.put(FIELD_NAME_PROCESS_KEY, inc.getProcessDefinitionKey());
+      // TODO in operate it used to retry to get the process with a wait time,I don't think we need
+      // that
+      final Optional<CachedProcessEntity> process = processCache.get(inc.getProcessDefinitionKey());
+      if (process.isPresent()) {
+        // FIXME do we need this?
+        // incidentFields.put(FIELD_NAME_BPMN_PROCESS_ID, process.get().getBpmnProcessId());
+        incidentFields.put(FIELD_NAME_PROCESS_NAME, process.get().name());
+        incidentFields.put(FIELD_NAME_PROCESS_VERSION, process.get().versionTag());
+      }
+      incidentList.add(incidentFields);
+    }
+    return MAPPER.writeValueAsString(Map.of(FIELD_NAME_ALERTS, incidentList));
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/IncidentNotifier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/IncidentNotifier.java
@@ -132,12 +132,9 @@ public class IncidentNotifier {
       incidentFields.put(FIELD_NAME_FLOW_NODE_INSTANCE_KEY, inc.getFlowNodeInstanceKey());
       incidentFields.put(FIELD_NAME_JOB_KEY, inc.getJobKey());
       incidentFields.put(FIELD_NAME_PROCESS_KEY, inc.getProcessDefinitionKey());
-      // TODO in operate it used to retry to get the process with a wait time,I don't think we need
-      // that
       final Optional<CachedProcessEntity> process = processCache.get(inc.getProcessDefinitionKey());
       if (process.isPresent()) {
-        // FIXME do we need this?
-        // incidentFields.put(FIELD_NAME_BPMN_PROCESS_ID, process.get().getBpmnProcessId());
+        incidentFields.put(FIELD_NAME_BPMN_PROCESS_ID, inc.getBpmnProcessId());
         incidentFields.put(FIELD_NAME_PROCESS_NAME, process.get().name());
         incidentFields.put(FIELD_NAME_PROCESS_VERSION, process.get().versionTag());
       }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/IncidentNotifier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/IncidentNotifier.java
@@ -24,6 +24,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,16 +58,24 @@ public class IncidentNotifier {
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
   private final IncidentNotifierConfiguration configuration;
   private final HttpClient httpClient;
+  private final Executor executor;
 
   public IncidentNotifier(
       final M2mTokenManager m2mTokenManager,
       final ExporterEntityCache<Long, CachedProcessEntity> processCache,
       final IncidentNotifierConfiguration configuration,
-      final HttpClient httpClient) {
+      final HttpClient httpClient,
+      final Executor executor) {
     this.m2mTokenManager = m2mTokenManager;
     this.processCache = processCache;
     this.configuration = configuration;
     this.httpClient = httpClient;
+    this.executor = executor;
+  }
+
+  public void notifyAsync(final List<IncidentEntity> incidents) {
+    CompletableFuture.runAsync(() -> notifyOnIncidents(incidents), executor);
+    LOGGER.debug("Incident notification is scheduled");
   }
 
   public void notifyOnIncidents(final List<IncidentEntity> incidents) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/IncidentNotifier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/IncidentNotifier.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.notifier;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.exporter.cache.ExporterEntityCache;
 import io.camunda.exporter.cache.process.CachedProcessEntity;
 import io.camunda.exporter.config.ExporterConfiguration.IncidentNotifierConfiguration;
@@ -47,7 +48,8 @@ public class IncidentNotifier {
   protected static final String FIELD_NAME_PROCESS_NAME = "processName";
   protected static final String FIELD_NAME_PROCESS_VERSION = "processVersion";
   private static final Logger LOGGER = LoggerFactory.getLogger(IncidentNotifier.class);
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper().registerModule(new JavaTimeModule());
 
   private final M2mTokenManager m2mTokenManager;
 
@@ -58,11 +60,12 @@ public class IncidentNotifier {
   public IncidentNotifier(
       final M2mTokenManager m2mTokenManager,
       final ExporterEntityCache<Long, CachedProcessEntity> processCache,
-      final IncidentNotifierConfiguration configuration) {
+      final IncidentNotifierConfiguration configuration,
+      final HttpClient httpClient) {
     this.m2mTokenManager = m2mTokenManager;
     this.processCache = processCache;
     this.configuration = configuration;
-    httpClient = HttpClient.newHttpClient();
+    this.httpClient = httpClient;
   }
 
   public void notifyOnIncidents(final List<IncidentEntity> incidents) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/IncidentNotifier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/IncidentNotifier.java
@@ -80,21 +80,23 @@ public class IncidentNotifier {
       if (status / 100 == 2) {
         LOGGER.debug("Incident notification is sent");
       } else if (status == 401) {
-        LOGGER.debug("Incident notification recieved 401 response");
+        LOGGER.debug("Incident notification unauthorized. Retrying with a new token");
         // retry
         status = notifyOnIncidents(incidents, m2mTokenManager.getToken(true));
         if (status / 100 == 2) {
           LOGGER.debug("Incident notification is sent");
         } else {
-          LOGGER.error("Failed to send incident notification. Response status: " + status);
+          LOGGER.warn(
+              "Failed to send incident notification after retrying with a new token. Response status: "
+                  + status);
         }
       } else {
-        LOGGER.error("Failed to send incident notification. Response status: " + status);
+        LOGGER.warn("Failed to send incident notification. Response status: " + status);
       }
     } catch (final JsonProcessingException e) {
-      LOGGER.error("Failed to create incident notification request: " + e.getMessage(), e);
+      LOGGER.warn("Failed to create incident notification request: " + e.getMessage(), e);
     } catch (final Exception e) {
-      LOGGER.error("Failed to notify on incidents: " + e.getMessage(), e);
+      LOGGER.warn("Failed to notify on incidents: " + e.getMessage(), e);
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/M2mTokenManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/M2mTokenManager.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.notifier;
+
+import com.auth0.jwt.JWT;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.camunda.exporter.config.ExporterConfiguration.IncidentNotifierConfiguration;
+import io.camunda.exporter.exceptions.IncidentNotifierException;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Date;
+import java.util.Map;
+
+/** Class to get and cache M2M Auth0 access token. */
+public class M2mTokenManager {
+
+  protected static final String FIELD_NAME_GRANT_TYPE = "grant_type";
+  protected static final String GRANT_TYPE_VALUE = "client_credentials";
+  protected static final String FIELD_NAME_CLIENT_ID = "client_id";
+  protected static final String FIELD_NAME_CLIENT_SECRET = "client_secret";
+  protected static final String FIELD_NAME_AUDIENCE = "audience";
+  protected static final String FIELD_NAME_ACCESS_TOKEN = "access_token";
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private final IncidentNotifierConfiguration configuration;
+  private final HttpClient client;
+
+  /** Cached token. */
+  private String token;
+
+  private Date tokenExpiresAt;
+  private final Object cacheLock = new Object();
+
+  public M2mTokenManager(final IncidentNotifierConfiguration configuration) {
+    this.configuration = configuration;
+    client = HttpClient.newHttpClient();
+  }
+
+  public String getToken() {
+    return getToken(false);
+  }
+
+  public String getToken(final boolean forceTokenUpdate) {
+    if (token == null || tokenIsExpired() || forceTokenUpdate) {
+      synchronized (cacheLock) {
+        if (token == null || tokenIsExpired() || forceTokenUpdate) {
+          token = getNewToken();
+          tokenExpiresAt = JWT.decode(token).getExpiresAt();
+        }
+      }
+    }
+    return token;
+  }
+
+  private boolean tokenIsExpired() {
+    // if tokenExpiresAt == null, we consider the token to be valid and will rely on 401 response
+    // code for incident notification
+    return tokenExpiresAt != null && !tokenExpiresAt.after(new Date());
+  }
+
+  private String getNewToken() {
+    try {
+      final String tokenURL = String.format("https://%s/oauth/token", configuration.getDomain());
+
+      final HttpRequest request =
+          HttpRequest.newBuilder()
+              .uri(URI.create(tokenURL))
+              .header("Content-Type", "application/json")
+              .POST(
+                  HttpRequest.BodyPublishers.ofString(
+                      MAPPER.writeValueAsString(createGetTokenRequest())))
+              .build();
+
+      final HttpResponse<String> response =
+          client.send(request, HttpResponse.BodyHandlers.ofString());
+
+      if (response.statusCode() != 200) {
+        throw new IncidentNotifierException(
+            String.format(
+                "Unable to get the M2M auth token, response status: %s.", response.statusCode()));
+      }
+
+      final Map<String, Object> responseBody = MAPPER.readValue(response.body(), Map.class);
+      return (String) responseBody.get(FIELD_NAME_ACCESS_TOKEN);
+    } catch (final IOException | InterruptedException e) {
+      throw new IncidentNotifierException("Unable to get the M2M auth token", e);
+    }
+  }
+
+  private ObjectNode createGetTokenRequest() {
+    final ObjectNode request =
+        MAPPER
+            .createObjectNode()
+            .put(FIELD_NAME_GRANT_TYPE, GRANT_TYPE_VALUE)
+            .put(FIELD_NAME_CLIENT_ID, configuration.getM2mClientId())
+            .put(FIELD_NAME_CLIENT_SECRET, configuration.getM2mClientSecret())
+            .put(FIELD_NAME_AUDIENCE, configuration.getM2mAudience());
+    return request;
+  }
+
+  /** Only for test usage. */
+  protected void clearCache() {
+    token = null;
+    tokenExpiresAt = null;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/M2mTokenManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/M2mTokenManager.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.notifier;
 import com.auth0.jwt.JWT;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.exporter.config.ExporterConfiguration.IncidentNotifierConfiguration;
 import io.camunda.exporter.exceptions.IncidentNotifierException;
 import java.io.IOException;
@@ -29,7 +30,8 @@ public class M2mTokenManager {
   protected static final String FIELD_NAME_CLIENT_SECRET = "client_secret";
   protected static final String FIELD_NAME_AUDIENCE = "audience";
   protected static final String FIELD_NAME_ACCESS_TOKEN = "access_token";
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper().registerModule(new JavaTimeModule());
   private final IncidentNotifierConfiguration configuration;
   private final HttpClient client;
 
@@ -39,9 +41,10 @@ public class M2mTokenManager {
   private Date tokenExpiresAt;
   private final Object cacheLock = new Object();
 
-  public M2mTokenManager(final IncidentNotifierConfiguration configuration) {
+  public M2mTokenManager(
+      final IncidentNotifierConfiguration configuration, final HttpClient client) {
     this.configuration = configuration;
-    client = HttpClient.newHttpClient();
+    this.client = client;
   }
 
   public String getToken() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/M2mTokenManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/M2mTokenManager.java
@@ -71,7 +71,8 @@ public class M2mTokenManager {
 
   private String getNewToken() {
     try {
-      final String tokenURL = String.format("https://%s/oauth/token", configuration.getDomain());
+      final String tokenURL =
+          String.format("https://%s/oauth/token", configuration.getAuth0Domain());
 
       final HttpRequest request =
           HttpRequest.newBuilder()

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.cache.TestProcessCache;
 import io.camunda.exporter.cache.process.CachedProcessEntity;
+import io.camunda.exporter.notifier.IncidentNotifier;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.entities.operate.IncidentEntity;
@@ -40,7 +41,9 @@ public class IncidentHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
   private final String indexName = "test-incident";
   private final TestProcessCache processCache = new TestProcessCache();
-  private final IncidentHandler underTest = new IncidentHandler(indexName, processCache);
+  private final IncidentNotifier incidentNotifier = mock(IncidentNotifier.class);
+  private final IncidentHandler underTest =
+      new IncidentHandler(indexName, processCache, incidentNotifier);
 
   @Test
   void testGetHandledValueType() {
@@ -118,6 +121,7 @@ public class IncidentHandlerTest {
 
     // then
     verify(mockRequest, times(1)).upsert(indexName, "0", inputEntity, Map.of("position", 1L));
+    verify(incidentNotifier).notifyOnIncidents(List.of(inputEntity));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
@@ -35,7 +35,6 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
 public class IncidentHandlerTest {
@@ -141,8 +140,7 @@ public class IncidentHandlerTest {
     // then
     verify(mockRequest, times(1))
         .upsert(indexName, String.valueOf(recordKey), incidentEntity, Map.of("position", 1L));
-    Awaitility.await()
-        .untilAsserted(() -> verify(incidentNotifier).notifyOnIncidents(List.of(incidentEntity)));
+    verify(incidentNotifier).notifyAsync(List.of(incidentEntity));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
@@ -35,6 +35,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
 public class IncidentHandlerTest {
@@ -140,7 +141,8 @@ public class IncidentHandlerTest {
     // then
     verify(mockRequest, times(1))
         .upsert(indexName, String.valueOf(recordKey), incidentEntity, Map.of("position", 1L));
-    verify(incidentNotifier).notifyOnIncidents(List.of(incidentEntity));
+    Awaitility.await()
+        .untilAsserted(() -> verify(incidentNotifier).notifyOnIncidents(List.of(incidentEntity)));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/notifier/IncidentNotifierTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/notifier/IncidentNotifierTest.java
@@ -87,7 +87,7 @@ class IncidentNotifierTest {
     final IncidentNotifierConfiguration configuration = new IncidentNotifierConfiguration();
     configuration.setWebhook(ALERT_WEBHOOKURL_URL);
     incidentNotifier =
-        new IncidentNotifier(m2mTokenManager, processCache, configuration, httpClient);
+        new IncidentNotifier(m2mTokenManager, processCache, configuration, httpClient, null);
     when(processCache.get(any()))
         .thenReturn(Optional.of(new CachedProcessEntity(processName, processVersion, null)));
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/notifier/IncidentNotifierTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/notifier/IncidentNotifierTest.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.notifier;
+
+import static io.camunda.exporter.notifier.IncidentNotifier.FIELD_NAME_ALERTS;
+import static io.camunda.exporter.notifier.IncidentNotifier.FIELD_NAME_CREATION_TIME;
+import static io.camunda.exporter.notifier.IncidentNotifier.FIELD_NAME_ERROR_MESSAGE;
+import static io.camunda.exporter.notifier.IncidentNotifier.FIELD_NAME_ERROR_TYPE;
+import static io.camunda.exporter.notifier.IncidentNotifier.FIELD_NAME_FLOW_NODE_ID;
+import static io.camunda.exporter.notifier.IncidentNotifier.FIELD_NAME_FLOW_NODE_INSTANCE_KEY;
+import static io.camunda.exporter.notifier.IncidentNotifier.FIELD_NAME_JOB_KEY;
+import static io.camunda.exporter.notifier.IncidentNotifier.FIELD_NAME_MESSAGE;
+import static io.camunda.exporter.notifier.IncidentNotifier.FIELD_NAME_PROCESS_INSTANCE_ID;
+import static io.camunda.exporter.notifier.IncidentNotifier.FIELD_NAME_PROCESS_KEY;
+import static io.camunda.exporter.notifier.IncidentNotifier.FIELD_NAME_PROCESS_NAME;
+import static io.camunda.exporter.notifier.IncidentNotifier.FIELD_NAME_PROCESS_VERSION;
+import static io.camunda.exporter.notifier.IncidentNotifier.FIELD_NAME_STATE;
+import static io.camunda.exporter.notifier.IncidentNotifier.MESSAGE;
+import static io.camunda.webapps.schema.entities.operate.ErrorType.JOB_NO_RETRIES;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import io.camunda.exporter.cache.ExporterEntityCache;
+import io.camunda.exporter.cache.process.CachedProcessEntity;
+import io.camunda.exporter.config.ExporterConfiguration.IncidentNotifierConfiguration;
+import io.camunda.webapps.schema.entities.operate.ErrorType;
+import io.camunda.webapps.schema.entities.operate.IncidentEntity;
+import io.camunda.webapps.schema.entities.operate.IncidentState;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.Flow.Subscriber;
+import java.util.concurrent.Flow.Subscription;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class IncidentNotifierTest {
+  protected static final String ALERT_WEBHOOKURL_URL = "http://WEBHOOKURL/path";
+  private final String m2mToken = "mockM2mToken";
+  private final String incident1Id = "incident1";
+  private final String incident2Id = "incident2";
+  private final Long processInstanceKey = 123L;
+  private final String errorMessage = "errorMessage";
+  private final ErrorType errorType = JOB_NO_RETRIES;
+  private final String flowNodeId = "flowNodeId1";
+  private final Long flowNodeInstanceId = 234L;
+  private final Long processDefinitionKey = 345L;
+  private final Long jobKey = 456L;
+  private final IncidentState incidentState = IncidentState.ACTIVE;
+  private final String bpmnProcessId = "testProcessId";
+  private final String processName = "processName";
+  private final String processVersion = "234";
+  private final M2mTokenManager m2mTokenManager = mock(M2mTokenManager.class);
+  private final ExporterEntityCache<Long, CachedProcessEntity> processCache =
+      mock(ExporterEntityCache.class);
+  private final HttpClient httpClient = mock(HttpClient.class);
+
+  private IncidentNotifier incidentNotifier;
+
+  @BeforeEach
+  public void setup() {
+    final IncidentNotifierConfiguration configuration = new IncidentNotifierConfiguration();
+    configuration.setWebhook(ALERT_WEBHOOKURL_URL);
+    incidentNotifier =
+        new IncidentNotifier(m2mTokenManager, processCache, configuration, httpClient);
+    when(processCache.get(any()))
+        .thenReturn(Optional.of(new CachedProcessEntity(processName, processVersion, null)));
+  }
+
+  @Test
+  public void testIncidentsNotificationIsSent() throws IOException, InterruptedException {
+    given(m2mTokenManager.getToken()).willReturn(m2mToken);
+    final HttpResponse mock = mock(HttpResponse.class);
+    when(mock.statusCode()).thenReturn(204);
+    when(httpClient.send(any(), any())).thenReturn(mock);
+    // when
+    final List<IncidentEntity> incidents =
+        asList(createIncident(incident1Id), createIncident(incident2Id));
+    incidentNotifier.notifyOnIncidents(incidents);
+
+    // then
+    final ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+    verify(httpClient, times(1))
+        .send(requestCaptor.capture(), eq(HttpResponse.BodyHandlers.ofString()));
+    final HttpRequest request = requestCaptor.getValue();
+    assertThat(request.uri().toString()).isEqualTo(ALERT_WEBHOOKURL_URL);
+    assertThat(request.headers().allValues("Authorization").getFirst())
+        .isEqualTo("Bearer " + m2mToken);
+
+    final String body = extractBody(request.bodyPublisher().orElseThrow());
+
+    // assert body
+    final DocumentContext jsonContext = JsonPath.parse(body);
+    final String alerts = "$." + FIELD_NAME_ALERTS;
+    assertThat(jsonContext.read(alerts, Object.class)).isNotNull();
+    assertThat(jsonContext.read(alerts + ".length()", Integer.class)).isEqualTo(2);
+    assertThat(jsonContext.read(alerts + "[0].id", String.class)).isEqualTo(incident1Id);
+    assertIncidentFields(jsonContext.read(alerts + "[0]", HashMap.class));
+    assertThat(jsonContext.read(alerts + "[1].id", String.class)).isEqualTo(incident2Id);
+    assertIncidentFields(jsonContext.read(alerts + "[1]", HashMap.class));
+  }
+
+  @Test
+  public void testTokenIsNotValid() throws IOException, InterruptedException {
+    given(m2mTokenManager.getToken()).willReturn(m2mToken);
+    given(m2mTokenManager.getToken(anyBoolean())).willReturn(m2mToken);
+    // the first call will return UNAUTHORIZED, the second - OK
+    final HttpResponse mock = mock(HttpResponse.class);
+    when(mock.statusCode()).thenReturn(401).thenReturn(200);
+    given(httpClient.send(any(), any())).willReturn(mock, mock);
+
+    // when
+    final List<IncidentEntity> incidents = asList(createIncident(incident1Id));
+    incidentNotifier.notifyOnIncidents(incidents);
+
+    // then
+    // new token was requested
+    verify(m2mTokenManager, times(1)).getToken(eq(true));
+    // incident data was sent
+    final ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
+    verify(httpClient, times(2))
+        .send(requestCaptor.capture(), eq(HttpResponse.BodyHandlers.ofString()));
+
+    final HttpRequest request = requestCaptor.getValue();
+    assertThat(request.headers().allValues("Authorization").getFirst())
+        .isEqualTo("Bearer " + m2mToken);
+    assertThat(request.uri().toString()).isEqualTo(ALERT_WEBHOOKURL_URL);
+
+    final String body = extractBody(request.bodyPublisher().orElseThrow());
+    final DocumentContext jsonContext = JsonPath.parse(body);
+    final String alerts = "$." + FIELD_NAME_ALERTS;
+    assertThat(jsonContext.read(alerts, Object.class)).isNotNull();
+    assertThat(jsonContext.read(alerts + ".length()", Integer.class)).isEqualTo(1);
+    assertThat(jsonContext.read(alerts + "[0].id", String.class)).isEqualTo(incident1Id);
+    assertIncidentFields(jsonContext.read(alerts + "[0]", HashMap.class));
+  }
+
+  @Test
+  public void testNotificationFailed() throws IOException, InterruptedException {
+    given(m2mTokenManager.getToken()).willReturn(m2mToken);
+    // webhook returns status 500
+    final HttpResponse mock = mock(HttpResponse.class);
+    when(mock.statusCode()).thenReturn(500);
+    given(httpClient.send(any(), any())).willReturn(mock);
+
+    // when
+    final List<IncidentEntity> incidents = asList(createIncident(incident1Id));
+    incidentNotifier.notifyOnIncidents(incidents);
+
+    // silently fails without exception
+  }
+
+  @Test
+  public void testNotificationFailedFromSecondAttempt() throws IOException, InterruptedException {
+    given(m2mTokenManager.getToken()).willReturn(m2mToken);
+    given(m2mTokenManager.getToken(anyBoolean())).willReturn(m2mToken);
+    // the first call will return UNAUTHORIZED, the second - 500
+    final HttpResponse mock = mock(HttpResponse.class);
+    when(mock.statusCode()).thenReturn(401).thenReturn(500);
+    given(httpClient.send(any(), any())).willReturn(mock, mock);
+
+    // when
+    final List<IncidentEntity> incidents = List.of(createIncident(incident1Id));
+    incidentNotifier.notifyOnIncidents(incidents);
+
+    // then
+    // new token was requested
+    verify(m2mTokenManager, times(1)).getToken(eq(true));
+    // silently fails without exception
+  }
+
+  @Test
+  public void testNotificationFailedWithException() throws IOException, InterruptedException {
+    given(m2mTokenManager.getToken()).willReturn(m2mToken);
+    // notification will throw exception
+    given(httpClient.send(any(), any())).willThrow(new RuntimeException("Something went wrong"));
+
+    // when
+    final List<IncidentEntity> incidents = List.of(createIncident(incident1Id));
+    incidentNotifier.notifyOnIncidents(incidents);
+
+    // then
+    // silently fails without exception
+  }
+
+  private String extractBody(final HttpRequest.BodyPublisher bodyPublisher)
+      throws IOException, InterruptedException {
+    final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    bodyPublisher.subscribe(
+        new Subscriber<>() {
+          @Override
+          public void onSubscribe(final Subscription subscription) {
+            subscription.request(Long.MAX_VALUE);
+          }
+
+          @Override
+          public void onNext(final ByteBuffer item) {
+            outputStream.write(item.array(), item.position(), item.remaining());
+          }
+
+          @Override
+          public void onError(final Throwable throwable) {
+            throw new RuntimeException(throwable);
+          }
+
+          @Override
+          public void onComplete() {
+            // No action needed
+          }
+        });
+
+    // Wait for the body to be fully written
+    Thread.sleep(100); // Adjust the sleep time as needed
+
+    return outputStream.toString(StandardCharsets.UTF_8);
+  }
+
+  private void assertIncidentFields(final HashMap incidentFields) {
+    assertThat(incidentFields.get(FIELD_NAME_MESSAGE)).isEqualTo(MESSAGE);
+    assertThat(incidentFields.get(FIELD_NAME_JOB_KEY)).isEqualTo(jobKey.intValue());
+    assertThat(incidentFields.get(FIELD_NAME_PROCESS_KEY))
+        .isEqualTo(processDefinitionKey.intValue());
+    assertThat(incidentFields.get(FIELD_NAME_PROCESS_NAME)).isEqualTo(processName);
+    assertThat(incidentFields.get(FIELD_NAME_PROCESS_VERSION)).isEqualTo(processVersion);
+    assertThat(incidentFields.get(FIELD_NAME_FLOW_NODE_INSTANCE_KEY))
+        .isEqualTo(flowNodeInstanceId.intValue());
+    assertThat(incidentFields.get(FIELD_NAME_CREATION_TIME)).isNotNull();
+    assertThat(incidentFields.get(FIELD_NAME_ERROR_MESSAGE)).isEqualTo(errorMessage);
+    assertThat(incidentFields.get(FIELD_NAME_ERROR_TYPE)).isEqualTo(errorType.name());
+    assertThat(incidentFields.get(FIELD_NAME_FLOW_NODE_ID)).isEqualTo(flowNodeId);
+    assertThat(incidentFields.get(FIELD_NAME_STATE)).isEqualTo(incidentState.name());
+    assertThat(incidentFields.get(FIELD_NAME_PROCESS_INSTANCE_ID))
+        .isEqualTo(String.valueOf(processInstanceKey));
+  }
+
+  private IncidentEntity createIncident(final String id) {
+    return new IncidentEntity()
+        .setId(id)
+        .setCreationTime(OffsetDateTime.now())
+        .setProcessInstanceKey(processInstanceKey)
+        .setErrorMessage(errorMessage)
+        .setErrorType(errorType)
+        .setFlowNodeId(flowNodeId)
+        .setFlowNodeInstanceKey(flowNodeInstanceId)
+        .setProcessDefinitionKey(processDefinitionKey)
+        .setBpmnProcessId(bpmnProcessId)
+        .setJobKey(jobKey)
+        .setState(incidentState);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/notifier/M2mTokenManagerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/notifier/M2mTokenManagerTest.java
@@ -69,7 +69,7 @@ class M2mTokenManagerTest {
   @BeforeEach
   public void setup() {
     final IncidentNotifierConfiguration configuration = new IncidentNotifierConfiguration();
-    configuration.setDomain(AUTH0_DOMAIN);
+    configuration.setAuth0Domain(AUTH0_DOMAIN);
     configuration.setM2mClientId(M2M_CLIENT_ID);
     configuration.setM2mClientSecret(M2M_CLIENT_SECRET);
     configuration.setM2mAudience(M2M_AUDIENCE);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/notifier/M2mTokenManagerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/notifier/M2mTokenManagerTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.notifier;
+
+import static io.camunda.exporter.notifier.M2mTokenManager.FIELD_NAME_ACCESS_TOKEN;
+import static io.camunda.exporter.notifier.M2mTokenManager.FIELD_NAME_AUDIENCE;
+import static io.camunda.exporter.notifier.M2mTokenManager.FIELD_NAME_CLIENT_ID;
+import static io.camunda.exporter.notifier.M2mTokenManager.FIELD_NAME_CLIENT_SECRET;
+import static io.camunda.exporter.notifier.M2mTokenManager.FIELD_NAME_GRANT_TYPE;
+import static io.camunda.exporter.notifier.M2mTokenManager.GRANT_TYPE_VALUE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import io.camunda.exporter.config.ExporterConfiguration.IncidentNotifierConfiguration;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.Flow.Subscriber;
+import java.util.concurrent.Flow.Subscription;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.quality.Strictness;
+
+class M2mTokenManagerTest {
+  protected static final String AUTH0_DOMAIN = "auth0.domain";
+  protected static final String M2M_CLIENT_ID = "clientId";
+  protected static final String M2M_CLIENT_SECRET = "clientSecret";
+  protected static final String M2M_AUDIENCE = "audience";
+  private static final ObjectMapper MAPPER =
+      new ObjectMapper().registerModule(new JavaTimeModule());
+  private final String mockJwtToken =
+      JWT.create()
+          .withExpiresAt(new Date(Instant.now().plus(10, ChronoUnit.MINUTES).toEpochMilli()))
+          .sign(Algorithm.HMAC256("secret"));
+  private final HttpClient httpClient = mock(HttpClient.class);
+  private M2mTokenManager m2mTokenManager;
+
+  @BeforeEach
+  public void setup() {
+    final IncidentNotifierConfiguration configuration = new IncidentNotifierConfiguration();
+    configuration.setDomain(AUTH0_DOMAIN);
+    configuration.setM2mClientId(M2M_CLIENT_ID);
+    configuration.setM2mClientSecret(M2M_CLIENT_SECRET);
+    configuration.setM2mAudience(M2M_AUDIENCE);
+
+    m2mTokenManager = new M2mTokenManager(configuration, httpClient);
+  }
+
+  @AfterEach
+  public void cleanup() {
+    m2mTokenManager.clearCache();
+  }
+
+  @Test
+  public void testGetTokenFromCache() throws IOException, InterruptedException {
+    final HttpResponse response =
+        mock(
+            HttpResponse.class,
+            withSettings().defaultAnswer(RETURNS_DEEP_STUBS).strictness(Strictness.LENIENT));
+    when(response.body())
+        .thenReturn(MAPPER.writeValueAsString(Map.of(FIELD_NAME_ACCESS_TOKEN, mockJwtToken)));
+    when(response.statusCode()).thenReturn(200);
+
+    given(httpClient.send(any(), any())).willReturn(response);
+
+    // when requesting the token for the 1st time
+    String token = m2mTokenManager.getToken();
+
+    // then
+    assertThat(token).isEqualTo(mockJwtToken);
+    assertAuth0IsRequested(1);
+
+    // when requesting the token for the 2nd time
+    token = m2mTokenManager.getToken();
+
+    // then
+    assertThat(token).isEqualTo(mockJwtToken);
+    // no request to Auth0 is sent
+    verifyNoMoreInteractions(httpClient);
+  }
+
+  @Test
+  public void testTokenWithForceUpdate() throws IOException, InterruptedException {
+    final HttpResponse response =
+        mock(
+            HttpResponse.class,
+            withSettings().defaultAnswer(RETURNS_DEEP_STUBS).strictness(Strictness.LENIENT));
+    when(response.body())
+        .thenReturn(MAPPER.writeValueAsString(Map.of(FIELD_NAME_ACCESS_TOKEN, mockJwtToken)));
+
+    when(response.statusCode()).thenReturn(200);
+
+    given(httpClient.send(any(), any())).willReturn(response);
+
+    // when
+    // requesting for the 1st time
+    m2mTokenManager.getToken();
+    // requesting with forceUpdate = true
+    String token = m2mTokenManager.getToken(true);
+
+    // then
+    assertThat(token).isEqualTo(mockJwtToken);
+    // rest call was sent twice
+    assertAuth0IsRequested(2);
+
+    // when requesting with forceUpdate = false
+    token = m2mTokenManager.getToken(false);
+
+    // then
+    assertThat(token).isEqualTo(mockJwtToken);
+    // no request to Auth0 is sent
+    verifyNoMoreInteractions(httpClient);
+  }
+
+  @Test
+  public void testTokenIsExpired() throws IOException, InterruptedException {
+    // given
+    final String mockExpiredJwtToken =
+        JWT.create()
+            .withExpiresAt(new Date(Instant.now().minus(10, ChronoUnit.MINUTES).toEpochMilli()))
+            .sign(Algorithm.HMAC256("secret"));
+
+    final HttpResponse response =
+        mock(
+            HttpResponse.class,
+            withSettings().defaultAnswer(RETURNS_DEEP_STUBS).strictness(Strictness.LENIENT));
+    when(response.body())
+        .thenReturn(MAPPER.writeValueAsString(Map.of(FIELD_NAME_ACCESS_TOKEN, mockExpiredJwtToken)))
+        .thenReturn(MAPPER.writeValueAsString(Map.of(FIELD_NAME_ACCESS_TOKEN, mockJwtToken)));
+
+    when(response.statusCode()).thenReturn(200);
+
+    given(httpClient.send(any(), any())).willReturn(response, response);
+
+    // cache the expired token
+    m2mTokenManager.getToken();
+    clearInvocations(httpClient);
+
+    // when asking for token again
+    final String token = m2mTokenManager.getToken();
+    assertAuth0IsRequested(1);
+    assertThat(token).isEqualTo(mockJwtToken);
+  }
+
+  private void assertAuth0IsRequested(final int times) throws IOException, InterruptedException {
+    // assert request to Auth0
+    final ArgumentCaptor<HttpRequest> tokenRequestCaptor =
+        ArgumentCaptor.forClass(HttpRequest.class);
+    verify(httpClient, times(times)).send(tokenRequestCaptor.capture(), any());
+
+    final HttpRequest request = tokenRequestCaptor.getValue();
+    assertThat(request.uri().toString())
+        .isEqualTo(String.format("https://%s/oauth/token", AUTH0_DOMAIN));
+
+    final String body = extractBody(request.bodyPublisher().orElseThrow());
+    final DocumentContext jsonContext = JsonPath.parse(body);
+    final Map<String, Object> value = jsonContext.read("$");
+    assertThat(value.get(FIELD_NAME_GRANT_TYPE)).isEqualTo(GRANT_TYPE_VALUE);
+    assertThat(value.get(FIELD_NAME_CLIENT_ID)).isEqualTo(M2M_CLIENT_ID);
+    assertThat(value.get(FIELD_NAME_CLIENT_SECRET)).isEqualTo(M2M_CLIENT_SECRET);
+    assertThat(value.get(FIELD_NAME_AUDIENCE)).isEqualTo(M2M_AUDIENCE);
+  }
+
+  private String extractBody(final HttpRequest.BodyPublisher bodyPublisher)
+      throws IOException, InterruptedException {
+    final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    bodyPublisher.subscribe(
+        new Subscriber<>() {
+          @Override
+          public void onSubscribe(final Subscription subscription) {
+            subscription.request(Long.MAX_VALUE);
+          }
+
+          @Override
+          public void onNext(final ByteBuffer item) {
+            outputStream.write(item.array(), item.position(), item.remaining());
+          }
+
+          @Override
+          public void onError(final Throwable throwable) {
+            throw new RuntimeException(throwable);
+          }
+
+          @Override
+          public void onComplete() {
+            // No action needed
+          }
+        });
+
+    // Wait for the body to be fully written
+    Thread.sleep(100); // Adjust the sleep time as needed
+
+    return outputStream.toString(StandardCharsets.UTF_8);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/notifier/M2mTokenManagerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/notifier/M2mTokenManagerTest.java
@@ -83,7 +83,8 @@ class M2mTokenManagerTest {
   }
 
   @Test
-  public void testGetTokenFromCache() throws IOException, InterruptedException {
+  public void shouldReturnCachedTokenOnSubsequentCalls() throws IOException, InterruptedException {
+    // given
     final HttpResponse response =
         mock(
             HttpResponse.class,
@@ -111,7 +112,8 @@ class M2mTokenManagerTest {
   }
 
   @Test
-  public void testTokenWithForceUpdate() throws IOException, InterruptedException {
+  public void shouldRequestNewTokenWhenForceUpdate() throws IOException, InterruptedException {
+    // given
     final HttpResponse response =
         mock(
             HttpResponse.class,
@@ -144,7 +146,8 @@ class M2mTokenManagerTest {
   }
 
   @Test
-  public void testTokenIsExpired() throws IOException, InterruptedException {
+  public void shouldRequestNewTokenIfCachedTokenIsExpired()
+      throws IOException, InterruptedException {
     // given
     final String mockExpiredJwtToken =
         JWT.create()
@@ -169,6 +172,8 @@ class M2mTokenManagerTest {
 
     // when asking for token again
     final String token = m2mTokenManager.getToken();
+
+    // then
     assertAuth0IsRequested(1);
     assertThat(token).isEqualTo(mockJwtToken);
   }


### PR DESCRIPTION
## Description

Support incident notification with camunda exporter

- [x] Moved IncidentNotifier and M2mTokenManager to Camunda exporter
- [x] De-Springfied both components
- [x] Extended `IncidentHandler` to send created incident notification after flushing
- [x] Supported configuration for the notifier
- [x] Ported and De-Springified the IncidentNotifier and the M2mTokenManager tests
- [x] Made incident notification calls async

### Improvements:
- [ ] Create and e2e test to verify the whole flow works and notifications are indeed sent.
- [ ] Remove IncidentNotifier from importer codebase

## Related issues

closes #25767
