### PR TITLE
fix: Improve user task assignment handling and `changedAttributes` population

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -330,6 +330,7 @@ public final class BpmnUserTaskBehavior {
   public void userTaskAssigning(final UserTaskRecord userTaskRecord, final String assignee) {
     final long userTaskKey = userTaskRecord.getUserTaskKey();
     userTaskRecord.setAssignee(assignee);
+    userTaskRecord.setAssigneeChanged();
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNING, userTaskRecord);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -329,8 +329,10 @@ public final class BpmnUserTaskBehavior {
 
   public void userTaskAssigning(final UserTaskRecord userTaskRecord, final String assignee) {
     final long userTaskKey = userTaskRecord.getUserTaskKey();
-    userTaskRecord.setAssignee(assignee);
-    userTaskRecord.setAssigneeChanged();
+    if (!userTaskRecord.getAssignee().equals(assignee)) {
+      userTaskRecord.setAssignee(assignee);
+      userTaskRecord.setAssigneeChanged();
+    }
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNING, userTaskRecord);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
@@ -55,6 +55,7 @@ public final class UserTaskAssignProcessor implements UserTaskCommandProcessor {
     final long userTaskKey = command.getKey();
 
     userTaskRecord.setAssignee(command.getValue().getAssignee());
+    userTaskRecord.setAssigneeChanged();
     userTaskRecord.setAction(command.getValue().getActionOrDefault(DEFAULT_ACTION));
 
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNING, userTaskRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
@@ -54,8 +54,11 @@ public final class UserTaskAssignProcessor implements UserTaskCommandProcessor {
       final TypedRecord<UserTaskRecord> command, final UserTaskRecord userTaskRecord) {
     final long userTaskKey = command.getKey();
 
-    userTaskRecord.setAssignee(command.getValue().getAssignee());
-    userTaskRecord.setAssigneeChanged();
+    final var newAssignee = command.getValue().getAssignee();
+    if (!userTaskRecord.getAssignee().equals(newAssignee)) {
+      userTaskRecord.setAssignee(newAssignee);
+      userTaskRecord.setAssigneeChanged();
+    }
     userTaskRecord.setAction(command.getValue().getActionOrDefault(DEFAULT_ACTION));
 
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNING, userTaskRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
@@ -65,6 +65,7 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
     final long userTaskKey = command.getKey();
 
     userTaskRecord.setAssignee(command.getValue().getAssignee());
+    userTaskRecord.setAssigneeChanged();
     userTaskRecord.setAction(command.getValue().getActionOrDefault(DEFAULT_ACTION));
 
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CLAIMING, userTaskRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
@@ -64,8 +64,11 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
       final TypedRecord<UserTaskRecord> command, final UserTaskRecord userTaskRecord) {
     final long userTaskKey = command.getKey();
 
-    userTaskRecord.setAssignee(command.getValue().getAssignee());
-    userTaskRecord.setAssigneeChanged();
+    final var newAssignee = command.getValue().getAssignee();
+    if (!userTaskRecord.getAssignee().equals(newAssignee)) {
+      userTaskRecord.setAssignee(newAssignee);
+      userTaskRecord.setAssigneeChanged();
+    }
     userTaskRecord.setAction(command.getValue().getActionOrDefault(DEFAULT_ACTION));
 
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CLAIMING, userTaskRecord);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -1448,7 +1448,7 @@ public class TaskListenerTest {
             // initial values that were before task assignment using the corrections.
             tuple(UserTaskIntent.ASSIGNED, List.of("candidateGroupsList", "dueDate")));
 
-    final var createUserTaskValue =
+    final var createdUserTaskValue =
         RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .getFirst()
@@ -1461,11 +1461,11 @@ public class TaskListenerTest {
 
     Assertions.assertThat(assignedUserTaskValue)
         // unchanged properties
-        .hasFollowUpDate(createUserTaskValue.getFollowUpDate())
-        .hasCandidateUsersList(createUserTaskValue.getCandidateUsersList())
+        .hasFollowUpDate(createdUserTaskValue.getFollowUpDate())
+        .hasCandidateUsersList(createdUserTaskValue.getCandidateUsersList())
         // properties reset to their initial values
-        .hasAssignee(createUserTaskValue.getAssignee())
-        .hasPriority(createUserTaskValue.getPriority())
+        .hasAssignee(createdUserTaskValue.getAssignee())
+        .hasPriority(createdUserTaskValue.getPriority())
         // changed properties
         .hasDueDate("corrected_due_date")
         .hasCandidateGroupsList("hobbits")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateUserTaskTest.java
@@ -398,12 +398,7 @@ public class MigrateUserTaskTest {
     // Note that while the user task is migrated, it's properties did not change even though they're
     // different in the target process. Because re-evaluation of these expressions is not yet
     // supported.
-    ENGINE
-        .userTask()
-        .ofInstance(processInstanceKey)
-        .withKey(userTaskKey)
-        .withoutAssignee()
-        .assign();
+    ENGINE.userTask().ofInstance(processInstanceKey).withKey(userTaskKey).unassign();
     ENGINE
         .userTask()
         .ofInstance(processInstanceKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/AssignUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/AssignUserTaskTest.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
-import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.function.Consumer;
@@ -63,17 +62,15 @@ public final class AssignUserTaskTest {
             .getKey();
 
     // when
-    final Record<UserTaskRecordValue> assignedRecord =
-        ENGINE.userTask().withKey(userTaskKey).withAssignee("foo").assign();
+    final var assigningRecord = ENGINE.userTask().withKey(userTaskKey).withAssignee("foo").assign();
 
     // then
-    final UserTaskRecordValue recordValue = assignedRecord.getValue();
-
-    Assertions.assertThat(assignedRecord)
+    Assertions.assertThat(assigningRecord)
         .hasRecordType(RecordType.EVENT)
         .hasIntent(UserTaskIntent.ASSIGNING);
 
-    Assertions.assertThat(recordValue)
+    final var assigningRecordValue = assigningRecord.getValue();
+    Assertions.assertThat(assigningRecordValue)
         .hasUserTaskKey(userTaskKey)
         .hasAction("assign")
         .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
@@ -125,7 +122,7 @@ public final class AssignUserTaskTest {
             .getKey();
 
     // when
-    final Record<UserTaskRecordValue> assignedRecord =
+    final var assigningRecord =
         ENGINE
             .userTask()
             .withKey(userTaskKey)
@@ -134,13 +131,12 @@ public final class AssignUserTaskTest {
             .assign();
 
     // then
-    final UserTaskRecordValue recordValue = assignedRecord.getValue();
-
-    Assertions.assertThat(assignedRecord)
+    Assertions.assertThat(assigningRecord)
         .hasRecordType(RecordType.EVENT)
         .hasIntent(UserTaskIntent.ASSIGNING);
 
-    Assertions.assertThat(recordValue)
+    final var assigningRecordValue = assigningRecord.getValue();
+    Assertions.assertThat(assigningRecordValue)
         .hasUserTaskKey(userTaskKey)
         .hasAction("customAction")
         .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
@@ -152,11 +148,11 @@ public final class AssignUserTaskTest {
     final int key = 123;
 
     // when
-    final Record<UserTaskRecordValue> assignedRecord =
+    final var assigningRecord =
         ENGINE.userTask().withKey(key).withAssignee("foo").expectRejection().assign();
 
     // then
-    Assertions.assertThat(assignedRecord).hasRejectionType(RejectionType.NOT_FOUND);
+    Assertions.assertThat(assigningRecord).hasRejectionType(RejectionType.NOT_FOUND);
   }
 
   @Test
@@ -166,14 +162,16 @@ public final class AssignUserTaskTest {
     final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
     // when
-    final Record<UserTaskRecordValue> assignedRecord =
+    final var assigningRecord =
         ENGINE.userTask().ofInstance(processInstanceKey).withAssignee("foo").assign();
 
     // then
-    Assertions.assertThat(assignedRecord)
+    Assertions.assertThat(assigningRecord)
         .hasRecordType(RecordType.EVENT)
         .hasIntent(UserTaskIntent.ASSIGNING);
-    Assertions.assertThat(assignedRecord.getValue()).hasAssignee("foo");
+
+    final var assigningRecordValue = assigningRecord.getValue();
+    Assertions.assertThat(assigningRecordValue).hasAssignee("foo");
   }
 
   @Test
@@ -183,14 +181,16 @@ public final class AssignUserTaskTest {
     final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
     // when
-    final Record<UserTaskRecordValue> assignedRecord =
+    final var assigningRecord =
         ENGINE.userTask().ofInstance(processInstanceKey).withoutAssignee().assign();
 
     // then
-    Assertions.assertThat(assignedRecord)
+    Assertions.assertThat(assigningRecord)
         .hasRecordType(RecordType.EVENT)
         .hasIntent(UserTaskIntent.ASSIGNING);
-    assertThat(assignedRecord.getValue().getAssignee()).isEmpty();
+
+    final var assigningRecordValue = assigningRecord.getValue();
+    Assertions.assertThat(assigningRecordValue).hasAssignee("");
   }
 
   @Test
@@ -202,11 +202,11 @@ public final class AssignUserTaskTest {
     ENGINE.userTask().ofInstance(processInstanceKey).complete();
 
     // when
-    final Record<UserTaskRecordValue> assignedRecord =
+    final var assigningRecord =
         ENGINE.userTask().ofInstance(processInstanceKey).expectRejection().assign();
 
     // then
-    Assertions.assertThat(assignedRecord).hasRejectionType(RejectionType.NOT_FOUND);
+    Assertions.assertThat(assigningRecord).hasRejectionType(RejectionType.NOT_FOUND);
   }
 
   @Test
@@ -218,7 +218,7 @@ public final class AssignUserTaskTest {
         ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(tenantId).create();
 
     // when
-    final Record<UserTaskRecordValue> assignedRecord =
+    final var assigningRecord =
         ENGINE
             .userTask()
             .ofInstance(processInstanceKey)
@@ -227,13 +227,12 @@ public final class AssignUserTaskTest {
             .assign();
 
     // then
-    final UserTaskRecordValue recordValue = assignedRecord.getValue();
-
-    Assertions.assertThat(assignedRecord)
+    Assertions.assertThat(assigningRecord)
         .hasRecordType(RecordType.EVENT)
         .hasIntent(UserTaskIntent.ASSIGNING);
 
-    Assertions.assertThat(recordValue).hasTenantId(tenantId);
+    final var assigningRecordValue = assigningRecord.getValue();
+    Assertions.assertThat(assigningRecordValue).hasTenantId(tenantId);
   }
 
   @Test
@@ -246,7 +245,7 @@ public final class AssignUserTaskTest {
         ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(tenantId).create();
 
     // when
-    final Record<UserTaskRecordValue> assignedRecord =
+    final var assigningRecord =
         ENGINE
             .userTask()
             .ofInstance(processInstanceKey)
@@ -255,6 +254,6 @@ public final class AssignUserTaskTest {
             .assign();
 
     // then
-    Assertions.assertThat(assignedRecord).hasRejectionType(RejectionType.NOT_FOUND);
+    Assertions.assertThat(assigningRecord).hasRejectionType(RejectionType.NOT_FOUND);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/AssignUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/AssignUserTaskTest.java
@@ -174,25 +174,6 @@ public final class AssignUserTaskTest {
   }
 
   @Test
-  public void shouldAssignUserTaskWithAssignee() {
-    // given
-    ENGINE.deployment().withXmlResource(process()).deploy();
-    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-
-    // when
-    final var assigningRecord =
-        ENGINE.userTask().ofInstance(processInstanceKey).withAssignee("foo").assign();
-
-    // then
-    Assertions.assertThat(assigningRecord)
-        .hasRecordType(RecordType.EVENT)
-        .hasIntent(UserTaskIntent.ASSIGNING);
-
-    final var assigningRecordValue = assigningRecord.getValue();
-    Assertions.assertThat(assigningRecordValue).hasAssignee("foo");
-  }
-
-  @Test
   public void shouldUnassignUserTaskWithNoAssignee() {
     // given
     final var initialAssignee = "pippin";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/AssignUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/AssignUserTaskTest.java
@@ -127,6 +127,47 @@ public final class AssignUserTaskTest {
   }
 
   @Test
+  public void shouldNotUpdateChangedAttributesWhenTaskAssignedToSameAssignee() {
+    // given
+    final var assignee = "frodo";
+    ENGINE.deployment().withXmlResource(process(t -> t.zeebeAssignee(assignee))).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final long userTaskKey =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+
+    // when
+    final var assigningRecord =
+        ENGINE.userTask().withKey(userTaskKey).withAssignee(assignee).assign();
+
+    // then
+    Assertions.assertThat(assigningRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(UserTaskIntent.ASSIGNING);
+
+    final var assigningRecordValue = assigningRecord.getValue();
+    final var assignedRecordValue =
+        RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+            .filter(r -> r.getPosition() > assigningRecord.getPosition())
+            .getFirst()
+            .getValue();
+
+    assertThat(List.of(assigningRecordValue, assignedRecordValue))
+        .allSatisfy(
+            recordValue ->
+                Assertions.assertThat(recordValue)
+                    .hasUserTaskKey(userTaskKey)
+                    .hasAction(DEFAULT_ACTION)
+                    .hasAssignee(assignee)
+                    .describedAs(
+                        "Expect that `changedAttributes` is empty as the task was assigned to the same assignee")
+                    .hasNoChangedAttributes()
+                    .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
+  }
+
+  @Test
   public void shouldEmitAssignEventsWithCustomAction() {
     // given
     ENGINE.deployment().withXmlResource(process()).deploy();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/AssignUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/AssignUserTaskTest.java
@@ -79,6 +79,9 @@ public final class AssignUserTaskTest {
         RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED).getFirst().getValue();
 
     assertThat(List.of(assigningRecordValue, assignedRecordValue))
+        .describedAs(
+            "Ensure ASSIGNING and ASSIGNED records have consistent attribute values "
+                + "as dependent applications will rely on them to update user task data internally")
         .allSatisfy(
             recordValue ->
                 Assertions.assertThat(recordValue)
@@ -155,6 +158,9 @@ public final class AssignUserTaskTest {
             .getValue();
 
     assertThat(List.of(assigningRecordValue, assignedRecordValue))
+        .describedAs(
+            "Ensure ASSIGNING and ASSIGNED records have consistent attribute values "
+                + "as dependent applications will rely on them to update user task data internally")
         .allSatisfy(
             recordValue ->
                 Assertions.assertThat(recordValue)
@@ -197,6 +203,9 @@ public final class AssignUserTaskTest {
         RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED).getFirst().getValue();
 
     assertThat(List.of(assigningRecordValue, assignedRecordValue))
+        .describedAs(
+            "Ensure ASSIGNING and ASSIGNED records have consistent attribute values "
+                + "as dependent applications will rely on them to update user task data internally")
         .allSatisfy(
             recordValue ->
                 Assertions.assertThat(recordValue)
@@ -303,11 +312,15 @@ public final class AssignUserTaskTest {
         RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED).getFirst().getValue();
 
     assertThat(List.of(assigningRecordValue, assignedRecordValue))
+        .describedAs(
+            "Ensure ASSIGNING and ASSIGNED records have consistent attribute values "
+                + "as dependent applications will rely on them to update user task data internally")
         .allSatisfy(
             recordValue ->
                 Assertions.assertThat(recordValue)
                     .hasAction(DEFAULT_ACTION)
                     .hasAssignee("foo")
+                    .hasOnlyChangedAttributes(UserTaskRecord.ASSIGNEE)
                     .hasTenantId(tenantId));
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/AssignUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/AssignUserTaskTest.java
@@ -188,12 +188,7 @@ public final class AssignUserTaskTest {
     final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
     // when
-    ENGINE
-        .userTask()
-        .ofInstance(processInstanceKey)
-        .withoutAssignee()
-        .withAction(unassignAction)
-        .assign();
+    ENGINE.userTask().ofInstance(processInstanceKey).unassign();
 
     // then
     final Predicate<Record<UserTaskRecordValue>> untilUserTaskUnassignedRecord =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/ClaimUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/ClaimUserTaskTest.java
@@ -137,7 +137,12 @@ public class ClaimUserTaskTest {
 
     // when
     final var claimingRecord =
-        ENGINE.userTask().ofInstance(processInstanceKey).withAssignee("").expectRejection().claim();
+        ENGINE
+            .userTask()
+            .ofInstance(processInstanceKey)
+            .withoutAssignee()
+            .expectRejection()
+            .claim();
 
     // then
     Assertions.assertThat(claimingRecord).hasRejectionType(RejectionType.INVALID_STATE);
@@ -193,7 +198,7 @@ public class ClaimUserTaskTest {
 
     // when
     final var claimingRecord =
-        ENGINE.userTask().withKey(userTaskKey).withAssignee("").expectRejection().claim();
+        ENGINE.userTask().withKey(userTaskKey).withoutAssignee().expectRejection().claim();
 
     // then
     Assertions.assertThat(claimingRecord).hasRejectionType(RejectionType.INVALID_STATE);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/ClaimUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/ClaimUserTaskTest.java
@@ -228,9 +228,12 @@ public class ClaimUserTaskTest {
                 Assertions.assertThat(recordValue)
                     .hasUserTaskKey(userTaskKey)
                     .hasAction(DEFAULT_ACTION)
+                    .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
                     .hasAssignee(initialAssignee)
-                    .hasOnlyChangedAttributes(UserTaskRecord.ASSIGNEE)
-                    .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
+                    .describedAs(
+                        "Expect that the `changedAttributes` field is empty because the task was "
+                            + "claimed by the same user and the `assignee` value did not change.")
+                    .hasNoChangedAttributes());
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/ClaimUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/ClaimUserTaskTest.java
@@ -12,12 +12,10 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.UserTaskBuilder;
 import io.camunda.zeebe.protocol.record.Assertions;
-import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
-import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.function.Consumer;
@@ -58,17 +56,15 @@ public class ClaimUserTaskTest {
             .getKey();
 
     // when
-    final Record<UserTaskRecordValue> claimedRecord =
-        ENGINE.userTask().withKey(userTaskKey).withAssignee("foo").claim();
+    final var claimingRecord = ENGINE.userTask().withKey(userTaskKey).withAssignee("foo").claim();
 
     // then
-    final UserTaskRecordValue recordValue = claimedRecord.getValue();
-
-    Assertions.assertThat(claimedRecord)
+    Assertions.assertThat(claimingRecord)
         .hasRecordType(RecordType.EVENT)
         .hasIntent(UserTaskIntent.CLAIMING);
 
-    Assertions.assertThat(recordValue)
+    final var claimingRecordValue = claimingRecord.getValue();
+    Assertions.assertThat(claimingRecordValue)
         .hasUserTaskKey(userTaskKey)
         .hasAction("claim")
         .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
@@ -86,7 +82,7 @@ public class ClaimUserTaskTest {
             .getKey();
 
     // when
-    final Record<UserTaskRecordValue> claimedRecord =
+    final var claimingRecord =
         ENGINE
             .userTask()
             .withKey(userTaskKey)
@@ -95,13 +91,12 @@ public class ClaimUserTaskTest {
             .claim();
 
     // then
-    final UserTaskRecordValue recordValue = claimedRecord.getValue();
-
-    Assertions.assertThat(claimedRecord)
+    Assertions.assertThat(claimingRecord)
         .hasRecordType(RecordType.EVENT)
         .hasIntent(UserTaskIntent.CLAIMING);
 
-    Assertions.assertThat(recordValue)
+    final var claimingRecordValue = claimingRecord.getValue();
+    Assertions.assertThat(claimingRecordValue)
         .hasUserTaskKey(userTaskKey)
         .hasAction("customAction")
         .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
@@ -114,14 +109,16 @@ public class ClaimUserTaskTest {
     final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
     // when
-    final Record<UserTaskRecordValue> claimedRecord =
+    final var claimingRecord =
         ENGINE.userTask().ofInstance(processInstanceKey).withAssignee("foo").claim();
 
     // then
-    Assertions.assertThat(claimedRecord)
+    Assertions.assertThat(claimingRecord)
         .hasRecordType(RecordType.EVENT)
         .hasIntent(UserTaskIntent.CLAIMING);
-    Assertions.assertThat(claimedRecord.getValue()).hasAssignee("foo");
+
+    final var claimingRecordValue = claimingRecord.getValue();
+    Assertions.assertThat(claimingRecordValue).hasAssignee("foo");
   }
 
   @Test
@@ -131,11 +128,11 @@ public class ClaimUserTaskTest {
     final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
     // when
-    final Record<UserTaskRecordValue> claimedRecord =
+    final var claimingRecord =
         ENGINE.userTask().ofInstance(processInstanceKey).withAssignee("").expectRejection().claim();
 
     // then
-    Assertions.assertThat(claimedRecord).hasRejectionType(RejectionType.INVALID_STATE);
+    Assertions.assertThat(claimingRecord).hasRejectionType(RejectionType.INVALID_STATE);
   }
 
   @Test
@@ -144,11 +141,11 @@ public class ClaimUserTaskTest {
     final int key = 123;
 
     // when
-    final Record<UserTaskRecordValue> claimedRecord =
+    final var claimingRecord =
         ENGINE.userTask().withKey(key).withAssignee("foo").expectRejection().claim();
 
     // then
-    Assertions.assertThat(claimedRecord).hasRejectionType(RejectionType.NOT_FOUND);
+    Assertions.assertThat(claimingRecord).hasRejectionType(RejectionType.NOT_FOUND);
   }
 
   @Test
@@ -163,7 +160,7 @@ public class ClaimUserTaskTest {
             .getKey();
 
     // when
-    final Record<UserTaskRecordValue> claimedRecord =
+    final var claimingRecord =
         ENGINE
             .userTask()
             .withKey(userTaskKey)
@@ -172,7 +169,7 @@ public class ClaimUserTaskTest {
             .claim();
 
     // then
-    Assertions.assertThat(claimedRecord).hasRejectionType(RejectionType.INVALID_STATE);
+    Assertions.assertThat(claimingRecord).hasRejectionType(RejectionType.INVALID_STATE);
   }
 
   @Test
@@ -187,11 +184,11 @@ public class ClaimUserTaskTest {
             .getKey();
 
     // when
-    final Record<UserTaskRecordValue> claimedRecord =
+    final var claimingRecord =
         ENGINE.userTask().withKey(userTaskKey).withAssignee("").expectRejection().claim();
 
     // then
-    Assertions.assertThat(claimedRecord).hasRejectionType(RejectionType.INVALID_STATE);
+    Assertions.assertThat(claimingRecord).hasRejectionType(RejectionType.INVALID_STATE);
   }
 
   @Test
@@ -206,14 +203,15 @@ public class ClaimUserTaskTest {
             .getKey();
 
     // when
-    final Record<UserTaskRecordValue> claimedRecord =
-        ENGINE.userTask().withKey(userTaskKey).withAssignee("foo").claim();
+    final var claimingRecord = ENGINE.userTask().withKey(userTaskKey).withAssignee("foo").claim();
 
     // then
-    Assertions.assertThat(claimedRecord)
+    Assertions.assertThat(claimingRecord)
         .hasRecordType(RecordType.EVENT)
         .hasIntent(UserTaskIntent.CLAIMING);
-    Assertions.assertThat(claimedRecord.getValue()).hasAssignee("foo");
+
+    final var claimingRecordValue = claimingRecord.getValue();
+    Assertions.assertThat(claimingRecordValue).hasAssignee("foo");
   }
 
   @Test
@@ -225,11 +223,11 @@ public class ClaimUserTaskTest {
     ENGINE.userTask().ofInstance(processInstanceKey).complete();
 
     // when
-    final Record<UserTaskRecordValue> claimedRecord =
+    final var claimingRecord =
         ENGINE.userTask().ofInstance(processInstanceKey).expectRejection().claim();
 
     // then
-    Assertions.assertThat(claimedRecord).hasRejectionType(RejectionType.NOT_FOUND);
+    Assertions.assertThat(claimingRecord).hasRejectionType(RejectionType.NOT_FOUND);
   }
 
   @Test
@@ -241,7 +239,7 @@ public class ClaimUserTaskTest {
         ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(tenantId).create();
 
     // when
-    final Record<UserTaskRecordValue> claimedRecord =
+    final var claimingRecord =
         ENGINE
             .userTask()
             .ofInstance(processInstanceKey)
@@ -250,13 +248,12 @@ public class ClaimUserTaskTest {
             .claim();
 
     // then
-    final UserTaskRecordValue recordValue = claimedRecord.getValue();
-
-    Assertions.assertThat(claimedRecord)
+    Assertions.assertThat(claimingRecord)
         .hasRecordType(RecordType.EVENT)
         .hasIntent(UserTaskIntent.CLAIMING);
 
-    Assertions.assertThat(recordValue).hasTenantId(tenantId);
+    final var claimingRecordValue = claimingRecord.getValue();
+    Assertions.assertThat(claimingRecordValue).hasTenantId(tenantId);
   }
 
   @Test
@@ -269,7 +266,7 @@ public class ClaimUserTaskTest {
         ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(tenantId).create();
 
     // when
-    final Record<UserTaskRecordValue> claimedRecord =
+    final var claimingRecord =
         ENGINE
             .userTask()
             .ofInstance(processInstanceKey)
@@ -278,6 +275,6 @@ public class ClaimUserTaskTest {
             .claim();
 
     // then
-    Assertions.assertThat(claimedRecord).hasRejectionType(RejectionType.NOT_FOUND);
+    Assertions.assertThat(claimingRecord).hasRejectionType(RejectionType.NOT_FOUND);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/ClaimUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/ClaimUserTaskTest.java
@@ -73,6 +73,9 @@ public class ClaimUserTaskTest {
         RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED).getFirst().getValue();
 
     assertThat(List.of(claimingRecordValue, assignedRecordValue))
+        .describedAs(
+            "Ensure CLAIMING and ASSIGNED records have consistent attribute values "
+                + "as dependent applications will rely on them to update user task data internally")
         .allSatisfy(
             recordValue ->
                 Assertions.assertThat(recordValue)
@@ -113,6 +116,9 @@ public class ClaimUserTaskTest {
         RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED).getFirst().getValue();
 
     assertThat(List.of(claimingRecordValue, assignedRecordValue))
+        .describedAs(
+            "Ensure CLAIMING and ASSIGNED records have consistent attribute values "
+                + "as dependent applications will rely on them to update user task data internally")
         .allSatisfy(
             recordValue ->
                 Assertions.assertThat(recordValue)
@@ -223,6 +229,9 @@ public class ClaimUserTaskTest {
             .getValue();
 
     assertThat(List.of(claimingRecordValue, assignedRecordValue))
+        .describedAs(
+            "Ensure CLAIMING and ASSIGNED records have consistent attribute values "
+                + "as dependent applications will rely on them to update user task data internally")
         .allSatisfy(
             recordValue ->
                 Assertions.assertThat(recordValue)
@@ -232,7 +241,7 @@ public class ClaimUserTaskTest {
                     .hasAssignee(initialAssignee)
                     .describedAs(
                         "Expect that the `changedAttributes` field is empty because the task was "
-                            + "claimed by the same user and the `assignee` value did not change.")
+                            + "claimed by the same user and the `assignee` value did not change")
                     .hasNoChangedAttributes());
   }
 
@@ -279,6 +288,9 @@ public class ClaimUserTaskTest {
         RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED).getFirst().getValue();
 
     assertThat(List.of(claimingRecordValue, assignedRecordValue))
+        .describedAs(
+            "Ensure CLAIMING and ASSIGNED records have consistent attribute values "
+                + "as dependent applications will rely on them to update user task data internally")
         .allSatisfy(
             recordValue ->
                 Assertions.assertThat(recordValue)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/ClaimUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/ClaimUserTaskTest.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.UserTaskBuilder;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -78,6 +79,7 @@ public class ClaimUserTaskTest {
                     .hasUserTaskKey(userTaskKey)
                     .hasAction(DEFAULT_ACTION)
                     .hasAssignee("foo")
+                    .hasOnlyChangedAttributes(UserTaskRecord.ASSIGNEE)
                     .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
   }
 
@@ -117,6 +119,7 @@ public class ClaimUserTaskTest {
                     .hasUserTaskKey(userTaskKey)
                     .hasAction("customAction")
                     .hasAssignee("foo")
+                    .hasOnlyChangedAttributes(UserTaskRecord.ASSIGNEE)
                     .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
   }
 
@@ -226,6 +229,7 @@ public class ClaimUserTaskTest {
                     .hasUserTaskKey(userTaskKey)
                     .hasAction(DEFAULT_ACTION)
                     .hasAssignee(initialAssignee)
+                    .hasOnlyChangedAttributes(UserTaskRecord.ASSIGNEE)
                     .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
@@ -119,6 +119,10 @@ public final class UserTaskClient {
     return userTaskKey;
   }
 
+  public Record<UserTaskRecordValue> unassign() {
+    return withoutAssignee().withAction(userTaskRecord.getActionOrDefault("unassign")).assign();
+  }
+
   public Record<UserTaskRecordValue> assign() {
     final long userTaskKey = findUserTaskKey();
     final long position =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -185,10 +185,7 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
     entity
         .setImplementation(TaskImplementation.ZEEBE_USER_TASK)
         .setState(TaskState.CREATED)
-        .setAssignee(
-            ExporterUtil.isEmpty(record.getValue().getAssignee())
-                ? null
-                : record.getValue().getAssignee())
+        .setAssignee(getAssigneeOrNull(record))
         .setDueDate(ExporterUtil.toOffsetDateTime(record.getValue().getDueDate()))
         .setFollowUpDate(ExporterUtil.toOffsetDateTime(record.getValue().getFollowUpDate()))
         .setFlowNodeInstanceId(String.valueOf(record.getValue().getElementInstanceKey()))
@@ -233,12 +230,11 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
     return key < exporterMetadata.getFirstUserTaskKey(TaskImplementation.ZEEBE_USER_TASK);
   }
 
-  private void setAssignee(final Record<UserTaskRecordValue> record, final TaskEntity entity) {
+  private static String getAssigneeOrNull(final Record<UserTaskRecordValue> record) {
     if (ExporterUtil.isEmpty(record.getValue().getAssignee())) {
-      entity.setAssignee(null);
-    } else {
-      entity.setAssignee(record.getValue().getAssignee());
+      return null;
     }
+    return record.getValue().getAssignee();
   }
 
   /**
@@ -263,7 +259,7 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
       entity.getChangedAttributes().add(attribute);
 
       switch (attribute) {
-        case "assignee" -> setAssignee(record, entity);
+        case "assignee" -> entity.setAssignee(getAssigneeOrNull(record));
         case "candidateGroupsList" ->
             entity.setCandidateGroups(value.getCandidateGroupsList().toArray(new String[0]));
         case "candidateUsersList" ->

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -99,8 +99,8 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
 
     switch (record.getIntent()) {
       case UserTaskIntent.CREATED -> createTaskEntity(entity, record);
-      case UserTaskIntent.ASSIGNED -> handleAssignment(record, entity);
-      case UserTaskIntent.UPDATED -> updateChangedAttributes(record, entity);
+      case UserTaskIntent.ASSIGNED, UserTaskIntent.UPDATED ->
+          updateChangedAttributes(record, entity);
       case UserTaskIntent.COMPLETED -> handleCompletion(record, entity);
       case UserTaskIntent.CANCELED -> handleCancellation(record, entity);
       case UserTaskIntent.MIGRATED -> handleMigration(record, entity);
@@ -231,17 +231,6 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
 
   private boolean refersToPreviousVersionRecord(final long key) {
     return key < exporterMetadata.getFirstUserTaskKey(TaskImplementation.ZEEBE_USER_TASK);
-  }
-
-  private void handleAssignment(final Record<UserTaskRecordValue> record, final TaskEntity entity) {
-    entity.getChangedAttributes().add("assignee");
-    if (ExporterUtil.isEmpty(record.getValue().getAssignee())) {
-      entity.setAssignee(null);
-    } else {
-      entity.setAssignee(record.getValue().getAssignee());
-    }
-
-    updateChangedAttributes(record, entity);
   }
 
   /**

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -233,6 +233,14 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
     return key < exporterMetadata.getFirstUserTaskKey(TaskImplementation.ZEEBE_USER_TASK);
   }
 
+  private void setAssignee(final Record<UserTaskRecordValue> record, final TaskEntity entity) {
+    if (ExporterUtil.isEmpty(record.getValue().getAssignee())) {
+      entity.setAssignee(null);
+    } else {
+      entity.setAssignee(record.getValue().getAssignee());
+    }
+  }
+
   /**
    * Applies changes to the user task fields based on the attributes in the {@link
    * UserTaskRecordValue}.
@@ -255,7 +263,7 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
       entity.getChangedAttributes().add(attribute);
 
       switch (attribute) {
-        case "assignee" -> entity.setAssignee(value.getAssignee());
+        case "assignee" -> setAssignee(record, entity);
         case "candidateGroupsList" ->
             entity.setCandidateGroups(value.getCandidateGroupsList().toArray(new String[0]));
         case "candidateUsersList" ->

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
@@ -343,8 +343,9 @@ public class UserTaskHandlerTest {
     final long processInstanceKey = 123;
     final UserTaskRecordValue taskRecordValue =
         ImmutableUserTaskRecordValue.builder()
-            .withAssignee("provided_assignee")
             .withProcessInstanceKey(processInstanceKey)
+            .withAssignee("provided_assignee")
+            .withChangedAttributes(List.of("assignee"))
             .build();
 
     final Record<UserTaskRecordValue> taskRecord =
@@ -387,6 +388,7 @@ public class UserTaskHandlerTest {
     final var followUpDateTime = OffsetDateTime.now().format(DateTimeFormatter.ISO_ZONED_DATE_TIME);
     final UserTaskRecordValue taskRecordValue =
         ImmutableUserTaskRecordValue.builder()
+            .withProcessInstanceKey(processInstanceKey)
             // corrected data
             .withAssignee("corrected_assignee")
             .withDueDate(dueDateTime)
@@ -614,6 +616,7 @@ public class UserTaskHandlerTest {
         ImmutableUserTaskRecordValue.builder()
             .withAssignee("test-assignee")
             .withProcessInstanceKey(processInstanceKey)
+            .withChangedAttributes(List.of("assignee"))
             .build();
 
     final Record<UserTaskRecordValue> taskRecord =
@@ -653,6 +656,7 @@ public class UserTaskHandlerTest {
         ImmutableUserTaskRecordValue.builder()
             .withAssignee("")
             .withProcessInstanceKey(processInstanceKey)
+            .withChangedAttributes(List.of("assignee"))
             .build();
 
     final Record<UserTaskRecordValue> taskRecord =
@@ -815,6 +819,7 @@ public class UserTaskHandlerTest {
         ImmutableUserTaskRecordValue.builder()
             .withAssignee("test-assignee")
             .withProcessInstanceKey(processInstanceKey)
+            .withChangedAttributes(List.of("assignee"))
             .build();
 
     final Record<UserTaskRecordValue> assignTaskRecord =

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -199,6 +199,8 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
    */
   public void correctAttributes(
       final List<String> correctedAttributes, final JobResultCorrections corrections) {
+    changedAttributesProp.reset();
+
     correctedAttributes.forEach(
         attribute -> {
           switch (attribute) {


### PR DESCRIPTION
## Description
PR description:


This PR addresses the following issues related to user task assignment handling and ensures consistent updates to the `changedAttributes` property:

- **Fixed Issue 1**: Correcting the `assignee` to an empty string (`""`) now properly clears the `assignee` in Tasklist instead of assigning an empty string.
- **Fixed Issue 2**: Resolved the issue where the `assignee` was shown multiple times as a corrected attribute in Operate after unassigning a user task.

### Key Changes:
1. Updated Zeebe code to include the `assignee` as an entry in the `changedAttributes` property after performing **assign**, **unassign**, or **claim** operations. This behavior is consistent regardless of whether user task listeners are configured or not.
2. Modified `camunda-exporter/UserTaskHandler.java` to rely on `record.getValue().getChangedAttributes()` when processing the `ASSIGNED` event for user tasks, and properly set the value for `entity.assignee` property as `null` instead of empty string `""`. This ensures downstream applications like Operate and Tasklist receive consistent and accurate data.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #26614
closes #26791
