### PR TITLE
feat: start enumerating backup parts from 1

### DIFF
--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/BackupServiceImpl.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/BackupServiceImpl.java
@@ -93,12 +93,12 @@ public class BackupServiceImpl implements BackupService {
     final int count = indexPatternsOrdered.size();
     final List<String> snapshotNames = new ArrayList<>();
     final String version = getCurrentVersion();
-    var index = 0;
+    var index = 1;
     for (var indexCollection : indexPatternsOrdered) {
       final Metadata metadata = new Metadata(request.getBackupId(), version, index++, count);
       final String snapshotName = repository.snapshotNameProvider().getSnapshotName(metadata);
       // Add all the dynamic indices in the last step
-      if (index == count) {
+      if (index == count + 1) {
         indexCollection =
             indexCollection.addSkippableIndices(dynamicIndicesProvider.getAllDynamicIndices());
       }

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/BackupServiceImplTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/BackupServiceImplTest.java
@@ -94,14 +94,14 @@ public class BackupServiceImplTest {
     assertThat(backup.getScheduledSnapshots())
         .isEqualTo(
             List.of(
-                "test_snapshot_1_0_8",
                 "test_snapshot_1_1_8",
                 "test_snapshot_1_2_8",
                 "test_snapshot_1_3_8",
                 "test_snapshot_1_4_8",
                 "test_snapshot_1_5_8",
                 "test_snapshot_1_6_8",
-                "test_snapshot_1_7_8"));
+                "test_snapshot_1_7_8",
+                "test_snapshot_1_8_8"));
     final var backupState = backupService.getBackupState(1L);
     assertThat(backupState).isNotNull();
     assertThat(backupState.getBackupId()).isEqualTo(1L);


### PR DESCRIPTION
## Description
Snapshots should start counting parts from 1, not from 0.

## Related issues
closes #26734
