### PR TITLE
fix: in NettyMessaging service heartbeats are sent as req/reply based on role

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/HeartbeatHandler.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/HeartbeatHandler.java
@@ -1,0 +1,130 @@
+/* * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under * one or more contributor license agreements. See the NOTICE file distributed * with this work for additional information regarding copyright ownership. * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.cluster.messaging.impl;
+
+import io.atomix.cluster.messaging.impl.ProtocolReply.Status;
+import io.atomix.utils.net.Address;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.timeout.IdleState;
+import io.netty.handler.timeout.IdleStateEvent;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicLong;
+import org.agrona.collections.LongHashSet;
+import org.slf4j.Logger;
+
+abstract sealed class HeartbeatHandler extends ChannelDuplexHandler {
+  // DO NOT CHANGE: changing the subject is a backward INCOMPATIBLE change.
+  static final String HEARTBEAT_SUBJECT = "internal-heartbeat";
+  static final byte[] HEARTBEAT_PAYLOAD = new byte[0];
+  protected final Logger log;
+
+  protected HeartbeatHandler(final Logger log) {
+    this.log = log;
+  }
+
+  static final class Server extends HeartbeatHandler {
+    boolean receivedHeartbeat = false;
+
+    Server(final Logger log) {
+      super(log);
+    }
+
+    @Override
+    public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
+      if (msg instanceof final ProtocolRequest request
+          && request.subject().equals(HEARTBEAT_SUBJECT)) {
+        receivedHeartbeat = true;
+        ctx.writeAndFlush(createHeartbeat(request.id()));
+        if (!Arrays.equals(request.payload(), HEARTBEAT_PAYLOAD)) {
+          log.warn(
+              "Received unexpected heartbeat payload from {}, perhaps the message subject {} is accidentally reused",
+              request.sender(),
+              HEARTBEAT_SUBJECT);
+        }
+      }
+
+      // Pass the message to the next handler, even though it's a heartbeat.
+      ctx.fireChannelRead(msg);
+    }
+
+    @Override
+    public void userEventTriggered(final ChannelHandlerContext ctx, final Object evt) {
+      if (!(evt instanceof final IdleStateEvent idleStateEvent)) {
+        return;
+      }
+      if (idleStateEvent.state() == IdleState.READER_IDLE) {
+        // don't close the connection if we did not receive any heartbeat
+        if (receivedHeartbeat) {
+          log.warn("Connection {} timed out on the server, closing channel", ctx.channel());
+          ctx.close();
+        }
+      }
+    }
+
+    private ProtocolMessage createHeartbeat(final long id) {
+      return new ProtocolReply(id, HEARTBEAT_PAYLOAD, Status.OK);
+    }
+  }
+
+  static final class Client extends HeartbeatHandler {
+    private final LongHashSet outstandingHeartbeats = new LongHashSet();
+    private final AtomicLong messageIdGenerator;
+    private final Address advertisedAddress;
+
+    Client(final Logger log, final AtomicLong messageIdGenerator, final Address advertisedAddress) {
+      super(log);
+      this.messageIdGenerator = messageIdGenerator;
+      this.advertisedAddress = advertisedAddress;
+    }
+
+    @Override
+    public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
+      if (msg instanceof final ProtocolReply reply && outstandingHeartbeats.contains(reply.id())) {
+        // remove all heartbeats sent before the last update
+        outstandingHeartbeats.removeIfLong(id -> id <= reply.id());
+        if (reply.status() != Status.OK) {
+          log.warn("Received a Heartbeat response with status {}", reply.status());
+        } else if (!Arrays.equals(reply.payload(), HEARTBEAT_PAYLOAD)) {
+          log.warn(
+              "Received unexpected heartbeat payload, perhaps the message subject {} is accidentally reused: {}",
+              HEARTBEAT_SUBJECT,
+              reply);
+        }
+      }
+
+      // Pass the message to the next handler, even though it's a heartbeat.
+      ctx.fireChannelRead(msg);
+    }
+
+    @Override
+    public void userEventTriggered(final ChannelHandlerContext ctx, final Object evt) {
+      if (!(evt instanceof final IdleStateEvent idleStateEvent)) {
+        return;
+      }
+      switch (idleStateEvent.state()) {
+        case READER_IDLE -> {
+          // don't close the connection if we did not send any heartbeat
+          if (!outstandingHeartbeats.isEmpty()) {
+            log.warn("Connection {} timed out on the client, closing channel", ctx.channel());
+            outstandingHeartbeats.clear();
+            ctx.close();
+          }
+        }
+        case WRITER_IDLE -> {
+          ctx.writeAndFlush(createHeartbeat());
+        }
+        default -> {}
+      }
+    }
+
+    private ProtocolRequest createHeartbeat() {
+      return new ProtocolRequest(
+          messageIdGenerator.incrementAndGet(),
+          advertisedAddress,
+          HEARTBEAT_SUBJECT,
+          HEARTBEAT_PAYLOAD);
+    }
+  }
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -36,7 +36,6 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -64,13 +63,11 @@ import io.netty.handler.codec.compression.ZlibWrapper;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
-import io.netty.handler.timeout.IdleStateEvent;
 import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.resolver.dns.BiDnsQueryLifecycleObserverFactory;
 import io.netty.resolver.dns.DnsAddressResolverGroup;
 import io.netty.resolver.dns.DnsNameResolverBuilder;
 import io.netty.resolver.dns.LoggingDnsQueryLifeCycleObserverFactory;
-import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.Future;
 import java.io.File;
@@ -167,6 +164,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
     this.advertisedAddress = advertisedAddress;
     this.protocolVersion = protocolVersion;
     this.config = verifyHeartbeatConfig(config);
+    // pool of client connections
     channelPool = new ChannelPool(this::openChannel, config.getConnectionPoolSize());
     this.actorSchedulerName = actorSchedulerName;
 
@@ -923,55 +921,6 @@ public final class NettyMessagingService implements ManagedMessagingService {
     }
   }
 
-  private final class HeartBeatHandler extends ChannelDuplexHandler {
-    private static final String HEARTBEAT_SUBJECT = "internal-heartbeat";
-    private static final byte[] HEARTBEAT_PAYLOAD = new byte[0];
-
-    @Override
-    public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
-      if (msg instanceof final ProtocolRequest request
-          && request.subject().equals(HEARTBEAT_SUBJECT)) {
-
-        if (!Arrays.equals(request.payload(), HEARTBEAT_PAYLOAD)) {
-          log.warn(
-              "Received unexpected heartbeat payload from {}, perhaps the message subject {} is accidentally reused",
-              request.sender(),
-              request.subject());
-        }
-
-        // Swallow the heartbeat message by releasing it and not passing it to the next handler
-        ReferenceCountUtil.release(msg);
-        return;
-      }
-
-      // Pass the message to the next handler, it wasn't a heartbeat
-      ctx.fireChannelRead(msg);
-    }
-
-    @Override
-    public void userEventTriggered(final ChannelHandlerContext ctx, final Object evt) {
-      if (!(evt instanceof final IdleStateEvent idleStateEvent)) {
-        return;
-      }
-      switch (idleStateEvent.state()) {
-        case READER_IDLE -> {
-          log.warn("Connection {} timed out, closing channel", ctx.channel());
-          ctx.close();
-        }
-        case WRITER_IDLE -> ctx.writeAndFlush(createHeartBeat());
-        default -> {}
-      }
-    }
-
-    private ProtocolRequest createHeartBeat() {
-      return new ProtocolRequest(
-          messageIdGenerator.incrementAndGet(),
-          advertisedAddress,
-          HEARTBEAT_SUBJECT,
-          HEARTBEAT_PAYLOAD);
-    }
-  }
-
   /** Channel initializer for basic connections. */
   private class BasicClientChannelInitializer extends ChannelInitializer<SocketChannel> {
 
@@ -1109,12 +1058,18 @@ public final class NettyMessagingService implements ManagedMessagingService {
     void activateProtocolVersion(
         final ChannelHandlerContext context,
         final Connection<M> connection,
-        final ProtocolVersion protocolVersion) {
+        final ProtocolVersion protocolVersion,
+        final boolean isClient) {
       final MessagingProtocol protocol = protocolVersion.createProtocol(advertisedAddress);
+      final var heartbeatHandler =
+          isClient
+              ? new HeartbeatHandler.Client(log, messageIdGenerator, advertisedAddress)
+              : new HeartbeatHandler.Server(log);
       context.pipeline().remove(this);
       context.pipeline().addLast("encoder", protocol.newEncoder());
       context.pipeline().addLast("decoder", protocol.newDecoder());
-      context.pipeline().addLast("heartbeat", new HeartBeatHandler());
+
+      context.pipeline().addLast("heartbeat", heartbeatHandler);
       context.pipeline().addLast("handler", new MessageDispatcher<>(connection));
     }
   }
@@ -1150,7 +1105,10 @@ public final class NettyMessagingService implements ManagedMessagingService {
                 final ProtocolVersion protocolVersion = ProtocolVersion.valueOf(version);
                 if (protocolVersion != null) {
                   activateProtocolVersion(
-                      context, getOrCreateClientConnection(context.channel()), protocolVersion);
+                      context,
+                      getOrCreateClientConnection(context.channel()),
+                      protocolVersion,
+                      true);
                 } else {
                   log.error("Failed to negotiate protocol version");
                   context.close();
@@ -1168,12 +1126,13 @@ public final class NettyMessagingService implements ManagedMessagingService {
     void activateProtocolVersion(
         final ChannelHandlerContext context,
         final Connection<ProtocolReply> connection,
-        final ProtocolVersion protocolVersion) {
+        final ProtocolVersion protocolVersion,
+        final boolean isClient) {
       log.debug(
           "Activating client protocol version {} for connection to {}",
           protocolVersion,
           context.channel().remoteAddress());
-      super.activateProtocolVersion(context, connection, protocolVersion);
+      super.activateProtocolVersion(context, connection, protocolVersion, isClient);
       future.complete(context.channel());
     }
   }
@@ -1199,7 +1158,8 @@ public final class NettyMessagingService implements ManagedMessagingService {
                 activateProtocolVersion(
                     context,
                     new RemoteServerConnection(handlers, context.channel()),
-                    protocolVersion);
+                    protocolVersion,
+                    false);
               });
     }
 
