### PR TITLE
Replace usage of internal Junit 5 helper removed in Junit 5.11

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateExtension.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateExtension.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.util;
 
 import static java.nio.file.FileVisitResult.CONTINUE;
 import static java.util.stream.Collectors.joining;
-import static org.junit.platform.commons.util.ReflectionUtils.makeAccessible;
 
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
@@ -21,6 +20,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
+import io.camunda.zeebe.util.ReflectUtil;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -101,7 +101,8 @@ public class ProcessingStateExtension implements BeforeEachCallback {
         .forEach(
             field -> {
               try {
-                makeAccessible(field).set(testInstance, lookupOrCreate(context).getZeebeDb());
+                ReflectUtil.makeAccessible(field, testInstance)
+                    .set(testInstance, lookupOrCreate(context).getZeebeDb());
               } catch (final Throwable t) {
                 ExceptionUtils.throwAsUncheckedException(t);
               }
@@ -115,7 +116,7 @@ public class ProcessingStateExtension implements BeforeEachCallback {
         .forEach(
             field -> {
               try {
-                makeAccessible(field)
+                ReflectUtil.makeAccessible(field, testInstance)
                     .set(testInstance, lookupOrCreate(context).getTransactionContext());
               } catch (final Throwable t) {
                 ExceptionUtils.throwAsUncheckedException(t);
@@ -131,7 +132,7 @@ public class ProcessingStateExtension implements BeforeEachCallback {
         .forEach(
             field -> {
               try {
-                makeAccessible(field)
+                ReflectUtil.makeAccessible(field, testInstance)
                     .set(testInstance, lookupOrCreate(context).getProcessingState());
               } catch (final Throwable t) {
                 ExceptionUtils.throwAsUncheckedException(t);

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.record.RecordLogger;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.util.FileUtil;
+import io.camunda.zeebe.util.ReflectUtil;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
@@ -252,7 +253,7 @@ final class ZeebeIntegrationExtension
     final TestCluster value;
 
     try {
-      value = (TestCluster) ReflectionUtils.makeAccessible(field).get(testInstance);
+      value = (TestCluster) ReflectUtil.makeAccessible(field, testInstance).get(testInstance);
     } catch (final IllegalAccessException e) {
       throw new UnsupportedOperationException(e);
     }
@@ -264,11 +265,8 @@ final class ZeebeIntegrationExtension
     final TestApplication<?> value;
 
     try {
-      if (!field.canAccess(testInstance)) {
-        field.setAccessible(true);
-      }
-
-      value = (TestApplication<?>) field.get(testInstance);
+      value =
+          (TestApplication<?>) ReflectUtil.makeAccessible(field, testInstance).get(testInstance);
     } catch (final IllegalAccessException e) {
       throw new UnsupportedOperationException(e);
     }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
@@ -264,7 +264,11 @@ final class ZeebeIntegrationExtension
     final TestApplication<?> value;
 
     try {
-      value = (TestApplication<?>) ReflectionUtils.makeAccessible(field).get(testInstance);
+      if (!field.canAccess(testInstance)) {
+        field.setAccessible(true);
+      }
+
+      value = (TestApplication<?>) field.get(testInstance);
     } catch (final IllegalAccessException e) {
       throw new UnsupportedOperationException(e);
     }

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatformExtension.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatformExtension.java
@@ -7,13 +7,12 @@
  */
 package io.camunda.zeebe.stream.impl;
 
-import static org.junit.platform.commons.util.ReflectionUtils.makeAccessible;
-
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.stream.util.DefaultZeebeDbFactory;
 import io.camunda.zeebe.util.FileUtil;
+import io.camunda.zeebe.util.ReflectUtil;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -62,7 +61,7 @@ public class StreamPlatformExtension implements BeforeEachCallback {
         .forEach(
             field -> {
               try {
-                makeAccessible(field)
+                ReflectUtil.makeAccessible(field, testInstance)
                     .set(testInstance, lookupOrCreate(extensionContext).streamPlatform);
               } catch (final Throwable t) {
                 ExceptionUtils.throwAsUncheckedException(t);
@@ -77,7 +76,8 @@ public class StreamPlatformExtension implements BeforeEachCallback {
         .forEach(
             field -> {
               try {
-                makeAccessible(field).set(testInstance, lookupOrCreate(extensionContext).clock);
+                ReflectUtil.makeAccessible(field, testInstance)
+                    .set(testInstance, lookupOrCreate(extensionContext).clock);
               } catch (final Throwable t) {
                 ExceptionUtils.throwAsUncheckedException(t);
               }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/junit/AutoCloseResourceExtension.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/junit/AutoCloseResourceExtension.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.test.util.junit;
 
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import io.camunda.zeebe.util.ReflectUtil;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.NoSuchElementException;
@@ -22,7 +23,6 @@ import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.commons.support.HierarchyTraversalMode;
 import org.junit.platform.commons.support.ModifierSupport;
 import org.junit.platform.commons.support.ReflectionSupport;
-import org.junit.platform.commons.util.ReflectionUtils;
 
 final class AutoCloseResourceExtension implements BeforeEachCallback, BeforeAllCallback {
   @Override
@@ -64,8 +64,8 @@ final class AutoCloseResourceExtension implements BeforeEachCallback, BeforeAllC
                         "No close method '%s' for object of type '%s'; did you forget to set a custom close method?"
                             .formatted(annotation.closeMethod(), field.getType().getName())));
 
-    ReflectionUtils.makeAccessible(field);
-    ReflectionUtils.makeAccessible(method);
+    ReflectUtil.makeAccessible(field, testInstance);
+    ReflectUtil.makeAccessible(method, testInstance);
 
     return new AnnotatedCloseable(testInstance, field, method);
   }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/ReflectUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/ReflectUtil.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.util;
 
+import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.InvocationTargetException;
 import java.util.stream.Stream;
 
@@ -26,6 +27,25 @@ public final class ReflectUtil {
               "Failed to instantiate class %s with the default constructor", clazz.getName()),
           e);
     }
+  }
+
+  /**
+   * Sets the field to be accessible via reflection if it is not currently for the given instance
+   * object. This replaces the old Junit 5 `ReflectUtils.makeAccessible` which was removed from
+   * their platform.
+   *
+   * @param field the field to make accessible
+   * @param instance the instance on which we check accessibility
+   * @return the field, accessible
+   * @param <T> the type of the field
+   * @param <U> the type of the instance, typically just {@code Object}
+   */
+  public static <T extends AccessibleObject, U> T makeAccessible(final T field, final U instance) {
+    if (!field.canAccess(instance)) {
+      field.setAccessible(true);
+    }
+
+    return field;
   }
 
   /**


### PR DESCRIPTION
## Description

It seems with the problem we had around having 2 JUnit versions at the same time, we missed that one helper we use a lot `ReflectionUtils.makeAccessible` was removed in Junit 5.11, which breaks many of our extensions' lifecycle.

This PR replaces usage with our own helper which emulates the old behavior.
