### PR TITLE
feat: use ProcessModelReader for rdbms + fix reading of start formId …

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -30,6 +30,7 @@ import io.camunda.exporter.rdbms.RdbmsExporterWrapper;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
 import io.camunda.search.entities.IncidentEntity.IncidentState;
+import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.security.entity.Permission;
 import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
@@ -137,6 +138,8 @@ class RdbmsExporterIT {
     final var key = ((Process) processDefinitionRecord.getValue()).getProcessDefinitionKey();
     final var processDefinition = rdbmsService.getProcessDefinitionReader().findOne(key);
     assertThat(processDefinition).isNotEmpty();
+    assertThat(processDefinition).map(ProcessDefinitionEntity::bpmnXml).isPresent();
+    assertThat(processDefinition).map(ProcessDefinitionEntity::formId).contains("test");
   }
 
   @Test

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -51,6 +51,9 @@ import io.camunda.zeebe.protocol.record.value.deployment.ImmutableDecisionRequir
 import io.camunda.zeebe.protocol.record.value.deployment.ImmutableProcess;
 import io.camunda.zeebe.protocol.record.value.deployment.Process;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
@@ -103,6 +106,16 @@ public class RecordFixtures {
     final io.camunda.zeebe.protocol.record.Record<RecordValue> recordValueRecord =
         FACTORY.generateRecord(ValueType.PROCESS);
 
+    final byte[] resource;
+    try {
+      final var resourceUrl =
+          RecordFixtures.class.getClassLoader().getResource("process/process_start_form.bpmn");
+      assert resourceUrl != null;
+      resource = Files.readAllBytes(Path.of(resourceUrl.getPath()));
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+
     return ImmutableRecord.builder()
         .from(recordValueRecord)
         .withIntent(ProcessIntent.CREATED)
@@ -112,6 +125,8 @@ public class RecordFixtures {
         .withValue(
             ImmutableProcess.builder()
                 .from((Process) recordValueRecord.getValue())
+                .withResource(resource)
+                .withBpmnProcessId("Process_11hxie4")
                 .withVersion(1)
                 .build())
         .build();

--- a/zeebe/exporters/rdbms-exporter/pom.xml
+++ b/zeebe/exporters/rdbms-exporter/pom.xml
@@ -54,16 +54,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>webapps-schema</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>operate-importer-common</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessExportHandler.java
@@ -10,12 +10,12 @@ package io.camunda.exporter.rdbms.handlers;
 import io.camunda.db.rdbms.write.domain.ProcessDefinitionDbModel;
 import io.camunda.db.rdbms.write.service.ProcessDefinitionWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
-import io.camunda.operate.zeebeimport.util.XMLUtil;
-import io.camunda.webapps.schema.entities.operate.ProcessEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.value.deployment.Process;
+import io.camunda.zeebe.util.modelreader.ProcessModelReader;
+import io.camunda.zeebe.util.modelreader.ProcessModelReader.StartFormLink;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -45,28 +45,28 @@ public class ProcessExportHandler implements RdbmsExportHandler<Process> {
   }
 
   private ProcessDefinitionDbModel map(final Process value) {
-    Optional<ProcessEntity> processEntity = Optional.empty();
+    final Optional<ProcessModelReader> processModelReader =
+        ProcessModelReader.of(value.getResource(), value.getBpmnProcessId());
 
-    try {
-      processEntity =
-          new XMLUtil().extractDiagramData(value.getResource(), value.getBpmnProcessId());
-    } catch (final Exception e) {
-      // skip
-      LOG.warn(
-          "Unable to parse XML diagram for process {}: {}",
-          value.getBpmnProcessId(),
-          e.getMessage());
+    String processName = null;
+    String formId = null;
+    if (processModelReader.isPresent()) {
+      final var reader = processModelReader.get();
+      processName = reader.extractProcessName();
+      formId = reader.extractStartFormLink().map(StartFormLink::formId).orElse(null);
+    } else {
+      LOG.warn("Failed to read process model for process with key '{}'", value.getBpmnProcessId());
     }
 
     return new ProcessDefinitionDbModel(
         value.getProcessDefinitionKey(),
         value.getBpmnProcessId(),
         value.getResourceName(),
-        processEntity.map(ProcessEntity::getName).orElse(null),
+        processName,
         value.getTenantId(),
         value.getVersionTag(),
         value.getVersion(),
         new String(value.getResource(), StandardCharsets.UTF_8),
-        processEntity.map(ProcessEntity::getFormId).orElse(null));
+        formId);
   }
 }


### PR DESCRIPTION
## Description

Use new ProcessModelReader instead of XMLUtil for rdbms + fix reading of start formId

## Related issues

closes #26848
