### PR TITLE
[Backport stable/8.3] Fixes Zeebe 8.5 Limiters inFlight concurrent access

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/backpressure/CommandRateLimiter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/backpressure/CommandRateLimiter.java
@@ -50,11 +50,17 @@ public final class CommandRateLimiter extends AbstractLimiter<Intent>
 
   @Override
   public Optional<Listener> acquire(final Intent intent) {
-    if (getInflight() >= getLimit() && !WHITE_LISTED_COMMANDS.contains(intent)) {
-      return createRejectedListener();
+    if (WHITE_LISTED_COMMANDS.contains(intent)) {
+      return Optional.of(createListener());
     }
-    final Listener listener = createListener();
-    return Optional.of(listener);
+
+    synchronized (this) {
+      if (getInflight() < getLimit()) {
+        return Optional.of(createListener());
+      }
+    }
+
+    return createRejectedListener();
   }
 
   private void registerListener(final int streamId, final long requestId, final Listener listener) {

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/AppendLimiter.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/AppendLimiter.java
@@ -26,11 +26,13 @@ final class AppendLimiter extends AbstractLimiter<Void> {
 
   @Override
   public Optional<Listener> acquire(final Void context) {
-    if (getInflight() >= getLimit()) {
-      return createRejectedListener();
-    } else {
-      return Optional.of(createListener());
+    synchronized (this) {
+      if (getInflight() < getLimit()) {
+        return Optional.of(createListener());
+      }
     }
+
+    return createRejectedListener();
   }
 
   @Override

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/AppenderFlowControlTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/AppenderFlowControlTest.java
@@ -7,8 +7,21 @@
  */
 package io.camunda.zeebe.logstreams.impl.flowcontrol;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.netflix.concurrency.limits.Limit;
+import com.netflix.concurrency.limits.Limiter.Listener;
+import com.netflix.concurrency.limits.limit.SettableLimit;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.LinkedList;
+import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -76,5 +89,44 @@ final class AppenderFlowControlTest {
 
     // then
     Awaitility.await("Eventually accepts appends again").until(() -> flow.tryAcquire().isPresent());
+  }
+
+  @Test
+  void shouldNotAllowInFlightHigherThanLimit() throws InterruptedException {
+    // given
+    final int numThreads = 3000;
+    final int poolSize = 300;
+    final int limit = 100;
+    final Limit myLimit = new SettableLimit(limit);
+    final AppenderMetrics appenderMetrics = new AppenderMetrics(1);
+    appenderMetrics.setInflightLimit(limit);
+    final AppendLimiter myRateLimiter =
+        AppendLimiter.builder().limit(myLimit).metrics(appenderMetrics).build();
+    final ExecutorService threadPool = Executors.newFixedThreadPool(poolSize);
+    final Optional<Listener>[] listeners = new Optional[numThreads];
+
+    final Collection<Callable<Object>> tasks =
+        IntStream.range(0, numThreads)
+            .mapToObj(
+                i ->
+                    (Callable<Object>)
+                        () -> {
+                          final int sleepTime = ThreadLocalRandom.current().nextInt(limit);
+                          listeners[i] = myRateLimiter.acquire(null);
+                          Thread.sleep(sleepTime);
+                          assertThat(myRateLimiter.getInflight()).isLessThanOrEqualTo(limit);
+                          listeners[i].get().onSuccess();
+                          return null;
+                        })
+            .collect(Collectors.toList());
+    try {
+      threadPool.invokeAll(tasks);
+    } finally {
+      // when
+      threadPool.shutdown();
+    }
+
+    // then
+    assertThat(myRateLimiter.getInflight()).isEqualTo(0);
   }
 }


### PR DESCRIPTION
# Description
Backport of #26408 to `stable/8.3`.

relates to #26104 #26104 #24521
original author: @filipecampos