### PR TITLE
Modify DbUserState to use usernames as identifier instead of a key

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
@@ -148,7 +148,6 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
               .setEntityType(EntityType.USER));
     }
 
-    stateWriter.appendFollowUpEvent(
-        userKey, UserIntent.DELETED, new UserRecord().setUserKey(userKey));
+    stateWriter.appendFollowUpEvent(userKey, UserIntent.DELETED, user.getUser());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -540,8 +540,7 @@ public final class EventAppliers implements EventApplier {
     register(TenantIntent.ENTITY_REMOVED, new TenantEntityRemovedApplier(state));
     register(
         TenantIntent.DELETED,
-        new TenantDeletedApplier(
-            state.getTenantState(), state.getUserState(), state.getAuthorizationState()));
+        new TenantDeletedApplier(state.getTenantState(), state.getAuthorizationState()));
   }
 
   private void registerMappingAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -510,8 +510,7 @@ public final class EventAppliers implements EventApplier {
     register(RoleIntent.ENTITY_REMOVED, new RoleEntityRemovedApplier(state));
     register(
         RoleIntent.DELETED,
-        new RoleDeletedApplier(
-            state.getRoleState(), state.getUserState(), state.getAuthorizationState()));
+        new RoleDeletedApplier(state.getRoleState(), state.getAuthorizationState()));
   }
 
   private void registerGroupAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupEntityAddedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupEntityAddedApplier.java
