### PR TITLE
Add OpenSearch testcase to BackupRestoreIT

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/conditions/DatabaseInfo.java
+++ b/operate/common/src/main/java/io/camunda/operate/conditions/DatabaseInfo.java
@@ -12,12 +12,13 @@ import static io.camunda.operate.conditions.DatabaseCondition.DATABASE_PROPERTY;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.stereotype.Component;
 
 @Component("databaseInfo")
-public class DatabaseInfo implements ApplicationContextAware {
+public class DatabaseInfo implements ApplicationContextAware, DisposableBean {
 
   static final DatabaseType DEFAULT_DATABASE = DatabaseType.Elasticsearch;
   private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseInfo.class);
@@ -59,6 +60,12 @@ public class DatabaseInfo implements ApplicationContextAware {
 
   public boolean isElasticsearchDb() {
     return isElasticsearch();
+  }
+
+  @Override
+  public void destroy() {
+    // unset current so it can be reinitialized
+    current = null;
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/ExtendedOpenSearchClient.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/ExtendedOpenSearchClient.java
@@ -33,7 +33,6 @@ import org.opensearch.client.Request;
 import org.opensearch.client.Response;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.json.JsonpMapper;
-import org.opensearch.client.json.ObjectBuilderDeserializer;
 import org.opensearch.client.json.jackson.JacksonJsonpGenerator;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
@@ -41,10 +40,6 @@ import org.opensearch.client.opensearch._types.ErrorResponse;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
-import org.opensearch.client.opensearch.snapshot.GetSnapshotRequest;
-import org.opensearch.client.opensearch.snapshot.GetSnapshotResponse;
-import org.opensearch.client.opensearch.snapshot.GetSnapshotResponse.Builder;
-import org.opensearch.client.opensearch.snapshot.SnapshotInfo;
 import org.opensearch.client.transport.JsonEndpoint;
 import org.opensearch.client.transport.OpenSearchTransport;
 import org.opensearch.client.transport.endpoints.EndpointWithResponseMapperAttr;
@@ -181,40 +176,6 @@ public class ExtendedOpenSearchClient extends OpenSearchClient {
     final JsonEndpoint<Map<String, Object>, HashMap, ErrorResponse> endpoint =
         arbitraryEndpoint(method, path, getDeserializer(HashMap.class));
     return arbitraryRequest(json, endpoint);
-  }
-
-  /**
-   * Standard opensearch GetSnapshotResponse builder considers fields "total" and "remaining" to be
-   * mandatory in response. Hovever, OS server doesn't provide them, so workarounding the
-   * getSnapshots request by setting them to 0.
-   */
-  public GetSnapshotResponse getSnapshots(final GetSnapshotRequest getSnapshotRequest)
-      throws IOException, OpenSearchException {
-    final JsonpMapper jsonpMapper = transport.jsonpMapper();
-    final String snapshots = String.join(",", getSnapshotRequest.snapshot());
-    final JsonpDeserializer<GetSnapshotResponse> deserializer =
-        ObjectBuilderDeserializer.lazy(
-            () -> new Builder().total(0).remaining(0),
-            op ->
-                op.add(
-                    Builder::snapshots,
-                    JsonpDeserializer.arrayDeserializer(SnapshotInfo._DESERIALIZER),
-                    "snapshots"));
-    final String json =
-        arbitraryRequestAsString(
-            "GET", format("/_snapshot/%s/%s", getSnapshotRequest.repository(), snapshots), "{}");
-    return deserialize(json, deserializer);
-  }
-
-  private <R> R deserialize(final String json, final JsonpDeserializer<R> deserializer) {
-    try (final JsonParser parser = parser(json)) {
-      return deserializer.deserialize(parser, transport.jsonpMapper());
-    }
-  }
-
-  private JsonParser parser(final String json) {
-    final InputStream is = new ByteArrayInputStream(json.getBytes());
-    return transport.jsonpMapper().jsonProvider().createParser(is);
   }
 
   private <R> R arbitraryRequest(

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/OptimizeOpenSearchClient.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/OptimizeOpenSearchClient.java
@@ -109,9 +109,6 @@ import org.opensearch.client.opensearch.indices.RolloverResponse;
 import org.opensearch.client.opensearch.indices.rollover.RolloverConditions;
 import org.opensearch.client.opensearch.snapshot.CreateSnapshotRequest;
 import org.opensearch.client.opensearch.snapshot.CreateSnapshotResponse;
-import org.opensearch.client.opensearch.snapshot.GetRepositoryRequest;
-import org.opensearch.client.opensearch.snapshot.GetSnapshotRequest;
-import org.opensearch.client.opensearch.snapshot.GetSnapshotResponse;
 import org.opensearch.client.opensearch.tasks.GetTasksResponse;
 import org.opensearch.client.opensearch.tasks.ListRequest;
 import org.opensearch.client.opensearch.tasks.ListResponse;
@@ -1031,16 +1028,6 @@ public class OptimizeOpenSearchClient extends DatabaseClient {
     }
   }
 
-  public void verifyRepositoryExists(final GetRepositoryRequest getRepositoriesRequest)
-      throws IOException, OpenSearchException {
-    openSearchClient.snapshot().getRepository(getRepositoriesRequest);
-  }
-
-  public GetSnapshotResponse getSnapshots(final GetSnapshotRequest getSnapshotRequest)
-      throws IOException {
-    return openSearchClient.getSnapshots(getSnapshotRequest);
-  }
-
   public CompletableFuture<CreateSnapshotResponse> triggerSnapshotAsync(
       final CreateSnapshotRequest createSnapshotRequest) {
     return safe(
@@ -1051,10 +1038,6 @@ public class OptimizeOpenSearchClient extends DatabaseClient {
 
   public ExtendedOpenSearchClient getOpenSearchClient() {
     return openSearchClient;
-  }
-
-  public OpenSearchAsyncClient getOpenSearchAsyncClient() {
-    return openSearchAsyncClient;
   }
 
   public RichOpenSearchClient getRichOpenSearchClient() {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -78,6 +78,7 @@
     <version.netty>4.1.117.Final</version.netty>
     <version.objenesis>3.4</version.objenesis>
     <version.opensearch>2.14.0</version.opensearch>
+    <version.opensearch-java>2.19.0</version.opensearch-java>
     <version.opensearch.testcontainers>2.1.2</version.opensearch.testcontainers>
     <version.prometheus>0.16.0</version.prometheus>
     <version.protobuf>4.29.3</version.protobuf>
@@ -1351,7 +1352,7 @@
       <dependency>
         <groupId>org.opensearch.client</groupId>
         <artifactId>opensearch-java</artifactId>
-        <version>${version.opensearch}</version>
+        <version>${version.opensearch-java}</version>
       </dependency>
 
       <dependency>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -114,6 +114,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
@@ -280,6 +286,22 @@
     <dependency>
       <groupId>org.elasticsearch.client</groupId>
       <artifactId>elasticsearch-rest-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>elasticsearch-rest-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.opensearch.client</groupId>
+      <artifactId>opensearch-rest-client</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -290,11 +290,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.elasticsearch.client</groupId>
-      <artifactId>elasticsearch-rest-client</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
       <scope>test</scope>
@@ -428,12 +423,6 @@
     <dependency>
       <groupId>org.agrona</groupId>
       <artifactId>agrona</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore</artifactId>
-      <version>4.4.16</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupDBClient.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupDBClient.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.backup;
+
+import io.camunda.qa.util.cluster.TestStandaloneCamunda;
+import io.camunda.search.connect.configuration.DatabaseType;
+import java.io.IOException;
+import java.util.Collection;
+
+public interface BackupDBClient extends AutoCloseable {
+  void restore(String repositoryName, Collection<String> snapshots) throws IOException;
+
+  void createRepository(String repositoryName) throws IOException;
+
+  static BackupDBClient create(
+      final TestStandaloneCamunda testStandaloneCamunda, final DatabaseType databaseType)
+      throws IOException {
+    return switch (databaseType) {
+      case ELASTICSEARCH -> new ESDBClientBackup(testStandaloneCamunda);
+      case OPENSEARCH -> new OSDBClientBackup(testStandaloneCamunda);
+      default -> throw new IllegalStateException("Unsupported database type: " + databaseType);
+    };
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupDBClient.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupDBClient.java
@@ -12,7 +12,11 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 
-/** interface to abstract Elasticsearch/Opensearch clients for testing purposes */
+/**
+ * interface to abstract Elasticsearch/Opensearch clients for testing purposes. Methods defined here
+ * are not implemented elsewhere as they are typically performed by users, not by the camunda
+ * application.
+ */
 public interface BackupDBClient extends AutoCloseable {
   void restore(String repositoryName, Collection<String> snapshots) throws IOException;
 
@@ -27,6 +31,7 @@ public interface BackupDBClient extends AutoCloseable {
     };
   }
 
+  // TODO remove this when purge functionality is available
   void deleteAllIndices(final String indexPrefix) throws IOException;
 
   List<String> cat() throws IOException;

--- a/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupDBClient.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupDBClient.java
@@ -7,23 +7,27 @@
  */
 package io.camunda.it.backup;
 
-import io.camunda.qa.util.cluster.TestStandaloneCamunda;
 import io.camunda.search.connect.configuration.DatabaseType;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 
+/** interface to abstract Elasticsearch/Opensearch clients for testing purposes */
 public interface BackupDBClient extends AutoCloseable {
   void restore(String repositoryName, Collection<String> snapshots) throws IOException;
 
   void createRepository(String repositoryName) throws IOException;
 
-  static BackupDBClient create(
-      final TestStandaloneCamunda testStandaloneCamunda, final DatabaseType databaseType)
+  static BackupDBClient create(final String url, final DatabaseType databaseType)
       throws IOException {
     return switch (databaseType) {
-      case ELASTICSEARCH -> new ESDBClientBackup(testStandaloneCamunda);
-      case OPENSEARCH -> new OSDBClientBackup(testStandaloneCamunda);
+      case ELASTICSEARCH -> new ESDBClientBackup(url);
+      case OPENSEARCH -> new OSDBClientBackup(url);
       default -> throw new IllegalStateException("Unsupported database type: " + databaseType);
     };
   }
+
+  void deleteAllIndices(final String indexPrefix) throws IOException;
+
+  List<String> cat() throws IOException;
 }

--- a/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
@@ -37,7 +37,7 @@ public class BackupRestoreIT {
   private static final String REPOSITORY_NAME = "test-repository";
   private static final String INDEX_PREFIX = "backup-restore";
   private static final String PROCESS_ID = "backup-process";
-  private static final int PROCESS_INSTANCE_NUMBER = 100;
+  private static final int PROCESS_INSTANCE_NUMBER = 10;
   protected CamundaClient camundaClient;
 
   @TestZeebe(autoStart = false)

--- a/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
@@ -19,63 +19,43 @@ import io.camunda.webapps.backup.BackupStateDto;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
-import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
-import java.io.IOException;
-import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
 import org.agrona.CloseHelper;
-import org.apache.http.HttpHost;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.Awaitility;
-import org.elasticsearch.client.RestClient;
 import org.junit.jupiter.api.AfterEach;
-import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AutoClose;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.opensearch.client.opensearch.OpenSearchClient;
-import org.testcontainers.shaded.org.awaitility.Awaitility;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.elasticsearch.ElasticsearchContainer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.BindMode;
-import org.testcontainers.containers.SelinuxContext;
 
 @ZeebeIntegration
 public class BackupRestoreIT {
-  private static final Logger LOG = LoggerFactory.getLogger(BackupRestoreIT.class);
   private static final String REPOSITORY_NAME = "test-repository";
   private static final String INDEX_PREFIX = "backup-restore";
   private static final String PROCESS_ID = "backup-process";
-  private static final int PROCESS_INSTANCE_NUMBER = 1;
-
-  @TempDir public Path repositoryDir;
+  private static final int PROCESS_INSTANCE_NUMBER = 100;
   protected CamundaClient camundaClient;
 
   @TestZeebe(autoStart = false)
   protected TestStandaloneApplication<?> testStandaloneCamunda;
 
-  @AutoClose protected BackupDBClient backupDbClient;
+  protected BackupDBClient backupDbClient;
+  private String dbUrl;
   private GenericContainer<?> searchContainer;
-  @AutoClose private DataGenerator generator;
+  private DataGenerator generator;
   private BackupRestoreTestConfig config;
   private HistoryBackupClient historyBackupClient;
 
   @AfterEach
   public void tearDown() {
-    CloseHelper.quietCloseAll(restClient, camundaClient, searchContainer);
+    CloseHelper.quietCloseAll(backupDbClient, camundaClient, generator, searchContainer);
   }
 
-  private void setup(final BackupRestoreTestConfig config) throws IOException {
-    final String dbUrl;
+  private void setup(final BackupRestoreTestConfig config) throws Exception {
     testStandaloneCamunda = new TestSimpleCamundaApplication();
     final var configurator = new MultiDbConfigurator(testStandaloneCamunda);
     searchContainer =
@@ -96,6 +76,18 @@ public class BackupRestoreIT {
             yield container;
           }
 
+          case OPENSEARCH -> {
+            final var container =
+                TestSearchContainers.createDefaultOpensearchContainer()
+                    .withStartupTimeout(Duration.ofMinutes(5))
+                    // location of the repository that will be used for snapshots
+                    .withEnv("path.repo", "~/");
+            container.start();
+            dbUrl = container.getHttpHostAddress();
+            configurator.configureOpenSearchSupport(dbUrl, INDEX_PREFIX, "admin", "admin");
+            yield container;
+          }
+
           default ->
               throw new IllegalArgumentException(
                   "Unsupported database type: " + config.databaseType);
@@ -105,9 +97,14 @@ public class BackupRestoreIT {
 
     this.config = config;
     testStandaloneCamunda.start().awaitCompleteTopology();
+
+    camundaClient = testStandaloneCamunda.newClientBuilder().build();
+    generator = new DataGenerator(camundaClient, PROCESS_ID);
+
+    generator.generate(PROCESS_INSTANCE_NUMBER);
     historyBackupClient = HistoryBackupClient.of(testStandaloneCamunda);
-    createSearchClient();
-    createRepository();
+    backupDbClient = BackupDBClient.create(dbUrl, config.databaseType);
+    backupDbClient.createRepository(REPOSITORY_NAME);
   }
 
   public static Stream<BackupRestoreTestConfig> sources() {
@@ -121,7 +118,7 @@ public class BackupRestoreIT {
   @ParameterizedTest
   @MethodSource(value = {"sources"})
   public void shouldBackupAndRestoreToPreviousState(final BackupRestoreTestConfig config)
-      throws IOException, InterruptedException {
+      throws Exception {
     // given
     setup(config);
 
@@ -141,296 +138,21 @@ public class BackupRestoreIT {
               assertThat(backupResponse.getDetails()).allMatch(d -> d.getState().equals("SUCCESS"));
             });
 
-    // then
+    // when
     // if we stop all apps and restart elasticsearch
     testStandaloneCamunda.stop();
 
-    // then
-    deleteAllIndices();
+    backupDbClient.deleteAllIndices(INDEX_PREFIX);
+    Awaitility.await().untilAsserted(() -> assertThat(backupDbClient.cat()).isEmpty());
 
     // restore with a new client is successful
-    restore(snapshots);
+    backupDbClient.restore(REPOSITORY_NAME, snapshots);
+
+    testStandaloneCamunda.start();
 
     // then
     generator.verifyAllExported();
   }
 
-  private void deleteAllIndices() throws IOException {
-    switch (config.databaseType) {
-      case ELASTICSEARCH -> {
-        esClient
-            .indices()
-            .delete(
-                DeleteIndexRequest.of(
-                    b -> b.index(INDEX_PREFIX + "*").expandWildcards(ExpandWildcard.All)));
-      }
-      default -> {
-        throw new UnsupportedOperationException("Opensearch is not yet supported");
-      }
-    }
-  }
-
-  public void createSearchClient() throws IOException {
-    switch (config.databaseType) {
-      case ELASTICSEARCH:
-        if (restClient != null) {
-          try {
-            restClient.close();
-          } catch (final IOException ignored) {
-            // ignore it
-          }
-        }
-        restClient =
-            RestClient.builder(HttpHost.create(testStandaloneCamunda.getElasticSearchHostAddress()))
-                .build();
-
-        esClient =
-            new ElasticsearchClient(new RestClientTransport(restClient, new JacksonJsonpMapper()));
-        break;
-      case OPENSEARCH:
-    }
-  }
-
-  private void createRepository(final String basePath) throws IOException {
-    //    final var repository =
-    //        switch (config.repositoryType) {
-    //          case S3 ->
-    //              Repository.of(
-    //                  b ->
-    //                      b.s3(
-    //                          S3Repository.of(
-    //                              sb -> sb.settings(s ->
-    // s.bucket(config.bucket).basePath(basePath)))));
-    //          case GCS ->
-    //              Repository.of(
-    //                  b ->
-    //                      b.gcs(
-    //                          GcsRepository.of(
-    //                              sb -> sb.settings(s ->
-    // s.bucket(config.bucket).basePath(basePath)))));
-    //          case AZURE -> Repository.of(b -> b.azure(ab -> ab.settings(s ->
-    // s.basePath(basePath))));
-    //        };
-    switch (config.databaseType) {
-      case ELASTICSEARCH -> {
-        final var repository =
-            Repository.of(r -> r.fs(rb -> rb.settings(s -> s.location(REPOSITORY_NAME))));
-        final var response =
-            esClient
-                .snapshot()
-                .createRepository(b -> b.repository(repository).name(REPOSITORY_NAME));
-        assertThat(response.acknowledged()).isTrue();
-      }
-      case OPENSEARCH -> {
-        final var repository =
-            org.opensearch.client.opensearch.snapshot.Repository.of(
-                r -> r.type("fs").settings(s -> s.location(REPOSITORY_NAME)));
-        final var response =
-            opensearchClient
-                .snapshot()
-                .createRepository(
-                    b ->
-                        b.repository(repository)
-                            .type("fs")
-                            .name(REPOSITORY_NAME)
-                            .settings(sb -> sb.location(REPOSITORY_NAME)));
-        assertThat(response.acknowledged()).isTrue();
-      }
-    }
-  }
-
-  private void restore(final Collection<String> snapshots) throws IOException {
-    for (final var snapshot : snapshots) {
-      switch (config.databaseType) {
-        case ELASTICSEARCH -> {
-          final var request =
-              RestoreRequest.of(
-                  rb ->
-                      rb.repository(REPOSITORY_NAME)
-                          .snapshot(snapshot)
-                          .indices("*")
-                          .ignoreUnavailable(true)
-                          .waitForCompletion(true));
-          final var response = esClient.snapshot().restore(request);
-          assertThat(response.snapshot().snapshot()).isEqualTo(snapshot);
-        }
-        case OPENSEARCH -> {
-          final var request =
-              org.opensearch.client.opensearch.snapshot.RestoreRequest.of(
-                  rb ->
-                      rb.repository(REPOSITORY_NAME)
-                          .snapshot(snapshot)
-                          .indices("*")
-                          .ignoreUnavailable(true)
-                          .waitForCompletion(true));
-          final var response = opensearchClient.snapshot().restore(request);
-          assertThat(response.snapshot().snapshot()).isEqualTo(snapshot);
-        }
-      }
-    }
-  }
-
-  //  private void startStorageContainer(final BackupRestoreTestConfig config) {
-  //    storagePath = "";
-  //    switch (config.repositoryType) {
-  //      case S3 -> {
-  //        final var minio = new MinioContainer().withDomain("minio.domain", config.bucket);
-  //        storageContainer = minio;
-  //        storageContainer.start();
-  //        storagePath = minio.externalEndpoint();
-  //        createS3Bucket(config, minio);
-  //      }
-  //      case GCS -> {
-  //        final var gcs = new GcsContainer();
-  //        storageContainer = gcs;
-  //        storageContainer.start();
-  //        storagePath = gcs.externalEndpoint();
-  //      }
-  //      case AZURE -> {
-  //        final var azure = new AzuriteContainer();
-  //        azure.start();
-  //        storagePath = azure.getConnectString();
-  //        storageContainer = azure;
-  //      }
-  //      default -> {}
-  //    }
-  //  }
-  //
-  //  private void createS3Bucket(final BackupRestoreTestConfig config, final MinioContainer minio)
-  // {
-  //    final var s3Config =
-  //        new Builder()
-  //            .withBucketName(config.bucket)
-  //            .withEndpoint(minio.externalEndpoint())
-  //            .withRegion(minio.region())
-  //            .withCredentials(minio.accessKey(), minio.secretKey())
-  //            .withApiCallTimeout(Duration.ofSeconds(25))
-  //            .forcePathStyleAccess(true)
-  //            .build();
-  //    try (final var client = S3BackupStore.buildClient(s3Config)) {
-  //      // it's possible to query to fast and get a 503 from the server here, so simply retry
-  // after
-  //      org.awaitility.Awaitility.await("until bucket is created")
-  //          .untilAsserted(
-  //              () ->
-  //                  client
-  //                      .createBucket(builder -> builder.bucket(s3Config.bucketName()).build())
-  //                      .join());
-  //    }
-  //  }
-
-  public record BackupRestoreTestConfig(
-      DatabaseType databaseType, RepositoryType repositoryType, String bucket) {
-    public void configure(
-        final TestStandaloneCamunda testStandaloneCamunda, final Path repositoryDir) {
-      testStandaloneCamunda.withBackupRepository(REPOSITORY_NAME);
-      switch (databaseType) {
-        case ELASTICSEARCH, OPENSEARCH ->
-            testStandaloneCamunda.withDBContainer(
-                c -> {
-                  c.addFileSystemBind(
-                      repositoryDir.toString(),
-                      "/home",
-                      BindMode.READ_WRITE,
-                      SelinuxContext.SHARED);
-                  return c.withEnv("path.repo", "/home");
-                });
-      }
-    }
-  }
-
-
-
-  private void createBackupDbClient() throws Exception {
-    if (backupDbClient != null) {
-      backupDbClient.close();
-    }
-    backupDbClient = BackupDBClient.create(testStandaloneCamunda, config.databaseType);
-  }
-
-
-  public void createSearchClient() {
-    switch (config.databaseType) {
-      case ELASTICSEARCH:
-        final var esContainer = (ElasticsearchContainer) searchContainer;
-        CloseHelper.quietClose(restClient);
-        restClient = RestClient.builder(HttpHost.create(esContainer.getHttpHostAddress())).build();
-
-        esClient =
-            new ElasticsearchClient(new RestClientTransport(restClient, new JacksonJsonpMapper()));
-        break;
-      case OPENSEARCH:
-      default:
-    }
-  }
-
-  private void createRepository() throws IOException {
-    switch (config.databaseType) {
-      case ELASTICSEARCH -> {
-        final var repository =
-            Repository.of(r -> r.fs(rb -> rb.settings(s -> s.location(REPOSITORY_NAME))));
-        final var response =
-            esClient
-                .snapshot()
-                .createRepository(b -> b.repository(repository).name(REPOSITORY_NAME));
-        assertThat(response.acknowledged()).isTrue();
-      }
-      case OPENSEARCH -> {
-        final var repository =
-            org.opensearch.client.opensearch.snapshot.Repository.of(
-                r -> r.type("fs").settings(s -> s.location(REPOSITORY_NAME)));
-        final var response =
-            opensearchClient
-                .snapshot()
-                .createRepository(
-                    b ->
-                        b.repository(repository)
-                            .type("fs")
-                            .name(REPOSITORY_NAME)
-                            .settings(sb -> sb.location(REPOSITORY_NAME)));
-        assertThat(response.acknowledged()).isTrue();
-      }
-      default -> {}
-    }
-  }
-
-  private void restore(final Collection<String> snapshots) throws IOException {
-    for (final var snapshot : snapshots) {
-      switch (config.databaseType) {
-        case ELASTICSEARCH -> {
-          final var request =
-              RestoreRequest.of(
-                  rb ->
-                      rb.repository(REPOSITORY_NAME)
-                          .snapshot(snapshot)
-                          .indices("*")
-                          .ignoreUnavailable(true)
-                          .waitForCompletion(true));
-          final var response = esClient.snapshot().restore(request);
-          assertThat(response.snapshot().snapshot()).isEqualTo(snapshot);
-        }
-        case OPENSEARCH -> {
-          final var request =
-              org.opensearch.client.opensearch.snapshot.RestoreRequest.of(
-                  rb ->
-                      rb.repository(REPOSITORY_NAME)
-                          .snapshot(snapshot)
-                          .indices("*")
-                          .ignoreUnavailable(true)
-                          .waitForCompletion(true));
-          final var response = opensearchClient.snapshot().restore(request);
-          assertThat(response.snapshot().snapshot()).isEqualTo(snapshot);
-        }
-        default -> {}
-      }
-    }
-  }
-
-
   public record BackupRestoreTestConfig(DatabaseType databaseType, String bucket) {}
-  enum RepositoryType {
-    S3,
-    AZURE,
-    GCS;
-  }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/it/backup/DataGenerator.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/backup/DataGenerator.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.client.api.search.response.SearchQueryResponse;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.awaitility.Awaitility;
+import org.hamcrest.Matchers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DataGenerator implements AutoCloseable {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DataGenerator.class);
+  // process id -> process instance key
+  public final ConcurrentSkipListSet<Long> instancekeys = new ConcurrentSkipListSet<>();
+  final String assignee = "user";
+  private CamundaClient camundaClient;
+  private final OneTaskProcess process;
+
+  public DataGenerator(final CamundaClient camundaClient, final String processId) {
+    this.camundaClient = camundaClient;
+    process = new OneTaskProcess(processId);
+  }
+
+  public void generate(final int processNumber) {
+    process.deploy();
+    for (int i = 0; i < processNumber; i++) {
+      process.startProcessInstance(processNumber);
+    }
+    // complete tasks
+    completeTask(process.tasks[0], "var1", processNumber);
+    LOGGER.debug("Service task completed");
+    completeUserTasks(processNumber);
+    LOGGER.debug("User task completed");
+
+    verifyAllExported();
+
+    // wait for everything to be exported
+    LOGGER.info("Finished generating data");
+  }
+
+  public void setCamundaClient(final CamundaClient camundaClient) {
+    this.camundaClient = camundaClient;
+  }
+
+  public void verifyAllExported() {
+    Awaitility.await("until all processes have been exported")
+        .atMost(Duration.ofSeconds(3000))
+        .untilAsserted(
+            () -> {
+              final Future<SearchQueryResponse<ProcessInstance>> response =
+                  camundaClient
+                      .newProcessInstanceQuery()
+                      .filter(
+                          b ->
+                              b.processInstanceKey(p -> p.in(instancekeys.stream().toList()))
+                                  .state("COMPLETED"))
+                      .page(b -> b.limit(instancekeys.size()).from(0))
+                      .send();
+              assertThat(response)
+                  .succeedsWithin(Duration.ofSeconds(30))
+                  .extracting(SearchQueryResponse::items)
+                  .asInstanceOf(InstanceOfAssertFactories.LIST)
+                  .hasSameSizeAs(instancekeys);
+            });
+  }
+
+  private void completeTask(final String jobType, final String varName, final int number) {
+    final var completedJobs = new AtomicInteger(0);
+    final var worker =
+        camundaClient
+            .newWorker()
+            .jobType(jobType)
+            .handler(
+                (jobClient, job) -> {
+                  jobClient
+                      .newCompleteCommand(job.getKey())
+                      .variable(varName, job.getKey())
+                      .send()
+                      .thenRun(completedJobs::incrementAndGet);
+                })
+            .timeout(5000)
+            .name("completeTask");
+    try (final var jobWorker = worker.open()) {
+      Awaitility.await("until all jobs have been completed")
+          .atMost(Duration.ofSeconds(30))
+          .untilAtomic(completedJobs, Matchers.equalTo(number));
+    }
+  }
+
+  private void completeUserTasks(final int number) {
+    final var items =
+        Awaitility.await("all user tasks are ready")
+            .atMost(Duration.ofSeconds(30))
+            .until(
+                () ->
+                    camundaClient
+                        .newUserTaskQuery()
+                        .filter(f -> f.assignee(assignee))
+                        .send()
+                        .join()
+                        .items(),
+                l -> l.size() == number);
+
+    items.forEach(
+        item -> camundaClient.newUserTaskCompleteCommand(item.getUserTaskKey()).send().join());
+  }
+
+  @Override
+  public void close() throws Exception {
+    camundaClient = null;
+  }
+
+  class OneTaskProcess {
+    final String bpmnProcessId;
+
+    private final String[] tasks = {"task1", "userTask"};
+
+    OneTaskProcess(final String bpmnProcessId) {
+      this.bpmnProcessId = bpmnProcessId;
+    }
+
+    private BpmnModelInstance createModel() {
+      return Bpmn.createExecutableProcess(bpmnProcessId)
+          .startEvent("start")
+          .serviceTask(tasks[0])
+          .zeebeJobType(tasks[0])
+          .zeebeInput("=var1", "varIn")
+          .userTask(tasks[1])
+          .zeebeUserTask()
+          .zeebeInput("=var3", "varIn")
+          .zeebeAssignee(assignee)
+          .endEvent()
+          .done();
+    }
+
+    private void startProcessInstance(final Object payload) {
+      final var evt =
+          camundaClient
+              .newCreateInstanceCommand()
+              .bpmnProcessId(bpmnProcessId)
+              .latestVersion()
+              .variables(Map.of("var1", payload))
+              .send()
+              .join();
+      LOGGER.debug("Process instance started with key {}", evt.getProcessInstanceKey());
+      instancekeys.add(evt.getProcessInstanceKey());
+    }
+
+    private void deploy() {
+      final var deployResourceCmd =
+          camundaClient
+              .newDeployResourceCommand()
+              .addProcessModel(process.createModel(), bpmnProcessId + ".bpmn");
+      final var deploymentEvent = deployResourceCmd.send().join();
+      LOGGER.debug("Deployed process {} with key {}", bpmnProcessId, deploymentEvent.getKey());
+    }
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/backup/DataGenerator.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/backup/DataGenerator.java
@@ -61,12 +61,12 @@ public class DataGenerator implements AutoCloseable {
   }
 
   public void verifyAllExported() {
-    verifyAllExported(30);
+    verifyAllExported(120);
   }
 
   public void verifyAllExported(final int timeoutSeconds) {
     Awaitility.await("until all processes have been exported")
-        .atMost(Duration.ofSeconds(30))
+        .atMost(Duration.ofSeconds(timeoutSeconds))
         .untilAsserted(
             () -> {
               final Future<SearchQueryResponse<ProcessInstance>> response =

--- a/qa/integration-tests/src/test/java/io/camunda/it/backup/ESDBClientBackup.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/backup/ESDBClientBackup.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.snapshot.Repository;
+import co.elastic.clients.elasticsearch.snapshot.RestoreRequest;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import io.camunda.qa.util.cluster.TestStandaloneCamunda;
+import java.io.IOException;
+import java.util.Collection;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+
+public class ESDBClientBackup implements BackupDBClient {
+
+  final RestClient restClient;
+  final ElasticsearchClient esClient;
+
+  public ESDBClientBackup(final TestStandaloneCamunda testStandaloneCamunda) throws IOException {
+    restClient =
+        RestClient.builder(HttpHost.create(testStandaloneCamunda.getDBHostAddress())).build();
+    esClient =
+        new ElasticsearchClient(new RestClientTransport(restClient, new JacksonJsonpMapper()));
+  }
+
+  @Override
+  public void restore(final String repositoryName, final Collection<String> snapshots)
+      throws IOException {
+    for (final var snapshot : snapshots) {
+      final var request =
+          RestoreRequest.of(
+              rb ->
+                  rb.repository(repositoryName)
+                      .snapshot(snapshot)
+                      .indices("*")
+                      .ignoreUnavailable(true)
+                      .waitForCompletion(true));
+      final var response = esClient.snapshot().restore(request);
+      assertThat(response.snapshot().snapshot()).isEqualTo(snapshot);
+    }
+  }
+
+  @Override
+  public void createRepository(final String repositoryName) throws IOException {
+    final var repository =
+        Repository.of(r -> r.fs(rb -> rb.settings(s -> s.location(repositoryName))));
+    final var response =
+        esClient.snapshot().createRepository(b -> b.repository(repository).name(repositoryName));
+    assertThat(response.acknowledged()).isTrue();
+  }
+
+  @Override
+  public void close() throws Exception {
+    System.out.println("CLOSING ESDB CLIENT");
+    restClient.close();
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfigurator.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfigurator.java
@@ -93,6 +93,11 @@ public class MultiDbConfigurator {
     operateOpensearch.setIndexPrefix(indexPrefix);
     operateOpensearch.setPassword(userPassword);
     operateOpensearch.setUsername(userName);
+
+    final var zeebeOS = operateProperties.getZeebeOpensearch();
+    zeebeOS.setUrl(opensearchUrl);
+    zeebeOS.setPassword(userPassword);
+    zeebeOS.setUsername(userName);
     tasklistProperties.setDatabase("opensearch");
 
     final TasklistOpenSearchProperties tasklistOpensearch = tasklistProperties.getOpenSearch();
@@ -100,6 +105,12 @@ public class MultiDbConfigurator {
     tasklistOpensearch.setIndexPrefix(indexPrefix);
     tasklistOpensearch.setPassword(userPassword);
     tasklistOpensearch.setUsername(userName);
+
+    final var zeebeTasklistOS = tasklistProperties.getZeebeOpenSearch();
+    zeebeTasklistOS.setUrl(opensearchUrl);
+    zeebeTasklistOS.setPassword(userPassword);
+    zeebeTasklistOS.setUsername(userName);
+
     testApplication.withExporter(
         "CamundaExporter",
         cfg -> {

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfigurator.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfigurator.java
@@ -99,8 +99,8 @@ public class MultiDbConfigurator {
     zeebeOS.setPassword(userPassword);
     zeebeOS.setUsername(userName);
     zeebeOS.setPrefix(indexPrefix);
-    tasklistProperties.setDatabase("opensearch");
 
+    tasklistProperties.setDatabase("opensearch");
     final TasklistOpenSearchProperties tasklistOpensearch = tasklistProperties.getOpenSearch();
     tasklistOpensearch.setUrl(opensearchUrl);
     tasklistOpensearch.setIndexPrefix(indexPrefix);

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfigurator.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfigurator.java
@@ -98,6 +98,7 @@ public class MultiDbConfigurator {
     zeebeOS.setUrl(opensearchUrl);
     zeebeOS.setPassword(userPassword);
     zeebeOS.setUsername(userName);
+    zeebeOS.setPrefix(indexPrefix);
     tasklistProperties.setDatabase("opensearch");
 
     final TasklistOpenSearchProperties tasklistOpensearch = tasklistProperties.getOpenSearch();
@@ -110,6 +111,7 @@ public class MultiDbConfigurator {
     zeebeTasklistOS.setUrl(opensearchUrl);
     zeebeTasklistOS.setPassword(userPassword);
     zeebeTasklistOS.setUsername(userName);
+    zeebeTasklistOS.setPrefix(indexPrefix);
 
     testApplication.withExporter(
         "CamundaExporter",

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -30,10 +30,6 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>camunda-search-client-connect</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>camunda-search-domain</artifactId>
     </dependency>
     <dependency>
@@ -47,11 +43,6 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>elasticsearch</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.opensearch</groupId>
-      <artifactId>opensearch-testcontainers</artifactId>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
@@ -70,10 +61,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-opensearch-exporter</artifactId>
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>

--- a/qa/util/pom.xml
+++ b/qa/util/pom.xml
@@ -30,6 +30,10 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-client-connect</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>camunda-search-domain</artifactId>
     </dependency>
     <dependency>
@@ -44,7 +48,11 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>elasticsearch</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.opensearch</groupId>
+      <artifactId>opensearch-testcontainers</artifactId>
+      <scope>compile</scope>
+    </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-gateway</artifactId>
@@ -63,7 +71,10 @@
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-opensearch-exporter</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-zeebe</artifactId>
@@ -145,6 +156,7 @@
       <groupId>io.camunda</groupId>
       <artifactId>webapps-backup</artifactId>
     </dependency>
+
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-elasticsearch-exporter</artifactId>

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneCamunda.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneCamunda.java
@@ -326,12 +326,6 @@ public final class TestStandaloneCamunda extends TestSpringApplication<TestStand
     return this;
   }
 
-  public TestStandaloneCamunda withBackupRepository(final String repositoryName) {
-    operateProperties.getBackup().setRepositoryName(repositoryName);
-    tasklistProperties.getBackup().setRepositoryName(repositoryName);
-    return this;
-  }
-
   /**
    * Registers or replaces a new exporter with the given ID. If it was already registered, the
    * existing configuration is passed to the modifier.

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneCamunda.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneCamunda.java
@@ -79,7 +79,9 @@ public final class TestStandaloneCamunda extends TestSpringApplication<TestStand
         // test overrides - to control data clean up; (and some components are not installed on
         // Tests)
         TestOperateElasticsearchSchemaManager.class,
+        TestOperateOpensearchSchemaManager.class,
         TestTasklistElasticsearchSchemaManager.class,
+        TestTasklistOpensearchSchemaManager.class,
         TestOperateSchemaStartup.class,
         TestTasklistSchemaStartup.class,
         IndexTemplateDescriptorsConfigurator.class);

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/SnapshotState.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/SnapshotState.java
@@ -11,5 +11,6 @@ public enum SnapshotState {
   FAILED,
   PARTIAL,
   STARTED,
-  SUCCESS;
+  SUCCESS,
+  IN_PROGRESS;
 }

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepositoryTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepositoryTest.java
@@ -92,8 +92,7 @@ class OpensearchBackupRepositoryTest {
                         .snapshot("test-snapshot")
                         .state(SnapshotState.STARTED.name())
                         .startTimeInMillis("23")));
-    final var response =
-        GetSnapshotResponse.of(b -> defaultFields(b).total(1).snapshots(snapshotInfos));
+    final var response = GetSnapshotResponse.of(b -> defaultFields(b).snapshots(snapshotInfos));
 
     when(openSearchClient.snapshot().get((GetSnapshotRequest) any())).thenReturn(response);
 
@@ -237,8 +236,7 @@ class OpensearchBackupRepositoryTest {
                         // end time was double the timeout from now
                         .endTimeInMillis(Long.toString(endtime))));
     when(openSearchClient.snapshot().get((GetSnapshotRequest) any()))
-        .thenReturn(
-            GetSnapshotResponse.of(b -> defaultFields(b).total(1).snapshots(snapshotInfos)));
+        .thenReturn(GetSnapshotResponse.of(b -> defaultFields(b).snapshots(snapshotInfos)));
 
     final var response = repository.getBackupState("repo", 5L);
 
@@ -294,7 +292,6 @@ class OpensearchBackupRepositoryTest {
             GetSnapshotResponse.of(
                 b ->
                     defaultFields(b)
-                        .total(1)
                         .snapshots(
                             List.of(
                                 SnapshotInfo.of(
@@ -446,7 +443,7 @@ class OpensearchBackupRepositoryTest {
   }
 
   private GetSnapshotResponse.Builder defaultFields(final GetSnapshotResponse.Builder b) {
-    return b.total(0).remaining(0);
+    return b.snapshots(List.of());
   }
 
   private GetSnapshotResponse emptyResponse() {


### PR DESCRIPTION
## Description
Adds support for a test case using OpenSearch

- missing IN_PROGRESS enum case in opensearch `SnapshotState`
- basic test with OS has been added, but it was failing because the OS java client is broken on the snapshot API. Fortunately, this bug was just fixed, so I bumped the version and cleaned up some code that's not in use anymore in optimize (part of the code in optimize was also a for this OS client bug)


## Related issues
relates  #25935 
