### PR TITLE
fix: version bumps for c8run official 8.7.0-alpha3 release

### DIFF
--- a/c8run/main.go
+++ b/c8run/main.go
@@ -196,11 +196,11 @@ func main() {
 	baseDir, _ := os.Getwd()
 	parentDir := baseDir
 	elasticsearchVersion := "8.13.4"
-	camundaReleaseTag := "untagged-fb93be48e97526f512dc"
-	camundaVersion := "8.7.0-alpha3-rc6"
+	camundaReleaseTag := "8.7.0-alpha3"
+	camundaVersion := "8.7.0-alpha3"
 	connectorsVersion := "8.7.0-alpha3.2"
-	composeTag := "8.7-alpha2"
-	composeExtractedFolder := "camunda-platform-8.7-alpha2"
+	composeTag := "8.7-alpha3"
+	composeExtractedFolder := "camunda-platform-8.7-alpha3"
 
 	if os.Getenv("CAMUNDA_VERSION") != "" {
 		camundaVersion = os.Getenv("CAMUNDA_VERSION")


### PR DESCRIPTION
## Description

We were previously building on rc6, and now we want to reference the official 8.7.0-alpha3 release

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
