### PR TITLE
fix: drop unsupported user claims

### DIFF
--- a/zeebe/auth/pom.xml
+++ b/zeebe/auth/pom.xml
@@ -40,6 +40,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>

--- a/zeebe/auth/src/main/java/io/camunda/zeebe/auth/ClaimTransformer.java
+++ b/zeebe/auth/src/main/java/io/camunda/zeebe/auth/ClaimTransformer.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.auth;
 
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import org.slf4j.Logger;
@@ -36,7 +37,8 @@ public final class ClaimTransformer {
    * </ul>
    *
    * Additionally, claims with unsupported value types will be dropped and a warning will be logged.
-   * Supported value types are {@link String}, {@link Boolean}, and {@link Number}.
+   * Supported value types are {@link String}, {@link Boolean}, and {@link Number}. We also pass
+   * through {@link Collection} values without checking the type of the elements.
    *
    * @param claims A collection of user claims to add to.
    * @param key The key of the claim, without prefix, as it appears in the token. If the key is not
@@ -53,7 +55,10 @@ public final class ClaimTransformer {
       return;
     }
 
-    if (value instanceof String || value instanceof Boolean || value instanceof Number) {
+    if (value instanceof String
+        || value instanceof Boolean
+        || value instanceof Number
+        || value instanceof Collection<?>) {
       claims.put(Authorization.USER_TOKEN_CLAIM_PREFIX + key, value);
     } else {
       LOG.debug("Dropping claim '{}' with unsupported value type '{}'", key, value.getClass());

--- a/zeebe/auth/src/main/java/io/camunda/zeebe/auth/ClaimTransformer.java
+++ b/zeebe/auth/src/main/java/io/camunda/zeebe/auth/ClaimTransformer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.auth;
+
+import java.util.Map;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class ClaimTransformer {
+  private static final Logger LOG = LoggerFactory.getLogger(ClaimTransformer.class);
+
+  /**
+   * These well-known claims are not forwarded as user claims because they are not useful for
+   * mapping rules. Additionally, their type is {@link java.time.Instant} which we don't support
+   * anyway. Listing these claims here avoids logging a warning when we drop them.
+   */
+  private static final Set<String> UNSUPPORTED_CLAIMS = Set.of("exp", "iat", "nbf");
+
+  private ClaimTransformer() {}
+
+  /**
+   * Takes a claim from a token and adds them to user claims by prefixing the keys with {@link
+   * Authorization#USER_TOKEN_CLAIM_PREFIX}. Some claims will be dropped because they are not useful
+   * for mapping rules:
+   *
+   * <ul>
+   *   <li>exp
+   *   <li>iat
+   *   <li>nbf
+   * </ul>
+   *
+   * Additionally, claims with unsupported value types will be dropped and a warning will be logged.
+   * Supported value types are {@link String}, {@link Boolean}, and {@link Number}.
+   *
+   * @param claims A collection of user claims to add to.
+   * @param key The key of the claim, without prefix, as it appears in the token. If the key is not
+   *     supported the claim will be dropped.
+   * @param value The value of the claim. If the type is not supported, the claim will be dropped.
+   */
+  public static void applyUserClaim(
+      final Map<String, Object> claims, final String key, final Object value) {
+    if (UNSUPPORTED_CLAIMS.contains(key)) {
+      return;
+    }
+
+    if (value == null) {
+      return;
+    }
+
+    if (value instanceof String || value instanceof Boolean || value instanceof Number) {
+      claims.put(Authorization.USER_TOKEN_CLAIM_PREFIX + key, value);
+    } else {
+      LOG.debug("Dropping claim '{}' with unsupported value type '{}'", key, value.getClass());
+    }
+  }
+}

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway;
 import io.atomix.utils.net.Address;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.zeebe.auth.Authorization;
+import io.camunda.zeebe.auth.ClaimTransformer;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
@@ -494,10 +495,7 @@ public final class EndpointManager {
     final Map<String, Object> userClaims =
         Context.current().call(AuthenticationInterceptor.USER_CLAIMS::get);
     if (userClaims != null) {
-      userClaims.forEach(
-          (key, value) -> {
-            claims.put(Authorization.USER_TOKEN_CLAIM_PREFIX + key, value);
-          });
+      userClaims.forEach((key, value) -> ClaimTransformer.applyUserClaim(claims, key, value));
     }
 
     // retrieve the user key from the context and add it to the authorization if present

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -56,6 +56,7 @@ import io.camunda.service.ResourceServices.ResourceDeletionRequest;
 import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.service.UserServices.UserDTO;
 import io.camunda.zeebe.auth.Authorization;
+import io.camunda.zeebe.auth.ClaimTransformer;
 import io.camunda.zeebe.gateway.protocol.rest.AuthorizationPatchRequest;
 import io.camunda.zeebe.gateway.protocol.rest.CancelProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.rest.Changeset;
@@ -551,8 +552,7 @@ public class RequestMapper {
       if (requestAuthentication instanceof final JwtAuthenticationToken jwtAuthenticationToken) {
         jwtAuthenticationToken
             .getTokenAttributes()
-            .forEach(
-                (key, value) -> claims.put(Authorization.USER_TOKEN_CLAIM_PREFIX + key, value));
+            .forEach((key, value) -> ClaimTransformer.applyUserClaim(claims, key, value));
       }
     }
 


### PR DESCRIPTION
This fixes #26712 by dropping the `exp`, `iat`, and `nbf` claims as well as any other claims with values that are not `String`, `Boolean` or `Number`.