### PR TITLE
pg-26808-add-pi-key-to-task-process

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistAssignUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistAssignUserTaskAuthorizationIT.java
@@ -17,6 +17,7 @@ import io.camunda.qa.util.cluster.TestRestTasklistClient;
 import io.camunda.qa.util.cluster.TestStandaloneCamunda;
 import io.camunda.search.clients.query.SearchQueryBuilders;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
+import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
 import io.camunda.zeebe.it.util.AuthorizationsUtil;
 import io.camunda.zeebe.it.util.AuthorizationsUtil.Permissions;
 import io.camunda.zeebe.it.util.SearchClientsUtil;
@@ -230,7 +231,10 @@ public class TasklistAssignUserTaskAuthorizationIT {
   public static long awaitJobBasedUserTaskBeingAvailable(final long processInstanceKey) {
     final AtomicLong userTaskKey = new AtomicLong();
     final var processInstanceQuery =
-        SearchQueryBuilders.term(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceKey);
+        SearchQueryBuilders.and(
+            SearchQueryBuilders.term(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceKey),
+            SearchQueryBuilders.term(
+                TaskTemplate.IMPLEMENTATION, TaskImplementation.JOB_WORKER.name()));
     Awaitility.await("should create a job-based user task")
         .atMost(Duration.ofSeconds(60))
         .ignoreExceptions() // Ignore exceptions and continue retrying

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistAssignUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistAssignUserTaskAuthorizationIT.java
@@ -17,7 +17,7 @@ import io.camunda.qa.util.cluster.TestRestTasklistClient;
 import io.camunda.qa.util.cluster.TestStandaloneCamunda;
 import io.camunda.search.clients.query.SearchQueryBuilders;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
-import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
+import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship.TaskJoinRelationshipType;
 import io.camunda.zeebe.it.util.AuthorizationsUtil;
 import io.camunda.zeebe.it.util.AuthorizationsUtil.Permissions;
 import io.camunda.zeebe.it.util.SearchClientsUtil;
@@ -234,7 +234,7 @@ public class TasklistAssignUserTaskAuthorizationIT {
         SearchQueryBuilders.and(
             SearchQueryBuilders.term(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceKey),
             SearchQueryBuilders.term(
-                TaskTemplate.IMPLEMENTATION, TaskImplementation.JOB_WORKER.name()));
+                TaskTemplate.JOIN_FIELD_NAME, TaskJoinRelationshipType.TASK.getType()));
     Awaitility.await("should create a job-based user task")
         .atMost(Duration.ofSeconds(60))
         .ignoreExceptions() // Ignore exceptions and continue retrying

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistCompleteUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistCompleteUserTaskAuthorizationIT.java
@@ -17,6 +17,7 @@ import io.camunda.qa.util.cluster.TestRestTasklistClient;
 import io.camunda.qa.util.cluster.TestStandaloneCamunda;
 import io.camunda.search.clients.query.SearchQueryBuilders;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
+import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
 import io.camunda.zeebe.it.util.AuthorizationsUtil;
 import io.camunda.zeebe.it.util.AuthorizationsUtil.Permissions;
 import io.camunda.zeebe.it.util.SearchClientsUtil;
@@ -247,7 +248,10 @@ public class TasklistCompleteUserTaskAuthorizationIT {
   public static long awaitJobBasedUserTaskBeingAvailable(final long processInstanceKey) {
     final AtomicLong userTaskKey = new AtomicLong();
     final var processInstanceQuery =
-        SearchQueryBuilders.term(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceKey);
+        SearchQueryBuilders.and(
+            SearchQueryBuilders.term(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceKey),
+            SearchQueryBuilders.term(
+                TaskTemplate.IMPLEMENTATION, TaskImplementation.JOB_WORKER.name()));
     Awaitility.await("should create a job-based user task")
         .atMost(Duration.ofSeconds(60))
         .ignoreExceptions() // Ignore exceptions and continue retrying

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistCompleteUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistCompleteUserTaskAuthorizationIT.java
@@ -17,7 +17,7 @@ import io.camunda.qa.util.cluster.TestRestTasklistClient;
 import io.camunda.qa.util.cluster.TestStandaloneCamunda;
 import io.camunda.search.clients.query.SearchQueryBuilders;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
-import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
+import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship.TaskJoinRelationshipType;
 import io.camunda.zeebe.it.util.AuthorizationsUtil;
 import io.camunda.zeebe.it.util.AuthorizationsUtil.Permissions;
 import io.camunda.zeebe.it.util.SearchClientsUtil;
@@ -251,7 +251,7 @@ public class TasklistCompleteUserTaskAuthorizationIT {
         SearchQueryBuilders.and(
             SearchQueryBuilders.term(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceKey),
             SearchQueryBuilders.term(
-                TaskTemplate.IMPLEMENTATION, TaskImplementation.JOB_WORKER.name()));
+                TaskTemplate.JOIN_FIELD_NAME, TaskJoinRelationshipType.TASK.getType()));
     Awaitility.await("should create a job-based user task")
         .atMost(Duration.ofSeconds(60))
         .ignoreExceptions() // Ignore exceptions and continue retrying

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistUnassignUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistUnassignUserTaskAuthorizationIT.java
@@ -17,7 +17,7 @@ import io.camunda.qa.util.cluster.TestRestTasklistClient;
 import io.camunda.qa.util.cluster.TestStandaloneCamunda;
 import io.camunda.search.clients.query.SearchQueryBuilders;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
-import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
+import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship.TaskJoinRelationshipType;
 import io.camunda.zeebe.it.util.AuthorizationsUtil;
 import io.camunda.zeebe.it.util.AuthorizationsUtil.Permissions;
 import io.camunda.zeebe.it.util.SearchClientsUtil;
@@ -251,7 +251,7 @@ public class TasklistUnassignUserTaskAuthorizationIT {
         SearchQueryBuilders.and(
             SearchQueryBuilders.term(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceKey),
             SearchQueryBuilders.term(
-                TaskTemplate.IMPLEMENTATION, TaskImplementation.JOB_WORKER.name()));
+                TaskTemplate.JOIN_FIELD_NAME, TaskJoinRelationshipType.TASK.getType()));
     Awaitility.await("should create a job-based user task")
         .atMost(Duration.ofSeconds(60))
         .ignoreExceptions() // Ignore exceptions and continue retrying

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistUnassignUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistUnassignUserTaskAuthorizationIT.java
@@ -17,6 +17,7 @@ import io.camunda.qa.util.cluster.TestRestTasklistClient;
 import io.camunda.qa.util.cluster.TestStandaloneCamunda;
 import io.camunda.search.clients.query.SearchQueryBuilders;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
+import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
 import io.camunda.zeebe.it.util.AuthorizationsUtil;
 import io.camunda.zeebe.it.util.AuthorizationsUtil.Permissions;
 import io.camunda.zeebe.it.util.SearchClientsUtil;
@@ -247,7 +248,10 @@ public class TasklistUnassignUserTaskAuthorizationIT {
   public static long awaitJobBasedUserTaskBeingAvailable(final long processInstanceKey) {
     final AtomicLong userTaskKey = new AtomicLong();
     final var processInstanceQuery =
-        SearchQueryBuilders.term(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceKey);
+        SearchQueryBuilders.and(
+            SearchQueryBuilders.term(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceKey),
+            SearchQueryBuilders.term(
+                TaskTemplate.IMPLEMENTATION, TaskImplementation.JOB_WORKER.name()));
     Awaitility.await("should create a job-based user task")
         .atMost(Duration.ofSeconds(60))
         .ignoreExceptions() // Ignore exceptions and continue retrying

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistAssignUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistAssignUserTaskAuthorizationIT.java
@@ -17,6 +17,7 @@ import io.camunda.qa.util.cluster.TestRestTasklistClient;
 import io.camunda.qa.util.cluster.TestStandaloneCamunda;
 import io.camunda.search.clients.query.SearchQueryBuilders;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
+import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
 import io.camunda.zeebe.it.util.AuthorizationsUtil;
 import io.camunda.zeebe.it.util.AuthorizationsUtil.Permissions;
 import io.camunda.zeebe.it.util.SearchClientsUtil;
@@ -228,7 +229,10 @@ public class CompatibilityTasklistAssignUserTaskAuthorizationIT {
   public static long awaitJobBasedUserTaskBeingAvailable(final long processInstanceKey) {
     final AtomicLong userTaskKey = new AtomicLong();
     final var processInstanceQuery =
-        SearchQueryBuilders.term(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceKey);
+        SearchQueryBuilders.and(
+            SearchQueryBuilders.term(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceKey),
+            SearchQueryBuilders.term(
+                TaskTemplate.IMPLEMENTATION, TaskImplementation.JOB_WORKER.name()));
     Awaitility.await("should create a job-based user task")
         .atMost(Duration.ofSeconds(60))
         .ignoreExceptions() // Ignore exceptions and continue retrying
@@ -244,7 +248,10 @@ public class CompatibilityTasklistAssignUserTaskAuthorizationIT {
   public static void ensureJobBasedUserTaskAssigneeChanged(
       final long processInstanceKey, final String newAssignee) {
     final var processInstanceQuery =
-        SearchQueryBuilders.term(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceKey);
+        SearchQueryBuilders.and(
+            SearchQueryBuilders.term(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceKey),
+            SearchQueryBuilders.term(
+                TaskTemplate.IMPLEMENTATION, TaskImplementation.JOB_WORKER.name()));
     final var assigneeQuery = SearchQueryBuilders.term(TaskTemplate.ASSIGNEE, newAssignee);
     final var finalQuery = SearchQueryBuilders.and(processInstanceQuery, assigneeQuery);
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistAssignUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistAssignUserTaskAuthorizationIT.java
@@ -17,7 +17,7 @@ import io.camunda.qa.util.cluster.TestRestTasklistClient;
 import io.camunda.qa.util.cluster.TestStandaloneCamunda;
 import io.camunda.search.clients.query.SearchQueryBuilders;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
-import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
+import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship.TaskJoinRelationshipType;
 import io.camunda.zeebe.it.util.AuthorizationsUtil;
 import io.camunda.zeebe.it.util.AuthorizationsUtil.Permissions;
 import io.camunda.zeebe.it.util.SearchClientsUtil;
@@ -232,7 +232,7 @@ public class CompatibilityTasklistAssignUserTaskAuthorizationIT {
         SearchQueryBuilders.and(
             SearchQueryBuilders.term(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceKey),
             SearchQueryBuilders.term(
-                TaskTemplate.IMPLEMENTATION, TaskImplementation.JOB_WORKER.name()));
+                TaskTemplate.JOIN_FIELD_NAME, TaskJoinRelationshipType.TASK.getType()));
     Awaitility.await("should create a job-based user task")
         .atMost(Duration.ofSeconds(60))
         .ignoreExceptions() // Ignore exceptions and continue retrying
@@ -251,7 +251,7 @@ public class CompatibilityTasklistAssignUserTaskAuthorizationIT {
         SearchQueryBuilders.and(
             SearchQueryBuilders.term(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceKey),
             SearchQueryBuilders.term(
-                TaskTemplate.IMPLEMENTATION, TaskImplementation.JOB_WORKER.name()));
+                TaskTemplate.JOIN_FIELD_NAME, TaskJoinRelationshipType.TASK.getType()));
     final var assigneeQuery = SearchQueryBuilders.term(TaskTemplate.ASSIGNEE, newAssignee);
     final var finalQuery = SearchQueryBuilders.and(processInstanceQuery, assigneeQuery);
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistCompleteUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistCompleteUserTaskAuthorizationIT.java
@@ -17,7 +17,7 @@ import io.camunda.qa.util.cluster.TestRestTasklistClient;
 import io.camunda.qa.util.cluster.TestStandaloneCamunda;
 import io.camunda.search.clients.query.SearchQueryBuilders;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
-import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
+import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship.TaskJoinRelationshipType;
 import io.camunda.zeebe.it.util.AuthorizationsUtil;
 import io.camunda.zeebe.it.util.AuthorizationsUtil.Permissions;
 import io.camunda.zeebe.it.util.SearchClientsUtil;
@@ -207,7 +207,7 @@ public class CompatibilityTasklistCompleteUserTaskAuthorizationIT {
         SearchQueryBuilders.and(
             SearchQueryBuilders.term(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceKey),
             SearchQueryBuilders.term(
-                TaskTemplate.IMPLEMENTATION, TaskImplementation.JOB_WORKER.name()));
+                TaskTemplate.JOIN_FIELD_NAME, TaskJoinRelationshipType.TASK.getType()));
     Awaitility.await("should create a job-based user task")
         .atMost(Duration.ofSeconds(60))
         .ignoreExceptions() // Ignore exceptions and continue retrying

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistCompleteUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistCompleteUserTaskAuthorizationIT.java
@@ -17,6 +17,7 @@ import io.camunda.qa.util.cluster.TestRestTasklistClient;
 import io.camunda.qa.util.cluster.TestStandaloneCamunda;
 import io.camunda.search.clients.query.SearchQueryBuilders;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
+import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
 import io.camunda.zeebe.it.util.AuthorizationsUtil;
 import io.camunda.zeebe.it.util.AuthorizationsUtil.Permissions;
 import io.camunda.zeebe.it.util.SearchClientsUtil;
@@ -203,7 +204,10 @@ public class CompatibilityTasklistCompleteUserTaskAuthorizationIT {
   public static long awaitJobBasedUserTaskBeingAvailable(final long processInstanceKey) {
     final AtomicLong userTaskKey = new AtomicLong();
     final var processInstanceQuery =
-        SearchQueryBuilders.term(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceKey);
+        SearchQueryBuilders.and(
+            SearchQueryBuilders.term(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceKey),
+            SearchQueryBuilders.term(
+                TaskTemplate.IMPLEMENTATION, TaskImplementation.JOB_WORKER.name()));
     Awaitility.await("should create a job-based user task")
         .atMost(Duration.ofSeconds(60))
         .ignoreExceptions() // Ignore exceptions and continue retrying

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistUnassignUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistUnassignUserTaskAuthorizationIT.java
@@ -17,7 +17,7 @@ import io.camunda.qa.util.cluster.TestRestTasklistClient;
 import io.camunda.qa.util.cluster.TestStandaloneCamunda;
 import io.camunda.search.clients.query.SearchQueryBuilders;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
-import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
+import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship.TaskJoinRelationshipType;
 import io.camunda.zeebe.it.util.AuthorizationsUtil;
 import io.camunda.zeebe.it.util.AuthorizationsUtil.Permissions;
 import io.camunda.zeebe.it.util.SearchClientsUtil;
@@ -207,7 +207,7 @@ public class CompatibilityTasklistUnassignUserTaskAuthorizationIT {
         SearchQueryBuilders.and(
             SearchQueryBuilders.term(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceKey),
             SearchQueryBuilders.term(
-                TaskTemplate.IMPLEMENTATION, TaskImplementation.JOB_WORKER.name()));
+                TaskTemplate.JOIN_FIELD_NAME, TaskJoinRelationshipType.TASK.getType()));
     Awaitility.await("should create a job-based user task")
         .atMost(Duration.ofSeconds(60))
         .ignoreExceptions() // Ignore exceptions and continue retrying

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistUnassignUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistUnassignUserTaskAuthorizationIT.java
@@ -17,6 +17,7 @@ import io.camunda.qa.util.cluster.TestRestTasklistClient;
 import io.camunda.qa.util.cluster.TestStandaloneCamunda;
 import io.camunda.search.clients.query.SearchQueryBuilders;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
+import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
 import io.camunda.zeebe.it.util.AuthorizationsUtil;
 import io.camunda.zeebe.it.util.AuthorizationsUtil.Permissions;
 import io.camunda.zeebe.it.util.SearchClientsUtil;
@@ -203,7 +204,10 @@ public class CompatibilityTasklistUnassignUserTaskAuthorizationIT {
   public static long awaitJobBasedUserTaskBeingAvailable(final long processInstanceKey) {
     final AtomicLong userTaskKey = new AtomicLong();
     final var processInstanceQuery =
-        SearchQueryBuilders.term(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceKey);
+        SearchQueryBuilders.and(
+            SearchQueryBuilders.term(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceKey),
+            SearchQueryBuilders.term(
+                TaskTemplate.IMPLEMENTATION, TaskImplementation.JOB_WORKER.name()));
     Awaitility.await("should create a job-based user task")
         .atMost(Duration.ofSeconds(60))
         .ignoreExceptions() // Ignore exceptions and continue retrying

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/BrokerITInvocationProvider.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/BrokerITInvocationProvider.java
@@ -127,8 +127,8 @@ public class BrokerITInvocationProvider
 
   @Override
   public void beforeAll(final ExtensionContext context) {
-    LOGGER.info("Starting up '{}' camunda instances", supportedExporterTypes.size());
-    supportedExporterTypes.parallelStream()
+    LOGGER.info("Starting up '{}' camunda instances", activeExporterTypes.size());
+    activeExporterTypes.parallelStream()
         .forEach(
             exporterType -> {
               LOGGER.info("Start up '{}'", exporterType);

--- a/qa/integration-tests/src/test/resources/process/process_with_assigned_job_based_user_task.bpmn
+++ b/qa/integration-tests/src/test/resources/process/process_with_assigned_job_based_user_task.bpmn
@@ -7,7 +7,6 @@
     <bpmn:sequenceFlow id="Flow_0a17qbl" sourceRef="StartEvent_1" targetRef="user-task" />
     <bpmn:userTask id="user-task">
       <bpmn:extensionElements>
-        <zeebe:userTask />
         <zeebe:assignmentDefinition assignee="bar" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0a17qbl</bpmn:incoming>

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/tasklist/TaskProcessInstanceEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/tasklist/TaskProcessInstanceEntity.java
@@ -12,6 +12,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 public class TaskProcessInstanceEntity extends TasklistEntity<TaskProcessInstanceEntity> {
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Long processInstanceId;
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   private TaskJoinRelationship join;
 
   public TaskProcessInstanceEntity() {}
@@ -27,6 +30,15 @@ public class TaskProcessInstanceEntity extends TasklistEntity<TaskProcessInstanc
 
   public TaskProcessInstanceEntity setJoin(final TaskJoinRelationship join) {
     this.join = join;
+    return this;
+  }
+
+  public Long getProcessInstanceId() {
+    return processInstanceId;
+  }
+
+  public TaskProcessInstanceEntity setProcessInstanceId(final Long processInstanceId) {
+    this.processInstanceId = processInstanceId;
     return this;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandler.java
@@ -59,7 +59,7 @@ public class UserTaskProcessInstanceHandler
   public void updateEntity(
       final Record<ProcessInstanceRecordValue> record, final TaskProcessInstanceEntity entity) {
     entity.setPartitionId(record.getPartitionId()).setTenantId(record.getValue().getTenantId());
-
+    entity.setProcessInstanceId(record.getKey());
     final TaskJoinRelationship join = new TaskJoinRelationship();
     join.setName(TaskJoinRelationshipType.PROCESS.getType());
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -37,7 +37,6 @@ import io.camunda.webapps.schema.descriptors.operate.template.IncidentTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.OperationTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.PostImporterQueueTemplate;
-import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
 import io.camunda.zeebe.util.error.FatalErrorHandler;
 import java.util.ArrayList;
 import java.util.List;
@@ -150,12 +149,6 @@ public final class BackgroundTaskManagerFactory {
         .filter(ProcessInstanceDependant.class::isInstance)
         .map(ProcessInstanceDependant.class::cast)
         .forEach(dependantTemplates::add);
-
-    // add a special case just for TaskTemplate, which has 2 kinds of documents in the same
-    // index
-    final var taskTemplate = resourceProvider.getIndexTemplateDescriptor(TaskTemplate.class);
-    dependantTemplates.add(
-        new ProcessInstanceDependantAdapter(taskTemplate.getFullQualifiedName(), TaskTemplate.ID));
 
     return buildReschedulingArchiverTask(
         new ProcessInstancesArchiverJob(
@@ -307,19 +300,5 @@ public final class BackgroundTaskManagerFactory {
             logger);
       }
     };
-  }
-
-  private record ProcessInstanceDependantAdapter(String name, String field)
-      implements ProcessInstanceDependant {
-
-    @Override
-    public String getFullQualifiedName() {
-      return name;
-    }
-
-    @Override
-    public String getProcessInstanceDependantField() {
-      return field;
-    }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandlerTest.java
@@ -152,6 +152,7 @@ public class UserTaskProcessInstanceHandlerTest {
 
     // then
     assertThat(processInstanceEntity.getId()).isEqualTo(String.valueOf(expectedId));
+    assertThat(processInstanceEntity.getProcessInstanceId()).isEqualTo(expectedId);
     assertThat(processInstanceEntity.getTenantId())
         .isEqualTo(processInstanceRecordValue.getTenantId());
     assertThat(processInstanceEntity.getJoin()).isNotNull();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- Persist ProcessInstanceId in TaskProcessInstanceEntity nested relationship to enable it being picked up by the Archiver
- Remove workaround on Archiver for this specified case
- Fix `BrokerITInvocationProvider` to correctly remove the RDBMS Exporter when required, communicated with @p-wunderlich regarding this to investigate the related disabled tests on why they should or not remain disabled since they were being triggered normally
- Fix Tasklist V1/V2 compatibility tests :point_down: 

cc: @romansmirnov I've made some changes in the Tasklist compatibility tests, basically, the search for Job Based User Tasks was failing because it was retrieving both Zeebe and Job Worker tasks. I'm curious to how these were passing before, could be timing issues, also the BPMN for Job Based User Task was creating a Zeebe User Task, so I've updated this as well.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #26808
