### PR TITLE
ci: add daily build to Unified CI to re-populate GHA caches

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -1,6 +1,12 @@
 ---
 name: Common paths filter for camunda/camunda
 
+inputs:
+  trigger_source:
+    required: false
+    default: "unknown"
+    description: "Source of the workflow trigger"
+
 description: |
   Common filters to detect and group changes against a base branch
   It leverages the `dorny/paths-filter` action to filter paths
@@ -12,6 +18,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
+        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
         steps.filter-common.outputs.github-actions-change == 'true'
       }}
   maven-spotless-linter:
@@ -19,6 +26,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
+        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
@@ -29,6 +37,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
+        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true'
@@ -38,6 +47,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
+        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-identity.outputs.identity-frontend-change == 'true'
       }}
@@ -46,6 +56,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
+        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-operate.outputs.operate-backend-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
@@ -57,6 +68,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
+        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-tasklist.outputs.tasklist-frontend-change == 'true'
       }}
@@ -65,6 +77,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
+        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-tasklist.outputs.tasklist-backend-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
@@ -76,6 +89,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
+        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-optimize.outputs.optimize-frontend-change == 'true'
       }}
@@ -84,6 +98,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
+        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-optimize.outputs.optimize-backend-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
@@ -94,6 +109,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
+        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
@@ -105,6 +121,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
+        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.frontend-change == 'true' ||
         steps.filter-identity.outputs.frontend-identity == 'true'
@@ -114,6 +131,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
+        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
@@ -124,6 +142,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
+        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
         steps.filter-common.outputs.protobuf-change == 'true'
       }}
   openapi-changes:
@@ -131,6 +150,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
+        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
         steps.filter-common.outputs.openapi-change == 'true'
       }}
 

--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -1,12 +1,6 @@
 ---
 name: Common paths filter for camunda/camunda
 
-inputs:
-  trigger_source:
-    required: false
-    default: "unknown"
-    description: "Source of the workflow trigger"
-
 description: |
   Common filters to detect and group changes against a base branch
   It leverages the `dorny/paths-filter` action to filter paths
@@ -18,7 +12,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
-        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
+        github.event_name == 'schedule' ||
         steps.filter-common.outputs.github-actions-change == 'true'
       }}
   maven-spotless-linter:
@@ -26,7 +20,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
-        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
+        github.event_name == 'schedule' ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
@@ -37,7 +31,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
-        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
+        github.event_name == 'schedule' ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true'
@@ -47,7 +41,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
-        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
+        github.event_name == 'schedule' ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-identity.outputs.identity-frontend-change == 'true'
       }}
@@ -56,7 +50,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
-        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
+        github.event_name == 'schedule' ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-operate.outputs.operate-backend-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
@@ -68,7 +62,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
-        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
+        github.event_name == 'schedule' ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-tasklist.outputs.tasklist-frontend-change == 'true'
       }}
@@ -77,7 +71,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
-        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
+        github.event_name == 'schedule' ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-tasklist.outputs.tasklist-backend-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
@@ -89,7 +83,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
-        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
+        github.event_name == 'schedule' ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-optimize.outputs.optimize-frontend-change == 'true'
       }}
@@ -98,7 +92,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
-        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
+        github.event_name == 'schedule' ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-optimize.outputs.optimize-backend-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
@@ -109,7 +103,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
-        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
+        github.event_name == 'schedule' ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
@@ -121,7 +115,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
-        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
+        github.event_name == 'schedule' ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.frontend-change == 'true' ||
         steps.filter-identity.outputs.frontend-identity == 'true'
@@ -131,7 +125,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
-        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
+        github.event_name == 'schedule' ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
@@ -142,7 +136,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
-        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
+        github.event_name == 'schedule' ||
         steps.filter-common.outputs.protobuf-change == 'true'
       }}
   openapi-changes:
@@ -150,7 +144,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
-        (github.event_name == 'schedule' && inputs.trigger_source == 'Unified CI') ||
+        github.event_name == 'schedule' ||
         steps.filter-common.outputs.openapi-change == 'true'
       }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
   pull_request: {}
   merge_group: {}
   workflow_dispatch: {}
+  schedule:
+    - cron: '0 6 * * *' # daily full build in the morning to re-populate GHA caches
 
 # Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
 # Exception for main branch: complete builds for every commit needed for confidenence
@@ -53,6 +55,8 @@ jobs:
       # Detect changes against the base branch
       - name: Detect changes
         uses: ./.github/actions/paths-filter
+        with:
+          trigger_source: "Unified CI"
         id: filter
 
   actionlint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,8 +55,6 @@ jobs:
       # Detect changes against the base branch
       - name: Detect changes
         uses: ./.github/actions/paths-filter
-        with:
-          trigger_source: "Unified CI"
         id: filter
 
   actionlint:


### PR DESCRIPTION
## Description

Add a daily full build to the Unified CI to re-populate GHA caches in the morning.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #25284
