### PR TITLE
[Backport stable/8.5] fix: @TestZeebe resources are closed even when constructed in a @BeforeEach

### DIFF
--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
@@ -139,13 +139,13 @@ final class ZeebeIntegrationExtension
     // starting one fails
     resources.forEach(resource -> store.put(resource, resource));
     for (final var resource : resources) {
-      final var directory = createManagedDirectory(store, resource.cluster.name());
+      final var directory = createManagedDirectory(store, resource.cluster().name());
       manageCluster(directory, resource);
     }
   }
 
   private void manageCluster(final Path directory, final ClusterResource resource) {
-    final var cluster = resource.cluster;
+    final var cluster = resource.cluster();
 
     // assign a working directory for each broker that gets deleted with the extension lifecycle,
     // and not when the broker is shutdown. this allows to introspect or move the data around even
@@ -170,7 +170,7 @@ final class ZeebeIntegrationExtension
     // assign a working directory to the broker that gets deleted with the extension lifecycle,
     // and not when the broker is shutdown. this allows to introspect or move the data around even
     // after stopping a broker
-    if (resource.app instanceof final TestStandaloneBroker broker) {
+    if (resource.app() instanceof final TestStandaloneBroker broker) {
       final var directory = createManagedDirectory(store, "broker-" + broker.nodeId().id());
       setWorkingDirectory(directory, broker.nodeId(), broker);
     }
@@ -222,97 +222,102 @@ final class ZeebeIntegrationExtension
   }
 
   private ClusterResource asClusterResource(final Object testInstance, final Field field) {
-    final TestCluster value;
+    ReflectUtil.makeAccessible(field, testInstance);
 
-    try {
-      value = (TestCluster) ReflectUtil.makeAccessible(field, testInstance).get(testInstance);
-    } catch (final IllegalAccessException e) {
-      throw new UnsupportedOperationException(e);
-    }
-
-    return new ClusterResource(value, field.getAnnotation(TestZeebe.class));
+    return new ClusterResource(testInstance, field, field.getAnnotation(TestZeebe.class));
   }
 
   private ApplicationResource asNodeResource(final Object testInstance, final Field field) {
-    final TestApplication<?> value;
+    ReflectUtil.makeAccessible(field, testInstance);
 
-    try {
-      value =
-          (TestApplication<?>) ReflectUtil.makeAccessible(field, testInstance).get(testInstance);
-    } catch (final IllegalAccessException e) {
-      throw new UnsupportedOperationException(e);
-    }
-
-    return new ApplicationResource(value, field.getAnnotation(TestZeebe.class));
+    return new ApplicationResource(testInstance, field, field.getAnnotation(TestZeebe.class));
   }
 
   private Store store(final ExtensionContext extensionContext) {
     return extensionContext.getStore(Namespace.create(ZeebeIntegrationExtension.class));
   }
 
-  private record ClusterResource(TestCluster cluster, TestZeebe annotation)
+  private record ClusterResource(Object testInstance, Field field, TestZeebe annotation)
       implements TestZeebeResource, CloseableResource {
+
+    public TestCluster cluster() {
+      try {
+        return (TestCluster) field.get(testInstance);
+      } catch (final IllegalAccessException e) {
+        throw new UnsupportedOperationException(e);
+      }
+    }
 
     @Override
     public void close() {
       CloseHelper.close(
-          error -> LOG.warn("Failed to close cluster {}, leaking resources", cluster.name(), error),
-          cluster);
+          error ->
+              LOG.warn("Failed to close cluster {}, leaking resources", cluster().name(), error),
+          cluster());
     }
 
     @Override
     public void start() {
-      cluster.start();
+      cluster().start();
     }
 
     @Override
     public void await(final TestHealthProbe probe) {
-      cluster.await(probe);
+      cluster().await(probe);
     }
 
     @Override
     public void awaitCompleteTopology() {
       final var clusterSize =
-          annotation.clusterSize() <= 0 ? cluster.brokers().size() : annotation.clusterSize();
+          annotation.clusterSize() <= 0 ? cluster().brokers().size() : annotation.clusterSize();
       final var partitionCount =
           annotation.partitionCount() <= 0
-              ? cluster.partitionsCount()
+              ? cluster().partitionsCount()
               : annotation.partitionCount();
       final var replicationFactor =
           annotation.replicationFactor() <= 0
-              ? cluster.replicationFactor()
+              ? cluster().replicationFactor()
               : annotation.replicationFactor();
       final var timeout =
           annotation.topologyTimeoutMs() == 0
               ? Duration.ofMinutes(clusterSize)
               : Duration.ofMillis(annotation().topologyTimeoutMs());
 
-      cluster.awaitCompleteTopology(clusterSize, partitionCount, replicationFactor, timeout);
+      cluster().awaitCompleteTopology(clusterSize, partitionCount, replicationFactor, timeout);
     }
   }
 
-  private record ApplicationResource(TestApplication<?> app, TestZeebe annotation)
+  private record ApplicationResource(Object testInstance, Field field, TestZeebe annotation)
       implements TestZeebeResource, CloseableResource {
+
+    public TestApplication<?> app() {
+      try {
+        return (TestApplication<?>) field.get(testInstance);
+      } catch (final IllegalAccessException e) {
+        throw new UnsupportedOperationException(e);
+      }
+    }
 
     @Override
     public void close() {
       CloseHelper.close(
-          error -> LOG.warn("Failed to close test app {}, leaking resources", app.nodeId()), app);
+          error -> LOG.warn("Failed to close test app {}, leaking resources", app().nodeId()),
+          app());
     }
 
     @Override
     public void start() {
-      app.start();
+      app().start();
     }
 
     @Override
     public void await(final TestHealthProbe probe) {
-      app.await(probe);
+      app().await(probe);
     }
 
     @Override
     public void awaitCompleteTopology() {
-      if (!(app.isGateway() && (app instanceof final TestGateway<?> gateway))) {
+      if (!(app().isGateway() && (app() instanceof final TestGateway<?> gateway))) {
         return;
       }
 

--- a/zeebe/qa/util/src/test/java/io/camunda/zeebe/qa/util/cluster/ZeebeIntegrationTest.java
+++ b/zeebe/qa/util/src/test/java/io/camunda/zeebe/qa/util/cluster/ZeebeIntegrationTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.qa.util.cluster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+public class ZeebeIntegrationTest {
+
+  private static final List<TestStandaloneBroker> ASSERTIONS = new ArrayList<>();
+
+  @TestZeebe(autoStart = false)
+  private TestStandaloneBroker testCluster;
+
+  @AfterAll
+  public static void checkAllClustersAreClosed() {
+    ASSERTIONS.forEach(c -> assertThat(c.isStarted()).isFalse());
+  }
+
+  @Test
+  public void shouldCloseCluster() {
+    // given
+    testCluster = new TestStandaloneBroker();
+    testCluster.start();
+    assertThat(testCluster.isStarted()).isTrue();
+
+    // when
+    ASSERTIONS.add(testCluster);
+
+    // then
+    // testCluster is closed in the @AfterEach callback.
+    // It's asserted in the @AfterAll callback
+  }
+}


### PR DESCRIPTION
# Description
Backport of #26737 to `stable/8.5`.

relates to 
original author: @entangled90