### PR TITLE
feat: add variable name filter for the user task variable query

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/SearchRequestBuilders.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/SearchRequestBuilders.java
@@ -23,6 +23,7 @@ import io.camunda.client.api.search.filter.IncidentFilter;
 import io.camunda.client.api.search.filter.ProcessDefinitionFilter;
 import io.camunda.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.client.api.search.filter.UserTaskFilter;
+import io.camunda.client.api.search.filter.UserTaskVariableFilter;
 import io.camunda.client.api.search.filter.VariableFilter;
 import io.camunda.client.api.search.sort.DecisionDefinitionSort;
 import io.camunda.client.api.search.sort.DecisionInstanceSort;
@@ -42,6 +43,7 @@ import io.camunda.client.impl.search.filter.IncidentFilterImpl;
 import io.camunda.client.impl.search.filter.ProcessDefinitionFilterImpl;
 import io.camunda.client.impl.search.filter.ProcessInstanceFilterImpl;
 import io.camunda.client.impl.search.filter.UserTaskFilterImpl;
+import io.camunda.client.impl.search.filter.UserTaskVariableFilterImpl;
 import io.camunda.client.impl.search.filter.VariableFilterImpl;
 import io.camunda.client.impl.search.sort.DecisionDefinitionSortImpl;
 import io.camunda.client.impl.search.sort.DecisionInstanceSortImpl;
