### PR TITLE
ci: switch to the default maven resolver

### DIFF
--- a/.github/actions/setup-maven-cache/action.yaml
+++ b/.github/actions/setup-maven-cache/action.yaml
@@ -24,10 +24,6 @@ runs:
       # `--update-snapshots` to force Maven into updating snapshots, but also to retry looking for
       #    release artifacts when an earlier lookup failure made it into the cache.
       #
-      # `maven.wagon.*` and `maven.resolver.transport` set the resolver's network transport to Wagon,
-      #    the old provider pre 3.9. Until Maven 3.9.2, we have to do this if we want to retry on
-      #    network issues, as otherwise any issue will fail the build.
-      #
       # `aether.enhancedLocalRepository.split` splits between local and remote artifacts.
       # `aether.enhancedLocalRepository.splitRemote` splits remote artifacts into released and snapshot
       # `aether.syncContext.*` config ensures that maven uses file locks to prevent corruption
@@ -37,12 +33,9 @@ runs:
         --errors
         --batch-mode
         --update-snapshots
-        -D maven.wagon.httpconnectionManager.ttlSeconds=120
-        -D maven.wagon.http.pool=${{ inputs.maven-wagon-http-pool }}
-        -D maven.resolver.transport=wagon
-        -D maven.wagon.http.retryHandler.class=standard
-        -D maven.wagon.http.retryHandler.requestSentEnabled=true
-        -D maven.wagon.http.retryHandler.count=5
+        -D aether.transport.http.connectionMaxTtl=120
+        -D aether.transport.http.reuseConnections=${{ inputs.maven-wagon-http-pool }}
+        -D aether.transport.http.retryHandler.count=5
         -D aether.enhancedLocalRepository.split=true
         -D aether.enhancedLocalRepository.splitRemote=true
         -D aether.syncContext.named.nameMapper=file-gav


### PR DESCRIPTION
We were using the old wagon resolver because the new native one was buggy in Maven versions < 3.9.2. 

This change lets maven choose the resolver itself but still stes connection TTL, connection pooling and retry counts to maintain the previous behavior mostly.