### PR TITLE
Fix DNS resolution on macOS

### DIFF
--- a/zeebe/atomix/cluster/pom.xml
+++ b/zeebe/atomix/cluster/pom.xml
@@ -277,6 +277,15 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-resolver-dns-native-macos</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-resolver-dns-classes-macos</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/zeebe/atomix/cluster/pom.xml
+++ b/zeebe/atomix/cluster/pom.xml
@@ -336,6 +336,8 @@
             <dependency>net.jqwik:jqwik</dependency>
             <dependency>io.netty:netty-tcnative-boringssl-static</dependency>
             <dependency>io.netty:netty-transport-native-epoll</dependency>
+            <dependency>io.netty:netty-resolver-dns-native-macos</dependency>
+            <dependency>io.netty:netty-resolver-dns-classes-macos</dependency>
           </usedDependencies>
         </configuration>
       </plugin>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/ClusterSmokeIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/ClusterSmokeIT.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.smoke;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.ProcessInstanceResult;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.asserts.TopologyAssert;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+
+@ZeebeIntegration
+final class ClusterSmokeIT {
+
+  @TestZeebe
+  private final TestCluster cluster =
+      TestCluster.builder()
+          .withBrokersCount(3)
+          .withReplicationFactor(3)
+          .withGatewaysCount(1)
+          .build();
+
+  @AutoClose private CamundaClient client;
+
+  @BeforeEach
+  void beforeEach() {
+    client = cluster.newClientBuilder().build();
+  }
+
+  /**
+   * A simple smoke test to ensure the cluster can perform basic functionality:
+   *
+   * <ul>
+   *   <li>Members can find each other to form a complete and healthy topology
+   *   <li>The gateway can find the external brokers and route requests/commands
+   *   <li>The gateway can route actuator/management requests
+   * </ul>
+   */
+  @SmokeTest
+  void smokeTest() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+    final var process = Bpmn.createExecutableProcess(processId).startEvent().endEvent().done();
+
+    // when
+    final var result = executeProcessInstance(processId, process);
+
+    // then
+    assertThat(result.getBpmnProcessId()).isEqualTo(processId);
+    Awaitility.await("until client topology view is healthy")
+        .untilAsserted(
+            () ->
+                TopologyAssert.assertThat(client.newTopologyRequest().send().join())
+                    .isComplete(3, 1, 3));
+    Awaitility.await("until cluster topology is active")
+        .untilAsserted(
+            () ->
+                ClusterActuatorAssert.assertThat(cluster)
+                    .hasActiveBroker(0)
+                    .hasActiveBroker(1)
+                    .hasActiveBroker(2));
+  }
+
+  private ProcessInstanceResult executeProcessInstance(
+      final String processId, final BpmnModelInstance process) {
+    client.newDeployResourceCommand().addProcessModel(process, processId + ".bpmn").send().join();
+    return client
+        .newCreateInstanceCommand()
+        .bpmnProcessId(processId)
+        .latestVersion()
+        .withResult()
+        .send()
+        .join();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/ClusterSmokeIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/smoke/ClusterSmokeIT.java
@@ -32,6 +32,7 @@ final class ClusterSmokeIT {
           .withBrokersCount(3)
           .withReplicationFactor(3)
           .withGatewaysCount(1)
+          .withBrokerConfig(b -> b.brokerConfig().getNetwork().setHost("localhost"))
           .build();
 
   @AutoClose private CamundaClient client;


### PR DESCRIPTION
## Description

This PR adds a new clustered smoke test to ensure that clustering works on all platforms, even those only supported for development and testing purposes (e.g. macOS, Windows).

It also fixes the DNS resolution problems on macOS by introducing the native dependencies required by Netty.

## Related issues

closes #26967 
