### PR TITLE
fix: make backoff configurable

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -288,6 +288,7 @@ public class ExporterConfiguration {
     private int rolloverBatchSize = 100;
     private String waitPeriodBeforeArchiving = "1h";
     private int delayBetweenRuns = 2000;
+    private int maxDelayBetweenRuns = 60000;
 
     public boolean isRolloverEnabled() {
       return rolloverEnabled;
@@ -341,27 +342,34 @@ public class ExporterConfiguration {
       this.delayBetweenRuns = delayBetweenRuns;
     }
 
+    public int getMaxDelayBetweenRuns() {
+      return maxDelayBetweenRuns;
+    }
+
+    public void setMaxDelayBetweenRuns(final int maxDelayBetweenRuns) {
+      this.maxDelayBetweenRuns = maxDelayBetweenRuns;
+    }
+
     @Override
     public String toString() {
-      return "RetentionConfiguration{"
+      return "ArchiverConfiguration{"
           + "rolloverEnabled="
           + rolloverEnabled
-          + '\''
           + ", elsRolloverDateFormat='"
           + elsRolloverDateFormat
           + '\''
           + ", rolloverInterval='"
           + rolloverInterval
           + '\''
-          + ", rolloverBatchSize='"
+          + ", rolloverBatchSize="
           + rolloverBatchSize
-          + '\''
           + ", waitPeriodBeforeArchiving='"
           + waitPeriodBeforeArchiving
           + '\''
-          + ", delayBetweenRuns='"
+          + ", delayBetweenRuns="
           + delayBetweenRuns
-          + '\''
+          + ", maxDelayBetweenRuns="
+          + maxDelayBetweenRuns
           + '}';
     }
   }
@@ -386,6 +394,7 @@ public class ExporterConfiguration {
   public static final class PostExportConfiguration {
     private int batchSize = 100;
     private int delayBetweenRuns = 2000;
+    private int maxDelayBetweenRuns = 60000;
     private boolean ignoreMissingData = false;
 
     public int getBatchSize() {
@@ -404,6 +413,14 @@ public class ExporterConfiguration {
       this.delayBetweenRuns = delayBetweenRuns;
     }
 
+    public int getMaxDelayBetweenRuns() {
+      return maxDelayBetweenRuns;
+    }
+
+    public void setMaxDelayBetweenRuns(final int maxDelayBetweenRuns) {
+      this.maxDelayBetweenRuns = maxDelayBetweenRuns;
+    }
+
     public boolean isIgnoreMissingData() {
       return ignoreMissingData;
     }
@@ -419,6 +436,8 @@ public class ExporterConfiguration {
           + batchSize
           + ", delayBetweenRuns="
           + delayBetweenRuns
+          + ", maxDelayBetweenRuns="
+          + maxDelayBetweenRuns
           + ", ignoreMissingData="
           + ignoreMissingData
           + '}';

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -128,15 +128,18 @@ public final class BackgroundTaskManagerFactory {
             logger),
         1,
         postExport.getDelayBetweenRuns(),
+        postExport.getMaxDelayBetweenRuns(),
         executor,
         logger);
   }
 
   private ReschedulingTask buildBatchOperationUpdateTask() {
+    final var postExport = config.getPostExport();
     return new ReschedulingTask(
         new BatchOperationUpdateTask(batchOperationUpdateRepository, logger, executor),
-        config.getArchiver().getRolloverBatchSize(),
-        config.getArchiver().getDelayBetweenRuns(),
+        1,
+        postExport.getDelayBetweenRuns(),
+        postExport.getMaxDelayBetweenRuns(),
         executor,
         logger);
   }
@@ -179,6 +182,7 @@ public final class BackgroundTaskManagerFactory {
         task,
         config.getArchiver().getRolloverBatchSize(),
         config.getArchiver().getDelayBetweenRuns(),
+        config.getArchiver().getMaxDelayBetweenRuns(),
         executor,
         logger);
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/ReschedulingTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/ReschedulingTask.java
@@ -28,6 +28,7 @@ public final class ReschedulingTask implements Runnable {
       final BackgroundTask task,
       final int minimumWorkCount,
       final long delayBetweenRunsMs,
+      final long maxDelayBetweenRunsMs,
       final ScheduledExecutorService executor,
       final Logger logger) {
     this.task = task;
@@ -35,7 +36,7 @@ public final class ReschedulingTask implements Runnable {
     this.executor = executor;
     this.logger = logger;
 
-    idleStrategy = new ExponentialBackoff(60_000, delayBetweenRunsMs, 1.2, 0);
+    idleStrategy = new ExponentialBackoff(maxDelayBetweenRunsMs, delayBetweenRunsMs, 1.2, 0);
     errorStrategy = new ExponentialBackoff(10_000, delayBetweenRunsMs, 1.2, 0);
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
In `BackgroundTask` mechanism we use idle backoff with hard-coded 1 minute maximum delay between runs. For runtime this is OK, but too big for tests. 
In this PR I make this maximum delay configurable, so that we can pass smaller value in E2E tests.

## Related issues

related with #24084
