### PR TITLE
refactor: get tenant by id instead of key

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -1545,10 +1545,10 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *  .send();
    * </pre>
    *
-   * @param tenantKey the key of the tenant to delete
+   * @param tenantId the id of the tenant to delete
    * @return a builder for the delete tenant command
    */
-  DeleteTenantCommandStep1 newDeleteTenantCommand(long tenantKey);
+  DeleteTenantCommandStep1 newDeleteTenantCommand(String tenantId);
 
   /**
    * Command to assign a mapping rule to a tenant.

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -1526,15 +1526,15 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * <pre>
    * camundaClient
-   *   .newUpdateTenantCommand(12345L) // Specify the tenant key
+   *   .newUpdateTenantCommand("my-tenant-id") // Specify the tenant id
    *   .name("Updated Tenant Name")   // Set the new tenant name
    *   .send();                       // Send the command to the broker
    * </pre>
    *
-   * @param tenantKey the unique identifier of the tenant to be updated
+   * @param tenantId the unique identifier of the tenant to be updated
    * @return a builder to configure and send the update tenant command
    */
-  UpdateTenantCommandStep1 newUpdateTenantCommand(long tenantKey);
+  UpdateTenantCommandStep1 newUpdateTenantCommand(String tenantId);
 
   /**
    * Command to delete a tenant.

--- a/clients/java/src/main/java/io/camunda/client/api/command/DeleteTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/DeleteTenantCommandStep1.java
@@ -19,10 +19,10 @@ import io.camunda.client.api.response.DeleteTenantResponse;
 
 public interface DeleteTenantCommandStep1 extends FinalCommandStep<DeleteTenantResponse> {
   /**
-   * Set the tenant key for the tenant to be deleted.
+   * Set the tenant id for the tenant to be deleted.
    *
-   * @param tenantKey the unique tenant key
+   * @param tenantId the unique tenant id
    * @return the builder for this command
    */
