### PR TITLE
feat: add support for followUpDate and dueDate filters

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/UserTaskFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/UserTaskFilter.java
@@ -224,7 +224,7 @@ public interface UserTaskFilter extends SearchRequestFilter {
   /**
    * Filters user tasks by the specified follow-up date.
    *
-   * @param followUpDate the creation date of the user task
+   * @param followUpDate the follow-up date of the user task
    * @return the updated filter
    */
   UserTaskFilter followUpDate(final OffsetDateTime followUpDate);
@@ -232,7 +232,7 @@ public interface UserTaskFilter extends SearchRequestFilter {
   /**
    * Filters user tasks by the specified {@link DateTimeProperty} follow-up date.
    *
-   * @param followUpDate the creation date of the user task
+   * @param followUpDate the follow-up date of the user task
    * @return the updated filter
    */
   UserTaskFilter followUpDate(final Consumer<DateTimeProperty> followUpDate);
@@ -240,7 +240,7 @@ public interface UserTaskFilter extends SearchRequestFilter {
   /**
    * Filters user tasks by the specified due date.
    *
-   * @param dueDate the creation date of the user task
+   * @param dueDate the due date of the user task
    * @return the updated filter
    */
   UserTaskFilter dueDate(final OffsetDateTime dueDate);
@@ -248,7 +248,7 @@ public interface UserTaskFilter extends SearchRequestFilter {
   /**
    * Filters user tasks by the specified {@link DateTimeProperty} due date.
    *
-   * @param dueDate the creation date of the user task
+   * @param dueDate the due date of the user task
    * @return the updated filter
    */
   UserTaskFilter dueDate(final Consumer<DateTimeProperty> dueDate);

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/UserTaskFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/UserTaskFilter.java
@@ -220,4 +220,36 @@ public interface UserTaskFilter extends SearchRequestFilter {
    * @return the updated filter
    */
   UserTaskFilter completionDate(final Consumer<DateTimeProperty> completionDate);
+
+  /**
+   * Filters user tasks by the specified follow-up date.
+   *
+   * @param followUpDate the creation date of the user task
+   * @return the updated filter
+   */
+  UserTaskFilter followUpDate(final OffsetDateTime followUpDate);
+
+  /**
+   * Filters user tasks by the specified {@link DateTimeProperty} follow-up date.
+   *
+   * @param followUpDate the creation date of the user task
+   * @return the updated filter
+   */
+  UserTaskFilter followUpDate(final Consumer<DateTimeProperty> followUpDate);
+
+  /**
+   * Filters user tasks by the specified due date.
+   *
+   * @param dueDate the creation date of the user task
+   * @return the updated filter
+   */
+  UserTaskFilter dueDate(final OffsetDateTime dueDate);
+
+  /**
+   * Filters user tasks by the specified {@link DateTimeProperty} due date.
+   *
+   * @param dueDate the creation date of the user task
+   * @return the updated filter
+   */
+  UserTaskFilter dueDate(final Consumer<DateTimeProperty> dueDate);
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskFilterImpl.java
@@ -226,6 +226,34 @@ public class UserTaskFilterImpl extends TypedSearchRequestPropertyProvider<UserT
   }
 
   @Override
+  public UserTaskFilter followUpDate(final OffsetDateTime followUpDate) {
+    followUpDate(b -> b.eq(followUpDate));
+    return this;
+  }
+
+  @Override
+  public UserTaskFilter followUpDate(final Consumer<DateTimeProperty> fn) {
+    final DateTimeProperty property = new DateTimePropertyImpl();
+    fn.accept(property);
+    filter.setFollowUpDate(property.build());
+    return this;
+  }
+
+  @Override
+  public UserTaskFilter dueDate(final OffsetDateTime dueDate) {
+    dueDate(b -> b.eq(dueDate));
+    return this;
+  }
+
+  @Override
+  public UserTaskFilter dueDate(final Consumer<DateTimeProperty> fn) {
+    final DateTimeProperty property = new DateTimePropertyImpl();
+    fn.accept(property);
+    filter.setDueDate(property.build());
+    return this;
+  }
+
+  @Override
   protected UserTaskFilterRequest getSearchRequestProperty() {
     return filter;
   }

--- a/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskTest.java
@@ -388,4 +388,114 @@ public final class SearchUserTaskTest extends ClientRestTest {
     assertThat(request.getFilter().getCompletionDate().get$Lt()).isNotNull();
     assertThat(request.getFilter().getCompletionDate().get$Gt()).isNotNull();
   }
+
+  @Test
+  void shouldReturnUserTaskByDueDateExists() {
+    // when
+    client.newUserTaskQuery().filter(f -> f.dueDate(b -> b.exists(true))).send().join();
+
+    // then
+    final UserTaskSearchQueryRequest request =
+        gatewayService.getLastRequest(UserTaskSearchQueryRequest.class);
+    assertThat(request.getFilter().getDueDate().get$Exists()).isTrue();
+  }
+
+  @Test
+  void shouldReturnUserTaskByDueDateGt() {
+    // when
+    client.newUserTaskQuery().filter(f -> f.dueDate(b -> b.gt(OffsetDateTime.now()))).send().join();
+
+    // then
+    final UserTaskSearchQueryRequest request =
+        gatewayService.getLastRequest(UserTaskSearchQueryRequest.class);
+    assertThat(request.getFilter().getDueDate().get$Gt()).isNotNull();
+  }
+
+  @Test
+  void shouldReturnUserTaskByDueDateLt() {
+    // when
+    client.newUserTaskQuery().filter(f -> f.dueDate(b -> b.lt(OffsetDateTime.now()))).send().join();
+
+    // then
+    final UserTaskSearchQueryRequest request =
+        gatewayService.getLastRequest(UserTaskSearchQueryRequest.class);
+    assertThat(request.getFilter().getDueDate().get$Lt()).isNotNull();
+  }
+
+  @Test
+  void shouldReturnUserTaskByDueDateGteLte() {
+    // when
+    client
+        .newUserTaskQuery()
+        .filter(
+            f -> f.dueDate(b -> b.gte(OffsetDateTime.now().minusDays(5)).lte(OffsetDateTime.now())))
+        .send()
+        .join();
+
+    // then
+    final UserTaskSearchQueryRequest request =
+        gatewayService.getLastRequest(UserTaskSearchQueryRequest.class);
+    assertThat(request.getFilter().getDueDate().get$Gte()).isNotNull();
+    assertThat(request.getFilter().getDueDate().get$Lte()).isNotNull();
+  }
+
+  @Test
+  void shouldReturnUserTaskByFollowUpDateExists() {
+    // when
+    client.newUserTaskQuery().filter(f -> f.followUpDate(b -> b.exists(true))).send().join();
+
+    // then
+    final UserTaskSearchQueryRequest request =
+        gatewayService.getLastRequest(UserTaskSearchQueryRequest.class);
+    assertThat(request.getFilter().getFollowUpDate().get$Exists()).isTrue();
+  }
+
+  @Test
+  void shouldReturnUserTaskByFollowUpDateGt() {
+    // when
+    client
+        .newUserTaskQuery()
+        .filter(f -> f.followUpDate(b -> b.gt(OffsetDateTime.now())))
+        .send()
+        .join();
+
+    // then
+    final UserTaskSearchQueryRequest request =
+        gatewayService.getLastRequest(UserTaskSearchQueryRequest.class);
+    assertThat(request.getFilter().getFollowUpDate().get$Gt()).isNotNull();
+  }
+
+  @Test
+  void shouldReturnUserTaskByFollowUpDateLt() {
+    // when
+    client
+        .newUserTaskQuery()
+        .filter(f -> f.followUpDate(b -> b.lt(OffsetDateTime.now())))
+        .send()
+        .join();
+
+    // then
+    final UserTaskSearchQueryRequest request =
+        gatewayService.getLastRequest(UserTaskSearchQueryRequest.class);
+    assertThat(request.getFilter().getFollowUpDate().get$Lt()).isNotNull();
+  }
+
+  @Test
+  void shouldReturnUserTaskByFollowUpDateGteLte() {
+    // when
+    client
+        .newUserTaskQuery()
+        .filter(
+            f ->
+                f.followUpDate(
+                    b -> b.gte(OffsetDateTime.now().minusDays(10)).lte(OffsetDateTime.now())))
+        .send()
+        .join();
+
+    // then
+    final UserTaskSearchQueryRequest request =
+        gatewayService.getLastRequest(UserTaskSearchQueryRequest.class);
+    assertThat(request.getFilter().getFollowUpDate().get$Gte()).isNotNull();
+    assertThat(request.getFilter().getFollowUpDate().get$Lte()).isNotNull();
+  }
 }

--- a/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
@@ -259,15 +259,7 @@
       </foreach>
     </if>
 
-    <!-- Due Date Filters -->
-    <if test="filter.dueDateOperations != null and !filter.dueDateOperations.isEmpty()">
-      <foreach collection="filter.dueDateOperations" item="operation">
-        AND ut.DUE_DATE
-        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-      </foreach>
-    </if>
-
-    <!-- Follo Up Date Filters -->
+    <!-- Follow-Up Date Filters -->
     <if test="filter.followUpDateOperations != null and !filter.followUpDateOperations.isEmpty()">
       <foreach collection="filter.followUpDateOperations" item="operation">
         AND ut.FOLLOW_UP_DATE

--- a/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
@@ -251,6 +251,29 @@
       </foreach>
     </if>
 
+    <!-- Due Date Filters -->
+    <if test="filter.dueDateOperations != null and !filter.dueDateOperations.isEmpty()">
+      <foreach collection="filter.dueDateOperations" item="operation">
+        AND ut.DUE_DATE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+
+    <!-- Due Date Filters -->
+    <if test="filter.dueDateOperations != null and !filter.dueDateOperations.isEmpty()">
+      <foreach collection="filter.dueDateOperations" item="operation">
+        AND ut.DUE_DATE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+
+    <!-- Follo Up Date Filters -->
+    <if test="filter.followUpDateOperations != null and !filter.followUpDateOperations.isEmpty()">
+      <foreach collection="filter.followUpDateOperations" item="operation">
+        AND ut.FOLLOW_UP_DATE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
 
 
     <!-- Variables Filter -->

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
@@ -1076,14 +1076,13 @@ class UserTaskQueryTest {
   @Test
   void shouldRetrieveTaskByDueDateEquals() {
     // when
-    final var userTaskList = camundaClient.newUserTaskQuery().send().join();
+    final var userTaskList = camundaClient.newUserTaskQuery().page(p -> p.limit(1)).send().join();
     final var dueDateExample = OffsetDateTime.parse(userTaskList.items().get(0).getDueDate());
 
     final var result =
         camundaClient
             .newUserTaskQuery()
             .filter(f -> f.dueDate(b -> b.eq(dueDateExample)))
-            .page(p -> p.limit(1))
             .send()
             .join();
 
@@ -1101,7 +1100,7 @@ class UserTaskQueryTest {
   @Test
   void shouldRetrieveTaskByFollowUpDateEquals() {
     // when
-    final var userTaskList = camundaClient.newUserTaskQuery().send().join();
+    final var userTaskList = camundaClient.newUserTaskQuery().page(p -> p.limit(1)).send().join();
     final var followUpDateExample =
         OffsetDateTime.parse(userTaskList.items().get(0).getFollowUpDate());
 
@@ -1109,7 +1108,6 @@ class UserTaskQueryTest {
         camundaClient
             .newUserTaskQuery()
             .filter(f -> f.followUpDate(b -> b.eq(followUpDateExample)))
-            .page(p -> p.limit(1))
             .send()
             .join();
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
@@ -1050,6 +1050,101 @@ class UserTaskQueryTest {
         .isEqualTo(thirdKey);
   }
 
+  @Test
+  void shouldRetrieveTaskByDueDateRange() {
+    // when
+    final var now = OffsetDateTime.now(ZoneId.of("UTC"));
+    final var result =
+        camundaClient
+            .newUserTaskQuery()
+            .filter(f -> f.dueDate(b -> b.gt(now.minusDays(2)).lt(now.plusDays(2))))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isGreaterThan(0);
+    result
+        .items()
+        .forEach(
+            item -> {
+              final var dueDate = OffsetDateTime.parse(item.getDueDate());
+              assertThat(dueDate).isAfter(now.minusDays(2));
+              assertThat(dueDate).isBefore(now.plusDays(2));
+            });
+  }
+
+  @Test
+  void shouldRetrieveTaskByDueDateEquals() {
+    // when
+    final var userTaskList = camundaClient.newUserTaskQuery().send().join();
+    final var dueDateExample = OffsetDateTime.parse(userTaskList.items().get(0).getDueDate());
+
+    final var result =
+        camundaClient
+            .newUserTaskQuery()
+            .filter(f -> f.dueDate(b -> b.eq(dueDateExample)))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isGreaterThan(0);
+    result
+        .items()
+        .forEach(
+            item -> {
+              final var dueDate = OffsetDateTime.parse(item.getDueDate());
+              assertThat(dueDate).isEqualTo(dueDateExample);
+            });
+  }
+
+  @Test
+  void shouldRetrieveTaskByFollowUpDateEquals() {
+    // when
+    final var userTaskList = camundaClient.newUserTaskQuery().send().join();
+    final var followUpDateExample =
+        OffsetDateTime.parse(userTaskList.items().get(0).getFollowUpDate());
+
+    final var result =
+        camundaClient
+            .newUserTaskQuery()
+            .filter(f -> f.followUpDate(b -> b.eq(followUpDateExample)))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isGreaterThan(0);
+    result
+        .items()
+        .forEach(
+            item -> {
+              final var followUpDate = OffsetDateTime.parse(item.getFollowUpDate());
+              assertThat(followUpDate).isEqualTo(followUpDateExample);
+            });
+  }
+
+  @Test
+  void shouldRetrieveTaskByFollowUpDateRange() {
+    // when
+    final var now = OffsetDateTime.now(ZoneId.of("UTC"));
+    final var result =
+        camundaClient
+            .newUserTaskQuery()
+            .filter(f -> f.followUpDate(b -> b.gte(now.minusDays(5)).lte(now.plusDays(5))))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isGreaterThan(0);
+    result
+        .items()
+        .forEach(
+            item -> {
+              final var followUpDate = OffsetDateTime.parse(item.getFollowUpDate());
+              assertThat(followUpDate).isAfterOrEqualTo(now.minusDays(5));
+              assertThat(followUpDate).isBeforeOrEqualTo(now.plusDays(5));
+            });
+  }
+
   private static void deployProcess(
       final String processId,
       final String resourceName,

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
@@ -1083,6 +1083,7 @@ class UserTaskQueryTest {
         camundaClient
             .newUserTaskQuery()
             .filter(f -> f.dueDate(b -> b.eq(dueDateExample)))
+            .page(p -> p.limit(1))
             .send()
             .join();
 
@@ -1108,6 +1109,7 @@ class UserTaskQueryTest {
         camundaClient
             .newUserTaskQuery()
             .filter(f -> f.followUpDate(b -> b.eq(followUpDateExample)))
+            .page(p -> p.limit(1))
             .send()
             .join();
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
@@ -23,8 +23,10 @@ import static io.camunda.webapps.schema.descriptors.tasklist.template.TaskTempla
 import static io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate.CANDIDATE_USERS;
 import static io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate.COMPLETION_TIME;
 import static io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate.CREATION_TIME;
+import static io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate.DUE_DATE;
 import static io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate.FLOW_NODE_BPMN_ID;
 import static io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate.FLOW_NODE_INSTANCE_ID;
+import static io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate.FOLLOW_UP_DATE;
 import static io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate.IMPLEMENTATION;
 import static io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate.KEY;
 import static io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate.PRIORITY;
@@ -77,6 +79,8 @@ public class UserTaskFilterTransformer extends IndexFilterTransformer<UserTaskFi
     ofNullable(getCreationTimeQuery(filter.creationDateOperations())).ifPresent(queries::addAll);
     ofNullable(getCompletionTimeQuery(filter.completionDateOperations()))
         .ifPresent(queries::addAll);
+    ofNullable(getFollowUpDateQuery(filter.followUpDateOperations())).ifPresent(queries::addAll);
+    ofNullable(getDueDateQuery(filter.dueDateOperations())).ifPresent(queries::addAll);
 
     // Process Instance Variable Query: Check if processVariable  with specified varName and
     // varValue exists
@@ -129,6 +133,15 @@ public class UserTaskFilterTransformer extends IndexFilterTransformer<UserTaskFi
   private List<SearchQuery> getCompletionTimeQuery(
       final List<Operation<OffsetDateTime>> completionTime) {
     return dateTimeOperations(COMPLETION_TIME, completionTime);
+  }
+
+  private List<SearchQuery> getFollowUpDateQuery(
+      final List<Operation<OffsetDateTime>> followUpTime) {
+    return dateTimeOperations(FOLLOW_UP_DATE, followUpTime);
+  }
+
+  private List<SearchQuery> getDueDateQuery(final List<Operation<OffsetDateTime>> dueTime) {
+    return dateTimeOperations(DUE_DATE, dueTime);
   }
 
   private SearchQuery getStateQuery(final List<String> state) {

--- a/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
@@ -36,6 +36,8 @@ public record UserTaskFilter(
     List<Long> elementInstanceKeys,
     List<Operation<OffsetDateTime>> creationDateOperations,
     List<Operation<OffsetDateTime>> completionDateOperations,
+    List<Operation<OffsetDateTime>> followUpDateOperations,
+    List<Operation<OffsetDateTime>> dueDateOperations,
     String type)
     implements FilterBase {
 
@@ -56,6 +58,8 @@ public record UserTaskFilter(
     private List<Long> elementInstanceKeys;
     private List<Operation<OffsetDateTime>> creationDateOperations;
     private List<Operation<OffsetDateTime>> completionDateOperations;
+    private List<Operation<OffsetDateTime>> followUpDateOperations;
+    private List<Operation<OffsetDateTime>> dueDateOperations;
     private String type;
 
     public Builder userTaskKeys(final Long... values) {
@@ -222,6 +226,29 @@ public record UserTaskFilter(
       return completionDateOperations(collectValues(operation, operations));
     }
 
+    public Builder followUpDateOperations(final List<Operation<OffsetDateTime>> operations) {
+      followUpDateOperations = addValuesToList(followUpDateOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder followUpDateOperations(
+        final Operation<OffsetDateTime> operation, final Operation<OffsetDateTime>... operations) {
+      return followUpDateOperations(collectValues(operation, operations));
+    }
+
+    // add builder for dueDate
+    public Builder dueDateOperations(final List<Operation<OffsetDateTime>> operations) {
+      dueDateOperations = addValuesToList(dueDateOperations, operations);
+      return this;
+    }
+
+    @SafeVarargs
+    public final Builder dueDateOperations(
+        final Operation<OffsetDateTime> operation, final Operation<OffsetDateTime>... operations) {
+      return dueDateOperations(collectValues(operation, operations));
+    }
+
     public Builder type(final String value) {
       type = value;
       return this;
@@ -246,6 +273,8 @@ public record UserTaskFilter(
           Objects.requireNonNullElse(elementInstanceKeys, Collections.emptyList()),
           Objects.requireNonNullElse(creationDateOperations, Collections.emptyList()),
           Objects.requireNonNullElse(completionDateOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(followUpDateOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(dueDateOperations, Collections.emptyList()),
           type);
     }
   }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
@@ -237,7 +237,6 @@ public record UserTaskFilter(
       return followUpDateOperations(collectValues(operation, operations));
     }
 
-    // add builder for dueDate
     public Builder dueDateOperations(final List<Operation<OffsetDateTime>> operations) {
       dueDateOperations = addValuesToList(dueDateOperations, operations);
       return this;

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4177,7 +4177,7 @@ components:
           allOf:
             - $ref: "#/components/schemas/DateTimeFilterProperty"
         followUpDate:
-          description: The user task follow up date.
+          description: The user task follow-up date.
           allOf:
               - $ref: "#/components/schemas/DateTimeFilterProperty"
         dueDate:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4176,6 +4176,14 @@ components:
           description: The user task completion date.
           allOf:
             - $ref: "#/components/schemas/DateTimeFilterProperty"
+        followUpDate:
+          description: The user task follow up date.
+          allOf:
+              - $ref: "#/components/schemas/DateTimeFilterProperty"
+        dueDate:
+            description: The user task due date.
+            allOf:
+                - $ref: "#/components/schemas/DateTimeFilterProperty"
         processInstanceVariables:
           type: array
           description: Process Instance variables associated with the user task.

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -631,6 +631,12 @@ public final class SearchQueryRequestMapper {
               Optional.ofNullable(f.getCompletionDate())
                   .map(mapToOperations(OffsetDateTime.class))
                   .ifPresent(builder::completionDateOperations);
+              Optional.ofNullable(f.getDueDate())
+                  .map(mapToOperations(OffsetDateTime.class))
+                  .ifPresent(builder::dueDateOperations);
+              Optional.ofNullable(f.getFollowUpDate())
+                  .map(mapToOperations(OffsetDateTime.class))
+                  .ifPresent(builder::followUpDateOperations);
             });
 
     return builder.build();


### PR DESCRIPTION
## Description

Add advanced filters for the follow attributes:
- followUpDate
- dueDate

For the endoint Search User Tasks

Note: Integration tests are combined, once the dates was extensive tested for creation and completion test, for followUp and dueDate range and equals tests were tested combination range queries, and one test case for equals. Unit test is covering all remaining test cases.

## Related issues

closes https://github.com/camunda/camunda/issues/26744