@@ -1207,12 +1167,13 @@ public final class NettyMessagingService implements ManagedMessagingService {
     void activateProtocolVersion(
         final ChannelHandlerContext context,
         final Connection<ProtocolRequest> connection,
-        final ProtocolVersion protocolVersion) {
+        final ProtocolVersion protocolVersion,
+        final boolean isClient) {
       log.debug(
           "Activating server protocol version {} for connection to {}",
           protocolVersion,
           context.channel().remoteAddress());
-      super.activateProtocolVersion(context, connection, protocolVersion);
+      super.activateProtocolVersion(context, connection, protocolVersion, isClient);
     }
   }
 
@@ -1252,6 +1213,8 @@ public final class NettyMessagingService implements ManagedMessagingService {
         connection.dispatch((M) message);
       } catch (final RejectedExecutionException e) {
         log.warn("Unable to dispatch message due to {}", e.getMessage());
+      } catch (final ClassCastException e) {
+        log.error("Failed to dispatch message due to {}", e.getMessage());
       }
     }
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -1063,7 +1063,8 @@ public final class NettyMessagingService implements ManagedMessagingService {
       final MessagingProtocol protocol = protocolVersion.createProtocol(advertisedAddress);
       final var heartbeatHandler =
           isClient
-              ? new HeartbeatHandler.Client(log, messageIdGenerator, advertisedAddress)
+              ? new HeartbeatHandler.Client(
+                  log, messageIdGenerator, advertisedAddress, config.getHeartbeatTimeout())
               : new HeartbeatHandler.Server(log);
       context.pipeline().remove(this);
       context.pipeline().addLast("encoder", protocol.newEncoder());

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -17,6 +17,7 @@
 package io.atomix.cluster.messaging.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -49,6 +50,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -698,18 +700,49 @@ final class NettyMessagingServiceTest {
     }
 
     @Test
-    void shouldGetChannelClosedWhenNotSendingHeartbeats() {
+    void shouldGetChannelClosedWhenNotSendingHeartbeatsAfterAWhile() {
       // given
       final var subject = nextSubject();
-      final var channelPool = netty1.getChannelPool();
-      final var channel = channelPool.getChannel(netty2.address(), subject).join();
+      final var receivedHeartbeat = new AtomicBoolean(false);
+      // register for heartbeats
+      netty2.registerHandler(
+          HeartbeatHandler.HEARTBEAT_SUBJECT,
+          (addr, bytes) -> {
+            receivedHeartbeat.set(true);
+            return CompletableFuture.completedFuture(null);
+          });
+      final var clientChannel =
+          netty1.getChannelPool().getChannel(netty2.address(), subject).join();
+      Awaitility.await("Until first heartbeat has been received on the server")
+          .until(receivedHeartbeat::get);
 
       // when - removing the `IdleStateHandler` from the pipeline such that `HeartBeatHandler` is
       // not triggered
-      channel.pipeline().remove("idle");
+      clientChannel.pipeline().remove("idle");
 
       // then - the other side notices a lack of heartbeats and closes the channel
-      assertThat(channel.closeFuture()).succeedsWithin(Duration.ofSeconds(5));
+      assertThat(clientChannel.closeFuture()).succeedsWithin(Duration.ofSeconds(5));
+    }
+
+    @Test
+    void shouldNotCloseTheConnectionIfNoHeartbeatsIsReceived() {
+      // given
+      final var subject = nextSubject();
+      // a client channel
+      final var channel = netty1.getChannelPool().getChannel(netty2.address(), subject).join();
+      // without heartbeat handler,
+      // so that client does not send any heartbeats
+      channel.pipeline().remove("heartbeat");
+
+      // when
+      // a request is made without heartbeats
+      netty1.sendAndReceive(netty2.address(), subject, new byte[0], true);
+
+      // then
+      // the channel is not closed (because the future times out)
+      final var timeout = defaultConfig().getHeartbeatTimeout().toSeconds() + 1;
+      assertThatThrownBy(() -> channel.closeFuture().get(timeout, TimeUnit.SECONDS))
+          .isInstanceOf(TimeoutException.class);
     }
   }
 }


### PR DESCRIPTION
# Description 

Heartbeats are now initiated only from the client, which sends a `ProtocolRequest` message with subject `"internal-heartbeat"` whenever the channel has been idle for too much.
The server, upon receive such message, will send a `ProtocolReply` response with the same id as the request.
The client is then able to diagnose missed heartbeats and close the channel if he does not receive a reply in time.

If the server has received at least one heartbeat, but it did not receive an heartbeat for more than the specified timeout, it will close the connection.
This will avoid closing the connection when a client does not support heartbeats (i.e. a previous version)

## Related issues
closes #26602
