### PR TITLE
ci: make sure also GHA *.yaml files are linted

### DIFF
--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -2,6 +2,14 @@ name: "C8Run: build/test"
 
 on:
   push:
+    branches:
+      - "main"
+      - "stable/**"
+      - "release/**"
+    paths:
+      - "c8run/**"
+      - ".github/workflows/c8run-build.yaml"
+  pull_request:
     paths:
       - "c8run/**"
       - ".github/workflows/c8run-build.yaml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
             object type "{}" cannot be filtered by object filtering `.*` since it has no object element
       - run: |
           curl -s -L "https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz" | tar xvz conftest
-          ./conftest test -o github --policy .github .github/workflows/*.yml
+          ./conftest test -o github --policy .github .github/workflows/*.y*ml
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/zeebe-update-long-running-migrating-benchmark.yaml
+++ b/.github/workflows/zeebe-update-long-running-migrating-benchmark.yaml
@@ -21,6 +21,7 @@ jobs:
     needs:
       - fetch-release
     uses: ./.github/workflows/zeebe-benchmark.yml
+    secrets: inherit
     with:
       name: release-rolling
       cluster: zeebe-cluster


### PR DESCRIPTION
## Description

As raised in Slack the https://github.com/camunda/camunda/blob/main/.github/workflows/c8run-build.yaml workflow doesn't follow all best practices but the lint rules were only executed on `*.yml` files (86 files), not `*.yaml` files (13 files).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

None
