### PR TITLE
feat: add generic properties and env variables for java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/client/ClientProperties.java
@@ -28,135 +28,129 @@ public final class ClientProperties {
    * @see CamundaClientBuilder#applyEnvironmentVariableOverrides(boolean)
    */
   public static final String APPLY_ENVIRONMENT_VARIABLES_OVERRIDES =
-      "zeebe.client.applyEnvironmentVariableOverrides";
-
-  /**
-   * @deprecated since 8.5 for removal with 8.8, replaced by {@link ClientProperties#GRPC_ADDRESS}
-   * @see CamundaClientBuilder#gatewayAddress(String)
-   */
-  @Deprecated public static final String GATEWAY_ADDRESS = "zeebe.client.gateway.address";
+      "client.applyEnvironmentVariableOverrides";
 
   /**
    * @deprecated since 8.5 for removal with 8.8, where toggling between both will not be possible
    * @see CamundaClientBuilder#preferRestOverGrpc(boolean)
    */
   @Deprecated
-  public static final String PREFER_REST_OVER_GRPC = "zeebe.client.gateway.preferRestOverGrpc";
+  public static final String PREFER_REST_OVER_GRPC = "client.gateway.preferRestOverGrpc";
 
   /**
    * @see CamundaClientBuilder#restAddress(URI)
    */
-  public static final String REST_ADDRESS = "zeebe.client.gateway.rest.address";
+  public static final String REST_ADDRESS = "client.gateway.rest.address";
 
   /**
    * @see CamundaClientBuilder#grpcAddress(URI)
    */
-  public static final String GRPC_ADDRESS = "zeebe.client.gateway.grpc.address";
+  public static final String GRPC_ADDRESS = "client.gateway.grpc.address";
 
   /**
    * @see CamundaClientBuilder#defaultTenantId(String)
    */
-  public static final String DEFAULT_TENANT_ID = "zeebe.client.tenantId";
+  public static final String DEFAULT_TENANT_ID = "client.tenantId";
 
   /**
    * @see CamundaClientBuilder#defaultJobWorkerTenantIds(List)
    */
-  public static final String DEFAULT_JOB_WORKER_TENANT_IDS = "zeebe.client.worker.tenantIds";
+  public static final String DEFAULT_JOB_WORKER_TENANT_IDS = "client.zeebe.worker.tenantIds";
 
   /**
    * @see CamundaClientBuilder#numJobWorkerExecutionThreads(int)
    */
-  public static final String JOB_WORKER_EXECUTION_THREADS = "zeebe.client.worker.threads";
+  public static final String JOB_WORKER_EXECUTION_THREADS = "client.zeebe.worker.threads";
 
   /**
    * @see CamundaClientBuilder#defaultJobWorkerMaxJobsActive(int)
    */
-  public static final String JOB_WORKER_MAX_JOBS_ACTIVE = "zeebe.client.worker.maxJobsActive";
+  public static final String JOB_WORKER_MAX_JOBS_ACTIVE = "client.zeebe.worker.maxJobsActive";
 
   /**
    * @see CamundaClientBuilder#defaultJobWorkerName(String)
    */
-  public static final String DEFAULT_JOB_WORKER_NAME = "zeebe.client.worker.name";
+  public static final String DEFAULT_JOB_WORKER_NAME = "client.zeebe.worker.name";
 
   /**
    * @see CamundaClientBuilder#defaultJobTimeout(Duration)
    */
-  public static final String DEFAULT_JOB_TIMEOUT = "zeebe.client.job.timeout";
+  public static final String DEFAULT_JOB_TIMEOUT = "client.zeebe.job.timeout";
 
   /**
    * @see CamundaClientBuilder#defaultJobPollInterval(Duration)
    */
-  public static final String DEFAULT_JOB_POLL_INTERVAL = "zeebe.client.job.pollinterval";
+  public static final String DEFAULT_JOB_POLL_INTERVAL = "client.zeebe.job.pollinterval";
 
   /**
    * @see CamundaClientBuilder#defaultMessageTimeToLive(Duration)
    */
-  public static final String DEFAULT_MESSAGE_TIME_TO_LIVE = "zeebe.client.message.timeToLive";
+  public static final String DEFAULT_MESSAGE_TIME_TO_LIVE = "client.zeebe.message.timeToLive";
 
   /**
    * @see CamundaClientBuilder#defaultRequestTimeout(Duration)
    */
-  public static final String DEFAULT_REQUEST_TIMEOUT = "zeebe.client.requestTimeout";
+  public static final String DEFAULT_REQUEST_TIMEOUT = "client.requestTimeout";
 
   /**
    * @see CamundaClientBuilder#usePlaintext()
    */
-  public static final String USE_PLAINTEXT_CONNECTION = "zeebe.client.security.plaintext";
+  public static final String USE_PLAINTEXT_CONNECTION = "client.security.plaintext";
 
   /**
    * @see CamundaClientBuilder#caCertificatePath(String)
    */
-  public static final String CA_CERTIFICATE_PATH = "zeebe.client.security.certpath";
+  public static final String CA_CERTIFICATE_PATH = "client.security.certpath";
 
   /**
    * @see CamundaClientBuilder#keepAlive(Duration)
    */
-  public static final String KEEP_ALIVE = "zeebe.client.keepalive";
+  public static final String KEEP_ALIVE = "client.keepalive";
 
   /**
    * @see CamundaClientBuilder#overrideAuthority(String)
    */
-  public static final String OVERRIDE_AUTHORITY = "zeebe.client.overrideauthority";
+  public static final String OVERRIDE_AUTHORITY = "client.overrideauthority";
 
   /**
    * @see CamundaClientBuilder#maxMessageSize(int) (String)
    */
-  public static final String MAX_MESSAGE_SIZE = "zeebe.client.maxMessageSize";
+  public static final String MAX_MESSAGE_SIZE = "client.maxMessageSize";
 
   /**
    * @see CamundaClientBuilder#maxMetadataSize(int)
    */
-  public static final String MAX_METADATA_SIZE = "zeebe.client.maxMetadataSize";
+  public static final String MAX_METADATA_SIZE = "client.maxMetadataSize";
 
   /**
    * @see CamundaClientCloudBuilderStep1#withClusterId(String)
    */
-  public static final String CLOUD_CLUSTER_ID = "zeebe.client.cloud.clusterId";
+  public static final String CLOUD_CLUSTER_ID = "client.cloud.clusterId";
 
   /**
    * @see CamundaClientCloudBuilderStep2#withClientId(String)
    */
-  public static final String CLOUD_CLIENT_ID = "zeebe.client.cloud.clientId";
+  public static final String CLOUD_CLIENT_ID = "client.cloud.clientId";
 
   /**
    * @see CamundaClientCloudBuilderStep3#withClientSecret( String)
    */
-  public static final String CLOUD_CLIENT_SECRET = "zeebe.client.cloud.secret";
+  public static final String CLOUD_CLIENT_SECRET = "client.cloud.secret";
 
   /**
    * @see CamundaClientCloudBuilderStep4#withRegion(String)
    */
-  public static final String CLOUD_REGION = "zeebe.client.cloud.region";
+  public static final String CLOUD_REGION = "client.cloud.region";
 
   /**
    * @see CamundaClientBuilder#defaultJobWorkerStreamEnabled(boolean)
    */
-  public static final String STREAM_ENABLED = "zeebe.client.worker.stream.enabled";
+  public static final String STREAM_ENABLED = "client.zeebe.worker.stream.enabled";
 
   /**
    * @see CamundaClientBuilder#useDefaultRetryPolicy(boolean)
    */
-  public static final String USE_DEFAULT_RETRY_POLICY = "zeebe.client.useDefaultRetryPolicy";
+  public static final String USE_DEFAULT_RETRY_POLICY = "client.useDefaultRetryPolicy";
 
   private ClientProperties() {}
 }

--- a/clients/java/src/main/java/io/camunda/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/client/ClientProperties.java
@@ -28,129 +28,129 @@ public final class ClientProperties {
    * @see CamundaClientBuilder#applyEnvironmentVariableOverrides(boolean)
    */
   public static final String APPLY_ENVIRONMENT_VARIABLES_OVERRIDES =
-      "client.applyEnvironmentVariableOverrides";
+      "camunda.client.applyEnvironmentVariableOverrides";
 
   /**
    * @deprecated since 8.5 for removal with 8.8, where toggling between both will not be possible
    * @see CamundaClientBuilder#preferRestOverGrpc(boolean)
    */
   @Deprecated
-  public static final String PREFER_REST_OVER_GRPC = "client.gateway.preferRestOverGrpc";
+  public static final String PREFER_REST_OVER_GRPC = "camunda.client.gateway.preferRestOverGrpc";
 
   /**
    * @see CamundaClientBuilder#restAddress(URI)
    */
-  public static final String REST_ADDRESS = "client.gateway.rest.address";
+  public static final String REST_ADDRESS = "camunda.client.gateway.rest.address";
 
   /**
    * @see CamundaClientBuilder#grpcAddress(URI)
    */
-  public static final String GRPC_ADDRESS = "client.gateway.grpc.address";
+  public static final String GRPC_ADDRESS = "camunda.client.gateway.grpc.address";
 
   /**
    * @see CamundaClientBuilder#defaultTenantId(String)
    */
-  public static final String DEFAULT_TENANT_ID = "client.tenantId";
+  public static final String DEFAULT_TENANT_ID = "camunda.client.tenantId";
 
   /**
    * @see CamundaClientBuilder#defaultJobWorkerTenantIds(List)
    */
-  public static final String DEFAULT_JOB_WORKER_TENANT_IDS = "client.zeebe.worker.tenantIds";
+  public static final String DEFAULT_JOB_WORKER_TENANT_IDS = "camunda.client.worker.tenantIds";
 
   /**
    * @see CamundaClientBuilder#numJobWorkerExecutionThreads(int)
    */
-  public static final String JOB_WORKER_EXECUTION_THREADS = "client.zeebe.worker.threads";
+  public static final String JOB_WORKER_EXECUTION_THREADS = "camunda.client.zeebe.worker.threads";
 
   /**
    * @see CamundaClientBuilder#defaultJobWorkerMaxJobsActive(int)
    */
-  public static final String JOB_WORKER_MAX_JOBS_ACTIVE = "client.zeebe.worker.maxJobsActive";
+  public static final String JOB_WORKER_MAX_JOBS_ACTIVE = "camunda.client.worker.maxJobsActive";
 
   /**
    * @see CamundaClientBuilder#defaultJobWorkerName(String)
    */
-  public static final String DEFAULT_JOB_WORKER_NAME = "client.zeebe.worker.name";
+  public static final String DEFAULT_JOB_WORKER_NAME = "camunda.client.worker.name";
 
   /**
    * @see CamundaClientBuilder#defaultJobTimeout(Duration)
    */
-  public static final String DEFAULT_JOB_TIMEOUT = "client.zeebe.job.timeout";
+  public static final String DEFAULT_JOB_TIMEOUT = "camunda.client.job.timeout";
 
   /**
    * @see CamundaClientBuilder#defaultJobPollInterval(Duration)
    */
-  public static final String DEFAULT_JOB_POLL_INTERVAL = "client.zeebe.job.pollinterval";
+  public static final String DEFAULT_JOB_POLL_INTERVAL = "camunda.client.job.pollinterval";
 
   /**
    * @see CamundaClientBuilder#defaultMessageTimeToLive(Duration)
    */
-  public static final String DEFAULT_MESSAGE_TIME_TO_LIVE = "client.zeebe.message.timeToLive";
+  public static final String DEFAULT_MESSAGE_TIME_TO_LIVE = "camunda.client.message.timeToLive";
 
   /**
    * @see CamundaClientBuilder#defaultRequestTimeout(Duration)
    */
-  public static final String DEFAULT_REQUEST_TIMEOUT = "client.requestTimeout";
+  public static final String DEFAULT_REQUEST_TIMEOUT = "camunda.client.requestTimeout";
 
   /**
    * @see CamundaClientBuilder#usePlaintext()
    */
-  public static final String USE_PLAINTEXT_CONNECTION = "client.security.plaintext";
+  public static final String USE_PLAINTEXT_CONNECTION = "camunda.client.security.plaintext";
 
   /**
    * @see CamundaClientBuilder#caCertificatePath(String)
    */
-  public static final String CA_CERTIFICATE_PATH = "client.security.certpath";
+  public static final String CA_CERTIFICATE_PATH = "camunda.client.security.certpath";
 
   /**
    * @see CamundaClientBuilder#keepAlive(Duration)
    */
-  public static final String KEEP_ALIVE = "client.keepalive";
+  public static final String KEEP_ALIVE = "camunda.client.keepalive";
 
   /**
    * @see CamundaClientBuilder#overrideAuthority(String)
    */
-  public static final String OVERRIDE_AUTHORITY = "client.overrideauthority";
+  public static final String OVERRIDE_AUTHORITY = "camunda.client.overrideauthority";
 
   /**
    * @see CamundaClientBuilder#maxMessageSize(int) (String)
    */
-  public static final String MAX_MESSAGE_SIZE = "client.maxMessageSize";
+  public static final String MAX_MESSAGE_SIZE = "camunda.client.maxMessageSize";
 
   /**
    * @see CamundaClientBuilder#maxMetadataSize(int)
    */
-  public static final String MAX_METADATA_SIZE = "client.maxMetadataSize";
+  public static final String MAX_METADATA_SIZE = "camunda.client.maxMetadataSize";
 
   /**
    * @see CamundaClientCloudBuilderStep1#withClusterId(String)
    */
-  public static final String CLOUD_CLUSTER_ID = "client.cloud.clusterId";
+  public static final String CLOUD_CLUSTER_ID = "camunda.client.cloud.clusterId";
 
   /**
    * @see CamundaClientCloudBuilderStep2#withClientId(String)
    */
-  public static final String CLOUD_CLIENT_ID = "client.cloud.clientId";
+  public static final String CLOUD_CLIENT_ID = "camunda.client.cloud.clientId";
 
   /**
    * @see CamundaClientCloudBuilderStep3#withClientSecret( String)
    */
-  public static final String CLOUD_CLIENT_SECRET = "client.cloud.secret";
+  public static final String CLOUD_CLIENT_SECRET = "camunda.client.cloud.secret";
 
   /**
    * @see CamundaClientCloudBuilderStep4#withRegion(String)
    */
-  public static final String CLOUD_REGION = "client.cloud.region";
+  public static final String CLOUD_REGION = "camunda.client.cloud.region";
 
   /**
    * @see CamundaClientBuilder#defaultJobWorkerStreamEnabled(boolean)
    */
-  public static final String STREAM_ENABLED = "client.zeebe.worker.stream.enabled";
+  public static final String STREAM_ENABLED = "camunda.client.worker.stream.enabled";
 
   /**
    * @see CamundaClientBuilder#useDefaultRetryPolicy(boolean)
    */
-  public static final String USE_DEFAULT_RETRY_POLICY = "client.useDefaultRetryPolicy";
+  public static final String USE_DEFAULT_RETRY_POLICY = "camunda.client.useDefaultRetryPolicy";
 
   private ClientProperties() {}
 }

