### PR TITLE
refactor: refactor getOrLegacyOrDefault method name and parameters

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/CamundaClientConfigurationImpl.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/CamundaClientConfigurationImpl.java
@@ -83,172 +83,172 @@ public class CamundaClientConfigurationImpl implements CamundaClientConfiguratio
 
   @Override
   public String getGatewayAddress() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrLatestOrDefault(
         "GatewayAddress",
-        this::composeGatewayAddress,
         () -> PropertiesUtil.getZeebeGatewayAddress(properties),
+        this::composeGatewayAddress,
         DEFAULT.getGatewayAddress(),
         configCache);
   }
 
   @Override
   public URI getRestAddress() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrLatestOrDefault(
         "RestAddress",
-        () -> camundaClientProperties.getZeebe().getRestAddress(),
         () -> properties.getBroker().getRestAddress(),
+        () -> camundaClientProperties.getZeebe().getRestAddress(),
         DEFAULT.getRestAddress(),
         configCache);
   }
 
   @Override
   public URI getGrpcAddress() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrLatestOrDefault(
         "GrpcAddress",
-        () -> camundaClientProperties.getZeebe().getGrpcAddress(),
         properties::getGrpcAddress,
+        () -> camundaClientProperties.getZeebe().getGrpcAddress(),
         DEFAULT.getGrpcAddress(),
         configCache);
   }
 
   @Override
   public String getDefaultTenantId() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrLatestOrDefault(
         "DefaultTenantId",
+        properties::getDefaultTenantId,
         prioritized(
             DEFAULT.getDefaultTenantId(),
             List.of(
                 () -> camundaClientProperties.getTenantIds().get(0),
                 () -> camundaClientProperties.getZeebe().getDefaults().getTenantIds().get(0))),
-        properties::getDefaultTenantId,
         DEFAULT.getDefaultTenantId(),
         configCache);
   }
 
   @Override
   public List<String> getDefaultJobWorkerTenantIds() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrLatestOrDefault(
         "DefaultJobWorkerTenantIds",
+        properties::getDefaultJobWorkerTenantIds,
         prioritized(
             DEFAULT.getDefaultJobWorkerTenantIds(),
             List.of(
                 camundaClientProperties::getTenantIds,
                 () -> camundaClientProperties.getZeebe().getDefaults().getTenantIds())),
-        properties::getDefaultJobWorkerTenantIds,
         DEFAULT.getDefaultJobWorkerTenantIds(),
         configCache);
   }
 
   @Override
   public int getNumJobWorkerExecutionThreads() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrLatestOrDefault(
         "NumJobWorkerExecutionThreads",
-        () -> camundaClientProperties.getZeebe().getExecutionThreads(),
         () -> properties.getWorker().getThreads(),
+        () -> camundaClientProperties.getZeebe().getExecutionThreads(),
         DEFAULT.getNumJobWorkerExecutionThreads(),
         configCache);
   }
 
   @Override
   public int getDefaultJobWorkerMaxJobsActive() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrLatestOrDefault(
         "DefaultJobWorkerMaxJobsActive",
-        () -> camundaClientProperties.getZeebe().getDefaults().getMaxJobsActive(),
         () -> properties.getWorker().getMaxJobsActive(),
+        () -> camundaClientProperties.getZeebe().getDefaults().getMaxJobsActive(),
         DEFAULT.getDefaultJobWorkerMaxJobsActive(),
         configCache);
   }
 
   @Override
   public String getDefaultJobWorkerName() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrLatestOrDefault(
         "DefaultJobWorkerName",
-        () -> camundaClientProperties.getZeebe().getDefaults().getName(),
         () -> properties.getWorker().getDefaultName(),
+        () -> camundaClientProperties.getZeebe().getDefaults().getName(),
         DEFAULT.getDefaultJobWorkerName(),
         configCache);
   }
 
   @Override
   public Duration getDefaultJobTimeout() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrLatestOrDefault(
         "DefaultJobTimeout",
-        () -> camundaClientProperties.getZeebe().getDefaults().getTimeout(),
         () -> properties.getJob().getTimeout(),
+        () -> camundaClientProperties.getZeebe().getDefaults().getTimeout(),
         DEFAULT.getDefaultJobTimeout(),
         configCache);
   }
 
   @Override
   public Duration getDefaultJobPollInterval() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrLatestOrDefault(
         "DefaultJobPollInterval",
-        () -> camundaClientProperties.getZeebe().getDefaults().getPollInterval(),
         () -> properties.getJob().getPollInterval(),
+        () -> camundaClientProperties.getZeebe().getDefaults().getPollInterval(),
         DEFAULT.getDefaultJobPollInterval(),
         configCache);
   }
 
   @Override
   public Duration getDefaultMessageTimeToLive() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrLatestOrDefault(
         "DefaultMessageTimeToLive",
-        () -> camundaClientProperties.getZeebe().getMessageTimeToLive(),
         () -> properties.getMessage().getTimeToLive(),
+        () -> camundaClientProperties.getZeebe().getMessageTimeToLive(),
         DEFAULT.getDefaultMessageTimeToLive(),
         configCache);
   }
 
   @Override
   public Duration getDefaultRequestTimeout() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrLatestOrDefault(
         "DefaultRequestTimeout",
+        properties::getRequestTimeout,
         prioritized(
             DEFAULT.getDefaultRequestTimeout(),
             List.of(
                 () -> camundaClientProperties.getZeebe().getRequestTimeout(),
                 () -> camundaClientProperties.getZeebe().getDefaults().getRequestTimeout())),
-        properties::getRequestTimeout,
         DEFAULT.getDefaultRequestTimeout(),
         configCache);
   }
 
   @Override
   public boolean isPlaintextConnectionEnabled() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrLatestOrDefault(
         "PlaintextConnectionEnabled",
-        this::composePlaintext,
         () -> properties.getSecurity().isPlaintext(),
+        this::composePlaintext,
         DEFAULT.isPlaintextConnectionEnabled(),
         configCache);
   }
 
   @Override
   public String getCaCertificatePath() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrLatestOrDefault(
         "CaCertificatePath",
-        () -> camundaClientProperties.getZeebe().getCaCertificatePath(),
         () -> properties.getSecurity().getCertPath(),
+        () -> camundaClientProperties.getZeebe().getCaCertificatePath(),
         DEFAULT.getCaCertificatePath(),
         configCache);
   }
 
   @Override
   public CredentialsProvider getCredentialsProvider() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrLatestOrDefault(
         "CredentialsProvider",
-        this::credentialsProvider,
         this::legacyCredentialsProvider,
+        this::credentialsProvider,
         null,
         configCache);
   }
 
   @Override
   public Duration getKeepAlive() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrLatestOrDefault(
         "KeepAlive",
-        () -> camundaClientProperties.getZeebe().getKeepAlive(),
         () -> properties.getBroker().getKeepAlive(),
+        () -> camundaClientProperties.getZeebe().getKeepAlive(),
         DEFAULT.getKeepAlive(),
         configCache);
   }
