### PR TITLE
feat: user key to username migration Identity client

### DIFF
--- a/identity/client/src/pages/users/List.tsx
+++ b/identity/client/src/pages/users/List.tsx
@@ -73,8 +73,8 @@ const List: FC = () => {
         title={t("Users")}
         data={userSearchResults == null ? [] : userSearchResults.items}
         headers={[
-          { header: t("Username"), key: "username" },
           { header: t("Name"), key: "name" },
+          { header: t("Username"), key: "username" },
           { header: t("Email"), key: "email" },
         ]}
         menuItems={[

--- a/identity/client/src/pages/users/detail/UserDetailsTab.tsx
+++ b/identity/client/src/pages/users/detail/UserDetailsTab.tsx
@@ -23,18 +23,14 @@ const UserDetails: FC<UserDetailsProps> = ({ user, loading }) => {
       label={t("User details")}
       data={[
         {
-          label: t("Username"),
-          value: user.username,
-        },
-        { label: t("Email"), value: user.email || "-" },
-        {
           label: t("Name"),
           value: user.name,
         },
         {
-          label: t("Key"),
-          value: user.key,
+          label: t("Username"),
+          value: user.username,
         },
+        { label: t("Email"), value: user.email || "-" },
       ]}
       loading={loading}
     />

--- a/identity/client/src/pages/users/detail/index.tsx
+++ b/identity/client/src/pages/users/detail/index.tsx
@@ -21,8 +21,6 @@ import Flex from "src/components/layout/Flex";
 import { useEntityModal } from "src/components/modal";
 import EditModal from "src/pages/users/modals/EditModal";
 import DeleteModal from "src/pages/users/modals/DeleteModal";
-import RoleList from "src/pages/users/detail/role/List";
-import AuthorizationList from "src/pages/users/detail/authorization/List";
 
 const Details: FC = () => {
   const { t } = useTranslate();
@@ -77,18 +75,6 @@ const Details: FC = () => {
                 key: "details",
                 label: t("User details"),
                 content: user && <UserDetails user={user} loading={loading} />,
-              },
-              {
-                key: "roles",
-                label: t("Assigned roles"),
-                content: user && <RoleList user={user} loadingUser={loading} />,
-              },
-              {
-                key: "authorizations",
-                label: t("Assigned Authorizations"),
-                content: user && (
-                  <AuthorizationList user={user} loadingUser={loading} />
-                ),
               },
             ]}
             selectedTabKey={tab}

--- a/identity/client/src/pages/users/modals/DeleteModal.tsx
+++ b/identity/client/src/pages/users/modals/DeleteModal.tsx
@@ -12,7 +12,7 @@ const DeleteModal: FC<UseEntityModalProps<User>> = ({
   open,
   onClose,
   onSuccess,
-  entity: { key, username },
+  entity: { username },
 }) => {
   const { t } = useTranslate();
   const { enqueueNotification } = useNotifications();
@@ -20,7 +20,7 @@ const DeleteModal: FC<UseEntityModalProps<User>> = ({
 
   const handleSubmit = async () => {
     const { success } = await apiCall({
-      key: key!,
+      username: username!,
     });
 
     if (success) {

--- a/identity/client/src/pages/users/modals/EditModal.tsx
+++ b/identity/client/src/pages/users/modals/EditModal.tsx
@@ -48,18 +48,18 @@ const EditModal: FC<UseEntityModalProps<User>> = ({
         autoFocus
       />
       <TextField
-        label={t("Email")}
-        value={user.email}
-        placeholder={t("Email")}
-        onChange={(email) => setUser({ ...user, email })}
-        errors={namedErrors?.email}
-      />
-      <TextField
         label={t("Username")}
         value={user.username}
         placeholder={t("Username")}
         errors={namedErrors?.username}
         disabled
+      />
+      <TextField
+        label={t("Email")}
+        value={user.email}
+        placeholder={t("Email")}
+        onChange={(email) => setUser({ ...user, email })}
+        errors={namedErrors?.email}
       />
       <TextField
         label={t("Password")}

--- a/identity/client/src/utility/api/users/index.ts
+++ b/identity/client/src/utility/api/users/index.ts
@@ -31,16 +31,16 @@ export const createUser: ApiDefinition<undefined, CreateUserParams> = (user) =>
   apiPost(USERS_ENDPOINT, { ...user, enabled: true });
 
 export const updateUser: ApiDefinition<undefined, User> = (user) => {
-  const { key, name, email, username, password } = user;
-  return apiPatch(`${USERS_ENDPOINT}/${key}`, {
-    changeset: { name, email, username, password: password ?? "" },
+  const { name, email, username, password } = user;
+  return apiPatch(`${USERS_ENDPOINT}/${username}`, {
+    changeset: { name, email, password: password ?? "" },
   });
 };
 
 type DeleteUserParams = {
-  key: number;
+  username: string;
 };
 
 export const deleteUser: ApiDefinition<undefined, DeleteUserParams> = ({
-  key,
-}) => apiDelete(`${USERS_ENDPOINT}/${key}`);
+  username,
+}) => apiDelete(`${USERS_ENDPOINT}/${username}`);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR achieves three goals:
1. Switch to use the username instead of the key when making user based API calls from the Identity client
2. Remove the option to edit a user
3. UI rearranging to better match the figma designs (column ordering, removing the `key`, etc)

## Related issues

closes #27002
closes #27003 