--- a/clients/java/src/main/java/io/camunda/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/client/ClientProperties.java
@@ -60,7 +60,7 @@ public final class ClientProperties {
   /**
    * @see CamundaClientBuilder#numJobWorkerExecutionThreads(int)
    */
-  public static final String JOB_WORKER_EXECUTION_THREADS = "camunda.client.zeebe.worker.threads";
+  public static final String JOB_WORKER_EXECUTION_THREADS = "camunda.client.worker.threads";
 
   /**
    * @see CamundaClientBuilder#defaultJobWorkerMaxJobsActive(int)

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
@@ -24,7 +24,6 @@ import static io.camunda.client.ClientProperties.DEFAULT_JOB_WORKER_TENANT_IDS;
 import static io.camunda.client.ClientProperties.DEFAULT_MESSAGE_TIME_TO_LIVE;
 import static io.camunda.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT;
 import static io.camunda.client.ClientProperties.DEFAULT_TENANT_ID;
-import static io.camunda.client.ClientProperties.GATEWAY_ADDRESS;
 import static io.camunda.client.ClientProperties.GRPC_ADDRESS;
 import static io.camunda.client.ClientProperties.JOB_WORKER_EXECUTION_THREADS;
 import static io.camunda.client.ClientProperties.JOB_WORKER_MAX_JOBS_ACTIVE;
@@ -37,6 +36,20 @@ import static io.camunda.client.ClientProperties.REST_ADDRESS;
 import static io.camunda.client.ClientProperties.STREAM_ENABLED;
 import static io.camunda.client.ClientProperties.USE_DEFAULT_RETRY_POLICY;
 import static io.camunda.client.ClientProperties.USE_PLAINTEXT_CONNECTION;
+import static io.camunda.client.impl.BuilderUtils.applyEnvironmentValueIfNotNull;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.CAMUNDA_CLIENT_WORKER_STREAM_ENABLED;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.CA_CERTIFICATE_VAR;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.DEFAULT_JOB_WORKER_TENANT_IDS_VAR;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.DEFAULT_TENANT_ID_VAR;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.GRPC_ADDRESS_VAR;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.KEEP_ALIVE_VAR;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_CLIENT_ID;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_CLIENT_SECRET;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OVERRIDE_AUTHORITY_VAR;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.PLAINTEXT_CONNECTION_VAR;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.PREFER_REST_VAR;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.REST_ADDRESS_VAR;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.USE_DEFAULT_RETRY_POLICY_VAR;
 import static io.camunda.client.impl.util.DataSizeUtil.ONE_KB;
 import static io.camunda.client.impl.util.DataSizeUtil.ONE_MB;
 
@@ -49,6 +62,7 @@ import io.camunda.client.api.command.CommandWithTenantStep;
 import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
 import io.camunda.client.impl.util.DataSizeUtil;
 import io.camunda.client.impl.util.Environment;
+import io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables;
 import io.grpc.ClientInterceptor;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -64,24 +78,11 @@ import org.apache.hc.client5.http.async.AsyncExecChainHandler;
 public final class CamundaClientBuilderImpl
     implements CamundaClientBuilder, CamundaClientConfiguration {
 
-  public static final String PLAINTEXT_CONNECTION_VAR = "ZEEBE_INSECURE_CONNECTION";
-  public static final String CA_CERTIFICATE_VAR = "ZEEBE_CA_CERTIFICATE_PATH";
-  public static final String KEEP_ALIVE_VAR = "ZEEBE_KEEP_ALIVE";
-  public static final String OVERRIDE_AUTHORITY_VAR = "ZEEBE_OVERRIDE_AUTHORITY";
-  public static final String CAMUNDA_CLIENT_WORKER_STREAM_ENABLED =
-      "ZEEBE_CLIENT_WORKER_STREAM_ENABLED";
   public static final String DEFAULT_GATEWAY_ADDRESS = "0.0.0.0:26500";
   public static final URI DEFAULT_GRPC_ADDRESS =
       getURIFromString("https://" + DEFAULT_GATEWAY_ADDRESS);
   public static final URI DEFAULT_REST_ADDRESS = getURIFromString("https://0.0.0.0:8080");
-  public static final String REST_ADDRESS_VAR = "ZEEBE_REST_ADDRESS";
-  public static final String GRPC_ADDRESS_VAR = "ZEEBE_GRPC_ADDRESS";
-  public static final String PREFER_REST_VAR = "ZEEBE_PREFER_REST";
-  public static final String DEFAULT_TENANT_ID_VAR = "ZEEBE_DEFAULT_TENANT_ID";
-  public static final String DEFAULT_JOB_WORKER_TENANT_IDS_VAR =
-      "ZEEBE_DEFAULT_JOB_WORKER_TENANT_IDS";
   public static final String DEFAULT_JOB_WORKER_NAME_VAR = "default";
-  public static final String USE_DEFAULT_RETRY_POLICY_VAR = "ZEEBE_CLIENT_USE_DEFAULT_RETRY_POLICY";
   private static final String TENANT_ID_LIST_SEPARATOR = ",";
   private static final boolean DEFAULT_PREFER_REST_OVER_GRPC = false;
 
@@ -254,69 +255,86 @@ public final class CamundaClientBuilderImpl
 
   @Override
   public CamundaClientBuilder withProperties(final Properties properties) {
-    BuilderUtils.applyIfNotNull(
+    BuilderUtils.applyPropertyValueIfNotNull(
         properties,
+        value -> applyEnvironmentVariableOverrides(Boolean.parseBoolean(value)),
         APPLY_ENVIRONMENT_VARIABLES_OVERRIDES,
-        value -> applyEnvironmentVariableOverrides(Boolean.parseBoolean(value)));
+        io.camunda.zeebe.client.ClientProperties.APPLY_ENVIRONMENT_VARIABLES_OVERRIDES);
 
-    BuilderUtils.applyIfNotNull(
-        properties, GRPC_ADDRESS, value -> grpcAddress(getURIFromString(value)));
-
-    BuilderUtils.applyIfNotNull(
-        properties, REST_ADDRESS, value -> restAddress(getURIFromString(value)));
-
-    BuilderUtils.applyIfNotNull(properties, GATEWAY_ADDRESS, this::gatewayAddress);
-
-    BuilderUtils.applyIfNotNull(
+    BuilderUtils.applyPropertyValueIfNotNull(
         properties,
+        value -> grpcAddress(getURIFromString(value)),
+        GRPC_ADDRESS,
+        io.camunda.zeebe.client.ClientProperties.GRPC_ADDRESS);
+
+    BuilderUtils.applyPropertyValueIfNotNull(
+        properties,
+        value -> restAddress(getURIFromString(value)),
+        REST_ADDRESS,
+        io.camunda.zeebe.client.ClientProperties.REST_ADDRESS);
+
+    BuilderUtils.applyPropertyValueIfNotNull(
+        properties, this::gatewayAddress, io.camunda.zeebe.client.ClientProperties.GATEWAY_ADDRESS);
+
+    BuilderUtils.applyPropertyValueIfNotNull(
+        properties,
+        value -> preferRestOverGrpc(Boolean.parseBoolean(value)),
         PREFER_REST_OVER_GRPC,
-        value -> preferRestOverGrpc(Boolean.parseBoolean(value)));
+        io.camunda.zeebe.client.ClientProperties.PREFER_REST_OVER_GRPC);
 
-    BuilderUtils.applyIfNotNull(properties, DEFAULT_TENANT_ID, this::defaultTenantId);
-
-    BuilderUtils.applyIfNotNull(
+    BuilderUtils.applyPropertyValueIfNotNull(
         properties,
+        this::defaultTenantId,
+        DEFAULT_TENANT_ID,
+        io.camunda.zeebe.client.ClientProperties.DEFAULT_TENANT_ID);
+
+    BuilderUtils.applyPropertyValueIfNotNull(
+        properties,
+        value -> defaultJobWorkerTenantIds(Arrays.asList(value.split(TENANT_ID_LIST_SEPARATOR))),
         DEFAULT_JOB_WORKER_TENANT_IDS,
-        value -> {
-          final List<String> tenantIds = Arrays.asList(value.split(TENANT_ID_LIST_SEPARATOR));
-          defaultJobWorkerTenantIds(tenantIds);
-        });
+        io.camunda.zeebe.client.ClientProperties.DEFAULT_JOB_WORKER_TENANT_IDS);
 
-    BuilderUtils.applyIfNotNull(
+    BuilderUtils.applyPropertyValueIfNotNull(
         properties,
+        value -> numJobWorkerExecutionThreads(Integer.parseInt(value)),
         JOB_WORKER_EXECUTION_THREADS,
-        value -> numJobWorkerExecutionThreads(Integer.parseInt(value)));
+        io.camunda.zeebe.client.ClientProperties.JOB_WORKER_EXECUTION_THREADS);
 
-    BuilderUtils.applyIfNotNull(
+    BuilderUtils.applyPropertyValueIfNotNull(
         properties,
+        value -> defaultJobWorkerMaxJobsActive(Integer.parseInt(value)),
         JOB_WORKER_MAX_JOBS_ACTIVE,
-        value -> defaultJobWorkerMaxJobsActive(Integer.parseInt(value)));
+        io.camunda.zeebe.client.ClientProperties.JOB_WORKER_MAX_JOBS_ACTIVE);
 
-    BuilderUtils.applyIfNotNull(properties, DEFAULT_JOB_WORKER_NAME, this::defaultJobWorkerName);
+    BuilderUtils.applyPropertyValueIfNotNull(
+        properties, this::defaultJobWorkerName, DEFAULT_JOB_WORKER_NAME);
 
-    BuilderUtils.applyIfNotNull(
+    BuilderUtils.applyPropertyValueIfNotNull(
         properties,
+        value -> defaultJobTimeout(Duration.ofMillis(Long.parseLong(value))),
         DEFAULT_JOB_TIMEOUT,
-        value -> defaultJobTimeout(Duration.ofMillis(Long.parseLong(value))));
+        io.camunda.zeebe.client.ClientProperties.DEFAULT_JOB_TIMEOUT);
 
-    BuilderUtils.applyIfNotNull(
+    BuilderUtils.applyPropertyValueIfNotNull(
         properties,
+        value -> defaultJobPollInterval(Duration.ofMillis(Long.parseLong(value))),
         DEFAULT_JOB_POLL_INTERVAL,
-        value -> defaultJobPollInterval(Duration.ofMillis(Long.parseLong(value))));
+        io.camunda.zeebe.client.ClientProperties.DEFAULT_JOB_POLL_INTERVAL);
 
-    BuilderUtils.applyIfNotNull(
+    BuilderUtils.applyPropertyValueIfNotNull(
         properties,
+        value -> defaultMessageTimeToLive(Duration.ofMillis(Long.parseLong(value))),
         DEFAULT_MESSAGE_TIME_TO_LIVE,
-        value -> defaultMessageTimeToLive(Duration.ofMillis(Long.parseLong(value))));
+        io.camunda.zeebe.client.ClientProperties.DEFAULT_MESSAGE_TIME_TO_LIVE);
 
-    BuilderUtils.applyIfNotNull(
+    BuilderUtils.applyPropertyValueIfNotNull(
         properties,
+        value -> defaultRequestTimeout(Duration.ofMillis(Long.parseLong(value))),
         DEFAULT_REQUEST_TIMEOUT,
-        value -> defaultRequestTimeout(Duration.ofMillis(Long.parseLong(value))));
+        io.camunda.zeebe.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT);
 
-    BuilderUtils.applyIfNotNull(
+    BuilderUtils.applyPropertyValueIfNotNull(
         properties,
-        USE_PLAINTEXT_CONNECTION,
         value -> {
           /**
            * The following condition is phrased in this particular way in order to be backwards
@@ -329,29 +347,47 @@ public final class CamundaClientBuilderImpl
           if (!"false".equalsIgnoreCase(value)) {
             usePlaintext();
           }
-        });
+        },
+        USE_PLAINTEXT_CONNECTION,
+        io.camunda.zeebe.client.ClientProperties.USE_PLAINTEXT_CONNECTION);
 
-    BuilderUtils.applyIfNotNull(properties, CA_CERTIFICATE_PATH, this::caCertificatePath);
-
-    BuilderUtils.applyIfNotNull(properties, KEEP_ALIVE, this::keepAlive);
-
-    BuilderUtils.applyIfNotNull(properties, OVERRIDE_AUTHORITY, this::overrideAuthority);
-
-    BuilderUtils.applyIfNotNull(
-        properties, MAX_MESSAGE_SIZE, value -> maxMessageSize(DataSizeUtil.parse(value)));
-
-    BuilderUtils.applyIfNotNull(
-        properties, MAX_METADATA_SIZE, value -> maxMetadataSize(DataSizeUtil.parse(value)));
-
-    BuilderUtils.applyIfNotNull(
+    BuilderUtils.applyPropertyValueIfNotNull(
         properties,
+        this::caCertificatePath,
+        CA_CERTIFICATE_PATH,
+        io.camunda.zeebe.client.ClientProperties.CA_CERTIFICATE_PATH);
+
+    BuilderUtils.applyPropertyValueIfNotNull(properties, this::keepAlive, KEEP_ALIVE);
+
+    BuilderUtils.applyPropertyValueIfNotNull(
+        properties,
+        this::overrideAuthority,
+        OVERRIDE_AUTHORITY,
+        io.camunda.zeebe.client.ClientProperties.OVERRIDE_AUTHORITY);
+
+    BuilderUtils.applyPropertyValueIfNotNull(
+        properties,
+        value -> maxMessageSize(DataSizeUtil.parse(value)),
+        MAX_MESSAGE_SIZE,
+        io.camunda.zeebe.client.ClientProperties.MAX_MESSAGE_SIZE);
+
+    BuilderUtils.applyPropertyValueIfNotNull(
+        properties,
+        value -> maxMetadataSize(DataSizeUtil.parse(value)),
+        MAX_METADATA_SIZE,
+        io.camunda.zeebe.client.ClientProperties.MAX_METADATA_SIZE);
+
+    BuilderUtils.applyPropertyValueIfNotNull(
+        properties,
+        value -> defaultJobWorkerStreamEnabled(Boolean.parseBoolean(value)),
         STREAM_ENABLED,
-        value -> defaultJobWorkerStreamEnabled(Boolean.parseBoolean(value)));
+        io.camunda.zeebe.client.ClientProperties.STREAM_ENABLED);
 
-    BuilderUtils.applyIfNotNull(
+    BuilderUtils.applyPropertyValueIfNotNull(
         properties,
+        value -> useDefaultRetryPolicy(Boolean.parseBoolean(value)),
         USE_DEFAULT_RETRY_POLICY,
-        value -> useDefaultRetryPolicy(Boolean.parseBoolean(value)));
+        io.camunda.zeebe.client.ClientProperties.USE_DEFAULT_RETRY_POLICY);
 
     return this;
   }
@@ -448,8 +484,7 @@ public final class CamundaClientBuilderImpl
 
   @Override
   public CamundaClientBuilder usePlaintext() {
-    usePlaintextConnection = true;
-    return this;
+    return usePlaintext(true);
   }
 
   @Override
@@ -542,49 +577,61 @@ public final class CamundaClientBuilderImpl
     return new CamundaClientImpl(this);
   }
 
+  private CamundaClientBuilder usePlaintext(final boolean usePlaintext) {
+    usePlaintextConnection = usePlaintext;
+    return this;
+  }
+
   private void keepAlive(final String keepAlive) {
     keepAlive(Duration.ofMillis(Long.parseUnsignedLong(keepAlive)));
   }
 
   private void applyOverrides() {
-    BuilderUtils.applyIfNotNull(
-        PLAINTEXT_CONNECTION_VAR, value -> usePlaintextConnection = Boolean.parseBoolean(value));
-
-    BuilderUtils.applyIfNotNull(CA_CERTIFICATE_VAR, this::caCertificatePath);
-
-    BuilderUtils.applyIfNotNull(KEEP_ALIVE_VAR, this::keepAlive);
-
-    BuilderUtils.applyIfNotNull(OVERRIDE_AUTHORITY_VAR, this::overrideAuthority);
-
+    applyEnvironmentValueIfNotNull(
+        value -> usePlaintext(Boolean.parseBoolean(value)),
+        PLAINTEXT_CONNECTION_VAR,
+        ZeebeClientEnvironmentVariables.PLAINTEXT_CONNECTION_VAR);
+    applyEnvironmentValueIfNotNull(
+        this::caCertificatePath,
+        CA_CERTIFICATE_VAR,
+        ZeebeClientEnvironmentVariables.CA_CERTIFICATE_VAR);
+    applyEnvironmentValueIfNotNull(
+        this::keepAlive, KEEP_ALIVE_VAR, ZeebeClientEnvironmentVariables.KEEP_ALIVE_VAR);
+    applyEnvironmentValueIfNotNull(
+        this::overrideAuthority,
+        OVERRIDE_AUTHORITY_VAR,
+        ZeebeClientEnvironmentVariables.OVERRIDE_AUTHORITY_VAR);
     if (shouldUseDefaultCredentialsProvider()) {
       credentialsProvider = createDefaultCredentialsProvider();
     }
-
-    BuilderUtils.applyIfNotNull(GRPC_ADDRESS_VAR, value -> grpcAddress(getURIFromString(value)));
-
-    BuilderUtils.applyIfNotNull(REST_ADDRESS_VAR, value -> restAddress(getURIFromString(value)));
-
-    BuilderUtils.applyIfNotNull(
-        PREFER_REST_VAR, value -> preferRestOverGrpc(Boolean.parseBoolean(value)));
-
-    if (Environment.system().isDefined(DEFAULT_TENANT_ID_VAR)) {
-      defaultTenantId(Environment.system().get(DEFAULT_TENANT_ID_VAR));
-    }
-    BuilderUtils.applyIfNotNull(DEFAULT_TENANT_ID_VAR, this::defaultTenantId);
-
-    BuilderUtils.applyIfNotNull(
+    applyEnvironmentValueIfNotNull(
+        value -> grpcAddress(getURIFromString(value)),
+        GRPC_ADDRESS_VAR,
+        ZeebeClientEnvironmentVariables.GRPC_ADDRESS_VAR);
+    applyEnvironmentValueIfNotNull(
+        value -> restAddress(getURIFromString(value)),
+        REST_ADDRESS_VAR,
+        ZeebeClientEnvironmentVariables.REST_ADDRESS_VAR);
+    applyEnvironmentValueIfNotNull(
+        value -> preferRestOverGrpc(Boolean.parseBoolean(value)),
+        PREFER_REST_VAR,
+        ZeebeClientEnvironmentVariables.PREFER_REST_VAR);
+    applyEnvironmentValueIfNotNull(
+        this::defaultTenantId,
+        DEFAULT_TENANT_ID_VAR,
+        ZeebeClientEnvironmentVariables.DEFAULT_TENANT_ID_VAR);
+    applyEnvironmentValueIfNotNull(
+        value -> defaultJobWorkerTenantIds(Arrays.asList(value.split(TENANT_ID_LIST_SEPARATOR))),
         DEFAULT_JOB_WORKER_TENANT_IDS_VAR,
-        value -> {
-          final List<String> tenantIds = Arrays.asList(value.split(TENANT_ID_LIST_SEPARATOR));
-          defaultJobWorkerTenantIds(tenantIds);
-        });
-
-    BuilderUtils.applyIfNotNull(
+        ZeebeClientEnvironmentVariables.DEFAULT_JOB_WORKER_TENANT_IDS_VAR);
+    applyEnvironmentValueIfNotNull(
+        value -> defaultJobWorkerStreamEnabled(Boolean.parseBoolean(value)),
         CAMUNDA_CLIENT_WORKER_STREAM_ENABLED,
-        value -> defaultJobWorkerStreamEnabled(Boolean.parseBoolean(value)));
-
-    BuilderUtils.applyIfNotNull(
-        USE_DEFAULT_RETRY_POLICY_VAR, value -> useDefaultRetryPolicy(Boolean.parseBoolean(value)));
+        ZeebeClientEnvironmentVariables.ZEEBE_CLIENT_WORKER_STREAM_ENABLED);
+    applyEnvironmentValueIfNotNull(
+        value -> useDefaultRetryPolicy(Boolean.parseBoolean(value)),
+        USE_DEFAULT_RETRY_POLICY_VAR,
+        ZeebeClientEnvironmentVariables.USE_DEFAULT_RETRY_POLICY_VAR);
   }
 
   @Override
@@ -615,9 +662,11 @@ public final class CamundaClientBuilderImpl
 
   private boolean shouldUseDefaultCredentialsProvider() {
     return credentialsProvider == null
-        && Environment.system().get(OAuthCredentialsProviderBuilder.OAUTH_ENV_CLIENT_ID) != null
-        && Environment.system().get(OAuthCredentialsProviderBuilder.OAUTH_ENV_CLIENT_SECRET)
-            != null;
+        && (Environment.system().isDefined(OAUTH_ENV_CLIENT_ID)
+            || Environment.system().isDefined(ZeebeClientEnvironmentVariables.OAUTH_ENV_CLIENT_ID))
+        && (Environment.system().isDefined(OAUTH_ENV_CLIENT_SECRET)
+            || Environment.system()
+                .isDefined(ZeebeClientEnvironmentVariables.OAUTH_ENV_CLIENT_SECRET));
   }
 
   private CredentialsProvider createDefaultCredentialsProvider() {

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCloudBuilderImpl.java
@@ -87,18 +87,35 @@ public class CamundaClientCloudBuilderImpl
 
   @Override
   public CamundaClientBuilder withProperties(final Properties properties) {
-    BuilderUtils.applyIfNotNull(properties, CLOUD_CLUSTER_ID, this::withClusterId);
-
-    BuilderUtils.applyIfNotNull(properties, CLOUD_CLIENT_ID, this::withClientId);
-
-    BuilderUtils.applyIfNotNull(properties, CLOUD_CLIENT_SECRET, this::withClientId);
-
-    BuilderUtils.applyIfNotNull(properties, CLOUD_REGION, this::withRegion);
-
-    BuilderUtils.applyIfNotNull(
+    BuilderUtils.applyPropertyValueIfNotNull(
         properties,
+        this::withClusterId,
+        CLOUD_CLUSTER_ID,
+        io.camunda.zeebe.client.ClientProperties.CLOUD_CLUSTER_ID);
+
+    BuilderUtils.applyPropertyValueIfNotNull(
+        properties,
+        this::withClientId,
+        CLOUD_CLIENT_ID,
+        io.camunda.zeebe.client.ClientProperties.CLOUD_CLIENT_ID);
+
+    BuilderUtils.applyPropertyValueIfNotNull(
+        properties,
+        this::withClientId,
+        CLOUD_CLIENT_SECRET,
+        io.camunda.zeebe.client.ClientProperties.CLOUD_CLIENT_SECRET);
+
+    BuilderUtils.applyPropertyValueIfNotNull(
+        properties,
+        this::withRegion,
+        CLOUD_REGION,
+        io.camunda.zeebe.client.ClientProperties.CLOUD_REGION);
+
+    BuilderUtils.applyPropertyValueIfNotNull(
+        properties,
+        value -> defaultJobWorkerStreamEnabled(Boolean.parseBoolean(value)),
         STREAM_ENABLED,
-        value -> defaultJobWorkerStreamEnabled(Boolean.parseBoolean(value)));
+        io.camunda.zeebe.client.ClientProperties.STREAM_ENABLED);
 
     innerBuilder.withProperties(properties);
 

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientEnvironmentVariables.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientEnvironmentVariables.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl;
+
+public final class CamundaClientEnvironmentVariables {
+  public static final String PLAINTEXT_CONNECTION_VAR = "CAMUNDA_INSECURE_CONNECTION";
+  public static final String CA_CERTIFICATE_VAR = "CAMUNDA_CA_CERTIFICATE_PATH";
+  public static final String KEEP_ALIVE_VAR = "CAMUNDA_KEEP_ALIVE";
+  public static final String OVERRIDE_AUTHORITY_VAR = "CAMUNDA_OVERRIDE_AUTHORITY";
+  public static final String CAMUNDA_CLIENT_WORKER_STREAM_ENABLED =
+      "CAMUNDA_CLIENT_WORKER_STREAM_ENABLED";
+  public static final String REST_ADDRESS_VAR = "CAMUNDA_REST_ADDRESS";
+  public static final String GRPC_ADDRESS_VAR = "CAMUNDA_GRPC_ADDRESS";
+  public static final String PREFER_REST_VAR = "CAMUNDA_PREFER_REST";
+  public static final String DEFAULT_TENANT_ID_VAR = "CAMUNDA_DEFAULT_TENANT_ID";
+  public static final String DEFAULT_JOB_WORKER_TENANT_IDS_VAR =
+      "CAMUNDA_DEFAULT_JOB_WORKER_TENANT_IDS";
+  public static final String USE_DEFAULT_RETRY_POLICY_VAR =
+      "CAMUNDA_CLIENT_USE_DEFAULT_RETRY_POLICY";
+
+  /** OAuth Environment Variables */
+  public static final String OAUTH_ENV_CLIENT_ID = "CAMUNDA_CLIENT_ID";
+
+  public static final String OAUTH_ENV_CLIENT_SECRET = "CAMUNDA_CLIENT_SECRET";
+  public static final String OAUTH_ENV_TOKEN_AUDIENCE = "CAMUNDA_TOKEN_AUDIENCE";
+  public static final String OAUTH_ENV_TOKEN_SCOPE = "CAMUNDA_TOKEN_SCOPE";
+  public static final String OAUTH_ENV_AUTHORIZATION_SERVER = "CAMUNDA_AUTHORIZATION_SERVER_URL";
+  public static final String OAUTH_ENV_SSL_CLIENT_KEYSTORE_PATH =
+      "CAMUNDA_SSL_CLIENT_KEYSTORE_PATH";
+  public static final String OAUTH_ENV_SSL_CLIENT_KEYSTORE_SECRET =
+      "CAMUNDA_SSL_CLIENT_KEYSTORE_SECRET";
+  public static final String OAUTH_ENV_SSL_CLIENT_KEYSTORE_KEY_SECRET =
+      "CAMUNDA_SSL_CLIENT_KEYSTORE_KEY_SECRET";
+  public static final String OAUTH_ENV_SSL_CLIENT_TRUSTSTORE_PATH =
+      "CAMUNDA_SSL_CLIENT_TRUSTSTORE_PATH";
+  public static final String OAUTH_ENV_SSL_CLIENT_TRUSTSTORE_SECRET =
+      "CAMUNDA_SSL_CLIENT_TRUSTSTORE_SECRET";
+  public static final String OAUTH_ENV_CACHE_PATH = "CAMUNDA_CLIENT_CONFIG_PATH";
+  public static final String OAUTH_ENV_CONNECT_TIMEOUT = "CAMUNDA_AUTH_CONNECT_TIMEOUT";
+  public static final String OAUTH_ENV_READ_TIMEOUT = "CAMUNDA_AUTH_READ_TIMEOUT";
+
+  private CamundaClientEnvironmentVariables() {}
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProviderBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProviderBuilder.java
@@ -15,7 +15,22 @@
  */
 package io.camunda.client.impl.oauth;
 
-import io.camunda.client.impl.util.Environment;
+import static io.camunda.client.impl.BuilderUtils.applyEnvironmentValueIfNotNull;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_AUTHORIZATION_SERVER;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_CACHE_PATH;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_CLIENT_ID;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_CLIENT_SECRET;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_CONNECT_TIMEOUT;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_READ_TIMEOUT;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_SSL_CLIENT_KEYSTORE_KEY_SECRET;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_SSL_CLIENT_KEYSTORE_PATH;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_SSL_CLIENT_KEYSTORE_SECRET;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_SSL_CLIENT_TRUSTSTORE_PATH;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_SSL_CLIENT_TRUSTSTORE_SECRET;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_TOKEN_AUDIENCE;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OAUTH_ENV_TOKEN_SCOPE;
+
+import io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -26,23 +41,6 @@ import java.util.Objects;
 
 public final class OAuthCredentialsProviderBuilder {
   public static final String INVALID_ARGUMENT_MSG = "Expected valid %s but none was provided.";
-  public static final String OAUTH_ENV_CLIENT_ID = "ZEEBE_CLIENT_ID";
-  public static final String OAUTH_ENV_CLIENT_SECRET = "ZEEBE_CLIENT_SECRET";
-  public static final String OAUTH_ENV_TOKEN_AUDIENCE = "ZEEBE_TOKEN_AUDIENCE";
-  public static final String OAUTH_ENV_TOKEN_SCOPE = "ZEEBE_TOKEN_SCOPE";
-  public static final String OAUTH_ENV_AUTHORIZATION_SERVER = "ZEEBE_AUTHORIZATION_SERVER_URL";
-  public static final String OAUTH_ENV_SSL_CLIENT_KEYSTORE_PATH = "ZEEBE_SSL_CLIENT_KEYSTORE_PATH";
-  public static final String OAUTH_ENV_SSL_CLIENT_KEYSTORE_SECRET =
-      "ZEEBE_SSL_CLIENT_KEYSTORE_SECRET";
-  public static final String OAUTH_ENV_SSL_CLIENT_KEYSTORE_KEY_SECRET =
-      "ZEEBE_SSL_CLIENT_KEYSTORE_KEY_SECRET";
-  public static final String OAUTH_ENV_SSL_CLIENT_TRUSTSTORE_PATH =
-      "ZEEBE_SSL_CLIENT_TRUSTSTORE_PATH";
-  public static final String OAUTH_ENV_SSL_CLIENT_TRUSTSTORE_SECRET =
-      "ZEEBE_SSL_CLIENT_TRUSTSTORE_SECRET";
-  public static final String OAUTH_ENV_CACHE_PATH = "ZEEBE_CLIENT_CONFIG_PATH";
-  public static final String OAUTH_ENV_CONNECT_TIMEOUT = "ZEEBE_AUTH_CONNECT_TIMEOUT";
-  public static final String OAUTH_ENV_READ_TIMEOUT = "ZEEBE_AUTH_READ_TIMEOUT";
   private static final String DEFAULT_AUTHZ_SERVER = "https://login.cloud.camunda.io/oauth/token/";
   private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(5);
   private static final Duration DEFAULT_READ_TIMEOUT = DEFAULT_CONNECT_TIMEOUT;
@@ -135,6 +133,13 @@ public final class OAuthCredentialsProviderBuilder {
     return this;
   }
 
+  private OAuthCredentialsProviderBuilder keystorePath(final String keystorePath) {
+    if (keystorePath != null) {
+      return keystorePath(Paths.get(keystorePath));
+    }
+    return this;
+  }
+
   /**
    * @see OAuthCredentialsProviderBuilder#keystorePath(Path)
    */
@@ -171,6 +176,13 @@ public final class OAuthCredentialsProviderBuilder {
   /** Path to truststore used for OAuth identity provider */
   public OAuthCredentialsProviderBuilder truststorePath(final Path truststorePath) {
     this.truststorePath = truststorePath;
+    return this;
+  }
+
+  private OAuthCredentialsProviderBuilder truststorePath(final String truststorePath) {
+    if (truststorePath != null) {
+      return truststorePath(Paths.get(truststorePath));
+    }
     return this;
   }
 
@@ -219,6 +231,13 @@ public final class OAuthCredentialsProviderBuilder {
     return this;
   }
 
+  private OAuthCredentialsProviderBuilder connectTimeout(final String connectTimeout) {
+    if (connectTimeout != null) {
+      return connectTimeout(Duration.ofMillis(Long.parseLong(connectTimeout)));
+    }
+    return this;
+  }
+
   /**
    * @see #connectTimeout(Duration)
    */
@@ -232,6 +251,13 @@ public final class OAuthCredentialsProviderBuilder {
    */
   public OAuthCredentialsProviderBuilder readTimeout(final Duration readTimeout) {
     this.readTimeout = readTimeout;
+    return this;
+  }
+
+  private OAuthCredentialsProviderBuilder readTimeout(final String readTimeout) {
+    if (readTimeout != null) {
+      return readTimeout(Duration.ofMillis(Long.parseLong(readTimeout)));
+    }
     return this;
   }
 
@@ -254,74 +280,54 @@ public final class OAuthCredentialsProviderBuilder {
   }
 
   private void checkEnvironmentOverrides() {
-    final String envClientId = Environment.system().get(OAUTH_ENV_CLIENT_ID);
-    final String envClientSecret = Environment.system().get(OAUTH_ENV_CLIENT_SECRET);
-    final String envAudience = Environment.system().get(OAUTH_ENV_TOKEN_AUDIENCE);
-    final String envScope = Environment.system().get(OAUTH_ENV_TOKEN_SCOPE);
-    final String envAuthorizationUrl = Environment.system().get(OAUTH_ENV_AUTHORIZATION_SERVER);
-    final String envKeystorePath = Environment.system().get(OAUTH_ENV_SSL_CLIENT_KEYSTORE_PATH);
-    final String envKeystorePassword =
-        Environment.system().get(OAUTH_ENV_SSL_CLIENT_KEYSTORE_SECRET);
-    final String envKeystoreKeyPassword =
-        Environment.system().get(OAUTH_ENV_SSL_CLIENT_KEYSTORE_KEY_SECRET);
-    final String envTruststorePath = Environment.system().get(OAUTH_ENV_SSL_CLIENT_TRUSTSTORE_PATH);
-    final String envTruststorePassword =
-        Environment.system().get(OAUTH_ENV_SSL_CLIENT_TRUSTSTORE_SECRET);
-    final String envCachePath = Environment.system().get(OAUTH_ENV_CACHE_PATH);
-    final String envReadTimeout = Environment.system().get(OAUTH_ENV_READ_TIMEOUT);
-    final String envConnectTimeout = Environment.system().get(OAUTH_ENV_CONNECT_TIMEOUT);
-
-    if (envClientId != null) {
-      clientId = envClientId;
-    }
-
-    if (envClientSecret != null) {
-      clientSecret = envClientSecret;
-    }
-
-    if (envAudience != null) {
-      audience = envAudience;
-    }
-
-    if (envScope != null) {
-      scope = envScope;
-    }
-
-    if (envAuthorizationUrl != null) {
-      authorizationServerUrl = envAuthorizationUrl;
-    }
-
-    if (envKeystorePath != null) {
-      keystorePath = Paths.get(envKeystorePath);
-    }
-
-    if (envKeystorePassword != null) {
-      keystorePassword = envKeystorePassword;
-    }
-
-    if (envKeystoreKeyPassword != null) {
-      keystoreKeyPassword = envKeystoreKeyPassword;
-    }
-
-    if (envTruststorePath != null) {
-      truststorePath = Paths.get(envTruststorePath);
-    }
-
-    if (envTruststorePassword != null) {
-      truststorePassword = envTruststorePassword;
-    }
-
-    if (envCachePath != null) {
-      credentialsCachePath = envCachePath;
-    }
-
-    if (envConnectTimeout != null) {
-      connectTimeout = Duration.ofMillis(Long.parseLong(envConnectTimeout));
-    }
-
-    if (envReadTimeout != null) {
-      readTimeout = Duration.ofMillis(Long.parseLong(envReadTimeout));
-    }
+    applyEnvironmentValueIfNotNull(
+        this::clientId, OAUTH_ENV_CLIENT_ID, ZeebeClientEnvironmentVariables.OAUTH_ENV_CLIENT_ID);
+    applyEnvironmentValueIfNotNull(
+        this::clientSecret,
+        OAUTH_ENV_CLIENT_SECRET,
+        ZeebeClientEnvironmentVariables.OAUTH_ENV_CLIENT_SECRET);
+    applyEnvironmentValueIfNotNull(
+        this::audience,
+        OAUTH_ENV_TOKEN_AUDIENCE,
+        ZeebeClientEnvironmentVariables.OAUTH_ENV_TOKEN_AUDIENCE);
+    applyEnvironmentValueIfNotNull(
+        this::scope, OAUTH_ENV_TOKEN_SCOPE, ZeebeClientEnvironmentVariables.OAUTH_ENV_TOKEN_SCOPE);
+    applyEnvironmentValueIfNotNull(
+        this::authorizationServerUrl,
+        OAUTH_ENV_AUTHORIZATION_SERVER,
+        ZeebeClientEnvironmentVariables.OAUTH_ENV_AUTHORIZATION_SERVER);
+    applyEnvironmentValueIfNotNull(
+        this::keystorePath,
+        OAUTH_ENV_SSL_CLIENT_KEYSTORE_PATH,
+        ZeebeClientEnvironmentVariables.OAUTH_ENV_SSL_CLIENT_KEYSTORE_PATH);
+    applyEnvironmentValueIfNotNull(
+        this::keystorePassword,
+        OAUTH_ENV_SSL_CLIENT_KEYSTORE_SECRET,
+        ZeebeClientEnvironmentVariables.OAUTH_ENV_SSL_CLIENT_KEYSTORE_SECRET);
+    applyEnvironmentValueIfNotNull(
+        this::keystoreKeyPassword,
+        OAUTH_ENV_SSL_CLIENT_KEYSTORE_KEY_SECRET,
+        ZeebeClientEnvironmentVariables.OAUTH_ENV_SSL_CLIENT_KEYSTORE_KEY_SECRET);
+    applyEnvironmentValueIfNotNull(
+        this::truststorePath,
+        OAUTH_ENV_SSL_CLIENT_TRUSTSTORE_PATH,
+        ZeebeClientEnvironmentVariables.OAUTH_ENV_SSL_CLIENT_TRUSTSTORE_PATH);
+    applyEnvironmentValueIfNotNull(
+        this::truststorePassword,
+        OAUTH_ENV_SSL_CLIENT_TRUSTSTORE_SECRET,
+        ZeebeClientEnvironmentVariables.OAUTH_ENV_SSL_CLIENT_TRUSTSTORE_SECRET);
+    applyEnvironmentValueIfNotNull(
+        this::credentialsCachePath,
+        OAUTH_ENV_CACHE_PATH,
+        ZeebeClientEnvironmentVariables.OAUTH_ENV_CACHE_PATH);
+    applyEnvironmentValueIfNotNull(
+        this::readTimeout,
+        OAUTH_ENV_READ_TIMEOUT,
+        ZeebeClientEnvironmentVariables.OAUTH_ENV_READ_TIMEOUT);
+    applyEnvironmentValueIfNotNull(
+        this::connectTimeout,
+        OAUTH_ENV_CONNECT_TIMEOUT,
+        ZeebeClientEnvironmentVariables.OAUTH_ENV_CONNECT_TIMEOUT);
   }
 
   private void applyDefaults() {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -37,6 +37,19 @@ import static io.camunda.zeebe.client.ClientProperties.REST_ADDRESS;
 import static io.camunda.zeebe.client.ClientProperties.STREAM_ENABLED;
 import static io.camunda.zeebe.client.ClientProperties.USE_DEFAULT_RETRY_POLICY;
 import static io.camunda.zeebe.client.ClientProperties.USE_PLAINTEXT_CONNECTION;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.CA_CERTIFICATE_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.DEFAULT_JOB_WORKER_TENANT_IDS_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.DEFAULT_TENANT_ID_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.GRPC_ADDRESS_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.KEEP_ALIVE_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.OAUTH_ENV_CLIENT_ID;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.OAUTH_ENV_CLIENT_SECRET;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.OVERRIDE_AUTHORITY_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.PLAINTEXT_CONNECTION_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.PREFER_REST_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.REST_ADDRESS_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.USE_DEFAULT_RETRY_POLICY_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.ZEEBE_CLIENT_WORKER_STREAM_ENABLED;
 import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_KB;
 import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_MB;
 
@@ -63,24 +76,11 @@ import org.apache.hc.client5.http.async.AsyncExecChainHandler;
 
 public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeClientConfiguration {
 
-  public static final String PLAINTEXT_CONNECTION_VAR = "ZEEBE_INSECURE_CONNECTION";
-  public static final String CA_CERTIFICATE_VAR = "ZEEBE_CA_CERTIFICATE_PATH";
-  public static final String KEEP_ALIVE_VAR = "ZEEBE_KEEP_ALIVE";
-  public static final String OVERRIDE_AUTHORITY_VAR = "ZEEBE_OVERRIDE_AUTHORITY";
-  public static final String CAMUNDA_CLIENT_WORKER_STREAM_ENABLED =
-      "ZEEBE_CLIENT_WORKER_STREAM_ENABLED";
   public static final String DEFAULT_GATEWAY_ADDRESS = "0.0.0.0:26500";
   public static final URI DEFAULT_GRPC_ADDRESS =
       getURIFromString("https://" + DEFAULT_GATEWAY_ADDRESS);
   public static final URI DEFAULT_REST_ADDRESS = getURIFromString("https://0.0.0.0:8080");
-  public static final String REST_ADDRESS_VAR = "ZEEBE_REST_ADDRESS";
-  public static final String GRPC_ADDRESS_VAR = "ZEEBE_GRPC_ADDRESS";
-  public static final String PREFER_REST_VAR = "ZEEBE_PREFER_REST";
-  public static final String DEFAULT_TENANT_ID_VAR = "ZEEBE_DEFAULT_TENANT_ID";
-  public static final String DEFAULT_JOB_WORKER_TENANT_IDS_VAR =
-      "ZEEBE_DEFAULT_JOB_WORKER_TENANT_IDS";
   public static final String DEFAULT_JOB_WORKER_NAME_VAR = "default";
-  public static final String USE_DEFAULT_RETRY_POLICY_VAR = "ZEEBE_CLIENT_USE_DEFAULT_RETRY_POLICY";
   private static final String TENANT_ID_LIST_SEPARATOR = ",";
   private static final boolean DEFAULT_PREFER_REST_OVER_GRPC = false;
 
@@ -566,9 +566,6 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     BuilderUtils.applyIfNotNull(
         PREFER_REST_VAR, value -> preferRestOverGrpc(Boolean.parseBoolean(value)));
 
-    if (Environment.system().isDefined(DEFAULT_TENANT_ID_VAR)) {
-      defaultTenantId(Environment.system().get(DEFAULT_TENANT_ID_VAR));
-    }
     BuilderUtils.applyIfNotNull(DEFAULT_TENANT_ID_VAR, this::defaultTenantId);
 
     BuilderUtils.applyIfNotNull(
@@ -579,7 +576,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
         });
 
     BuilderUtils.applyIfNotNull(
-        CAMUNDA_CLIENT_WORKER_STREAM_ENABLED,
+        ZEEBE_CLIENT_WORKER_STREAM_ENABLED,
         value -> defaultJobWorkerStreamEnabled(Boolean.parseBoolean(value)));
 
     BuilderUtils.applyIfNotNull(
@@ -614,9 +611,8 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
 
   private boolean shouldUseDefaultCredentialsProvider() {
     return credentialsProvider == null
-        && Environment.system().get(OAuthCredentialsProviderBuilder.OAUTH_ENV_CLIENT_ID) != null
-        && Environment.system().get(OAuthCredentialsProviderBuilder.OAUTH_ENV_CLIENT_SECRET)
-            != null;
+        && Environment.system().get(OAUTH_ENV_CLIENT_ID) != null
+        && Environment.system().get(OAUTH_ENV_CLIENT_SECRET) != null;
   }
 
   private CredentialsProvider createDefaultCredentialsProvider() {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientEnvironmentVariables.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientEnvironmentVariables.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl;
+
+public final class ZeebeClientEnvironmentVariables {
+  public static final String PLAINTEXT_CONNECTION_VAR = "ZEEBE_INSECURE_CONNECTION";
+  public static final String CA_CERTIFICATE_VAR = "ZEEBE_CA_CERTIFICATE_PATH";
+  public static final String KEEP_ALIVE_VAR = "ZEEBE_KEEP_ALIVE";
+  public static final String OVERRIDE_AUTHORITY_VAR = "ZEEBE_OVERRIDE_AUTHORITY";
+  public static final String ZEEBE_CLIENT_WORKER_STREAM_ENABLED =
+      "ZEEBE_CLIENT_WORKER_STREAM_ENABLED";
+  public static final String REST_ADDRESS_VAR = "ZEEBE_REST_ADDRESS";
+  public static final String GRPC_ADDRESS_VAR = "ZEEBE_GRPC_ADDRESS";
+  public static final String PREFER_REST_VAR = "ZEEBE_PREFER_REST";
+  public static final String DEFAULT_TENANT_ID_VAR = "ZEEBE_DEFAULT_TENANT_ID";
+  public static final String DEFAULT_JOB_WORKER_TENANT_IDS_VAR =
+      "ZEEBE_DEFAULT_JOB_WORKER_TENANT_IDS";
+  public static final String USE_DEFAULT_RETRY_POLICY_VAR = "ZEEBE_CLIENT_USE_DEFAULT_RETRY_POLICY";
+
+  /** OAuth Environment Variables */
+  public static final String OAUTH_ENV_CLIENT_ID = "ZEEBE_CLIENT_ID";
+
+  public static final String OAUTH_ENV_CLIENT_SECRET = "ZEEBE_CLIENT_SECRET";
+  public static final String OAUTH_ENV_TOKEN_AUDIENCE = "ZEEBE_TOKEN_AUDIENCE";
+  public static final String OAUTH_ENV_TOKEN_SCOPE = "ZEEBE_TOKEN_SCOPE";
+  public static final String OAUTH_ENV_AUTHORIZATION_SERVER = "ZEEBE_AUTHORIZATION_SERVER_URL";
+  public static final String OAUTH_ENV_SSL_CLIENT_KEYSTORE_PATH = "ZEEBE_SSL_CLIENT_KEYSTORE_PATH";
+  public static final String OAUTH_ENV_SSL_CLIENT_KEYSTORE_SECRET =
+      "ZEEBE_SSL_CLIENT_KEYSTORE_SECRET";
+  public static final String OAUTH_ENV_SSL_CLIENT_KEYSTORE_KEY_SECRET =
+      "ZEEBE_SSL_CLIENT_KEYSTORE_KEY_SECRET";
+  public static final String OAUTH_ENV_SSL_CLIENT_TRUSTSTORE_PATH =
+      "ZEEBE_SSL_CLIENT_TRUSTSTORE_PATH";
+  public static final String OAUTH_ENV_SSL_CLIENT_TRUSTSTORE_SECRET =
+      "ZEEBE_SSL_CLIENT_TRUSTSTORE_SECRET";
+  public static final String OAUTH_ENV_CACHE_PATH = "ZEEBE_CLIENT_CONFIG_PATH";
+  public static final String OAUTH_ENV_CONNECT_TIMEOUT = "ZEEBE_AUTH_CONNECT_TIMEOUT";
+  public static final String OAUTH_ENV_READ_TIMEOUT = "ZEEBE_AUTH_READ_TIMEOUT";
+
+  private ZeebeClientEnvironmentVariables() {}
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProviderBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProviderBuilder.java
@@ -15,6 +15,15 @@
  */
 package io.camunda.zeebe.client.impl.oauth;
 
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.OAUTH_ENV_AUTHORIZATION_SERVER;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.OAUTH_ENV_CACHE_PATH;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.OAUTH_ENV_CLIENT_ID;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.OAUTH_ENV_CLIENT_SECRET;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.OAUTH_ENV_CONNECT_TIMEOUT;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.OAUTH_ENV_READ_TIMEOUT;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.OAUTH_ENV_TOKEN_AUDIENCE;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.OAUTH_ENV_TOKEN_SCOPE;
+
 import io.camunda.zeebe.client.impl.util.Environment;
 import java.io.File;
 import java.io.IOException;
@@ -25,14 +34,6 @@ import java.util.Objects;
 
 public final class OAuthCredentialsProviderBuilder {
   public static final String INVALID_ARGUMENT_MSG = "Expected valid %s but none was provided.";
-  public static final String OAUTH_ENV_CLIENT_ID = "ZEEBE_CLIENT_ID";
-  public static final String OAUTH_ENV_CLIENT_SECRET = "ZEEBE_CLIENT_SECRET";
-  public static final String OAUTH_ENV_TOKEN_AUDIENCE = "ZEEBE_TOKEN_AUDIENCE";
-  public static final String OAUTH_ENV_TOKEN_SCOPE = "ZEEBE_TOKEN_SCOPE";
-  public static final String OAUTH_ENV_AUTHORIZATION_SERVER = "ZEEBE_AUTHORIZATION_SERVER_URL";
-  public static final String OAUTH_ENV_CACHE_PATH = "ZEEBE_CLIENT_CONFIG_PATH";
-  public static final String OAUTH_ENV_CONNECT_TIMEOUT = "ZEEBE_AUTH_CONNECT_TIMEOUT";
-  public static final String OAUTH_ENV_READ_TIMEOUT = "ZEEBE_AUTH_READ_TIMEOUT";
   private static final String DEFAULT_AUTHZ_SERVER = "https://login.cloud.camunda.io/oauth/token/";
   private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(5);
   private static final Duration DEFAULT_READ_TIMEOUT = DEFAULT_CONNECT_TIMEOUT;

--- a/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
+++ b/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
@@ -27,22 +27,23 @@ import static io.camunda.client.ClientProperties.REST_ADDRESS;
 import static io.camunda.client.ClientProperties.STREAM_ENABLED;
 import static io.camunda.client.ClientProperties.USE_DEFAULT_RETRY_POLICY;
 import static io.camunda.client.ClientProperties.USE_PLAINTEXT_CONNECTION;
-import static io.camunda.client.impl.CamundaClientBuilderImpl.CAMUNDA_CLIENT_WORKER_STREAM_ENABLED;
-import static io.camunda.client.impl.CamundaClientBuilderImpl.CA_CERTIFICATE_VAR;
 import static io.camunda.client.impl.CamundaClientBuilderImpl.DEFAULT_GATEWAY_ADDRESS;
 import static io.camunda.client.impl.CamundaClientBuilderImpl.DEFAULT_GRPC_ADDRESS;
-import static io.camunda.client.impl.CamundaClientBuilderImpl.DEFAULT_JOB_WORKER_TENANT_IDS_VAR;
 import static io.camunda.client.impl.CamundaClientBuilderImpl.DEFAULT_REST_ADDRESS;
-import static io.camunda.client.impl.CamundaClientBuilderImpl.DEFAULT_TENANT_ID_VAR;
-import static io.camunda.client.impl.CamundaClientBuilderImpl.GRPC_ADDRESS_VAR;
-import static io.camunda.client.impl.CamundaClientBuilderImpl.KEEP_ALIVE_VAR;
-import static io.camunda.client.impl.CamundaClientBuilderImpl.OVERRIDE_AUTHORITY_VAR;
-import static io.camunda.client.impl.CamundaClientBuilderImpl.PLAINTEXT_CONNECTION_VAR;
-import static io.camunda.client.impl.CamundaClientBuilderImpl.PREFER_REST_VAR;
-import static io.camunda.client.impl.CamundaClientBuilderImpl.REST_ADDRESS_VAR;
-import static io.camunda.client.impl.CamundaClientBuilderImpl.USE_DEFAULT_RETRY_POLICY_VAR;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.CAMUNDA_CLIENT_WORKER_STREAM_ENABLED;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.CA_CERTIFICATE_VAR;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.DEFAULT_JOB_WORKER_TENANT_IDS_VAR;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.DEFAULT_TENANT_ID_VAR;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.GRPC_ADDRESS_VAR;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.KEEP_ALIVE_VAR;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.OVERRIDE_AUTHORITY_VAR;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.PLAINTEXT_CONNECTION_VAR;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.PREFER_REST_VAR;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.REST_ADDRESS_VAR;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.USE_DEFAULT_RETRY_POLICY_VAR;
 import static io.camunda.client.impl.util.DataSizeUtil.ONE_KB;
 import static io.camunda.client.impl.util.DataSizeUtil.ONE_MB;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.ZEEBE_CLIENT_WORKER_STREAM_ENABLED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -57,8 +58,8 @@ import io.camunda.client.impl.CamundaClientCloudBuilderImpl;
 import io.camunda.client.impl.NoopCredentialsProvider;
 import io.camunda.client.impl.oauth.OAuthCredentialsProvider;
 import io.camunda.client.impl.util.Environment;
-import io.camunda.client.impl.util.EnvironmentRule;
-import io.camunda.client.util.ClientTest;
+import io.camunda.client.impl.util.EnvironmentExtension;
+import io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables;
 import java.io.FileNotFoundException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -70,16 +71,18 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
-public final class CamundaClientTest extends ClientTest {
-  @Rule public final EnvironmentRule environmentRule = new EnvironmentRule();
-  @Rule public ExpectedException thrown = ExpectedException.none();
+@ExtendWith(EnvironmentExtension.class)
+public final class CamundaClientTest {
 
   @Test
   public void shouldNotFailIfClosedTwice() {
+    final CamundaClient client = CamundaClient.newClient();
     client.close();
     client.close();
   }
@@ -132,10 +135,15 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(new CamundaClientBuilderImpl().isPlaintextConnectionEnabled()).isFalse();
   }
 
-  @Test
-  public void shouldUseInsecureWithEnvVar() {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        PLAINTEXT_CONNECTION_VAR,
+        ZeebeClientEnvironmentVariables.PLAINTEXT_CONNECTION_VAR
+      })
+  public void shouldUseInsecureWithEnvVar(final String envVarName) {
     // given
-    Environment.system().put(PLAINTEXT_CONNECTION_VAR, "true");
+    Environment.system().put(envVarName, "true");
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
 
     // when
@@ -145,12 +153,23 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.isPlaintextConnectionEnabled()).isTrue();
   }
 
-  @Test
-  public void shouldOverridePropertyWithEnvVariable() {
+  @ParameterizedTest
+  @CsvSource({
+    PLAINTEXT_CONNECTION_VAR + "," + USE_PLAINTEXT_CONNECTION,
+    ZeebeClientEnvironmentVariables.PLAINTEXT_CONNECTION_VAR + "," + USE_PLAINTEXT_CONNECTION,
+    PLAINTEXT_CONNECTION_VAR
+        + ","
+        + io.camunda.zeebe.client.ClientProperties.USE_PLAINTEXT_CONNECTION,
+    ZeebeClientEnvironmentVariables.PLAINTEXT_CONNECTION_VAR
+        + ","
+        + io.camunda.zeebe.client.ClientProperties.USE_PLAINTEXT_CONNECTION
+  })
+  public void shouldOverridePropertyWithEnvVariable(
+      final String envName, final String propertyName) {
     // given
-    Environment.system().put(PLAINTEXT_CONNECTION_VAR, "false");
+    Environment.system().put(envName, "false");
     final Properties properties = new Properties();
-    properties.putIfAbsent(USE_PLAINTEXT_CONNECTION, "true");
+    properties.putIfAbsent(propertyName, "true");
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
     builder.withProperties(properties);
 
@@ -161,12 +180,23 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.isPlaintextConnectionEnabled()).isFalse();
   }
 
-  @Test
-  public void shouldNotOverridePropertyWithEnvVariableIfOverridingIsDisabled() {
+  @ParameterizedTest
+  @CsvSource({
+    PLAINTEXT_CONNECTION_VAR + "," + USE_PLAINTEXT_CONNECTION,
+    ZeebeClientEnvironmentVariables.PLAINTEXT_CONNECTION_VAR + "," + USE_PLAINTEXT_CONNECTION,
+    PLAINTEXT_CONNECTION_VAR
+        + ","
+        + io.camunda.zeebe.client.ClientProperties.USE_PLAINTEXT_CONNECTION,
+    ZeebeClientEnvironmentVariables.PLAINTEXT_CONNECTION_VAR
+        + ","
+        + io.camunda.zeebe.client.ClientProperties.USE_PLAINTEXT_CONNECTION
+  })
+  public void shouldNotOverridePropertyWithEnvVariableIfOverridingIsDisabled(
+      final String envName, final String propertyName) {
     // given
-    Environment.system().put(PLAINTEXT_CONNECTION_VAR, "false");
+    Environment.system().put(envName, "false");
     final Properties properties = new Properties();
-    properties.putIfAbsent(USE_PLAINTEXT_CONNECTION, "true");
+    properties.putIfAbsent(propertyName, "true");
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
     builder.applyEnvironmentVariableOverrides(false);
     builder.withProperties(properties);
@@ -178,11 +208,12 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.isPlaintextConnectionEnabled()).isTrue();
   }
 
-  @Test
-  public void shouldEnableStreamingWithProperty() {
+  @ParameterizedTest
+  @ValueSource(strings = {STREAM_ENABLED, io.camunda.zeebe.client.ClientProperties.STREAM_ENABLED})
+  public void shouldEnableStreamingWithProperty(final String propertyName) {
     // given
     final Properties properties = new Properties();
-    properties.putIfAbsent(STREAM_ENABLED, "true");
+    properties.putIfAbsent(propertyName, "true");
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
     builder.withProperties(properties);
 
@@ -193,10 +224,11 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.getDefaultJobWorkerStreamEnabled()).isTrue();
   }
 
-  @Test
-  public void shouldEnableStreamingWithEnvironmentVariableWhenApplied() {
+  @ParameterizedTest
+  @ValueSource(strings = {CAMUNDA_CLIENT_WORKER_STREAM_ENABLED, ZEEBE_CLIENT_WORKER_STREAM_ENABLED})
+  public void shouldEnableStreamingWithEnvironmentVariableWhenApplied(final String envName) {
     // given
-    Environment.system().put(CAMUNDA_CLIENT_WORKER_STREAM_ENABLED, "true");
+    Environment.system().put(envName, "true");
 
     final CamundaClientBuilderImpl builder1 = new CamundaClientBuilderImpl();
     final CamundaClientBuilderImpl builder2 = new CamundaClientBuilderImpl();
@@ -210,12 +242,23 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder2.getDefaultJobWorkerStreamEnabled()).isTrue();
   }
 
-  @Test
-  public void environmentVariableShouldOverrideProperty() {
+  @ParameterizedTest
+  @CsvSource({
+    CAMUNDA_CLIENT_WORKER_STREAM_ENABLED + "," + STREAM_ENABLED,
+    ZEEBE_CLIENT_WORKER_STREAM_ENABLED + "," + STREAM_ENABLED,
+    CAMUNDA_CLIENT_WORKER_STREAM_ENABLED
+        + ","
+        + io.camunda.zeebe.client.ClientProperties.STREAM_ENABLED,
+    ZEEBE_CLIENT_WORKER_STREAM_ENABLED
+        + ","
+        + io.camunda.zeebe.client.ClientProperties.STREAM_ENABLED
+  })
+  public void environmentVariableShouldOverrideProperty(
+      final String envName, final String propertyName) {
     // given
-    Environment.system().put(CAMUNDA_CLIENT_WORKER_STREAM_ENABLED, "true");
+    Environment.system().put(envName, "true");
     final Properties properties = new Properties();
-    properties.putIfAbsent(STREAM_ENABLED, "false");
+    properties.putIfAbsent(propertyName, "false");
 
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
     builder.withProperties(properties).applyEnvironmentVariableOverrides(true);
@@ -225,11 +268,12 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.getDefaultJobWorkerStreamEnabled()).isTrue();
   }
 
-  @Test
-  public void shouldCaCertificateWithEnvVar() {
+  @ParameterizedTest
+  @ValueSource(strings = {CA_CERTIFICATE_VAR, ZeebeClientEnvironmentVariables.CA_CERTIFICATE_VAR})
+  public void shouldCaCertificateWithEnvVar(final String envName) {
     // given
     final String certPath = getClass().getClassLoader().getResource("ca.cert.pem").getPath();
-    Environment.system().put(CA_CERTIFICATE_VAR, certPath);
+    Environment.system().put(envName, certPath);
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
 
     // when
@@ -252,8 +296,9 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.getKeepAlive()).isEqualTo(Duration.ofMinutes(2));
   }
 
-  @Test
-  public void shouldOverrideKeepAliveWithEnvVar() {
+  @ParameterizedTest
+  @ValueSource(strings = {KEEP_ALIVE_VAR, ZeebeClientEnvironmentVariables.KEEP_ALIVE_VAR})
+  public void shouldOverrideKeepAliveWithEnvVar(final String envName) {
     // given
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
     builder.keepAlive(Duration.ofMinutes(2));
@@ -279,12 +324,14 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.getOverrideAuthority()).isEqualTo("virtualhost");
   }
 
-  @Test
-  public void shouldOverrideAuthorityWithEnvVar() {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {OVERRIDE_AUTHORITY_VAR, ZeebeClientEnvironmentVariables.OVERRIDE_AUTHORITY_VAR})
+  public void shouldOverrideAuthorityWithEnvVar(final String envName) {
     // given
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
     builder.overrideAuthority("localhost");
-    Environment.system().put(OVERRIDE_AUTHORITY_VAR, "virtualhost");
+    Environment.system().put(envName, "virtualhost");
 
     // when
     builder.build();
@@ -319,13 +366,15 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.getMaxMetadataSize()).isEqualTo(10 * 1024);
   }
 
-  @Test
-  public void shouldSetMaxMessageSizeWithProperty() {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {MAX_MESSAGE_SIZE, io.camunda.zeebe.client.ClientProperties.MAX_MESSAGE_SIZE})
+  public void shouldSetMaxMessageSizeWithProperty(final String propertyName) {
     // given
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
 
     final Properties properties = new Properties();
-    properties.setProperty(MAX_MESSAGE_SIZE, "10MB");
+    properties.setProperty(propertyName, "10MB");
     builder.withProperties(properties);
     // when
     builder.build();
@@ -334,13 +383,15 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.getMaxMessageSize()).isEqualTo(10 * ONE_MB);
   }
 
-  @Test
-  public void shouldSetMaxMetadataSizeWithProperty() {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {MAX_METADATA_SIZE, io.camunda.zeebe.client.ClientProperties.MAX_METADATA_SIZE})
+  public void shouldSetMaxMetadataSizeWithProperty(final String propertyName) {
     // given
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
 
     final Properties properties = new Properties();
-    properties.setProperty(MAX_METADATA_SIZE, "10KB");
+    properties.setProperty(propertyName, "10KB");
     builder.withProperties(properties);
     // when
     builder.build();
@@ -349,10 +400,11 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.getMaxMetadataSize()).isEqualTo(10 * ONE_KB);
   }
 
-  @Test
-  public void shouldRejectUnsupportedTimeUnitWithEnvVar() {
+  @ParameterizedTest
+  @ValueSource(strings = {KEEP_ALIVE_VAR, ZeebeClientEnvironmentVariables.KEEP_ALIVE_VAR})
+  public void shouldRejectUnsupportedTimeUnitWithEnvVar(final String envName) {
     // when/then
-    Environment.system().put(KEEP_ALIVE_VAR, "30d");
+    Environment.system().put(envName, "30d");
     assertThatThrownBy(() -> new CamundaClientBuilderImpl().build())
         .isInstanceOf(IllegalArgumentException.class);
   }
@@ -365,10 +417,11 @@ public final class CamundaClientTest extends ClientTest {
         .isInstanceOf(IllegalArgumentException.class);
   }
 
-  @Test
-  public void shouldRejectNegativeTimeAsEnvVar() {
+  @ParameterizedTest
+  @ValueSource(strings = {KEEP_ALIVE_VAR, ZeebeClientEnvironmentVariables.KEEP_ALIVE_VAR})
+  public void shouldRejectNegativeTimeAsEnvVar(final String envName) {
     // when/then
-    Environment.system().put(KEEP_ALIVE_VAR, "-2s");
+    Environment.system().put(envName, "-2s");
     assertThatThrownBy(() -> new CamundaClientBuilderImpl().build())
         .isInstanceOf(IllegalArgumentException.class);
   }
@@ -439,12 +492,14 @@ public final class CamundaClientTest extends ClientTest {
     }
   }
 
-  @Test
-  public void shouldCloudBuilderBuildProperClientWithRegionPropertyProvided() {
+  @ParameterizedTest
+  @ValueSource(strings = {CLOUD_REGION, io.camunda.zeebe.client.ClientProperties.CLOUD_REGION})
+  public void shouldCloudBuilderBuildProperClientWithRegionPropertyProvided(
+      final String propertyName) {
     // given
     final String region = "asdf-123";
     final Properties properties = new Properties();
-    properties.putIfAbsent(CLOUD_REGION, region);
+    properties.putIfAbsent(propertyName, region);
     try (final CamundaClient client =
         CamundaClient.newCloudClientBuilder()
             .withClusterId("clusterId")
@@ -550,12 +605,14 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.getRestAddress()).isEqualTo(restAddress);
   }
 
-  @Test
-  public void shouldSetRestAddressPortFromPropertyWithClientBuilder() throws URISyntaxException {
+  @ParameterizedTest
+  @ValueSource(strings = {REST_ADDRESS, io.camunda.zeebe.client.ClientProperties.REST_ADDRESS})
+  public void shouldSetRestAddressPortFromPropertyWithClientBuilder(final String propertyName)
+      throws URISyntaxException {
     // given
     final URI restAddress = new URI("localhost:9090");
     final Properties properties = new Properties();
-    properties.setProperty(REST_ADDRESS, restAddress.toString());
+    properties.setProperty(propertyName, restAddress.toString());
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
     builder.withProperties(properties);
 
@@ -566,11 +623,13 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.getRestAddress()).isEqualTo(restAddress);
   }
 
-  @Test
-  public void shouldSetRestAddressPortFromEnvVarWithClientBuilder() throws URISyntaxException {
+  @ParameterizedTest
+  @ValueSource(strings = {REST_ADDRESS_VAR, ZeebeClientEnvironmentVariables.REST_ADDRESS_VAR})
+  public void shouldSetRestAddressPortFromEnvVarWithClientBuilder(final String envName)
+      throws URISyntaxException {
     // given
     final URI restAddress = new URI("localhost:9090");
-    Environment.system().put(REST_ADDRESS_VAR, restAddress.toString());
+    Environment.system().put(envName, restAddress.toString());
 
     // when
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
@@ -594,12 +653,14 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.getGrpcAddress()).isEqualTo(grpcAddress);
   }
 
-  @Test
-  public void shouldSetGrpcAddressFromPropertyWithClientBuilder() throws URISyntaxException {
+  @ParameterizedTest
+  @ValueSource(strings = {GRPC_ADDRESS, io.camunda.zeebe.client.ClientProperties.GRPC_ADDRESS})
+  public void shouldSetGrpcAddressFromPropertyWithClientBuilder(final String propertyName)
+      throws URISyntaxException {
     // given
     final URI grpcAddress = new URI("https://localhost:9090");
     final Properties properties = new Properties();
-    properties.setProperty(GRPC_ADDRESS, grpcAddress.toString());
+    properties.setProperty(propertyName, grpcAddress.toString());
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
     builder.withProperties(properties);
 
@@ -610,11 +671,13 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.getGrpcAddress()).isEqualTo(grpcAddress);
   }
 
-  @Test
-  public void shouldSetGrpcAddressFromEnvVarWithClientBuilder() throws URISyntaxException {
+  @ParameterizedTest
+  @ValueSource(strings = {GRPC_ADDRESS_VAR, ZeebeClientEnvironmentVariables.GRPC_ADDRESS_VAR})
+  public void shouldSetGrpcAddressFromEnvVarWithClientBuilder(final String envName)
+      throws URISyntaxException {
     // given
     final URI grpcAddress = new URI("https://localhost:9090");
-    Environment.system().put(GRPC_ADDRESS_VAR, grpcAddress.toString());
+    Environment.system().put(envName, grpcAddress.toString());
 
     // when
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
@@ -638,12 +701,17 @@ public final class CamundaClientTest extends ClientTest {
     }
   }
 
-  @Test
-  public void shouldSetPreferRestFromPropertyWithClientBuilder() {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        PREFER_REST_OVER_GRPC,
+        io.camunda.zeebe.client.ClientProperties.PREFER_REST_OVER_GRPC
+      })
+  public void shouldSetPreferRestFromPropertyWithClientBuilder(final String propertyName) {
     // given
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
     final Properties properties = new Properties();
-    properties.setProperty(PREFER_REST_OVER_GRPC, "false");
+    properties.setProperty(propertyName, "false");
 
     // when
     builder.withProperties(properties);
@@ -654,11 +722,12 @@ public final class CamundaClientTest extends ClientTest {
     }
   }
 
-  @Test
-  public void shouldSetPreferRestFromEnvVarWithClientBuilder() {
+  @ParameterizedTest
+  @ValueSource(strings = {PREFER_REST_VAR, ZeebeClientEnvironmentVariables.PREFER_REST_VAR})
+  public void shouldSetPreferRestFromEnvVarWithClientBuilder(final String envName) {
     // given
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
-    Environment.system().put(PREFER_REST_VAR, "false");
+    Environment.system().put(envName, "false");
 
     // when
     builder.preferRestOverGrpc(true);
@@ -674,7 +743,8 @@ public final class CamundaClientTest extends ClientTest {
     // given
     final String gatewayAddress = "localhost:26500";
     final Properties properties = new Properties();
-    properties.setProperty(ClientProperties.GATEWAY_ADDRESS, gatewayAddress);
+    properties.setProperty(
+        io.camunda.zeebe.client.ClientProperties.GATEWAY_ADDRESS, gatewayAddress);
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
     builder.withProperties(properties);
 
@@ -712,12 +782,14 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.getDefaultTenantId()).isEqualTo(overrideTenant);
   }
 
-  @Test
-  public void shouldSetDefaultTenantIdFromPropertyWithClientBuilder() {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {DEFAULT_TENANT_ID, io.camunda.zeebe.client.ClientProperties.DEFAULT_TENANT_ID})
+  public void shouldSetDefaultTenantIdFromPropertyWithClientBuilder(final String propertyName) {
     // given
     final String tenantId = "test-tenant";
     final Properties properties = new Properties();
-    properties.setProperty(DEFAULT_TENANT_ID, tenantId);
+    properties.setProperty(propertyName, tenantId);
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
     builder.withProperties(properties);
 
@@ -728,11 +800,13 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.getDefaultTenantId()).isEqualTo(tenantId);
   }
 
-  @Test
-  public void shouldSetDefaultTenantIdFromEnvVarWithClientBuilder() {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {DEFAULT_TENANT_ID_VAR, ZeebeClientEnvironmentVariables.DEFAULT_TENANT_ID_VAR})
+  public void shouldSetDefaultTenantIdFromEnvVarWithClientBuilder(final String envName) {
     // given
     final String overrideTenant = "override-tenant";
-    Environment.system().put(DEFAULT_TENANT_ID_VAR, overrideTenant);
+    Environment.system().put(envName, overrideTenant);
 
     // when
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
@@ -742,14 +816,23 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.getDefaultTenantId()).isEqualTo(overrideTenant);
   }
 
-  @Test
-  public void shouldSetFinalDefaultTenantIdFromEnvVarWithClientBuilder() {
+  @ParameterizedTest
+  @CsvSource({
+    DEFAULT_TENANT_ID_VAR + "," + DEFAULT_TENANT_ID,
+    ZeebeClientEnvironmentVariables.DEFAULT_TENANT_ID_VAR + "," + DEFAULT_TENANT_ID,
+    DEFAULT_TENANT_ID_VAR + "," + io.camunda.zeebe.client.ClientProperties.DEFAULT_TENANT_ID,
+    ZeebeClientEnvironmentVariables.DEFAULT_TENANT_ID_VAR
+        + ","
+        + io.camunda.zeebe.client.ClientProperties.DEFAULT_TENANT_ID
+  })
+  public void shouldSetFinalDefaultTenantIdFromEnvVarWithClientBuilder(
+      final String envName, final String propertyName) {
     // given
     final String propertyTenantId = "test-tenant";
     final Properties properties = new Properties();
-    properties.setProperty(DEFAULT_TENANT_ID, propertyTenantId);
+    properties.setProperty(propertyName, propertyTenantId);
     final String envVarTenantId = "override-tenant";
-    Environment.system().put(DEFAULT_TENANT_ID_VAR, envVarTenantId);
+    Environment.system().put(envName, envVarTenantId);
     final String setterTenantId = "setter-tenant";
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
     builder.defaultTenantId(setterTenantId);
@@ -761,13 +844,16 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.getDefaultTenantId()).isEqualTo(envVarTenantId);
   }
 
-  @Test
-  public void shouldNotSetDefaultTenantIdFromPropertyWithCloudClientBuilder() {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {DEFAULT_TENANT_ID, io.camunda.zeebe.client.ClientProperties.DEFAULT_TENANT_ID})
+  public void shouldNotSetDefaultTenantIdFromPropertyWithCloudClientBuilder(
+      final String propertyName) {
     // given
     final String tenantId = "test-tenant";
     final CamundaClientCloudBuilderImpl builder = new CamundaClientCloudBuilderImpl();
     final Properties properties = new Properties();
-    properties.setProperty(DEFAULT_TENANT_ID, tenantId);
+    properties.setProperty(propertyName, tenantId);
     builder.withProperties(properties);
 
     // when
@@ -828,12 +914,18 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.getDefaultJobWorkerTenantIds()).containsExactly(overrideTenant);
   }
 
-  @Test
-  public void shouldSetDefaultJobWorkerTenantIdsFromPropertyWithClientBuilder() {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        DEFAULT_JOB_WORKER_TENANT_IDS,
+        io.camunda.zeebe.client.ClientProperties.DEFAULT_JOB_WORKER_TENANT_IDS
+      })
+  public void shouldSetDefaultJobWorkerTenantIdsFromPropertyWithClientBuilder(
+      final String propertyName) {
     // given
     final List<String> tenantIdList = Arrays.asList("test-tenant-1", "test-tenant-2");
     final Properties properties = new Properties();
-    properties.setProperty(DEFAULT_JOB_WORKER_TENANT_IDS, String.join(",", tenantIdList));
+    properties.setProperty(propertyName, String.join(",", tenantIdList));
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
     builder.withProperties(properties);
 
@@ -844,11 +936,16 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.getDefaultJobWorkerTenantIds()).containsExactlyElementsOf(tenantIdList);
   }
 
-  @Test
-  public void shouldSetDefaultJobWorkerTenantIdsFromEnvVarWithClientBuilder() {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        DEFAULT_JOB_WORKER_TENANT_IDS_VAR,
+        ZeebeClientEnvironmentVariables.DEFAULT_JOB_WORKER_TENANT_IDS_VAR
+      })
+  public void shouldSetDefaultJobWorkerTenantIdsFromEnvVarWithClientBuilder(final String envName) {
     // given
     final List<String> tenantIdList = Arrays.asList("test-tenant-1", "test-tenant-2");
-    Environment.system().put(DEFAULT_JOB_WORKER_TENANT_IDS_VAR, String.join(",", tenantIdList));
+    Environment.system().put(envName, String.join(",", tenantIdList));
 
     // when
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
@@ -858,14 +955,27 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.getDefaultJobWorkerTenantIds()).containsExactlyElementsOf(tenantIdList);
   }
 
-  @Test
-  public void shouldSetFinalDefaultJobWorkerTenantIdsFromEnvVarWithClientBuilder() {
+  @ParameterizedTest
+  @CsvSource({
+    DEFAULT_JOB_WORKER_TENANT_IDS_VAR + "," + DEFAULT_JOB_WORKER_TENANT_IDS,
+    ZeebeClientEnvironmentVariables.DEFAULT_JOB_WORKER_TENANT_IDS_VAR
+        + ","
+        + DEFAULT_JOB_WORKER_TENANT_IDS,
+    DEFAULT_JOB_WORKER_TENANT_IDS_VAR
+        + ","
+        + io.camunda.zeebe.client.ClientProperties.DEFAULT_JOB_WORKER_TENANT_IDS,
+    ZeebeClientEnvironmentVariables.DEFAULT_JOB_WORKER_TENANT_IDS_VAR
+        + ","
+        + io.camunda.zeebe.client.ClientProperties.DEFAULT_JOB_WORKER_TENANT_IDS
+  })
+  public void shouldSetFinalDefaultJobWorkerTenantIdsFromEnvVarWithClientBuilder(
+      final String envName, final String propertyName) {
     // given
     final String propertyTenantId = "test-tenant";
     final Properties properties = new Properties();
-    properties.setProperty(DEFAULT_JOB_WORKER_TENANT_IDS, propertyTenantId);
+    properties.setProperty(propertyName, propertyTenantId);
     final List<String> tenantIdList = Arrays.asList("test-tenant-1", "test-tenant-2");
-    Environment.system().put(DEFAULT_JOB_WORKER_TENANT_IDS_VAR, String.join(",", tenantIdList));
+    Environment.system().put(envName, String.join(",", tenantIdList));
     final String setterTenantId = "setter-tenant";
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
     builder.defaultJobWorkerTenantIds(Arrays.asList(setterTenantId));
@@ -877,13 +987,19 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.getDefaultJobWorkerTenantIds()).containsExactlyElementsOf(tenantIdList);
   }
 
-  @Test
-  public void shouldNotSetDefaultJobWorkerTenantIdsFromPropertyWithCloudClientBuilder() {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        DEFAULT_JOB_WORKER_TENANT_IDS,
+        io.camunda.zeebe.client.ClientProperties.DEFAULT_JOB_WORKER_TENANT_IDS
+      })
+  public void shouldNotSetDefaultJobWorkerTenantIdsFromPropertyWithCloudClientBuilder(
+      final String propertyName) {
     // given
     final CamundaClientCloudBuilderImpl builder = new CamundaClientCloudBuilderImpl();
     final Properties properties = new Properties();
     final List<String> tenantIdList = Arrays.asList("test-tenant-1", "test-tenant-2");
-    properties.setProperty(DEFAULT_JOB_WORKER_TENANT_IDS, String.join(",", tenantIdList));
+    properties.setProperty(propertyName, String.join(",", tenantIdList));
     builder.withProperties(properties);
 
     // when
@@ -930,12 +1046,17 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.useDefaultRetryPolicy()).isTrue();
   }
 
