### PR TITLE
Add AuthorizationState create method

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedAuthorization.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedAuthorization.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.authorization;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import io.camunda.zeebe.db.DbValue;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public class PersistedAuthorization extends UnpackedObject implements DbValue {
+
+  private final LongProperty authorizationKeyProp = new LongProperty("authorizationKey");
+  private final StringProperty ownerIdProp = new StringProperty("ownerId", "");
+  private final EnumProperty<AuthorizationOwnerType> ownerTypeProp =
+      new EnumProperty<>(
+          "ownerType", AuthorizationOwnerType.class, AuthorizationOwnerType.UNSPECIFIED);
+  private final StringProperty resourceIdProp = new StringProperty("resourceId");
+  private final EnumProperty<AuthorizationResourceType> resourceTypeProp =
+      new EnumProperty<>("resourceType", AuthorizationResourceType.class);
+  private final ArrayProperty<StringValue> authorizationPermissionsProp =
+      new ArrayProperty<>("authorizationPermissions", StringValue::new);
+
+  public PersistedAuthorization() {
+    super(6);
+    declareProperty(authorizationKeyProp)
+        .declareProperty(ownerIdProp)
+        .declareProperty(ownerTypeProp)
+        .declareProperty(resourceIdProp)
+        .declareProperty(resourceTypeProp)
+        .declareProperty(authorizationPermissionsProp);
+  }
+
+  public void wrap(final AuthorizationRecord authorizationRecord) {
+    setAuthorizationKey(authorizationRecord.getAuthorizationKey())
+        .setOwnerId(authorizationRecord.getOwnerId())
+        .setOwnerType(authorizationRecord.getOwnerType())
+        .setResourceId(authorizationRecord.getResourceId())
+        .setResourceType(authorizationRecord.getResourceType())
+        .setAuthorizationPermissions(authorizationRecord.getAuthorizationPermissions());
+  }
+
+  public long getAuthorizationKey() {
+    return authorizationKeyProp.getValue();
+  }
+
+  public PersistedAuthorization setAuthorizationKey(final long authorizationKey) {
+    authorizationKeyProp.setValue(authorizationKey);
+    return this;
+  }
+
+  public String getOwnerId() {
+    return bufferAsString(ownerIdProp.getValue());
+  }
+
+  public PersistedAuthorization setOwnerId(final String ownerId) {
+    ownerIdProp.setValue(ownerId);
+    return this;
+  }
+
+  public AuthorizationOwnerType getOwnerType() {
+    return ownerTypeProp.getValue();
+  }
+
+  public PersistedAuthorization setOwnerType(final AuthorizationOwnerType ownerType) {
+    ownerTypeProp.setValue(ownerType);
+    return this;
+  }
+
+  public String getResourceId() {
+    return bufferAsString(resourceIdProp.getValue());
+  }
+
+  public PersistedAuthorization setResourceId(final String resourceId) {
+    resourceIdProp.setValue(resourceId);
+    return this;
+  }
+
+  public AuthorizationResourceType getResourceType() {
+    return resourceTypeProp.getValue();
+  }
+
+  public PersistedAuthorization setResourceType(final AuthorizationResourceType resourceType) {
+    resourceTypeProp.setValue(resourceType);
+    return this;
+  }
+
+  public Set<PermissionType> getAuthorizationPermissions() {
+    return StreamSupport.stream(authorizationPermissionsProp.spliterator(), false)
+        .map(StringValue::getValue)
+        .map(BufferUtil::bufferAsString)
+        .map(PermissionType::valueOf)
+        .collect(Collectors.toSet());
+  }
+
+  public PersistedAuthorization setAuthorizationPermissions(
+      final Set<PermissionType> authorizationPermissions) {
+    authorizationPermissionsProp.reset();
+    authorizationPermissions.forEach(
+        permission ->
+            authorizationPermissionsProp.add().wrap(BufferUtil.wrapString(permission.name())));
+    return this;
+  }
+
+  public PersistedAuthorization addAuthorizationPermission(final PermissionType permission) {
+    authorizationPermissionsProp.add().wrap(BufferUtil.wrapString(permission.name()));
+    return this;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedAuthorization.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedAuthorization.java
@@ -28,15 +28,14 @@ import java.util.stream.StreamSupport;
 public class PersistedAuthorization extends UnpackedObject implements DbValue {
 
   private final LongProperty authorizationKeyProp = new LongProperty("authorizationKey");
-  private final StringProperty ownerIdProp = new StringProperty("ownerId", "");
+  private final StringProperty ownerIdProp = new StringProperty("ownerId");
   private final EnumProperty<AuthorizationOwnerType> ownerTypeProp =
-      new EnumProperty<>(
-          "ownerType", AuthorizationOwnerType.class, AuthorizationOwnerType.UNSPECIFIED);
+      new EnumProperty<>("ownerType", AuthorizationOwnerType.class);
   private final StringProperty resourceIdProp = new StringProperty("resourceId");
   private final EnumProperty<AuthorizationResourceType> resourceTypeProp =
       new EnumProperty<>("resourceType", AuthorizationResourceType.class);
-  private final ArrayProperty<StringValue> authorizationPermissionsProp =
-      new ArrayProperty<>("authorizationPermissions", StringValue::new);
+  private final ArrayProperty<StringValue> permissionsProp =
+      new ArrayProperty<>("permissions", StringValue::new);
 
   public PersistedAuthorization() {
     super(6);
@@ -45,7 +44,7 @@ public class PersistedAuthorization extends UnpackedObject implements DbValue {
         .declareProperty(ownerTypeProp)
         .declareProperty(resourceIdProp)
         .declareProperty(resourceTypeProp)
-        .declareProperty(authorizationPermissionsProp);
+        .declareProperty(permissionsProp);
   }
 
   public void wrap(final AuthorizationRecord authorizationRecord) {
@@ -54,7 +53,7 @@ public class PersistedAuthorization extends UnpackedObject implements DbValue {
         .setOwnerType(authorizationRecord.getOwnerType())
         .setResourceId(authorizationRecord.getResourceId())
         .setResourceType(authorizationRecord.getResourceType())
-        .setAuthorizationPermissions(authorizationRecord.getAuthorizationPermissions());
+        .setPermissions(authorizationRecord.getAuthorizationPermissions());
   }
 
   public long getAuthorizationKey() {
@@ -102,25 +101,23 @@ public class PersistedAuthorization extends UnpackedObject implements DbValue {
     return this;
   }
 
-  public Set<PermissionType> getAuthorizationPermissions() {
-    return StreamSupport.stream(authorizationPermissionsProp.spliterator(), false)
+  public Set<PermissionType> getPermissions() {
+    return StreamSupport.stream(permissionsProp.spliterator(), false)
         .map(StringValue::getValue)
         .map(BufferUtil::bufferAsString)
         .map(PermissionType::valueOf)
         .collect(Collectors.toSet());
   }
 
-  public PersistedAuthorization setAuthorizationPermissions(
-      final Set<PermissionType> authorizationPermissions) {
-    authorizationPermissionsProp.reset();
-    authorizationPermissions.forEach(
-        permission ->
-            authorizationPermissionsProp.add().wrap(BufferUtil.wrapString(permission.name())));
+  public PersistedAuthorization setPermissions(final Set<PermissionType> permissions) {
+    permissionsProp.reset();
+    permissions.forEach(
+        permission -> permissionsProp.add().wrap(BufferUtil.wrapString(permission.name())));
     return this;
   }
 
-  public PersistedAuthorization addAuthorizationPermission(final PermissionType permission) {
-    authorizationPermissionsProp.add().wrap(BufferUtil.wrapString(permission.name()));
+  public PersistedAuthorization addPermission(final PermissionType permission) {
+    permissionsProp.add().wrap(BufferUtil.wrapString(permission.name()));
     return this;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AuthorizationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AuthorizationState.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.state.immutable;
 
+import io.camunda.zeebe.engine.state.authorization.PersistedAuthorization;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -14,6 +15,8 @@ import java.util.Optional;
 import java.util.Set;
 
 public interface AuthorizationState {
+  Optional<PersistedAuthorization> get(final long authorizationKey);
+
   Set<String> getResourceIdentifiers(
       Long ownerKey, AuthorizationResourceType resourceType, final PermissionType permissionType);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableAuthorizationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableAuthorizationState.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.mutable;
 
 import io.camunda.zeebe.engine.state.immutable.AuthorizationState;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -31,6 +32,14 @@ public interface MutableAuthorizationState extends AuthorizationState {
       AuthorizationResourceType resourceType,
       PermissionType permissionType,
       Set<String> resourceIds);
+
+  /**
+   * Stores the provided authorization in the state.
+   *
+   * @param authorizationKey the key of the authorization
+   * @param authorization the authorization record to store
+   */
+  void create(final long authorizationKey, final AuthorizationRecord authorization);
 
   /**
    * Removes the resource ids for the provided ownerKey, resourceType, permissionType. If there are

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
@@ -75,8 +75,7 @@ public class AuthorizationStateTest {
     assertThat(authorization.getOwnerType()).isEqualTo(ownerType);
     assertThat(authorization.getResourceId()).isEqualTo(resourceId);
     assertThat(authorization.getResourceType()).isEqualTo(resourceType);
-    assertThat(authorization.getAuthorizationPermissions())
-        .containsExactlyInAnyOrderElementsOf(permissions);
+    assertThat(authorization.getPermissions()).containsExactlyInAnyOrderElementsOf(permissions);
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Add `create` and `get` methods to the `AuthorizationState`. The PR also implements a `PersistedAuthorization` class that will store the `AuthorizationRecord` data.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #27026
