### PR TITLE
[backport stable/8.6] fix: handle RawApiEntityConsumer buffer size correctly

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/ApiEntityConsumer.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/ApiEntityConsumer.java
@@ -72,7 +72,7 @@ final class ApiEntityConsumer<T> extends AbstractBinAsyncEntityConsumer<ApiEntit
       final boolean isResponse =
           String.class.equals(type)
               && SUPPORTED_TEXT_CONTENT_TYPES.stream().anyMatch(t -> t.isSameMimeType(contentType));
-      entityConsumer = new RawApiEntityConsumer<>(isResponse);
+      entityConsumer = new RawApiEntityConsumer<>(isResponse, maxCapacity);
     }
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/TypedApiEntityConsumer.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/TypedApiEntityConsumer.java
@@ -164,13 +164,15 @@ public interface TypedApiEntityConsumer<T> {
   class RawApiEntityConsumer<T> implements TypedApiEntityConsumer<T> {
 
     private final boolean isResponse;
+    private final int maxCapacity;
 
     private byte[] body = new byte[1024];
 
     private int bufferedBytes;
 
-    public RawApiEntityConsumer(final boolean isResponse) {
+    public RawApiEntityConsumer(final boolean isResponse, final int maxCapacity) {
       this.isResponse = isResponse;
+      this.maxCapacity = maxCapacity;
     }
 
     @Override
@@ -191,7 +193,11 @@ public interface TypedApiEntityConsumer<T> {
       final int offset = bufferedBytes;
       bufferedBytes += src.remaining();
       if (body.length < bufferedBytes) {
-        body = Arrays.copyOf(body, body.length + 1024);
+        if (bufferedBytes > maxCapacity) {
+          throw new IllegalArgumentException(
+              "The message size exceeds the maximum allowed size of " + maxCapacity);
+        }
+        body = Arrays.copyOf(body, bufferedBytes);
       }
       src.get(body, offset, src.remaining());
     }


### PR DESCRIPTION
## Related issues

backports #24781 
fixes https://github.com/camunda/camunda/issues/24779
