### PR TITLE
[Backport stable/8.6] feat: remove CDN as font path

### DIFF
--- a/operate/client/src/index.scss
+++ b/operate/client/src/index.scss
@@ -6,9 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-@use '@carbon/react' as * with (
-  $font-path: 'https://fonts.camunda.io'
-);
+@use '@carbon/react' as *;
 
 @use '@carbon/react/scss/themes';
 @use '@carbon/react/scss/theme';


### PR DESCRIPTION
# Description
Backport of #26829 to `stable/8.6`.

relates to #24550
original author: @pedesen