@@ -270,20 +270,20 @@ public class CamundaClientConfigurationImpl implements CamundaClientConfiguratio
 
   @Override
   public String getOverrideAuthority() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrLatestOrDefault(
         "OverrideAuthority",
-        () -> camundaClientProperties.getZeebe().getOverrideAuthority(),
         () -> properties.getSecurity().getOverrideAuthority(),
+        () -> camundaClientProperties.getZeebe().getOverrideAuthority(),
         DEFAULT.getOverrideAuthority(),
         configCache);
   }
 
   @Override
   public int getMaxMessageSize() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrLatestOrDefault(
         "MaxMessageSize",
-        () -> camundaClientProperties.getZeebe().getMaxMessageSize(),
         () -> properties.getMessage().getMaxMessageSize(),
+        () -> camundaClientProperties.getZeebe().getMaxMessageSize(),
         DEFAULT.getMaxMessageSize(),
         configCache);
   }
@@ -304,20 +304,20 @@ public class CamundaClientConfigurationImpl implements CamundaClientConfiguratio
 
   @Override
   public boolean ownsJobWorkerExecutor() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrLatestOrDefault(
         "ownsJobWorkerExecutor",
-        zeebeClientExecutorService::isOwnedByZeebeClient,
         properties::ownsJobWorkerExecutor,
+        zeebeClientExecutorService::isOwnedByZeebeClient,
         DEFAULT.ownsJobWorkerExecutor(),
         configCache);
   }
 
   @Override
   public boolean getDefaultJobWorkerStreamEnabled() {
-    return getOrLegacyOrDefault(
+    return getLegacyOrLatestOrDefault(
         "DefaultJobWorkerStreamEnabled",
-        () -> camundaClientProperties.getZeebe().getDefaults().getStreamEnabled(),
         properties::getDefaultJobWorkerStreamEnabled,
+        () -> camundaClientProperties.getZeebe().getDefaults().getStreamEnabled(),
         DEFAULT.getDefaultJobWorkerStreamEnabled(),
         configCache);
   }

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ExecutorServiceConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ExecutorServiceConfiguration.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.zeebe.spring.client.configuration;
 
-import static io.camunda.zeebe.spring.client.configuration.PropertyUtil.getOrLegacyOrDefault;
+import static io.camunda.zeebe.spring.client.configuration.PropertyUtil.getLegacyOrLatestOrDefault;
 import static io.camunda.zeebe.spring.client.properties.ZeebeClientConfigurationProperties.DEFAULT;
 
 import io.camunda.zeebe.spring.client.jobhandling.ZeebeClientExecutorService;
@@ -51,10 +51,10 @@ public class ExecutorServiceConfiguration {
       @Autowired(required = false) final MeterRegistry meterRegistry) {
     final ScheduledExecutorService threadPool =
         Executors.newScheduledThreadPool(
-            getOrLegacyOrDefault(
+            getLegacyOrLatestOrDefault(
                 "NumJobWorkerExecutionThreads",
-                () -> camundaClientProperties.getZeebe().getExecutionThreads(),
                 configurationProperties::getNumJobWorkerExecutionThreads,
+                () -> camundaClientProperties.getZeebe().getExecutionThreads(),
                 DEFAULT.getNumJobWorkerExecutionThreads(),
                 null));
     if (meterRegistry != null) {

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/PropertyUtil.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/PropertyUtil.java
@@ -27,18 +27,18 @@ public class PropertyUtil {
   /**
    * Returns the property in the given relevance: legacyProperty, property,defaultProperty
    *
+   * @param <T> the type of the property
    * @param propertyName the name of the property, used for logging
-   * @param propertySupplier a function to supply the property, may throw
    * @param legacyPropertySupplier a function to supply the legacy property, may throw
+   * @param latestPropertySupplier a function to supply the property, may throw
    * @param defaultProperty the default to apply if nothing else suits, may be null
    * @param configCache the cache to save the property to, may be null
    * @return the property resolved
-   * @param <T> the type of the property
    */
-  public static <T> T getOrLegacyOrDefault(
+  public static <T> T getLegacyOrLatestOrDefault(
       final String propertyName,
-      final Supplier<T> propertySupplier,
       final Supplier<T> legacyPropertySupplier,
+      final Supplier<T> latestPropertySupplier,
       final T defaultProperty,
       final Map<String, Object> configCache) {
 
@@ -50,7 +50,7 @@ public class PropertyUtil {
     }
     T property = getPropertyFromSupplier(legacyPropertySupplier, propertyName, "legacy");
     if (property == null || property.equals(defaultProperty)) {
-      property = getPropertyFromSupplier(propertySupplier, propertyName, "property");
+      property = getPropertyFromSupplier(latestPropertySupplier, propertyName, "property");
     }
     if (property == null || property.equals(defaultProperty)) {
       LOG.debug("Property {}: not set or default, using default", propertyName);
@@ -79,8 +79,8 @@ public class PropertyUtil {
       final Supplier<T> propertySupplier,
       final T defaultProperty,
       final Map<String, Object> configCache) {
-    return getOrLegacyOrDefault(
-        propertyName, propertySupplier, noPropertySupplier(), defaultProperty, configCache);
+    return getLegacyOrLatestOrDefault(
+        propertyName, noPropertySupplier(), propertySupplier, defaultProperty, configCache);
   }
 
   private static <T> Supplier<T> noPropertySupplier() {

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientAllAutoConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientAllAutoConfiguration.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.zeebe.spring.client.configuration;
 
-import static io.camunda.zeebe.spring.client.configuration.PropertyUtil.getOrLegacyOrDefault;
+import static io.camunda.zeebe.spring.client.configuration.PropertyUtil.getLegacyOrLatestOrDefault;
 import static io.camunda.zeebe.spring.client.properties.ZeebeClientConfigurationProperties.DEFAULT;
 
 import io.camunda.client.api.JsonMapper;
@@ -66,10 +66,10 @@ public class ZeebeClientAllAutoConfiguration {
   @ConditionalOnMissingBean
   public ZeebeClientExecutorService zeebeClientExecutorService() {
     return ZeebeClientExecutorService.createDefault(
-        getOrLegacyOrDefault(
+        getLegacyOrLatestOrDefault(
             "NumJobWorkerExecutionThreads",
-            () -> camundaClientProperties.getZeebe().getExecutionThreads(),
             configurationProperties::getNumJobWorkerExecutionThreads,
+            () -> camundaClientProperties.getZeebe().getExecutionThreads(),
             DEFAULT.getNumJobWorkerExecutionThreads(),
             null));
   }

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizer.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizer.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.zeebe.spring.client.properties;
 
-import static io.camunda.zeebe.spring.client.configuration.PropertyUtil.getOrLegacyOrDefault;
+import static io.camunda.zeebe.spring.client.configuration.PropertyUtil.getLegacyOrLatestOrDefault;
 import static io.camunda.zeebe.spring.client.configuration.PropertyUtil.prioritized;
 import static io.camunda.zeebe.spring.client.properties.ZeebeClientConfigurationProperties.DEFAULT;
 import static java.util.Optional.ofNullable;
@@ -136,10 +136,10 @@ public class PropertyBasedZeebeWorkerValueCustomizer implements ZeebeWorkerValue
 
   private void applyOverrides(final ZeebeWorkerValue zeebeWorker) {
     final Map<String, ZeebeWorkerValue> workerConfigurationMap =
-        getOrLegacyOrDefault(
+        getLegacyOrLatestOrDefault(
             "Override",
-            () -> camundaClientProperties.getZeebe().getOverride(),
             () -> zeebeClientConfigurationProperties.getWorker().getOverride(),
+            () -> camundaClientProperties.getZeebe().getOverride(),
             new HashMap<>(),
             null);
     try {
@@ -172,10 +172,10 @@ public class PropertyBasedZeebeWorkerValueCustomizer implements ZeebeWorkerValue
 
   private void applyDefaultWorkerName(final ZeebeWorkerValue zeebeWorker) {
     final String defaultJobWorkerName =
-        getOrLegacyOrDefault(
+        getLegacyOrLatestOrDefault(
             "DefaultJobWorkerName",
-            () -> camundaClientProperties.getZeebe().getDefaults().getName(),
             zeebeClientConfigurationProperties::getDefaultJobWorkerName,
+            () -> camundaClientProperties.getZeebe().getDefaults().getName(),
             null,
             null);
     if (isBlank(zeebeWorker.getName())) {
@@ -199,10 +199,10 @@ public class PropertyBasedZeebeWorkerValueCustomizer implements ZeebeWorkerValue
 
   private void applyDefaultJobWorkerType(final ZeebeWorkerValue zeebeWorker) {
     final String defaultJobWorkerType =
-        getOrLegacyOrDefault(
+        getLegacyOrLatestOrDefault(
             "DefaultJobWorkerType",
-            () -> camundaClientProperties.getZeebe().getDefaults().getType(),
             zeebeClientConfigurationProperties::getDefaultJobWorkerType,
+            () -> camundaClientProperties.getZeebe().getDefaults().getType(),
             null,
             null);
     if (isBlank(zeebeWorker.getType())) {
@@ -223,14 +223,14 @@ public class PropertyBasedZeebeWorkerValueCustomizer implements ZeebeWorkerValue
 
   private void applyDefaultJobWorkerTenantIds(final ZeebeWorkerValue zeebeWorker) {
     final List<String> defaultJobWorkerTenantIds =
-        getOrLegacyOrDefault(
+        getLegacyOrLatestOrDefault(
             "DefaultJobWorkerTenantIds",
+            zeebeClientConfigurationProperties::getDefaultJobWorkerTenantIds,
             prioritized(
                 DEFAULT.getDefaultJobWorkerTenantIds(),
                 List.of(
                     camundaClientProperties::getTenantIds,
                     () -> camundaClientProperties.getZeebe().getDefaults().getTenantIds())),
-            zeebeClientConfigurationProperties::getDefaultJobWorkerTenantIds,
             DEFAULT.getDefaultJobWorkerTenantIds(),
             null);
 

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/PropertyUtilTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/PropertyUtilTest.java
@@ -25,15 +25,15 @@ public class PropertyUtilTest {
   @Test
   void shouldPreferLegacy() {
     final String property =
-        PropertyUtil.getOrLegacyOrDefault(
-            "Test", () -> "prop", () -> "legacy", "default", new HashMap<>());
+        PropertyUtil.getLegacyOrLatestOrDefault(
+            "Test", () -> "legacy", () -> "prop", "default", new HashMap<>());
     assertThat(property).isEqualTo("legacy");
   }
 
   @Test
   void shouldApplyDefault() {
     final String property =
-        PropertyUtil.getOrLegacyOrDefault(
+        PropertyUtil.getLegacyOrLatestOrDefault(
             "Test", () -> null, () -> null, "default", new HashMap<>());
     assertThat(property).isEqualTo("default");
   }
@@ -41,20 +41,20 @@ public class PropertyUtilTest {
   @Test
   void shouldIgnoreDefaultOnLegacy() {
     final String property =
-        PropertyUtil.getOrLegacyOrDefault(
-            "Test", () -> "prop", () -> "default", "default", new HashMap<>());
+        PropertyUtil.getLegacyOrLatestOrDefault(
+            "Test", () -> "default", () -> "prop", "default", new HashMap<>());
     assertThat(property).isEqualTo("prop");
   }
 
   @Test
   void shouldHandleExceptionOnPropertySupplier() {
     final String property =
-        PropertyUtil.getOrLegacyOrDefault(
+        PropertyUtil.getLegacyOrLatestOrDefault(
             "Test",
+            () -> null,
             () -> {
               throw new NullPointerException();
             },
-            () -> null,
             "default",
             new HashMap<>());
     assertThat(property).isEqualTo("default");
@@ -63,12 +63,12 @@ public class PropertyUtilTest {
   @Test
   void shouldHandleExceptionOnLegacyPropertySupplier() {
     final String property =
-        PropertyUtil.getOrLegacyOrDefault(
+        PropertyUtil.getLegacyOrLatestOrDefault(
             "Test",
-            () -> null,
             () -> {
               throw new NullPointerException();
             },
+            () -> null,
             "default",
             new HashMap<>());
     assertThat(property).isEqualTo("default");


### PR DESCRIPTION
## Description

When debugging a property issue with the Connectors pod, we blindly trusted this method name (getOrLegacyOrDefault) to work in this order:
- get the latest property if available
- get the legacy if not
- get the default if not

It's written in the method's Javadoc, but the signature + parameters order are misleading.

I propose to change the name + the order of the params.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

