### PR TITLE
feat: c8run build script to use CI Nexus cache

### DIFF
--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -35,6 +35,18 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c # v3.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/distribution/ci NEXUS_USERNAME;
+            secret/data/products/distribution/ci NEXUS_PASSWORD;
+
       - name: print architecture
         run: arch
 
@@ -56,6 +68,8 @@ jobs:
         working-directory: ./c8run
         env:
           GH_TOKEN: ${{ github.token }}
+          JAVA_ARTIFACTS_USER: ${{ steps.secrets.outputs.NEXUS_USERNAME }}
+          JAVA_ARTIFACTS_PASSWORD: ${{ steps.secrets.outputs.NEXUS_PASSWORD }}
 
       - name: ls
         run: ls
@@ -130,6 +144,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c # v3.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/distribution/ci NEXUS_USERNAME;
+            secret/data/products/distribution/ci NEXUS_PASSWORD;
+
       - uses: actions/setup-go@v5
         with:
           go-version: '>=1.23.1'
@@ -144,6 +170,8 @@ jobs:
         working-directory: .\c8run
         env:
           GH_TOKEN: ${{ github.token }}
+          JAVA_ARTIFACTS_USER: ${{ steps.secrets.outputs.NEXUS_USERNAME }}
+          JAVA_ARTIFACTS_PASSWORD: ${{ steps.secrets.outputs.NEXUS_PASSWORD }}
 
       - name: ls
         run: ls

--- a/c8run/internal/archive/archive.go
+++ b/c8run/internal/archive/archive.go
@@ -35,7 +35,10 @@ func DownloadFile(filepath string, url string, authToken string) error {
 	if err != nil {
 		return fmt.Errorf("DownloadFile: failed to create request for url: %s\n%w\n%s", url)
 	}
-	if authToken != "" {
+
+	if strings.HasPrefix(authToken, "Basic ") {
+		req.Header.Add("Authorization", authToken)
+	} else if authToken != "" {
 		req.Header.Add("Authorization", "Bearer "+authToken)
 	}
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fetch connectors JAR for C8Run indirectly, via authenticated CI Cache and not Artifactory directly, saving on traffic costs.

- CI Cache credentials fetched from Vault and attributed to the Distro team.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
