### PR TITLE
ci: add daily build to unified ci to re-populate GHA caches - fix protobuf behaviour

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -136,7 +136,7 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
-        steps.filter-common.outputs.protobuf-change == 'true'
+        (steps.filter-common.outputs.protobuf-change == 'true' &&  github.event_name != 'schedule')
       }}
   openapi-changes:
     description: Output whether any C8 OpenAPI code has changed


### PR DESCRIPTION
## Description

Prevent `protobuf` job running when called from a scheduled workflow.
As `path-filter` [always sees changes](https://github.com/dorny/paths-filter/issues/213), the `protobuf` jobs gets called and it fails when is called from the scheduled run of the Unified CI.
Like here: https://github.com/camunda/camunda/actions/runs/12803109495/job/35695288287#step:4:28
As the purpose of this scheduled run is to re-populate caches, there's no need for the `protobuf` job to run. 

## Checklist

- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #25284
