### PR TITLE
fix: ignore MIGRATED variable records

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandler.java
@@ -16,6 +16,7 @@ import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.operate.listview.VariableForListViewEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import java.util.HashMap;
 import java.util.List;
@@ -47,7 +48,10 @@ public class ListViewVariableFromVariableHandler
 
   @Override
   public boolean handlesRecord(final Record<VariableRecordValue> record) {
-    return true;
+    if (!record.getIntent().equals(VariableIntent.MIGRATED)) {
+      return true;
+    }
+    return false;
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandlerTest.java
@@ -25,6 +25,9 @@ import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
 
 public class ListViewVariableFromVariableHandlerTest {
 
@@ -41,6 +44,34 @@ public class ListViewVariableFromVariableHandlerTest {
   @Test
   public void testGetEntityType() {
     assertThat(underTest.getEntityType()).isEqualTo(VariableForListViewEntity.class);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = VariableIntent.class,
+      names = {"CREATED", "UPDATED"},
+      mode = Mode.INCLUDE)
+  void shouldHandleRecord(final VariableIntent intent) {
+    // given
+    final Record<VariableRecordValue> variableRecord =
+        factory.generateRecord(ValueType.VARIABLE, r -> r.withIntent(intent));
+
+    // when - then
+    assertThat(underTest.handlesRecord(variableRecord)).isTrue();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = VariableIntent.class,
+      names = {"MIGRATED"},
+      mode = Mode.INCLUDE)
+  void shouldNotHandleRecord(final VariableIntent intent) {
+    // given
+    final Record<VariableRecordValue> variableRecord =
+        factory.generateRecord(ValueType.VARIABLE, r -> r.withIntent(intent));
+
+    // when - then
+    assertThat(underTest.handlesRecord(variableRecord)).isFalse();
   }
 
   @Test


### PR DESCRIPTION
## Description

1. Variable MIGRATED Zeebe record does not provide the value, therefore we need to fully skip it when persisting in `list-view` index. More context: values store in `list-view` index are used to perform filtering by variable name and value in Processes tab.
2. I additionally reworked how the new variables are persisted (basically I brought back the code that was there[ before introducing and removing again of concurrency mode](https://github.com/camunda/camunda/commit/992afbf741f25b2d04d2ac1dc0254516a32b8add#diff-c871546cf084ee89e36386017b5ee7350014b13f14df4f466cbf867ba35ee449)): when variable is created in this batch, we execute add query and only if it was updated - upsert query. This should improve performance.

## Related issues

closes #26490
