### PR TITLE
fix: use username instead of key in user export handlers

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -300,10 +300,10 @@
 
   <changeSet id="create_user_table" author="cthiel">
     <createTable tableName="USERS">
-      <column name="USER_KEY" type="BIGINT" >
+      <column name="USERNAME" type="VARCHAR(255)">
         <constraints primaryKey="true"/>
       </column>
-      <column name="USERNAME" type="VARCHAR(255)" />
+      <column name="USER_KEY" type="BIGINT"/>
       <column name="NAME" type="VARCHAR(255)" />
       <column name="EMAIL" type="VARCHAR(255)" />
       <column name="PASSWORD" type="VARCHAR(255)" />

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/UpsertMerger.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/UpsertMerger.java
@@ -14,24 +14,24 @@ import java.util.function.Function;
 public class UpsertMerger<T extends Copyable<T>> implements QueueItemMerger {
 
   private final ContextType contextType;
-  private final Long key;
+  private final Object id;
   private final Class<T> clazz;
   private final Function<ObjectBuilder<T>, ObjectBuilder<T>> mergeFunction;
 
   public UpsertMerger(
       final ContextType contextType,
-      final Long key,
+      final Object id,
       final Class<T> clazz,
       final Function<? extends ObjectBuilder<T>, ? extends ObjectBuilder<T>> mergeFunction) {
     this.contextType = contextType;
-    this.key = key;
+    this.id = id;
     this.clazz = clazz;
     this.mergeFunction = (Function<ObjectBuilder<T>, ObjectBuilder<T>>) mergeFunction;
   }
 
   @Override
   public boolean canBeMerged(final QueueItem queueItem) {
-    return queueItem.id().equals(key)
+    return queueItem.id().equals(id)
         && queueItem.contextType() == contextType
         && clazz.isInstance(queueItem.parameter());
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/UserWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/UserWriter.java
@@ -32,12 +32,7 @@ public class UserWriter {
     final boolean wasMerged =
         mergeToQueue(
             user.username(),
-            b ->
-                b.userKey(user.userKey())
-                    .username(user.username())
-                    .name(user.name())
-                    .email(user.email())
-                    .password(user.password()));
+            b -> b.name(user.name()).email(user.email()).password(user.password()));
 
     if (!wasMerged) {
       executionQueue.executeInQueue(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/UserWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/UserWriter.java
@@ -40,10 +40,13 @@ public class UserWriter {
     }
   }
 
-  public void delete(final long userKey) {
+  public void delete(final UserDbModel user) {
     executionQueue.executeInQueue(
         new QueueItem(
-            ContextType.USER, userKey, "io.camunda.db.rdbms.sql.UserMapper.delete", userKey));
+            ContextType.USER,
+            user.userKey(),
+            "io.camunda.db.rdbms.sql.UserMapper.delete",
+            user.username()));
   }
 
   private boolean mergeToQueue(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/UserWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/UserWriter.java
@@ -30,28 +30,28 @@ public class UserWriter {
 
   public void update(final UserDbModel user) {
     final boolean wasMerged =
-        mergeToQueue(
-            user.userKey(), b -> b.username(user.username()).name(user.name()).email(user.email()));
+        mergeToQueue(user.username(), b -> b.name(user.name()).email(user.email()));
 
     if (!wasMerged) {
       executionQueue.executeInQueue(
           new QueueItem(
-              ContextType.USER, user.userKey(), "io.camunda.db.rdbms.sql.UserMapper.update", user));
+              ContextType.USER,
+              user.username(),
+              "io.camunda.db.rdbms.sql.UserMapper.update",
+              user));
     }
   }
 
-  public void delete(final UserDbModel user) {
+  public void delete(final String username) {
     executionQueue.executeInQueue(
         new QueueItem(
-            ContextType.USER,
-            user.userKey(),
-            "io.camunda.db.rdbms.sql.UserMapper.delete",
-            user.username()));
+            ContextType.USER, username, "io.camunda.db.rdbms.sql.UserMapper.delete", username));
   }
 
   private boolean mergeToQueue(
-      final long key, final Function<UserDbModel.Builder, UserDbModel.Builder> mergeFunction) {
+      final String username,
+      final Function<UserDbModel.Builder, UserDbModel.Builder> mergeFunction) {
     return executionQueue.tryMergeWithExistingQueueItem(
-        new UpsertMerger<>(ContextType.USER, key, UserDbModel.class, mergeFunction));
+        new UpsertMerger<>(ContextType.USER, username, UserDbModel.class, mergeFunction));
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/UserWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/UserWriter.java
@@ -30,7 +30,14 @@ public class UserWriter {
 
   public void update(final UserDbModel user) {
     final boolean wasMerged =
-        mergeToQueue(user.username(), b -> b.name(user.name()).email(user.email()));
+        mergeToQueue(
+            user.username(),
+            b ->
+                b.userKey(user.userKey())
+                    .username(user.username())
+                    .name(user.name())
+                    .email(user.email())
+                    .password(user.password()));
 
     if (!wasMerged) {
       executionQueue.executeInQueue(

--- a/db/rdbms/src/main/resources/mapper/UserMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserMapper.xml
@@ -68,12 +68,12 @@
         NAME     = #{name},
         EMAIL    = #{email},
         PASSWORD = #{password}
-    WHERE USER_KEY = #{userKey}
+    WHERE USERNAME = #{username}
   </update>
 
   <delete id="delete" parameterType="java.lang.Long" flushCache="true">
     DELETE FROM USERS
-    WHERE USER_KEY = #{userKey}
+    WHERE USERNAME = #{username}
   </delete>
 
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/UserMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserMapper.xml
@@ -71,7 +71,7 @@
     WHERE USERNAME = #{username}
   </update>
 
-  <delete id="delete" parameterType="java.lang.Long" flushCache="true">
+  <delete id="delete" parameterType="java.lang.String" flushCache="true">
     DELETE FROM USERS
     WHERE USERNAME = #{username}
   </delete>

--- a/db/rdbms/src/main/resources/mapper/UserMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserMapper.xml
@@ -64,8 +64,7 @@
     parameterType="io.camunda.db.rdbms.write.domain.UserDbModel"
     flushCache="true">
     UPDATE USERS
-    SET USERNAME = #{username},
-        NAME     = #{name},
+    SET NAME     = #{name},
         EMAIL    = #{email},
         PASSWORD = #{password}
     WHERE USERNAME = #{username}

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/user/UserIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/user/UserIT.java
@@ -78,7 +78,7 @@ public class UserIT {
     final var instance = userReader.findOne(user.userKey()).orElse(null);
     compareUsers(instance, user);
 
-    rdbmsWriter.getUserWriter().delete(user.userKey());
+    rdbmsWriter.getUserWriter().delete(user);
     rdbmsWriter.flush();
 
     final var deletedInstance = userReader.findOne(user.userKey()).orElse(null);

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/user/UserIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/user/UserIT.java
@@ -58,7 +58,8 @@ public class UserIT {
     final var user = UserFixtures.createRandomized(b -> b);
     createAndSaveUser(rdbmsWriter, user);
 
-    final var userUpdate = UserFixtures.createRandomized(b -> b.userKey(user.userKey()));
+    final var userUpdate =
+        UserFixtures.createRandomized(b -> b.userKey(user.userKey()).username(user.username()));
     rdbmsWriter.getUserWriter().update(userUpdate);
     rdbmsWriter.flush();
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/user/UserIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/user/UserIT.java
@@ -79,7 +79,7 @@ public class UserIT {
     final var instance = userReader.findOne(user.userKey()).orElse(null);
     compareUsers(instance, user);
 
-    rdbmsWriter.getUserWriter().delete(user);
+    rdbmsWriter.getUserWriter().delete(user.username());
     rdbmsWriter.flush();
 
     final var deletedInstance = userReader.findOne(user.userKey()).orElse(null);

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -262,7 +262,7 @@ class RdbmsExporterIT {
   @Test
   public void shouldExportUpdateAndDeleteUser() {
     // given
-    final var userRecord = getUserRecord(42L, UserIntent.CREATED);
+    final var userRecord = getUserRecord(42L, "test", UserIntent.CREATED);
     final var userRecordValue = ((UserRecordValue) userRecord.getValue());
 
     // when
@@ -278,7 +278,7 @@ class RdbmsExporterIT {
     assertThat(user.get().password()).isEqualTo(userRecordValue.getPassword());
 
     // given
-    final var updateUserRecord = getUserRecord(42L, UserIntent.UPDATED);
+    final var updateUserRecord = getUserRecord(42L, "test", UserIntent.UPDATED);
     final var updateUserRecordValue = ((UserRecordValue) updateUserRecord.getValue());
 
     // when
@@ -294,7 +294,7 @@ class RdbmsExporterIT {
     assertThat(updatedUser.get().password()).isEqualTo(updateUserRecordValue.getPassword());
 
     // when
-    exporter.export(getUserRecord(42L, UserIntent.DELETED));
+    exporter.export(getUserRecord(42L, "test", UserIntent.DELETED));
 
     // then
     final var deletedUser = rdbmsService.getUserReader().findOne(userRecord.getKey());

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -252,7 +252,7 @@ public class RecordFixtures {
   }
 
   protected static ImmutableRecord<RecordValue> getUserRecord(
-      final Long userKey, final UserIntent intent) {
+      final Long userKey, final String username, final UserIntent intent) {
     final Record<RecordValue> recordValueRecord = FACTORY.generateRecord(ValueType.USER);
 
     return ImmutableRecord.builder()
@@ -265,6 +265,7 @@ public class RecordFixtures {
             ImmutableUserRecordValue.builder()
                 .from((UserRecordValue) recordValueRecord.getValue())
                 .withUserKey(userKey)
+                .withUsername(username)
                 .build())
         .build();
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
@@ -147,9 +147,6 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
               .setEntityType(EntityType.USER));
     }
 
-    stateWriter.appendFollowUpEvent(
-        userKey,
-        UserIntent.DELETED,
-        new UserRecord().setUserKey(userKey).setUsername(user.getUsername()));
+    stateWriter.appendFollowUpEvent(userKey, UserIntent.DELETED, user.getUser());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
@@ -148,6 +148,8 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
     }
 
     stateWriter.appendFollowUpEvent(
-        userKey, UserIntent.DELETED, new UserRecord().setUserKey(userKey));
+        userKey,
+        UserIntent.DELETED,
+        new UserRecord().setUserKey(userKey).setUsername(user.getUsername()));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserCreatedUpdatedHandler.java
@@ -45,7 +45,7 @@ public class UserCreatedUpdatedHandler implements ExportHandler<UserEntity, User
 
   @Override
   public List<String> generateIds(final Record<UserRecordValue> record) {
-    return List.of(String.valueOf(record.getKey()));
+    return List.of(record.getValue().getUsername());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserDeletedHandler.java
@@ -44,7 +44,7 @@ public class UserDeletedHandler implements ExportHandler<UserEntity, UserRecordV
 
   @Override
   public List<String> generateIds(final Record<UserRecordValue> record) {
-    return List.of(String.valueOf(record.getKey()));
+    return List.of(record.getValue().getUsername());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserCreatedUpdatedHandlerTest.java
@@ -61,7 +61,7 @@ public class UserCreatedUpdatedHandlerTest {
     final var idList = underTest.generateIds(userRecord);
 
     // then
-    assertThat(idList).containsExactly(String.valueOf(userRecord.getKey()));
+    assertThat(idList).containsExactly(userRecord.getValue().getUsername());
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserDeletedHandlerTest.java
@@ -57,7 +57,7 @@ public class UserDeletedHandlerTest {
     final var idList = underTest.generateIds(userRecord);
 
     // then
-    assertThat(idList).containsExactly(String.valueOf(userRecord.getKey()));
+    assertThat(idList).containsExactly(String.valueOf(userRecord.getValue().getUsername()));
   }
 
   @Test

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/UserExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/UserExportHandler.java
@@ -44,7 +44,7 @@ public class UserExportHandler implements RdbmsExportHandler<UserRecordValue> {
     } else if (record.getIntent() == UserIntent.UPDATED) {
       userWriter.update(map(value));
     } else if (record.getIntent() == UserIntent.DELETED) {
-      userWriter.delete(value.getUserKey());
+      userWriter.delete(map(value));
     } else {
       LOG.warn("Unexpected intent {} for user record", record.getIntent());
     }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/UserExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/UserExportHandler.java
@@ -44,7 +44,7 @@ public class UserExportHandler implements RdbmsExportHandler<UserRecordValue> {
     } else if (record.getIntent() == UserIntent.UPDATED) {
       userWriter.update(map(value));
     } else if (record.getIntent() == UserIntent.DELETED) {
-      userWriter.delete(map(value));
+      userWriter.delete(value.getUsername());
     } else {
       LOG.warn("Unexpected intent {} for user record", record.getIntent());
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR updates the exporters (both OS/ES and RDBMS) to use the username instead of the key as the ID of the user object during exports.

I've tested this locally and observed the exporters successfully exporting the ID of the record as the username, I was also able to successfully perform updates and deletes.

## Related issues

closes https://github.com/camunda/camunda/issues/26857 https://github.com/camunda/camunda/issues/26858 https://github.com/camunda/camunda/issues/26859
