### PR TITLE
ci: add daily build to unified ci to re-populate GHA caches - remove protobuf job from the scheduled run list

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -136,7 +136,6 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
-        github.event_name == 'schedule' ||
         steps.filter-common.outputs.protobuf-change == 'true'
       }}
   openapi-changes:


### PR DESCRIPTION
## Description

Remove protobuf job from the scheduled list. Unified CI doesn't need to run this job when it re-populates GHA caches.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #25284
