### PR TITLE
docs: Changing `reset` to `clear`

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -102,23 +102,24 @@ message CompleteJobRequest {
   // a JSON document representing the variables in the current task scope
   string variables = 2;
   // The result of the completed job as determined by the worker.
+  // This functionality is currently supported only by user task listeners.
   optional JobResult result = 3;
 }
 
 message JobResult{
   // Indicates whether the worker denies the work, i.e. explicitly doesn't approve it.
-  // For example, a Task Listener can deny the completion of a task by setting this flag to true.
+  // For example, a user task listener can deny the completion of a user task by setting this flag to true.
   // In this example, the completion of a task is represented by a job that the worker can complete as denied.
   // As a result, the completion request is rejected and the task remains active.
   // Defaults to false.
   optional bool denied = 1;
   // Attributes that were corrected by the worker.
   // The following attributes can be corrected, additional attributes will be ignored:
-  //   * `assignee` - reset by providing an empty String
-  //   * `dueDate` - reset by providing an empty String
-  //   * `followUpDate` - reset by providing an empty String
-  //   * `candidateGroups` - reset by providing an empty list
-  //   * `candidateUsers` - reset by providing an empty list
+  //   * `assignee` - clear by providing an empty string
+  //   * `dueDate` - clear by providing an empty string
+  //   * `followUpDate` - clear by providing an empty string
+  //   * `candidateGroups` - clear by providing an empty list
+  //   * `candidateUsers` - clear by providing an empty list
   //   * `priority` - minimum 0, maximum 100, default 50
   //  Omitting any of the attributes will preserve the persisted attribute's value.
   optional JobResultCorrections corrections = 2;

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6564,11 +6564,11 @@ components:
 
         The following attributes can be corrected, additional attributes will be ignored:
 
-        * `assignee` - reset by providing an empty String
-        * `dueDate` - reset by providing an empty String
-        * `followUpDate` - reset by providing an empty String
-        * `candidateGroups` - reset by providing an empty list
-        * `candidateUsers` - reset by providing an empty list
+        * `assignee` - clear by providing an empty String
+        * `dueDate` - clear by providing an empty String
+        * `followUpDate` - clear by providing an empty String
+        * `candidateGroups` - clear by providing an empty list
+        * `candidateUsers` - clear by providing an empty list
         * `priority` - minimum 0, maximum 100, default 50
 
         Providing any of those attributes with a `null` value or omitting it preserves


### PR DESCRIPTION
## Description

As there might be multiple user task listeners that are triggered in sequence, the word `reset` might be misleading as it may imply that a previously made correction can be "reset" (i.e. undone).

Solution: using `clear` instead of `reset`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #26346
