### PR TITLE
[backport stable/8.6] ci: add backport label when touching the deprecated java client in 8.6

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -77,3 +77,11 @@ component/build-pipeline:
           - '.github/workflows/**'
           - '.github/actionlint*'
           - 'maven-settings.xml'
+# to Forward-port PRs fixes to the deprecated java client classes in 8.7 (from 8.6)
+backport main: # TODO replace with 'backport stable/8.7' once the stable branch is created https://github.com/camunda/camunda/issues/26820
+  - all:
+      - changed-files:
+          - any-glob-to-any-file:
+              - 'clients/java/src/main/java/io/camunda/zeebe/**'
+              - 'clients/java/src/test/java/io/camunda/zeebe/**'
+      - base-branch: 'stable/8.6'


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
My mistake, it seems that the workflow from main is used. But the configuration file of the labeler GHA is used from the current branch. `ref: github.context.sha` https://github.com/actions/labeler/blob/d24f7f3731b2a06433c0bccc364d560c5329c48f/src/api/get-content.ts#L8-L13

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

backports #26742 
