### PR TITLE
ci: add backport label when touching the deprecated java client in 8.7

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -82,3 +82,21 @@ component/c8-api:
       - any-glob-to-any-file:
           - 'zeebe/gateway-protocol/src/main/proto/rest-api.yaml'
           - 'zeebe/gateway-rest/**'
+# to Forward-port PRs fixes to the deprecated java client classes in 8.7 (from 8.6)
+backport main: # TODO replace with 'backport stable/8.7' once the stable branch is created https://github.com/camunda/camunda/issues/26820
+  - all:
+      - changed-files:
+          - any-glob-to-any-file:
+              - 'clients/java/src/main/java/io/camunda/zeebe/**'
+              - 'clients/java/src/test/java/io/camunda/zeebe/**'
+      - base-branch: 'stable/8.6'
+# hint on changes done to the deprecated java client, and that might need to applied to the supported client
+deprecated-client:
+  - all:
+      - changed-files:
+          - any-glob-to-any-file:
+              - 'clients/java/src/main/java/io/camunda/zeebe/**'
+              - 'clients/java/src/test/java/io/camunda/zeebe/**'
+      - base-branch:
+          - 'main' # TODO remove in https://github.com/camunda/camunda/issues/26820
+          - 'stable/8.7'


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
As described in https://github.com/camunda/camunda/pull/26689 to mitigate double maintenance of Camunda and Zeebe client in main branch and in the future stable/8.7

`backport main` label is added to PRs touching zeebe client classes in stable/8.7, this ensure that we don't forget to update the Zeebe client classes in main branch (and future stable/8.8)

The scenario that can happen:
1- a developer does a fix in Camunda client classes
2- developer backports the fix to stable/8.7 => Zeebe client classes are changed in stable/8.7
3- the label `backport main` is automatically added to the backport PR, and ensure that the Zeebe client classes are also updated in main branch

I also add `deprecated-client` label (to be set with Red color) in a PR when a it updates files in from Zeebe client namespace


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates to https://github.com/camunda/camunda/issues/26814