@@ -271,5 +273,16 @@ public final class SearchRequestBuilders {
     final VariableSort sort = variableSort();
     fn.accept(sort);
     return sort;
+  }
+
+  public static UserTaskVariableFilter userTaskVariableFilter() {
+    return new UserTaskVariableFilterImpl();
+  }
+
+  public static UserTaskVariableFilter userTaskVariableFilter(
+      final Consumer<UserTaskVariableFilter> fn) {
+    final UserTaskVariableFilter filter = userTaskVariableFilter();
+    fn.accept(filter);
+    return filter;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/UserTaskVariableFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/UserTaskVariableFilter.java
@@ -15,6 +15,24 @@
  */
 package io.camunda.client.api.search.filter;
 
+import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.search.query.TypedSearchQueryRequest.SearchRequestFilter;
+import java.util.function.Consumer;
 
-public interface UserTaskVariableFilter extends SearchRequestFilter {}
+public interface UserTaskVariableFilter extends SearchRequestFilter {
+  /**
+   * Filters variables by the specified name.
+   *
+   * @param name the name of the variable
+   * @return the updated filter
+   */
+  UserTaskVariableFilter name(final String name);
+
+  /**
+   * Filters variables by the specified name using {@link StringProperty} consumer.
+   *
+   * @param fn the name {@link StringProperty} consumer of the variable
+   * @return the updated filter
+   */
+  UserTaskVariableFilter name(final Consumer<StringProperty> fn);
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskVariableFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/UserTaskVariableFilterImpl.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter;
+
+import io.camunda.client.api.search.filter.UserTaskVariableFilter;
+import io.camunda.client.api.search.filter.builder.StringProperty;
+import io.camunda.client.impl.search.TypedSearchRequestPropertyProvider;
+import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
+import io.camunda.client.protocol.rest.VariableUserTaskFilterRequest;
+import java.util.function.Consumer;
+
+public class UserTaskVariableFilterImpl
+    extends TypedSearchRequestPropertyProvider<VariableUserTaskFilterRequest>
+    implements UserTaskVariableFilter {
+
+  private final VariableUserTaskFilterRequest filter;
+
+  public UserTaskVariableFilterImpl() {
+    filter = new VariableUserTaskFilterRequest();
+  }
+
+  @Override
+  public UserTaskVariableFilter name(final String name) {
+    name(b -> b.eq(name));
+    return this;
+  }
+
+  @Override
+  public UserTaskVariableFilter name(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.setName(property.build());
+    return this;
+  }
+
+  @Override
+  protected VariableUserTaskFilterRequest getSearchRequestProperty() {
+    return filter;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/query/UserTaskVariableQueryImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/query/UserTaskVariableQueryImpl.java
@@ -16,6 +16,7 @@
 package io.camunda.client.impl.search.query;
 
 import static io.camunda.client.api.search.SearchRequestBuilders.searchRequestPage;
+import static io.camunda.client.api.search.SearchRequestBuilders.userTaskVariableFilter;
 import static io.camunda.client.api.search.SearchRequestBuilders.variableSort;
 
 import io.camunda.client.api.CamundaFuture;
@@ -35,6 +36,7 @@ import io.camunda.client.impl.search.TypedSearchRequestPropertyProvider;
 import io.camunda.client.impl.search.sort.VariableSortImpl;
 import io.camunda.client.protocol.rest.UserTaskVariableSearchQueryRequest;
 import io.camunda.client.protocol.rest.VariableSearchQueryResult;
+import io.camunda.client.protocol.rest.VariableUserTaskFilterRequest;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -80,12 +82,14 @@ public class UserTaskVariableQueryImpl
 
   @Override
   public UserTaskVariableQuery filter(final UserTaskVariableFilter value) {
-    return null; // There is no Filter for UserTaskVariableQuery
+    final VariableUserTaskFilterRequest filter = provideSearchRequestProperty(value);
+    request.setFilter(filter);
+    return this;
   }
 
   @Override
   public UserTaskVariableQuery filter(final Consumer<UserTaskVariableFilter> fn) {
-    return null; // There is no Filter for UserTaskVariableQuery
+    return filter(userTaskVariableFilter(fn));
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/usertask/SearchUserTaskVariableTest.java
@@ -35,4 +35,55 @@ public final class SearchUserTaskVariableTest extends ClientRestTest {
         gatewayService.getLastRequest(VariableSearchQueryRequest.class);
     assertThat(request.getFilter()).isNull();
   }
+
+  @Test
+  void shouldSearchVariablesByNameWithEqOperator() {
+    final long userTaskKey = 1L;
+    final String variableName = "variableName";
+
+    // when
+    client.newUserTaskVariableQuery(userTaskKey).filter(f -> f.name(variableName)).send().join();
+
+    // then
+    final VariableSearchQueryRequest request =
+        gatewayService.getLastRequest(VariableSearchQueryRequest.class);
+    assertThat(request.getFilter().getName().get$Eq()).isEqualTo(variableName);
+  }
+
+  @Test
+  void shouldSearchVariablesByNameWithLikeOperator() {
+    final long userTaskKey = 1L;
+    final String variableName = "variableName";
+
+    // when
+    client
+        .newUserTaskVariableQuery(userTaskKey)
+        .filter(f -> f.name(b -> b.like(variableName)))
+        .send()
+        .join();
+
+    // then
+    final VariableSearchQueryRequest request =
+        gatewayService.getLastRequest(VariableSearchQueryRequest.class);
+    assertThat(request.getFilter().getName().get$Like()).isEqualTo(variableName);
+  }
+
+  @Test
+  void shouldSearchVariablesByNameWithInOperator() {
+    // Given
+    final long userTaskKey = 1L;
+    final String variableName = "variableName";
+
+    // When
+    client
+        .newUserTaskVariableQuery(userTaskKey)
+        .filter(f -> f.name(b -> b.in(variableName)))
+        .send()
+        .join();
+
+    // Then
+    final VariableSearchQueryRequest request =
+        gatewayService.getLastRequest(VariableSearchQueryRequest.class);
+    assertThat(request.getFilter().getName().get$In()).containsExactly(variableName);
+  }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
@@ -602,6 +602,69 @@ class UserTaskQueryTest {
   }
 
   @Test
+  void shouldReturnUserTaskVariablesFilteredByNameEq() {
+    // when
+    final var userTaskList =
+        camundaClient.newUserTaskQuery().filter(f -> f.elementId("TaskSub")).send().join();
+
+    final var userTaskKey = userTaskList.items().stream().findFirst().get().getUserTaskKey();
+
+    final var result =
+        camundaClient
+            .newUserTaskVariableQuery(userTaskKey)
+            .filter(f -> f.name(b -> b.eq("localVariable")))
+            .send()
+            .join();
+    // then
+    assertThat(result.items().size()).isEqualTo(1);
+    assertThat(result.items().get(0).getName()).isEqualTo("localVariable");
+  }
+
+  @Test
+  void shouldReturnUserTaskVariablesFilteredByNameLike() {
+    // When
+    final var userTaskList =
+        camundaClient.newUserTaskQuery().filter(f -> f.elementId("TaskSub")).send().join();
+
+    final var userTaskKey =
+        userTaskList.items().stream().findFirst().orElseThrow().getUserTaskKey();
+
+    final var result =
+        camundaClient
+            .newUserTaskVariableQuery(userTaskKey)
+            .filter(f -> f.name(b -> b.like("*rocess*")))
+            .send()
+            .join();
+
+    // Then
+    assertThat(result.items()).hasSize(2);
+    assertThat(result.items().stream().map(item -> item.getName()))
+        .containsExactlyInAnyOrder("processVariable", "subProcessVariable");
+  }
+
+  @Test
+  void shouldReturnUserTaskVariablesFilteredByIn() {
+    // When
+    final var userTaskList =
+        camundaClient.newUserTaskQuery().filter(f -> f.elementId("TaskSub")).send().join();
+
+    final var userTaskKey =
+        userTaskList.items().stream().findFirst().orElseThrow().getUserTaskKey();
+
+    final var result =
+        camundaClient
+            .newUserTaskVariableQuery(userTaskKey)
+            .filter(f -> f.name(b -> b.in(List.of("processVariable", "subProcessVariable"))))
+            .send()
+            .join();
+
+    // Then
+    assertThat(result.items()).hasSize(2);
+    assertThat(result.items().stream().map(item -> item.getName()))
+        .containsExactlyInAnyOrder("processVariable", "subProcessVariable");
+  }
+
+  @Test
   void shouldReturnUserTaskByCreationDateExists() {
     // when
     final var result =

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4094,7 +4094,7 @@ components:
       type: object
       properties:
         filter:
-          description: The user task search filters.
+          description: The user task variable search filters.
           allOf:
             - $ref: "#/components/schemas/VariableUserTaskFilterRequest"
     UserTaskSearchQueryResponse:
@@ -4201,7 +4201,7 @@ components:
           type: string
           description: The value of the variable.
     VariableUserTaskFilterRequest:
-      description: Variable
+      description: The user task variable search filters.
       type: object
       properties:
         name:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4092,6 +4092,11 @@ components:
         - $ref: "#/components/schemas/SearchQueryRequest"
       description: User task search query request.
       type: object
+      properties:
+        filter:
+          description: The user task search filters.
+          allOf:
+            - $ref: "#/components/schemas/VariableUserTaskFilterRequest"
     UserTaskSearchQueryResponse:
       description: User task search query response. Key attributes as numeric values.
       deprecated: true
@@ -4195,6 +4200,14 @@ components:
         value:
           type: string
           description: The value of the variable.
+    VariableUserTaskFilterRequest:
+      description: Variable
+      type: object
+      properties:
+        name:
+          description: Name of the variable.
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
     UserTaskItemBase:
       description: Base properties for UserTaskItem.
       type: object

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -348,6 +348,8 @@ public final class SearchQueryRequestMapper {
     if (request == null) {
       return Either.right(SearchQueryBuilders.variableSearchQuery().build());
     }
+
+    final var filter = toUserTaskVariableFilter(request.getFilter());
     final var page = toSearchQueryPage(request.getPage());
     final var sort =
         toSearchQuerySort(
@@ -355,8 +357,21 @@ public final class SearchQueryRequestMapper {
             SortOptionBuilders::variable,
             SearchQueryRequestMapper::applyVariableSortField);
 
-    return buildSearchQuery(
-        FilterBuilders.variable().build(), sort, page, SearchQueryBuilders::variableSearchQuery);
+    return buildSearchQuery(filter, sort, page, SearchQueryBuilders::variableSearchQuery);
+  }
+
+  private static VariableFilter toUserTaskVariableFilter(
+      final VariableUserTaskFilterRequest filter) {
+    if (filter == null) {
+      return FilterBuilders.variable().build();
+    }
+
+    final var builder = FilterBuilders.variable();
+    ofNullable(filter.getName())
+        .map(mapToOperations(String.class))
+        .ifPresent(builder::nameOperations);
+
+    return builder.build();
   }
 
   public static Either<ProblemDetail, VariableQuery> toVariableQuery(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -20,6 +20,7 @@ import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.UserTaskEntity.UserTaskState;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.exception.NotFoundException;
+import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.UserTaskFilter;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SearchQueryResult.Builder;
@@ -610,14 +611,27 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
 
   @Test
   public void shouldReturnVariableForValidUserTaskKey() {
+    final var request =
+        """
+            {
+                "filter":
+                    {
+                        "name": "varName"
+                    }
+
+            }""";
+
     when(userTaskServices.searchUserTaskVariables(
-            VALID_USER_TASK_KEY, variableSearchQuery().build()))
+            VALID_USER_TASK_KEY,
+            variableSearchQuery().filter(f -> f.nameOperations(Operation.eq("varName"))).build()))
         .thenReturn(SEARCH_VAR_QUERY_RESULT);
     // when and then
     webClient
         .post()
         .uri("/v2/user-tasks/" + VALID_USER_TASK_KEY + "/variables/search")
         .accept(APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
         .exchange()
         .expectStatus()
         .isOk()
@@ -625,7 +639,9 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .json(EXPECTED_VARIABLE_RESULT_JSON);
 
     verify(userTaskServices)
-        .searchUserTaskVariables(VALID_USER_TASK_KEY, variableSearchQuery().build());
+        .searchUserTaskVariables(
+            VALID_USER_TASK_KEY,
+            variableSearchQuery().filter(f -> f.nameOperations(Operation.eq("varName"))).build());
   }
 
   private static Stream<Arguments> provideAdvancedSearchParameters() {


### PR DESCRIPTION
## Description

Add filtering capabilities on Search User Task Variable endpoint to the follow attributes:

- name

## Related issues

closes https://github.com/camunda/camunda/issues/26745
