### PR TITLE
Add username length validation in Rest API

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ErrorMessages.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ErrorMessages.java
@@ -30,4 +30,6 @@ public final class ErrorMessages {
   public static final String ERROR_MESSAGE_ONLY_ONE_FIELD = "Only one of %s is allowed";
   public static final String ERROR_MESSAGE_INVALID_EMAIL = "The provided email '%s' is not valid";
   public static final String ERROR_MESSAGE_ALL_REQUIRED_FIELD = "All %s are required";
+  public static final String ERROR_MESSAGE_TOO_MANY_CHARACTERS =
+      "The provided %s exceeds the limit of %d characters";
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/UserValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/UserValidator.java
@@ -33,14 +33,18 @@ public final class UserValidator {
   public static Optional<ProblemDetail> validateUserCreateRequest(final UserRequest request) {
     return validate(
         violations -> {
-          if (request.getUsername() == null || request.getUsername().isBlank()) {
-            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("username"));
-          }
+          validateUsername(request, violations);
           if (request.getPassword() == null || request.getPassword().isBlank()) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("password"));
           }
           violations.addAll(validateUserNameAndEmail(request.getName(), request.getEmail()));
         });
+  }
+
+  private static void validateUsername(final UserRequest request, final List<String> violations) {
+    if (request.getUsername() == null || request.getUsername().isBlank()) {
+      violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("username"));
+    }
   }
 
   private static List<String> validateUserNameAndEmail(final String name, final String email) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/UserValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/UserValidator.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.rest.validator;
 
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_INVALID_EMAIL;
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
 
 import io.camunda.zeebe.gateway.protocol.rest.UserChangeset;
@@ -21,6 +22,8 @@ import org.apache.commons.validator.routines.EmailValidator;
 import org.springframework.http.ProblemDetail;
 
 public final class UserValidator {
+
+  private static final int MAX_USERNAME_LENGTH = 256;
 
   public static Optional<ProblemDetail> validateUserUpdateRequest(final UserUpdateRequest request) {
     final UserChangeset changeset = request.getChangeset();
@@ -42,8 +45,11 @@ public final class UserValidator {
   }
 
   private static void validateUsername(final UserRequest request, final List<String> violations) {
-    if (request.getUsername() == null || request.getUsername().isBlank()) {
+    final var username = request.getUsername();
+    if (username == null || username.isBlank()) {
       violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("username"));
+    } else if (username.length() > MAX_USERNAME_LENGTH) {
+      violations.add(ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted("username", MAX_USERNAME_LENGTH));
     }
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
@@ -293,6 +293,27 @@ public class UserControllerTest extends RestControllerTest {
   }
 
   @Test
+  void shouldRejectUserCreationWithTooLongUsername() {
+    // given
+    final var username = "x".repeat(257);
+    final var request = validUserWithPasswordRequest().username(username);
+
+    // when then
+    assertRequestRejectedExceptionally(
+        request,
+        """
+            {
+              "type": "about:blank",
+              "status": 400,
+              "title": "INVALID_ARGUMENT",
+              "detail": "The provided username exceeds the limit of 256 characters.",
+              "instance": "%s"
+            }"""
+            .formatted(USER_BASE_URL));
+    verifyNoInteractions(userServices);
+  }
+
+  @Test
   void deleteUserShouldReturnNoContent() {
     // given
     final long key = 1234L;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Usernames are limited to 256 characters, as defined in [this document](https://docs.google.com/document/d/1-XeTGEnRPzsSuFdDJblwoLuSVNWvzT0bRclnLhEJe0A/edit?tab=t.0#heading=h.tdo3oan2anbm) (internal).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #26796 