-  @Test
-  public void shouldOverrideDefaultRetryPolicyWithEnvVar() {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        USE_DEFAULT_RETRY_POLICY_VAR,
+        ZeebeClientEnvironmentVariables.USE_DEFAULT_RETRY_POLICY_VAR
+      })
+  public void shouldOverrideDefaultRetryPolicyWithEnvVar(final String envName) {
     // given
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
     builder.useDefaultRetryPolicy(true);
-    Environment.system().put(USE_DEFAULT_RETRY_POLICY_VAR, "false");
+    Environment.system().put(envName, "false");
 
     // when
     builder.build();
@@ -944,13 +1065,18 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.useDefaultRetryPolicy()).isFalse();
   }
 
-  @Test
-  public void shouldOverrideDefaultRetryPolicyWithProperty() {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        USE_DEFAULT_RETRY_POLICY,
+        io.camunda.zeebe.client.ClientProperties.USE_DEFAULT_RETRY_POLICY
+      })
+  public void shouldOverrideDefaultRetryPolicyWithProperty(final String propertyName) {
     // given
     final Properties properties = new Properties();
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
     builder.useDefaultRetryPolicy(true);
-    properties.setProperty(USE_DEFAULT_RETRY_POLICY, "false");
+    properties.setProperty(propertyName, "false");
     builder.withProperties(properties);
 
     // when
@@ -960,12 +1086,17 @@ public final class CamundaClientTest extends ClientTest {
     assertThat(builder.useDefaultRetryPolicy()).isFalse();
   }
 
-  @Test
-  public void shouldSetTimeoutInMillis() {
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        DEFAULT_REQUEST_TIMEOUT,
+        io.camunda.zeebe.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT
+      })
+  public void shouldSetTimeoutInMillis(final String propertyName) {
     // given
     final Properties properties = new Properties();
     final CamundaClientBuilderImpl builder = new CamundaClientBuilderImpl();
-    properties.setProperty(DEFAULT_REQUEST_TIMEOUT, "1000");
+    properties.setProperty(propertyName, "1000");
     builder.withProperties(properties);
 
     // when

--- a/clients/java/src/test/java/io/camunda/client/impl/BuilderUtilsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/BuilderUtilsTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import io.camunda.client.impl.util.Environment;
+import io.camunda.client.impl.util.EnvironmentExtension;
+import java.util.Properties;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(EnvironmentExtension.class)
+class BuilderUtilsTest {
+  private Properties properties;
+  private Consumer<String> action;
+
+  @BeforeEach
+  void setup() {
+    properties = new Properties();
+    action = mock(Consumer.class);
+  }
+
+  @Test
+  void shouldApplyActionOnFirstNonNullPropertyValue() {
+    // given
+    properties.setProperty("property1", "value1");
+    properties.setProperty("property2", "value2");
+
+    // when
+    BuilderUtils.applyPropertyValueIfNotNull(properties, action, "property1", "property2");
+
+    // then
+    verify(action).accept("value1");
+    verifyNoMoreInteractions(action);
+  }
+
+  @Test
+  void shouldSkipNullPropertyValues() {
+    // given
+    properties.setProperty("property2", "value2");
+
+    // when
+    BuilderUtils.applyPropertyValueIfNotNull(properties, action, "property1", "property2");
+
+    // then
+    verify(action).accept("value2");
+    verifyNoMoreInteractions(action);
+  }
+
+  @Test
+  void shouldNotApplyActionIfNoPropertyValuesFound() {
+    // when
+    BuilderUtils.applyPropertyValueIfNotNull(properties, action, "property1", "property2");
+
+    // then
+    verifyNoInteractions(action);
+  }
+
+  @Test
+  void shouldApplyActionOnFirstNonNullEnvironmentVariableValue() {
+    // given
+    Environment.system().put("env1", "value1");
+    Environment.system().put("env2", "value2");
+    // when
+    BuilderUtils.applyEnvironmentValueIfNotNull(action, "env1", "env2");
+
+    // then
+    verify(action).accept("value1");
+    verifyNoMoreInteractions(action);
+  }
+
+  @Test
+  void shouldSkipNullEnvironmentValues() {
+    // given
+    Environment.system().put("env2", "value2");
+    // when
+    BuilderUtils.applyEnvironmentValueIfNotNull(action, "env1", "env2");
+
+    // then
+    verify(action).accept("value2");
+    verifyNoMoreInteractions(action);
+  }
+
+  @Test
+  void shouldNotApplyActionIfNoEnvironmentVariablesFound() {
+    // when
+    BuilderUtils.applyEnvironmentValueIfNotNull(action, "env1", "env2");
+
+    // then
+    verifyNoInteractions(action);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/impl/util/EnvironmentExtension.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/util/EnvironmentExtension.java
@@ -16,19 +16,37 @@
 package io.camunda.client.impl.util;
 
 import java.util.Map;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.rules.ExternalResource;
 
-public final class EnvironmentRule extends ExternalResource {
+/**
+ * we still need to support JUnit 4 for {@link io.camunda.client.impl.worker.JobWorkerImplTest} that
+ * uses {@link io.grpc.testing.GrpcCleanupRule}
+ */
+public final class EnvironmentExtension extends ExternalResource
+    implements BeforeEachCallback, AfterEachCallback {
 
   private Map<String, String> previousEnvironment;
 
   @Override
-  protected void before() throws Throwable {
+  protected void before() {
     previousEnvironment = Environment.system().copy();
   }
 
   @Override
   protected void after() {
     Environment.system().overwrite(previousEnvironment);
+  }
+
+  @Override
+  public void beforeEach(final ExtensionContext context) {
+    before();
+  }
+
+  @Override
+  public void afterEach(final ExtensionContext context) {
+    after();
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/worker/JobWorkerImplTest.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.impl.worker;
 
-import static io.camunda.client.impl.CamundaClientBuilderImpl.CAMUNDA_CLIENT_WORKER_STREAM_ENABLED;
+import static io.camunda.client.impl.CamundaClientEnvironmentVariables.CAMUNDA_CLIENT_WORKER_STREAM_ENABLED;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -26,7 +26,7 @@ import io.camunda.client.api.worker.JobWorkerBuilderStep1.JobWorkerBuilderStep3;
 import io.camunda.client.impl.CamundaClientBuilderImpl;
 import io.camunda.client.impl.CamundaClientImpl;
 import io.camunda.client.impl.util.Environment;
-import io.camunda.client.impl.util.EnvironmentRule;
+import io.camunda.client.impl.util.EnvironmentExtension;
 import io.camunda.client.impl.util.ExecutorResource;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayImplBase;
@@ -69,7 +69,7 @@ public final class JobWorkerImplTest {
   private static final Duration SLOW_POLL_THRESHOLD = Duration.ofMillis(SLOW_POLL_DELAY_IN_MS / 2);
 
   @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
-  @Rule public final EnvironmentRule environmentRule = new EnvironmentRule();
+  @Rule public final EnvironmentExtension environmentRule = new EnvironmentExtension();
 
   private MockedGateway gateway;
   private CamundaClient client;

--- a/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -27,20 +27,20 @@ import static io.camunda.zeebe.client.ClientProperties.REST_ADDRESS;
 import static io.camunda.zeebe.client.ClientProperties.STREAM_ENABLED;
 import static io.camunda.zeebe.client.ClientProperties.USE_DEFAULT_RETRY_POLICY;
 import static io.camunda.zeebe.client.ClientProperties.USE_PLAINTEXT_CONNECTION;
-import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.CAMUNDA_CLIENT_WORKER_STREAM_ENABLED;
-import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.CA_CERTIFICATE_VAR;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_GATEWAY_ADDRESS;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_GRPC_ADDRESS;
-import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_JOB_WORKER_TENANT_IDS_VAR;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_REST_ADDRESS;
-import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.DEFAULT_TENANT_ID_VAR;
-import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.GRPC_ADDRESS_VAR;
-import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.KEEP_ALIVE_VAR;
-import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.OVERRIDE_AUTHORITY_VAR;
-import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.PLAINTEXT_CONNECTION_VAR;
-import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.PREFER_REST_VAR;
-import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.REST_ADDRESS_VAR;
-import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.USE_DEFAULT_RETRY_POLICY_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.CA_CERTIFICATE_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.DEFAULT_JOB_WORKER_TENANT_IDS_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.DEFAULT_TENANT_ID_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.GRPC_ADDRESS_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.KEEP_ALIVE_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.OVERRIDE_AUTHORITY_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.PLAINTEXT_CONNECTION_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.PREFER_REST_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.REST_ADDRESS_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.USE_DEFAULT_RETRY_POLICY_VAR;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.ZEEBE_CLIENT_WORKER_STREAM_ENABLED;
 import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_KB;
 import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_MB;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -196,7 +196,7 @@ public final class ZeebeClientTest extends ClientTest {
   @Test
   public void shouldEnableStreamingWithEnvironmentVariableWhenApplied() {
     // given
-    Environment.system().put(CAMUNDA_CLIENT_WORKER_STREAM_ENABLED, "true");
+    Environment.system().put(ZEEBE_CLIENT_WORKER_STREAM_ENABLED, "true");
 
     final ZeebeClientBuilderImpl builder1 = new ZeebeClientBuilderImpl();
     final ZeebeClientBuilderImpl builder2 = new ZeebeClientBuilderImpl();
@@ -213,7 +213,7 @@ public final class ZeebeClientTest extends ClientTest {
   @Test
   public void environmentVariableShouldOverrideProperty() {
     // given
-    Environment.system().put(CAMUNDA_CLIENT_WORKER_STREAM_ENABLED, "true");
+    Environment.system().put(ZEEBE_CLIENT_WORKER_STREAM_ENABLED, "true");
     final Properties properties = new Properties();
     properties.putIfAbsent(STREAM_ENABLED, "false");
 

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerImplTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerImplTest.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.worker;
 
-import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.CAMUNDA_CLIENT_WORKER_STREAM_ENABLED;
+import static io.camunda.zeebe.client.impl.ZeebeClientEnvironmentVariables.ZEEBE_CLIENT_WORKER_STREAM_ENABLED;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.util.concurrent.Uninterruptibles;
@@ -180,7 +180,7 @@ public final class JobWorkerImplTest {
   @Test
   public void workerBuilderShouldOverrideEnvVariables() {
     // given
-    Environment.system().put(CAMUNDA_CLIENT_WORKER_STREAM_ENABLED, "false");
+    Environment.system().put(ZEEBE_CLIENT_WORKER_STREAM_ENABLED, "false");
 
     final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
     builder.applyEnvironmentVariableOverrides(true).build();

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
@@ -16,7 +16,6 @@
 package io.camunda.zeebe.spring.client.properties;
 
 import io.camunda.client.CamundaClientConfiguration;
-import io.camunda.client.ClientProperties;
 import io.camunda.client.impl.CamundaClientBuilderImpl;
 import io.camunda.client.impl.util.Environment;
 import io.camunda.zeebe.spring.client.annotation.value.ZeebeWorkerValue;
@@ -118,21 +117,30 @@ public class ZeebeClientConfigurationProperties {
       // Java Client has some name differences in properties - support those as well in case people
       // use those (https://github.com/camunda-community-hub/spring-zeebe/issues/350)
       if (broker.gatewayAddress == null
-          && environment.containsProperty(ClientProperties.GATEWAY_ADDRESS)) {
-        broker.gatewayAddress = environment.getProperty(ClientProperties.GATEWAY_ADDRESS);
+          && environment.containsProperty(
+              io.camunda.zeebe.client.ClientProperties.GATEWAY_ADDRESS)) {
+        broker.gatewayAddress =
+            environment.getProperty(io.camunda.zeebe.client.ClientProperties.GATEWAY_ADDRESS);
       }
       if (cloud.clientSecret == null
-          && environment.containsProperty(ClientProperties.CLOUD_CLIENT_SECRET)) {
-        cloud.clientSecret = environment.getProperty(ClientProperties.CLOUD_CLIENT_SECRET);
+          && environment.containsProperty(
+              io.camunda.zeebe.client.ClientProperties.CLOUD_CLIENT_SECRET)) {
+        cloud.clientSecret =
+            environment.getProperty(io.camunda.zeebe.client.ClientProperties.CLOUD_CLIENT_SECRET);
       }
       if (worker.defaultName == null
-          && environment.containsProperty(ClientProperties.DEFAULT_JOB_WORKER_NAME)) {
-        worker.defaultName = environment.getProperty(ClientProperties.DEFAULT_JOB_WORKER_NAME);
+          && environment.containsProperty(
+              io.camunda.zeebe.client.ClientProperties.DEFAULT_JOB_WORKER_NAME)) {
+        worker.defaultName =
+            environment.getProperty(
+                io.camunda.zeebe.client.ClientProperties.DEFAULT_JOB_WORKER_NAME);
       }
       // Support environment based default tenant id override if value is client default fallback
       if ((defaultTenantId == null || defaultTenantId.equals(DEFAULT.getDefaultTenantId()))
-          && environment.containsProperty(ClientProperties.DEFAULT_TENANT_ID)) {
-        defaultTenantId = environment.getProperty(ClientProperties.DEFAULT_TENANT_ID);
+          && environment.containsProperty(
+              io.camunda.zeebe.client.ClientProperties.DEFAULT_TENANT_ID)) {
+        defaultTenantId =
+            environment.getProperty(io.camunda.zeebe.client.ClientProperties.DEFAULT_TENANT_ID);
       }
     }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adding a generic properties and environment variables to be used to configure the java client. The old properties and variables are still supported as fallback value when the generic property is not provided.

**Properties:**
- `zeebe.client.applyEnvironmentVariableOverrides` -> `camunda.client.applyEnvironmentVariableOverrides`
- `zeebe.client.gateway.address` -> no replacement `camunda.client.gateway.grpc.address` or `zeebe.client.gateway.grpc.address` can be used
- `zeebe.client.gateway.preferRestOverGrpc` -> `camunda.client.gateway.preferRestOverGrpc`
- `zeebe.client.gateway.rest.address` -> `camunda.client.gateway.rest.address`
- `zeebe.client.gateway.grpc.address` -> `camunda.client.gateway.grpc.address`
- `zeebe.client.tenantId` -> `camunda.client.tenantId`
- `zeebe.client.worker.tenantIds` -> `camunda.client.worker.tenantIds`
- `zeebe.client.worker.threads` -> `camunda.client.worker.threads`
- `zeebe.client.worker.maxJobsActive` -> `camunda.client.worker.maxJobsActive`
- `zeebe.client.worker.name` -> `camunda.client.worker.name`
- `zeebe.client.job.timeout` -> `camunda.client.job.timeout`
- `zeebe.client.job.pollinterval` -> `camunda.client.job.pollinterval`
- `zeebe.client.message.timeToLive` -> `camunda.client.message.timeToLive`
- `zeebe.client.requestTimeout` -> `camunda.client.requestTimeout`
- `zeebe.client.security.plaintext` -> `camunda.client.security.plaintext`
- `zeebe.client.security.certpath` -> `camunda.client.security.certpath`
- `zeebe.client.keepalive` -> `camunda.client.keepalive`
- `zeebe.client.overrideauthority` -> `camunda.client.overrideauthority`
- `zeebe.client.maxMessageSize` -> `camunda.client.maxMessageSize`
- `zeebe.client.maxMetadataSize` -> `camunda.client.maxMetadataSize`
- `zeebe.client.cloud.clusterId` -> `camunda.client.cloud.clusterId`
- `zeebe.client.cloud.clientId` -> `camunda.client.cloud.clientId`
- `zeebe.client.cloud.secret` -> `camunda.client.cloud.secret`
- `zeebe.client.cloud.region` -> `camunda.client.cloud.region`
- `zeebe.client.worker.stream.enabled` -> `camunda.client.worker.stream.enabled`
- `zeebe.client.useDefaultRetryPolicy` -> `camunda.client.useDefaultRetryPolicy`

**Environment variables:**
- `ZEEBE_INSECURE_CONNECTION` -> `CAMUNDA_INSECURE_CONNECTION`
- `ZEEBE_CA_CERTIFICATE_PATH` -> `CAMUNDA_CA_CERTIFICATE_PATH`
- `ZEEBE_KEEP_ALIVE` -> `CAMUNDA_KEEP_ALIVE`
- `ZEEBE_OVERRIDE_AUTHORITY` -> `CAMUNDA_OVERRIDE_AUTHORITY`
- `ZEEBE_CLIENT_WORKER_STREAM_ENABLED` -> `CAMUNDA_CLIENT_WORKER_STREAM_ENABLED`
- `ZEEBE_REST_ADDRESS` -> `CAMUNDA_REST_ADDRESS`
- `ZEEBE_GRPC_ADDRESS` -> `CAMUNDA_GRPC_ADDRESS`
- `ZEEBE_PREFER_REST` -> `CAMUNDA_PREFER_REST`
- `ZEEBE_DEFAULT_TENANT_ID` -> `CAMUNDA_DEFAULT_TENANT_ID`
- `ZEEBE_DEFAULT_JOB_WORKER_TENANT_IDS` -> `CAMUNDA_DEFAULT_JOB_WORKER_TENANT_IDS`
- `ZEEBE_CLIENT_USE_DEFAULT_RETRY_POLICY` -> `CAMUNDA_CLIENT_USE_DEFAULT_RETRY_POLICY`
- `ZEEBE_CLIENT_ID` -> `CAMUNDA_CLIENT_ID`
- `ZEEBE_CLIENT_SECRET` -> `CAMUNDA_CLIENT_SECRET`
- `ZEEBE_TOKEN_AUDIENCE` - > `CAMUNDA_TOKEN_AUDIENCE`
- `ZEEBE_TOKEN_SCOPE` -> `CAMUNDA_TOKEN_SCOPE`
- `ZEEBE_AUTHORIZATION_SERVER_URL` -> `CAMUNDA_AUTHORIZATION_SERVER_URL`
- `ZEEBE_CLIENT_CONFIG_PATH` -> `CAMUNDA_CLIENT_CONFIG_PATH`
- `ZEEBE_AUTH_CONNECT_TIMEOUT` -> `CAMUNDA_AUTH_CONNECT_TIMEOUT`
- `ZEEBE_AUTH_READ_TIMEOUT` ->  `CAMUNDA_AUTH_READ_TIMEOUT`
The following variables were introduced in 8.7.0-alpha3 https://github.com/camunda/product-hub/issues/2451
- `ZEEBE_SSL_CLIENT_KEYSTORE_PATH` -> `CAMUNDA_SSL_CLIENT_KEYSTORE_PATH`
- `ZEEBE_SSL_CLIENT_KEYSTORE_SECRET` -> `CAMUNDA_SSL_CLIENT_KEYSTORE_SECRET`
- `ZEEBE_SSL_CLIENT_KEYSTORE_SECRET` -> `CAMUNDA_SSL_CLIENT_KEYSTORE_SECRET`
- `ZEEBE_SSL_CLIENT_TRUSTSTORE_PATH` -> `CAMUNDA_SSL_CLIENT_TRUSTSTORE_PATH`
- `ZEEBE_SSL_CLIENT_TRUSTSTORE_SECRET` -> `CAMUNDA_SSL_CLIENT_TRUSTSTORE_SECRET`

The handling of these properties in Spring SDK will be done in another task

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes [#26216](https://github.com/camunda/camunda/issues/26216)
