### PR TITLE
docs: improve REST API spec documentation

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4557,6 +4557,7 @@ components:
           allOf:
             - $ref: "#/components/schemas/ProcessInstanceFilterRequest"
     AdvancedIntegerFilter:
+      title: Advanced filter
       description: Advanced integer (int32) filter.
       type: object
       properties:
@@ -4599,8 +4600,11 @@ components:
       oneOf:
         - type: integer
           format: int32
+          title: Exact match
+          description: Matches the value exactly.
         - $ref: "#/components/schemas/AdvancedIntegerFilter"
     BasicLongFilter:
+      title: Advanced filter
       description: Basic advanced long (int64) filter.
       type: object
       properties:
@@ -4622,6 +4626,7 @@ components:
             type: integer
             format: int64
     AdvancedLongFilter:
+      title: Advanced filter
       description: Advanced long (int64) filter.
       allOf:
         - $ref: "#/components/schemas/BasicLongFilter"
@@ -4644,6 +4649,7 @@ components:
               type: integer
               format: int64
     AdvancedStringFilter:
+      title: Advanced filter
       description: Advanced string filter.
       type: object
       properties:
@@ -4667,6 +4673,7 @@ components:
             Supported wildcard characters depend on the configured search client.
           type: string
     AdvancedProcessInstanceStateFilter:
+      title: Advanced filter
       description: Advanced ProcessInstanceStateEnum filter.
       type: object
       properties:
@@ -4692,6 +4699,7 @@ components:
             Supported wildcard characters depend on the configured search client.
           type: string
     AdvancedDateTimeFilter:
+      title: Advanced filter
       description: Advanced date-time filter.
       type: object
       properties:
@@ -4734,6 +4742,8 @@ components:
       oneOf:
         - type: integer
           format: int64
+          title: Exact match
+          description: Matches the value exactly.
         - $ref: "#/components/schemas/BasicLongFilter"
     LongFilterProperty:
       description: Long property with full advanced search capabilities.
@@ -4741,18 +4751,26 @@ components:
       oneOf:
         - type: integer
           format: int64
+          title: Exact match
+          description: Matches the value exactly.
         - $ref: "#/components/schemas/AdvancedLongFilter"
     StringFilterProperty:
       description: String property with full advanced search capabilities.
       type: object
       oneOf:
         - type: string
+          title: Exact match
+          description: Matches the value exactly.
         - $ref: "#/components/schemas/AdvancedStringFilter"
     ProcessInstanceStateFilterProperty:
       description: ProcessInstanceStateEnum property with full advanced search capabilities.
       type: object
       oneOf:
-        - $ref: "#/components/schemas/ProcessInstanceStateEnum"
+        - type: string
+          title: Exact match
+          description: Matches the value exactly.
+          allOf:
+            - $ref: "#/components/schemas/ProcessInstanceStateEnum"
         - $ref: "#/components/schemas/AdvancedProcessInstanceStateFilter"
     DateTimeFilterProperty:
       description: Date-time property with full advanced search capabilities.
@@ -4760,6 +4778,8 @@ components:
       oneOf:
         - type: string
           format: date-time
+          title: Exact match
+          description: Matches the value exactly.
         - $ref: "#/components/schemas/AdvancedDateTimeFilter"
     ProcessInstanceFilterRequest:
       description: Process instance search filter.

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3252,6 +3252,7 @@ paths:
               properties:
                 files:
                   type: array
+                  description: The documents to upload.
                   items:
                     type: string
                     format: binary
@@ -7389,10 +7390,12 @@ components:
           properties:
             createdDocuments:
               type: array
+              description: Documents that were successfully created.
               items:
                 $ref: "#/components/schemas/DocumentReference"
             failedDocuments:
               type: array
+              description: Documents that failed creation.
               items:
                 $ref: "#/components/schemas/DocumentCreationFailureDetail"
 

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3234,10 +3234,8 @@ paths:
 
         Note that this currently only supports an in-memory document store, which is not meant for production use.
 
-        :::note
-        This endpoint is an [alpha feature](/components/early-access/alpha/alpha-features.md) and may be subject to change
+        This endpoint is an alpha feature and may be subject to change
         in future releases.
-        :::
       parameters:
         - name: storeId
           in: query

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4182,11 +4182,11 @@ components:
         followUpDate:
           description: The user task follow-up date.
           allOf:
-              - $ref: "#/components/schemas/DateTimeFilterProperty"
+            - $ref: "#/components/schemas/DateTimeFilterProperty"
         dueDate:
-            description: The user task due date.
-            allOf:
-                - $ref: "#/components/schemas/DateTimeFilterProperty"
+          description: The user task due date.
+          allOf:
+            - $ref: "#/components/schemas/DateTimeFilterProperty"
         processInstanceVariables:
           type: array
           description: Process Instance variables associated with the user task.


### PR DESCRIPTION
## Description

Improves the REST API spec documentation, including: 

1. Brings some subtle documentation changes upstream from https://github.com/camunda/camunda-docs/pull/4811.
2. Addresses #26741, by adding `title` properties to filtering union types.

### Filtering union titles

Previously, the union type switcher which appears on multiple filtering requests would emit a nonsense title for the "exact match" tab, and a schema name for the "advanced filter" tab, as shown in #26741.

With this PR, these switchers now all emit the title "Exact match" for the exactly matching type, and "Advanced filter" for the advanced filtering type, like this:

<img width="336" alt="image" src="https://github.com/user-attachments/assets/6cbde181-b180-4969-a5fc-a5ed29385428" />

There is one specific change that introduces more than a `title` or `description` property, and I'll call it out with a review comment. 

#### Strange lack of precision in exact match type descriptions

Strangely, the documentation plugin doesn't emit as much precision in the types for the "exact match" option. `date-time` strings are described as `string`, and `int32` integers are described as `integer`. This can be seen in the above screenshot.

This strangeness isn't introduced by this PR, but it will be obvious when you review, so I wanted to call it out as a known issue. 

## Related issues

closes #26741
