### PR TITLE
Work with username instead of user key in the Gateway (REST+GRPC)

### DIFF
--- a/zeebe/auth/src/main/java/io/camunda/zeebe/auth/Authorization.java
+++ b/zeebe/auth/src/main/java/io/camunda/zeebe/auth/Authorization.java
@@ -11,6 +11,6 @@ public class Authorization {
 
   public static final String AUTHORIZED_ANONYMOUS_USER = "authorized_anonymous_user";
   public static final String AUTHORIZED_TENANTS = "authorized_tenants";
-  public static final String AUTHORIZED_USER_KEY = "authorized_user_key";
+  public static final String AUTHORIZED_USERNAME = "authorized_username";
   public static final String USER_TOKEN_CLAIM_PREFIX = "user_token_";
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -134,7 +134,7 @@ public final class AuthorizationCheckBehavior {
     return Optional.ofNullable(authorizedAnonymousUserClaim).map(Boolean.class::cast).orElse(false);
   }
 
-  private static Optional<Long> getUserKey(final AuthorizationRequest request) {
+  private Optional<Long> getUserKey(final AuthorizationRequest request) {
     return getUserKey(request.getCommand());
   }
 
@@ -319,9 +319,11 @@ public final class AuthorizationCheckBehavior {
         : new AuthenticatedAuthorizedTenants(tenantsOfMapping);
   }
 
-  private static Optional<Long> getUserKey(final TypedRecord<?> command) {
+  private Optional<Long> getUserKey(final TypedRecord<?> command) {
     return Optional.ofNullable(
-        (Long) command.getAuthorizations().get(Authorization.AUTHORIZED_USER_KEY));
+            (String) command.getAuthorizations().get(Authorization.AUTHORIZED_USERNAME))
+        .flatMap(userState::getUser)
+        .map(PersistedUser::getUserKey);
   }
 
   private static Stream<UserTokenClaim> extractUserTokenClaims(final TypedRecord<?> command) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AnonymousAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AnonymousAuthorizationTest.java
@@ -41,7 +41,7 @@ public class AnonymousAuthorizationTest {
   private static final String PROCESS_ID = "PROCESS";
   private static final String PROCESS_ID_WITH_NOT_EXISTING_FORM = "PROCESS_WITH_NOT_EXISTING_FORM";
   private static final String TENANT = "foo";
-  private static long userKey;
+  private static String username;
 
   private static final BpmnModelInstance PROCESS =
       Bpmn.createExecutableProcess(PROCESS_ID)
@@ -64,13 +64,13 @@ public class AnonymousAuthorizationTest {
 
   @BeforeClass
   public static void setUp() {
-    final var username = UUID.randomUUID().toString();
-    userKey = ENGINE.user().newUser(username).create().getValue().getUserKey();
+    username = UUID.randomUUID().toString();
+    final var user = ENGINE.user().newUser(username).create().getValue();
     final var tenantKey = ENGINE.tenant().newTenant().withTenantId(TENANT).create().getKey();
     ENGINE
         .tenant()
         .addEntity(tenantKey)
-        .withEntityKey(userKey)
+        .withEntityKey(user.getUserKey())
         .withEntityType(EntityType.USER)
         .add();
 
@@ -79,11 +79,11 @@ public class AnonymousAuthorizationTest {
         .permission()
         .withPermission(PermissionType.CREATE, "*")
         .withResourceType(AuthorizationResourceType.DEPLOYMENT)
-        .withOwnerKey(userKey)
+        .withOwnerKey(user.getUserKey())
         .withOwnerType(AuthorizationOwnerType.USER)
         .add();
 
-    ENGINE.deployment().withXmlResource(PROCESS).deploy(userKey);
+    ENGINE.deployment().withXmlResource(PROCESS).deploy(username);
   }
 
   @Test
@@ -155,7 +155,7 @@ public class AnonymousAuthorizationTest {
         .deployment()
         .withXmlResource(PROCESS_WITH_NOT_EXISTING_FORM)
         .withTenantId(TENANT)
-        .deploy(userKey);
+        .deploy(username);
 
     final long processInstanceKey =
         ENGINE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationAddPermissionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationAddPermissionAuthorizationTest.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -35,8 +34,8 @@ public class AuthorizationAddPermissionAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
 
-  @ClassRule
-  public static final EngineRule ENGINE =
+  @Rule
+  public final EngineRule engine =
       EngineRule.singlePartition()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
@@ -49,7 +48,7 @@ public class AuthorizationAddPermissionAuthorizationTest {
     final var user = createUser();
 
     // when
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(user.getUserKey())
@@ -73,7 +72,7 @@ public class AuthorizationAddPermissionAuthorizationTest {
         user.getUserKey(), AuthorizationResourceType.AUTHORIZATION, PermissionType.UPDATE);
 
     // when
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(user.getUserKey())
@@ -96,7 +95,7 @@ public class AuthorizationAddPermissionAuthorizationTest {
 
     // when
     final var rejection =
-        ENGINE
+        engine
             .authorization()
             .permission()
             .withOwnerKey(user.getUserKey())
@@ -112,8 +111,8 @@ public class AuthorizationAddPermissionAuthorizationTest {
             "Insufficient permissions to perform operation 'UPDATE' on resource 'AUTHORIZATION'");
   }
 
-  private static UserRecordValue createUser() {
-    return ENGINE
+  private UserRecordValue createUser() {
+    return engine
         .user()
         .newUser(UUID.randomUUID().toString())
         .withPassword(UUID.randomUUID().toString())
@@ -127,7 +126,7 @@ public class AuthorizationAddPermissionAuthorizationTest {
       final long userKey,
       final AuthorizationResourceType authorization,
       final PermissionType permissionType) {
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(userKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationRemovePermissionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationRemovePermissionAuthorizationTest.java
@@ -14,14 +14,13 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
-import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,21 +37,11 @@ public class AuthorizationRemovePermissionAuthorizationTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withoutAwaitingIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
   private static long defaultUserKey = -1L;
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
-
-  @BeforeClass
-  public static void beforeAll() {
-    defaultUserKey =
-        RecordingExporter.userRecords(UserIntent.CREATED)
-            .withUsername(DEFAULT_USER.getUsername())
-            .getFirst()
-            .getKey();
-  }
 
   @Test
   public void shouldBeAuthorizedToRemovePermissionsWithDefaultUser() {
@@ -60,22 +49,22 @@ public class AuthorizationRemovePermissionAuthorizationTest {
     final var resourceId = "resourceId";
     final var resourceType = AuthorizationResourceType.DEPLOYMENT;
     final var permissionType = PermissionType.DELETE;
-    final var userKey = createUser();
-    addPermissionsToUser(userKey, resourceType, permissionType, resourceId);
+    final var user = createUser();
+    addPermissionsToUser(user.getUserKey(), resourceType, permissionType, resourceId);
 
     // when
     ENGINE
         .authorization()
         .permission()
-        .withOwnerKey(userKey)
+        .withOwnerKey(user.getUserKey())
         .withResourceType(resourceType)
         .withPermission(permissionType, resourceId)
-        .remove(defaultUserKey);
+        .remove(DEFAULT_USER.getUsername());
 
     // when
     assertThat(
             RecordingExporter.authorizationRecords(AuthorizationIntent.PERMISSION_REMOVED)
-                .withOwnerKey(userKey)
+                .withOwnerKey(user.getUserKey())
                 .exists())
         .isTrue();
   }
@@ -86,22 +75,22 @@ public class AuthorizationRemovePermissionAuthorizationTest {
     final var resourceId = "resourceId";
     final var resourceType = AuthorizationResourceType.AUTHORIZATION;
     final var permissionType = PermissionType.UPDATE;
-    final var userKey = createUser();
-    addPermissionsToUser(userKey, resourceType, permissionType, resourceId, "*");
+    final var user = createUser();
+    addPermissionsToUser(user.getUserKey(), resourceType, permissionType, resourceId, "*");
 
     // when
     ENGINE
         .authorization()
         .permission()
-        .withOwnerKey(userKey)
+        .withOwnerKey(user.getUserKey())
         .withResourceType(resourceType)
         .withPermission(permissionType, resourceId)
-        .remove(userKey);
+        .remove(user.getUsername());
 
     // then
     assertThat(
             RecordingExporter.authorizationRecords(AuthorizationIntent.PERMISSION_REMOVED)
-                .withOwnerKey(userKey)
+                .withOwnerKey(user.getUserKey())
                 .exists())
         .isTrue();
   }
@@ -109,18 +98,18 @@ public class AuthorizationRemovePermissionAuthorizationTest {
   @Test
   public void shouldBeUnauthorizedToRemovePermissionsIfNoPermissions() {
     // given
-    final var userKey = createUser();
+    final var user = createUser();
 
     // when
     final var rejection =
         ENGINE
             .authorization()
             .permission()
-            .withOwnerKey(userKey)
+            .withOwnerKey(user.getUserKey())
             .withResourceType(AuthorizationResourceType.DEPLOYMENT)
             .withPermission(PermissionType.DELETE, "*")
             .expectRejection()
-            .remove(userKey);
+            .remove(user.getUsername());
 
     // then
     Assertions.assertThat(rejection)
@@ -129,7 +118,7 @@ public class AuthorizationRemovePermissionAuthorizationTest {
             "Insufficient permissions to perform operation 'UPDATE' on resource 'AUTHORIZATION'");
   }
 
-  private static long createUser() {
+  private static UserRecordValue createUser() {
     return ENGINE
         .user()
         .newUser(UUID.randomUUID().toString())
@@ -137,7 +126,7 @@ public class AuthorizationRemovePermissionAuthorizationTest {
         .withName(UUID.randomUUID().toString())
         .withEmail(UUID.randomUUID().toString())
         .create()
-        .getKey();
+        .getValue();
   }
 
   private void addPermissionsToUser(
@@ -151,6 +140,6 @@ public class AuthorizationRemovePermissionAuthorizationTest {
         .withOwnerKey(userKey)
         .withResourceType(authorization)
         .withPermission(permissionType, resourceIds)
-        .add(defaultUserKey);
+        .add(DEFAULT_USER.getUsername());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationRemovePermissionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationRemovePermissionAuthorizationTest.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -33,14 +32,14 @@ public class AuthorizationRemovePermissionAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
+  private static long defaultUserKey = -1L;
 
-  @ClassRule
-  public static final EngineRule ENGINE =
+  @Rule
+  public final EngineRule engine =
       EngineRule.singlePartition()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
-  private static long defaultUserKey = -1L;
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
   @Test
@@ -53,7 +52,7 @@ public class AuthorizationRemovePermissionAuthorizationTest {
     addPermissionsToUser(user.getUserKey(), resourceType, permissionType, resourceId);
 
     // when
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(user.getUserKey())
@@ -79,7 +78,7 @@ public class AuthorizationRemovePermissionAuthorizationTest {
     addPermissionsToUser(user.getUserKey(), resourceType, permissionType, resourceId, "*");
 
     // when
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(user.getUserKey())
@@ -102,7 +101,7 @@ public class AuthorizationRemovePermissionAuthorizationTest {
 
     // when
     final var rejection =
-        ENGINE
+        engine
             .authorization()
             .permission()
             .withOwnerKey(user.getUserKey())
@@ -118,8 +117,8 @@ public class AuthorizationRemovePermissionAuthorizationTest {
             "Insufficient permissions to perform operation 'UPDATE' on resource 'AUTHORIZATION'");
   }
 
-  private static UserRecordValue createUser() {
-    return ENGINE
+  private UserRecordValue createUser() {
+    return engine
         .user()
         .newUser(UUID.randomUUID().toString())
         .withPassword(UUID.randomUUID().toString())
@@ -134,7 +133,7 @@ public class AuthorizationRemovePermissionAuthorizationTest {
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
       final String... resourceIds) {
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(userKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clock/ClockPinAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clock/ClockPinAuthorizationTest.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -35,8 +34,8 @@ public class ClockPinAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
 
-  @ClassRule
-  public static final EngineRule ENGINE =
+  @Rule
+  public final EngineRule engine =
       EngineRule.singlePartition()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
@@ -49,7 +48,7 @@ public class ClockPinAuthorizationTest {
     final var instant = Instant.now();
 
     // when
-    ENGINE.clock().pinAt(instant, DEFAULT_USER.getUsername());
+    engine.clock().pinAt(instant, DEFAULT_USER.getUsername());
 
     // when
     assertThat(RecordingExporter.clockRecords(ClockIntent.PINNED).withTimestamp(instant).exists())
@@ -66,7 +65,7 @@ public class ClockPinAuthorizationTest {
     addPermissionsToUser(user.getUserKey(), resourceType, permissionType);
 
     // when
-    ENGINE.clock().pinAt(instant, user.getUsername());
+    engine.clock().pinAt(instant, user.getUsername());
 
     // when
     assertThat(RecordingExporter.clockRecords(ClockIntent.PINNED).withTimestamp(instant).exists())
@@ -80,7 +79,7 @@ public class ClockPinAuthorizationTest {
     final var user = createUser();
 
     // when
-    final var rejection = ENGINE.clock().expectRejection().pinAt(instant, user.getUsername());
+    final var rejection = engine.clock().expectRejection().pinAt(instant, user.getUsername());
 
     // then
     Assertions.assertThat(rejection)
@@ -89,8 +88,8 @@ public class ClockPinAuthorizationTest {
             "Insufficient permissions to perform operation 'UPDATE' on resource 'SYSTEM'");
   }
 
-  private static UserRecordValue createUser() {
-    return ENGINE
+  private UserRecordValue createUser() {
+    return engine
         .user()
         .newUser(UUID.randomUUID().toString())
         .withPassword(UUID.randomUUID().toString())
@@ -104,7 +103,7 @@ public class ClockPinAuthorizationTest {
       final long userKey,
       final AuthorizationResourceType authorization,
       final PermissionType permissionType) {
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(userKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateAuthorizationTest.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -36,8 +35,8 @@ public class DeploymentCreateAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
 
-  @ClassRule
-  public static final EngineRule ENGINE =
+  @Rule
+  public final EngineRule engine =
       EngineRule.singlePartition()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
@@ -50,7 +49,7 @@ public class DeploymentCreateAuthorizationTest {
     final var processId = Strings.newRandomValidBpmnId();
 
     // when
-    ENGINE
+    engine
         .deployment()
         .withXmlResource(
             "process.bpmn", Bpmn.createExecutableProcess(processId).startEvent().endEvent().done())
@@ -73,7 +72,7 @@ public class DeploymentCreateAuthorizationTest {
         user.getUserKey(), AuthorizationResourceType.DEPLOYMENT, PermissionType.CREATE);
 
     // when
-    ENGINE
+    engine
         .deployment()
         .withXmlResource(
             "process.bpmn", Bpmn.createExecutableProcess(processId).startEvent().endEvent().done())
@@ -95,7 +94,7 @@ public class DeploymentCreateAuthorizationTest {
 
     // when
     final var rejection =
-        ENGINE
+        engine
             .deployment()
             .withXmlResource(
                 "process.bpmn",
@@ -110,8 +109,8 @@ public class DeploymentCreateAuthorizationTest {
             "Insufficient permissions to perform operation 'CREATE' on resource 'DEPLOYMENT'");
   }
 
-  private static UserRecordValue createUser() {
-    return ENGINE
+  private UserRecordValue createUser() {
+    return engine
         .user()
         .newUser(UUID.randomUUID().toString())
         .withPassword(UUID.randomUUID().toString())
@@ -125,7 +124,7 @@ public class DeploymentCreateAuthorizationTest {
       final long userKey,
       final AuthorizationResourceType authorization,
       final PermissionType permissionType) {
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(userKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluateAuthorizationTest.java
@@ -19,8 +19,7 @@ import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -32,28 +31,27 @@ public class DecisionEvaluationEvaluateAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
+  private static final String DMN_RESOURCE = "/dmn/drg-force-user.dmn";
+  private static final String DECISION_ID = "jedi_or_sith";
 
-  @ClassRule
-  public static final EngineRule ENGINE =
+  @Rule
+  public final EngineRule engine =
       EngineRule.singlePartition()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
-  private static final String DMN_RESOURCE = "/dmn/drg-force-user.dmn";
-  private static final String DECISION_ID = "jedi_or_sith";
-
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
-  @BeforeClass
-  public static void beforeAll() {
-    ENGINE.deployment().withXmlClasspathResource(DMN_RESOURCE).deploy(DEFAULT_USER.getUsername());
+  @Before
+  public void before() {
+    engine.deployment().withXmlClasspathResource(DMN_RESOURCE).deploy(DEFAULT_USER.getUsername());
   }
 
   @Test
   public void shouldBeAuthorizedToEvaluateDecisionWithDefaultUser() {
     // when
     final var response =
-        ENGINE
+        engine
             .decision()
             .ofDecisionId(DECISION_ID)
             .withVariable("lightsaberColor", "red")
@@ -74,7 +72,7 @@ public class DecisionEvaluationEvaluateAuthorizationTest {
 
     // when
     final var response =
-        ENGINE
+        engine
             .decision()
             .ofDecisionId(DECISION_ID)
             .withVariable("lightsaberColor", "red")
@@ -91,7 +89,7 @@ public class DecisionEvaluationEvaluateAuthorizationTest {
 
     // when
     final var rejection =
-        ENGINE
+        engine
             .decision()
             .ofDecisionId(DECISION_ID)
             .withVariable("lightsaberColor", "red")
@@ -106,8 +104,8 @@ public class DecisionEvaluationEvaluateAuthorizationTest {
                 .formatted(DECISION_ID));
   }
 
-  private static UserRecordValue createUser() {
-    return ENGINE
+  private UserRecordValue createUser() {
+    return engine
         .user()
         .newUser(UUID.randomUUID().toString())
         .withPassword(UUID.randomUUID().toString())
@@ -121,7 +119,7 @@ public class DecisionEvaluationEvaluateAuthorizationTest {
       final long userKey,
       final AuthorizationResourceType authorization,
       final PermissionType permissionType) {
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(userKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveAuthorizationTest.java
@@ -23,8 +23,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -39,17 +38,17 @@ public class IncidentResolveAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
 
-  @ClassRule
-  public static final EngineRule ENGINE =
+  @Rule
+  public final EngineRule engine =
       EngineRule.singlePartition()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
-  @BeforeClass
-  public static void beforeAll() {
-    ENGINE
+  @Before
+  public void before() {
+    engine
         .deployment()
         .withXmlResource(
             "process.bpmn",
@@ -67,7 +66,7 @@ public class IncidentResolveAuthorizationTest {
     final var processInstanceKey = createIncident();
 
     // when
-    ENGINE.incident().ofInstance(processInstanceKey).resolve(DEFAULT_USER.getUsername());
+    engine.incident().ofInstance(processInstanceKey).resolve(DEFAULT_USER.getUsername());
 
     // then
     assertThat(
@@ -88,7 +87,7 @@ public class IncidentResolveAuthorizationTest {
         PermissionType.UPDATE_PROCESS_INSTANCE);
 
     // when
-    ENGINE.incident().ofInstance(processInstanceKey).resolve(user.getUsername());
+    engine.incident().ofInstance(processInstanceKey).resolve(user.getUsername());
 
     // then
     assertThat(
@@ -106,7 +105,7 @@ public class IncidentResolveAuthorizationTest {
 
     // when
     final var rejection =
-        ENGINE
+        engine
             .incident()
             .ofInstance(processInstanceKey)
             .expectRejection()
@@ -120,8 +119,8 @@ public class IncidentResolveAuthorizationTest {
                 .formatted(PROCESS_ID));
   }
 
-  private static UserRecordValue createUser() {
-    return ENGINE
+  private UserRecordValue createUser() {
+    return engine
         .user()
         .newUser(UUID.randomUUID().toString())
         .withPassword(UUID.randomUUID().toString())
@@ -135,7 +134,7 @@ public class IncidentResolveAuthorizationTest {
       final long userKey,
       final AuthorizationResourceType authorization,
       final PermissionType permissionType) {
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(userKey)
@@ -145,6 +144,6 @@ public class IncidentResolveAuthorizationTest {
   }
 
   private long createIncident() {
-    return ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+    return engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
@@ -48,7 +48,7 @@ public final class CompleteJobTest {
 
   private static final String PROCESS_ID = "process";
   private static String jobType;
-  private static long userKey;
+  private static String username;
   private static String tenantId;
 
   @Rule
@@ -58,8 +58,8 @@ public final class CompleteJobTest {
   @BeforeClass
   public static void setUp() {
     tenantId = UUID.randomUUID().toString();
-    final var username = UUID.randomUUID().toString();
-    userKey = ENGINE.user().newUser(username).create().getValue().getUserKey();
+    username = UUID.randomUUID().toString();
+    final var userKey = ENGINE.user().newUser(username).create().getValue().getUserKey();
     final var tenantKey =
         ENGINE.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
     ENGINE
@@ -89,7 +89,7 @@ public final class CompleteJobTest {
     // given
     ENGINE.createJob(jobType, PROCESS_ID);
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(jobType).activate(userKey);
+        ENGINE.jobs().withType(jobType).activate(username);
     final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
 
     // when
@@ -129,7 +129,7 @@ public final class CompleteJobTest {
     // given
     ENGINE.createJob(jobType, PROCESS_ID);
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(jobType).activate(userKey);
+        ENGINE.jobs().withType(jobType).activate(username);
 
     // when
     final Record<JobRecordValue> completedRecord =
@@ -151,7 +151,7 @@ public final class CompleteJobTest {
     // given
     ENGINE.createJob(jobType, PROCESS_ID);
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(jobType).activate(userKey);
+        ENGINE.jobs().withType(jobType).activate(username);
 
     // when
     final Record<JobRecordValue> completedRecord =
@@ -173,7 +173,7 @@ public final class CompleteJobTest {
     // given
     ENGINE.createJob(jobType, PROCESS_ID);
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(jobType).activate(userKey);
+        ENGINE.jobs().withType(jobType).activate(username);
 
     // when
     final Record<JobRecordValue> completedRecord =
@@ -195,7 +195,7 @@ public final class CompleteJobTest {
     // given
     ENGINE.createJob(jobType, PROCESS_ID);
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(jobType).activate(userKey);
+        ENGINE.jobs().withType(jobType).activate(username);
 
     final byte[] invalidVariables = new byte[] {1}; // positive fixnum, i.e. no object
 
@@ -222,7 +222,7 @@ public final class CompleteJobTest {
     // given
     ENGINE.createJob(jobType, PROCESS_ID);
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(jobType).activate(userKey);
+        ENGINE.jobs().withType(jobType).activate(username);
 
     // when
     final Record<JobRecordValue> completedRecord =
@@ -245,7 +245,7 @@ public final class CompleteJobTest {
     // given
     ENGINE.createJob(jobType, PROCESS_ID);
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(jobType).activate(userKey);
+        ENGINE.jobs().withType(jobType).activate(username);
 
     // when
     final Record<JobRecordValue> completedRecord =
@@ -268,7 +268,7 @@ public final class CompleteJobTest {
     // given
     ENGINE.createJob(jobType, PROCESS_ID);
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(jobType).activate(userKey);
+        ENGINE.jobs().withType(jobType).activate(username);
 
     final JobResultCorrections corrections = new JobResultCorrections();
     corrections.setAssignee("TestAssignee");
@@ -306,7 +306,7 @@ public final class CompleteJobTest {
     // given
     ENGINE.createJob(jobType, PROCESS_ID);
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(jobType).activate(userKey);
+        ENGINE.jobs().withType(jobType).activate(username);
 
     final JobResultCorrections corrections = new JobResultCorrections();
     corrections.setAssignee("TestAssignee");
@@ -341,7 +341,7 @@ public final class CompleteJobTest {
     // given
     ENGINE.createJob(jobType, PROCESS_ID);
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(jobType).activate(userKey);
+        ENGINE.jobs().withType(jobType).activate(username);
 
     final Long jobKey = batchRecord.getValue().getJobKeys().get(0);
     ENGINE.job().withKey(jobKey).complete();
@@ -361,7 +361,7 @@ public final class CompleteJobTest {
 
     // when
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(jobType).activate(userKey);
+        ENGINE.jobs().withType(jobType).activate(username);
     final Long jobKey = batchRecord.getValue().getJobKeys().get(0);
     ENGINE.job().withKey(jobKey).fail();
 
@@ -378,7 +378,7 @@ public final class CompleteJobTest {
     ENGINE.createJob(jobType, PROCESS_ID, Collections.emptyMap(), tenantId);
 
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(jobType).withTenantId(tenantId).activate(userKey);
+        ENGINE.jobs().withType(jobType).withTenantId(tenantId).activate(username);
 
     // when
     final Record<JobRecordValue> jobCompletedRecord =
@@ -405,7 +405,7 @@ public final class CompleteJobTest {
     ENGINE.createJob(jobType, PROCESS_ID, Collections.emptyMap(), tenantId);
 
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(jobType).withTenantId(tenantId).activate(userKey);
+        ENGINE.jobs().withType(jobType).withTenantId(tenantId).activate(username);
 
     // when
     final Record<JobRecordValue> jobRecord =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
@@ -55,7 +55,7 @@ public final class FailJobTest {
 
   private static final String PROCESS_ID = "process";
   private static String jobType;
-  private static long userKey;
+  private static String username;
   private static String tenantId;
 
   @Rule
@@ -65,8 +65,8 @@ public final class FailJobTest {
   @BeforeClass
   public static void setUp() {
     tenantId = UUID.randomUUID().toString();
-    final var username = UUID.randomUUID().toString();
-    userKey = ENGINE.user().newUser(username).create().getValue().getUserKey();
+    username = UUID.randomUUID().toString();
+    final var userKey = ENGINE.user().newUser(username).create().getValue().getUserKey();
     final var tenantKey =
         ENGINE.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
     ENGINE
@@ -96,7 +96,7 @@ public final class FailJobTest {
     // given
     ENGINE.createJob(jobType, PROCESS_ID);
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(jobType).activate(userKey);
+        ENGINE.jobs().withType(jobType).activate(username);
     final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
     final long jobKey = batchRecord.getValue().getJobKeys().get(0);
     final int retries = 23;
@@ -124,7 +124,7 @@ public final class FailJobTest {
     // given
     ENGINE.createJob(jobType, PROCESS_ID);
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(jobType).activate(userKey);
+        ENGINE.jobs().withType(jobType).activate(username);
 
     final long jobKey = batchRecord.getValue().getJobKeys().get(0);
     final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
@@ -156,7 +156,7 @@ public final class FailJobTest {
     final Record<JobRecordValue> job = ENGINE.createJob(jobType, PROCESS_ID);
 
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(jobType).activate(userKey);
+        ENGINE.jobs().withType(jobType).activate(username);
     final long jobKey = batchRecord.getValue().getJobKeys().get(0);
 
     // when
@@ -167,7 +167,7 @@ public final class FailJobTest {
             .ofInstance(job.getValue().getProcessInstanceKey())
             .withRetries(3)
             .fail();
-    ENGINE.jobs().withType(jobType).activate(userKey);
+    ENGINE.jobs().withType(jobType).activate(username);
 
     // then
     Assertions.assertThat(failRecord).hasRecordType(RecordType.EVENT).hasIntent(FAILED);
@@ -212,7 +212,7 @@ public final class FailJobTest {
     final Record<JobRecordValue> job = ENGINE.createJob(jobType, PROCESS_ID);
 
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(jobType).activate(userKey);
+        ENGINE.jobs().withType(jobType).activate(username);
     final long jobKey = batchRecord.getValue().getJobKeys().get(0);
 
     // when
@@ -299,7 +299,7 @@ public final class FailJobTest {
     // given
     ENGINE.createJob(jobType, PROCESS_ID);
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(jobType).activate(userKey);
+        ENGINE.jobs().withType(jobType).activate(username);
     final long jobKey = batchRecord.getValue().getJobKeys().get(0);
     ENGINE.job().withKey(jobKey).withRetries(0).fail();
 
@@ -317,7 +317,7 @@ public final class FailJobTest {
     // given
     ENGINE.createJob(jobType, PROCESS_ID);
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(jobType).activate(userKey);
+        ENGINE.jobs().withType(jobType).activate(username);
     final long jobKey = batchRecord.getValue().getJobKeys().get(0);
 
     ENGINE.job().withKey(jobKey).complete();
@@ -351,7 +351,7 @@ public final class FailJobTest {
     // given
     ENGINE.createJob(jobType, PROCESS_ID);
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(jobType).activate(userKey);
+        ENGINE.jobs().withType(jobType).activate(username);
     final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
     final long jobKey = batchRecord.getValue().getJobKeys().get(0);
     final int retries = 23;
@@ -435,7 +435,7 @@ public final class FailJobTest {
     ENGINE.createJob(jobType, PROCESS_ID, Collections.emptyMap(), tenantId);
 
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(jobType).withTenantId(tenantId).activate(userKey);
+        ENGINE.jobs().withType(jobType).withTenantId(tenantId).activate(username);
 
     final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
     final long jobKey = batchRecord.getValue().getJobKeys().get(0);
@@ -463,7 +463,7 @@ public final class FailJobTest {
     ENGINE.createJob(jobType, PROCESS_ID, Collections.emptyMap(), tenantId);
 
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(jobType).withTenantId(tenantId).activate(userKey);
+        ENGINE.jobs().withType(jobType).withTenantId(tenantId).activate(username);
     final long jobKey = batchRecord.getValue().getJobKeys().get(0);
 
     // when

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateAuthorizationTest.java
@@ -13,16 +13,15 @@ import io.camunda.security.configuration.ConfiguredUser;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
-import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -37,25 +36,14 @@ public class JobBatchActivateAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
-  private static long defaultUserKey = -1L;
 
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
-          .withoutAwaitingIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
-
-  @Before
-  public void beforeEach() {
-    defaultUserKey =
-        RecordingExporter.userRecords(UserIntent.CREATED)
-            .withUsername(DEFAULT_USER.getUsername())
-            .getFirst()
-            .getKey();
-  }
 
   @Test
   public void shouldBeAuthorizedToActivateAllJobsWithDefaultUser() {
@@ -66,7 +54,11 @@ public class JobBatchActivateAuthorizationTest {
 
     // when
     final var response =
-        engine.jobs().withType(JOB_TYPE).withMaxJobsToActivate(2).activate(defaultUserKey);
+        engine
+            .jobs()
+            .withType(JOB_TYPE)
+            .withMaxJobsToActivate(2)
+            .activate(DEFAULT_USER.getUsername());
 
     // then
     assertThat(response.getValue().getJobs())
@@ -81,9 +73,9 @@ public class JobBatchActivateAuthorizationTest {
     final var processId1 = Strings.newRandomValidBpmnId();
     final var processId2 = Strings.newRandomValidBpmnId();
     createJobs(processId1, processId2);
-    final var userKey = createUser();
+    final var user = createUser();
     addPermissionsToUser(
-        userKey,
+        user.getUserKey(),
         AuthorizationResourceType.PROCESS_DEFINITION,
         PermissionType.UPDATE_PROCESS_INSTANCE,
         processId1,
@@ -91,7 +83,7 @@ public class JobBatchActivateAuthorizationTest {
 
     // when
     final var response =
-        engine.jobs().withType(JOB_TYPE).withMaxJobsToActivate(2).activate(userKey);
+        engine.jobs().withType(JOB_TYPE).withMaxJobsToActivate(2).activate(user.getUsername());
 
     // then
     assertThat(response.getValue().getJobs())
@@ -106,16 +98,16 @@ public class JobBatchActivateAuthorizationTest {
     final var processId1 = Strings.newRandomValidBpmnId();
     final var processId2 = Strings.newRandomValidBpmnId();
     createJobs(processId1, processId2);
-    final var userKey = createUser();
+    final var user = createUser();
     addPermissionsToUser(
-        userKey,
+        user.getUserKey(),
         AuthorizationResourceType.PROCESS_DEFINITION,
         PermissionType.UPDATE_PROCESS_INSTANCE,
         processId1);
 
     // when
     final var response =
-        engine.jobs().withType(JOB_TYPE).withMaxJobsToActivate(2).activate(userKey);
+        engine.jobs().withType(JOB_TYPE).withMaxJobsToActivate(2).activate(user.getUsername());
 
     // then
     assertThat(response.getValue().getJobs())
@@ -130,17 +122,17 @@ public class JobBatchActivateAuthorizationTest {
     final var processId1 = Strings.newRandomValidBpmnId();
     final var processId2 = Strings.newRandomValidBpmnId();
     createJobs(processId1, processId2);
-    final var userKey = createUser();
+    final var user = createUser();
 
     // when
     final var response =
-        engine.jobs().withType(JOB_TYPE).withMaxJobsToActivate(2).activate(userKey);
+        engine.jobs().withType(JOB_TYPE).withMaxJobsToActivate(2).activate(user.getUsername());
 
     // then
     assertThat(response.getValue().getJobs()).isEmpty();
   }
 
-  private long createUser() {
+  private UserRecordValue createUser() {
     return engine
         .user()
         .newUser(UUID.randomUUID().toString())
@@ -148,7 +140,7 @@ public class JobBatchActivateAuthorizationTest {
         .withName(UUID.randomUUID().toString())
         .withEmail(UUID.randomUUID().toString())
         .create()
-        .getKey();
+        .getValue();
   }
 
   private void addPermissionsToUser(
@@ -162,7 +154,7 @@ public class JobBatchActivateAuthorizationTest {
         .withOwnerKey(userKey)
         .withResourceType(authorization)
         .withPermission(permissionType, resourceIds)
-        .add(defaultUserKey);
+        .add(DEFAULT_USER.getUsername());
   }
 
   private void createJobs(final String... processIds) {
@@ -176,9 +168,9 @@ public class JobBatchActivateAuthorizationTest {
                   .serviceTask("serviceTask", t -> t.zeebeJobType(JOB_TYPE))
                   .endEvent()
                   .done())
-          .deploy(defaultUserKey);
+          .deploy(DEFAULT_USER.getUsername());
 
-      engine.processInstance().ofBpmnProcessId(processId).create(defaultUserKey);
+      engine.processInstance().ofBpmnProcessId(processId).create(DEFAULT_USER.getUsername());
     }
 
     RecordingExporter.jobRecords(JobIntent.CREATED).limit(processIds.length).await();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobFailAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobFailAuthorizationTest.java
@@ -22,8 +22,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -38,17 +37,17 @@ public class JobFailAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
 
-  @ClassRule
-  public static final EngineRule ENGINE =
+  @Rule
+  public final EngineRule engine =
       EngineRule.singlePartition()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
-  @BeforeClass
-  public static void before() {
-    ENGINE
+  @Before
+  public void before() {
+    engine
         .deployment()
         .withXmlResource(
             "process.bpmn",
@@ -66,7 +65,7 @@ public class JobFailAuthorizationTest {
     final var jobKey = createJob();
 
     // when
-    ENGINE.job().withKey(jobKey).fail(DEFAULT_USER.getUsername());
+    engine.job().withKey(jobKey).fail(DEFAULT_USER.getUsername());
 
     // then
     assertThat(RecordingExporter.jobRecords(JobIntent.FAILED).withRecordKey(jobKey).exists())
@@ -84,7 +83,7 @@ public class JobFailAuthorizationTest {
         PermissionType.UPDATE_PROCESS_INSTANCE);
 
     // when
-    ENGINE.job().withKey(jobKey).fail(user.getUsername());
+    engine.job().withKey(jobKey).fail(user.getUsername());
 
     // then
     assertThat(RecordingExporter.jobRecords(JobIntent.FAILED).withRecordKey(jobKey).exists())
@@ -98,7 +97,7 @@ public class JobFailAuthorizationTest {
     final var user = createUser();
 
     // when
-    final var rejection = ENGINE.job().withKey(jobKey).expectRejection().fail(user.getUsername());
+    final var rejection = engine.job().withKey(jobKey).expectRejection().fail(user.getUsername());
 
     // then
     Assertions.assertThat(rejection)
@@ -109,7 +108,7 @@ public class JobFailAuthorizationTest {
   }
 
   private UserRecordValue createUser() {
-    return ENGINE
+    return engine
         .user()
         .newUser(UUID.randomUUID().toString())
         .withPassword(UUID.randomUUID().toString())
@@ -123,7 +122,7 @@ public class JobFailAuthorizationTest {
       final long userKey,
       final AuthorizationResourceType authorization,
       final PermissionType permissionType) {
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(userKey)
@@ -134,7 +133,7 @@ public class JobFailAuthorizationTest {
 
   private long createJob() {
     final var processInstanceKey =
-        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+        engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
     return RecordingExporter.jobRecords(JobIntent.CREATED)
         .withProcessInstanceKey(processInstanceKey)
         .getFirst()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobFailAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobFailAuthorizationTest.java
@@ -15,9 +15,9 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
-import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
@@ -41,21 +41,13 @@ public class JobFailAuthorizationTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withoutAwaitingIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
-  private static long defaultUserKey = -1L;
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
   @BeforeClass
   public static void before() {
-    defaultUserKey =
-        RecordingExporter.userRecords(UserIntent.CREATED)
-            .withUsername(DEFAULT_USER.getUsername())
-            .getFirst()
-            .getKey();
-
     ENGINE
         .deployment()
         .withXmlResource(
@@ -65,7 +57,7 @@ public class JobFailAuthorizationTest {
                 .serviceTask("serviceTask", t -> t.zeebeJobType(JOB_TYPE))
                 .endEvent()
                 .done())
-        .deploy(defaultUserKey);
+        .deploy(DEFAULT_USER.getUsername());
   }
 
   @Test
@@ -74,7 +66,7 @@ public class JobFailAuthorizationTest {
     final var jobKey = createJob();
 
     // when
-    ENGINE.job().withKey(jobKey).fail(defaultUserKey);
+    ENGINE.job().withKey(jobKey).fail(DEFAULT_USER.getUsername());
 
     // then
     assertThat(RecordingExporter.jobRecords(JobIntent.FAILED).withRecordKey(jobKey).exists())
@@ -85,14 +77,14 @@ public class JobFailAuthorizationTest {
   public void shouldBeAuthorizedToFailJobWithUser() {
     // given
     final var jobKey = createJob();
-    final var userKey = createUser();
+    final var user = createUser();
     addPermissionsToUser(
-        userKey,
+        user.getUserKey(),
         AuthorizationResourceType.PROCESS_DEFINITION,
         PermissionType.UPDATE_PROCESS_INSTANCE);
 
     // when
-    ENGINE.job().withKey(jobKey).fail(userKey);
+    ENGINE.job().withKey(jobKey).fail(user.getUsername());
 
     // then
     assertThat(RecordingExporter.jobRecords(JobIntent.FAILED).withRecordKey(jobKey).exists())
@@ -103,10 +95,10 @@ public class JobFailAuthorizationTest {
   public void shouldBeUnauthorizedToFailJobIfNoPermissions() {
     // given
     final var jobKey = createJob();
-    final var userKey = createUser();
+    final var user = createUser();
 
     // when
-    final var rejection = ENGINE.job().withKey(jobKey).expectRejection().fail(userKey);
+    final var rejection = ENGINE.job().withKey(jobKey).expectRejection().fail(user.getUsername());
 
     // then
     Assertions.assertThat(rejection)
@@ -116,7 +108,7 @@ public class JobFailAuthorizationTest {
                 .formatted(PROCESS_ID));
   }
 
-  private long createUser() {
+  private UserRecordValue createUser() {
     return ENGINE
         .user()
         .newUser(UUID.randomUUID().toString())
@@ -124,7 +116,7 @@ public class JobFailAuthorizationTest {
         .withName(UUID.randomUUID().toString())
         .withEmail(UUID.randomUUID().toString())
         .create()
-        .getKey();
+        .getValue();
   }
 
   private void addPermissionsToUser(
@@ -137,12 +129,12 @@ public class JobFailAuthorizationTest {
         .withOwnerKey(userKey)
         .withResourceType(authorization)
         .withPermission(permissionType, "*")
-        .add(defaultUserKey);
+        .add(DEFAULT_USER.getUsername());
   }
 
   private long createJob() {
     final var processInstanceKey =
-        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create(defaultUserKey);
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
     return RecordingExporter.jobRecords(JobIntent.CREATED)
         .withProcessInstanceKey(processInstanceKey)
         .getFirst()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorTest.java
@@ -46,7 +46,7 @@ public final class JobThrowErrorTest {
   private static final String PROCESS_ID = "process";
   private static String jobType;
   private static final String ERROR_CODE = "ERROR";
-  private static long userKey;
+  private static String username;
   private static String tenantId;
 
   @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
@@ -54,15 +54,15 @@ public final class JobThrowErrorTest {
   @BeforeClass
   public static void setUp() {
     tenantId = UUID.randomUUID().toString();
-    final var username = UUID.randomUUID().toString();
-    userKey = ENGINE.user().newUser(username).create().getValue().getUserKey();
+    username = UUID.randomUUID().toString();
+    final var user = ENGINE.user().newUser(username).create().getValue();
     final var tenantKey =
         ENGINE.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
     ENGINE
         .tenant()
         .addEntity(tenantKey)
         .withEntityType(EntityType.USER)
-        .withEntityKey(userKey)
+        .withEntityKey(user.getUserKey())
         .add();
 
     ENGINE
@@ -70,7 +70,7 @@ public final class JobThrowErrorTest {
         .permission()
         .withPermission(PermissionType.UPDATE_PROCESS_INSTANCE, PROCESS_ID)
         .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
-        .withOwnerKey(userKey)
+        .withOwnerKey(user.getUserKey())
         .withOwnerType(AuthorizationOwnerType.USER)
         .add();
   }
@@ -502,7 +502,7 @@ public final class JobThrowErrorTest {
     // given
     final String falseTenantId = "foo";
     final var job = ENGINE.createJob(jobType, PROCESS_ID, Collections.emptyMap(), tenantId);
-    ENGINE.jobs().withType(jobType).withTenantId(tenantId).activate(userKey);
+    ENGINE.jobs().withType(jobType).withTenantId(tenantId).activate(username);
 
     // when
     final Record<JobRecordValue> result =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateAuthorizationTest.java
@@ -22,8 +22,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -38,17 +37,17 @@ public class JobUpdateAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
 
-  @ClassRule
-  public static final EngineRule ENGINE =
+  @Rule
+  public final EngineRule engine =
       EngineRule.singlePartition()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
-  @BeforeClass
-  public static void before() {
-    ENGINE
+  @Before
+  public void before() {
+    engine
         .deployment()
         .withXmlResource(
             "process.bpmn",
@@ -66,7 +65,7 @@ public class JobUpdateAuthorizationTest {
     final var jobKey = createJob();
 
     // when
-    ENGINE.job().withKey(jobKey).withRetries(1).updateRetries(DEFAULT_USER.getUsername());
+    engine.job().withKey(jobKey).withRetries(1).updateRetries(DEFAULT_USER.getUsername());
 
     // then
     assertThat(
@@ -85,7 +84,7 @@ public class JobUpdateAuthorizationTest {
         PermissionType.UPDATE_PROCESS_INSTANCE);
 
     // when
-    ENGINE.job().withKey(jobKey).withRetries(1).updateRetries(user.getUsername());
+    engine.job().withKey(jobKey).withRetries(1).updateRetries(user.getUsername());
 
     // then
     assertThat(
@@ -101,7 +100,7 @@ public class JobUpdateAuthorizationTest {
 
     // when
     final var rejection =
-        ENGINE
+        engine
             .job()
             .withKey(jobKey)
             .withRetries(1)
@@ -117,7 +116,7 @@ public class JobUpdateAuthorizationTest {
   }
 
   private UserRecordValue createUser() {
-    return ENGINE
+    return engine
         .user()
         .newUser(UUID.randomUUID().toString())
         .withPassword(UUID.randomUUID().toString())
@@ -131,7 +130,7 @@ public class JobUpdateAuthorizationTest {
       final long userKey,
       final AuthorizationResourceType authorization,
       final PermissionType permissionType) {
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(userKey)
@@ -142,7 +141,7 @@ public class JobUpdateAuthorizationTest {
 
   private long createJob() {
     final var processInstanceKey =
-        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+        engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
     return RecordingExporter.jobRecords(JobIntent.CREATED)
         .withProcessInstanceKey(processInstanceKey)
         .getFirst()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesTest.java
@@ -36,7 +36,7 @@ public final class JobUpdateRetriesTest {
   private static final int NEW_RETRIES = 20;
   private static final String PROCESS_ID = "process";
   private static String jobType;
-  private static long userKey;
+  private static String username;
   private static String tenantId;
 
   @Rule
@@ -46,8 +46,8 @@ public final class JobUpdateRetriesTest {
   @BeforeClass
   public static void setUp() {
     tenantId = UUID.randomUUID().toString();
-    final var username = UUID.randomUUID().toString();
-    userKey = ENGINE.user().newUser(username).create().getValue().getUserKey();
+    username = UUID.randomUUID().toString();
+    final var userKey = ENGINE.user().newUser(username).create().getValue().getUserKey();
     final var tenantKey =
         ENGINE.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
     ENGINE
@@ -197,7 +197,7 @@ public final class JobUpdateRetriesTest {
     // given
     ENGINE.createJob(jobType, PROCESS_ID, Collections.emptyMap(), tenantId);
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(jobType).withTenantId(tenantId).activate(userKey);
+        ENGINE.jobs().withType(jobType).withTenantId(tenantId).activate(username);
     final long jobKey = batchRecord.getValue().getJobKeys().get(0);
 
     // when
@@ -219,7 +219,7 @@ public final class JobUpdateRetriesTest {
     final String falseTenantId = "foo";
     ENGINE.createJob(jobType, PROCESS_ID, Collections.emptyMap(), tenantId);
     final Record<JobBatchRecordValue> batchRecord =
-        ENGINE.jobs().withType(jobType).withTenantId(tenantId).activate(userKey);
+        ENGINE.jobs().withType(jobType).withTenantId(tenantId).activate(username);
     final long jobKey = batchRecord.getValue().getJobKeys().get(0);
 
     // when

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutTest.java
@@ -44,7 +44,7 @@ public class JobUpdateTimeoutTest {
 
   private static final String PROCESS_ID = "process";
   private static String jobType;
-  private static long userKey;
+  private static String username;
   private static String tenantId;
 
   @Rule
@@ -54,8 +54,8 @@ public class JobUpdateTimeoutTest {
   @BeforeClass
   public static void setUp() {
     tenantId = UUID.randomUUID().toString();
-    final var username = UUID.randomUUID().toString();
-    userKey = ENGINE.user().newUser(username).create().getValue().getUserKey();
+    username = UUID.randomUUID().toString();
+    final var userKey = ENGINE.user().newUser(username).create().getValue().getUserKey();
     final var tenantKey =
         ENGINE.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
     ENGINE
@@ -89,7 +89,7 @@ public class JobUpdateTimeoutTest {
             .jobs()
             .withType(jobType)
             .withTimeout(Duration.ofMinutes(5).toMillis())
-            .activate(userKey);
+            .activate(username);
     final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
     final long jobKey = batchRecord.getValue().getJobKeys().get(0);
     final long timeout = Duration.ofMinutes(10).toMillis();
@@ -110,7 +110,7 @@ public class JobUpdateTimeoutTest {
             .jobs()
             .withType(jobType)
             .withTimeout(Duration.ofMinutes(15).toMillis())
-            .activate(userKey);
+            .activate(username);
     final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
     final long jobKey = batchRecord.getValue().getJobKeys().get(0);
     final long timeout = Duration.ofMinutes(10).toMillis();
@@ -166,7 +166,7 @@ public class JobUpdateTimeoutTest {
             .jobs()
             .withType(jobType)
             .withTimeout(Duration.ofMinutes(5).toMillis())
-            .activate(userKey);
+            .activate(username);
     final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
     final long jobKey = batchRecord.getValue().getJobKeys().get(0);
     final long firstTimeout = Duration.ofMinutes(10).toMillis();
@@ -190,7 +190,7 @@ public class JobUpdateTimeoutTest {
             .jobs()
             .withType(jobType)
             .withTimeout(Duration.ofMinutes(10).toMillis())
-            .activate(userKey);
+            .activate(username);
     final long jobKey = batchRecord.getValue().getJobKeys().get(0);
     final long timeout = Duration.ofMinutes(5).toMillis();
 
@@ -218,7 +218,7 @@ public class JobUpdateTimeoutTest {
             .jobs()
             .withType(jobType)
             .withTimeout(Duration.ofMinutes(10).toMillis())
-            .activate(userKey);
+            .activate(username);
     final long jobKey = batchRecord.getValue().getJobKeys().get(0);
     final long timeout = Duration.ofMinutes(15).toMillis();
 
@@ -248,7 +248,7 @@ public class JobUpdateTimeoutTest {
             .withType(jobType)
             .withTimeout(Duration.ofMinutes(5).toMillis())
             .withTenantId(tenantId)
-            .activate(userKey);
+            .activate(username);
 
     final JobRecordValue job = batchRecord.getValue().getJobs().get(0);
     final long jobKey = batchRecord.getValue().getJobKeys().get(0);
@@ -280,7 +280,7 @@ public class JobUpdateTimeoutTest {
             .withType(jobType)
             .withTimeout(Duration.ofMinutes(5).toMillis())
             .withTenantId(tenantId)
-            .activate(userKey);
+            .activate(username);
 
     final long jobKey = batchRecord.getValue().getJobKeys().get(0);
     final long timeout = Duration.ofMinutes(10).toMillis();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingCreateAuthorizationTest.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -34,8 +33,8 @@ public class MappingCreateAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
 
-  @ClassRule
-  public static final EngineRule ENGINE =
+  @Rule
+  public final EngineRule engine =
       EngineRule.singlePartition()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
@@ -49,7 +48,7 @@ public class MappingCreateAuthorizationTest {
     final var claimValue = UUID.randomUUID().toString();
 
     // when
-    ENGINE
+    engine
         .mapping()
         .newMapping(claimName)
         .withClaimValue(claimValue)
@@ -74,7 +73,7 @@ public class MappingCreateAuthorizationTest {
         user.getUserKey(), AuthorizationResourceType.MAPPING_RULE, PermissionType.CREATE);
 
     // when
-    ENGINE.mapping().newMapping(claimName).withClaimValue(claimValue).create(user.getUsername());
+    engine.mapping().newMapping(claimName).withClaimValue(claimValue).create(user.getUsername());
 
     // then
     assertThat(
@@ -94,7 +93,7 @@ public class MappingCreateAuthorizationTest {
 
     // when
     final var rejection =
-        ENGINE
+        engine
             .mapping()
             .newMapping(claimName)
             .withClaimValue(claimValue)
@@ -108,8 +107,8 @@ public class MappingCreateAuthorizationTest {
             "Insufficient permissions to perform operation 'CREATE' on resource 'MAPPING_RULE'");
   }
 
-  private static UserRecordValue createUser() {
-    return ENGINE
+  private UserRecordValue createUser() {
+    return engine
         .user()
         .newUser(UUID.randomUUID().toString())
         .withPassword(UUID.randomUUID().toString())
@@ -123,7 +122,7 @@ public class MappingCreateAuthorizationTest {
       final long userKey,
       final AuthorizationResourceType authorization,
       final PermissionType permissionType) {
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(userKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateAuthorizationTest.java
@@ -22,8 +22,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -41,17 +40,17 @@ public class MessageCorrelationCorrelateAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
 
-  @ClassRule
-  public static final EngineRule ENGINE =
+  @Rule
+  public final EngineRule engine =
       EngineRule.singlePartition()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
-  @BeforeClass
-  public static void beforeAll() {
-    ENGINE
+  @Before
+  public void before() {
+    engine
         .deployment()
         .withXmlResource(
             "process.bpmn",
@@ -77,7 +76,7 @@ public class MessageCorrelationCorrelateAuthorizationTest {
     createProcessInstance(correlationKey);
 
     // when
-    ENGINE
+    engine
         .messageCorrelation()
         .withName(INTERMEDIATE_MSG_NAME)
         .withCorrelationKey(correlationKey)
@@ -104,7 +103,7 @@ public class MessageCorrelationCorrelateAuthorizationTest {
         PermissionType.UPDATE_PROCESS_INSTANCE);
 
     // when
-    ENGINE
+    engine
         .messageCorrelation()
         .withName(INTERMEDIATE_MSG_NAME)
         .withCorrelationKey(correlationKey)
@@ -128,7 +127,7 @@ public class MessageCorrelationCorrelateAuthorizationTest {
 
     // when
     final var rejection =
-        ENGINE
+        engine
             .messageCorrelation()
             .withName(INTERMEDIATE_MSG_NAME)
             .withCorrelationKey(correlationKey)
@@ -146,7 +145,7 @@ public class MessageCorrelationCorrelateAuthorizationTest {
   @Test
   public void shouldBeAuthorizedToCorrelateMessageToStartEventWithDefaultUser() {
     // when
-    ENGINE
+    engine
         .messageCorrelation()
         .withName(START_MSG_NAME)
         .withCorrelationKey("")
@@ -171,7 +170,7 @@ public class MessageCorrelationCorrelateAuthorizationTest {
         PROCESS_ID);
 
     // when
-    ENGINE
+    engine
         .messageCorrelation()
         .withName(START_MSG_NAME)
         .withCorrelationKey("")
@@ -192,7 +191,7 @@ public class MessageCorrelationCorrelateAuthorizationTest {
 
     // when
     final var rejection =
-        ENGINE
+        engine
             .messageCorrelation()
             .withName(START_MSG_NAME)
             .withCorrelationKey("")
@@ -220,7 +219,7 @@ public class MessageCorrelationCorrelateAuthorizationTest {
         PROCESS_ID);
     final var unauthorizedProcessId = "unauthorizedProcessId";
     final var resourceName = "unauthorizedProcess.xml";
-    ENGINE
+    engine
         .deployment()
         .withXmlResource(
             resourceName,
@@ -234,7 +233,7 @@ public class MessageCorrelationCorrelateAuthorizationTest {
 
     // when
     final var rejection =
-        ENGINE
+        engine
             .messageCorrelation()
             .withName(START_MSG_NAME)
             .withCorrelationKey("")
@@ -249,8 +248,8 @@ public class MessageCorrelationCorrelateAuthorizationTest {
                 .formatted(unauthorizedProcessId));
   }
 
-  private static UserRecordValue createUser() {
-    return ENGINE
+  private UserRecordValue createUser() {
+    return engine
         .user()
         .newUser(UUID.randomUUID().toString())
         .withPassword(UUID.randomUUID().toString())
@@ -272,7 +271,7 @@ public class MessageCorrelationCorrelateAuthorizationTest {
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
       final String... resourceIds) {
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(userKey)
@@ -282,7 +281,7 @@ public class MessageCorrelationCorrelateAuthorizationTest {
   }
 
   private void createProcessInstance(final String correlationKey) {
-    ENGINE
+    engine
         .processInstance()
         .ofBpmnProcessId(PROCESS_ID)
         .withVariable(CORRELATION_KEY_VARIABLE, correlationKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessagePublishAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessagePublishAuthorizationTest.java
@@ -22,8 +22,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -41,17 +40,17 @@ public class MessagePublishAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
 
-  @ClassRule
-  public static final EngineRule ENGINE =
+  @Rule
+  public final EngineRule engine =
       EngineRule.singlePartition()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
-  @BeforeClass
-  public static void beforeAll() {
-    ENGINE
+  @Before
+  public void before() {
+    engine
         .deployment()
         .withXmlResource(
             "process.bpmn",
@@ -77,7 +76,7 @@ public class MessagePublishAuthorizationTest {
     createProcessInstance(correlationKey);
 
     // when
-    ENGINE
+    engine
         .message()
         .withName(INTERMEDIATE_MSG_NAME)
         .withCorrelationKey(correlationKey)
@@ -102,7 +101,7 @@ public class MessagePublishAuthorizationTest {
         user.getUserKey(), AuthorizationResourceType.MESSAGE, PermissionType.CREATE);
 
     // when
-    ENGINE
+    engine
         .message()
         .withName(INTERMEDIATE_MSG_NAME)
         .withCorrelationKey(correlationKey)
@@ -125,7 +124,7 @@ public class MessagePublishAuthorizationTest {
 
     // when
     final var rejection =
-        ENGINE
+        engine
             .message()
             .withName(INTERMEDIATE_MSG_NAME)
             .withCorrelationKey(correlationKey)
@@ -139,8 +138,8 @@ public class MessagePublishAuthorizationTest {
             "Insufficient permissions to perform operation 'CREATE' on resource 'MESSAGE'");
   }
 
-  private static UserRecordValue createUser() {
-    return ENGINE
+  private UserRecordValue createUser() {
+    return engine
         .user()
         .newUser(UUID.randomUUID().toString())
         .withPassword(UUID.randomUUID().toString())
@@ -154,7 +153,7 @@ public class MessagePublishAuthorizationTest {
       final long userKey,
       final AuthorizationResourceType authorization,
       final PermissionType permissionType) {
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(userKey)
@@ -164,7 +163,7 @@ public class MessagePublishAuthorizationTest {
   }
 
   private void createProcessInstance(final String correlationKey) {
-    ENGINE
+    engine
         .processInstance()
         .ofBpmnProcessId(PROCESS_ID)
         .withVariable(CORRELATION_KEY_VARIABLE, correlationKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareActivateJobBatchTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareActivateJobBatchTest.java
@@ -34,20 +34,25 @@ public class TenantAwareActivateJobBatchTest {
     // given
     final var username = UUID.randomUUID().toString();
     final var tenantId = UUID.randomUUID().toString();
-    final var userKey = ENGINE.user().newUser(username).create().getValue().getUserKey();
+    final var user = ENGINE.user().newUser(username).create().getValue();
     final var tenantKey =
         ENGINE.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
     ENGINE
         .tenant()
         .addEntity(tenantKey)
         .withEntityType(EntityType.USER)
-        .withEntityKey(userKey)
+        .withEntityKey(user.getUserKey())
         .add();
 
     // when
     final var tenantIds = new java.util.ArrayList<>(List.of("custom-tenant", "another-tenant"));
     final var rejection =
-        ENGINE.jobs().withTenantIds(tenantIds).withType("test").expectRejection().activate(userKey);
+        ENGINE
+            .jobs()
+            .withTenantIds(tenantIds)
+            .withType("test")
+            .expectRejection()
+            .activate(user.getUsername());
 
     // then
     assertThat(rejection)
@@ -62,21 +67,26 @@ public class TenantAwareActivateJobBatchTest {
     // given
     final var username = UUID.randomUUID().toString();
     final var tenantId = UUID.randomUUID().toString();
-    final var userKey = ENGINE.user().newUser(username).create().getValue().getUserKey();
+    final var user = ENGINE.user().newUser(username).create().getValue();
     final var tenantKey =
         ENGINE.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
     ENGINE
         .tenant()
         .addEntity(tenantKey)
         .withEntityType(EntityType.USER)
-        .withEntityKey(userKey)
+        .withEntityKey(user.getUserKey())
         .add();
 
     // when
     final var tenantIds =
         new java.util.ArrayList<>(List.of("custom-tenant", "another-tenant", "tenantId"));
     final var rejection =
-        ENGINE.jobs().withTenantIds(tenantIds).withType("test").expectRejection().activate(userKey);
+        ENGINE
+            .jobs()
+            .withTenantIds(tenantIds)
+            .withType("test")
+            .expectRejection()
+            .activate(user.getUsername());
 
     // then
     assertThat(rejection)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareCancelProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareCancelProcessInstanceTest.java
@@ -68,7 +68,7 @@ public class TenantAwareCancelProcessInstanceTest {
   @Test
   public void shouldRejectCancelInstanceForUnauthorizedTenant() {
     // given
-    final var userKey = ENGINE.user().newUser("username").create().getValue().getUserKey();
+    final var user = ENGINE.user().newUser("username").create().getValue();
     final var tenantKey =
         ENGINE
             .tenant()
@@ -81,7 +81,7 @@ public class TenantAwareCancelProcessInstanceTest {
         .tenant()
         .addEntity(tenantKey)
         .withEntityType(EntityType.USER)
-        .withEntityKey(userKey)
+        .withEntityKey(user.getUserKey())
         .add();
 
     ENGINE
@@ -104,7 +104,7 @@ public class TenantAwareCancelProcessInstanceTest {
             .processInstance()
             .withInstanceKey(processInstanceKey)
             .expectRejection()
-            .cancel(userKey);
+            .cancel(user.getUsername());
 
     // then
     assertThat(rejection)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareModifyProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareModifyProcessInstanceTest.java
@@ -79,7 +79,7 @@ public class TenantAwareModifyProcessInstanceTest {
   @Test
   public void shouldRejectModifyInstanceForUnauthorizedTenant() {
     // given
-    final var userKey = ENGINE.user().newUser("username").create().getValue().getUserKey();
+    final var user = ENGINE.user().newUser("username").create().getValue();
     final var tenantKey =
         ENGINE
             .tenant()
@@ -92,7 +92,7 @@ public class TenantAwareModifyProcessInstanceTest {
         .tenant()
         .addEntity(tenantKey)
         .withEntityType(EntityType.USER)
-        .withEntityKey(userKey)
+        .withEntityKey(user.getUserKey())
         .add();
 
     ENGINE
@@ -124,7 +124,7 @@ public class TenantAwareModifyProcessInstanceTest {
             .activateElement("task")
             .terminateElement(task.getKey())
             .expectRejection()
-            .modify(userKey);
+            .modify(user.getUsername());
 
     // then
     assertThat(rejection)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareUpdateVariablesTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareUpdateVariablesTest.java
@@ -70,7 +70,7 @@ public class TenantAwareUpdateVariablesTest {
   @Test
   public void shouldRejectUpdateVariablesForUnauthorizedTenant() {
     // given
-    final var userKey = ENGINE.user().newUser("username").create().getValue().getUserKey();
+    final var user = ENGINE.user().newUser("username").create().getValue();
     final var tenantKey =
         ENGINE
             .tenant()
@@ -83,7 +83,7 @@ public class TenantAwareUpdateVariablesTest {
         .tenant()
         .addEntity(tenantKey)
         .withEntityType(EntityType.USER)
-        .withEntityKey(userKey)
+        .withEntityKey(user.getUserKey())
         .add();
 
     ENGINE
@@ -107,7 +107,7 @@ public class TenantAwareUpdateVariablesTest {
             .ofScope(processInstanceKey)
             .withDocument(Map.of("foo", "bar"))
             .expectRejection()
-            .update(userKey);
+            .update(user.getUsername());
 
     // then
     assertThat(rejection)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelAuthorizationTest.java
@@ -22,8 +22,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -38,17 +37,17 @@ public class ProcessInstanceCancelAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
 
-  @ClassRule
-  public static final EngineRule ENGINE =
+  @Rule
+  public final EngineRule engine =
       EngineRule.singlePartition()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
-  @BeforeClass
-  public static void beforeAll() {
-    ENGINE
+  @Before
+  public void before() {
+    engine
         .deployment()
         .withXmlResource(
             "process.bpmn",
@@ -62,7 +61,7 @@ public class ProcessInstanceCancelAuthorizationTest {
     final var processInstanceKey = createProcessInstance();
 
     // when
-    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel(DEFAULT_USER.getUsername());
+    engine.processInstance().withInstanceKey(processInstanceKey).cancel(DEFAULT_USER.getUsername());
 
     // then
     assertThat(
@@ -84,7 +83,7 @@ public class ProcessInstanceCancelAuthorizationTest {
         PROCESS_ID);
 
     // when
-    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel(user.getUsername());
+    engine.processInstance().withInstanceKey(processInstanceKey).cancel(user.getUsername());
 
     // then
     assertThat(
@@ -102,7 +101,7 @@ public class ProcessInstanceCancelAuthorizationTest {
 
     // when
     final var rejection =
-        ENGINE
+        engine
             .processInstance()
             .withInstanceKey(processInstanceKey)
             .expectRejection()
@@ -116,8 +115,8 @@ public class ProcessInstanceCancelAuthorizationTest {
                 .formatted(PROCESS_ID));
   }
 
-  private static UserRecordValue createUser() {
-    return ENGINE
+  private UserRecordValue createUser() {
+    return engine
         .user()
         .newUser(UUID.randomUUID().toString())
         .withPassword(UUID.randomUUID().toString())
@@ -132,7 +131,7 @@ public class ProcessInstanceCancelAuthorizationTest {
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
       final String... resourceIds) {
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(userKey)
@@ -142,6 +141,6 @@ public class ProcessInstanceCancelAuthorizationTest {
   }
 
   private long createProcessInstance() {
-    return ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+    return engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelAuthorizationTest.java
@@ -15,9 +15,9 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
-import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
@@ -41,27 +41,19 @@ public class ProcessInstanceCancelAuthorizationTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withoutAwaitingIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
-  private static long defaultUserKey = -1L;
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
   @BeforeClass
   public static void beforeAll() {
-    defaultUserKey =
-        RecordingExporter.userRecords(UserIntent.CREATED)
-            .withUsername(DEFAULT_USER.getUsername())
-            .getFirst()
-            .getKey();
-
     ENGINE
         .deployment()
         .withXmlResource(
             "process.bpmn",
             Bpmn.createExecutableProcess(PROCESS_ID).startEvent().userTask().endEvent().done())
-        .deploy(defaultUserKey);
+        .deploy(DEFAULT_USER.getUsername());
   }
 
   @Test
@@ -70,7 +62,7 @@ public class ProcessInstanceCancelAuthorizationTest {
     final var processInstanceKey = createProcessInstance();
 
     // when
-    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel(defaultUserKey);
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel(DEFAULT_USER.getUsername());
 
     // then
     assertThat(
@@ -84,15 +76,15 @@ public class ProcessInstanceCancelAuthorizationTest {
   public void shouldBeAuthorizedToCancelInstanceWithUser() {
     // given
     final var processInstanceKey = createProcessInstance();
-    final var userKey = createUser();
+    final var user = createUser();
     addPermissionsToUser(
-        userKey,
+        user.getUserKey(),
         AuthorizationResourceType.PROCESS_DEFINITION,
         PermissionType.UPDATE_PROCESS_INSTANCE,
         PROCESS_ID);
 
     // when
-    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel(userKey);
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel(user.getUsername());
 
     // then
     assertThat(
@@ -106,7 +98,7 @@ public class ProcessInstanceCancelAuthorizationTest {
   public void shouldBeUnauthorizedToCancelInstanceIfNoPermissions() {
     // given
     final var processInstanceKey = createProcessInstance();
-    final var userKey = createUser();
+    final var user = createUser();
 
     // when
     final var rejection =
@@ -114,7 +106,7 @@ public class ProcessInstanceCancelAuthorizationTest {
             .processInstance()
             .withInstanceKey(processInstanceKey)
             .expectRejection()
-            .cancel(userKey);
+            .cancel(user.getUsername());
 
     // then
     Assertions.assertThat(rejection)
@@ -124,7 +116,7 @@ public class ProcessInstanceCancelAuthorizationTest {
                 .formatted(PROCESS_ID));
   }
 
-  private static long createUser() {
+  private static UserRecordValue createUser() {
     return ENGINE
         .user()
         .newUser(UUID.randomUUID().toString())
@@ -132,7 +124,7 @@ public class ProcessInstanceCancelAuthorizationTest {
         .withName(UUID.randomUUID().toString())
         .withEmail(UUID.randomUUID().toString())
         .create()
-        .getKey();
+        .getValue();
   }
 
   private void addPermissionsToUser(
@@ -146,10 +138,10 @@ public class ProcessInstanceCancelAuthorizationTest {
         .withOwnerKey(userKey)
         .withResourceType(authorization)
         .withPermission(permissionType, resourceIds)
-        .add(defaultUserKey);
+        .add(DEFAULT_USER.getUsername());
   }
 
   private long createProcessInstance() {
-    return ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create(defaultUserKey);
+    return ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreateAuthorizationTest.java
@@ -22,8 +22,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -38,17 +37,17 @@ public class ProcessInstanceCreateAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
 
-  @ClassRule
-  public static final EngineRule ENGINE =
+  @Rule
+  public final EngineRule engine =
       EngineRule.singlePartition()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
-  @BeforeClass
-  public static void beforeAll() {
-    ENGINE
+  @Before
+  public void before() {
+    engine
         .deployment()
         .withXmlResource(
             "process.bpmn", Bpmn.createExecutableProcess(PROCESS_ID).startEvent().endEvent().done())
@@ -59,7 +58,7 @@ public class ProcessInstanceCreateAuthorizationTest {
   public void shouldBeAuthorizedToCreateInstanceWithDefaultUser() {
     // when
     final var processInstanceKey =
-        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+        engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
 
     // then
     assertThat(
@@ -73,7 +72,7 @@ public class ProcessInstanceCreateAuthorizationTest {
   public void shouldBeAuthorizedToCreateInstanceWithResultWithDefaultUser() {
     // when
     final var processInstanceKey =
-        ENGINE
+        engine
             .processInstance()
             .ofBpmnProcessId(PROCESS_ID)
             .withResult()
@@ -99,7 +98,7 @@ public class ProcessInstanceCreateAuthorizationTest {
 
     // when
     final var processInstanceKey =
-        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create(user.getUsername());
+        engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(user.getUsername());
 
     // then
     assertThat(
@@ -121,7 +120,7 @@ public class ProcessInstanceCreateAuthorizationTest {
 
     // when
     final var processInstanceKey =
-        ENGINE
+        engine
             .processInstance()
             .ofBpmnProcessId(PROCESS_ID)
             .withResult()
@@ -141,7 +140,7 @@ public class ProcessInstanceCreateAuthorizationTest {
     final var user = createUser();
 
     // when
-    ENGINE
+    engine
         .processInstance()
         .ofBpmnProcessId(PROCESS_ID)
         .expectRejection()
@@ -162,7 +161,7 @@ public class ProcessInstanceCreateAuthorizationTest {
     final var user = createUser();
 
     // when
-    ENGINE
+    engine
         .processInstance()
         .ofBpmnProcessId(PROCESS_ID)
         .expectRejection()
@@ -178,8 +177,8 @@ public class ProcessInstanceCreateAuthorizationTest {
                 .formatted(PROCESS_ID));
   }
 
-  private static UserRecordValue createUser() {
-    return ENGINE
+  private UserRecordValue createUser() {
+    return engine
         .user()
         .newUser(UUID.randomUUID().toString())
         .withPassword(UUID.randomUUID().toString())
@@ -194,7 +193,7 @@ public class ProcessInstanceCreateAuthorizationTest {
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
       final String... resourceIds) {
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(userKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyAuthorizationTest.java
@@ -16,9 +16,9 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
-import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
@@ -44,21 +44,13 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withoutAwaitingIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
-  private static long defaultUserKey = -1L;
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
   @BeforeClass
   public static void beforeAll() {
-    defaultUserKey =
-        RecordingExporter.userRecords(UserIntent.CREATED)
-            .withUsername(DEFAULT_USER.getUsername())
-            .getFirst()
-            .getKey();
-
     ENGINE
         .deployment()
         .withXmlResource(
@@ -68,7 +60,7 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
                 .serviceTask(SERVICE_TASK_ID, t -> t.zeebeJobType(JOB_TYPE))
                 .endEvent()
                 .done())
-        .deploy(defaultUserKey)
+        .deploy(DEFAULT_USER.getUsername())
         .getValue();
   }
 
@@ -84,7 +76,7 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
         .withInstanceKey(processInstanceKey)
         .modification()
         .terminateElement(serviceTaskKey)
-        .modify(defaultUserKey);
+        .modify(DEFAULT_USER.getUsername());
 
     // then
     assertThat(
@@ -100,9 +92,9 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
     // given
     final var processInstanceKey = createProcessInstance();
     final var serviceTaskKey = getServiceTaskKey(processInstanceKey);
-    final var userKey = createUser();
+    final var user = createUser();
     addPermissionsToUser(
-        userKey,
+        user.getUserKey(),
         AuthorizationResourceType.PROCESS_DEFINITION,
         PermissionType.UPDATE_PROCESS_INSTANCE,
         PROCESS_ID);
@@ -113,7 +105,7 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
         .withInstanceKey(processInstanceKey)
         .modification()
         .terminateElement(serviceTaskKey)
-        .modify(userKey);
+        .modify(user.getUsername());
 
     // then
     assertThat(
@@ -129,7 +121,7 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
     // given
     final var processInstanceKey = createProcessInstance();
     final var serviceTaskKey = getServiceTaskKey(processInstanceKey);
-    final var userKey = createUser();
+    final var user = createUser();
 
     // when
     ENGINE
@@ -138,7 +130,7 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
         .modification()
         .terminateElement(serviceTaskKey)
         .expectRejection()
-        .modify(userKey);
+        .modify(user.getUsername());
 
     // then
     Assertions.assertThat(
@@ -151,7 +143,7 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
                 .formatted(PROCESS_ID));
   }
 
-  private static long createUser() {
+  private static UserRecordValue createUser() {
     return ENGINE
         .user()
         .newUser(UUID.randomUUID().toString())
@@ -159,7 +151,7 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
         .withName(UUID.randomUUID().toString())
         .withEmail(UUID.randomUUID().toString())
         .create()
-        .getKey();
+        .getValue();
   }
 
   private void addPermissionsToUser(
@@ -173,11 +165,11 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
         .withOwnerKey(userKey)
         .withResourceType(authorization)
         .withPermission(permissionType, resourceIds)
-        .add(defaultUserKey);
+        .add(DEFAULT_USER.getUsername());
   }
 
   private long createProcessInstance() {
-    return ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create(defaultUserKey);
+    return ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
   }
 
   private long getServiceTaskKey(final long processInstanceKey) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyAuthorizationTest.java
@@ -23,8 +23,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -41,17 +40,17 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
 
-  @ClassRule
-  public static final EngineRule ENGINE =
+  @Rule
+  public final EngineRule engine =
       EngineRule.singlePartition()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
-  @BeforeClass
-  public static void beforeAll() {
-    ENGINE
+  @Before
+  public void before() {
+    engine
         .deployment()
         .withXmlResource(
             "process.bpmn",
@@ -71,7 +70,7 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
     final var serviceTaskKey = getServiceTaskKey(processInstanceKey);
 
     // when
-    ENGINE
+    engine
         .processInstance()
         .withInstanceKey(processInstanceKey)
         .modification()
@@ -100,7 +99,7 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
         PROCESS_ID);
 
     // when
-    ENGINE
+    engine
         .processInstance()
         .withInstanceKey(processInstanceKey)
         .modification()
@@ -124,7 +123,7 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
     final var user = createUser();
 
     // when
-    ENGINE
+    engine
         .processInstance()
         .withInstanceKey(processInstanceKey)
         .modification()
@@ -143,8 +142,8 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
                 .formatted(PROCESS_ID));
   }
 
-  private static UserRecordValue createUser() {
-    return ENGINE
+  private UserRecordValue createUser() {
+    return engine
         .user()
         .newUser(UUID.randomUUID().toString())
         .withPassword(UUID.randomUUID().toString())
@@ -159,7 +158,7 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
       final String... resourceIds) {
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(userKey)
@@ -169,7 +168,7 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
   }
 
   private long createProcessInstance() {
-    return ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+    return engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
   }
 
   private long getServiceTaskKey(final long processInstanceKey) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/ProcessInstanceMigrationMigrateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/ProcessInstanceMigrationMigrateAuthorizationTest.java
@@ -22,8 +22,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -40,20 +39,20 @@ public class ProcessInstanceMigrationMigrateAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
+  private static long targetProcDefKey = -1L;
 
-  @ClassRule
-  public static final EngineRule ENGINE =
+  @Rule
+  public final EngineRule engine =
       EngineRule.singlePartition()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
-  private static long targetProcDefKey = -1L;
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
-  @BeforeClass
-  public static void beforeAll() {
+  @Before
+  public void before() {
     final var deployment =
-        ENGINE
+        engine
             .deployment()
             .withXmlResource(
                 "process.bpmn",
@@ -85,7 +84,7 @@ public class ProcessInstanceMigrationMigrateAuthorizationTest {
     final var processInstanceKey = createProcessInstance();
 
     // when
-    ENGINE
+    engine
         .processInstance()
         .withInstanceKey(processInstanceKey)
         .migration()
@@ -114,7 +113,7 @@ public class ProcessInstanceMigrationMigrateAuthorizationTest {
         PROCESS_ID);
 
     // when
-    ENGINE
+    engine
         .processInstance()
         .withInstanceKey(processInstanceKey)
         .migration()
@@ -138,7 +137,7 @@ public class ProcessInstanceMigrationMigrateAuthorizationTest {
     final var user = createUser();
 
     // when
-    ENGINE
+    engine
         .processInstance()
         .withInstanceKey(processInstanceKey)
         .migration()
@@ -156,8 +155,8 @@ public class ProcessInstanceMigrationMigrateAuthorizationTest {
                 .formatted(PROCESS_ID));
   }
 
-  private static UserRecordValue createUser() {
-    return ENGINE
+  private UserRecordValue createUser() {
+    return engine
         .user()
         .newUser(UUID.randomUUID().toString())
         .withPassword(UUID.randomUUID().toString())
@@ -172,7 +171,7 @@ public class ProcessInstanceMigrationMigrateAuthorizationTest {
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
       final String... resourceIds) {
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(userKey)
@@ -182,6 +181,6 @@ public class ProcessInstanceMigrationMigrateAuthorizationTest {
   }
 
   private long createProcessInstance() {
-    return ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+    return engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationTest.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -36,8 +35,8 @@ public class ResourceDeletionAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
 
-  @ClassRule
-  public static final EngineRule ENGINE =
+  @Rule
+  public final EngineRule engine =
       EngineRule.singlePartition()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
@@ -50,7 +49,7 @@ public class ResourceDeletionAuthorizationTest {
     final var processDefinitionKey = deployProcessDefinition(Strings.newRandomValidBpmnId());
 
     // when
-    ENGINE
+    engine
         .resourceDeletion()
         .withResourceKey(processDefinitionKey)
         .delete(DEFAULT_USER.getUsername());
@@ -76,7 +75,7 @@ public class ResourceDeletionAuthorizationTest {
         processId);
 
     // when
-    ENGINE.resourceDeletion().withResourceKey(processDefinitionKey).delete(user.getUsername());
+    engine.resourceDeletion().withResourceKey(processDefinitionKey).delete(user.getUsername());
 
     // then
     assertThat(
@@ -94,7 +93,7 @@ public class ResourceDeletionAuthorizationTest {
     final var user = createUser();
 
     // when
-    ENGINE
+    engine
         .resourceDeletion()
         .withResourceKey(processDefinitionKey)
         .expectRejection()
@@ -117,7 +116,7 @@ public class ResourceDeletionAuthorizationTest {
     final var drdKey = deployDrd();
 
     // when
-    ENGINE.resourceDeletion().withResourceKey(drdKey).delete(DEFAULT_USER.getUsername());
+    engine.resourceDeletion().withResourceKey(drdKey).delete(DEFAULT_USER.getUsername());
 
     // then
     assertThat(
@@ -137,7 +136,7 @@ public class ResourceDeletionAuthorizationTest {
         user.getUserKey(), AuthorizationResourceType.DEPLOYMENT, PermissionType.DELETE_DRD, drdId);
 
     // when
-    ENGINE.resourceDeletion().withResourceKey(drdKey).delete(user.getUsername());
+    engine.resourceDeletion().withResourceKey(drdKey).delete(user.getUsername());
 
     // then
     assertThat(
@@ -155,7 +154,7 @@ public class ResourceDeletionAuthorizationTest {
     final var user = createUser();
 
     // when
-    ENGINE.resourceDeletion().withResourceKey(drdKey).expectRejection().delete(user.getUsername());
+    engine.resourceDeletion().withResourceKey(drdKey).expectRejection().delete(user.getUsername());
 
     // then
     Assertions.assertThat(
@@ -174,7 +173,7 @@ public class ResourceDeletionAuthorizationTest {
     final var formKey = deployForm();
 
     // when
-    ENGINE.resourceDeletion().withResourceKey(formKey).delete(DEFAULT_USER.getUsername());
+    engine.resourceDeletion().withResourceKey(formKey).delete(DEFAULT_USER.getUsername());
 
     // then
     assertThat(
@@ -197,7 +196,7 @@ public class ResourceDeletionAuthorizationTest {
         formId);
 
     // when
-    ENGINE.resourceDeletion().withResourceKey(formKey).delete(user.getUsername());
+    engine.resourceDeletion().withResourceKey(formKey).delete(user.getUsername());
 
     // then
     assertThat(
@@ -215,7 +214,7 @@ public class ResourceDeletionAuthorizationTest {
     final var user = createUser();
 
     // when
-    ENGINE.resourceDeletion().withResourceKey(formKey).expectRejection().delete(user.getUsername());
+    engine.resourceDeletion().withResourceKey(formKey).expectRejection().delete(user.getUsername());
 
     // then
     Assertions.assertThat(
@@ -228,8 +227,8 @@ public class ResourceDeletionAuthorizationTest {
                 .formatted(formId));
   }
 
-  private static UserRecordValue createUser() {
-    return ENGINE
+  private UserRecordValue createUser() {
+    return engine
         .user()
         .newUser(UUID.randomUUID().toString())
         .withPassword(UUID.randomUUID().toString())
@@ -244,7 +243,7 @@ public class ResourceDeletionAuthorizationTest {
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
       final String... resourceIds) {
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(userKey)
@@ -254,7 +253,7 @@ public class ResourceDeletionAuthorizationTest {
   }
 
   private long deployProcessDefinition(final String processId) {
-    return ENGINE
+    return engine
         .deployment()
         .withXmlResource(
             "process.bpmn", Bpmn.createExecutableProcess(processId).startEvent().endEvent().done())
@@ -266,7 +265,7 @@ public class ResourceDeletionAuthorizationTest {
   }
 
   private long deployDrd() {
-    return ENGINE
+    return engine
         .deployment()
         .withXmlClasspathResource("/dmn/drg-force-user.dmn")
         .deploy(DEFAULT_USER.getUsername())
@@ -277,7 +276,7 @@ public class ResourceDeletionAuthorizationTest {
   }
 
   private long deployForm() {
-    return ENGINE
+    return engine
         .deployment()
         .withXmlClasspathResource("/form/test-form-1.form")
         .deploy(DEFAULT_USER.getUsername())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationTest.java
@@ -15,15 +15,14 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
-import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,21 +39,10 @@ public class ResourceDeletionAuthorizationTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withoutAwaitingIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
-  private static long defaultUserKey = -1L;
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
-
-  @BeforeClass
-  public static void beforeAll() {
-    defaultUserKey =
-        RecordingExporter.userRecords(UserIntent.CREATED)
-            .withUsername(DEFAULT_USER.getUsername())
-            .getFirst()
-            .getKey();
-  }
 
   @Test
   public void shouldBeAuthorizedToDeleteProcessDefinitionWithDefaultUser() {
@@ -62,7 +50,10 @@ public class ResourceDeletionAuthorizationTest {
     final var processDefinitionKey = deployProcessDefinition(Strings.newRandomValidBpmnId());
 
     // when
-    ENGINE.resourceDeletion().withResourceKey(processDefinitionKey).delete(defaultUserKey);
+    ENGINE
+        .resourceDeletion()
+        .withResourceKey(processDefinitionKey)
+        .delete(DEFAULT_USER.getUsername());
 
     // then
     assertThat(
@@ -77,12 +68,15 @@ public class ResourceDeletionAuthorizationTest {
     // given
     final var processId = Strings.newRandomValidBpmnId();
     final var processDefinitionKey = deployProcessDefinition(processId);
-    final var userKey = createUser();
+    final var user = createUser();
     addPermissionsToUser(
-        userKey, AuthorizationResourceType.DEPLOYMENT, PermissionType.DELETE_PROCESS, processId);
+        user.getUserKey(),
+        AuthorizationResourceType.DEPLOYMENT,
+        PermissionType.DELETE_PROCESS,
+        processId);
 
     // when
-    ENGINE.resourceDeletion().withResourceKey(processDefinitionKey).delete(userKey);
+    ENGINE.resourceDeletion().withResourceKey(processDefinitionKey).delete(user.getUsername());
 
     // then
     assertThat(
@@ -97,14 +91,14 @@ public class ResourceDeletionAuthorizationTest {
     // given
     final var processId = Strings.newRandomValidBpmnId();
     final var processDefinitionKey = deployProcessDefinition(processId);
-    final var userKey = createUser();
+    final var user = createUser();
 
     // when
     ENGINE
         .resourceDeletion()
         .withResourceKey(processDefinitionKey)
         .expectRejection()
-        .delete(userKey);
+        .delete(user.getUsername());
 
     // then
     Assertions.assertThat(
@@ -123,7 +117,7 @@ public class ResourceDeletionAuthorizationTest {
     final var drdKey = deployDrd();
 
     // when
-    ENGINE.resourceDeletion().withResourceKey(drdKey).delete(defaultUserKey);
+    ENGINE.resourceDeletion().withResourceKey(drdKey).delete(DEFAULT_USER.getUsername());
 
     // then
     assertThat(
@@ -138,12 +132,12 @@ public class ResourceDeletionAuthorizationTest {
     // given
     final var drdId = "force_users";
     final var drdKey = deployDrd();
-    final var userKey = createUser();
+    final var user = createUser();
     addPermissionsToUser(
-        userKey, AuthorizationResourceType.DEPLOYMENT, PermissionType.DELETE_DRD, drdId);
+        user.getUserKey(), AuthorizationResourceType.DEPLOYMENT, PermissionType.DELETE_DRD, drdId);
 
     // when
-    ENGINE.resourceDeletion().withResourceKey(drdKey).delete(userKey);
+    ENGINE.resourceDeletion().withResourceKey(drdKey).delete(user.getUsername());
 
     // then
     assertThat(
@@ -158,10 +152,10 @@ public class ResourceDeletionAuthorizationTest {
     // given
     final var drdId = "force_users";
     final var drdKey = deployDrd();
-    final var userKey = createUser();
+    final var user = createUser();
 
     // when
-    ENGINE.resourceDeletion().withResourceKey(drdKey).expectRejection().delete(userKey);
+    ENGINE.resourceDeletion().withResourceKey(drdKey).expectRejection().delete(user.getUsername());
 
     // then
     Assertions.assertThat(
@@ -180,7 +174,7 @@ public class ResourceDeletionAuthorizationTest {
     final var formKey = deployForm();
 
     // when
-    ENGINE.resourceDeletion().withResourceKey(formKey).delete(defaultUserKey);
+    ENGINE.resourceDeletion().withResourceKey(formKey).delete(DEFAULT_USER.getUsername());
 
     // then
     assertThat(
@@ -195,12 +189,15 @@ public class ResourceDeletionAuthorizationTest {
     // given
     final var formId = "Form_0w7r08e";
     final var formKey = deployForm();
-    final var userKey = createUser();
+    final var user = createUser();
     addPermissionsToUser(
-        userKey, AuthorizationResourceType.DEPLOYMENT, PermissionType.DELETE_FORM, formId);
+        user.getUserKey(),
+        AuthorizationResourceType.DEPLOYMENT,
+        PermissionType.DELETE_FORM,
+        formId);
 
     // when
-    ENGINE.resourceDeletion().withResourceKey(formKey).delete(userKey);
+    ENGINE.resourceDeletion().withResourceKey(formKey).delete(user.getUsername());
 
     // then
     assertThat(
@@ -215,10 +212,10 @@ public class ResourceDeletionAuthorizationTest {
     // given
     final var formId = "Form_0w7r08e";
     final var formKey = deployForm();
-    final var userKey = createUser();
+    final var user = createUser();
 
     // when
-    ENGINE.resourceDeletion().withResourceKey(formKey).expectRejection().delete(userKey);
+    ENGINE.resourceDeletion().withResourceKey(formKey).expectRejection().delete(user.getUsername());
 
     // then
     Assertions.assertThat(
@@ -231,7 +228,7 @@ public class ResourceDeletionAuthorizationTest {
                 .formatted(formId));
   }
 
-  private static long createUser() {
+  private static UserRecordValue createUser() {
     return ENGINE
         .user()
         .newUser(UUID.randomUUID().toString())
@@ -239,7 +236,7 @@ public class ResourceDeletionAuthorizationTest {
         .withName(UUID.randomUUID().toString())
         .withEmail(UUID.randomUUID().toString())
         .create()
-        .getKey();
+        .getValue();
   }
 
   private void addPermissionsToUser(
@@ -253,7 +250,7 @@ public class ResourceDeletionAuthorizationTest {
         .withOwnerKey(userKey)
         .withResourceType(authorization)
         .withPermission(permissionType, resourceIds)
-        .add(defaultUserKey);
+        .add(DEFAULT_USER.getUsername());
   }
 
   private long deployProcessDefinition(final String processId) {
@@ -261,7 +258,7 @@ public class ResourceDeletionAuthorizationTest {
         .deployment()
         .withXmlResource(
             "process.bpmn", Bpmn.createExecutableProcess(processId).startEvent().endEvent().done())
-        .deploy(defaultUserKey)
+        .deploy(DEFAULT_USER.getUsername())
         .getValue()
         .getProcessesMetadata()
         .getFirst()
@@ -272,7 +269,7 @@ public class ResourceDeletionAuthorizationTest {
     return ENGINE
         .deployment()
         .withXmlClasspathResource("/dmn/drg-force-user.dmn")
-        .deploy(defaultUserKey)
+        .deploy(DEFAULT_USER.getUsername())
         .getValue()
         .getDecisionRequirementsMetadata()
         .getFirst()
@@ -283,7 +280,7 @@ public class ResourceDeletionAuthorizationTest {
     return ENGINE
         .deployment()
         .withXmlClasspathResource("/form/test-form-1.form")
-        .deploy(defaultUserKey)
+        .deploy(DEFAULT_USER.getUsername())
         .getValue()
         .getFormMetadata()
         .getFirst()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleCreateAuthorizationTest.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -34,8 +33,8 @@ public class RoleCreateAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
 
-  @ClassRule
-  public static final EngineRule ENGINE =
+  @Rule
+  public final EngineRule engine =
       EngineRule.singlePartition()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
@@ -48,7 +47,7 @@ public class RoleCreateAuthorizationTest {
     final var roleName = UUID.randomUUID().toString();
 
     // when
-    ENGINE.role().newRole(roleName).create(DEFAULT_USER.getUsername());
+    engine.role().newRole(roleName).create(DEFAULT_USER.getUsername());
 
     // then
     assertThat(RecordingExporter.roleRecords(RoleIntent.CREATED).withName(roleName).exists())
@@ -63,7 +62,7 @@ public class RoleCreateAuthorizationTest {
     addPermissionsToUser(user.getUserKey(), AuthorizationResourceType.ROLE, PermissionType.CREATE);
 
     // when
-    ENGINE.role().newRole(roleName).create(user.getUsername());
+    engine.role().newRole(roleName).create(user.getUsername());
 
     // then
     assertThat(RecordingExporter.roleRecords(RoleIntent.CREATED).withName(roleName).exists())
@@ -78,7 +77,7 @@ public class RoleCreateAuthorizationTest {
 
     // when
     final var rejection =
-        ENGINE.role().newRole(roleName).expectRejection().create(user.getUsername());
+        engine.role().newRole(roleName).expectRejection().create(user.getUsername());
 
     // then
     Assertions.assertThat(rejection)
@@ -87,8 +86,8 @@ public class RoleCreateAuthorizationTest {
             "Insufficient permissions to perform operation 'CREATE' on resource 'ROLE'");
   }
 
-  private static UserRecordValue createUser() {
-    return ENGINE
+  private UserRecordValue createUser() {
+    return engine
         .user()
         .newUser(UUID.randomUUID().toString())
         .withPassword(UUID.randomUUID().toString())
@@ -102,7 +101,7 @@ public class RoleCreateAuthorizationTest {
       final long userKey,
       final AuthorizationResourceType authorization,
       final PermissionType permissionType) {
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(userKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastAuthorizationTest.java
@@ -22,8 +22,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -38,17 +37,17 @@ public class SignalBroadcastAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
 
-  @ClassRule
-  public static final EngineRule ENGINE =
+  @Rule
+  public final EngineRule engine =
       EngineRule.singlePartition()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
-  @BeforeClass
-  public static void beforeAll() {
-    ENGINE
+  @Before
+  public void before() {
+    engine
         .deployment()
         .withXmlResource(
             "process.bpmn",
@@ -70,7 +69,7 @@ public class SignalBroadcastAuthorizationTest {
     createProcessInstance();
 
     // when
-    ENGINE.signal().withSignalName(SIGNAL_NAME).broadcast(DEFAULT_USER.getUsername());
+    engine.signal().withSignalName(SIGNAL_NAME).broadcast(DEFAULT_USER.getUsername());
 
     // then
     assertThat(
@@ -95,7 +94,7 @@ public class SignalBroadcastAuthorizationTest {
         PermissionType.UPDATE_PROCESS_INSTANCE);
 
     // when
-    ENGINE.signal().withSignalName(SIGNAL_NAME).broadcast(user.getUsername());
+    engine.signal().withSignalName(SIGNAL_NAME).broadcast(user.getUsername());
 
     // then
     assertThat(
@@ -113,7 +112,7 @@ public class SignalBroadcastAuthorizationTest {
 
     // when
     final var rejection =
-        ENGINE.signal().withSignalName(SIGNAL_NAME).expectRejection().broadcast(user.getUsername());
+        engine.signal().withSignalName(SIGNAL_NAME).expectRejection().broadcast(user.getUsername());
 
     // then
     Assertions.assertThat(rejection)
@@ -135,7 +134,7 @@ public class SignalBroadcastAuthorizationTest {
 
     // when
     final var rejection =
-        ENGINE.signal().withSignalName(SIGNAL_NAME).expectRejection().broadcast(user.getUsername());
+        engine.signal().withSignalName(SIGNAL_NAME).expectRejection().broadcast(user.getUsername());
 
     // then
     Assertions.assertThat(rejection)
@@ -145,8 +144,8 @@ public class SignalBroadcastAuthorizationTest {
                 .formatted(PROCESS_ID));
   }
 
-  private static UserRecordValue createUser() {
-    return ENGINE
+  private UserRecordValue createUser() {
+    return engine
         .user()
         .newUser(UUID.randomUUID().toString())
         .withPassword(UUID.randomUUID().toString())
@@ -160,7 +159,7 @@ public class SignalBroadcastAuthorizationTest {
       final long userKey,
       final AuthorizationResourceType authorization,
       final PermissionType permissionType) {
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(userKey)
@@ -170,6 +169,6 @@ public class SignalBroadcastAuthorizationTest {
   }
 
   private long createProcessInstance() {
-    return ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+    return engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UserCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UserCreateAuthorizationTest.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -35,8 +34,8 @@ public class UserCreateAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
 
-  @ClassRule
-  public static final EngineRule ENGINE =
+  @Rule
+  public final EngineRule engine =
       EngineRule.singlePartition()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
@@ -83,7 +82,7 @@ public class UserCreateAuthorizationTest {
 
     // when
     final var rejection =
-        ENGINE
+        engine
             .user()
             .newUser(UUID.randomUUID().toString())
             .withPassword(UUID.randomUUID().toString())
@@ -99,8 +98,8 @@ public class UserCreateAuthorizationTest {
             "Insufficient permissions to perform operation 'CREATE' on resource 'USER'");
   }
 
-  private static UserRecordValue createUser(final String authorizedUsername) {
-    return ENGINE
+  private UserRecordValue createUser(final String authorizedUsername) {
+    return engine
         .user()
         .newUser(UUID.randomUUID().toString())
         .withPassword(UUID.randomUUID().toString())
@@ -114,7 +113,7 @@ public class UserCreateAuthorizationTest {
       final long userKey,
       final AuthorizationResourceType authorization,
       final PermissionType permissionType) {
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(userKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskAssignAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskAssignAuthorizationTest.java
@@ -22,8 +22,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -38,17 +37,17 @@ public class UserTaskAssignAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
 
-  @ClassRule
-  public static final EngineRule ENGINE =
+  @Rule
+  public final EngineRule engine =
       EngineRule.singlePartition()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
-  @BeforeClass
-  public static void beforeAll() {
-    ENGINE
+  @Before
+  public void before() {
+    engine
         .deployment()
         .withXmlResource(
             "process.bpmn",
@@ -67,7 +66,7 @@ public class UserTaskAssignAuthorizationTest {
     final var processInstanceKey = createProcessInstance();
 
     // when
-    ENGINE
+    engine
         .userTask()
         .ofInstance(processInstanceKey)
         .withAssignee("assignee")
@@ -93,7 +92,7 @@ public class UserTaskAssignAuthorizationTest {
         PROCESS_ID);
 
     // when
-    ENGINE
+    engine
         .userTask()
         .ofInstance(processInstanceKey)
         .withAssignee("assignee")
@@ -115,7 +114,7 @@ public class UserTaskAssignAuthorizationTest {
 
     // when
     final var rejection =
-        ENGINE
+        engine
             .userTask()
             .ofInstance(processInstanceKey)
             .withAssignee("assignee")
@@ -130,8 +129,8 @@ public class UserTaskAssignAuthorizationTest {
                 .formatted(PROCESS_ID));
   }
 
-  private static UserRecordValue createUser() {
-    return ENGINE
+  private UserRecordValue createUser() {
+    return engine
         .user()
         .newUser(UUID.randomUUID().toString())
         .withPassword(UUID.randomUUID().toString())
@@ -146,7 +145,7 @@ public class UserTaskAssignAuthorizationTest {
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
       final String... resourceIds) {
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(userKey)
@@ -156,6 +155,6 @@ public class UserTaskAssignAuthorizationTest {
   }
 
   private long createProcessInstance() {
-    return ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+    return engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimAuthorizationTest.java
@@ -22,8 +22,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -39,17 +38,17 @@ public class UserTaskClaimAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
 
-  @ClassRule
-  public static final EngineRule ENGINE =
+  @Rule
+  public final EngineRule engine =
       EngineRule.singlePartition()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
-  @BeforeClass
-  public static void beforeAll() {
-    ENGINE
+  @Before
+  public void before() {
+    engine
         .deployment()
         .withXmlResource(
             "process.bpmn",
@@ -68,7 +67,7 @@ public class UserTaskClaimAuthorizationTest {
     final var processInstanceKey = createProcessInstance();
 
     // when
-    ENGINE
+    engine
         .userTask()
         .ofInstance(processInstanceKey)
         .withAssignee("assignee")
@@ -94,7 +93,7 @@ public class UserTaskClaimAuthorizationTest {
         PROCESS_ID);
 
     // when
-    ENGINE
+    engine
         .userTask()
         .ofInstance(processInstanceKey)
         .withAssignee("assignee")
@@ -116,7 +115,7 @@ public class UserTaskClaimAuthorizationTest {
 
     // when
     final var rejection =
-        ENGINE
+        engine
             .userTask()
             .ofInstance(processInstanceKey)
             .withAssignee("assignee")
@@ -131,8 +130,8 @@ public class UserTaskClaimAuthorizationTest {
                 .formatted(PROCESS_ID));
   }
 
-  private static UserRecordValue createUser() {
-    return ENGINE
+  private UserRecordValue createUser() {
+    return engine
         .user()
         .newUser(UUID.randomUUID().toString())
         .withPassword(UUID.randomUUID().toString())
@@ -147,7 +146,7 @@ public class UserTaskClaimAuthorizationTest {
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
       final String... resourceIds) {
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(userKey)
@@ -157,6 +156,6 @@ public class UserTaskClaimAuthorizationTest {
   }
 
   private long createProcessInstance() {
-    return ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+    return engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCompleteAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCompleteAuthorizationTest.java
@@ -22,8 +22,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -39,17 +38,17 @@ public class UserTaskCompleteAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
 
-  @ClassRule
-  public static final EngineRule ENGINE =
+  @Rule
+  public final EngineRule engine =
       EngineRule.singlePartition()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
-  @BeforeClass
-  public static void beforeAll() {
-    ENGINE
+  @Before
+  public void before() {
+    engine
         .deployment()
         .withXmlResource(
             "process.bpmn",
@@ -68,7 +67,7 @@ public class UserTaskCompleteAuthorizationTest {
     final var processInstanceKey = createProcessInstance();
 
     // when
-    ENGINE
+    engine
         .userTask()
         .ofInstance(processInstanceKey)
         .withAssignee("assignee")
@@ -94,7 +93,7 @@ public class UserTaskCompleteAuthorizationTest {
         PROCESS_ID);
 
     // when
-    ENGINE
+    engine
         .userTask()
         .ofInstance(processInstanceKey)
         .withAssignee("assignee")
@@ -116,7 +115,7 @@ public class UserTaskCompleteAuthorizationTest {
 
     // when
     final var rejection =
-        ENGINE
+        engine
             .userTask()
             .ofInstance(processInstanceKey)
             .withAssignee("assignee")
@@ -131,8 +130,8 @@ public class UserTaskCompleteAuthorizationTest {
                 .formatted(PROCESS_ID));
   }
 
-  private static UserRecordValue createUser() {
-    return ENGINE
+  private UserRecordValue createUser() {
+    return engine
         .user()
         .newUser(UUID.randomUUID().toString())
         .withPassword(UUID.randomUUID().toString())
@@ -147,7 +146,7 @@ public class UserTaskCompleteAuthorizationTest {
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
       final String... resourceIds) {
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(userKey)
@@ -157,6 +156,6 @@ public class UserTaskCompleteAuthorizationTest {
   }
 
   private long createProcessInstance() {
-    return ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+    return engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCompleteAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCompleteAuthorizationTest.java
@@ -14,10 +14,10 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
@@ -42,21 +42,13 @@ public class UserTaskCompleteAuthorizationTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withoutAwaitingIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
-  private static long defaultUserKey = -1L;
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
   @BeforeClass
   public static void beforeAll() {
-    defaultUserKey =
-        RecordingExporter.userRecords(UserIntent.CREATED)
-            .withUsername(DEFAULT_USER.getUsername())
-            .getFirst()
-            .getKey();
-
     ENGINE
         .deployment()
         .withXmlResource(
@@ -67,7 +59,7 @@ public class UserTaskCompleteAuthorizationTest {
                 .zeebeUserTask()
                 .endEvent()
                 .done())
-        .deploy(defaultUserKey);
+        .deploy(DEFAULT_USER.getUsername());
   }
 
   @Test
@@ -80,7 +72,7 @@ public class UserTaskCompleteAuthorizationTest {
         .userTask()
         .ofInstance(processInstanceKey)
         .withAssignee("assignee")
-        .complete(defaultUserKey);
+        .complete(DEFAULT_USER.getUsername());
 
     // then
     assertThat(
@@ -94,15 +86,19 @@ public class UserTaskCompleteAuthorizationTest {
   public void shouldBeAuthorizedToCompleteUserTaskWithUser() {
     // given
     final var processInstanceKey = createProcessInstance();
-    final var userKey = createUser();
+    final var user = createUser();
     addPermissionsToUser(
-        userKey,
+        user.getUserKey(),
         AuthorizationResourceType.PROCESS_DEFINITION,
         PermissionType.UPDATE_USER_TASK,
         PROCESS_ID);
 
     // when
-    ENGINE.userTask().ofInstance(processInstanceKey).withAssignee("assignee").complete(userKey);
+    ENGINE
+        .userTask()
+        .ofInstance(processInstanceKey)
+        .withAssignee("assignee")
+        .complete(user.getUsername());
 
     // then
     assertThat(
@@ -116,7 +112,7 @@ public class UserTaskCompleteAuthorizationTest {
   public void shouldBeUnauthorizedToCompleteUserTaskIfNoPermissions() {
     // given
     final var processInstanceKey = createProcessInstance();
-    final var userKey = createUser();
+    final var user = createUser();
 
     // when
     final var rejection =
@@ -125,7 +121,7 @@ public class UserTaskCompleteAuthorizationTest {
             .ofInstance(processInstanceKey)
             .withAssignee("assignee")
             .expectRejection()
-            .complete(userKey);
+            .complete(user.getUsername());
 
     // then
     Assertions.assertThat(rejection)
@@ -135,7 +131,7 @@ public class UserTaskCompleteAuthorizationTest {
                 .formatted(PROCESS_ID));
   }
 
-  private static long createUser() {
+  private static UserRecordValue createUser() {
     return ENGINE
         .user()
         .newUser(UUID.randomUUID().toString())
@@ -143,7 +139,7 @@ public class UserTaskCompleteAuthorizationTest {
         .withName(UUID.randomUUID().toString())
         .withEmail(UUID.randomUUID().toString())
         .create()
-        .getKey();
+        .getValue();
   }
 
   private void addPermissionsToUser(
@@ -157,10 +153,10 @@ public class UserTaskCompleteAuthorizationTest {
         .withOwnerKey(userKey)
         .withResourceType(authorization)
         .withPermission(permissionType, resourceIds)
-        .add(defaultUserKey);
+        .add(DEFAULT_USER.getUsername());
   }
 
   private long createProcessInstance() {
-    return ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create(defaultUserKey);
+    return ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskUpdateAuthorizationTest.java
@@ -23,8 +23,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.UUID;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -40,17 +39,17 @@ public class UserTaskUpdateAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
 
-  @ClassRule
-  public static final EngineRule ENGINE =
+  @Rule
+  public final EngineRule engine =
       EngineRule.singlePartition()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
-  @BeforeClass
-  public static void beforeAll() {
-    ENGINE
+  @Before
+  public void before() {
+    engine
         .deployment()
         .withXmlResource(
             "process.bpmn",
@@ -69,7 +68,7 @@ public class UserTaskUpdateAuthorizationTest {
     final var processInstanceKey = createProcessInstance();
 
     // when
-    ENGINE
+    engine
         .userTask()
         .ofInstance(processInstanceKey)
         .update(new UserTaskRecord(), DEFAULT_USER.getUsername());
@@ -94,7 +93,7 @@ public class UserTaskUpdateAuthorizationTest {
         PROCESS_ID);
 
     // when
-    ENGINE
+    engine
         .userTask()
         .ofInstance(processInstanceKey)
         .update(new UserTaskRecord(), user.getUsername());
@@ -115,7 +114,7 @@ public class UserTaskUpdateAuthorizationTest {
 
     // when
     final var rejection =
-        ENGINE
+        engine
             .userTask()
             .ofInstance(processInstanceKey)
             .update(new UserTaskRecord(), user.getUsername());
@@ -128,8 +127,8 @@ public class UserTaskUpdateAuthorizationTest {
                 .formatted(PROCESS_ID));
   }
 
-  private static UserRecordValue createUser() {
-    return ENGINE
+  private UserRecordValue createUser() {
+    return engine
         .user()
         .newUser(UUID.randomUUID().toString())
         .withPassword(UUID.randomUUID().toString())
@@ -144,7 +143,7 @@ public class UserTaskUpdateAuthorizationTest {
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
       final String... resourceIds) {
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(userKey)
@@ -154,6 +153,6 @@ public class UserTaskUpdateAuthorizationTest {
   }
 
   private long createProcessInstance() {
-    return ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+    return engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateAuthorizationTest.java
@@ -23,8 +23,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -39,17 +38,17 @@ public class VariableDocumentUpdateAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
 
-  @ClassRule
-  public static final EngineRule ENGINE =
+  @Rule
+  public final EngineRule engine =
       EngineRule.singlePartition()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
-  @BeforeClass
-  public static void beforeAll() {
-    ENGINE
+  @Before
+  public void before() {
+    engine
         .deployment()
         .withXmlResource(
             "process.bpmn",
@@ -67,7 +66,7 @@ public class VariableDocumentUpdateAuthorizationTest {
     final var processInstanceKey = createProcessInstance();
 
     // when
-    ENGINE
+    engine
         .variables()
         .ofScope(processInstanceKey)
         .withDocument(Map.of("foo", "bar"))
@@ -93,7 +92,7 @@ public class VariableDocumentUpdateAuthorizationTest {
         PROCESS_ID);
 
     // when
-    ENGINE
+    engine
         .variables()
         .ofScope(processInstanceKey)
         .withDocument(Map.of("foo", "bar"))
@@ -115,7 +114,7 @@ public class VariableDocumentUpdateAuthorizationTest {
 
     // when
     final var rejection =
-        ENGINE
+        engine
             .variables()
             .ofScope(processInstanceKey)
             .withDocument(Map.of("foo", "bar"))
@@ -130,8 +129,8 @@ public class VariableDocumentUpdateAuthorizationTest {
                 .formatted(PROCESS_ID));
   }
 
-  private static UserRecordValue createUser() {
-    return ENGINE
+  private UserRecordValue createUser() {
+    return engine
         .user()
         .newUser(UUID.randomUUID().toString())
         .withPassword(UUID.randomUUID().toString())
@@ -146,7 +145,7 @@ public class VariableDocumentUpdateAuthorizationTest {
       final AuthorizationResourceType authorization,
       final PermissionType permissionType,
       final String... resourceIds) {
-    ENGINE
+    engine
         .authorization()
         .permission()
         .withOwnerKey(userKey)
@@ -156,6 +155,6 @@ public class VariableDocumentUpdateAuthorizationTest {
   }
 
   private long createProcessInstance() {
-    return ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
+    return engine.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateAuthorizationTest.java
@@ -14,10 +14,10 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
@@ -42,21 +42,13 @@ public class VariableDocumentUpdateAuthorizationTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withoutAwaitingIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 
-  private static long defaultUserKey = -1L;
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
   @BeforeClass
   public static void beforeAll() {
-    defaultUserKey =
-        RecordingExporter.userRecords(UserIntent.CREATED)
-            .withUsername(DEFAULT_USER.getUsername())
-            .getFirst()
-            .getKey();
-
     ENGINE
         .deployment()
         .withXmlResource(
@@ -66,7 +58,7 @@ public class VariableDocumentUpdateAuthorizationTest {
                 .userTask("task")
                 .endEvent()
                 .done())
-        .deploy(defaultUserKey);
+        .deploy(DEFAULT_USER.getUsername());
   }
 
   @Test
@@ -79,7 +71,7 @@ public class VariableDocumentUpdateAuthorizationTest {
         .variables()
         .ofScope(processInstanceKey)
         .withDocument(Map.of("foo", "bar"))
-        .update(defaultUserKey);
+        .update(DEFAULT_USER.getUsername());
 
     // then
     assertThat(
@@ -93,9 +85,9 @@ public class VariableDocumentUpdateAuthorizationTest {
   public void shouldBeAuthorizedToUpdateVariablesWithUser() {
     // given
     final var processInstanceKey = createProcessInstance();
-    final var userKey = createUser();
+    final var user = createUser();
     addPermissionsToUser(
-        userKey,
+        user.getUserKey(),
         AuthorizationResourceType.PROCESS_DEFINITION,
         PermissionType.UPDATE_PROCESS_INSTANCE,
         PROCESS_ID);
@@ -105,7 +97,7 @@ public class VariableDocumentUpdateAuthorizationTest {
         .variables()
         .ofScope(processInstanceKey)
         .withDocument(Map.of("foo", "bar"))
-        .update(userKey);
+        .update(user.getUsername());
 
     // then
     assertThat(
@@ -119,7 +111,7 @@ public class VariableDocumentUpdateAuthorizationTest {
   public void shouldBeUnauthorizedToUpdateVariablesIfNoPermissions() {
     // given
     final var processInstanceKey = createProcessInstance();
-    final var userKey = createUser();
+    final var user = createUser();
 
     // when
     final var rejection =
@@ -128,7 +120,7 @@ public class VariableDocumentUpdateAuthorizationTest {
             .ofScope(processInstanceKey)
             .withDocument(Map.of("foo", "bar"))
             .expectRejection()
-            .update(userKey);
+            .update(user.getUsername());
 
     // then
     Assertions.assertThat(rejection)
@@ -138,7 +130,7 @@ public class VariableDocumentUpdateAuthorizationTest {
                 .formatted(PROCESS_ID));
   }
 
-  private static long createUser() {
+  private static UserRecordValue createUser() {
     return ENGINE
         .user()
         .newUser(UUID.randomUUID().toString())
@@ -146,7 +138,7 @@ public class VariableDocumentUpdateAuthorizationTest {
         .withName(UUID.randomUUID().toString())
         .withEmail(UUID.randomUUID().toString())
         .create()
-        .getKey();
+        .getValue();
   }
 
   private void addPermissionsToUser(
@@ -160,10 +152,10 @@ public class VariableDocumentUpdateAuthorizationTest {
         .withOwnerKey(userKey)
         .withResourceType(authorization)
         .withPermission(permissionType, resourceIds)
-        .add(defaultUserKey);
+        .add(DEFAULT_USER.getUsername());
   }
 
   private long createProcessInstance() {
-    return ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create(defaultUserKey);
+    return ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create(DEFAULT_USER.getUsername());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/AuthorizationUtil.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/AuthorizationUtil.java
@@ -31,7 +31,7 @@ public class AuthorizationUtil {
     final var auth = new AuthInfo();
     auth.setClaims(
         Map.of(
-            Authorization.AUTHORIZED_USER_KEY,
+            Authorization.AUTHORIZED_USERNAME,
             userKey,
             Authorization.AUTHORIZED_TENANTS,
             List.of(authorizedTenantIds)));
@@ -40,7 +40,7 @@ public class AuthorizationUtil {
 
   public static AuthInfo getAuthInfo(final long userKey) {
     final var auth = new AuthInfo();
-    auth.setClaims(Map.of(Authorization.AUTHORIZED_USER_KEY, userKey));
+    auth.setClaims(Map.of(Authorization.AUTHORIZED_USERNAME, userKey));
     return auth;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/AuthorizationUtil.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/AuthorizationUtil.java
@@ -27,20 +27,21 @@ public class AuthorizationUtil {
     return auth;
   }
 
-  public static AuthInfo getAuthInfo(final long userKey, final String... authorizedTenantIds) {
+  public static AuthInfo getUsernameAuthInfo(
+      final String username, final String... authorizedTenantIds) {
     final var auth = new AuthInfo();
     auth.setClaims(
         Map.of(
             Authorization.AUTHORIZED_USERNAME,
-            userKey,
+            username,
             Authorization.AUTHORIZED_TENANTS,
             List.of(authorizedTenantIds)));
     return auth;
   }
 
-  public static AuthInfo getAuthInfo(final long userKey) {
+  public static AuthInfo getAuthInfo(final String username) {
     final var auth = new AuthInfo();
-    auth.setClaims(Map.of(Authorization.AUTHORIZED_USERNAME, userKey));
+    auth.setClaims(Map.of(Authorization.AUTHORIZED_USERNAME, username));
     return auth;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -184,8 +184,8 @@ public class StreamProcessingComposite implements CommandWriter {
   @Override
   public long writeCommand(
       final Intent intent,
-      final UnifiedRecordValue value,
       final long userKey,
+      final UnifiedRecordValue value,
       final String... authorizedTenants) {
     final var requestId = new Random().nextLong();
     final var requestStreamId = new Random().nextInt();
@@ -244,8 +244,8 @@ public class StreamProcessingComposite implements CommandWriter {
   public long writeCommand(
       final long key,
       final Intent intent,
-      final UnifiedRecordValue recordValue,
       final long userKey,
+      final UnifiedRecordValue recordValue,
       final String... authorizedTenants) {
     final var requestId = new Random().nextLong();
     final var requestStreamId = new Random().nextInt();
@@ -289,8 +289,8 @@ public class StreamProcessingComposite implements CommandWriter {
       final int requestStreamId,
       final long requestId,
       final Intent intent,
-      final UnifiedRecordValue recordValue,
       final long userKey,
+      final UnifiedRecordValue recordValue,
       final String... authorizedTenants) {
     final var writer =
         streams
@@ -417,8 +417,8 @@ public class StreamProcessingComposite implements CommandWriter {
       final int partition,
       final long key,
       final Intent intent,
-      final UnifiedRecordValue value,
       final long userKey,
+      final UnifiedRecordValue value,
       final String... authorizedTenants) {
     final var requestId = new Random().nextLong();
     final var requestStreamId = new Random().nextInt();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -184,7 +184,7 @@ public class StreamProcessingComposite implements CommandWriter {
   @Override
   public long writeCommand(
       final Intent intent,
-      final long userKey,
+      final String username,
       final UnifiedRecordValue value,
       final String... authorizedTenants) {
     final var requestId = new Random().nextLong();
@@ -194,7 +194,7 @@ public class StreamProcessingComposite implements CommandWriter {
             .newRecord(getLogName(partitionId))
             .recordType(RecordType.COMMAND)
             .intent(intent)
-            .authorizationsWithUserKey(userKey, authorizedTenants)
+            .authorizationsWithUsername(username, authorizedTenants)
             .requestId(requestId)
             .requestStreamId(requestStreamId)
             .event(value);
@@ -244,7 +244,7 @@ public class StreamProcessingComposite implements CommandWriter {
   public long writeCommand(
       final long key,
       final Intent intent,
-      final long userKey,
+      final String username,
       final UnifiedRecordValue recordValue,
       final String... authorizedTenants) {
     final var requestId = new Random().nextLong();
@@ -255,7 +255,7 @@ public class StreamProcessingComposite implements CommandWriter {
             .recordType(RecordType.COMMAND)
             .key(key)
             .intent(intent)
-            .authorizationsWithUserKey(userKey, authorizedTenants)
+            .authorizationsWithUsername(username, authorizedTenants)
             .requestId(requestId)
             .requestStreamId(requestStreamId)
             .event(recordValue);
@@ -289,7 +289,7 @@ public class StreamProcessingComposite implements CommandWriter {
       final int requestStreamId,
       final long requestId,
       final Intent intent,
-      final long userKey,
+      final String username,
       final UnifiedRecordValue recordValue,
       final String... authorizedTenants) {
     final var writer =
@@ -300,7 +300,7 @@ public class StreamProcessingComposite implements CommandWriter {
             .requestStreamId(requestStreamId)
             .requestId(requestId)
             .intent(intent)
-            .authorizationsWithUserKey(userKey, authorizedTenants)
+            .authorizationsWithUsername(username, authorizedTenants)
             .event(recordValue);
     return writeActor.submit(writer::write).join();
   }
@@ -329,7 +329,7 @@ public class StreamProcessingComposite implements CommandWriter {
       final long requestId,
       final Intent intent,
       final UnifiedRecordValue value,
-      final long userKey) {
+      final String username) {
     final var writer =
         streams
             .newRecord(getLogName(partitionId))
@@ -337,7 +337,7 @@ public class StreamProcessingComposite implements CommandWriter {
             .requestId(requestId)
             .requestStreamId(requestStreamId)
             .intent(intent)
-            .authorizationsWithUserKey(userKey, TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+            .authorizationsWithUsername(username, TenantOwned.DEFAULT_TENANT_IDENTIFIER)
             .event(value);
     return writeActor.submit(writer::write).join();
   }
@@ -361,7 +361,7 @@ public class StreamProcessingComposite implements CommandWriter {
       final int partition,
       final Intent intent,
       final UnifiedRecordValue value,
-      final long userKey) {
+      final String username) {
     final var requestId = new Random().nextLong();
     final var requestStreamId = new Random().nextInt();
     final var writer =
@@ -369,7 +369,7 @@ public class StreamProcessingComposite implements CommandWriter {
             .newRecord(getLogName(partition))
             .recordType(RecordType.COMMAND)
             .intent(intent)
-            .authorizations(userKey)
+            .usernameAuthorizations(username)
             .requestId(requestId)
             .requestStreamId(requestStreamId)
             .event(value);
@@ -417,7 +417,7 @@ public class StreamProcessingComposite implements CommandWriter {
       final int partition,
       final long key,
       final Intent intent,
-      final long userKey,
+      final String username,
       final UnifiedRecordValue value,
       final String... authorizedTenants) {
     final var requestId = new Random().nextLong();
@@ -428,7 +428,7 @@ public class StreamProcessingComposite implements CommandWriter {
             .key(key)
             .recordType(RecordType.COMMAND)
             .intent(intent)
-            .authorizationsWithUserKey(userKey, authorizedTenants)
+            .authorizationsWithUsername(username, authorizedTenants)
             .requestId(requestId)
             .requestStreamId(requestStreamId)
             .event(value);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -222,10 +222,10 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
   @Override
   public long writeCommand(
       final Intent intent,
-      final long userKey,
+      final String username,
       final UnifiedRecordValue recordValue,
       final String... authorizedTenants) {
-    return streamProcessingComposite.writeCommand(intent, userKey, recordValue, authorizedTenants);
+    return streamProcessingComposite.writeCommand(intent, username, recordValue, authorizedTenants);
   }
 
   @Override
@@ -252,11 +252,11 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
   public long writeCommand(
       final long key,
       final Intent intent,
-      final long userKey,
+      final String username,
       final UnifiedRecordValue recordValue,
       final String... authorizedTenants) {
     return streamProcessingComposite.writeCommand(
-        key, intent, userKey, recordValue, authorizedTenants);
+        key, intent, username, recordValue, authorizedTenants);
   }
 
   @Override
@@ -277,11 +277,11 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
       final int requestStreamId,
       final long requestId,
       final Intent intent,
-      final long userKey,
+      final String username,
       final UnifiedRecordValue recordValue,
       final String... authorizedTenants) {
     return streamProcessingComposite.writeCommand(
-        key, requestStreamId, requestId, intent, userKey, recordValue, authorizedTenants);
+        key, requestStreamId, requestId, intent, username, recordValue, authorizedTenants);
   }
 
   @Override
@@ -299,9 +299,9 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
       final long requestId,
       final Intent intent,
       final UnifiedRecordValue value,
-      final long userKey) {
+      final String username) {
     return streamProcessingComposite.writeCommand(
-        requestStreamId, requestId, intent, value, userKey);
+        requestStreamId, requestId, intent, value, username);
   }
 
   @Override
@@ -315,9 +315,9 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
       final int partitionId,
       final Intent intent,
       final UnifiedRecordValue recordValue,
-      final long userKey) {
+      final String username) {
     return streamProcessingComposite.writeCommandOnPartition(
-        partitionId, intent, recordValue, userKey);
+        partitionId, intent, recordValue, username);
   }
 
   @Override
@@ -353,11 +353,11 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
       final int partitionId,
       final long key,
       final Intent intent,
-      final long userKey,
+      final String username,
       final UnifiedRecordValue recordValue,
       final String... authorizedTenants) {
     return streamProcessingComposite.writeCommandOnPartition(
-        partitionId, key, intent, userKey, recordValue, authorizedTenants);
+        partitionId, key, intent, username, recordValue, authorizedTenants);
   }
 
   public void snapshot() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -222,10 +222,10 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
   @Override
   public long writeCommand(
       final Intent intent,
-      final UnifiedRecordValue recordValue,
       final long userKey,
+      final UnifiedRecordValue recordValue,
       final String... authorizedTenants) {
-    return streamProcessingComposite.writeCommand(intent, recordValue, userKey, authorizedTenants);
+    return streamProcessingComposite.writeCommand(intent, userKey, recordValue, authorizedTenants);
   }
 
   @Override
@@ -252,11 +252,11 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
   public long writeCommand(
       final long key,
       final Intent intent,
-      final UnifiedRecordValue recordValue,
       final long userKey,
+      final UnifiedRecordValue recordValue,
       final String... authorizedTenants) {
     return streamProcessingComposite.writeCommand(
-        key, intent, recordValue, userKey, authorizedTenants);
+        key, intent, userKey, recordValue, authorizedTenants);
   }
 
   @Override
@@ -277,11 +277,11 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
       final int requestStreamId,
       final long requestId,
       final Intent intent,
-      final UnifiedRecordValue recordValue,
       final long userKey,
+      final UnifiedRecordValue recordValue,
       final String... authorizedTenants) {
     return streamProcessingComposite.writeCommand(
-        key, requestStreamId, requestId, intent, recordValue, userKey, authorizedTenants);
+        key, requestStreamId, requestId, intent, userKey, recordValue, authorizedTenants);
   }
 
   @Override
@@ -353,11 +353,11 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
       final int partitionId,
       final long key,
       final Intent intent,
-      final UnifiedRecordValue recordValue,
       final long userKey,
+      final UnifiedRecordValue recordValue,
       final String... authorizedTenants) {
     return streamProcessingComposite.writeCommandOnPartition(
-        partitionId, key, intent, recordValue, userKey, authorizedTenants);
+        partitionId, key, intent, userKey, recordValue, authorizedTenants);
   }
 
   public void snapshot() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -417,13 +417,13 @@ public final class TestStreams {
       return authorizations(AuthorizationUtil.getAuthInfo(tenantIds));
     }
 
-    public FluentLogWriter authorizations(final long userKey) {
-      return authorizations(AuthorizationUtil.getAuthInfo(userKey));
+    public FluentLogWriter usernameAuthorizations(final String username) {
+      return authorizations(AuthorizationUtil.getAuthInfo(username));
     }
 
-    public FluentLogWriter authorizationsWithUserKey(
-        final long userKey, final String... tenantIds) {
-      return authorizations(AuthorizationUtil.getAuthInfo(userKey, tenantIds));
+    public FluentLogWriter authorizationsWithUsername(
+        final String username, final String... tenantIds) {
+      return authorizations(AuthorizationUtil.getUsernameAuthInfo(username, tenantIds));
     }
 
     public FluentLogWriter authorizations(final AuthInfo authorizations) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AuthorizationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AuthorizationClient.java
@@ -110,7 +110,7 @@ public final class AuthorizationClient {
       expectation = expectRejection ? ADD_REJECTION_SUPPLIER : ADD_SUCCESS_SUPPLIER;
       final long position =
           writer.writeCommand(
-              AuthorizationIntent.ADD_PERMISSION, authorizationCreationRecord, userKey);
+              AuthorizationIntent.ADD_PERMISSION, userKey, authorizationCreationRecord);
       return expectation.apply(position);
     }
 
@@ -130,7 +130,7 @@ public final class AuthorizationClient {
       expectation = expectRejection ? REMOVE_REJECTION_SUPPLIER : REMOVE_SUCCESS_SUPPLIER;
       final long position =
           writer.writeCommand(
-              AuthorizationIntent.REMOVE_PERMISSION, authorizationCreationRecord, userKey);
+              AuthorizationIntent.REMOVE_PERMISSION, userKey, authorizationCreationRecord);
       return expectation.apply(position);
     }
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AuthorizationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AuthorizationClient.java
@@ -106,11 +106,11 @@ public final class AuthorizationClient {
       return expectation.apply(position);
     }
 
-    public Record<AuthorizationRecordValue> add(final long userKey) {
+    public Record<AuthorizationRecordValue> add(final String username) {
       expectation = expectRejection ? ADD_REJECTION_SUPPLIER : ADD_SUCCESS_SUPPLIER;
       final long position =
           writer.writeCommand(
-              AuthorizationIntent.ADD_PERMISSION, userKey, authorizationCreationRecord);
+              AuthorizationIntent.ADD_PERMISSION, username, authorizationCreationRecord);
       return expectation.apply(position);
     }
 
@@ -126,11 +126,11 @@ public final class AuthorizationClient {
       return expectation.apply(position);
     }
 
-    public Record<AuthorizationRecordValue> remove(final long userKey) {
+    public Record<AuthorizationRecordValue> remove(final String username) {
       expectation = expectRejection ? REMOVE_REJECTION_SUPPLIER : REMOVE_SUCCESS_SUPPLIER;
       final long position =
           writer.writeCommand(
-              AuthorizationIntent.REMOVE_PERMISSION, userKey, authorizationCreationRecord);
+              AuthorizationIntent.REMOVE_PERMISSION, username, authorizationCreationRecord);
       return expectation.apply(position);
     }
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ClockClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ClockClient.java
@@ -70,14 +70,14 @@ public class ClockClient {
     return pinAt(instant.toEpochMilli());
   }
 
-  public Record<ClockRecordValue> pinAt(final Instant instant, final long userKey) {
-    return pinAt(instant.toEpochMilli(), userKey);
+  public Record<ClockRecordValue> pinAt(final Instant instant, final String username) {
+    return pinAt(instant.toEpochMilli(), username);
   }
 
-  public Record<ClockRecordValue> pinAt(final long timestamp, final long userKey) {
+  public Record<ClockRecordValue> pinAt(final long timestamp, final String username) {
     record.pinAt(timestamp);
 
-    final long position = writeCommand(ClockIntent.PIN, userKey);
+    final long position = writeCommand(ClockIntent.PIN, username);
     return Objects.requireNonNullElse(expectation, PIN_SUCCESS_EXPECTATION).apply(position);
   }
 
@@ -96,7 +96,7 @@ public class ClockClient {
     return writer.writeCommand(intent, record);
   }
 
-  private long writeCommand(final ClockIntent intent, final long userKey) {
-    return writer.writeCommand(intent, userKey, record);
+  private long writeCommand(final ClockIntent intent, final String username) {
+    return writer.writeCommand(intent, username, record);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ClockClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ClockClient.java
@@ -97,6 +97,6 @@ public class ClockClient {
   }
 
   private long writeCommand(final ClockIntent intent, final long userKey) {
-    return writer.writeCommand(intent, record, userKey);
+    return writer.writeCommand(intent, userKey, record);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/CommandWriter.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/CommandWriter.java
@@ -20,8 +20,8 @@ public interface CommandWriter {
 
   long writeCommand(
       final Intent intent,
-      final UnifiedRecordValue recordValue,
       final long userKey,
+      final UnifiedRecordValue recordValue,
       String... authorizedTenants);
 
   long writeCommand(long key, Intent intent, UnifiedRecordValue recordValue);
@@ -38,8 +38,8 @@ public interface CommandWriter {
   long writeCommand(
       final long key,
       final Intent intent,
-      final UnifiedRecordValue recordValue,
       final long userKey,
+      final UnifiedRecordValue recordValue,
       final String... authorizedTenants);
 
   long writeCommand(
@@ -55,8 +55,8 @@ public interface CommandWriter {
       final int requestStreamId,
       final long requestId,
       final Intent intent,
-      final UnifiedRecordValue recordValue,
       final long userKey,
+      final UnifiedRecordValue recordValue,
       final String... authorizedTenants);
 
   long writeCommand(
@@ -102,7 +102,7 @@ public interface CommandWriter {
       int partitionId,
       long key,
       Intent intent,
-      UnifiedRecordValue recordValue,
       final long userKey,
+      UnifiedRecordValue recordValue,
       final String... authorizedTenants);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/CommandWriter.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/CommandWriter.java
@@ -20,7 +20,7 @@ public interface CommandWriter {
 
   long writeCommand(
       final Intent intent,
-      final long userKey,
+      final String username,
       final UnifiedRecordValue recordValue,
       String... authorizedTenants);
 
@@ -38,7 +38,7 @@ public interface CommandWriter {
   long writeCommand(
       final long key,
       final Intent intent,
-      final long userKey,
+      final String username,
       final UnifiedRecordValue recordValue,
       final String... authorizedTenants);
 
@@ -55,7 +55,7 @@ public interface CommandWriter {
       final int requestStreamId,
       final long requestId,
       final Intent intent,
-      final long userKey,
+      final String username,
       final UnifiedRecordValue recordValue,
       final String... authorizedTenants);
 
@@ -70,7 +70,7 @@ public interface CommandWriter {
       final long requestId,
       final Intent intent,
       final UnifiedRecordValue value,
-      final long userKey);
+      final String username);
 
   long writeCommandOnPartition(
       final int partitionId, final Intent intent, final UnifiedRecordValue recordValue);
@@ -79,7 +79,7 @@ public interface CommandWriter {
       final int partitionId,
       final Intent intent,
       final UnifiedRecordValue recordValue,
-      final long userKey);
+      final String username);
 
   long writeCommandOnPartition(
       int partitionId, long key, Intent intent, UnifiedRecordValue recordValue);
@@ -102,7 +102,7 @@ public interface CommandWriter {
       int partitionId,
       long key,
       Intent intent,
-      final long userKey,
+      final String username,
       UnifiedRecordValue recordValue,
       final String... authorizedTenants);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/DecisionEvaluationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/DecisionEvaluationClient.java
@@ -85,9 +85,9 @@ public class DecisionEvaluationClient {
     return expectation.apply(position);
   }
 
-  public Record<DecisionEvaluationRecordValue> evaluate(final long userKey) {
+  public Record<DecisionEvaluationRecordValue> evaluate(final String username) {
     final long position =
-        writer.writeCommand(DecisionEvaluationIntent.EVALUATE, userKey, decisionEvaluationRecord);
+        writer.writeCommand(DecisionEvaluationIntent.EVALUATE, username, decisionEvaluationRecord);
 
     return expectation.apply(position);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/DecisionEvaluationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/DecisionEvaluationClient.java
@@ -87,7 +87,7 @@ public class DecisionEvaluationClient {
 
   public Record<DecisionEvaluationRecordValue> evaluate(final long userKey) {
     final long position =
-        writer.writeCommand(DecisionEvaluationIntent.EVALUATE, decisionEvaluationRecord, userKey);
+        writer.writeCommand(DecisionEvaluationIntent.EVALUATE, userKey, decisionEvaluationRecord);
 
     return expectation.apply(position);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/DeploymentClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/DeploymentClient.java
@@ -176,8 +176,8 @@ public final class DeploymentClient {
     return expectation.apply(position, forEachPartition);
   }
 
-  public Record<DeploymentRecordValue> deploy(final long userKey) {
-    final long position = writer.writeCommand(DeploymentIntent.CREATE, userKey, deploymentRecord);
+  public Record<DeploymentRecordValue> deploy(final String username) {
+    final long position = writer.writeCommand(DeploymentIntent.CREATE, username, deploymentRecord);
 
     return expectation.apply(position, forEachPartition);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/DeploymentClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/DeploymentClient.java
@@ -177,7 +177,7 @@ public final class DeploymentClient {
   }
 
   public Record<DeploymentRecordValue> deploy(final long userKey) {
-    final long position = writer.writeCommand(DeploymentIntent.CREATE, deploymentRecord, userKey);
+    final long position = writer.writeCommand(DeploymentIntent.CREATE, userKey, deploymentRecord);
 
     return expectation.apply(position, forEachPartition);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/IncidentClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/IncidentClient.java
@@ -130,8 +130,8 @@ public final class IncidentClient {
               Protocol.decodePartitionId(incidentKey),
               incidentKey,
               IncidentIntent.RESOLVE,
-              incidentRecord,
               userKey,
+              incidentRecord,
               TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
       return expectation.apply(position);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/IncidentClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/IncidentClient.java
@@ -116,7 +116,7 @@ public final class IncidentClient {
       return expectation.apply(position);
     }
 
-    public Record<IncidentRecordValue> resolve(final long userKey) {
+    public Record<IncidentRecordValue> resolve(final String username) {
       if (incidentKey == DEFAULT_KEY) {
         incidentKey =
             RecordingExporter.incidentRecords(IncidentIntent.CREATED)
@@ -130,7 +130,7 @@ public final class IncidentClient {
               Protocol.decodePartitionId(incidentKey),
               incidentKey,
               IncidentIntent.RESOLVE,
-              userKey,
+              username,
               incidentRecord,
               TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobActivationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobActivationClient.java
@@ -116,10 +116,10 @@ public final class JobActivationClient {
     return expectation.apply(partitionId, position);
   }
 
-  public Record<JobBatchRecordValue> activate(final long userKey) {
+  public Record<JobBatchRecordValue> activate(final String username) {
     final long position =
         writer.writeCommandOnPartition(
-            partitionId, JobBatchIntent.ACTIVATE, jobBatchRecord, userKey);
+            partitionId, JobBatchIntent.ACTIVATE, jobBatchRecord, username);
 
     return expectation.apply(partitionId, position);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobClient.java
@@ -161,8 +161,8 @@ public final class JobClient {
         writer.writeCommand(
             jobKey,
             JobIntent.COMPLETE,
-            jobRecord,
             userKey,
+            jobRecord,
             authorizedTenantIds.toArray(new String[0]));
     return expectation.apply(position);
   }
@@ -180,7 +180,7 @@ public final class JobClient {
     final long jobKey = findJobKey();
     final long position =
         writer.writeCommand(
-            jobKey, JobIntent.FAIL, jobRecord, userKey, authorizedTenantIds.toArray(new String[0]));
+            jobKey, JobIntent.FAIL, userKey, jobRecord, authorizedTenantIds.toArray(new String[0]));
 
     return expectation.apply(position);
   }
@@ -209,8 +209,8 @@ public final class JobClient {
         writer.writeCommand(
             jobKey,
             JobIntent.UPDATE_RETRIES,
-            jobRecord,
             userKey,
+            jobRecord,
             authorizedTenantIds.toArray(new String[0]));
     return expectation.apply(position);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobClient.java
@@ -155,13 +155,13 @@ public final class JobClient {
     return expectation.apply(position);
   }
 
-  public Record<JobRecordValue> complete(final long userKey) {
+  public Record<JobRecordValue> complete(final String username) {
     final long jobKey = findJobKey();
     final long position =
         writer.writeCommand(
             jobKey,
             JobIntent.COMPLETE,
-            userKey,
+            username,
             jobRecord,
             authorizedTenantIds.toArray(new String[0]));
     return expectation.apply(position);
@@ -176,11 +176,15 @@ public final class JobClient {
     return expectation.apply(position);
   }
 
-  public Record<JobRecordValue> fail(final long userKey) {
+  public Record<JobRecordValue> fail(final String username) {
     final long jobKey = findJobKey();
     final long position =
         writer.writeCommand(
-            jobKey, JobIntent.FAIL, userKey, jobRecord, authorizedTenantIds.toArray(new String[0]));
+            jobKey,
+            JobIntent.FAIL,
+            username,
+            jobRecord,
+            authorizedTenantIds.toArray(new String[0]));
 
     return expectation.apply(position);
   }
@@ -203,13 +207,13 @@ public final class JobClient {
     return expectation.apply(position);
   }
 
-  public Record<JobRecordValue> updateRetries(final long userKey) {
+  public Record<JobRecordValue> updateRetries(final String username) {
     final long jobKey = findJobKey();
     final long position =
         writer.writeCommand(
             jobKey,
             JobIntent.UPDATE_RETRIES,
-            userKey,
+            username,
             jobRecord,
             authorizedTenantIds.toArray(new String[0]));
     return expectation.apply(position);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/MappingClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/MappingClient.java
@@ -71,8 +71,8 @@ public class MappingClient {
       return expectation.apply(position);
     }
 
-    public Record<MappingRecordValue> create(final long userKey) {
-      final long position = writer.writeCommand(MappingIntent.CREATE, userKey, mappingRecord);
+    public Record<MappingRecordValue> create(final String username) {
+      final long position = writer.writeCommand(MappingIntent.CREATE, username, mappingRecord);
       return expectation.apply(position);
     }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/MappingClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/MappingClient.java
@@ -72,7 +72,7 @@ public class MappingClient {
     }
 
     public Record<MappingRecordValue> create(final long userKey) {
-      final long position = writer.writeCommand(MappingIntent.CREATE, mappingRecord, userKey);
+      final long position = writer.writeCommand(MappingIntent.CREATE, userKey, mappingRecord);
       return expectation.apply(position);
     }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/MessageCorrelationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/MessageCorrelationClient.java
@@ -128,7 +128,7 @@ public final class MessageCorrelationClient {
         new Message(messageCorrelationRecord.getCorrelationKey(), position, partitionId));
   }
 
-  public Record<MessageCorrelationRecordValue> correlate(final long userKey) {
+  public Record<MessageCorrelationRecordValue> correlate(final String username) {
 
     if (partitionId == NOT_SET) {
       partitionId =
@@ -138,7 +138,7 @@ public final class MessageCorrelationClient {
 
     final var position =
         writer.writeCommandOnPartition(
-            partitionId, MessageCorrelationIntent.CORRELATE, messageCorrelationRecord, userKey);
+            partitionId, MessageCorrelationIntent.CORRELATE, messageCorrelationRecord, username);
     return expectation.apply(
         new Message(messageCorrelationRecord.getCorrelationKey(), position, partitionId));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -142,8 +142,8 @@ public final class ProcessInstanceClient {
       return resultingRecord.getValue().getProcessInstanceKey();
     }
 
-    public long create(final long userKey) {
-      return create(AuthorizationUtil.getAuthInfo(userKey));
+    public long create(final String username) {
+      return create(AuthorizationUtil.getAuthInfo(username));
     }
 
     public ProcessInstanceCreationClient expectRejection() {
@@ -197,14 +197,14 @@ public final class ProcessInstanceClient {
           .getProcessInstanceKey();
     }
 
-    public long create(final long userKey) {
+    public long create(final String username) {
       final long position =
           writer.writeCommand(
               requestStreamId,
               requestId,
               ProcessInstanceCreationIntent.CREATE_WITH_AWAITING_RESULT,
               record,
-              userKey);
+              username);
 
       return RecordingExporter.processInstanceCreationRecords()
           .withIntent(ProcessInstanceCreationIntent.CREATED)
@@ -222,13 +222,13 @@ public final class ProcessInstanceClient {
           record);
     }
 
-    public void asyncCreate(final long userKey) {
+    public void asyncCreate(final String username) {
       writer.writeCommand(
           requestStreamId,
           requestId,
           ProcessInstanceCreationIntent.CREATE_WITH_AWAITING_RESULT,
           record,
-          userKey);
+          username);
     }
   }
 
@@ -284,8 +284,8 @@ public final class ProcessInstanceClient {
       return expectation.apply(processInstanceKey);
     }
 
-    public Record<ProcessInstanceRecordValue> cancel(final long userKey) {
-      writeCancelCommandWithUserKey(userKey);
+    public Record<ProcessInstanceRecordValue> cancel(final String username) {
+      writeCancelCommandWithUserKey(username);
       return expectation.apply(processInstanceKey);
     }
 
@@ -311,7 +311,7 @@ public final class ProcessInstanceClient {
           authorizedTenants);
     }
 
-    private void writeCancelCommandWithUserKey(final long userKey) {
+    private void writeCancelCommandWithUserKey(final String username) {
       if (partition == DEFAULT_PARTITION) {
         partition =
             RecordingExporter.processInstanceRecords()
@@ -324,7 +324,7 @@ public final class ProcessInstanceClient {
           partition,
           processInstanceKey,
           ProcessInstanceIntent.CANCEL,
-          userKey,
+          username,
           new ProcessInstanceRecord().setProcessInstanceKey(processInstanceKey),
           authorizedTenants);
     }
@@ -467,7 +467,7 @@ public final class ProcessInstanceClient {
       }
     }
 
-    public Record<ProcessInstanceModificationRecordValue> modify(final long userKey) {
+    public Record<ProcessInstanceModificationRecordValue> modify(final String username) {
       record.setProcessInstanceKey(processInstanceKey);
       activateInstructions.forEach(record::addActivateInstruction);
 
@@ -475,7 +475,7 @@ public final class ProcessInstanceClient {
           writer.writeCommand(
               processInstanceKey,
               ProcessInstanceModificationIntent.MODIFY,
-              userKey,
+              username,
               record,
               authorizedTenants);
 
@@ -685,7 +685,7 @@ public final class ProcessInstanceClient {
       }
     }
 
-    public Record<ProcessInstanceMigrationRecordValue> migrate(final long userKey) {
+    public Record<ProcessInstanceMigrationRecordValue> migrate(final String username) {
       record.setProcessInstanceKey(processInstanceKey);
       mappingInstructions.forEach(record::addMappingInstruction);
 
@@ -693,7 +693,7 @@ public final class ProcessInstanceClient {
           writer.writeCommand(
               processInstanceKey,
               ProcessInstanceMigrationIntent.MIGRATE,
-              userKey,
+              username,
               record,
               authorizedTenants);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -324,8 +324,8 @@ public final class ProcessInstanceClient {
           partition,
           processInstanceKey,
           ProcessInstanceIntent.CANCEL,
-          new ProcessInstanceRecord().setProcessInstanceKey(processInstanceKey),
           userKey,
+          new ProcessInstanceRecord().setProcessInstanceKey(processInstanceKey),
           authorizedTenants);
     }
 
@@ -475,8 +475,8 @@ public final class ProcessInstanceClient {
           writer.writeCommand(
               processInstanceKey,
               ProcessInstanceModificationIntent.MODIFY,
-              record,
               userKey,
+              record,
               authorizedTenants);
 
       if (expectation == REJECTION_EXPECTATION) {
@@ -693,8 +693,8 @@ public final class ProcessInstanceClient {
           writer.writeCommand(
               processInstanceKey,
               ProcessInstanceMigrationIntent.MIGRATE,
-              record,
               userKey,
+              record,
               authorizedTenants);
 
       if (expectation == REJECTION_EXPECTATION) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/PublishMessageClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/PublishMessageClient.java
@@ -127,7 +127,7 @@ public final class PublishMessageClient {
     return expectation.apply(new Message(partitionId, messageRecord.getCorrelationKey(), position));
   }
 
-  public Record<MessageRecordValue> publish(final long userKey) {
+  public Record<MessageRecordValue> publish(final String username) {
 
     if (partitionId == DEFAULT_VALUE) {
       partitionId =
@@ -136,7 +136,7 @@ public final class PublishMessageClient {
     }
 
     final long position =
-        writer.writeCommandOnPartition(partitionId, MessageIntent.PUBLISH, messageRecord, userKey);
+        writer.writeCommandOnPartition(partitionId, MessageIntent.PUBLISH, messageRecord, username);
 
     return expectation.apply(new Message(partitionId, messageRecord.getCorrelationKey(), position));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ResourceDeletionClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ResourceDeletionClient.java
@@ -67,8 +67,9 @@ public class ResourceDeletionClient {
     return expectation.apply(position);
   }
 
-  public Record<ResourceDeletionRecordValue> delete(final long userKey) {
-    return delete(AuthorizationUtil.getAuthInfo(userKey, TenantOwned.DEFAULT_TENANT_IDENTIFIER));
+  public Record<ResourceDeletionRecordValue> delete(final String username) {
+    return delete(
+        AuthorizationUtil.getUsernameAuthInfo(username, TenantOwned.DEFAULT_TENANT_IDENTIFIER));
   }
 
   public ResourceDeletionClient expectRejection() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/RoleClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/RoleClient.java
@@ -74,8 +74,8 @@ public class RoleClient {
       return expectation.apply(position);
     }
 
-    public Record<RoleRecordValue> create(final long userKey) {
-      final long position = writer.writeCommand(RoleIntent.CREATE, userKey, roleRecord);
+    public Record<RoleRecordValue> create(final String username) {
+      final long position = writer.writeCommand(RoleIntent.CREATE, username, roleRecord);
       return expectation.apply(position);
     }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/RoleClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/RoleClient.java
@@ -75,7 +75,7 @@ public class RoleClient {
     }
 
     public Record<RoleRecordValue> create(final long userKey) {
-      final long position = writer.writeCommand(RoleIntent.CREATE, roleRecord, userKey);
+      final long position = writer.writeCommand(RoleIntent.CREATE, userKey, roleRecord);
       return expectation.apply(position);
     }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/SignalClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/SignalClient.java
@@ -81,8 +81,8 @@ public class SignalClient {
     return expectation.apply(position);
   }
 
-  public Record<SignalRecordValue> broadcast(final long userKey) {
-    final long position = writer.writeCommand(SignalIntent.BROADCAST, userKey, signalRecord);
+  public Record<SignalRecordValue> broadcast(final String username) {
+    final long position = writer.writeCommand(SignalIntent.BROADCAST, username, signalRecord);
     return expectation.apply(position);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/SignalClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/SignalClient.java
@@ -82,7 +82,7 @@ public class SignalClient {
   }
 
   public Record<SignalRecordValue> broadcast(final long userKey) {
-    final long position = writer.writeCommand(SignalIntent.BROADCAST, signalRecord, userKey);
+    final long position = writer.writeCommand(SignalIntent.BROADCAST, userKey, signalRecord);
     return expectation.apply(position);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserClient.java
@@ -90,7 +90,7 @@ public final class UserClient {
     }
 
     public Record<UserRecordValue> create(final long userKey) {
-      final long position = writer.writeCommand(UserIntent.CREATE, userCreationRecord, userKey);
+      final long position = writer.writeCommand(UserIntent.CREATE, userKey, userCreationRecord);
       return expectation.apply(position);
     }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserClient.java
@@ -89,8 +89,8 @@ public final class UserClient {
       return expectation.apply(position);
     }
 
-    public Record<UserRecordValue> create(final long userKey) {
-      final long position = writer.writeCommand(UserIntent.CREATE, userKey, userCreationRecord);
+    public Record<UserRecordValue> create(final String username) {
+      final long position = writer.writeCommand(UserIntent.CREATE, username, userCreationRecord);
       return expectation.apply(position);
     }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
@@ -140,8 +140,8 @@ public final class UserTaskClient {
             DEFAULT_REQUEST_STREAM_ID,
             DEFAULT_REQUEST_ID,
             UserTaskIntent.ASSIGN,
-            userTaskRecord.setUserTaskKey(userTaskKey),
             userKey,
+            userTaskRecord.setUserTaskKey(userTaskKey),
             TenantOwned.DEFAULT_TENANT_IDENTIFIER);
     return expectation.apply(position);
   }
@@ -183,8 +183,8 @@ public final class UserTaskClient {
             DEFAULT_REQUEST_STREAM_ID,
             DEFAULT_REQUEST_ID,
             UserTaskIntent.CLAIM,
-            userTaskRecord.setUserTaskKey(userTaskKey),
             userKey,
+            userTaskRecord.setUserTaskKey(userTaskKey),
             TenantOwned.DEFAULT_TENANT_IDENTIFIER);
     return expectation.apply(position);
   }
@@ -210,8 +210,8 @@ public final class UserTaskClient {
             DEFAULT_REQUEST_STREAM_ID,
             DEFAULT_REQUEST_ID,
             UserTaskIntent.COMPLETE,
-            userTaskRecord.setUserTaskKey(userTaskKey),
             userKey,
+            userTaskRecord.setUserTaskKey(userTaskKey),
             TenantOwned.DEFAULT_TENANT_IDENTIFIER);
     return expectation.apply(position);
   }
@@ -282,8 +282,8 @@ public final class UserTaskClient {
             DEFAULT_REQUEST_STREAM_ID,
             DEFAULT_REQUEST_ID,
             UserTaskIntent.UPDATE,
-            userTaskRecord.setUserTaskKey(userTaskKey),
             userKey,
+            userTaskRecord.setUserTaskKey(userTaskKey),
             TenantOwned.DEFAULT_TENANT_IDENTIFIER);
     return expectation.apply(position);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
@@ -132,7 +132,7 @@ public final class UserTaskClient {
     return expectation.apply(position);
   }
 
-  public Record<UserTaskRecordValue> assign(final long userKey) {
+  public Record<UserTaskRecordValue> assign(final String username) {
     final long userTaskKey = findUserTaskKey();
     final long position =
         writer.writeCommand(
@@ -140,7 +140,7 @@ public final class UserTaskClient {
             DEFAULT_REQUEST_STREAM_ID,
             DEFAULT_REQUEST_ID,
             UserTaskIntent.ASSIGN,
-            userKey,
+            username,
             userTaskRecord.setUserTaskKey(userTaskKey),
             TenantOwned.DEFAULT_TENANT_IDENTIFIER);
     return expectation.apply(position);
@@ -175,7 +175,7 @@ public final class UserTaskClient {
     return expectation.apply(position);
   }
 
-  public Record<UserTaskRecordValue> claim(final long userKey) {
+  public Record<UserTaskRecordValue> claim(final String username) {
     final long userTaskKey = findUserTaskKey();
     final long position =
         writer.writeCommand(
@@ -183,7 +183,7 @@ public final class UserTaskClient {
             DEFAULT_REQUEST_STREAM_ID,
             DEFAULT_REQUEST_ID,
             UserTaskIntent.CLAIM,
-            userKey,
+            username,
             userTaskRecord.setUserTaskKey(userTaskKey),
             TenantOwned.DEFAULT_TENANT_IDENTIFIER);
     return expectation.apply(position);
@@ -202,7 +202,7 @@ public final class UserTaskClient {
     return expectation.apply(position);
   }
 
-  public Record<UserTaskRecordValue> complete(final long userKey) {
+  public Record<UserTaskRecordValue> complete(final String username) {
     final long userTaskKey = findUserTaskKey();
     final long position =
         writer.writeCommand(
@@ -210,7 +210,7 @@ public final class UserTaskClient {
             DEFAULT_REQUEST_STREAM_ID,
             DEFAULT_REQUEST_ID,
             UserTaskIntent.COMPLETE,
-            userKey,
+            username,
             userTaskRecord.setUserTaskKey(userTaskKey),
             TenantOwned.DEFAULT_TENANT_IDENTIFIER);
     return expectation.apply(position);
@@ -267,7 +267,7 @@ public final class UserTaskClient {
     return expectation.apply(position);
   }
 
-  public Record<UserTaskRecordValue> update(final UserTaskRecord changes, final long userKey) {
+  public Record<UserTaskRecordValue> update(final UserTaskRecord changes, final String username) {
     changes
         .setCandidateGroupsChanged()
         .setCandidateUsersChanged()
@@ -282,7 +282,7 @@ public final class UserTaskClient {
             DEFAULT_REQUEST_STREAM_ID,
             DEFAULT_REQUEST_ID,
             UserTaskIntent.UPDATE,
-            userKey,
+            username,
             userTaskRecord.setUserTaskKey(userTaskKey),
             TenantOwned.DEFAULT_TENANT_IDENTIFIER);
     return expectation.apply(position);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/VariableClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/VariableClient.java
@@ -95,7 +95,7 @@ public final class VariableClient {
   public Record<VariableDocumentRecordValue> update(final long userKey) {
     final long position =
         writer.writeCommand(
-            VariableDocumentIntent.UPDATE, variableDocumentRecord, userKey, authorizedTenants);
+            VariableDocumentIntent.UPDATE, userKey, variableDocumentRecord, authorizedTenants);
     return expectation.apply(position);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/VariableClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/VariableClient.java
@@ -92,10 +92,10 @@ public final class VariableClient {
     return expectation.apply(position);
   }
 
-  public Record<VariableDocumentRecordValue> update(final long userKey) {
+  public Record<VariableDocumentRecordValue> update(final String username) {
     final long position =
         writer.writeCommand(
-            VariableDocumentIntent.UPDATE, userKey, variableDocumentRecord, authorizedTenants);
+            VariableDocumentIntent.UPDATE, username, variableDocumentRecord, authorizedTenants);
     return expectation.apply(position);
   }
 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -500,10 +500,10 @@ public final class EndpointManager {
           });
     }
 
-    // retrieve the user key from the context and add it to the authorization if present
-    final Long userKey = Context.current().call(AuthenticationInterceptor.USER_KEY::get);
-    if (userKey != null) {
-      claims.put(Authorization.AUTHORIZED_USER_KEY, userKey);
+    // retrieve the username from the context and add it to the authorization if present
+    final String username = Context.current().call(AuthenticationInterceptor.USERNAME::get);
+    if (username != null) {
+      claims.put(Authorization.AUTHORIZED_USERNAME, username);
     }
 
     brokerRequest.setAuthorization(claims);

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptor.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptor.java
@@ -32,7 +32,7 @@ public class AuthenticationInterceptor implements ServerInterceptor {
 
   public static final Context.Key<Map<String, Object>> USER_CLAIMS =
       Context.key("io.camunda.zeebe:user_claim");
-  public static final Context.Key<Long> USER_KEY = Context.key("io.camunda.zeebe:user_key");
+  public static final Context.Key<String> USERNAME = Context.key("io.camunda.zeebe:username");
   private static final Logger LOGGER = LoggerFactory.getLogger(AuthenticationInterceptor.class);
   private static final Metadata.Key<String> AUTH_KEY =
       Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
@@ -114,7 +114,7 @@ public class AuthenticationInterceptor implements ServerInterceptor {
                 .withCause(new IllegalArgumentException("Invalid credentials")));
       }
 
-      final var context = Context.current().withValue(USER_KEY, user.userKey());
+      final var context = Context.current().withValue(USERNAME, user.username());
       return Contexts.interceptCall(context, call, headers, next);
     } catch (final RuntimeException e) {
       LOGGER.debug(

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
@@ -27,8 +27,8 @@ import io.grpc.Status;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
-import org.assertj.core.api.LongAssert;
 import org.assertj.core.api.MapAssert;
+import org.assertj.core.api.StringAssert;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -217,10 +217,10 @@ public class AuthenticationInterceptorTest {
     }
   }
 
-  private static LongAssert assertUserKey() {
+  private static StringAssert assertUserKey() {
     try {
-      return (LongAssert)
-          assertThat(Context.current().call(() -> AuthenticationInterceptor.USER_KEY.get()));
+      return (StringAssert)
+          assertThat(Context.current().call(() -> AuthenticationInterceptor.USERNAME.get()));
     } catch (final Exception e) {
       throw new RuntimeException("Unable to retrieve user key from context", e);
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -549,6 +549,7 @@ public class RequestMapper {
                 .toList());
         if (authenticatedPrincipal instanceof final CamundaUser user) {
           authenticatedUserKey = user.getUserKey();
+          claims.put(Authorization.AUTHORIZED_USERNAME, user.getUsername());
         }
       }
 
@@ -558,10 +559,6 @@ public class RequestMapper {
             .forEach(
                 (key, value) -> claims.put(Authorization.USER_TOKEN_CLAIM_PREFIX + key, value));
       }
-    }
-
-    if (authenticatedUserKey != null) {
-      claims.put(Authorization.AUTHORIZED_USER_KEY, authenticatedUserKey);
     }
 
     return new Builder()

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
@@ -40,19 +40,19 @@ class RequestMapperTest {
   }
 
   @Test
-  void tokenContainsUserKeyWithBasicAuth() {
+  void tokenContainsUsernameWithBasicAuth() {
 
     // given
-    final long userKey = 1L;
-    setUsernamePasswordAuthenticationInContext(userKey);
+    final var username = "username";
+    setUsernamePasswordAuthenticationInContext(username);
 
     // when
     final var claims = RequestMapper.getAuthentication().claims();
 
     // then
     assertNotNull(claims);
-    assertThat(claims).containsKey(Authorization.AUTHORIZED_USER_KEY);
-    assertThat(claims.get(Authorization.AUTHORIZED_USER_KEY)).isEqualTo(userKey);
+    assertThat(claims).containsKey(Authorization.AUTHORIZED_USERNAME);
+    assertThat(claims.get(Authorization.AUTHORIZED_USERNAME)).isEqualTo(username);
   }
 
   @Test
@@ -92,13 +92,13 @@ class RequestMapperTest {
     SecurityContextHolder.getContext().setAuthentication(jwtAuthenticationToken);
   }
 
-  private void setUsernamePasswordAuthenticationInContext(final long userKey) {
+  private void setUsernamePasswordAuthenticationInContext(final String username) {
     final UsernamePasswordAuthenticationToken authenticationToken =
         new UsernamePasswordAuthenticationToken(
             CamundaUserBuilder.aCamundaUser()
-                .withUsername("admin")
+                .withUsername(username)
                 .withPassword("admin")
-                .withUserKey(userKey)
+                .withUserKey(1L)
                 .build(),
             null);
     SecurityContextHolder.getContext().setAuthentication(authenticationToken);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

We will move from working with a user key to working with a username throughout the stack. In the gateways we currently find the authenticated user and put the user key on the command. With this PR we will change this and put the username on the command instead.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #26778 
