### PR TITLE
feat: add configuration for disabling authentication for the API

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -88,6 +88,10 @@
       <artifactId>jsr305</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/security/security-core/src/main/java/io/camunda/security/configuration/AuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/AuthenticationConfiguration.java
@@ -12,6 +12,7 @@ import io.camunda.security.entity.AuthenticationMethod;
 public class AuthenticationConfiguration {
 
   private AuthenticationMethod method = AuthenticationMethod.NONE;
+  private BasicAuthenticationConfiguration basicAuthenticationConfiguration;
 
   public AuthenticationMethod getMethod() {
     return method;
@@ -19,5 +20,13 @@ public class AuthenticationConfiguration {
 
   public void setMethod(final AuthenticationMethod method) {
     this.method = method;
+  }
+
+  public BasicAuthenticationConfiguration getBasic() {
+    return basicAuthenticationConfiguration;
+  }
+
+  public void setBasic(final BasicAuthenticationConfiguration configuration) {
+    basicAuthenticationConfiguration = configuration;
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/configuration/BasicAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/BasicAuthenticationConfiguration.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.configuration;
+
+public class BasicAuthenticationConfiguration {
+  private boolean allowUnauthenticatedApiAccess = false;
+
+  public boolean getAllowUnauthenticatedApiAccess() {
+    return allowUnauthenticatedApiAccess;
+  }
+
+  public void setAllowUnauthenticatedApiAccess(final boolean value) {
+    allowUnauthenticatedApiAccess = value;
+  }
+}


### PR DESCRIPTION
We introduce a new boolean settings, `camunda.security.authentication.basic.allowUnauthenticatedApiAccess`, that toggles whether API requests require authentication. The default is false. This setting will be enabled in the default configuration.

closes #26819
relates to #26804