-  DeleteTenantCommandStep1 tenantKey(long tenantKey);
+  DeleteTenantCommandStep1 tenantId(String tenantId);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/response/CreateTenantResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/CreateTenantResponse.java
@@ -22,4 +22,10 @@ public interface CreateTenantResponse {
    * @return the key of the created tenant.
    */
   long getTenantKey();
+
+  /** Returns the id of the created tenant. */
+  String getTenantId();
+
+  /** Returns the name of the created tenant. */
+  String getName();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -874,8 +874,8 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public DeleteTenantCommandStep1 newDeleteTenantCommand(final long tenantKey) {
-    return new DeleteTenantCommandImpl(httpClient).tenantKey(tenantKey);
+  public DeleteTenantCommandStep1 newDeleteTenantCommand(final String tenantId) {
+    return new DeleteTenantCommandImpl(httpClient).tenantId(tenantId);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -869,8 +869,8 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public UpdateTenantCommandStep1 newUpdateTenantCommand(final long tenantKey) {
-    return new UpdateTenantCommandImpl(httpClient, jsonMapper, tenantKey);
+  public UpdateTenantCommandStep1 newUpdateTenantCommand(final String tenantId) {
+    return new UpdateTenantCommandImpl(httpClient, jsonMapper, tenantId);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/DeleteTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/DeleteTenantCommandImpl.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 public final class DeleteTenantCommandImpl implements DeleteTenantCommandStep1 {
-  private long tenantKey;
+  private String tenantId;
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
 
@@ -36,8 +36,8 @@ public final class DeleteTenantCommandImpl implements DeleteTenantCommandStep1 {
   }
 
   @Override
-  public DeleteTenantCommandStep1 tenantKey(final long tenantKey) {
-    this.tenantKey = tenantKey;
+  public DeleteTenantCommandStep1 tenantId(final String tenantId) {
+    this.tenantId = tenantId;
     return this;
   }
 
@@ -50,7 +50,7 @@ public final class DeleteTenantCommandImpl implements DeleteTenantCommandStep1 {
   @Override
   public CamundaFuture<DeleteTenantResponse> send() {
     final HttpCamundaFuture<DeleteTenantResponse> result = new HttpCamundaFuture<>();
-    httpClient.delete("/tenants/" + tenantKey, httpRequestConfig.build(), result);
+    httpClient.delete("/tenants/" + tenantId, httpRequestConfig.build(), result);
     return result;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateTenantCommandImpl.java
@@ -34,15 +34,15 @@ public final class UpdateTenantCommandImpl implements UpdateTenantCommandStep1 {
   private final JsonMapper jsonMapper;
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
-  private final long tenantKey;
+  private final String tenantId;
 
   public UpdateTenantCommandImpl(
-      final HttpClient httpClient, final JsonMapper jsonMapper, final long tenantKey) {
+      final HttpClient httpClient, final JsonMapper jsonMapper, final String tenantId) {
     request = new TenantUpdateRequest();
     this.httpClient = httpClient;
     this.jsonMapper = jsonMapper;
     httpRequestConfig = httpClient.newRequestConfig();
-    this.tenantKey = tenantKey;
+    this.tenantId = tenantId;
   }
 
   @Override
@@ -64,7 +64,7 @@ public final class UpdateTenantCommandImpl implements UpdateTenantCommandStep1 {
     final UpdateTenantResponseImpl response = new UpdateTenantResponseImpl();
 
     httpClient.patch(
-        "/tenants/" + tenantKey,
+        "/tenants/" + tenantId,
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
         TenantUpdateResult.class,

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateTenantResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateTenantResponseImpl.java
@@ -20,14 +20,28 @@ import io.camunda.client.protocol.rest.TenantCreateResult;
 
 public class CreateTenantResponseImpl implements CreateTenantResponse {
   private long tenantKey;
+  private String tenantId;
+  private String name;
 
   @Override
   public long getTenantKey() {
     return tenantKey;
   }
 
+  @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
   public CreateTenantResponseImpl setResponse(final TenantCreateResult response) {
     tenantKey = Long.parseLong(response.getTenantKey());
+    tenantId = response.getTenantId();
+    name = response.getName();
     return this;
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/tenant/DeleteTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/DeleteTenantTest.java
@@ -27,27 +27,27 @@ import org.junit.jupiter.api.Test;
 
 public class DeleteTenantTest extends ClientRestTest {
 
-  private static final long TENANT_KEY = 123L;
+  private static final String TENANT_ID = "my-tenant-id";
 
   @Test
   void shouldDeleteTenant() {
     // when
-    client.newDeleteTenantCommand(TENANT_KEY).send().join();
+    client.newDeleteTenantCommand(TENANT_ID).send().join();
 
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();
-    assertThat(requestPath).isEqualTo(REST_API_PATH + "/tenants/" + TENANT_KEY);
+    assertThat(requestPath).isEqualTo(REST_API_PATH + "/tenants/" + TENANT_ID);
   }
 
   @Test
   void shouldRaiseExceptionOnNotFoundTenant() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_KEY,
+        REST_API_PATH + "/tenants/" + TENANT_ID,
         () -> new ProblemDetail().title("Not Found").status(404));
 
     // when / then
-    assertThatThrownBy(() -> client.newDeleteTenantCommand(TENANT_KEY).send().join())
+    assertThatThrownBy(() -> client.newDeleteTenantCommand(TENANT_ID).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -56,11 +56,11 @@ public class DeleteTenantTest extends ClientRestTest {
   void shouldHandleServerError() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_KEY,
+        REST_API_PATH + "/tenants/" + TENANT_ID,
         () -> new ProblemDetail().title("Internal Server Error").status(500));
 
     // when / then
-    assertThatThrownBy(() -> client.newDeleteTenantCommand(TENANT_KEY).send().join())
+    assertThatThrownBy(() -> client.newDeleteTenantCommand(TENANT_ID).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 500: 'Internal Server Error'");
   }
@@ -69,11 +69,11 @@ public class DeleteTenantTest extends ClientRestTest {
   void shouldRaiseExceptionOnForbiddenRequest() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_KEY,
+        REST_API_PATH + "/tenants/" + TENANT_ID,
         () -> new ProblemDetail().title("Forbidden").status(403));
 
     // when / then
-    assertThatThrownBy(() -> client.newDeleteTenantCommand(TENANT_KEY).send().join())
+    assertThatThrownBy(() -> client.newDeleteTenantCommand(TENANT_ID).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 403: 'Forbidden'");
   }

--- a/clients/java/src/test/java/io/camunda/client/tenant/UpdateTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/UpdateTenantTest.java
@@ -27,13 +27,13 @@ import org.junit.jupiter.api.Test;
 
 public class UpdateTenantTest extends ClientRestTest {
 
-  private static final long TENANT_KEY = 123L;
+  private static final String TENANT_ID = "my-tenant-id";
   private static final String UPDATED_NAME = "Updated Tenant Name";
 
   @Test
   void shouldUpdateTenant() {
     // when
-    client.newUpdateTenantCommand(TENANT_KEY).name(UPDATED_NAME).send().join();
+    client.newUpdateTenantCommand(TENANT_ID).name(UPDATED_NAME).send().join();
 
     // then
     final TenantUpdateRequest request = gatewayService.getLastRequest(TenantUpdateRequest.class);
@@ -43,7 +43,7 @@ public class UpdateTenantTest extends ClientRestTest {
   @Test
   void shouldRaiseExceptionOnNullName() {
     // when / then
-    assertThatThrownBy(() -> client.newUpdateTenantCommand(TENANT_KEY).name(null).send().join())
+    assertThatThrownBy(() -> client.newUpdateTenantCommand(TENANT_ID).name(null).send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("name must not be null");
   }
@@ -52,12 +52,12 @@ public class UpdateTenantTest extends ClientRestTest {
   void shouldRaiseExceptionOnNotFoundTenant() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_KEY,
+        REST_API_PATH + "/tenants/" + TENANT_ID,
         () -> new ProblemDetail().title("Not Found").status(404));
 
     // when / then
     assertThatThrownBy(
-            () -> client.newUpdateTenantCommand(TENANT_KEY).name(UPDATED_NAME).send().join())
+            () -> client.newUpdateTenantCommand(TENANT_ID).name(UPDATED_NAME).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -72,7 +72,9 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
   }
 
   public CompletableFuture<TenantRecord> updateTenant(final TenantDTO request) {
-    return sendBrokerRequest(new BrokerTenantUpdateRequest(request.key()).setName(request.name()));
+    final var tenantEntity = getById(request.tenantId());
+    return sendBrokerRequest(
+        new BrokerTenantUpdateRequest(tenantEntity.key()).setName(request.name()));
   }
 
   public CompletableFuture<TenantRecord> deleteTenant(final long key) {

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -72,9 +72,8 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
   }
 
   public CompletableFuture<TenantRecord> updateTenant(final TenantDTO request) {
-    final var tenantEntity = getById(request.tenantId());
     return sendBrokerRequest(
-        new BrokerTenantUpdateRequest(tenantEntity.key()).setName(request.name()));
+        new BrokerTenantUpdateRequest(request.tenantId()).setName(request.name()));
   }
 
   public CompletableFuture<TenantRecord> deleteTenant(final String tenantId) {

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -77,8 +77,9 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
         new BrokerTenantUpdateRequest(tenantEntity.key()).setName(request.name()));
   }
 
-  public CompletableFuture<TenantRecord> deleteTenant(final long key) {
-    return sendBrokerRequest(new BrokerTenantDeleteRequest(key));
+  public CompletableFuture<TenantRecord> deleteTenant(final String tenantId) {
+    final var tenantEntity = getById(tenantId);
+    return sendBrokerRequest(new BrokerTenantDeleteRequest(tenantEntity.key()));
   }
 
   public TenantEntity getByKey(final Long tenantKey) {

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -78,8 +78,7 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
   }
 
   public CompletableFuture<TenantRecord> deleteTenant(final String tenantId) {
-    final var tenantEntity = getById(tenantId);
-    return sendBrokerRequest(new BrokerTenantDeleteRequest(tenantEntity.key()));
+    return sendBrokerRequest(new BrokerTenantDeleteRequest(tenantId));
   }
 
   public TenantEntity getByKey(final Long tenantKey) {

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -80,10 +80,6 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
     return sendBrokerRequest(new BrokerTenantDeleteRequest(tenantId));
   }
 
-  public TenantEntity getByKey(final Long tenantKey) {
-    return getSingle(TenantQuery.of(q -> q.filter(f -> f.key(tenantKey))));
-  }
-
   public CompletableFuture<TenantRecord> addMember(
       final Long tenantKey, final EntityType entityType, final long entityKey) {
     return sendBrokerRequest(

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -86,7 +86,7 @@ public class TenantServiceTest {
     when(client.searchTenants(any())).thenReturn(result);
 
     // when
-    final var searchQueryResult = services.getByKey(100L);
+    final var searchQueryResult = services.getById("tenant-id");
 
     // then
     assertThat(searchQueryResult).isEqualTo(tenantEntity);
@@ -100,7 +100,7 @@ public class TenantServiceTest {
     when(client.searchTenants(any())).thenReturn(result);
 
     // when
-    final var searchQueryResult = services.getByKey(100L);
+    final var searchQueryResult = services.getById("tenant-id");
 
     // then
     assertThat(searchQueryResult).isEqualTo(tenantEntity);
@@ -109,12 +109,11 @@ public class TenantServiceTest {
   @Test
   public void shouldThrowExceptionIfNotFoundByKey() {
     // given
-    final var key = 100L;
     when(client.searchTenants(any())).thenReturn(new SearchQueryResult(0, List.of(), null, null));
 
     // when / then
 
-    assertThatCode(() -> services.getByKey(key))
+    assertThatCode(() -> services.getById("non-existent-tenant-id"))
         .isInstanceOf(NotFoundException.class)
         .hasMessageMatching("Tenant matching TenantQuery\\[.*] not found");
   }

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -145,7 +145,6 @@ public class TenantServiceTest {
         new TenantDTO(tenantEntity.key(), tenantEntity.tenantId(), "UpdatedTenantId");
 
     // when
-    when(client.searchTenants(any())).thenReturn(result);
     services.updateTenant(tenantDTO);
 
     // then
@@ -153,7 +152,7 @@ public class TenantServiceTest {
     assertThat(request.getIntent()).isEqualTo(TenantIntent.UPDATE);
     assertThat(request.getValueType()).isEqualTo(ValueType.TENANT);
     final TenantRecord brokerRequestValue = request.getRequestWriter();
-    assertThat(brokerRequestValue.getTenantKey()).isEqualTo(tenantDTO.key());
+    assertThat(brokerRequestValue.getTenantId()).isEqualTo(tenantDTO.tenantId());
     assertThat(brokerRequestValue.getName()).isEqualTo(tenantDTO.name());
   }
 

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -159,19 +159,14 @@ public class TenantServiceTest {
 
   @Test
   public void shouldDeleteTenant() {
-    // Given
-    final var result =
-        new SearchQueryResult<>(1, List.of(tenantEntity), Arrays.array(), Arrays.array());
-
     // when
-    when(client.searchTenants(any())).thenReturn(result);
     services.deleteTenant(tenantEntity.tenantId());
 
     // then
     final BrokerTenantDeleteRequest request = stubbedBrokerClient.getSingleBrokerRequest();
     assertThat(request.getIntent()).isEqualTo(TenantIntent.DELETE);
     assertThat(request.getValueType()).isEqualTo(ValueType.TENANT);
-    assertThat(request.getRequestWriter().getTenantKey()).isEqualTo(tenantEntity.key());
+    assertThat(request.getRequestWriter().getTenantId()).isEqualTo(tenantEntity.tenantId());
   }
 
   @ParameterizedTest

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -137,10 +137,15 @@ public class TenantServiceTest {
 
   @Test
   public void shouldUpdateTenantName() {
+
     // given
-    final var tenantDTO = new TenantDTO(100L, "ignored", "UpdatedTenantId");
+    final var result =
+        new SearchQueryResult<>(1, List.of(tenantEntity), Arrays.array(), Arrays.array());
+    final var tenantDTO =
+        new TenantDTO(tenantEntity.key(), tenantEntity.tenantId(), "UpdatedTenantId");
 
     // when
+    when(client.searchTenants(any())).thenReturn(result);
     services.updateTenant(tenantDTO);
 
     // then

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -159,14 +159,19 @@ public class TenantServiceTest {
 
   @Test
   public void shouldDeleteTenant() {
+    // Given
+    final var result =
+        new SearchQueryResult<>(1, List.of(tenantEntity), Arrays.array(), Arrays.array());
+
     // when
-    services.deleteTenant(100L);
+    when(client.searchTenants(any())).thenReturn(result);
+    services.deleteTenant(tenantEntity.tenantId());
 
     // then
     final BrokerTenantDeleteRequest request = stubbedBrokerClient.getSingleBrokerRequest();
     assertThat(request.getIntent()).isEqualTo(TenantIntent.DELETE);
     assertThat(request.getValueType()).isEqualTo(ValueType.TENANT);
-    assertThat(request.getRequestWriter().getTenantKey()).isEqualTo(100L);
+    assertThat(request.getRequestWriter().getTenantKey()).isEqualTo(tenantEntity.key());
   }
 
   @ParameterizedTest

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
@@ -21,12 +21,12 @@ import io.camunda.zeebe.engine.state.immutable.TenantState;
 import io.camunda.zeebe.engine.state.tenant.PersistedTenant;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
-import org.apache.commons.lang3.StringUtils;
 
 public class TenantUpdateProcessor implements DistributedTypedRecordProcessor<TenantRecord> {
 
@@ -57,24 +57,15 @@ public class TenantUpdateProcessor implements DistributedTypedRecordProcessor<Te
   public void processNewCommand(final TypedRecord<TenantRecord> command) {
 
     final var record = command.getValue();
-    final var tenantKey = record.getTenantKey();
+    final var tenantId = record.getTenantId();
 
-    final var persistedTenant = tenantState.getTenantByKey(tenantKey);
+    final var persistedTenant = tenantState.getTenantById(tenantId);
     if (persistedTenant.isEmpty()) {
       rejectCommand(
           command,
           RejectionType.NOT_FOUND,
-          "Expected to update tenant with key '%s', but no tenant with this key exists."
-              .formatted(tenantKey));
-      return;
-    }
-
-    if (!StringUtils.isEmpty(record.getTenantId())) {
-      rejectCommand(
-          command,
-          RejectionType.INVALID_ARGUMENT,
-          "Tenant ID cannot be updated. Expected no tenant ID, but received '%s'."
-              .formatted(record.getTenantId()));
+          "Expected to update tenant with id '%s', but no tenant with this id exists."
+              .formatted(tenantId));
       return;
     }
 
@@ -126,15 +117,15 @@ public class TenantUpdateProcessor implements DistributedTypedRecordProcessor<Te
         persistedTenant.getTenantKey(), TenantIntent.UPDATED, updatedRecord);
     responseWriter.writeEventOnCommand(
         persistedTenant.getTenantKey(), TenantIntent.UPDATED, updatedRecord, command);
-    distributeCommand(command);
+    distributeUpdate(updatedRecord);
   }
 
-  private void distributeCommand(final TypedRecord<TenantRecord> command) {
+  private void distributeUpdate(final TenantRecord updatedTenant) {
     final long distributionKey = keyGenerator.nextKey();
     commandDistributionBehavior
         .withKey(distributionKey)
         .inQueue(DistributionQueue.IDENTITY.getQueueId())
-        .distribute(command);
+        .distribute(ValueType.TENANT, TenantIntent.UPDATE, updatedTenant);
   }
 
   private void rejectCommandWithUnauthorizedError(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/TenantState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/TenantState.java
@@ -67,4 +67,7 @@ public interface TenantState {
    * visited.
    */
   void forEachTenant(final Function<String, Boolean> callback);
+
+  /** Retrieves a tenant record by its ID. */
+  Optional<PersistedTenant> getTenantById(String tenantId);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/DbTenantState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/DbTenantState.java
@@ -164,4 +164,10 @@ public class DbTenantState implements MutableTenantState {
   public void forEachTenant(final Function<String, Boolean> callback) {
     tenantsColumnFamily.whileTrue((k, p) -> callback.apply(p.getTenantId()));
   }
+
+  @Override
+  public Optional<PersistedTenant> getTenantById(final String tenantId) {
+    // TODO: Change cfs to look up by id directly
+    return getTenantKeyById(tenantId).flatMap(this::getTenantByKey);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -418,7 +418,7 @@ public class CommandDistributionIdempotencyTest {
                   final var tenant = createTenant();
                   ENGINE
                       .tenant()
-                      .updateTenant(tenant.getKey())
+                      .updateTenant(tenant.getValue().getTenantId())
                       .withName(UUID.randomUUID().toString())
                       .update();
                 },

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -404,7 +404,7 @@ public class CommandDistributionIdempotencyTest {
                 TenantIntent.DELETE,
                 () -> {
                   final var tenant = createTenant();
-                  ENGINE.tenant().deleteTenant(tenant.getKey()).delete();
+                  ENGINE.tenant().deleteTenant(tenant.getValue().getTenantId()).delete();
                 },
                 2),
             TenantDeleteProcessor.class

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/DeleteTenantMultiPartitionTest.java
@@ -39,7 +39,7 @@ public class DeleteTenantMultiPartitionTest {
     final var tenantId = UUID.randomUUID().toString();
     final var tenantKey =
         engine.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
-    engine.tenant().deleteTenant(tenantKey).delete();
+    engine.tenant().deleteTenant(tenantId).delete();
 
     assertThat(
             RecordingExporter.records()
@@ -96,7 +96,7 @@ public class DeleteTenantMultiPartitionTest {
             .create()
             .getValue()
             .getTenantKey();
-    engine.tenant().deleteTenant(tenantKey).delete().getValue();
+    engine.tenant().deleteTenant(tenantId).delete().getValue();
     assertThat(
             RecordingExporter.commandDistributionRecords()
                 .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
@@ -121,7 +121,7 @@ public class DeleteTenantMultiPartitionTest {
             .create()
             .getValue()
             .getTenantKey();
-    engine.tenant().deleteTenant(tenantKey).delete();
+    engine.tenant().deleteTenant(tenantId).delete();
 
     engine.increaseTime(Duration.ofMinutes(1));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessorTest.java
@@ -45,7 +45,7 @@ public class TenantDeleteProcessorTest {
         .isNotNull();
 
     // When
-    engine.tenant().deleteTenant(tenantKey).delete();
+    engine.tenant().deleteTenant(tenantId).delete();
 
     // Then confirms the Tenant.DELETED event was written
     assertThat(
@@ -61,15 +61,15 @@ public class TenantDeleteProcessorTest {
   @Test
   public void shouldRejectIfTenantDoesNotExist() {
     // When
-    final var notPresentTenantKey = 1L;
+    final var notPresentTenantId = UUID.randomUUID().toString();
     final var rejectedDeleteRecord =
-        engine.tenant().deleteTenant(notPresentTenantKey).expectRejection().delete();
+        engine.tenant().deleteTenant(notPresentTenantId).expectRejection().delete();
     // Then
     assertThat(rejectedDeleteRecord)
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
-            "Expected to delete tenant with key '%s', but no tenant with this key exists."
-                .formatted(notPresentTenantKey));
+            "Expected to delete tenant with id '%s', but no tenant with this id exists."
+                .formatted(notPresentTenantId));
   }
 
   @Test
@@ -105,7 +105,7 @@ public class TenantDeleteProcessorTest {
         .add();
 
     // When: delete the tenant
-    final var deletedTenant = engine.tenant().deleteTenant(tenantKey).delete().getValue();
+    final var deletedTenant = engine.tenant().deleteTenant(tenantId).delete().getValue();
 
     // Then: verify the ENTITY_REMOVED and DELETED events
     final var tenantRecords =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/UpdateTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/UpdateTenantMultiPartitionTest.java
@@ -40,16 +40,15 @@ public class UpdateTenantMultiPartitionTest {
   public void shouldDistributeTenantUpdateCommand() {
     // when
     final var tenantId = UUID.randomUUID().toString();
-    final var tenantKey =
-        engine
-            .tenant()
-            .newTenant()
-            .withTenantId(tenantId)
-            .withName("Tenant 1")
-            .create()
-            .getValue()
-            .getTenantKey();
-    engine.tenant().updateTenant(tenantKey).withName("Tenant 2").update();
+    engine
+        .tenant()
+        .newTenant()
+        .withTenantId(tenantId)
+        .withName("Tenant 1")
+        .create()
+        .getValue()
+        .getTenantKey();
+    engine.tenant().updateTenant(tenantId).withName("Tenant 2").update();
 
     RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
         .withDistributionIntent(TenantIntent.CREATE)
@@ -105,9 +104,8 @@ public class UpdateTenantMultiPartitionTest {
   public void shouldDistributeInIdentityQueue() {
     // when
     final var tenantId = UUID.randomUUID().toString();
-    final var tenantRecord =
-        engine.tenant().newTenant().withTenantId(tenantId).withName("Tenant 1").create();
-    engine.tenant().updateTenant(tenantRecord.getKey()).withName("Tenant 2").update();
+    engine.tenant().newTenant().withTenantId(tenantId).withName("Tenant 1").create();
+    engine.tenant().updateTenant(tenantId).withName("Tenant 2").update();
 
     // then
     assertThat(
@@ -126,16 +124,15 @@ public class UpdateTenantMultiPartitionTest {
     }
     final var tenantId = UUID.randomUUID().toString();
     final var name = UUID.randomUUID().toString();
-    final var tenantKey =
-        engine
-            .tenant()
-            .newTenant()
-            .withTenantId(tenantId)
-            .withName(name)
-            .create()
-            .getValue()
-            .getTenantKey();
-    engine.tenant().updateTenant(tenantKey).withName(name + "-updated").update();
+    engine
+        .tenant()
+        .newTenant()
+        .withTenantId(tenantId)
+        .withName(name)
+        .create()
+        .getValue()
+        .getTenantKey();
+    engine.tenant().updateTenant(tenantId).withName(name + "-updated").update();
 
     // Increase time to trigger a redistribution
     engine.increaseTime(Duration.ofMinutes(1));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/UpdateTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/UpdateTenantTest.java
@@ -35,11 +35,7 @@ public class UpdateTenantTest {
     // when
     final var newName = "Updated Tenant Name";
     final var updatedTenantRecord =
-        ENGINE
-            .tenant()
-            .updateTenant(createdRecord.getValue().getTenantKey())
-            .withName(newName)
-            .update();
+        ENGINE.tenant().updateTenant(tenantId).withName(newName).update();
 
     // then
     final var updatedTenant = updatedTenantRecord.getValue();
@@ -54,11 +50,11 @@ public class UpdateTenantTest {
         ENGINE.tenant().newTenant().withTenantId(tenantId).withName("Existing Tenant").create();
 
     // when
-    final var nonExistentTenantKey = 1L;
+    final var nonExistentTenantId = UUID.randomUUID().toString();
     final var notPresentUpdateRecord =
         ENGINE
             .tenant()
-            .updateTenant(nonExistentTenantKey)
+            .updateTenant(nonExistentTenantId)
             .withName("New Tenant Name")
             .expectRejection()
             .update();
@@ -72,40 +68,8 @@ public class UpdateTenantTest {
     assertThat(notPresentUpdateRecord)
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
-            "Expected to update tenant with key '"
-                + nonExistentTenantKey
-                + "', but no tenant with this key exists.");
-  }
-
-  @Test
-  public void shouldRejectIfTryToUpdateTenantId() {
-    // given
-    final var tenantId = "tenant-original-id";
-    final var updatedTenant = "tenant-updated-id";
-    final var tenantKey =
-        ENGINE
-            .tenant()
-            .newTenant()
-            .withTenantId(tenantId)
-            .withName("Tenant Name")
-            .create()
-            .getValue()
-            .getTenantKey();
-
-    // when
-    final var updateRecord =
-        ENGINE
-            .tenant()
-            .updateTenant(tenantKey)
-            .withTenantId(updatedTenant)
-            .expectRejection()
-            .update();
-
-    // then
-    assertThat(updateRecord)
-        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
-        .hasRejectionReason(
-            "Tenant ID cannot be updated. Expected no tenant ID, but received '%s'."
-                .formatted(updatedTenant));
+            "Expected to update tenant with id '"
+                + nonExistentTenantId
+                + "', but no tenant with this id exists.");
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/tenant/DbTenantStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/tenant/DbTenantStateTest.java
@@ -318,4 +318,22 @@ public class DbTenantStateTest {
     assertThat(entities.get(EntityType.USER)).containsExactly(100L);
     assertThat(entities.get(EntityType.MAPPING)).containsExactly(200L);
   }
+
+  @Test
+  void shouldFindTenantById() {
+    // given
+    final long tenantKey = 1L;
+    final String tenantId = "tenant-1";
+    final var tenantRecord =
+        new TenantRecord().setTenantKey(tenantKey).setTenantId(tenantId).setName("Tenant One");
+
+    tenantState.createTenant(tenantRecord);
+
+    // when
+    final var tenant = tenantState.getTenantById(tenantId);
+
+    // then
+    assertThat(tenant).isPresent();
+    assertThat(tenant.get().getTenantKey()).isEqualTo(tenantKey);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/TenantClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/TenantClient.java
@@ -74,11 +74,11 @@ public class TenantClient {
    * Creates a new {@link TenantDeleteClient} for deleting a tenant. The client uses the internal
    * command writer to submit the delete tenant commands.
    *
-   * @param tenantKey the key of the tenant to be deleted
+   * @param tenantId the id of the tenant to be deleted
    * @return a new instance of {@link TenantDeleteClient}
    */
-  public TenantDeleteClient deleteTenant(final long tenantKey) {
-    return new TenantDeleteClient(writer, tenantKey);
+  public TenantDeleteClient deleteTenant(final String tenantId) {
+    return new TenantDeleteClient(writer, tenantId);
   }
 
   public static class TenantCreationClient {
@@ -359,10 +359,10 @@ public class TenantClient {
     private final TenantRecord tenantRecord;
     private Function<Long, Record<TenantRecordValue>> expectation = SUCCESS_SUPPLIER;
 
-    public TenantDeleteClient(final CommandWriter writer, final long tenantKey) {
+    public TenantDeleteClient(final CommandWriter writer, final String tenantId) {
       this.writer = writer;
       tenantRecord = new TenantRecord();
-      tenantRecord.setTenantKey(tenantKey);
+      tenantRecord.setTenantId(tenantId);
     }
 
     /**

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/TenantClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/TenantClient.java
@@ -37,11 +37,11 @@ public class TenantClient {
    * Creates a new {@link TenantUpdateClient} for updating a tenant. The client uses the internal
    * command writer to submit tenant update commands.
    *
-   * @param tenantKey the key of the tenant to be updated
+   * @param tenantId the id of the tenant to be updated
    * @return a new instance of {@link TenantUpdateClient}
    */
-  public TenantUpdateClient updateTenant(final long tenantKey) {
-    return new TenantUpdateClient(writer, tenantKey);
+  public TenantUpdateClient updateTenant(final String tenantId) {
+    return new TenantUpdateClient(writer, tenantId);
   }
 
   /**
@@ -182,10 +182,10 @@ public class TenantClient {
     private final TenantRecord tenantRecord;
     private Function<Long, Record<TenantRecordValue>> expectation = SUCCESS_SUPPLIER;
 
-    public TenantUpdateClient(final CommandWriter writer, final long tenantKey) {
+    public TenantUpdateClient(final CommandWriter writer, final String tenantId) {
       this.writer = writer;
       tenantRecord = new TenantRecord();
-      tenantRecord.setTenantKey(tenantKey);
+      tenantRecord.setTenantId(tenantId);
     }
 
     /**

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -464,8 +464,6 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
-
-  /tenants/{tenantKey}:
     patch:
       tags:
         - Tenant

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -471,13 +471,12 @@ paths:
       summary: Update tenant
       description: Updates an existing tenant.
       parameters:
-        - name: tenantKey
+        - name: tenantId
           in: path
           required: true
           description: The unique identifier of the tenant.
           schema:
-            type: integer
-            format: int64
+            type: string
       requestBody:
         content:
           application/json:
@@ -521,13 +520,12 @@ paths:
       summary: Delete tenant
       description: Deletes an existing tenant.
       parameters:
-        - name: tenantKey
+        - name: tenantId
           in: path
           required: true
           description: The unique identifier of the tenant.
           schema:
-            type: integer
-            format: int64
+            type: string
       responses:
         "204":
           description: The tenant was deleted successfully.

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -419,6 +419,52 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /tenants/{tenantId}:
+    get:
+      tags:
+        - Tenant
+      operationId: getTenant
+      summary: Get tenant
+      description: Retrieves a single tenant by tenant ID.
+      parameters:
+        - name: tenantId
+          in: path
+          required: true
+          description: The unique identifier of the tenant.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The tenant was retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TenantResult"
+            application/vnd.camunda.api.keys.number+json:
+              schema:
+                $ref: "#/components/schemas/TenantItem"
+            application/vnd.camunda.api.keys.string+json:
+              schema:
+                $ref: "#/components/schemas/TenantResult"
+        "400":
+          description: The provided data is not valid.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: Tenant not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   /tenants/{tenantKey}:
     patch:
       tags:
@@ -463,52 +509,6 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           description: Not found. The tenant was not found.
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ProblemDetail"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-
-    get:
-      tags:
-        - Tenant
-      operationId: getTenant
-      summary: Get tenant
-      description: Retrieves a single tenant by tenant Key.
-      parameters:
-        - name: tenantKey
-          in: path
-          required: true
-          description: The unique identifier of the tenant.
-          schema:
-            type: integer
-            format: int64
-      responses:
-        "200":
-          description: The tenant was retrieved successfully.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/TenantResult"
-            application/vnd.camunda.api.keys.number+json:
-              schema:
-                $ref: "#/components/schemas/TenantItem"
-            application/vnd.camunda.api.keys.string+json:
-              schema:
-                $ref: "#/components/schemas/TenantResult"
-        "400":
-          description: The provided data is not valid.
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ProblemDetail"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "403":
-          $ref: "#/components/responses/Forbidden"
-        "404":
-          description: Tenant not found.
           content:
             application/problem+json:
               schema:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3993,7 +3993,7 @@ components:
       type: object
       properties:
         tenantKey:
-          description: The external key of the created tenant
+          description: The unique system-generated internal tenant ID.
           type: string
         tenantId:
           type: string

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -396,12 +396,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/TenantCreateResult"
-            application/vnd.camunda.api.keys.number+json:
-              schema:
-                $ref: "#/components/schemas/TenantCreateResponse"
-            application/vnd.camunda.api.keys.string+json:
-              schema:
-                $ref: "#/components/schemas/TenantCreateResult"
         "400":
           description: The provided data is not valid.
           content:
@@ -3995,20 +3989,18 @@ components:
       required:
         - tenantId
 
-    TenantCreateResponse:
-      deprecated: true
-      type: object
-      properties:
-        tenantKey:
-          description: The external key of the created tenant
-          type: integer
-          format: int64
     TenantCreateResult:
       type: object
       properties:
         tenantKey:
           description: The external key of the created tenant
           type: string
+        tenantId:
+          type: string
+          description: The unique external tenant ID
+        name:
+          type: string
+          description: The name of the tenant.
 
     TenantUpdateRequest:
       type: object

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -779,10 +779,10 @@ public class RequestMapper {
   }
 
   public static Either<ProblemDetail, TenantDTO> toTenantUpdateDto(
-      final Long tenantKey, final TenantUpdateRequest tenantUpdateRequest) {
+      final String tenantId, final TenantUpdateRequest tenantUpdateRequest) {
     return getResult(
         TenantRequestValidator.validateTenantUpdateRequest(tenantUpdateRequest),
-        () -> new TenantDTO(tenantKey, null, tenantUpdateRequest.getName()));
+        () -> new TenantDTO(null, tenantId, tenantUpdateRequest.getName()));
   }
 
   private static List<ProcessInstanceModificationActivateInstruction>

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -51,7 +51,7 @@ import io.camunda.zeebe.gateway.protocol.rest.MessageCorrelationResponse;
 import io.camunda.zeebe.gateway.protocol.rest.MessagePublicationResponse;
 import io.camunda.zeebe.gateway.protocol.rest.RoleCreateResponse;
 import io.camunda.zeebe.gateway.protocol.rest.SignalBroadcastResponse;
-import io.camunda.zeebe.gateway.protocol.rest.TenantCreateResponse;
+import io.camunda.zeebe.gateway.protocol.rest.TenantCreateResult;
 import io.camunda.zeebe.gateway.protocol.rest.TenantUpdateResponse;
 import io.camunda.zeebe.gateway.protocol.rest.UserCreateResponse;
 import io.camunda.zeebe.msgpack.value.LongValue;
@@ -484,7 +484,11 @@ public final class ResponseMapper {
   }
 
   public static ResponseEntity<Object> toTenantCreateResponse(final TenantRecord record) {
-    final var response = new TenantCreateResponse().tenantKey(record.getTenantKey());
+    final var response =
+        new TenantCreateResult()
+            .tenantKey(Long.toString(record.getTenantKey()))
+            .tenantId(record.getTenantId())
+            .name(record.getName());
     return new ResponseEntity<>(response, HttpStatus.CREATED);
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -49,13 +49,14 @@ public class TenantController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createTenant);
   }
 
-  private CompletableFuture<ResponseEntity<Object>> createTenant(final TenantDTO tenantDTO) {
-    return RequestMapper.executeServiceMethod(
-        () ->
-            tenantServices
-                .withAuthentication(RequestMapper.getAuthentication())
-                .createTenant(tenantDTO),
-        ResponseMapper::toTenantCreateResponse);
+  @CamundaGetMapping(path = "/{tenantId}")
+  public ResponseEntity<TenantItem> getTenant(@PathVariable final String tenantId) {
+    try {
+      return ResponseEntity.ok()
+          .body(SearchQueryResponseMapper.toTenant(tenantServices.getById(tenantId)));
+    } catch (final Exception exception) {
+      return RestErrorMapper.mapErrorToResponse(exception);
+    }
   }
 
   @CamundaPatchMapping(path = "/{tenantKey}")

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -84,14 +84,14 @@ public class TenantController {
                 .addMember(tenantKey, EntityType.USER, userKey));
   }
 
-  @CamundaDeleteMapping(path = "/{tenantKey}")
+  @CamundaDeleteMapping(path = "/{tenantId}")
   public CompletableFuture<ResponseEntity<Object>> deleteTenant(
-      @PathVariable final long tenantKey) {
+      @PathVariable final String tenantId) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             tenantServices
                 .withAuthentication(RequestMapper.getAuthentication())
-                .deleteTenant(tenantKey));
+                .deleteTenant(tenantId));
   }
 
   @CamundaPutMapping(path = "/{tenantKey}/mapping-rules/{mappingKey}")

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -66,11 +66,11 @@ public class TenantController {
         .fold(RestErrorMapper::mapProblemToResponse, this::search);
   }
 
-  @CamundaPatchMapping(path = "/{tenantKey}")
+  @CamundaPatchMapping(path = "/{tenantId}")
   public CompletableFuture<ResponseEntity<Object>> updateTenant(
-      @PathVariable final long tenantKey,
+      @PathVariable final String tenantId,
       @RequestBody final TenantUpdateRequest tenantUpdateRequest) {
-    return RequestMapper.toTenantUpdateDto(tenantKey, tenantUpdateRequest)
+    return RequestMapper.toTenantUpdateDto(tenantId, tenantUpdateRequest)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::updateTenant);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -209,24 +209,24 @@ public class TenantControllerTest extends RestControllerTest {
   @Test
   void deleteTenantShouldReturnNoContent() {
     // given
-    final long key = 1234L;
+    final String tenantId = "tenant-to-delete-id";
 
-    final var tenantRecord = new TenantRecord().setTenantKey(key);
+    final var tenantRecord = new TenantRecord().setTenantId(tenantId);
 
-    when(tenantServices.deleteTenant(key))
+    when(tenantServices.deleteTenant(tenantId))
         .thenReturn(CompletableFuture.completedFuture(tenantRecord));
 
     // when
     webClient
         .delete()
-        .uri(TENANT_BASE_URL + "/{key}", key)
+        .uri(TENANT_BASE_URL + "/{tenantId}", tenantId)
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
         .isNoContent();
 
     // then
-    verify(tenantServices, times(1)).deleteTenant(key);
+    verify(tenantServices, times(1)).deleteTenant(tenantId);
   }
 
   @ParameterizedTest

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -110,7 +110,7 @@ public class TenantControllerTest extends RestControllerTest {
     final var tenantKey = 100L;
     final var tenantName = "Updated Tenant Name";
     final var tenantId = "tenant-test-id";
-    when(tenantServices.updateTenant(new TenantDTO(tenantKey, null, tenantName)))
+    when(tenantServices.updateTenant(new TenantDTO(null, tenantId, tenantName)))
         .thenReturn(
             CompletableFuture.completedFuture(
                 new TenantRecord()
@@ -121,7 +121,7 @@ public class TenantControllerTest extends RestControllerTest {
     // when
     webClient
         .patch()
-        .uri("%s/%s".formatted(TENANT_BASE_URL, tenantKey))
+        .uri("%s/%s".formatted(TENANT_BASE_URL, tenantId))
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(new TenantUpdateRequest().name(tenantName))
@@ -140,7 +140,7 @@ public class TenantControllerTest extends RestControllerTest {
                 .formatted(tenantKey, tenantId, tenantName));
 
     // then
-    verify(tenantServices, times(1)).updateTenant(new TenantDTO(tenantKey, null, tenantName));
+    verify(tenantServices, times(1)).updateTenant(new TenantDTO(null, tenantId, tenantName));
   }
 
   @Test
@@ -178,10 +178,11 @@ public class TenantControllerTest extends RestControllerTest {
   @Test
   void updateNonExistingTenantShouldReturnError() {
     // given
+    final var tenantId = "tenant-id";
+    final var tenantName = "My tenant";
     final var tenantKey = 100L;
-    final var tenantName = "Updated Tenant Name";
-    final var path = "%s/%s".formatted(TENANT_BASE_URL, tenantKey);
-    when(tenantServices.updateTenant(new TenantDTO(tenantKey, null, tenantName)))
+    final var path = "%s/%s".formatted(TENANT_BASE_URL, tenantId);
+    when(tenantServices.updateTenant(new TenantDTO(null, tenantId, tenantName)))
         .thenReturn(
             CompletableFuture.failedFuture(
                 new CamundaBrokerException(
@@ -202,7 +203,7 @@ public class TenantControllerTest extends RestControllerTest {
         .expectStatus()
         .isNotFound();
 
-    verify(tenantServices, times(1)).updateTenant(new TenantDTO(tenantKey, null, tenantName));
+    verify(tenantServices, times(1)).updateTenant(new TenantDTO(null, tenantId, tenantName));
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -74,6 +74,45 @@ public class TenantControllerTest extends RestControllerTest {
   }
 
   @Test
+  void createTenantShouldReturnAllDetails() {
+    // given
+    final var tenantName = "Test Tenant";
+    final var tenantId = "tenant-test-id";
+    final var tenantKey = 100L;
+    when(tenantServices.createTenant(new TenantDTO(null, tenantId, tenantName)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new TenantRecord()
+                    .setTenantKey(tenantKey)
+                    .setName(tenantName)
+                    .setTenantId(tenantId)));
+
+    // when
+    webClient
+        .post()
+        .uri(TENANT_BASE_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(new TenantCreateRequest().name(tenantName).tenantId(tenantId))
+        .exchange()
+        .expectStatus()
+        .isCreated()
+        .expectBody()
+        .json(
+            """
+            {
+              "tenantKey": "%d",
+              "tenantId": "%s",
+              "name": "%s"
+            }
+            """
+                .formatted(tenantKey, tenantId, tenantName));
+
+    // then
+    verify(tenantServices, times(1)).createTenant(new TenantDTO(null, tenantId, tenantName));
+  }
+
+  @Test
   void createTenantWithEmptyTenantIdShouldFail() {
     // given
     final var tenantName = "Tenant Name";

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -129,12 +129,12 @@ public class TenantQueryControllerTest extends RestControllerTest {
     final var tenantName = "Tenant Name";
     final var tenantId = "tenant-id";
     final var tenant = new TenantEntity(100L, tenantId, tenantName, Set.of());
-    when(tenantServices.getByKey(tenant.key())).thenReturn(tenant);
+    when(tenantServices.getById(tenant.tenantId())).thenReturn(tenant);
 
     // when
     webClient
         .get()
-        .uri("%s/%s".formatted(TENANT_BASE_URL, tenant.key()))
+        .uri("%s/%s".formatted(TENANT_BASE_URL, tenant.tenantId()))
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
@@ -152,15 +152,15 @@ public class TenantQueryControllerTest extends RestControllerTest {
                 .formatted(tenant.key(), tenantName, tenantId));
 
     // then
-    verify(tenantServices, times(1)).getByKey(tenant.key());
+    verify(tenantServices, times(1)).getById(tenant.tenantId());
   }
 
   @Test
   void getNonExistingTenantShouldReturnNotFound() {
     // given
-    final var tenantKey = 100L;
-    final var path = "%s/%s".formatted(TENANT_BASE_URL, tenantKey);
-    when(tenantServices.getByKey(tenantKey)).thenThrow(new NotFoundException("tenant not found"));
+    final var tenantId = "non-existing-tenant";
+    final var path = "%s/%s".formatted(TENANT_BASE_URL, tenantId);
+    when(tenantServices.getById(tenantId)).thenThrow(new NotFoundException("tenant not found"));
 
     // when
     webClient
@@ -183,7 +183,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
                 .formatted(path));
 
     // then
-    verify(tenantServices, times(1)).getByKey(tenantKey);
+    verify(tenantServices, times(1)).getById(tenantId);
   }
 
   @Test

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/tenant/BrokerTenantDeleteRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/tenant/BrokerTenantDeleteRequest.java
@@ -18,14 +18,14 @@ public class BrokerTenantDeleteRequest extends BrokerExecuteCommand<TenantRecord
 
   private final TenantRecord requestDto = new TenantRecord();
 
-  public BrokerTenantDeleteRequest(final long key) {
+  public BrokerTenantDeleteRequest(final String tenantId) {
     super(ValueType.TENANT, TenantIntent.DELETE);
     setPartitionId(Protocol.DEPLOYMENT_PARTITION);
-    setTenantKey(key);
+    setTenantId(tenantId);
   }
 
-  public BrokerTenantDeleteRequest setTenantKey(final long tenantKey) {
-    requestDto.setTenantKey(tenantKey);
+  public BrokerTenantDeleteRequest setTenantId(final String tenantId) {
+    requestDto.setTenantId(tenantId);
     return this;
   }
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/tenant/BrokerTenantUpdateRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/tenant/BrokerTenantUpdateRequest.java
@@ -17,10 +17,10 @@ import org.agrona.DirectBuffer;
 public class BrokerTenantUpdateRequest extends BrokerExecuteCommand<TenantRecord> {
   private final TenantRecord tenantDto = new TenantRecord();
 
-  public BrokerTenantUpdateRequest(final long key) {
+  public BrokerTenantUpdateRequest(final String tenantId) {
     super(ValueType.TENANT, TenantIntent.UPDATE);
     setPartitionId(Protocol.DEPLOYMENT_PARTITION);
-    tenantDto.setTenantKey(key);
+    tenantDto.setTenantId(tenantId);
   }
 
   public BrokerTenantUpdateRequest setName(final String name) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/DeleteTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/DeleteTenantTest.java
@@ -24,11 +24,12 @@ import org.junit.jupiter.api.Test;
 @ZeebeIntegration
 class DeleteTenantTest {
 
+  private static final String TENANT_ID = "tenant-id";
+
   @TestZeebe
   private final TestStandaloneBroker zeebe = new TestStandaloneBroker().withRecordingExporter(true);
 
   @AutoClose private CamundaClient client;
-
   private long tenantKey;
 
   @BeforeEach
@@ -37,7 +38,7 @@ class DeleteTenantTest {
     tenantKey =
         client
             .newCreateTenantCommand()
-            .tenantId("tenant-id")
+            .tenantId(TENANT_ID)
             .name("Tenant Name")
             .send()
             .join()
@@ -47,7 +48,7 @@ class DeleteTenantTest {
   @Test
   void shouldDeleteTenant() {
     // when
-    client.newDeleteTenantCommand(tenantKey).send().join();
+    client.newDeleteTenantCommand(TENANT_ID).send().join();
 
     // then
     ZeebeAssertHelper.assertTenantDeleted(
@@ -57,14 +58,14 @@ class DeleteTenantTest {
   @Test
   void shouldRejectIfTenantDoesNotExist() {
     // given
-    final long nonExistentTenantKey = 999999L;
+    final var nonExistentTenantId = "does-not-exist";
 
     // when / then
-    assertThatThrownBy(() -> client.newDeleteTenantCommand(nonExistentTenantKey).send().join())
+    assertThatThrownBy(() -> client.newDeleteTenantCommand(nonExistentTenantId).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
         .hasMessageContaining(
-            "Expected to delete tenant with key '%d', but no tenant with this key exists."
-                .formatted(nonExistentTenantKey));
+            "Expected to delete tenant with id '%s', but no tenant with this id exists."
+                .formatted(nonExistentTenantId));
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UpdateTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UpdateTenantTest.java
@@ -50,7 +50,7 @@ class UpdateTenantTest {
   @Test
   void shouldUpdateTenantName() {
     // when
-    client.newUpdateTenantCommand(tenantKey).name(UPDATED_TENANT_NAME).send().join();
+    client.newUpdateTenantCommand(TENANT_ID).name(UPDATED_TENANT_NAME).send().join();
 
     // then
     ZeebeAssertHelper.assertTenantUpdated(
@@ -60,7 +60,7 @@ class UpdateTenantTest {
   @Test
   void shouldRejectUpdateIfNameIsNull() {
     // when / then
-    assertThatThrownBy(() -> client.newUpdateTenantCommand(tenantKey).name(null).send().join())
+    assertThatThrownBy(() -> client.newUpdateTenantCommand(TENANT_ID).name(null).send().join())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("name must not be null");
   }
@@ -68,18 +68,18 @@ class UpdateTenantTest {
   @Test
   void shouldRejectUpdateIfTenantDoesNotExist() {
     // when / then
-    final long notExistingTenantKey = 67677634L;
+    final String notExistingTenantId = "does-not-exist";
     assertThatThrownBy(
             () ->
                 client
-                    .newUpdateTenantCommand(67677634L)
+                    .newUpdateTenantCommand(notExistingTenantId)
                     .name("Non-Existent Tenant Name")
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
         .hasMessageContaining(
-            "Expected to update tenant with key '%d', but no tenant with this key exists."
-                .formatted(notExistingTenantKey));
+            "Expected to update tenant with id '%s', but no tenant with this id exists."
+                .formatted(notExistingTenantId));
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR achieves two goals:
1. Neatens/restructures the tenant controller to match CRUD ordering/access levels
2. Reactors the getTenant endpoint to use tenant id instead of tenant key

## Related issues

closes #27054
closes #27055
closes #27056
closes #27057