@@ -37,7 +37,10 @@ public class GroupEntityAddedApplier implements TypedEventApplier<GroupIntent, G
     final var entityKey = value.getEntityKey();
     final var entityType = value.getEntityType();
     switch (entityType) {
-      case USER -> userState.addGroup(entityKey, groupKey);
+      case USER ->
+          userState
+              .getUser(entityKey)
+              .ifPresent(user -> userState.addGroup(user.getUsername(), groupKey));
       case MAPPING -> mappingState.addGroup(entityKey, groupKey);
       default ->
           throw new IllegalStateException(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupEntityRemovedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupEntityRemovedApplier.java
@@ -38,7 +38,10 @@ public class GroupEntityRemovedApplier implements TypedEventApplier<GroupIntent,
     groupState.removeEntity(groupKey, entityKey);
 
     switch (entityType) {
-      case USER -> userState.removeGroup(entityKey, key);
+      case USER ->
+          userState
+              .getUser(entityKey)
+              .ifPresent(user -> userState.removeGroup(user.getUsername(), key));
       case MAPPING -> mappingState.removeGroup(entityKey, key);
       default ->
           throw new IllegalStateException(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleDeletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleDeletedApplier.java
@@ -37,7 +37,11 @@ public class RoleDeletedApplier implements TypedEventApplier<RoleIntent, RoleRec
     // Remove roles from users if EntityType.USER exists
     final var userEntities = entities.get(EntityType.USER);
     if (userEntities != null) {
-      userEntities.forEach(userKey -> userState.removeRole(userKey, roleKey));
+      userEntities.forEach(
+          userKey ->
+              userState
+                  .getUser(userKey)
+                  .ifPresent(user -> userState.removeRole(user.getUsername(), roleKey)));
     }
     // todo remove entity from mapping state
     // delete role from authorization state

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleDeletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleDeletedApplier.java
@@ -10,40 +10,24 @@ package io.camunda.zeebe.engine.state.appliers;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableAuthorizationState;
 import io.camunda.zeebe.engine.state.mutable.MutableRoleState;
-import io.camunda.zeebe.engine.state.mutable.MutableUserState;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
-import io.camunda.zeebe.protocol.record.value.EntityType;
 
 public class RoleDeletedApplier implements TypedEventApplier<RoleIntent, RoleRecord> {
 
   private final MutableRoleState roleState;
-  private final MutableUserState userState;
   private final MutableAuthorizationState authorizationState;
 
   public RoleDeletedApplier(
-      final MutableRoleState roleState,
-      final MutableUserState userState,
-      final MutableAuthorizationState authorizationState) {
+      final MutableRoleState roleState, final MutableAuthorizationState authorizationState) {
     this.roleState = roleState;
-    this.userState = userState;
     this.authorizationState = authorizationState;
   }
 
   @Override
   public void applyState(final long key, final RoleRecord value) {
     final var roleKey = value.getRoleKey();
-    final var entities = roleState.getEntitiesByType(roleKey);
-    // Remove roles from users if EntityType.USER exists
-    final var userEntities = entities.get(EntityType.USER);
-    if (userEntities != null) {
-      userEntities.forEach(
-          userKey ->
-              userState
-                  .getUser(userKey)
-                  .ifPresent(user -> userState.removeRole(user.getUsername(), roleKey)));
-    }
-    // todo remove entity from mapping state
+
     // delete role from authorization state
     authorizationState.deleteAuthorizationsByOwnerKeyPrefix(roleKey);
     authorizationState.deleteOwnerTypeByKey(roleKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleEntityAddedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleEntityAddedApplier.java
@@ -31,7 +31,13 @@ public class RoleEntityAddedApplier implements TypedEventApplier<RoleIntent, Rol
   public void applyState(final long key, final RoleRecord value) {
     roleState.addEntity(value);
     switch (value.getEntityType()) {
-      case USER -> userState.addRole(value.getEntityKey(), value.getRoleKey());
+      case USER ->
+          userState
+              .getUser(
+                  value
+                      .getEntityKey()) // TODO should be removed once we refactor roles to work with
+              // ids
+              .ifPresent(user -> userState.addRole(user.getUsername(), value.getRoleKey()));
       case MAPPING -> mappingState.addRole(value.getEntityKey(), value.getRoleKey());
       default ->
           throw new IllegalStateException(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleEntityRemovedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleEntityRemovedApplier.java
@@ -22,16 +22,19 @@ public class RoleEntityRemovedApplier implements TypedEventApplier<RoleIntent, R
   private final MutableMappingState mappingState;
 
   public RoleEntityRemovedApplier(final MutableProcessingState state) {
-    this.roleState = state.getRoleState();
-    this.userState = state.getUserState();
-    this.mappingState = state.getMappingState();
+    roleState = state.getRoleState();
+    userState = state.getUserState();
+    mappingState = state.getMappingState();
   }
 
   @Override
   public void applyState(final long key, final RoleRecord value) {
     roleState.removeEntity(value.getRoleKey(), value.getEntityKey());
     switch (value.getEntityType()) {
-      case USER -> userState.removeRole(value.getEntityKey(), value.getRoleKey());
+      case USER ->
+          userState
+              .getUser(value.getEntityKey())
+              .ifPresent(user -> userState.removeRole(user.getUsername(), value.getRoleKey()));
       case MAPPING -> mappingState.removeRole(value.getEntityKey(), value.getRoleKey());
       default ->
           throw new IllegalStateException(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantDeletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantDeletedApplier.java
@@ -47,7 +47,11 @@ public class TenantDeletedApplier implements TypedEventApplier<TenantIntent, Ten
       final Map<EntityType, List<Long>> entities, final String tenantId) {
     final List<Long> userEntities = entities.get(EntityType.USER);
     if (userEntities != null) {
-      userEntities.forEach(userKey -> userState.removeTenant(userKey, tenantId));
+      userEntities.forEach(
+          userKey ->
+              userState
+                  .getUser(userKey)
+                  .ifPresent(user -> userState.removeTenant(user.getUsername(), tenantId)));
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantDeletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantDeletedApplier.java
@@ -10,61 +10,24 @@ package io.camunda.zeebe.engine.state.appliers;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableAuthorizationState;
 import io.camunda.zeebe.engine.state.mutable.MutableTenantState;
-import io.camunda.zeebe.engine.state.mutable.MutableUserState;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
-import io.camunda.zeebe.protocol.record.value.EntityType;
-import java.util.List;
-import java.util.Map;
 
 public class TenantDeletedApplier implements TypedEventApplier<TenantIntent, TenantRecord> {
   private final MutableTenantState tenantState;
-  private final MutableUserState userState;
   private final MutableAuthorizationState authorizationState;
 
   public TenantDeletedApplier(
-      final MutableTenantState tenantState,
-      final MutableUserState userState,
-      final MutableAuthorizationState authorizationState) {
+      final MutableTenantState tenantState, final MutableAuthorizationState authorizationState) {
     this.tenantState = tenantState;
-    this.userState = userState;
     this.authorizationState = authorizationState;
   }
 
   @Override
   public void applyState(final long key, final TenantRecord tenantRecord) {
     final var tenantKey = tenantRecord.getTenantKey();
-    final String tenantId = tenantRecord.getTenantId();
-    final Map<EntityType, List<Long>> entities = tenantState.getEntitiesByType(tenantKey);
-
-    handleUserEntities(entities, tenantId);
-    handleMappingEntities(entities, tenantKey);
     deleteTenantAuthorizations(tenantKey);
     tenantState.delete(tenantRecord);
-  }
-
-  private void handleUserEntities(
-      final Map<EntityType, List<Long>> entities, final String tenantId) {
-    final List<Long> userEntities = entities.get(EntityType.USER);
-    if (userEntities != null) {
-      userEntities.forEach(
-          userKey ->
-              userState
-                  .getUser(userKey)
-                  .ifPresent(user -> userState.removeTenant(user.getUsername(), tenantId)));
-    }
-  }
-
-  private void handleMappingEntities(
-      final Map<EntityType, List<Long>> entities, final long tenantId) {
-    final List<Long> mappingEntities = entities.get(EntityType.MAPPING);
-    if (mappingEntities != null) {
-      mappingEntities.forEach(
-          mappingKey -> {
-            // todo  Uncomment when the mapping state is implemented
-            // mappingState.removeTenant(mappingKey, tenantId);
-          });
-    }
   }
 
   private void deleteTenantAuthorizations(final long tenantKey) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityAddedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityAddedApplier.java
@@ -34,7 +34,10 @@ public class TenantEntityAddedApplier implements TypedEventApplier<TenantIntent,
   public void applyState(final long key, final TenantRecord tenant) {
     tenantState.addEntity(tenant);
     switch (tenant.getEntityType()) {
-      case USER -> userState.addTenantId(tenant.getEntityKey(), tenant.getTenantId());
+      case USER ->
+          userState
+              .getUser(tenant.getEntityKey())
+              .ifPresent(user -> userState.addTenantId(user.getUsername(), tenant.getTenantId()));
       case MAPPING -> mappingState.addTenant(tenant.getEntityKey(), tenant.getTenantId());
       case GROUP -> groupState.addTenant(tenant.getEntityKey(), tenant.getTenantId());
       default ->

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityRemovedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityRemovedApplier.java
@@ -34,7 +34,10 @@ public class TenantEntityRemovedApplier implements TypedEventApplier<TenantInten
   public void applyState(final long key, final TenantRecord tenant) {
     tenantState.removeEntity(tenant.getTenantKey(), tenant.getEntityKey());
     switch (tenant.getEntityType()) {
-      case USER -> userState.removeTenant(tenant.getEntityKey(), tenant.getTenantId());
+      case USER ->
+          userState
+              .getUser(tenant.getEntityKey())
+              .ifPresent(user -> userState.removeTenant(user.getUsername(), tenant.getTenantId()));
       case MAPPING -> mappingState.removeTenant(tenant.getEntityKey(), tenant.getTenantId());
       case GROUP -> groupState.removeTenant(tenant.getEntityKey(), tenant.getTenantId());
       default ->

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserDeletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserDeletedApplier.java
@@ -27,6 +27,6 @@ public class UserDeletedApplier implements TypedEventApplier<UserIntent, UserRec
   public void applyState(final long key, final UserRecord value) {
     authorizationState.deleteAuthorizationsByOwnerKeyPrefix(value.getUserKey());
     authorizationState.deleteOwnerTypeByKey(value.getUserKey());
-    userState.delete(value.getUserKey());
+    userState.delete(value.getUsername());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/UserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/UserState.java
@@ -10,11 +10,8 @@ package io.camunda.zeebe.engine.state.immutable;
 import io.camunda.zeebe.engine.state.user.PersistedUser;
 import java.util.List;
 import java.util.Optional;
-import org.agrona.DirectBuffer;
 
 public interface UserState {
-
-  Optional<PersistedUser> getUser(final DirectBuffer username);
 
   Optional<PersistedUser> getUser(final String username);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/UserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/UserState.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.engine.state.user.PersistedUser;
-import java.util.List;
 import java.util.Optional;
 
 public interface UserState {
@@ -22,6 +21,4 @@ public interface UserState {
    * @return An optional containing the user if it was found, otherwise an empty optional
    */
   Optional<PersistedUser> getUser(final long userKey);
-
-  List<String> getTenantIds(final long userKey);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
@@ -18,7 +18,7 @@ public interface MutableUserState extends UserState {
 
   void delete(final String username);
 
-  void addRole(final long userKey, final long roleKey);
+  void addRole(final String username, final long roleKey);
 
   void removeRole(final long userKey, final long roleKey);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
@@ -16,7 +16,7 @@ public interface MutableUserState extends UserState {
 
   void update(final UserRecord user);
 
-  void delete(final long userKey);
+  void delete(final String username);
 
   void addRole(final long userKey, final long roleKey);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
@@ -26,7 +26,7 @@ public interface MutableUserState extends UserState {
 
   void removeTenant(final String username, final String tenantId);
 
-  void addGroup(final long userKey, final long groupKey);
+  void addGroup(final String username, final long groupKey);
 
   void removeGroup(final long userKey, final long groupKey);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
@@ -22,7 +22,7 @@ public interface MutableUserState extends UserState {
 
   void removeRole(final String username, final long roleKey);
 
-  void addTenantId(final long userKey, final String tenantId);
+  void addTenantId(final String username, final String tenantId);
 
   void removeTenant(final long userKey, final String tenantId);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
@@ -24,7 +24,7 @@ public interface MutableUserState extends UserState {
 
   void addTenantId(final String username, final String tenantId);
 
-  void removeTenant(final long userKey, final String tenantId);
+  void removeTenant(final String username, final String tenantId);
 
   void addGroup(final long userKey, final long groupKey);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
@@ -20,7 +20,7 @@ public interface MutableUserState extends UserState {
 
   void addRole(final String username, final long roleKey);
 
-  void removeRole(final long userKey, final long roleKey);
+  void removeRole(final String username, final long roleKey);
 
   void addTenantId(final long userKey, final String tenantId);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
@@ -28,5 +28,5 @@ public interface MutableUserState extends UserState {
 
   void addGroup(final String username, final long groupKey);
 
-  void removeGroup(final long userKey, final long groupKey);
+  void removeGroup(final String username, final long groupKey);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
@@ -59,10 +59,9 @@ public class DbUserState implements UserState, MutableUserState {
   @Override
   public void update(final UserRecord user) {
     username.wrapBuffer(user.getUsernameBuffer());
-    final var key = userKeyByUsernameColumnFamily.get(username);
     persistedUser.setUser(user);
 
-    usersColumnFamily.update(key, persistedUser);
+    usersColumnFamily.update(username, persistedUser);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
@@ -97,13 +97,13 @@ public class DbUserState implements UserState, MutableUserState {
   }
 
   @Override
-  public void removeTenant(final long userKey, final String tenantId) {
-    this.userKey.wrapLong(userKey);
-    final var persistedUser = usersColumnFamily.get(this.userKey);
+  public void removeTenant(final String username, final String tenantId) {
+    this.username.wrapString(username);
+    final var persistedUser = usersColumnFamily.get(this.username);
     final List<String> tenantIds = persistedUser.getTenantIdsList();
     tenantIds.remove(tenantId);
     persistedUser.setTenantIdsList(tenantIds);
-    usersColumnFamily.update(this.userKey, persistedUser);
+    usersColumnFamily.update(this.username, persistedUser);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import java.util.List;
 import java.util.Optional;
-import org.agrona.DirectBuffer;
 
 public class DbUserState implements UserState, MutableUserState {
 
@@ -122,18 +121,6 @@ public class DbUserState implements UserState, MutableUserState {
     groupKeys.remove(groupKey);
     persistedUser.setGroupKeysList(groupKeys);
     usersColumnFamily.update(this.username, persistedUser);
-  }
-
-  @Override
-  public Optional<PersistedUser> getUser(final DirectBuffer username) {
-    this.username.wrapBuffer(username);
-    final var key = userKeyByUsernameColumnFamily.get(this.username);
-
-    if (key == null) {
-      return Optional.empty();
-    }
-
-    return getUser(key.inner().getValue());
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
@@ -107,11 +107,11 @@ public class DbUserState implements UserState, MutableUserState {
   }
 
   @Override
-  public void addGroup(final long userKey, final long groupKey) {
-    this.userKey.wrapLong(userKey);
-    final var persistedUser = usersColumnFamily.get(this.userKey);
+  public void addGroup(final String username, final long groupKey) {
+    this.username.wrapString(username);
+    final var persistedUser = usersColumnFamily.get(this.username);
     persistedUser.addGroupKey(groupKey);
-    usersColumnFamily.update(this.userKey, persistedUser);
+    usersColumnFamily.update(this.username, persistedUser);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.engine.state.user;
 
-import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
-
 import io.camunda.zeebe.db.ColumnFamily;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
@@ -125,7 +123,13 @@ public class DbUserState implements UserState, MutableUserState {
 
   @Override
   public Optional<PersistedUser> getUser(final String username) {
-    return getUser(wrapString(username));
+    this.username.wrapString(username);
+    final var persistedUser = usersColumnFamily.get(this.username);
+
+    if (persistedUser == null) {
+      return Optional.empty();
+    }
+    return Optional.of(persistedUser.copy());
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
@@ -65,9 +65,9 @@ public class DbUserState implements UserState, MutableUserState {
   }
 
   @Override
-  public void delete(final long userKey) {
-    this.userKey.wrapLong(userKey);
-    usersColumnFamily.deleteExisting(this.userKey);
+  public void delete(final String username) {
+    this.username.wrapString(username);
+    usersColumnFamily.deleteExisting(this.username);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
@@ -71,11 +71,11 @@ public class DbUserState implements UserState, MutableUserState {
   }
 
   @Override
-  public void addRole(final long userKey, final long roleKey) {
-    this.userKey.wrapLong(userKey);
-    final var persistedUser = usersColumnFamily.get(this.userKey);
+  public void addRole(final String username, final long roleKey) {
+    this.username.wrapString(username);
+    final var persistedUser = usersColumnFamily.get(this.username);
     persistedUser.addRoleKey(roleKey);
-    usersColumnFamily.update(this.userKey, persistedUser);
+    usersColumnFamily.update(this.username, persistedUser);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
@@ -79,13 +79,13 @@ public class DbUserState implements UserState, MutableUserState {
   }
 
   @Override
-  public void removeRole(final long userKey, final long roleKey) {
-    this.userKey.wrapLong(userKey);
-    final var persistedUser = usersColumnFamily.get(this.userKey);
+  public void removeRole(final String username, final long roleKey) {
+    this.username.wrapString(username);
+    final var persistedUser = usersColumnFamily.get(this.username);
     final List<Long> roleKeys = persistedUser.getRoleKeysList();
     roleKeys.remove(roleKey);
     persistedUser.setRoleKeysList(roleKeys);
-    usersColumnFamily.update(this.userKey, persistedUser);
+    usersColumnFamily.update(this.username, persistedUser);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
@@ -115,13 +115,13 @@ public class DbUserState implements UserState, MutableUserState {
   }
 
   @Override
-  public void removeGroup(final long userKey, final long groupKey) {
-    this.userKey.wrapLong(userKey);
-    final var persistedUser = usersColumnFamily.get(this.userKey);
+  public void removeGroup(final String username, final long groupKey) {
+    this.username.wrapString(username);
+    final var persistedUser = usersColumnFamily.get(this.username);
     final List<Long> groupKeys = persistedUser.getGroupKeysList();
     groupKeys.remove(groupKey);
     persistedUser.setGroupKeysList(groupKeys);
-    usersColumnFamily.update(this.userKey, persistedUser);
+    usersColumnFamily.update(this.username, persistedUser);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
@@ -52,7 +52,7 @@ public class DbUserState implements UserState, MutableUserState {
     userKey.wrapLong(user.getUserKey());
     persistedUser.setUser(user);
 
-    usersColumnFamily.insert(userKey, persistedUser);
+    usersColumnFamily.insert(username, persistedUser);
     userKeyByUsernameColumnFamily.insert(username, fkUserKey);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
@@ -140,15 +140,4 @@ public class DbUserState implements UserState, MutableUserState {
     return Optional.ofNullable(username)
         .flatMap(dbUsername -> getUser(dbUsername.inner().toString()));
   }
-
-  @Override
-  public List<String> getTenantIds(final long userKey) {
-    this.userKey.wrapLong(userKey);
-    final var persistedUser = usersColumnFamily.get(this.userKey);
-
-    if (persistedUser == null) {
-      return List.of();
-    }
-    return persistedUser.getTenantIdsList();
-  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
@@ -89,11 +89,11 @@ public class DbUserState implements UserState, MutableUserState {
   }
 
   @Override
-  public void addTenantId(final long userKey, final String tenantId) {
-    this.userKey.wrapLong(userKey);
-    final var persistedUser = usersColumnFamily.get(this.userKey);
+  public void addTenantId(final String username, final String tenantId) {
+    this.username.wrapString(username);
+    final var persistedUser = usersColumnFamily.get(this.username);
     persistedUser.addTenantId(tenantId);
-    usersColumnFamily.update(this.userKey, persistedUser);
+    usersColumnFamily.update(this.username, persistedUser);
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
@@ -49,7 +49,7 @@ public final class ProcessExecutionCleanStateTest {
           ZbColumnFamilies.MIGRATIONS_STATE,
           ZbColumnFamilies.DEPLOYMENT_RAW,
           ZbColumnFamilies.USERS,
-          ZbColumnFamilies.USER_KEY_BY_USERNAME,
+          ZbColumnFamilies.USERNAME_BY_USER_KEY,
           ZbColumnFamilies.PERMISSIONS,
           ZbColumnFamilies.OWNER_TYPE_BY_OWNER_KEY,
           ZbColumnFamilies.ROLES,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/RoleAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/RoleAppliersTest.java
@@ -142,19 +142,20 @@ public class RoleAppliersTest {
   @Test
   void shouldRemoveEntityFromRoleWithTypeUser() {
     // given
-    final long entityKey = 1L;
+    final var username = "foo";
+    final var userKey = 123L;
     userState.create(
         new UserRecord()
-            .setUserKey(entityKey)
-            .setUsername("username")
+            .setUserKey(userKey)
+            .setUsername(username)
             .setName("Foo")
             .setEmail("foo@bar.com")
             .setPassword("password"));
     final long roleKey = 11L;
-    userState.addRole(entityKey, roleKey);
+    userState.addRole(username, roleKey);
     final var roleRecord = new RoleRecord().setRoleKey(roleKey).setName("foo");
     roleState.create(roleRecord);
-    roleRecord.setEntityKey(entityKey).setEntityType(EntityType.USER);
+    roleRecord.setEntityKey(userKey).setEntityType(EntityType.USER);
     roleState.addEntity(roleRecord);
 
     // when
@@ -162,7 +163,7 @@ public class RoleAppliersTest {
 
     // then
     assertThat(roleState.getEntitiesByType(roleKey)).isEmpty();
-    final var persistedUser = userState.getUser(entityKey).get();
+    final var persistedUser = userState.getUser(username).get();
     assertThat(persistedUser.getRoleKeysList()).isEmpty();
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/RoleAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/RoleAppliersTest.java
@@ -106,18 +106,9 @@ public class RoleAppliersTest {
   @Test
   void shouldDeleteRole() {
     // given
-    userState.create(
-        new UserRecord()
-            .setUserKey(1L)
-            .setUsername("username")
-            .setName("Foo")
-            .setEmail("foo@bar.com")
-            .setPassword("password"));
     final long roleKey = 11L;
     final var roleRecord = new RoleRecord().setRoleKey(roleKey).setName("foo");
     roleState.create(roleRecord);
-    roleRecord.setEntityKey(1L).setEntityType(EntityType.USER);
-    roleEntityAddedApplier.applyState(roleKey, roleRecord);
     authorizationState.insertOwnerTypeByKey(roleKey, AuthorizationOwnerType.ROLE);
     authorizationState.createOrAddPermission(
         roleKey, AuthorizationResourceType.ROLE, PermissionType.DELETE, Set.of("role1", "role2"));
@@ -127,8 +118,6 @@ public class RoleAppliersTest {
 
     // then
     assertThat(roleState.getRole(roleKey)).isEmpty();
-    final var persistedUser = userState.getUser(1L).get();
-    assertThat(persistedUser.getRoleKeysList()).isEmpty();
     final var ownerType = authorizationState.getOwnerType(roleKey);
     assertThat(ownerType).isEmpty();
     final var resourceIdentifiers =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/RoleAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/RoleAppliersTest.java
@@ -48,9 +48,7 @@ public class RoleAppliersTest {
     mappingState = processingState.getMappingState();
     roleDeletedApplier =
         new RoleDeletedApplier(
-            processingState.getRoleState(),
-            processingState.getUserState(),
-            processingState.getAuthorizationState());
+            processingState.getRoleState(), processingState.getAuthorizationState());
     roleEntityAddedApplier = new RoleEntityAddedApplier(processingState);
     roleEntityRemovedApplier = new RoleEntityRemovedApplier(processingState);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
@@ -47,9 +47,7 @@ public class TenantAppliersTest {
     authorizationState = processingState.getAuthorizationState();
     tenantDeletedApplier =
         new TenantDeletedApplier(
-            processingState.getTenantState(),
-            processingState.getUserState(),
-            processingState.getAuthorizationState());
+            processingState.getTenantState(), processingState.getAuthorizationState());
     tenantEntityAddedApplier = new TenantEntityAddedApplier(processingState);
     tenantEntityRemovedApplier = new TenantEntityRemovedApplier(processingState);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java
@@ -266,7 +266,7 @@ public class UserStateTest {
     userState.addRole(username, roleKey);
 
     // when
-    userState.removeRole(userKey, roleKey);
+    userState.removeRole(username, roleKey);
 
     // then
     final var persistedUser = userState.getUser(username).get();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java
@@ -240,10 +240,10 @@ public class UserStateTest {
 
     // when
     final long roleKey = 1L;
-    userState.addRole(userKey, roleKey);
+    userState.addRole(username, roleKey);
 
     // then
-    final var persistedUser = userState.getUser(userKey).get();
+    final var persistedUser = userState.getUser(username).get();
     assertThat(persistedUser.getRoleKeysList()).contains(roleKey);
   }
 
@@ -263,13 +263,13 @@ public class UserStateTest {
             .setEmail(email)
             .setPassword(password));
     final long roleKey = 1L;
-    userState.addRole(userKey, roleKey);
+    userState.addRole(username, roleKey);
 
     // when
     userState.removeRole(userKey, roleKey);
 
     // then
-    final var persistedUser = userState.getUser(userKey).get();
+    final var persistedUser = userState.getUser(username).get();
     assertThat(persistedUser.getRoleKeysList()).isEmpty();
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java
@@ -173,7 +173,7 @@ public class UserStateTest {
 
     assertThat(userState.getUser(username)).isNotEmpty();
 
-    userState.delete(userKey);
+    userState.delete(username);
 
     assertThat(userState.getUser(username)).isEmpty();
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java
@@ -403,7 +403,7 @@ public class UserStateTest {
     userState.addTenantId(username, tenantId);
 
     // when
-    userState.removeTenant(userKey, tenantId);
+    userState.removeTenant(username, tenantId);
 
     // then
     final var persistedUser = userState.getUser(username).get();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java
@@ -293,10 +293,10 @@ public class UserStateTest {
 
     // when
     final var tenantId = "tenant-1";
-    userState.addTenantId(userKey, tenantId);
+    userState.addTenantId(username, tenantId);
 
     // then
-    final var persistedUser = userState.getUser(userKey).get();
+    final var persistedUser = userState.getUser(username).get();
     assertThat(persistedUser.getTenantIdsList()).contains(tenantId);
   }
 
@@ -321,11 +321,11 @@ public class UserStateTest {
     // when
     final var tenantId1 = "tenant-1";
     final var tenantId2 = "tenant-2";
-    userState.addTenantId(userKey, tenantId1);
-    userState.addTenantId(userKey, tenantId2);
+    userState.addTenantId(username, tenantId1);
+    userState.addTenantId(username, tenantId2);
 
     // then
-    final var persistedUser = userState.getUser(userKey).get();
+    final var persistedUser = userState.getUser(username).get();
     assertThat(persistedUser.getTenantIdsList()).containsExactlyInAnyOrder(tenantId1, tenantId2);
   }
 
@@ -348,14 +348,14 @@ public class UserStateTest {
             .setPassword(password));
 
     final var tenantId1 = "tenant-1";
-    userState.addTenantId(userKey, tenantId1);
+    userState.addTenantId(username, tenantId1);
 
     // when
     final var tenantId2 = "tenant-2";
-    userState.addTenantId(userKey, tenantId2);
+    userState.addTenantId(username, tenantId2);
 
     // then
-    final var persistedUser = userState.getUser(userKey).get();
+    final var persistedUser = userState.getUser(username).get();
     assertThat(persistedUser.getTenantIdsList()).containsExactlyInAnyOrder(tenantId1, tenantId2);
   }
 
@@ -400,13 +400,13 @@ public class UserStateTest {
             .setEmail(email)
             .setPassword(password));
     final var tenantId = "test-tenant-id";
-    userState.addTenantId(userKey, tenantId);
+    userState.addTenantId(username, tenantId);
 
     // when
     userState.removeTenant(userKey, tenantId);
 
     // then
-    final var persistedUser = userState.getUser(userKey).get();
+    final var persistedUser = userState.getUser(username).get();
     assertThat(persistedUser.getTenantIdsList()).isEmpty();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java
@@ -76,7 +76,7 @@ public class UserStateTest {
     // when/then
     assertThatThrownBy(() -> userState.create(user))
         .isInstanceOf(ZeebeDbInconsistentException.class)
-        .hasMessage("Key DbLong{2} in ColumnFamily USERS already exists");
+        .hasMessage("Key %s in ColumnFamily USERS already exists".formatted(username));
   }
 
   @DisplayName("should return the correct user by username")

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -178,7 +178,7 @@ public enum ZbColumnFamilies implements EnumValue {
   MESSAGE_CORRELATION(85),
 
   USERS(86),
-  USER_KEY_BY_USERNAME(87),
+  USERNAME_BY_USER_KEY(87),
 
   CLOCK(88),
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -178,7 +178,8 @@ public enum ZbColumnFamilies implements EnumValue {
   MESSAGE_CORRELATION(85),
 
   USERS(86),
-  USERNAME_BY_USER_KEY(87),
+  @Deprecated
+  USER_KEY_BY_USERNAME(87),
 
   CLOCK(88),
 
@@ -224,7 +225,9 @@ public enum ZbColumnFamilies implements EnumValue {
   RESOURCE_VERSION(115),
   RESOURCE_BY_ID_AND_VERSION(116),
   RESOURCE_KEY_BY_RESOURCE_ID_AND_VERSION_TAG(117),
-  RESOURCE_KEY_BY_RESOURCE_ID_AND_DEPLOYMENT_KEY(118);
+  RESOURCE_KEY_BY_RESOURCE_ID_AND_DEPLOYMENT_KEY(118),
+
+  USERNAME_BY_USER_KEY(119);
 
   private final int value;
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

With this PR the CFs get refactored to work with a username instead of the `userKey`. Some noteworthy things:
1. We had a CF tracking keys by username. I had to swap this around so we can retrieve the username by the key. The initial plan was to remove it but since we haven't refactored the other entities this would become a huge PR in which I'd have to tackle it all.
2. Since we didn't refactor the roles/groups/tenants yet I had to add a user lookup in a few places which we didn't have before. These can/should be removed once we refacor these other entities.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #26801 
closes #26803 
