### PR TITLE
[Backport stable/8.3] Replace usage of internal Junit 5 helper removed in Junit 5.11

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateExtension.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateExtension.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.util;
 
 import static java.nio.file.FileVisitResult.CONTINUE;
 import static java.util.stream.Collectors.joining;
-import static org.junit.platform.commons.util.ReflectionUtils.makeAccessible;
 
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
@@ -21,6 +20,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
+import io.camunda.zeebe.util.ReflectUtil;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -100,7 +100,8 @@ public class ProcessingStateExtension implements BeforeEachCallback {
         .forEach(
             field -> {
               try {
-                makeAccessible(field).set(testInstance, lookupOrCreate(context).getZeebeDb());
+                ReflectUtil.makeAccessible(field, testInstance)
+                    .set(testInstance, lookupOrCreate(context).getZeebeDb());
               } catch (final Throwable t) {
                 ExceptionUtils.throwAsUncheckedException(t);
               }
@@ -114,7 +115,7 @@ public class ProcessingStateExtension implements BeforeEachCallback {
         .forEach(
             field -> {
               try {
-                makeAccessible(field)
+                ReflectUtil.makeAccessible(field, testInstance)
                     .set(testInstance, lookupOrCreate(context).getTransactionContext());
               } catch (final Throwable t) {
                 ExceptionUtils.throwAsUncheckedException(t);
@@ -130,7 +131,7 @@ public class ProcessingStateExtension implements BeforeEachCallback {
         .forEach(
             field -> {
               try {
-                makeAccessible(field)
+                ReflectUtil.makeAccessible(field, testInstance)
                     .set(testInstance, lookupOrCreate(context).getProcessingState());
               } catch (final Throwable t) {
                 ExceptionUtils.throwAsUncheckedException(t);

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.record.RecordLogger;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.util.FileUtil;
+import io.camunda.zeebe.util.ReflectUtil;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
@@ -224,7 +225,7 @@ final class ZeebeIntegrationExtension
     final TestCluster value;
 
     try {
-      value = (TestCluster) ReflectionUtils.makeAccessible(field).get(testInstance);
+      value = (TestCluster) ReflectUtil.makeAccessible(field, testInstance).get(testInstance);
     } catch (final IllegalAccessException e) {
       throw new UnsupportedOperationException(e);
     }
@@ -236,7 +237,8 @@ final class ZeebeIntegrationExtension
     final TestApplication<?> value;
 
     try {
-      value = (TestApplication<?>) ReflectionUtils.makeAccessible(field).get(testInstance);
+      value =
+          (TestApplication<?>) ReflectUtil.makeAccessible(field, testInstance).get(testInstance);
     } catch (final IllegalAccessException e) {
       throw new UnsupportedOperationException(e);
     }

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatformExtension.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatformExtension.java
@@ -7,13 +7,12 @@
  */
 package io.camunda.zeebe.stream.impl;
 
-import static org.junit.platform.commons.util.ReflectionUtils.makeAccessible;
-
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.stream.util.DefaultZeebeDbFactory;
 import io.camunda.zeebe.util.FileUtil;
+import io.camunda.zeebe.util.ReflectUtil;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -62,7 +61,7 @@ public class StreamPlatformExtension implements BeforeEachCallback {
         .forEach(
             field -> {
               try {
-                makeAccessible(field)
+                ReflectUtil.makeAccessible(field, testInstance)
                     .set(testInstance, lookupOrCreate(extensionContext).streamPlatform);
               } catch (final Throwable t) {
                 ExceptionUtils.throwAsUncheckedException(t);
@@ -77,7 +76,8 @@ public class StreamPlatformExtension implements BeforeEachCallback {
         .forEach(
             field -> {
               try {
-                makeAccessible(field).set(testInstance, lookupOrCreate(extensionContext).clock);
+                ReflectUtil.makeAccessible(field, testInstance)
+                    .set(testInstance, lookupOrCreate(extensionContext).clock);
               } catch (final Throwable t) {
                 ExceptionUtils.throwAsUncheckedException(t);
               }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/junit/AutoCloseResourceExtension.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/junit/AutoCloseResourceExtension.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.test.util.junit;
 
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import io.camunda.zeebe.util.ReflectUtil;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.NoSuchElementException;
@@ -22,7 +23,6 @@ import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.commons.support.HierarchyTraversalMode;
 import org.junit.platform.commons.support.ModifierSupport;
 import org.junit.platform.commons.support.ReflectionSupport;
-import org.junit.platform.commons.util.ReflectionUtils;
 
 final class AutoCloseResourceExtension implements BeforeEachCallback, BeforeAllCallback {
   @Override
@@ -64,8 +64,8 @@ final class AutoCloseResourceExtension implements BeforeEachCallback, BeforeAllC
                         "No close method '%s' for object of type '%s'; did you forget to set a custom close method?"
                             .formatted(annotation.closeMethod(), field.getType().getName())));
 
-    ReflectionUtils.makeAccessible(field);
-    ReflectionUtils.makeAccessible(method);
+    ReflectUtil.makeAccessible(field, testInstance);
+    ReflectUtil.makeAccessible(method, testInstance);
 
     return new AnnotatedCloseable(testInstance, field, method);
   }

--- a/util/src/main/java/io/camunda/zeebe/util/ReflectUtil.java
+++ b/util/src/main/java/io/camunda/zeebe/util/ReflectUtil.java
@@ -7,7 +7,11 @@
  */
 package io.camunda.zeebe.util;
 
+import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Member;
+import java.lang.reflect.Modifier;
+import java.util.stream.Stream;
 
 public final class ReflectUtil {
 
@@ -25,5 +29,54 @@ public final class ReflectUtil {
               "Failed to instantiate class %s with the default constructor", clazz.getName()),
           e);
     }
+  }
+
+  /**
+   * Sets the field to be accessible via reflection if it is not currently for the given instance
+   * object. This replaces the old Junit 5 `ReflectUtils.makeAccessible` which was removed from
+   * their platform.
+   *
+   * @param member the field to make accessible
+   * @param instance the instance on which we check accessibility
+   * @return the field, accessible
+   * @param <M> the type of the member
+   * @param <U> the type of the instance, typically just {@code Object}
+   */
+  public static <M extends AccessibleObject & Member, U> M makeAccessible(
+      final M member, final U instance) {
+    var canAccess = false;
+    try {
+      // this throws an IllegalArgumentException if member is not a field/method of Instance
+      canAccess = member.canAccess(instance);
+    } catch (final IllegalArgumentException e) {
+      final var modifiers = member.getModifiers();
+      if (Modifier.isPublic(modifiers)
+          && Modifier.isPublic(member.getDeclaringClass().getModifiers())) {
+        canAccess = true;
+      }
+    }
+    if (!canAccess) {
+      member.setAccessible(true);
+    }
+
+    return member;
+  }
+
+  /**
+   * Returns a stream of all non-interface classes that are a subtypes of the given sealed class.
+   */
+  public static <T> Stream<Class<T>> implementationsOfSealedInterface(final Class<T> clazz) {
+    if (!clazz.isSealed()) {
+      throw new IllegalArgumentException(String.format("Class %s is not sealed", clazz.getName()));
+    }
+    return Stream.of(clazz.getPermittedSubclasses())
+        .flatMap(
+            c -> {
+              if (c.isSealed()) {
+                return implementationsOfSealedInterface((Class<T>) c);
+              } else {
+                return Stream.of((Class<T>) c);
+              }
+            });
   }
 }


### PR DESCRIPTION
# Description
Backport of #26722 to `stable/8.3`.

relates to 
original author: @npepinpe