### PR TITLE
feat: c8run build script to use CI Nexus cache

### DIFF
--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -35,6 +35,18 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c # v3.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/distribution/ci NEXUS_USERNAME;
+            secret/data/products/distribution/ci NEXUS_PASSWORD;
+
       - name: print architecture
         run: arch
 
@@ -43,6 +55,8 @@ jobs:
         working-directory: ./c8run
         env:
           GH_TOKEN: ${{ github.token }}
+          JAVA_ARTIFACTS_USER: ${{ steps.secrets.outputs.NEXUS_USERNAME }}
+          JAVA_ARTIFACTS_PASSWORD: ${{ steps.secrets.outputs.NEXUS_PASSWORD }}
 
       - if: ${{ matrix.os == 'macos-13' }}
         name: Set env
@@ -108,11 +122,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c # v3.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/distribution/ci NEXUS_USERNAME;
+            secret/data/products/distribution/ci NEXUS_PASSWORD;
+
       - name: make a package
         run: .\package.bat
         working-directory: .\c8run
         env:
           GH_TOKEN: ${{ github.token }}
+          JAVA_ARTIFACTS_USER: ${{ steps.secrets.outputs.NEXUS_USERNAME }}
+          JAVA_ARTIFACTS_PASSWORD: ${{ steps.secrets.outputs.NEXUS_PASSWORD }}
 
       - uses: actions/setup-java@v4
         with:

--- a/c8run/package.bat
+++ b/c8run/package.bat
@@ -7,6 +7,16 @@ set ELASTICSEARCH_VERSION=8.13.4
 set BASEDIR=%~dp0
 echo BASEDIR=%BASEDIR%
 
+if not defined JAVA_ARTIFACTS_USER (
+    echo Error: JAVA_ARTIFACTS_USER env var not set or is empty.
+    exit /b 1
+)
+
+if not defined JAVA_ARTIFACTS_PASSWORD (
+    echo Error: JAVA_ARTIFACTS_PASSWORD env var is not set or is empty.
+    exit /b 1
+)
+
 REM Delete testing data before tar
 rmdir /S /Q elasticsearch-%ELASTICSEARCH_VERSION%
 rmdir /S /Q camunda-zeebe-%CAMUNDA_VERSION%
@@ -27,9 +37,8 @@ tar -xf camunda-zeebe-%CAMUNDA_VERSION%.zip -C %BASEDIR%
 
 set connectorsFileName=connector-runtime-bundle-%CAMUNDA_CONNECTORS_VERSION%-with-dependencies.jar
 if not exist "%connectorsFileName%" (
-    curl -L -o "%connectorsFileName%" "https://artifacts.camunda.com/artifactory/connectors/io/camunda/connector/connector-runtime-bundle/%CAMUNDA_CONNECTORS_VERSION%/%connectorsFileName%"
+    curl -L --user "%JAVA_ARTIFACTS_USER%:%JAVA_ARTIFACTS_PASSWORD%" -o "%connectorsFileName%" "https://repository.nexus.camunda.cloud/content/groups/internal/io/camunda/connector/connector-runtime-bundle/%CAMUNDA_CONNECTORS_VERSION%/%connectorsFileName%"
 )
-
 
 go build -C windows -trimpath -o ..\c8run.exe
 

--- a/c8run/package.sh
+++ b/c8run/package.sh
@@ -25,6 +25,11 @@ elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
     export PLATFORM=linux
 fi
 
+if [ -z "$JAVA_ARTIFACTS_USER" ] || [ -z "$JAVA_ARTIFACTS_PASSWORD" ]; then
+  echo "Error: JAVA_ARTIFACTS_USER or JAVA_ARTIFACTS_PASSWORD env vars are not set or are empty."
+  exit 1
+fi
+
 # Retrieve elasticsearch
 if [ ! -d "elasticsearch-$ELASTICSEARCH_VERSION" ]; then
   wget -q "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}-${PLATFORM}-${architecture}.tar.gz"
@@ -38,7 +43,7 @@ fi
 
 connectorsFileName="connector-runtime-bundle-$CAMUNDA_CONNECTORS_VERSION-with-dependencies.jar"
 if [ ! -f "$connectorsFileName" ]; then
-  wget -q "https://artifacts.camunda.com/artifactory/connectors/io/camunda/connector/connector-runtime-bundle/$CAMUNDA_CONNECTORS_VERSION/$connectorsFileName"
+  wget -q --user="$JAVA_ARTIFACTS_USER" --password="$JAVA_ARTIFACTS_PASSWORD" "https://repository.nexus.camunda.cloud/content/groups/internal/io/camunda/connector/connector-runtime-bundle/$CAMUNDA_CONNECTORS_VERSION/$connectorsFileName"
 fi
 
 tar -czf camunda8-run-$CAMUNDA_VERSION-$PLATFORM-$architecture.tar.gz \


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fetch connectors JAR for C8Run indirectly, via authenticated CI Cache and not Artifactory directly, saving on traffic costs.

- CI Cache credentials fetched from Vault and attributed to the Distro team.

This is a backport of https://github.com/camunda/camunda/pull/27031 to 8.6

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
