### PR TITLE
Cleanup task listener jobs on element instance termination

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
@@ -118,7 +118,7 @@ public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<Ex
       final ExecutableUserTask element, final BpmnElementContext context) {
     final var flowScopeInstance = stateBehavior.getFlowScopeInstance(context);
 
-    if (element.hasExecutionListeners()) {
+    if (element.hasExecutionListeners() || element.hasTaskListeners()) {
       jobBehavior.cancelJob(context);
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableUserTask.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableUserTask.java
@@ -29,7 +29,7 @@ public final class ExecutableUserTask extends ExecutableJobWorkerTask {
     this.userTaskProperties = userTaskProperties;
   }
 
-  public List<TaskListener> getTaskListeners(ZeebeTaskListenerEventType eventType) {
+  public List<TaskListener> getTaskListeners(final ZeebeTaskListenerEventType eventType) {
     return taskListeners.stream().filter(tl -> tl.getEventType() == eventType).toList();
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableUserTask.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableUserTask.java
@@ -44,4 +44,8 @@ public final class ExecutableUserTask extends ExecutableJobWorkerTask {
   public boolean hasTaskListeners(final ZeebeTaskListenerEventType eventType) {
     return !getTaskListeners(eventType).isEmpty();
   }
+
+  public boolean hasTaskListeners() {
+    return !getTaskListeners().isEmpty();
+  }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This resolves a bug where the job of a task listener is not cleaned up after the element instance is terminated (e.g. when canceling the process instance, or when interrupting the user task).

This had an additional effect: an incident associated to such a job was also not cleaned up.

This PR solves both problems by:
- canceling the associated job
- resolving the associated incident

## Related issues

closes #26786
