### PR TITLE
Authorization creation endpoint

### DIFF
--- a/service/src/main/java/io/camunda/service/AuthorizationServices.java
+++ b/service/src/main/java/io/camunda/service/AuthorizationServices.java
@@ -18,9 +18,11 @@ import io.camunda.security.entity.Permission;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerAuthorizationCreateRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerAuthorizationPatchRequest;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionAction;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -129,9 +131,28 @@ public class AuthorizationServices
     return sendBrokerRequest(brokerRequest);
   }
 
+  public CompletableFuture<AuthorizationRecord> createAuthorization(
+      final CreateAuthorizationRequest request) {
+    final var brokerRequest =
+        new BrokerAuthorizationCreateRequest()
+            .setOwnerId(request.ownerId())
+            .setOwnerType(request.ownerType())
+            .setResourceId(request.resourceId())
+            .setResourceType(request.resourceType())
+            .setPermissions(request.permissions());
+    return sendBrokerRequest(brokerRequest);
+  }
+
   public record PatchAuthorizationRequest(
       long ownerKey,
       PermissionAction action,
       AuthorizationResourceType resourceType,
       Map<PermissionType, Set<String>> permissions) {}
+
+  public record CreateAuthorizationRequest(
+      String ownerId,
+      AuthorizationOwnerType ownerType,
+      String resourceId,
+      AuthorizationResourceType resourceType,
+      Set<PermissionType> permissions) {}
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.engine.state.EventApplier.NoSuchEventApplier;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
@@ -167,6 +168,8 @@ public class EventAppliersTest {
             .flatMap(c -> Arrays.stream(c.getEnumConstants()))
             .filter(Intent::isEvent)
             // CheckpointIntent is not handled by the engine
+            // TODO: remove when the appliers are implemented
+            .filter(intent -> !(intent instanceof AuthorizationIntent))
             .filter(intent -> !(intent instanceof CheckpointIntent));
 
     // when

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -104,6 +104,7 @@ final class TestSupport {
             ValueType.SCALE,
             ValueType.REDISTRIBUTION,
             // these are not yet supported
+            ValueType.AUTHORIZATION,
             ValueType.ROLE,
             ValueType.TENANT,
             ValueType.GROUP,

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -104,6 +104,7 @@ final class TestSupport {
             ValueType.SCALE,
             ValueType.REDISTRIBUTION,
             // these are not yet supported
+            ValueType.AUTHORIZATION,
             ValueType.ROLE,
             ValueType.TENANT,
             ValueType.GROUP,

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5566,7 +5566,7 @@ components:
       type: object
       properties:
         ownerId:
-          description: The id of the owner of the permissions.
+          description: The ID of the owner of the permissions.
           type: string
         ownerType:
           description: The type of the owner of the permissions.
@@ -5574,7 +5574,7 @@ components:
           allOf:
             - $ref: "#/components/schemas/OwnerTypeEnum"
         resourceId:
-          description: The id of the resource to add permissions to.
+          description: The ID of the resource to add permissions to.
           type: string
         resourceType:
           description: The type of resource to add permissions to.

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -2377,6 +2377,54 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /authorizations:
+    post:
+      tags:
+        - Authorization
+      operationId: createAuthorization
+      summary: Create authorization
+      description: Create the authorization.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AuthorizationCreateRequest"
+        required: true
+      responses:
+        "201":
+          description: |
+            The authorization was created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AuthorizationCreateResult"
+            application/vnd.camunda.api.keys.number+json:
+              schema:
+                $ref: "#/components/schemas/AuthorizationCreateResponse"
+            application/vnd.camunda.api.keys.string+json:
+              schema:
+                $ref: "#/components/schemas/AuthorizationCreateResult"
+        "400":
+          description: |
+            The authorization could not be created.
+            More details are provided in the response body.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: |
+            The owner was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /authorizations/{ownerKey}:
     patch:
       tags:
@@ -5454,6 +5502,7 @@ components:
           description: The amount of executed decision instances.
           type: integer
           format: int64
+
     PermissionTypeEnum:
       description: Specifies the type of permissions.
       enum:
@@ -5512,6 +5561,54 @@ components:
           uniqueItems: true
           items:
             type: string
+
+    AuthorizationCreateRequest:
+      type: object
+      properties:
+        ownerId:
+          description: The id of the owner of the permissions.
+          type: string
+        ownerType:
+          description: The type of the owner of the permissions.
+          type: object
+          allOf:
+            - $ref: "#/components/schemas/OwnerTypeEnum"
+        resourceId:
+          description: The id of the resource to add permissions to.
+          type: string
+        resourceType:
+          description: The type of resource to add permissions to.
+          type: object
+          allOf:
+            - $ref: "#/components/schemas/ResourceTypeEnum"
+        permissions:
+          type: array
+          description: The permissions to add.
+          items:
+            type: string
+            allOf:
+             - $ref: "#/components/schemas/PermissionTypeEnum"
+      required:
+        - ownerId
+        - ownerType
+        - resourceId
+        - resourceType
+        - permissions
+    AuthorizationCreateResponse:
+      deprecated: true
+      type: object
+      properties:
+        authorizationKey:
+          description: The key of the created authorization.
+          type: integer
+          format: int64
+    AuthorizationCreateResult:
+      type: object
+      properties:
+        authorizationKey:
+          description: The key of the created authorization.
+          type: string
+
     AuthorizationPatchRequest:
       type: object
       properties:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -457,8 +457,9 @@ public final class ResponseMapper {
 
   public static ResponseEntity<Object> toAuthorizationCreateResponse(
       final AuthorizationRecord authorizationRecord) {
-    final var response = new AuthorizationCreateResponse();
-    // TODO: add set method https://github.com/camunda/camunda/issues/26883
+    final var response =
+        new AuthorizationCreateResponse()
+            .authorizationKey(authorizationRecord.getAuthenticationKey());
     return new ResponseEntity<>(response, HttpStatus.CREATED);
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -25,6 +25,7 @@ import io.camunda.service.DocumentServices.DocumentReferenceResponse;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.gateway.impl.job.JobActivationResult;
 import io.camunda.zeebe.gateway.protocol.rest.ActivatedJob;
+import io.camunda.zeebe.gateway.protocol.rest.AuthorizationCreateResponse;
 import io.camunda.zeebe.gateway.protocol.rest.CreateProcessInstanceResponse;
 import io.camunda.zeebe.gateway.protocol.rest.DeploymentDecision;
 import io.camunda.zeebe.gateway.protocol.rest.DeploymentDecisionRequirements;
@@ -55,6 +56,7 @@ import io.camunda.zeebe.gateway.protocol.rest.TenantUpdateResponse;
 import io.camunda.zeebe.gateway.protocol.rest.UserCreateResponse;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.msgpack.value.ValueArray;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
@@ -451,6 +453,13 @@ public final class ResponseMapper {
             .signalKey(brokerResponse.getKey())
             .tenantId(brokerResponse.getResponse().getTenantId());
     return new ResponseEntity<>(response, HttpStatus.OK);
+  }
+
+  public static ResponseEntity<Object> toAuthorizationCreateResponse(
+      final AuthorizationRecord authorizationRecord) {
+    final var response = new AuthorizationCreateResponse();
+    // TODO: add set method https://github.com/camunda/camunda/issues/26883
+    return new ResponseEntity<>(response, HttpStatus.CREATED);
   }
 
   public static ResponseEntity<Object> toUserCreateResponse(final UserRecord userRecord) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -459,7 +459,7 @@ public final class ResponseMapper {
       final AuthorizationRecord authorizationRecord) {
     final var response =
         new AuthorizationCreateResponse()
-            .authorizationKey(authorizationRecord.getAuthenticationKey());
+            .authorizationKey(authorizationRecord.getAuthorizationKey());
     return new ResponseEntity<>(response, HttpStatus.CREATED);
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationController.java
@@ -42,7 +42,7 @@ public class AuthorizationController {
     this.authorizationServices = authorizationServices;
   }
 
-  @CamundaPostMapping(path = "/authorizations}")
+  @CamundaPostMapping(path = "/authorizations")
   public CompletableFuture<ResponseEntity<Object>> create(
       @RequestBody final AuthorizationCreateRequest authorizationCreateRequest) {
     return RequestMapper.toCreateAuthorizationRequest(authorizationCreateRequest)

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/AuthorizationRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/AuthorizationRequestValidator.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAG
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_NESTED_ATTRIBUTE;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
 
+import io.camunda.zeebe.gateway.protocol.rest.AuthorizationCreateRequest;
 import io.camunda.zeebe.gateway.protocol.rest.AuthorizationPatchRequest;
 import io.camunda.zeebe.gateway.protocol.rest.PermissionDTO;
 import io.camunda.zeebe.gateway.protocol.rest.PermissionTypeEnum;
@@ -30,6 +31,33 @@ public final class AuthorizationRequestValidator {
               PermissionTypeEnum.DELETE_PROCESS, ResourceTypeEnum.DEPLOYMENT,
               PermissionTypeEnum.DELETE_DRD, ResourceTypeEnum.DEPLOYMENT,
               PermissionTypeEnum.DELETE_FORM, ResourceTypeEnum.DEPLOYMENT);
+
+  public static Optional<ProblemDetail> validateAuthorizationCreateRequest(
+      final AuthorizationCreateRequest request) {
+    return validate(
+        violations -> {
+          // owner validation
+          if (request.getOwnerId() == null) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("ownerId"));
+          }
+          if (request.getOwnerType() == null) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("ownerType"));
+          }
+
+          // resource validation
+          if (request.getResourceId() == null) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("resourceId"));
+          }
+          if (request.getResourceType() == null) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("resourceType"));
+          }
+
+          // permissions validation
+          if (request.getPermissions() == null || request.getPermissions().isEmpty()) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("permissions"));
+          }
+        });
+  }
 
   public static Optional<ProblemDetail> validateAuthorizationAssignRequest(
       final AuthorizationPatchRequest authorizationPatchRequest) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
