### PR TITLE
[Backport stable/8.6] ci: make sure also GHA *.yaml files are linted

### DIFF
--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -2,6 +2,14 @@ name: "C8Run: build/test"
 
 on:
   push:
+    branches:
+      - "main"
+      - "stable/**"
+      - "release/**"
+    paths:
+      - "c8run/**"
+      - ".github/workflows/c8run-build.yaml"
+  pull_request:
     paths:
       - "c8run/**"
       - ".github/workflows/c8run-build.yaml"

--- a/.github/workflows/zeebe-update-long-running-migrating-benchmark.yaml
+++ b/.github/workflows/zeebe-update-long-running-migrating-benchmark.yaml
@@ -21,6 +21,7 @@ jobs:
     needs:
       - fetch-release
     uses: ./.github/workflows/zeebe-benchmark.yml
+    secrets: inherit
     with:
       name: release-rolling
       cluster: zeebe-cluster


### PR DESCRIPTION
# Description
Backport of #27010 to `stable/8.6`.

relates to 
original author: @cmur2