### PR TITLE
feat: read java client header in LongSerializer

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/serializer/LongSerializer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/serializer/LongSerializer.java
@@ -19,6 +19,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 
 public class LongSerializer extends JsonSerializer<Long> {
 
+  public static final String HEADER_JAVA_CLIENT_AGENT = "camunda-client-java/";
   public static final String PACKAGE_GATEWAY_REST = "io.camunda.zeebe.gateway.protocol.rest";
   public static final String KEY = "Key";
   public static final String KEYS = "Keys";
@@ -72,6 +73,16 @@ public class LongSerializer extends JsonSerializer<Long> {
       if (acceptHeader != null && acceptHeader.equals(RequestMapper.MEDIA_TYPE_KEYS_STRING_VALUE)) {
         writeString(value, gen);
         return;
+      }
+
+      final var userAgentHeader = r.getRequest().getHeader(HttpHeaders.USER_AGENT);
+      if (userAgentHeader != null && userAgentHeader.startsWith(HEADER_JAVA_CLIENT_AGENT)) {
+        final var clientVersion = userAgentHeader.substring(HEADER_JAVA_CLIENT_AGENT.length());
+
+        if (clientVersion.startsWith("8.5") || clientVersion.startsWith("8.6")) {
+          writeNumber(value, gen);
+          return;
+        }
       }
     }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/serializer/LongSerializer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/serializer/LongSerializer.java
@@ -19,7 +19,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 
 public class LongSerializer extends JsonSerializer<Long> {
 
-  public static final String HEADER_JAVA_CLIENT_AGENT = "camunda-client-java/";
+  public static final String HEADER_ZEEBE_CLIENT_AGENT = "zeebe-client-java/";
   public static final String PACKAGE_GATEWAY_REST = "io.camunda.zeebe.gateway.protocol.rest";
   public static final String KEY = "Key";
   public static final String KEYS = "Keys";
@@ -76,13 +76,9 @@ public class LongSerializer extends JsonSerializer<Long> {
       }
 
       final var userAgentHeader = r.getRequest().getHeader(HttpHeaders.USER_AGENT);
-      if (userAgentHeader != null && userAgentHeader.startsWith(HEADER_JAVA_CLIENT_AGENT)) {
-        final var clientVersion = userAgentHeader.substring(HEADER_JAVA_CLIENT_AGENT.length());
-
-        if (clientVersion.startsWith("8.5") || clientVersion.startsWith("8.6")) {
-          writeNumber(value, gen);
-          return;
-        }
+      if (userAgentHeader != null && userAgentHeader.startsWith(HEADER_ZEEBE_CLIENT_AGENT)) {
+        writeNumber(value, gen);
+        return;
       }
     }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/serializer/LongSerializerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/serializer/LongSerializerTest.java
@@ -136,11 +136,11 @@ class LongSerializerTest {
   }
 
   @Test
-  void shouldSerializeRestClassWithNumberIfClientIs87x() throws IOException {
+  void shouldSerializeRestClassWithDefaultStringIfClientIsCamunda() throws IOException {
     // given
     doReturn(new UserTaskItem()).when(context).getCurrentValue();
     doReturn("elementInstanceKey").when(context).getCurrentName();
-    doReturn(LongSerializer.HEADER_JAVA_CLIENT_AGENT + "8.7.0")
+    doReturn("camunda-client-java/8.7.0")
         .when(httpServletRequest)
         .getHeader(HttpHeaders.USER_AGENT);
     // when
@@ -152,27 +152,11 @@ class LongSerializerTest {
   }
 
   @Test
-  void shouldSerializeRestClassWithNumberIfClientIs86x() throws IOException {
+  void shouldSerializeRestClassWithNumberIfClientIsZeebe() throws IOException {
     // given
     doReturn(new UserTaskItem()).when(context).getCurrentValue();
     doReturn("elementInstanceKey").when(context).getCurrentName();
-    doReturn(LongSerializer.HEADER_JAVA_CLIENT_AGENT + "8.6.9")
-        .when(httpServletRequest)
-        .getHeader(HttpHeaders.USER_AGENT);
-    // when
-    longSerializer.serialize(1L, jsonGenerator, null);
-    // then
-    verify(jsonGenerator).writeNumber(1L);
-    verify(jsonGenerator, never()).writeString(anyString());
-    verify(httpServletRequest).getHeader(HttpHeaders.ACCEPT);
-  }
-
-  @Test
-  void shouldSerializeRestClassWithStringIfClientIs85x() throws IOException {
-    // given
-    doReturn(new UserTaskItem()).when(context).getCurrentValue();
-    doReturn("elementInstanceKey").when(context).getCurrentName();
-    doReturn(LongSerializer.HEADER_JAVA_CLIENT_AGENT + "8.5.0")
+    doReturn(LongSerializer.HEADER_ZEEBE_CLIENT_AGENT + "8.5.0")
         .when(httpServletRequest)
         .getHeader(HttpHeaders.USER_AGENT);
     // when

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/serializer/LongSerializerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/serializer/LongSerializerTest.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.gateway.rest.serializer;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -56,6 +58,7 @@ class LongSerializerTest {
     longSerializer.serialize(1L, jsonGenerator, null);
     // then
     verify(jsonGenerator).writeNumber(1L);
+    verify(jsonGenerator, never()).writeString(anyString());
     verify(httpServletRequest, never()).getHeader(any());
   }
 
@@ -68,6 +71,7 @@ class LongSerializerTest {
     longSerializer.serialize(1L, jsonGenerator, null);
     // then
     verify(jsonGenerator).writeNumber(1L);
+    verify(jsonGenerator, never()).writeString(anyString());
     verify(httpServletRequest, never()).getHeader(HttpHeaders.ACCEPT);
   }
 
@@ -80,6 +84,7 @@ class LongSerializerTest {
     longSerializer.serialize(1L, jsonGenerator, null);
     // then
     verify(jsonGenerator).writeString("1");
+    verify(jsonGenerator, never()).writeNumber(anyLong());
     verify(httpServletRequest).getHeader(HttpHeaders.ACCEPT);
   }
 
@@ -95,6 +100,7 @@ class LongSerializerTest {
     longSerializer.serialize(1L, jsonGenerator, null);
     // then
     verify(jsonGenerator).writeNumber(1L);
+    verify(jsonGenerator, never()).writeString(anyString());
     verify(httpServletRequest).getHeader(HttpHeaders.ACCEPT);
   }
 
@@ -110,6 +116,7 @@ class LongSerializerTest {
     longSerializer.serialize(1L, jsonGenerator, null);
     // then
     verify(jsonGenerator).writeString(String.valueOf(1L));
+    verify(jsonGenerator, never()).writeNumber(anyLong());
     verify(httpServletRequest).getHeader(HttpHeaders.ACCEPT);
   }
 
@@ -124,6 +131,55 @@ class LongSerializerTest {
     longSerializer.serialize(1L, jsonGenerator, null);
     // then
     verify(jsonGenerator).writeString("1");
+    verify(jsonGenerator, never()).writeNumber(anyLong());
+    verify(httpServletRequest).getHeader(HttpHeaders.ACCEPT);
+  }
+
+  @Test
+  void shouldSerializeRestClassWithNumberIfClientIs87x() throws IOException {
+    // given
+    doReturn(new UserTaskItem()).when(context).getCurrentValue();
+    doReturn("elementInstanceKey").when(context).getCurrentName();
+    doReturn(LongSerializer.HEADER_JAVA_CLIENT_AGENT + "8.7.0")
+        .when(httpServletRequest)
+        .getHeader(HttpHeaders.USER_AGENT);
+    // when
+    longSerializer.serialize(1L, jsonGenerator, null);
+    // then
+    verify(jsonGenerator).writeString(String.valueOf(1L));
+    verify(jsonGenerator, never()).writeNumber(anyLong());
+    verify(httpServletRequest).getHeader(HttpHeaders.ACCEPT);
+  }
+
+  @Test
+  void shouldSerializeRestClassWithNumberIfClientIs86x() throws IOException {
+    // given
+    doReturn(new UserTaskItem()).when(context).getCurrentValue();
+    doReturn("elementInstanceKey").when(context).getCurrentName();
+    doReturn(LongSerializer.HEADER_JAVA_CLIENT_AGENT + "8.6.9")
+        .when(httpServletRequest)
+        .getHeader(HttpHeaders.USER_AGENT);
+    // when
+    longSerializer.serialize(1L, jsonGenerator, null);
+    // then
+    verify(jsonGenerator).writeNumber(1L);
+    verify(jsonGenerator, never()).writeString(anyString());
+    verify(httpServletRequest).getHeader(HttpHeaders.ACCEPT);
+  }
+
+  @Test
+  void shouldSerializeRestClassWithStringIfClientIs85x() throws IOException {
+    // given
+    doReturn(new UserTaskItem()).when(context).getCurrentValue();
+    doReturn("elementInstanceKey").when(context).getCurrentName();
+    doReturn(LongSerializer.HEADER_JAVA_CLIENT_AGENT + "8.5.0")
+        .when(httpServletRequest)
+        .getHeader(HttpHeaders.USER_AGENT);
+    // when
+    longSerializer.serialize(1L, jsonGenerator, null);
+    // then
+    verify(jsonGenerator).writeNumber(1L);
+    verify(jsonGenerator, never()).writeString(anyString());
     verify(httpServletRequest).getHeader(HttpHeaders.ACCEPT);
   }
 }


### PR DESCRIPTION
## Description

- Extend LongSerializer to also handle Java client version
- Serialize to numbers for 8.5 & 8.6 clients

## Related issues

closes https://github.com/camunda/camunda/issues/26653
