### PR TITLE
fix: use global prefix in TaskTemplate

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/schema/IndexTemplateDescriptorsConfigurator.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/IndexTemplateDescriptorsConfigurator.java
@@ -141,8 +141,11 @@ public class IndexTemplateDescriptorsConfigurator {
   }
 
   @Bean
-  public TaskTemplate getTaskTemplate(final DatabaseInfo databaseInfo) {
-    return new TaskTemplate("", databaseInfo.isElasticsearchDb());
+  public TaskTemplate getTaskTemplate(
+      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
+    return new TaskTemplate(
+        operateProperties.getIndexPrefix(databaseInfo.getCurrent()),
+        databaseInfo.isElasticsearchDb());
   }
 
   @Bean


### PR DESCRIPTION
## Description

* use global prefix in TaskTemplate: this helps when running E2E tests with `make start-e2e`, as we define `e2eoperate` index prefix there
* take into account JOIN field when querying for user tasks: since we joined index with Tasklist task index, we now store hierarchies of documents using "join" field type (similar to `list-view` index). This means that one index stores not only tasks, but also process instances and variables. Therefore to make sure that we search for tasks and not variables e.g. we should put additional filter on `join` field.