### PR TITLE
refactor: deprecate zeebe client api classes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -97,6 +97,4 @@ deprecated-client:
           - any-glob-to-any-file:
               - 'clients/java/src/main/java/io/camunda/zeebe/**'
               - 'clients/java/src/test/java/io/camunda/zeebe/**'
-      - base-branch:
-          - 'main' # TODO remove in https://github.com/camunda/camunda/issues/26820
-          - 'stable/8.7'
+      - base-branch: 'main' # TODO replace with 'backport stable/8.7' in https://github.com/camunda/camunda/issues/26820

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
@@ -22,6 +22,10 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link io.camunda.client.ClientProperties}
+ */
+@Deprecated
 public final class ClientProperties {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java
@@ -20,7 +20,13 @@ import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder;
 import io.grpc.Metadata;
 import java.io.IOException;
 
-/** Implementations of this interface must be thread-safe. */
+/**
+ * Implementations of this interface must be thread-safe.
+ *
+ * @deprecated since 8.7 for removal in 8.8. replaced by {@link
+ *     io.camunda.client.CredentialsProvider}
+ */
+@Deprecated
 public interface CredentialsProvider {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -55,7 +55,12 @@ import io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl;
 import io.camunda.zeebe.client.impl.ZeebeClientCloudBuilderImpl;
 import io.camunda.zeebe.client.impl.ZeebeClientImpl;
 
-/** The client to communicate with a Zeebe broker/cluster. */
+/**
+ * The client to communicate with a Zeebe broker/cluster.
+ *
+ * @deprecated since 8.7 for removal with 8.8, replaced by {@link io.camunda.client.CamundaClient}
+ */
+@Deprecated
 public interface ZeebeClient extends AutoCloseable, JobClient {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -28,6 +28,11 @@ import java.util.Properties;
 import java.util.concurrent.ScheduledExecutorService;
 import org.apache.hc.client5.http.async.AsyncExecChainHandler;
 
+/**
+ * @deprecated since 8.7 for removal with 8.8, replaced by {@link
+ *     io.camunda.client.CamundaClientBuilder}
+ */
+@Deprecated
 public interface ZeebeClientBuilder {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientCloudBuilderStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientCloudBuilderStep1.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.CamundaClientCloudBuilderStep1}
+ */
+@Deprecated
 public interface ZeebeClientCloudBuilderStep1 {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
@@ -24,6 +24,11 @@ import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import org.apache.hc.client5.http.async.AsyncExecChainHandler;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.CamundaClientConfiguration}
+ */
+@Deprecated
 public interface ZeebeClientConfiguration {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/ExperimentalApi.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/ExperimentalApi.java
@@ -42,7 +42,11 @@ import java.lang.annotation.Target;
  *
  * <p>This annotation was originally copied from io.grpc.ExperimentalApi, licensed under the Apache
  * License, Version 2.0. Copyright 2015 The gRPC Authors. Changes have been made since.
+ *
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.ExperimentalApi}
  */
+@Deprecated
 @Retention(RetentionPolicy.CLASS)
 @Target({
   ElementType.ANNOTATION_TYPE,

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/JsonMapper.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/JsonMapper.java
@@ -51,7 +51,9 @@ import java.util.Map;
  * Null values won't pass in the JSON with variables: {@code { "a": "b" } }
  *
  * @see ZeebeObjectMapper
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link io.camunda.client.api.JsonMapper}
  */
+@Deprecated
 public interface JsonMapper {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/ZeebeFuture.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/ZeebeFuture.java
@@ -21,6 +21,10 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link io.camunda.client.api.CamundaFuture}
+ */
+@Deprecated
 public interface ZeebeFuture<T> extends Future<T>, CompletionStage<T> {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ActivateJobsCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ActivateJobsCommandStep1.java
@@ -19,6 +19,11 @@ import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
 import java.time.Duration;
 import java.util.List;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.ActivateJobsCommandStep1}
+ */
+@Deprecated
 public interface ActivateJobsCommandStep1
     extends CommandWithCommunicationApiStep<ActivateJobsCommandStep1> {
 
@@ -30,6 +35,11 @@ public interface ActivateJobsCommandStep1
    */
   ActivateJobsCommandStep2 jobType(String jobType);
 
+  /**
+   * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+   *     io.camunda.client.api.command.ActivateJobsCommandStep1.ActivateJobsCommandStep2}
+   */
+  @Deprecated
   interface ActivateJobsCommandStep2 {
 
     /**
@@ -42,6 +52,11 @@ public interface ActivateJobsCommandStep1
     ActivateJobsCommandStep3 maxJobsToActivate(int maxJobsToActivate);
   }
 
+  /**
+   * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+   *     io.camunda.client.api.command.ActivateJobsCommandStep1.ActivateJobsCommandStep3}
+   */
+  @Deprecated
   interface ActivateJobsCommandStep3
       extends CommandWithOneOrMoreTenantsStep<ActivateJobsCommandStep3>,
           FinalCommandStep<ActivateJobsResponse> {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/AddPermissionsCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/AddPermissionsCommandStep1.java
@@ -20,6 +20,11 @@ import io.camunda.client.protocol.rest.ResourceTypeEnum;
 import io.camunda.zeebe.client.api.response.AddPermissionsResponse;
 import java.util.List;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.AddPermissionsCommandStep1}
+ */
+@Deprecated
 public interface AddPermissionsCommandStep1 {
 
   /**
@@ -30,6 +35,11 @@ public interface AddPermissionsCommandStep1 {
    */
   AddPermissionsCommandStep2 resourceType(ResourceTypeEnum resourceType);
 
+  /**
+   * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+   *     io.camunda.client.api.command.AddPermissionsCommandStep1.AddPermissionsCommandStep2}
+   */
+  @Deprecated
   interface AddPermissionsCommandStep2 {
 
     /**
@@ -41,6 +51,10 @@ public interface AddPermissionsCommandStep1 {
     AddPermissionsCommandStep3 permission(PermissionTypeEnum permissionType);
   }
 
+  /**
+   * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+   *     io.camunda.client.api.command.AddPermissionsCommandStep1.AddPermissionsCommandStep3}
+   */
   interface AddPermissionsCommandStep3 {
 
     /**
@@ -60,6 +74,10 @@ public interface AddPermissionsCommandStep1 {
     AddPermissionsCommandStep4 resourceId(String resourceId);
   }
 
+  /**
+   * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+   *     io.camunda.client.api.command.AddPermissionsCommandStep1.AddPermissionsCommandStep4}
+   */
   interface AddPermissionsCommandStep4
       extends AddPermissionsCommandStep2,
           AddPermissionsCommandStep3,

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/AssignUserTaskCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/AssignUserTaskCommandStep1.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.command;
 
 import io.camunda.zeebe.client.api.response.AssignUserTaskResponse;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.AssignUserTaskCommandStep1}
+ */
+@Deprecated
 public interface AssignUserTaskCommandStep1 extends FinalCommandStep<AssignUserTaskResponse> {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/BroadcastSignalCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/BroadcastSignalCommandStep1.java
@@ -19,6 +19,11 @@ import io.camunda.zeebe.client.api.response.BroadcastSignalResponse;
 import java.io.InputStream;
 import java.util.Map;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.BroadcastSignalCommandStep1}
+ */
+@Deprecated
 public interface BroadcastSignalCommandStep1
     extends CommandWithCommunicationApiStep<BroadcastSignalCommandStep1> {
 
@@ -30,6 +35,11 @@ public interface BroadcastSignalCommandStep1
    */
   BroadcastSignalCommandStep2 signalName(String signalName);
 
+  /**
+   * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+   *     io.camunda.client.api.command.BroadcastSignalCommandStep1.BroadcastSignalCommandStep2}
+   */
+  @Deprecated
   interface BroadcastSignalCommandStep2
       extends CommandWithTenantStep<BroadcastSignalCommandStep2>,
           FinalCommandStep<BroadcastSignalResponse> {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CancelProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CancelProcessInstanceCommandStep1.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.command;
 
 import io.camunda.zeebe.client.api.response.CancelProcessInstanceResponse;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.CancelProcessInstanceCommandStep1}
+ */
+@Deprecated
 public interface CancelProcessInstanceCommandStep1
     extends CommandWithOperationReferenceStep<CancelProcessInstanceCommandStep1>,
         CommandWithCommunicationApiStep<CancelProcessInstanceCommandStep1>,

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ClientException.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ClientException.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client.api.command;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.ClientException}
+ */
+@Deprecated
 public class ClientException extends RuntimeException {
   private static final long serialVersionUID = 1L;
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ClientHttpException.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ClientHttpException.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client.api.command;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.ClientHttpException}
+ */
+@Deprecated
 public class ClientHttpException extends ClientException {
   private final int code;
   private final String reason;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ClientStatusException.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ClientStatusException.java
@@ -18,6 +18,11 @@ package io.camunda.zeebe.client.api.command;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.ClientStatusException}
+ */
+@Deprecated
 public final class ClientStatusException extends ClientException {
 
   private static final long serialVersionUID = -6130332019397045094L;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ClockPinCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ClockPinCommandStep1.java
@@ -18,6 +18,11 @@ package io.camunda.zeebe.client.api.command;
 import io.camunda.zeebe.client.api.response.PinClockResponse;
 import java.time.Instant;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.ClockPinCommandStep1}
+ */
+@Deprecated
 public interface ClockPinCommandStep1 extends FinalCommandStep<PinClockResponse> {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ClockResetCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ClockResetCommandStep1.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.command;
 
 import io.camunda.zeebe.client.api.response.ResetClockResponse;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.ClockResetCommandStep1}
+ */
+@Deprecated
 public interface ClockResetCommandStep1 extends FinalCommandStep<ResetClockResponse> {
   // the place for new optional parameters
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithCommunicationApiStep.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithCommunicationApiStep.java
@@ -18,6 +18,11 @@ package io.camunda.zeebe.client.api.command;
 import io.camunda.zeebe.client.ZeebeClientBuilder;
 import io.camunda.zeebe.client.api.ExperimentalApi;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.CommandWithCommunicationApiStep}
+ */
+@Deprecated
 public interface CommandWithCommunicationApiStep<T> {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithOneOrMoreTenantsStep.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithOneOrMoreTenantsStep.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.command;
 
 import java.util.List;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.CommandWithOneOrMoreTenantsStep}
+ */
+@Deprecated
 public interface CommandWithOneOrMoreTenantsStep<T> extends CommandWithTenantStep<T> {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithOperationReferenceStep.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithOperationReferenceStep.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client.api.command;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.CommandWithOperationReferenceStep}
+ */
+@Deprecated
 public interface CommandWithOperationReferenceStep<T> {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithTenantStep.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithTenantStep.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client.api.command;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.CommandWithTenantStep}
+ */
+@Deprecated
 public interface CommandWithTenantStep<T> {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CompleteJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CompleteJobCommandStep1.java
@@ -19,6 +19,11 @@ import io.camunda.zeebe.client.api.response.CompleteJobResponse;
 import java.io.InputStream;
 import java.util.Map;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.CompleteJobCommandStep1}
+ */
+@Deprecated
 public interface CompleteJobCommandStep1
     extends CommandWithCommunicationApiStep<CompleteJobCommandStep1>,
         FinalCommandStep<CompleteJobResponse> {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CompleteUserTaskCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CompleteUserTaskCommandStep1.java
@@ -22,7 +22,11 @@ import java.util.Map;
  * The user task completion currently only accepts variables as a {@link Map} due to the current
  * request handling before sending it the gateway. The list of options might be extended in the
  * future.
+ *
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.CompleteUserTaskCommandStep1}
  */
+@Deprecated
 public interface CompleteUserTaskCommandStep1 extends FinalCommandStep<CompleteUserTaskResponse> {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CorrelateMessageCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CorrelateMessageCommandStep1.java
@@ -19,6 +19,11 @@ import io.camunda.zeebe.client.api.response.CorrelateMessageResponse;
 import java.io.InputStream;
 import java.util.Map;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.CorrelateMessageCommandStep1}
+ */
+@Deprecated
 public interface CorrelateMessageCommandStep1 {
   /**
    * Set the name of the message.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateProcessInstanceCommandStep1.java
@@ -21,6 +21,11 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.CreateProcessInstanceCommandStep1}
+ */
+@Deprecated
 public interface CreateProcessInstanceCommandStep1
     extends CommandWithCommunicationApiStep<CreateProcessInstanceCommandStep1> {
   /** Use the latest version of the process (without guarantee). */

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateUserCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateUserCommandStep1.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.command;
 
 import io.camunda.zeebe.client.api.response.CreateUserResponse;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.CreateUserCommandStep1}
+ */
+@Deprecated
 public interface CreateUserCommandStep1 extends FinalCommandStep<CreateUserResponse> {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/DeleteResourceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/DeleteResourceCommandStep1.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.command;
 
 import io.camunda.zeebe.client.api.response.DeleteResourceResponse;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.DeleteResourceCommandStep1}
+ */
+@Deprecated
 public interface DeleteResourceCommandStep1
     extends CommandWithOperationReferenceStep<DeleteResourceCommandStep1>,
         CommandWithCommunicationApiStep<DeleteResourceCommandStep1>,

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/DeployResourceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/DeployResourceCommandStep1.java
@@ -21,6 +21,11 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.io.InputStream;
 import java.nio.charset.Charset;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.DeployResourceCommandStep1}
+ */
+@Deprecated
 public interface DeployResourceCommandStep1
     extends CommandWithCommunicationApiStep<DeployResourceCommandStep1> {
 
@@ -97,6 +102,11 @@ public interface DeployResourceCommandStep1
   DeployResourceCommandStep2 addProcessModel(
       BpmnModelInstance processDefinition, String resourceName);
 
+  /**
+   * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+   *     io.camunda.client.api.command.DeployResourceCommandStep1.DeployResourceCommandStep2}
+   */
+  @Deprecated
   interface DeployResourceCommandStep2
       extends DeployResourceCommandStep1,
           CommandWithTenantStep<DeployResourceCommandStep2>,

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/EvaluateDecisionCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/EvaluateDecisionCommandStep1.java
@@ -19,6 +19,11 @@ import io.camunda.zeebe.client.api.response.EvaluateDecisionResponse;
 import java.io.InputStream;
 import java.util.Map;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.EvaluateDecisionCommandStep1}
+ */
+@Deprecated
 public interface EvaluateDecisionCommandStep1
     extends CommandWithCommunicationApiStep<EvaluateDecisionCommandStep1> {
 
@@ -40,6 +45,10 @@ public interface EvaluateDecisionCommandStep1
    */
   EvaluateDecisionCommandStep2 decisionKey(long decisionKey);
 
+  /**
+   * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+   *     io.camunda.client.api.command.EvaluateDecisionCommandStep1.EvaluateDecisionCommandStep2}
+   */
   interface EvaluateDecisionCommandStep2
       extends CommandWithTenantStep<EvaluateDecisionCommandStep2>,
           FinalCommandStep<EvaluateDecisionResponse> {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/FailJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/FailJobCommandStep1.java
@@ -20,6 +20,10 @@ import java.io.InputStream;
 import java.time.Duration;
 import java.util.Map;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.FailJobCommandStep1}
+ */
 public interface FailJobCommandStep1 extends CommandWithCommunicationApiStep<FailJobCommandStep1> {
 
   /**
@@ -34,6 +38,10 @@ public interface FailJobCommandStep1 extends CommandWithCommunicationApiStep<Fai
    */
   FailJobCommandStep2 retries(int remainingRetries);
 
+  /**
+   * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+   *     io.camunda.client.api.command.FailJobCommandStep1.FailJobCommandStep2}
+   */
   interface FailJobCommandStep2 extends FinalCommandStep<FailJobResponse> {
     // the place for new optional parameters
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/FinalCommandStep.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/FinalCommandStep.java
@@ -19,6 +19,10 @@ import io.camunda.zeebe.client.ZeebeClientBuilder;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import java.time.Duration;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.FinalCommandStep}
+ */
 public interface FinalCommandStep<T> {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/InternalClientException.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/InternalClientException.java
@@ -15,7 +15,13 @@
  */
 package io.camunda.zeebe.client.api.command;
 
-/** Exception which is thrown on internal errors inside the client itself. */
+/**
+ * Exception which is thrown on internal errors inside the client itself.
+ *
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.InternalClientException}
+ */
+@Deprecated
 public final class InternalClientException extends ClientException {
 
   public InternalClientException(final String message) {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/MalformedResponseException.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/MalformedResponseException.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client.api.command;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.MalformedResponseException}
+ */
+@Deprecated
 public class MalformedResponseException extends ClientHttpException {
 
   public MalformedResponseException(final int code, final String reason, final Throwable cause) {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/MigrateProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/MigrateProcessInstanceCommandStep1.java
@@ -18,6 +18,11 @@ package io.camunda.zeebe.client.api.command;
 import io.camunda.zeebe.client.api.ExperimentalApi;
 import io.camunda.zeebe.client.api.response.MigrateProcessInstanceResponse;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.MigrateProcessInstanceCommandStep1}
+ */
+@Deprecated
 @ExperimentalApi("https://github.com/camunda/camunda/issues/14907")
 public interface MigrateProcessInstanceCommandStep1
     extends CommandWithCommunicationApiStep<MigrateProcessInstanceCommandStep1> {
@@ -66,6 +71,11 @@ public interface MigrateProcessInstanceCommandStep1
         final String sourceElementId, final String targetElementId);
   }
 
+  /**
+   * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+   *     io.camunda.client.api.command.MigrateProcessInstanceCommandStep1.MigrateProcessInstanceCommandStep2}
+   */
+  @Deprecated
   interface MigrateProcessInstanceCommandFinalStep
       extends MigrateProcessInstanceCommandStep2,
           CommandWithOperationReferenceStep<MigrateProcessInstanceCommandFinalStep>,

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/MigrationPlan.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/MigrationPlan.java
@@ -18,6 +18,11 @@ package io.camunda.zeebe.client.api.command;
 import io.camunda.zeebe.client.api.command.MigrationPlanBuilderImpl.MappingInstruction;
 import java.util.List;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.MigrationPlan}
+ */
+@Deprecated
 public interface MigrationPlan {
 
   /** Create a new migration plan builder to build {@link MigrationPlan} object */
@@ -41,6 +46,11 @@ public interface MigrationPlan {
    */
   public List<MappingInstruction> getMappingInstructions();
 
+  /**
+   * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+   *     io.camunda.client.api.command.MigrationPlan.MigrationPlanBuilderStep1}
+   */
+  @Deprecated
   interface MigrationPlanBuilderStep1 {
 
     /**
@@ -52,6 +62,11 @@ public interface MigrationPlan {
     MigrationPlanBuilderStep2 withTargetProcessDefinitionKey(final long targetProcessDefinitionKey);
   }
 
+  /**
+   * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+   *     io.camunda.client.api.command.MigrationPlan.MigrationPlanBuilderStep2}
+   */
+  @Deprecated
   interface MigrationPlanBuilderStep2 {
 
     /**
@@ -80,6 +95,11 @@ public interface MigrationPlan {
         final String sourceElementId, final String targetElementId);
   }
 
+  /**
+   * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+   *     io.camunda.client.api.command.MigrationPlan.MigrationPlanBuilderFinalStep}
+   */
+  @Deprecated
   interface MigrationPlanBuilderFinalStep extends MigrationPlanBuilderStep2 {
 
     /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/MigrationPlanBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/MigrationPlanBuilderImpl.java
@@ -21,6 +21,11 @@ import io.camunda.zeebe.client.api.command.MigrationPlan.MigrationPlanBuilderSte
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.MigrationPlanBuilderImpl}
+ */
+@Deprecated
 public final class MigrationPlanBuilderImpl
     implements MigrationPlanBuilderStep1, MigrationPlanBuilderStep2, MigrationPlanBuilderFinalStep {
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/MigrationPlanImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/MigrationPlanImpl.java
@@ -18,6 +18,11 @@ package io.camunda.zeebe.client.api.command;
 import io.camunda.zeebe.client.api.command.MigrationPlanBuilderImpl.MappingInstruction;
 import java.util.List;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.MigrationPlanImpl}
+ */
+@Deprecated
 public final class MigrationPlanImpl implements MigrationPlan {
 
   final long targetProcessDefinitionKey;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ModifyProcessInstanceCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ModifyProcessInstanceCommandStep1.java
@@ -19,6 +19,11 @@ import io.camunda.zeebe.client.api.response.ModifyProcessInstanceResponse;
 import java.io.InputStream;
 import java.util.Map;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.ModifyProcessInstanceCommandStep1}
+ */
+@Deprecated
 public interface ModifyProcessInstanceCommandStep1
     extends CommandWithCommunicationApiStep<ModifyProcessInstanceCommandStep1> {
 
@@ -57,6 +62,11 @@ public interface ModifyProcessInstanceCommandStep1
    */
   ModifyProcessInstanceCommandStep2 terminateElement(final long elementInstanceKey);
 
+  /**
+   * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+   *     io.camunda.client.api.command.ModifyProcessInstanceCommandStep1.ModifyProcessInstanceCommandStep2}
+   */
+  @Deprecated
   interface ModifyProcessInstanceCommandStep2
       extends CommandWithOperationReferenceStep<ModifyProcessInstanceCommandStep2>,
           FinalCommandStep<ModifyProcessInstanceResponse> {
@@ -69,6 +79,11 @@ public interface ModifyProcessInstanceCommandStep1
     ModifyProcessInstanceCommandStep1 and();
   }
 
+  /**
+   * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+   *     io.camunda.client.api.command.ModifyProcessInstanceCommandStep1.ModifyProcessInstanceCommandStep3}
+   */
+  @Deprecated
   interface ModifyProcessInstanceCommandStep3 extends ModifyProcessInstanceCommandStep2 {
 
     /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ProblemException.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ProblemException.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.command;
 
 import io.camunda.zeebe.client.protocol.rest.ProblemDetail;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.ProblemException}
+ */
+@Deprecated
 public class ProblemException extends ClientHttpException {
   private final ProblemDetail details;
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/PublishMessageCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/PublishMessageCommandStep1.java
@@ -20,6 +20,11 @@ import java.io.InputStream;
 import java.time.Duration;
 import java.util.Map;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.PublishMessageCommandStep1}
+ */
+@Deprecated
 public interface PublishMessageCommandStep1
     extends CommandWithCommunicationApiStep<PublishMessageCommandStep1> {
 
@@ -31,6 +36,11 @@ public interface PublishMessageCommandStep1
    */
   PublishMessageCommandStep2 messageName(String messageName);
 
+  /**
+   * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+   *     io.camunda.client.api.command.PublishMessageCommandStep1.PublishMessageCommandStep2}
+   */
+  @Deprecated
   interface PublishMessageCommandStep2 {
     /**
      * Set the value of the correlation key of the message.
@@ -56,6 +66,11 @@ public interface PublishMessageCommandStep1
     PublishMessageCommandStep3 withoutCorrelationKey();
   }
 
+  /**
+   * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+   *     io.camunda.client.api.command.PublishMessageCommandStep1.PublishMessageCommandStep3}
+   */
+  @Deprecated
   interface PublishMessageCommandStep3
       extends CommandWithTenantStep<PublishMessageCommandStep3>,
           FinalCommandStep<PublishMessageResponse> {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ResolveIncidentCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ResolveIncidentCommandStep1.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.command;
 
 import io.camunda.zeebe.client.api.response.ResolveIncidentResponse;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.ResolveIncidentCommandStep1}
+ */
+@Deprecated
 public interface ResolveIncidentCommandStep1
     extends CommandWithOperationReferenceStep<ResolveIncidentCommandStep1>,
         CommandWithCommunicationApiStep<ResolveIncidentCommandStep1>,

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/SetVariablesCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/SetVariablesCommandStep1.java
@@ -19,6 +19,11 @@ import io.camunda.zeebe.client.api.response.SetVariablesResponse;
 import java.io.InputStream;
 import java.util.Map;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.SetVariablesCommandStep1}
+ */
+@Deprecated
 public interface SetVariablesCommandStep1
     extends CommandWithCommunicationApiStep<SetVariablesCommandStep1> {
   /**
@@ -57,6 +62,11 @@ public interface SetVariablesCommandStep1
    */
   SetVariablesCommandStep2 variables(Object variables);
 
+  /**
+   * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+   *     io.camunda.client.api.command.SetVariablesCommandStep1.SetVariablesCommandStep2}
+   */
+  @Deprecated
   interface SetVariablesCommandStep2
       extends CommandWithOperationReferenceStep<SetVariablesCommandStep2>,
           FinalCommandStep<SetVariablesResponse> {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/StreamJobsCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/StreamJobsCommandStep1.java
@@ -23,6 +23,11 @@ import java.util.List;
 import java.util.function.Consumer;
 
 @ExperimentalApi("https://github.com/camunda/camunda/issues/11231")
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.StreamJobsCommandStep1}
+ */
+@Deprecated
 public interface StreamJobsCommandStep1 {
   /**
    * Set the type of jobs to work on; only jobs of this type will be activated and consumed by this
@@ -33,6 +38,11 @@ public interface StreamJobsCommandStep1 {
    */
   StreamJobsCommandStep2 jobType(String jobType);
 
+  /**
+   * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+   *     io.camunda.client.api.command.StreamJobsCommandStep1.StreamJobsCommandStep2}
+   */
+  @Deprecated
   interface StreamJobsCommandStep2 {
 
     /**
@@ -46,6 +56,11 @@ public interface StreamJobsCommandStep1 {
     StreamJobsCommandStep3 consumer(final Consumer<ActivatedJob> consumer);
   }
 
+  /**
+   * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+   *     io.camunda.client.api.command.StreamJobsCommandStep1.StreamJobsCommandStep3}
+   */
+  @Deprecated
   interface StreamJobsCommandStep3
       extends CommandWithOneOrMoreTenantsStep<StreamJobsCommandStep3>,
           FinalCommandStep<StreamJobsResponse> {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ThrowErrorCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ThrowErrorCommandStep1.java
@@ -18,6 +18,11 @@ package io.camunda.zeebe.client.api.command;
 import java.io.InputStream;
 import java.util.Map;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.ThrowErrorCommandStep1}
+ */
+@Deprecated
 public interface ThrowErrorCommandStep1
     extends CommandWithCommunicationApiStep<ThrowErrorCommandStep1> {
   /**
@@ -32,6 +37,11 @@ public interface ThrowErrorCommandStep1
    */
   ThrowErrorCommandStep2 errorCode(String errorCode);
 
+  /**
+   * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+   *     io.camunda.client.api.command.ThrowErrorCommandStep1.ThrowErrorCommandStep2}
+   */
+  @Deprecated
   interface ThrowErrorCommandStep2 extends FinalCommandStep<Void> {
     /**
      * Provide an error message describing the reason for the non-technical error. If the error is

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/TopologyRequestStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/TopologyRequestStep1.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.command;
 
 import io.camunda.zeebe.client.api.response.Topology;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.TopologyRequestStep1}
+ */
+@Deprecated
 public interface TopologyRequestStep1
     extends CommandWithCommunicationApiStep<TopologyRequestStep1>, FinalCommandStep<Topology> {
   // the place for new optional parameters

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UnassignUserTaskCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UnassignUserTaskCommandStep1.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.command;
 
 import io.camunda.zeebe.client.api.response.UnassignUserTaskResponse;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.UnassignUserTaskCommandStep1}
+ */
+@Deprecated
 public interface UnassignUserTaskCommandStep1 extends FinalCommandStep<UnassignUserTaskResponse> {
   // the place for new optional parameters
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UpdateJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UpdateJobCommandStep1.java
@@ -19,6 +19,11 @@ import io.camunda.zeebe.client.api.response.UpdateJobResponse;
 import io.camunda.zeebe.client.protocol.rest.JobChangeset;
 import java.time.Duration;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.UpdateJobCommandStep1}
+ */
+@Deprecated
 public interface UpdateJobCommandStep1 {
 
   /**
@@ -89,6 +94,11 @@ public interface UpdateJobCommandStep1 {
    */
   UpdateJobCommandStep2 updateTimeout(Duration timeout);
 
+  /**
+   * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+   *     io.camunda.client.api.command.UpdateJobCommandStep1.UpdateJobCommandStep2}
+   */
+  @Deprecated
   interface UpdateJobCommandStep2 extends FinalCommandStep<UpdateJobResponse> {
     // the place for new optional parameters
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UpdateRetriesJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UpdateRetriesJobCommandStep1.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.command;
 
 import io.camunda.zeebe.client.api.response.UpdateRetriesJobResponse;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.UpdateRetriesJobCommandStep1}
+ */
+@Deprecated
 public interface UpdateRetriesJobCommandStep1
     extends CommandWithCommunicationApiStep<UpdateRetriesJobCommandStep1> {
   /**
@@ -31,6 +36,11 @@ public interface UpdateRetriesJobCommandStep1
    */
   UpdateRetriesJobCommandStep2 retries(int retries);
 
+  /**
+   * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+   *     io.camunda.client.api.command.UpdateRetriesJobCommandStep1.UpdateRetriesJobCommandStep2}
+   */
+  @Deprecated
   interface UpdateRetriesJobCommandStep2
       extends CommandWithOperationReferenceStep<UpdateRetriesJobCommandStep2>,
           FinalCommandStep<UpdateRetriesJobResponse> {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UpdateTimeoutJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UpdateTimeoutJobCommandStep1.java
@@ -18,6 +18,11 @@ package io.camunda.zeebe.client.api.command;
 import io.camunda.zeebe.client.api.response.UpdateTimeoutJobResponse;
 import java.time.Duration;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.UpdateTimeoutJobCommandStep1}
+ */
+@Deprecated
 public interface UpdateTimeoutJobCommandStep1
     extends CommandWithCommunicationApiStep<UpdateTimeoutJobCommandStep1> {
 
@@ -45,6 +50,11 @@ public interface UpdateTimeoutJobCommandStep1
    */
   UpdateTimeoutJobCommandStep2 timeout(Duration timeout);
 
+  /**
+   * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+   *     io.camunda.client.api.command.UpdateTimeoutJobCommandStep1.UpdateTimeoutJobCommandStep2}
+   */
+  @Deprecated
   interface UpdateTimeoutJobCommandStep2
       extends CommandWithOperationReferenceStep<UpdateTimeoutJobCommandStep2>,
           FinalCommandStep<UpdateTimeoutJobResponse> {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UpdateUserTaskCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UpdateUserTaskCommandStep1.java
@@ -18,6 +18,11 @@ package io.camunda.zeebe.client.api.command;
 import io.camunda.zeebe.client.api.response.UpdateUserTaskResponse;
 import java.util.List;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.command.UpdateUserTaskCommandStep1}
+ */
+@Deprecated
 public interface UpdateUserTaskCommandStep1 extends FinalCommandStep<UpdateUserTaskResponse> {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/fetch/DecisionDefinitionGetXmlRequest.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/fetch/DecisionDefinitionGetXmlRequest.java
@@ -17,4 +17,9 @@ package io.camunda.zeebe.client.api.fetch;
 
 import io.camunda.zeebe.client.api.command.FinalCommandStep;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.fetch.DecisionDefinitionGetXmlRequest}
+ */
+@Deprecated
 public interface DecisionDefinitionGetXmlRequest extends FinalCommandStep<String> {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ActivateJobsResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ActivateJobsResponse.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.response;
 
 import java.util.List;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.ActivateJobsResponse}
+ */
+@Deprecated
 public interface ActivateJobsResponse {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ActivatedJob.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ActivatedJob.java
@@ -19,6 +19,11 @@ import io.camunda.zeebe.client.api.ExperimentalApi;
 import io.camunda.zeebe.client.api.command.ClientException;
 import java.util.Map;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.ActivatedJob}
+ */
+@Deprecated
 public interface ActivatedJob {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/AddPermissionsResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/AddPermissionsResponse.java
@@ -15,4 +15,9 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.AddPermissionsResponse}
+ */
+@Deprecated
 public interface AddPermissionsResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/AssignUserTaskResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/AssignUserTaskResponse.java
@@ -15,4 +15,9 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.AssignUserTaskResponse}
+ */
+@Deprecated
 public interface AssignUserTaskResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/BroadcastSignalResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/BroadcastSignalResponse.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.BroadcastSignalResponse}
+ */
+@Deprecated
 public interface BroadcastSignalResponse {
   /**
    * Returns the unique key of the signal that was broadcasted.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/BrokerInfo.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/BrokerInfo.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.response;
 
 import java.util.List;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.BrokerInfo}
+ */
+@Deprecated
 public interface BrokerInfo {
   /**
    * @return the node if of the broker

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CancelProcessInstanceResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CancelProcessInstanceResponse.java
@@ -15,4 +15,9 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.CancelProcessInstanceResponse}
+ */
+@Deprecated
 public interface CancelProcessInstanceResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CompleteJobResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CompleteJobResponse.java
@@ -15,4 +15,9 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.CompleteJobResponse}
+ */
+@Deprecated
 public interface CompleteJobResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CompleteUserTaskResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CompleteUserTaskResponse.java
@@ -15,4 +15,9 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.CompleteUserTaskResponse}
+ */
+@Deprecated
 public interface CompleteUserTaskResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CorrelateMessageResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CorrelateMessageResponse.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.CorrelateMessageResponse}
+ */
+@Deprecated
 public interface CorrelateMessageResponse {
   /**
    * Returns the record key of the message that was correlated.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CreateUserResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CreateUserResponse.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.CreateUserResponse}
+ */
+@Deprecated
 public interface CreateUserResponse {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/Decision.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/Decision.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.Decision}
+ */
+@Deprecated
 public interface Decision {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DecisionRequirements.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DecisionRequirements.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.DecisionRequirements}
+ */
+@Deprecated
 public interface DecisionRequirements {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DeleteResourceResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DeleteResourceResponse.java
@@ -15,4 +15,9 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.DeleteResourceResponse}
+ */
+@Deprecated
 public interface DeleteResourceResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DeploymentEvent.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DeploymentEvent.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.response;
 
 import java.util.List;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.DeploymentEvent}
+ */
+@Deprecated
 public interface DeploymentEvent {
   /**
    * @return the unique key of the deployment

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluateDecisionResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluateDecisionResponse.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.response;
 
 import java.util.List;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.EvaluateDecisionResponse}
+ */
+@Deprecated
 public interface EvaluateDecisionResponse {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluatedDecision.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluatedDecision.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.response;
 
 import java.util.List;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.EvaluatedDecision}
+ */
+@Deprecated
 public interface EvaluatedDecision {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluatedDecisionInput.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluatedDecisionInput.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.EvaluatedDecisionInput}
+ */
+@Deprecated
 public interface EvaluatedDecisionInput {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluatedDecisionOutput.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluatedDecisionOutput.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.EvaluatedDecisionOutput}
+ */
+@Deprecated
 public interface EvaluatedDecisionOutput {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/FailJobResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/FailJobResponse.java
@@ -15,4 +15,9 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.FailJobResponse}
+ */
+@Deprecated
 public interface FailJobResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/Form.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/Form.java
@@ -15,6 +15,10 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link io.camunda.client.api.response.Form}
+ */
+@Deprecated
 public interface Form {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/MatchedDecisionRule.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/MatchedDecisionRule.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.response;
 
 import java.util.List;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.MatchedDecisionRule}
+ */
+@Deprecated
 public interface MatchedDecisionRule {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/MigrateProcessInstanceResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/MigrateProcessInstanceResponse.java
@@ -17,5 +17,10 @@ package io.camunda.zeebe.client.api.response;
 
 import io.camunda.zeebe.client.api.ExperimentalApi;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.MigrateProcessInstanceResponse}
+ */
 @ExperimentalApi("https://github.com/camunda/camunda/issues/14907")
+@Deprecated
 public interface MigrateProcessInstanceResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ModifyProcessInstanceResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ModifyProcessInstanceResponse.java
@@ -15,4 +15,9 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.ModifyProcessInstanceResponse}
+ */
+@Deprecated
 public interface ModifyProcessInstanceResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/PartitionBrokerHealth.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/PartitionBrokerHealth.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.PartitionBrokerHealth}
+ */
+@Deprecated
 public enum PartitionBrokerHealth {
   HEALTHY,
   UNHEALTHY,

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/PartitionBrokerRole.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/PartitionBrokerRole.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.PartitionBrokerRole}
+ */
+@Deprecated
 public enum PartitionBrokerRole {
   LEADER,
   FOLLOWER,

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/PartitionInfo.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/PartitionInfo.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.PartitionInfo}
+ */
+@Deprecated
 public interface PartitionInfo {
   /**
    * @return the partition's id

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/PinClockResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/PinClockResponse.java
@@ -15,4 +15,9 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.PinClockResponse}
+ */
+@Deprecated
 public interface PinClockResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/Process.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/Process.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.Process}
+ */
+@Deprecated
 public interface Process {
   /**
    * @return the BPMN process id of the process

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ProcessInstanceEvent.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ProcessInstanceEvent.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.response;
 
 import io.camunda.zeebe.client.api.ExperimentalApi;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.ProcessInstanceEvent}
+ */
+@Deprecated
 public interface ProcessInstanceEvent {
 
   /** Key of the process which this instance was created for */

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ProcessInstanceResult.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ProcessInstanceResult.java
@@ -19,6 +19,11 @@ import io.camunda.zeebe.client.api.ExperimentalApi;
 import io.camunda.zeebe.client.api.command.ClientException;
 import java.util.Map;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.ProcessInstanceResult}
+ */
+@Deprecated
 public interface ProcessInstanceResult {
   /** Key of the process which this instance was created for */
   long getProcessDefinitionKey();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/PublishMessageResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/PublishMessageResponse.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.PublishMessageResponse}
+ */
+@Deprecated
 public interface PublishMessageResponse {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ResetClockResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ResetClockResponse.java
@@ -15,4 +15,9 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.ResetClockResponse}
+ */
+@Deprecated
 public interface ResetClockResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ResolveIncidentResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ResolveIncidentResponse.java
@@ -15,4 +15,9 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.ResolveIncidentResponse}
+ */
+@Deprecated
 public interface ResolveIncidentResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/SetVariablesResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/SetVariablesResponse.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.SetVariablesResponse}
+ */
+@Deprecated
 public interface SetVariablesResponse {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/StreamJobsResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/StreamJobsResponse.java
@@ -17,5 +17,10 @@ package io.camunda.zeebe.client.api.response;
 
 import io.camunda.zeebe.client.api.ExperimentalApi;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.StreamJobsResponse}
+ */
 @ExperimentalApi("https://github.com/camunda/camunda/issues/11231")
+@Deprecated
 public interface StreamJobsResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/Topology.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/Topology.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.response;
 
 import java.util.List;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.Topology}
+ */
+@Deprecated
 public interface Topology {
   /**
    * @return all (known) brokers of the cluster

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UnassignUserTaskResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UnassignUserTaskResponse.java
@@ -15,4 +15,9 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.UnassignUserTaskResponse}
+ */
+@Deprecated
 public interface UnassignUserTaskResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UpdateJobResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UpdateJobResponse.java
@@ -15,4 +15,9 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.UpdateJobResponse}
+ */
+@Deprecated
 public interface UpdateJobResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UpdateRetriesJobResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UpdateRetriesJobResponse.java
@@ -15,4 +15,9 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.UpdateRetriesJobResponse}
+ */
+@Deprecated
 public interface UpdateRetriesJobResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UpdateTimeoutJobResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UpdateTimeoutJobResponse.java
@@ -15,4 +15,9 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.UpdateTimeoutJobResponse}
+ */
+@Deprecated
 public interface UpdateTimeoutJobResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UpdateUserTaskResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UpdateUserTaskResponse.java
@@ -15,4 +15,9 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.response.UpdateUserTaskResponse}
+ */
+@Deprecated
 public interface UpdateUserTaskResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/SearchRequestBuilders.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/SearchRequestBuilders.java
@@ -30,6 +30,11 @@ import io.camunda.zeebe.client.api.search.sort.ProcessInstanceSort;
 import io.camunda.zeebe.client.api.search.sort.UserTaskSort;
 import java.util.function.Consumer;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.SearchRequestBuilders}
+ */
+@Deprecated
 public final class SearchRequestBuilders {
 
   private SearchRequestBuilders() {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/SearchRequestPage.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/SearchRequestPage.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.search;
 
 import java.util.List;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.SearchRequestPage}
+ */
+@Deprecated
 public interface SearchRequestPage {
 
   /** Start the page from. */

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/DecisionDefinitionFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/DecisionDefinitionFilter.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.search.filter;
 
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestFilter;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.DecisionDefinitionFilter}
+ */
+@Deprecated
 public interface DecisionDefinitionFilter extends SearchRequestFilter {
 
   /** Filter by decision key. */

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/DecisionRequirementsFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/DecisionRequirementsFilter.java
@@ -17,7 +17,13 @@ package io.camunda.zeebe.client.api.search.filter;
 
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestFilter;
 
-/** Interface for defining Decision Requirmeent in search queries. */
+/**
+ * Interface for defining Decision Requirmeent in search queries.
+ *
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.filter.DecisionRequirementsFilter}
+ */
+@Deprecated
 public interface DecisionRequirementsFilter extends SearchRequestFilter {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/FlownodeInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/FlownodeInstanceFilter.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.search.filter;
 
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestFilter;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.filter.FlownodeInstanceFilter}
+ */
+@Deprecated
 public interface FlownodeInstanceFilter extends SearchRequestFilter {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/IncidentFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/IncidentFilter.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.search.filter;
 
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestFilter;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.filter.IncidentFilter}
+ */
+@Deprecated
 public interface IncidentFilter extends SearchRequestFilter {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/ProcessInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/ProcessInstanceFilter.java
@@ -18,6 +18,11 @@ package io.camunda.zeebe.client.api.search.filter;
 import io.camunda.client.protocol.rest.ProcessInstanceVariableFilterRequest;
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestFilter;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.filter.ProcessInstanceFilter}
+ */
+@Deprecated
 public interface ProcessInstanceFilter extends SearchRequestFilter {
 
   /** Filter by running */

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/UserTaskFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/UserTaskFilter.java
@@ -19,7 +19,11 @@ import io.camunda.client.protocol.rest.UserTaskVariableFilterRequest;
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestFilter;
 import java.util.List;
 
-/** Interface for defining user task filters in search queries. */
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.filter.UserTaskFilter}
+ */
+@Deprecated
 public interface UserTaskFilter extends SearchRequestFilter {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/VariableValueFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/VariableValueFilter.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.search.filter;
 
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestFilter;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.filter.VariableValueFilter}
+ */
+@Deprecated
 public interface VariableValueFilter extends SearchRequestFilter {
 
   /** Filter by variable name */

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/DecisionDefinitionQuery.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/DecisionDefinitionQuery.java
@@ -19,6 +19,11 @@ import io.camunda.zeebe.client.api.search.filter.DecisionDefinitionFilter;
 import io.camunda.zeebe.client.api.search.response.DecisionDefinition;
 import io.camunda.zeebe.client.api.search.sort.DecisionDefinitionSort;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.query.DecisionDefinitionQuery}
+ */
+@Deprecated
 public interface DecisionDefinitionQuery
     extends TypedSearchQueryRequest<
             DecisionDefinitionFilter, DecisionDefinitionSort, DecisionDefinitionQuery>,

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/DecisionRequirementsQuery.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/DecisionRequirementsQuery.java
@@ -20,6 +20,11 @@ import io.camunda.zeebe.client.api.search.filter.DecisionRequirementsFilter;
 import io.camunda.zeebe.client.api.search.response.DecisionRequirements;
 import io.camunda.zeebe.client.api.search.sort.DecisionRequirementsSort;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.query.DecisionRequirementsQuery}
+ */
+@Deprecated
 public interface DecisionRequirementsQuery
     extends TypedSearchQueryRequest<
             DecisionRequirementsFilter, DecisionRequirementsSort, DecisionRequirementsQuery>,

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/FinalSearchQueryStep.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/FinalSearchQueryStep.java
@@ -19,6 +19,11 @@ import io.camunda.zeebe.client.api.command.FinalCommandStep;
 import io.camunda.zeebe.client.api.search.response.SearchQueryResponse;
 import java.time.Duration;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.query.FinalSearchQueryStep}
+ */
+@Deprecated
 public interface FinalSearchQueryStep<T> extends FinalCommandStep<SearchQueryResponse<T>> {
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/FlownodeInstanceQuery.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/FlownodeInstanceQuery.java
@@ -19,6 +19,11 @@ import io.camunda.zeebe.client.api.search.filter.FlownodeInstanceFilter;
 import io.camunda.zeebe.client.api.search.response.FlowNodeInstance;
 import io.camunda.zeebe.client.api.search.sort.FlownodeInstanceSort;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.query.FlownodeInstanceQuery}
+ */
+@Deprecated
 public interface FlownodeInstanceQuery
     extends TypedSearchQueryRequest<
             FlownodeInstanceFilter, FlownodeInstanceSort, FlownodeInstanceQuery>,

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/IncidentQuery.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/IncidentQuery.java
@@ -19,6 +19,11 @@ import io.camunda.zeebe.client.api.search.filter.IncidentFilter;
 import io.camunda.zeebe.client.api.search.response.Incident;
 import io.camunda.zeebe.client.api.search.sort.IncidentSort;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.query.IncidentQuery}
+ */
+@Deprecated
 public interface IncidentQuery
     extends TypedSearchQueryRequest<IncidentFilter, IncidentSort, IncidentQuery>,
         FinalSearchQueryStep<Incident> {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/ProcessInstanceQuery.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/ProcessInstanceQuery.java
@@ -19,6 +19,11 @@ import io.camunda.zeebe.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.zeebe.client.api.search.response.ProcessInstance;
 import io.camunda.zeebe.client.api.search.sort.ProcessInstanceSort;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.query.ProcessInstanceQuery}
+ */
+@Deprecated
 public interface ProcessInstanceQuery
     extends TypedSearchQueryRequest<
             ProcessInstanceFilter, ProcessInstanceSort, ProcessInstanceQuery>,

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/TypedSearchQueryRequest.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/TypedSearchQueryRequest.java
@@ -20,6 +20,11 @@ import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRe
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestSort;
 import java.util.function.Consumer;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.query.TypedSearchQueryRequest}
+ */
+@Deprecated
 public interface TypedSearchQueryRequest<
     F extends SearchRequestFilter,
     S extends SearchRequestSort<S>,

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/UserTaskQuery.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/query/UserTaskQuery.java
@@ -20,6 +20,11 @@ import io.camunda.zeebe.client.api.search.filter.UserTaskFilter;
 import io.camunda.zeebe.client.api.search.response.UserTask;
 import io.camunda.zeebe.client.api.search.sort.UserTaskSort;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.query.UserTaskQuery}
+ */
+@Deprecated
 public interface UserTaskQuery
     extends TypedSearchQueryRequest<UserTaskFilter, UserTaskSort, UserTaskQuery>,
         FinalSearchQueryStep<UserTask> {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/DecisionDefinition.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/DecisionDefinition.java
@@ -17,4 +17,9 @@ package io.camunda.zeebe.client.api.search.response;
 
 import io.camunda.zeebe.client.api.response.Decision;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.response.DecisionDefinition}
+ */
+@Deprecated
 public interface DecisionDefinition extends Decision {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/DecisionInstanceReference.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/DecisionInstanceReference.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client.api.search.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.response.DecisionInstanceReference}
+ */
+@Deprecated
 public interface DecisionInstanceReference {
 
   String getInstanceId();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/DecisionRequirements.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/DecisionRequirements.java
@@ -15,5 +15,10 @@
  */
 package io.camunda.zeebe.client.api.search.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.response.DecisionRequirements}
+ */
+@Deprecated
 public interface DecisionRequirements
     extends io.camunda.zeebe.client.api.response.DecisionRequirements {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/FlowNodeInstance.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/FlowNodeInstance.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client.api.search.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.response.FlowNodeInstance}
+ */
+@Deprecated
 public interface FlowNodeInstance {
 
   /** key */

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/Incident.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/Incident.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client.api.search.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.response.Incident}
+ */
+@Deprecated
 public interface Incident {
 
   Long getKey();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/Operation.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/Operation.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client.api.search.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.response.Operation}
+ */
+@Deprecated
 public interface Operation {
 
   String getId();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/ProcessInstance.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/ProcessInstance.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client.api.search.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.response.ProcessInstance}
+ */
+@Deprecated
 public interface ProcessInstance {
 
   Long getKey();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/ProcessInstanceReference.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/ProcessInstanceReference.java
@@ -15,6 +15,11 @@
  */
 package io.camunda.zeebe.client.api.search.response;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.response.ProcessInstanceReference}
+ */
+@Deprecated
 public interface ProcessInstanceReference {
 
   String getInstanceId();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/SearchQueryResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/SearchQueryResponse.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.search.response;
 
 import java.util.List;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.response.SearchQueryResponse}
+ */
+@Deprecated
 public interface SearchQueryResponse<T> {
 
   /** Returns the list of items */

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/SearchResponsePage.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/SearchResponsePage.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.search.response;
 
 import java.util.List;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.response.SearchResponsePage}
+ */
+@Deprecated
 public interface SearchResponsePage {
 
   /** Total number of items that matches the query */

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/UserTask.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/UserTask.java
@@ -18,6 +18,11 @@ package io.camunda.zeebe.client.api.search.response;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.response.UserTask}
+ */
+@Deprecated
 public interface UserTask {
 
   Long getKey();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/DecisionDefinitionSort.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/DecisionDefinitionSort.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.search.sort;
 
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestSort;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.sort.DecisionDefinitionSort}
+ */
+@Deprecated
 public interface DecisionDefinitionSort extends SearchRequestSort<DecisionDefinitionSort> {
 
   /** Sort by decision key. */

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/DecisionRequirementsSort.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/DecisionRequirementsSort.java
@@ -18,6 +18,11 @@ package io.camunda.zeebe.client.api.search.sort;
 
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestSort;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.sort.DecisionRequirementsSort}
+ */
+@Deprecated
 public interface DecisionRequirementsSort extends SearchRequestSort<DecisionRequirementsSort> {
   /** Sort by decision requirement key. */
   DecisionRequirementsSort decisionRequirementsKey();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/FlownodeInstanceSort.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/FlownodeInstanceSort.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.search.sort;
 
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestSort;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.sort.FlownodeInstanceSort}
+ */
+@Deprecated
 public interface FlownodeInstanceSort extends SearchRequestSort<FlownodeInstanceSort> {
 
   FlownodeInstanceSort key();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/IncidentSort.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/IncidentSort.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.search.sort;
 
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestSort;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.sort.IncidentSort}
+ */
+@Deprecated
 public interface IncidentSort extends SearchRequestSort<IncidentSort> {
 
   IncidentSort key();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/ProcessInstanceSort.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/ProcessInstanceSort.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.search.sort;
 
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestSort;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.sort.ProcessInstanceSort}
+ */
+@Deprecated
 public interface ProcessInstanceSort extends SearchRequestSort<ProcessInstanceSort> {
 
   ProcessInstanceSort key();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/UserTaskSort.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/UserTaskSort.java
@@ -18,6 +18,11 @@ package io.camunda.zeebe.client.api.search.sort;
 
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestSort;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.search.sort.UserTaskSort}
+ */
+@Deprecated
 public interface UserTaskSort extends SearchRequestSort<UserTaskSort> {
 
   UserTaskSort creationDate();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/BackoffSupplier.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/BackoffSupplier.java
@@ -27,7 +27,11 @@ import java.time.Duration;
  *
  * <p>The supplier is called after a failed request. The worker will then await the supplied delay
  * before sending the next request.
+ *
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.worker.BackoffSupplier}
  */
+@Deprecated
 @FunctionalInterface
 public interface BackoffSupplier {
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/ExponentialBackoffBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/ExponentialBackoffBuilder.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.worker;
 
 import java.util.Random;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.worker.ExponentialBackoffBuilder}
+ */
+@Deprecated
 public interface ExponentialBackoffBuilder {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobClient.java
@@ -31,7 +31,11 @@ import java.time.Duration;
  * <li>complete a job
  * <li>mark a job as failed
  * <li>update the retries of a job
+ *
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.worker.JobClient}
  */
+@Deprecated
 public interface JobClient {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobHandler.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobHandler.java
@@ -18,7 +18,13 @@ package io.camunda.zeebe.client.api.worker;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 
-/** Implementations MUST be thread-safe. */
+/**
+ * Implementations MUST be thread-safe.
+ *
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.worker.JobHandler}
+ */
+@Deprecated
 @FunctionalInterface
 public interface JobHandler {
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorker.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorker.java
@@ -19,7 +19,11 @@ package io.camunda.zeebe.client.api.worker;
  * Represents an active job worker that performs jobs of a certain type. While a registration is
  * open, the client continuously receives jobs from the broker and hands them to a registered {@link
  * JobHandler}.
+ *
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.worker.JobWorker}
  */
+@Deprecated
 public interface JobWorker extends AutoCloseable {
   /**
    * @return true if this registration is currently active and work items are being received for it

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerBuilderStep1.java
@@ -21,6 +21,11 @@ import io.camunda.zeebe.client.api.command.CommandWithOneOrMoreTenantsStep;
 import java.time.Duration;
 import java.util.List;
 
+/**
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.worker.JobWorkerBuilderStep1}
+ */
+@Deprecated
 public interface JobWorkerBuilderStep1 {
   /**
    * Set the type of jobs to work on.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerMetrics.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/JobWorkerMetrics.java
@@ -18,7 +18,13 @@ package io.camunda.zeebe.client.api.worker;
 import io.camunda.zeebe.client.api.worker.metrics.MicrometerJobWorkerMetricsBuilder;
 import io.camunda.zeebe.client.impl.worker.metrics.MicrometerJobWorkerMetricsBuilderImpl;
 
-/** Worker metrics API. Allows basic instrumenting of job activation and handling. */
+/**
+ * Worker metrics API. Allows basic instrumenting of job activation and handling.
+ *
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.worker.JobWorkerMetrics}
+ */
+@Deprecated
 public interface JobWorkerMetrics {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/metrics/MicrometerJobWorkerMetricsBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/worker/metrics/MicrometerJobWorkerMetricsBuilder.java
@@ -39,7 +39,11 @@ import io.micrometer.core.instrument.Tag;
  *
  * <p>NOTE: the names may be changed depending on the registry backing Micrometer (e.g. Prometheus
  * names will replace the periods with underscore, etc.)
+ *
+ * @deprecated since 8.7 for removal in 8.8, replaced by {@link
+ *     io.camunda.client.api.worker.metrics.MicrometerJobWorkerMetricsBuilder}
  */
+@Deprecated
 public interface MicrometerJobWorkerMetricsBuilder {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/protocol/rest/JobChangeset.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/protocol/rest/JobChangeset.java
@@ -20,7 +20,11 @@ import java.util.Objects;
 /**
  * Added to keep compatibility with the previous version of the client. Used in {@link
  * io.camunda.zeebe.client.api.command.UpdateJobCommandStep1#update(JobChangeset)}
+ *
+ * @deprecated since 8.7 for removal in 8.8, replaced by #TODO
+ *     https://github.com/camunda/camunda/issues/26851
  */
+@Deprecated
 public class JobChangeset {
 
   private final io.camunda.client.protocol.rest.JobChangeset delegate;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/protocol/rest/ProblemDetail.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/protocol/rest/ProblemDetail.java
@@ -21,7 +21,11 @@ import java.util.Objects;
 /**
  * Added to keep compatibility with the previous version of the client. Used in {@link
  * io.camunda.zeebe.client.api.command.ProblemException#details()}.
+ *
+ * @deprecated since 8.7 for removal in 8.8, replaced by #TODO
+ *     https://github.com/camunda/camunda/issues/26851
  */
+@Deprecated
 public class ProblemDetail {
 
   private final io.camunda.client.protocol.rest.ProblemDetail delegate;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Deprecating all Zeebe client API classes

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates to https://github.com/camunda/camunda/issues/26814
