### PR TITLE
ci: fix variable substitution for e2e tests

### DIFF
--- a/.github/workflows/zeebe-e2e-testbench.yaml
+++ b/.github/workflows/zeebe-e2e-testbench.yaml
@@ -78,23 +78,23 @@ jobs:
       processId: e2e_testbench_protocol
       variables: >
         {
-        \"zeebeImage\":\"$IMAGE\",
-        \"generationTemplate\":\"${{ inputs.generation || 'Zeebe SNAPSHOT' }}\",
-        \"channel\": \"Internal Dev\",
-        \"branch\": \"${{ inputs.branch || 'main' }}\",
-        \"build\":  \"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\",
-        \"clusterPlan\":\"${{ inputs.clusterPlan }}\",
-        \"region\":\"Chaos, Belgium, Europe (europe-west1)\",
-        \"properties\":[\"allInstancesAreCompleted\"],
-        \"testProcessId\": \"e2e-test\",
-        \"testParams\":
-        {
-        \"maxTestDuration\": \"${{ inputs.maxTestDuration || 'P5D' }}\",
-        \"starter\": [ {\"rate\": 20, \"processId\": \"one-task-one-timer\" },
-                       {\"rate\": 10, \"processId\": \"ping-pong-message\" } ],
-        \"verifier\" : { \"maxInstanceDuration\" : \"${{ inputs.maxInstanceDuration }}\" },
-        \"fault\": ${{ inputs.fault || 'null' }}
-        }
+          "zeebeImage": "$IMAGE",
+          "generationTemplate": "${{ inputs.generation || 'Zeebe SNAPSHOT' }}",
+          "channel": "Internal Dev",
+          "branch": "${{ inputs.branch || 'main' }}",
+          "build":  "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+          "clusterPlan": "${{ inputs.clusterPlan }}",
+          "region": "Chaos, Belgium, Europe (europe-west1)",
+          "properties": ["allInstancesAreCompleted"],
+          "testProcessId": "e2e-test",
+          "testParams":
+            {
+              "maxTestDuration": "${{ inputs.maxTestDuration || 'P5D' }}",
+              "starter": [{"rate": 20, "processId": "one-task-one-timer" },
+                          {"rate": 10, "processId": "ping-pong-message" } ],
+              "verifier": { "maxInstanceDuration" : "${{ inputs.maxInstanceDuration }}" },
+              "fault": ${{ inputs.fault || 'null' }}
+            }
         }
       branch: ${{ inputs.branch }}
     secrets: inherit


### PR DESCRIPTION
The JSON variables need to be provided un-escaped because the testbench workflow no longer does this for us.

closes #27042