@@ -79,7 +79,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
 
     final var authorizationRecord =
         new AuthorizationRecord()
-            .setAuthenticationKey(authorizationKey)
+            .setAuthorizationKey(authorizationKey)
             .setOwnerId(ownerId)
             .setOwnerType(AuthorizationOwnerType.USER)
             .setResourceId(resourceId)

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerAuthorizationCreateRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerAuthorizationCreateRequest.java
@@ -28,7 +28,7 @@ public class BrokerAuthorizationCreateRequest extends BrokerExecuteCommand<Autho
   }
 
   public BrokerAuthorizationCreateRequest setOwnerId(final String ownerId) {
-    // TODO: add set method https://github.com/camunda/camunda/issues/26883
+    requestDto.setOwnerId(ownerId);
     return this;
   }
 
@@ -38,7 +38,7 @@ public class BrokerAuthorizationCreateRequest extends BrokerExecuteCommand<Autho
   }
 
   public BrokerAuthorizationCreateRequest setResourceId(final String resourceId) {
-    // TODO: add set method https://github.com/camunda/camunda/issues/26883
+    requestDto.setResourceId(resourceId);
     return this;
   }
 
@@ -49,7 +49,8 @@ public class BrokerAuthorizationCreateRequest extends BrokerExecuteCommand<Autho
   }
 
   public BrokerAuthorizationCreateRequest setPermissions(final Set<PermissionType> permissions) {
-    // TODO: add set method https://github.com/camunda/camunda/issues/26883
+    // TODO: rename in: https://github.com/camunda/camunda/issues/26883
+    requestDto.setAuthorizationPermissions(permissions);
     return this;
   }
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerAuthorizationCreateRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerAuthorizationCreateRequest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.util.Set;
+import org.agrona.DirectBuffer;
+
+public class BrokerAuthorizationCreateRequest extends BrokerExecuteCommand<AuthorizationRecord> {
+  private final AuthorizationRecord requestDto = new AuthorizationRecord();
+
+  public BrokerAuthorizationCreateRequest() {
+    super(ValueType.AUTHORIZATION, AuthorizationIntent.CREATE);
+    setPartitionId(Protocol.DEPLOYMENT_PARTITION);
+  }
+
+  public BrokerAuthorizationCreateRequest setOwnerId(final String ownerId) {
+    // TODO: add set method https://github.com/camunda/camunda/issues/26883
+    return this;
+  }
+
+  public BrokerAuthorizationCreateRequest setOwnerType(final AuthorizationOwnerType ownerType) {
+    requestDto.setOwnerType(ownerType);
+    return this;
+  }
+
+  public BrokerAuthorizationCreateRequest setResourceId(final String resourceId) {
+    // TODO: add set method https://github.com/camunda/camunda/issues/26883
+    return this;
+  }
+
+  public BrokerAuthorizationCreateRequest setResourceType(
+      final AuthorizationResourceType resourceType) {
+    requestDto.setResourceType(resourceType);
+    return this;
+  }
+
+  public BrokerAuthorizationCreateRequest setPermissions(final Set<PermissionType> permissions) {
+    // TODO: add set method https://github.com/camunda/camunda/issues/26883
+    return this;
+  }
+
+  @Override
+  public BufferWriter getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected AuthorizationRecord toResponseDto(final DirectBuffer buffer) {
+    final var response = new AuthorizationRecord();
+    response.wrap(buffer);
+    return response;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/AuthorizationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/AuthorizationRecord.java
@@ -7,32 +7,74 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.authorization;
 
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public final class AuthorizationRecord extends UnifiedRecordValue
     implements AuthorizationRecordValue {
+  // TODO: remove default value in: https://github.com/camunda/camunda/issues/26883
+  private final LongProperty authenticationKeyProp = new LongProperty("authenticationKey", -1L);
+  private final StringProperty ownerIdProp = new StringProperty("ownerId", "");
+  // TODO: remove in: https://github.com/camunda/camunda/issues/26883
   private final LongProperty ownerKeyProp = new LongProperty("ownerKey");
   private final EnumProperty<AuthorizationOwnerType> ownerTypeProp =
       new EnumProperty<>(
           "ownerType", AuthorizationOwnerType.class, AuthorizationOwnerType.UNSPECIFIED);
+  // TODO: remove default value in: https://github.com/camunda/camunda/issues/26883
+  private final StringProperty resourceIdProp = new StringProperty("resourceId", "");
   private final EnumProperty<AuthorizationResourceType> resourceTypeProp =
       new EnumProperty<>("resourceType", AuthorizationResourceType.class);
+  // TODO: remove in: https://github.com/camunda/camunda/issues/26883
   private final ArrayProperty<Permission> permissionsProp =
       new ArrayProperty<>("permissions", Permission::new);
+  // TODO: rename in: https://github.com/camunda/camunda/issues/26883
+  private final ArrayProperty<StringValue> authorizationPermissionsProp =
+      new ArrayProperty<>("permissions", StringValue::new);
 
   public AuthorizationRecord() {
     super(4);
-    declareProperty(ownerTypeProp)
+    declareProperty(authenticationKeyProp)
+        .declareProperty(ownerIdProp)
+        .declareProperty(ownerTypeProp)
         .declareProperty(ownerKeyProp)
+        .declareProperty(resourceIdProp)
         .declareProperty(resourceTypeProp)
-        .declareProperty(permissionsProp);
+        .declareProperty(permissionsProp)
+        .declareProperty(authorizationPermissionsProp);
+  }
+
+  @Override
+  public Long getAuthenticationKey() {
+    return authenticationKeyProp.getValue();
+  }
+
+  public AuthorizationRecord setAuthenticationKey(final Long authenticationKey) {
+    authenticationKeyProp.setValue(authenticationKey);
+    return this;
+  }
+
+  @Override
+  public String getOwnerId() {
+    return bufferAsString(ownerIdProp.getValue());
+  }
+
+  public AuthorizationRecord setOwnerId(final String ownerId) {
+    ownerIdProp.setValue(ownerId);
+    return this;
   }
 
   @Override
@@ -50,8 +92,13 @@ public final class AuthorizationRecord extends UnifiedRecordValue
     return ownerTypeProp.getValue();
   }
 
-  public AuthorizationRecord setOwnerType(final AuthorizationOwnerType ownerType) {
-    ownerTypeProp.setValue(ownerType);
+  @Override
+  public String getResourceId() {
+    return bufferAsString(resourceIdProp.getValue());
+  }
+
+  public AuthorizationRecord setResourceId(final String resourceId) {
+    resourceIdProp.setValue(resourceId);
     return this;
   }
 
@@ -71,8 +118,30 @@ public final class AuthorizationRecord extends UnifiedRecordValue
         .toList();
   }
 
+  @Override
+  public Set<PermissionType> getAuthorizationPermissions() {
+    return authorizationPermissionsProp.stream()
+        .map(StringValue::getValue)
+        .map(BufferUtil::bufferAsString)
+        .map(PermissionType::valueOf)
+        .collect(Collectors.toSet());
+  }
+
+  public AuthorizationRecord setAuthorizationPermissions(final Set<PermissionType> permissions) {
+    authorizationPermissionsProp.reset();
+    permissions.forEach(
+        permission ->
+            authorizationPermissionsProp.add().wrap(BufferUtil.wrapString(permission.name())));
+    return this;
+  }
+
   public AuthorizationRecord setResourceType(final AuthorizationResourceType resourceType) {
     resourceTypeProp.setValue(resourceType);
+    return this;
+  }
+
+  public AuthorizationRecord setOwnerType(final AuthorizationOwnerType ownerType) {
+    ownerTypeProp.setValue(ownerType);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/AuthorizationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/AuthorizationRecord.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 public final class AuthorizationRecord extends UnifiedRecordValue
     implements AuthorizationRecordValue {
   // TODO: remove default value in: https://github.com/camunda/camunda/issues/26883
-  private final LongProperty authenticationKeyProp = new LongProperty("authenticationKey", -1L);
+  private final LongProperty authorizationKeyProp = new LongProperty("authorizationKey", -1L);
   private final StringProperty ownerIdProp = new StringProperty("ownerId", "");
   // TODO: remove in: https://github.com/camunda/camunda/issues/26883
   private final LongProperty ownerKeyProp = new LongProperty("ownerKey");
@@ -43,11 +43,11 @@ public final class AuthorizationRecord extends UnifiedRecordValue
       new ArrayProperty<>("permissions", Permission::new);
   // TODO: rename in: https://github.com/camunda/camunda/issues/26883
   private final ArrayProperty<StringValue> authorizationPermissionsProp =
-      new ArrayProperty<>("permissions", StringValue::new);
+      new ArrayProperty<>("authorizationPermissions", StringValue::new);
 
   public AuthorizationRecord() {
     super(4);
-    declareProperty(authenticationKeyProp)
+    declareProperty(authorizationKeyProp)
         .declareProperty(ownerIdProp)
         .declareProperty(ownerTypeProp)
         .declareProperty(ownerKeyProp)
@@ -58,12 +58,12 @@ public final class AuthorizationRecord extends UnifiedRecordValue
   }
 
   @Override
-  public Long getAuthenticationKey() {
-    return authenticationKeyProp.getValue();
+  public Long getAuthorizationKey() {
+    return authorizationKeyProp.getValue();
   }
 
-  public AuthorizationRecord setAuthenticationKey(final Long authenticationKey) {
-    authenticationKeyProp.setValue(authenticationKey);
+  public AuthorizationRecord setAuthorizationKey(final Long authenticationKey) {
+    authorizationKeyProp.setValue(authenticationKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2705,8 +2705,11 @@ final class JsonSerializableToJsonTest {
         (Supplier<AuthorizationRecord>)
             () ->
                 new AuthorizationRecord()
+                    .setAuthorizationKey(1L)
                     .setOwnerKey(1L)
+                    .setOwnerId("ownerId")
                     .setOwnerType(AuthorizationOwnerType.USER)
+                    .setResourceId("resourceId")
                     .setResourceType(AuthorizationResourceType.DEPLOYMENT)
                     .addPermission(
                         new Permission()
@@ -2714,11 +2717,15 @@ final class JsonSerializableToJsonTest {
                             .addResourceId("*")
                             .addResourceId("bpmnProcessId:foo"))
                     .addPermission(
-                        new Permission().setPermissionType(PermissionType.READ).addResourceId("*")),
+                        new Permission().setPermissionType(PermissionType.READ).addResourceId("*"))
+                    .setAuthorizationPermissions(Set.of(PermissionType.CREATE)),
         """
         {
+          "authorizationKey": 1,
           "ownerKey": 1,
+          "ownerId": "ownerId",
           "ownerType": "USER",
+          "resourceId": "resourceId",
           "resourceType": "DEPLOYMENT",
           "permissions": [
             {
@@ -2729,6 +2736,9 @@ final class JsonSerializableToJsonTest {
               "permissionType": "READ",
               "resourceIds": ["*"]
             }
+          ],
+          "authorizationPermissions": [
+            "CREATE"
           ]
         }
         """
@@ -2745,10 +2755,14 @@ final class JsonSerializableToJsonTest {
                     .setResourceType(AuthorizationResourceType.DEPLOYMENT),
         """
         {
+          "authorizationKey": -1,
+          "ownerId": "",
           "ownerKey": 1,
           "ownerType": "UNSPECIFIED",
+          "resourceId": "",
           "resourceType": "DEPLOYMENT",
-          "permissions": []
+          "permissions": [],
+          "authorizationPermissions": []
         }
         """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AuthorizationIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AuthorizationIntent.java
@@ -19,7 +19,9 @@ public enum AuthorizationIntent implements Intent {
   ADD_PERMISSION(0),
   PERMISSION_ADDED(1),
   REMOVE_PERMISSION(2),
-  PERMISSION_REMOVED(3);
+  PERMISSION_REMOVED(3),
+  CREATE(4),
+  CREATED(5);
 
   private final short value;
 
@@ -37,6 +39,7 @@ public enum AuthorizationIntent implements Intent {
     switch (this) {
       case PERMISSION_ADDED:
       case PERMISSION_REMOVED:
+      case CREATED:
         return true;
       default:
         return false;
@@ -53,6 +56,10 @@ public enum AuthorizationIntent implements Intent {
         return REMOVE_PERMISSION;
       case 3:
         return PERMISSION_REMOVED;
+      case 4:
+        return CREATE;
+      case 5:
+        return CREATED;
       default:
         return UNKNOWN;
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationRecordValue.java
@@ -25,13 +25,21 @@ import org.immutables.value.Value;
 @ImmutableProtocol(builder = ImmutableAuthorizationRecordValue.Builder.class)
 public interface AuthorizationRecordValue extends RecordValue {
 
+  Long getAuthenticationKey();
+
+  String getOwnerId();
+
   Long getOwnerKey();
 
   AuthorizationOwnerType getOwnerType();
 
+  String getResourceId();
+
   AuthorizationResourceType getResourceType();
 
   List<PermissionValue> getPermissions();
+
+  Set<PermissionType> getAuthorizationPermissions();
 
   @Value.Immutable
   @ImmutableProtocol(builder = ImmutablePermissionValue.Builder.class)

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationRecordValue.java
@@ -25,7 +25,7 @@ import org.immutables.value.Value;
 @ImmutableProtocol(builder = ImmutableAuthorizationRecordValue.Builder.class)
 public interface AuthorizationRecordValue extends RecordValue {
 
-  Long getAuthenticationKey();
+  Long getAuthorizationKey();
 
   String getOwnerId();
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds:

- authorization creation endpoint
- new fields in the authorization record
- service layer to send request to the broker
- new CREATE/CREATED authorization intents

## Related issues

closes #26876 
closes #26889
