### PR TITLE
feat: remove CDN as font path

### DIFF
--- a/operate/client/src/index.scss
+++ b/operate/client/src/index.scss
@@ -6,9 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-@use '@carbon/react' as * with (
-  $font-path: 'https://fonts.camunda.io'
-);
+@use '@carbon/react' as *;
 
 @use '@carbon/react/scss/themes';
 @use '@carbon/react/scss/theme';


### PR DESCRIPTION
## Description

This PR removes the CDN (https://fonts.camunda.io) as font path. Instead all necessary fonts will be bundled with Operate, so no internet access is needed anymore to fetch fonts.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24550
Link to the test case: 
[User can see correct font in Operate when there is no Internet access](https://camunda.testrail.com/index.php?/cases/view/569439)