### PR TITLE
Env for StandaloneSchemaManager.

### DIFF
--- a/dist/src/main/java/io/camunda/application/StandaloneSchemaManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneSchemaManager.java
@@ -91,6 +91,7 @@ public class StandaloneSchemaManager {
 
     final ExporterConfiguration exporterConfig = new ExporterConfiguration();
     exporterConfig.setConnect(connectConfiguration);
+    exporterConfig.getIndex().setPrefix(connectConfiguration.getIndexPrefix());
 
     final IndexDescriptors indexDescriptors =
         new IndexDescriptors(connectConfiguration.getIndexPrefix(), IS_ELASTICSEARCH);


### PR DESCRIPTION
## Description

When running the StandaloneSchemaManager currently the prefix for the created indices cannot be configured, this allows that.

## Related issues

relates to https://github.com/camunda/camunda-docs/pull/4844
