### PR TITLE
Rename `DEPLOYMENT` authorization type to `RESOURCE`

### DIFF
--- a/clients/java/src/test/java/io/camunda/client/authorization/AddPermissionsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/authorization/AddPermissionsTest.java
@@ -37,7 +37,7 @@ public final class AddPermissionsTest extends ClientRestTest {
     // when
     client
         .newAddPermissionsCommand(1L)
-        .resourceType(ResourceTypeEnum.DEPLOYMENT)
+        .resourceType(ResourceTypeEnum.RESOURCE)
         .permission(PermissionTypeEnum.CREATE)
         .resourceId("resourceId1")
         .permission(PermissionTypeEnum.UPDATE)
@@ -52,7 +52,7 @@ public final class AddPermissionsTest extends ClientRestTest {
     final AuthorizationPatchRequest request =
         gatewayService.getLastRequest(AuthorizationPatchRequest.class);
     assertThat(request.getAction()).isEqualTo(ActionEnum.ADD);
-    assertThat(request.getResourceType()).isEqualTo(ResourceTypeEnum.DEPLOYMENT);
+    assertThat(request.getResourceType()).isEqualTo(ResourceTypeEnum.RESOURCE);
 
     assertThat(request.getPermissions())
         .hasSize(3)
@@ -90,7 +90,7 @@ public final class AddPermissionsTest extends ClientRestTest {
             () ->
                 client
                     .newAddPermissionsCommand(1L)
-                    .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                    .resourceType(ResourceTypeEnum.RESOURCE)
                     .permission(null)
                     .resourceId("resourceId")
                     .send()
@@ -106,7 +106,7 @@ public final class AddPermissionsTest extends ClientRestTest {
             () ->
                 client
                     .newAddPermissionsCommand(1L)
-                    .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                    .resourceType(ResourceTypeEnum.RESOURCE)
                     .permission(PermissionTypeEnum.CREATE)
                     .resourceId(null)
                     .send()
@@ -122,7 +122,7 @@ public final class AddPermissionsTest extends ClientRestTest {
             () ->
                 client
                     .newAddPermissionsCommand(1L)
-                    .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                    .resourceType(ResourceTypeEnum.RESOURCE)
                     .permission(PermissionTypeEnum.CREATE)
                     .resourceId("")
                     .send()
@@ -138,7 +138,7 @@ public final class AddPermissionsTest extends ClientRestTest {
             () ->
                 client
                     .newAddPermissionsCommand(1L)
-                    .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                    .resourceType(ResourceTypeEnum.RESOURCE)
                     .permission(PermissionTypeEnum.CREATE)
                     .resourceIds(null)
                     .send()
@@ -154,7 +154,7 @@ public final class AddPermissionsTest extends ClientRestTest {
             () ->
                 client
                     .newAddPermissionsCommand(1L)
-                    .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                    .resourceType(ResourceTypeEnum.RESOURCE)
                     .permission(PermissionTypeEnum.CREATE)
                     .resourceIds(Collections.emptyList())
                     .send()

--- a/clients/java/src/test/java/io/camunda/client/authorization/CreateAuthorizationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/authorization/CreateAuthorizationTest.java
@@ -37,7 +37,7 @@ public class CreateAuthorizationTest extends ClientRestTest {
         .ownerId("ownerId")
         .ownerType(OwnerTypeEnum.USER)
         .resourceId("resourceId")
-        .resourceType(ResourceTypeEnum.DEPLOYMENT)
+        .resourceType(ResourceTypeEnum.RESOURCE)
         .permissions(Arrays.asList(PermissionTypeEnum.CREATE, PermissionTypeEnum.READ))
         .send()
         .join();
@@ -48,7 +48,7 @@ public class CreateAuthorizationTest extends ClientRestTest {
     assertThat(request.getOwnerId()).isEqualTo("ownerId");
     assertThat(request.getOwnerType()).isEqualTo(OwnerTypeEnum.USER);
     assertThat(request.getResourceId()).isEqualTo("resourceId");
-    assertThat(request.getResourceType()).isEqualTo(ResourceTypeEnum.DEPLOYMENT);
+    assertThat(request.getResourceType()).isEqualTo(ResourceTypeEnum.RESOURCE);
     assertThat(request.getPermissions())
         .containsExactly(PermissionTypeEnum.CREATE, PermissionTypeEnum.READ);
   }
@@ -63,7 +63,7 @@ public class CreateAuthorizationTest extends ClientRestTest {
                     .ownerId(null)
                     .ownerType(OwnerTypeEnum.USER)
                     .resourceId("resourceId")
-                    .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                    .resourceType(ResourceTypeEnum.RESOURCE)
                     .permissions(Arrays.asList(PermissionTypeEnum.CREATE, PermissionTypeEnum.READ))
                     .send()
                     .join())
@@ -81,7 +81,7 @@ public class CreateAuthorizationTest extends ClientRestTest {
                     .ownerId("")
                     .ownerType(OwnerTypeEnum.USER)
                     .resourceId("resourceId")
-                    .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                    .resourceType(ResourceTypeEnum.RESOURCE)
                     .permissions(Arrays.asList(PermissionTypeEnum.CREATE, PermissionTypeEnum.READ))
                     .send()
                     .join())
@@ -99,7 +99,7 @@ public class CreateAuthorizationTest extends ClientRestTest {
                     .ownerId("ownerId")
                     .ownerType(null)
                     .resourceId("resourceId")
-                    .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                    .resourceType(ResourceTypeEnum.RESOURCE)
                     .permissions(Arrays.asList(PermissionTypeEnum.CREATE, PermissionTypeEnum.READ))
                     .send()
                     .join())
@@ -117,7 +117,7 @@ public class CreateAuthorizationTest extends ClientRestTest {
                     .ownerId("ownerId")
                     .ownerType(OwnerTypeEnum.USER)
                     .resourceId(null)
-                    .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                    .resourceType(ResourceTypeEnum.RESOURCE)
                     .permissions(Arrays.asList(PermissionTypeEnum.CREATE, PermissionTypeEnum.READ))
                     .send()
                     .join())
@@ -135,7 +135,7 @@ public class CreateAuthorizationTest extends ClientRestTest {
                     .ownerId("ownerId")
                     .ownerType(OwnerTypeEnum.USER)
                     .resourceId("")
-                    .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                    .resourceType(ResourceTypeEnum.RESOURCE)
                     .permissions(Arrays.asList(PermissionTypeEnum.CREATE, PermissionTypeEnum.READ))
                     .send()
                     .join())
@@ -171,7 +171,7 @@ public class CreateAuthorizationTest extends ClientRestTest {
                     .ownerId("ownerId")
                     .ownerType(OwnerTypeEnum.USER)
                     .resourceId("resourceId")
-                    .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                    .resourceType(ResourceTypeEnum.RESOURCE)
                     .permissions(null)
                     .send()
                     .join())
@@ -189,7 +189,7 @@ public class CreateAuthorizationTest extends ClientRestTest {
                     .ownerId("ownerId")
                     .ownerType(OwnerTypeEnum.USER)
                     .resourceId("resourceId")
-                    .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                    .resourceType(ResourceTypeEnum.RESOURCE)
                     .permissions(new ArrayList<>())
                     .send()
                     .join())
@@ -207,7 +207,7 @@ public class CreateAuthorizationTest extends ClientRestTest {
                     .ownerId("ownerId")
                     .ownerType(OwnerTypeEnum.USER)
                     .resourceId("resourceId")
-                    .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                    .resourceType(ResourceTypeEnum.RESOURCE)
                     .permission(null)
                     .send()
                     .join())

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ProcessRestServiceIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ProcessRestServiceIT.java
@@ -104,7 +104,7 @@ public class ProcessRestServiceIT extends OperateAbstractIT {
         .thenReturn(
             new ProcessEntity().setKey(processDefinitionKey).setBpmnProcessId(bpmnProcessId));
     when(permissionsService.permissionsEnabled()).thenReturn(true);
-    when(permissionsService.hasPermissionForDeployment(
+    when(permissionsService.hasPermissionForResource(
             processDefinitionKey, IdentityPermission.DELETE_PROCESS))
         .thenReturn(true);
     when(batchOperationWriter.scheduleDeleteProcessDefinition(any()))
@@ -156,7 +156,7 @@ public class ProcessRestServiceIT extends OperateAbstractIT {
         .thenReturn(
             new ProcessEntity().setKey(processDefinitionKey).setBpmnProcessId(bpmnProcessId));
     when(permissionsService.permissionsEnabled()).thenReturn(true);
-    when(permissionsService.hasPermissionForDeployment(
+    when(permissionsService.hasPermissionForResource(
             processDefinitionKey, IdentityPermission.DELETE_PROCESS))
         .thenReturn(false);
     when(batchOperationWriter.scheduleDeleteProcessDefinition(any()))

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ProcessRestService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ProcessRestService.java
@@ -95,7 +95,7 @@ public class ProcessRestService extends InternalAPIErrorController {
 
   private void checkIdentityDeletePermission(final Long processDefinitionKey) {
     if (permissionsService.permissionsEnabled()
-        && !permissionsService.hasPermissionForDeployment(
+        && !permissionsService.hasPermissionForResource(
             processDefinitionKey, IdentityPermission.DELETE_PROCESS)) {
       throw new NotAuthorizedException(
           String.format("No delete permission for process definition %s", processDefinitionKey));

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsService.java
@@ -90,7 +90,7 @@ public class PermissionsService {
   public boolean hasPermissionForDeployment(
       final Long deploymentKey, final IdentityPermission identityPermission) {
     return hasPermissionForResource(
-        deploymentKey.toString(), AuthorizationResourceType.DEPLOYMENT, identityPermission);
+        deploymentKey.toString(), AuthorizationResourceType.RESOURCE, identityPermission);
   }
 
   /**

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/permission/PermissionsService.java
@@ -83,11 +83,11 @@ public class PermissionsService {
   }
 
   /**
-   * hasPermissionForDeployment
+   * hasPermissionForResource
    *
    * @return true if the user has the given permission for the process
    */
-  public boolean hasPermissionForDeployment(
+  public boolean hasPermissionForResource(
       final Long deploymentKey, final IdentityPermission identityPermission) {
     return hasPermissionForResource(
         deploymentKey.toString(), AuthorizationResourceType.RESOURCE, identityPermission);

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/DecisionAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/DecisionAuthorizationIT.java
@@ -12,7 +12,7 @@ import static io.camunda.client.protocol.rest.PermissionTypeEnum.READ;
 import static io.camunda.client.protocol.rest.PermissionTypeEnum.READ_DECISION_DEFINITION;
 import static io.camunda.client.protocol.rest.ResourceTypeEnum.DECISION_DEFINITION;
 import static io.camunda.client.protocol.rest.ResourceTypeEnum.DECISION_REQUIREMENTS_DEFINITION;
-import static io.camunda.client.protocol.rest.ResourceTypeEnum.DEPLOYMENT;
+import static io.camunda.client.protocol.rest.ResourceTypeEnum.RESOURCE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -48,7 +48,7 @@ class DecisionAuthorizationIT {
           ADMIN,
           "password",
           List.of(
-              new Permissions(DEPLOYMENT, CREATE, List.of("*")),
+              new Permissions(RESOURCE, CREATE, List.of("*")),
               new Permissions(DECISION_DEFINITION, READ_DECISION_DEFINITION, List.of("*")),
               new Permissions(DECISION_REQUIREMENTS_DEFINITION, READ, List.of("*"))));
   private static final User RESTRICTED_USER =

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/DecisionInstanceAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/DecisionInstanceAuthorizationIT.java
@@ -11,7 +11,7 @@ import static io.camunda.client.protocol.rest.PermissionTypeEnum.CREATE;
 import static io.camunda.client.protocol.rest.PermissionTypeEnum.CREATE_DECISION_INSTANCE;
 import static io.camunda.client.protocol.rest.PermissionTypeEnum.READ_DECISION_INSTANCE;
 import static io.camunda.client.protocol.rest.ResourceTypeEnum.DECISION_DEFINITION;
-import static io.camunda.client.protocol.rest.ResourceTypeEnum.DEPLOYMENT;
+import static io.camunda.client.protocol.rest.ResourceTypeEnum.RESOURCE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -47,7 +47,7 @@ class DecisionInstanceAuthorizationIT {
           ADMIN,
           "password",
           List.of(
-              new Permissions(DEPLOYMENT, CREATE, List.of("*")),
+              new Permissions(RESOURCE, CREATE, List.of("*")),
               new Permissions(DECISION_DEFINITION, CREATE_DECISION_INSTANCE, List.of("*")),
               new Permissions(DECISION_DEFINITION, READ_DECISION_INSTANCE, List.of("*"))));
   private static final User RESTRICTED_USER =

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/ProcessAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/ProcessAuthorizationIT.java
@@ -9,8 +9,8 @@ package io.camunda.it.auth;
 
 import static io.camunda.client.protocol.rest.PermissionTypeEnum.CREATE;
 import static io.camunda.client.protocol.rest.PermissionTypeEnum.READ_PROCESS_DEFINITION;
-import static io.camunda.client.protocol.rest.ResourceTypeEnum.DEPLOYMENT;
 import static io.camunda.client.protocol.rest.ResourceTypeEnum.PROCESS_DEFINITION;
+import static io.camunda.client.protocol.rest.ResourceTypeEnum.RESOURCE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -42,7 +42,7 @@ class ProcessAuthorizationIT {
           ADMIN,
           "password",
           List.of(
-              new Permissions(DEPLOYMENT, CREATE, List.of("*")),
+              new Permissions(RESOURCE, CREATE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, READ_PROCESS_DEFINITION, List.of("*"))));
   private static final User RESTRICTED_USER =
       new User(

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/ProcessInstanceAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/ProcessInstanceAuthorizationIT.java
@@ -11,8 +11,8 @@ import static io.camunda.client.protocol.rest.PermissionTypeEnum.CREATE;
 import static io.camunda.client.protocol.rest.PermissionTypeEnum.CREATE_PROCESS_INSTANCE;
 import static io.camunda.client.protocol.rest.PermissionTypeEnum.READ_PROCESS_DEFINITION;
 import static io.camunda.client.protocol.rest.PermissionTypeEnum.READ_PROCESS_INSTANCE;
-import static io.camunda.client.protocol.rest.ResourceTypeEnum.DEPLOYMENT;
 import static io.camunda.client.protocol.rest.ResourceTypeEnum.PROCESS_DEFINITION;
+import static io.camunda.client.protocol.rest.ResourceTypeEnum.RESOURCE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -45,7 +45,7 @@ class ProcessInstanceAuthorizationIT {
           ADMIN,
           "password",
           List.of(
-              new Permissions(DEPLOYMENT, CREATE, List.of("*")),
+              new Permissions(RESOURCE, CREATE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, READ_PROCESS_DEFINITION, List.of("*")),
               new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of("*"))));

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/UserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/UserTaskAuthorizationIT.java
@@ -10,8 +10,8 @@ package io.camunda.it.auth;
 import static io.camunda.client.protocol.rest.PermissionTypeEnum.CREATE;
 import static io.camunda.client.protocol.rest.PermissionTypeEnum.CREATE_PROCESS_INSTANCE;
 import static io.camunda.client.protocol.rest.PermissionTypeEnum.READ_USER_TASK;
-import static io.camunda.client.protocol.rest.ResourceTypeEnum.DEPLOYMENT;
 import static io.camunda.client.protocol.rest.ResourceTypeEnum.PROCESS_DEFINITION;
+import static io.camunda.client.protocol.rest.ResourceTypeEnum.RESOURCE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -44,7 +44,7 @@ class UserTaskAuthorizationIT {
           ADMIN,
           "password",
           List.of(
-              new Permissions(DEPLOYMENT, CREATE, List.of("*")),
+              new Permissions(RESOURCE, CREATE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of("*"))));
   private static final User USER1_USER =

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistAssignUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistAssignUserTaskAuthorizationIT.java
@@ -78,7 +78,7 @@ public class TasklistAssignUserTaskAuthorizationIT {
       intermediateAuthClient.createUserWithPermissions(
           ADMIN_USER_NAME,
           ADMIN_USER_PASSWORD,
-          new Permissions(ResourceTypeEnum.DEPLOYMENT, PermissionTypeEnum.CREATE, List.of("*")),
+          new Permissions(ResourceTypeEnum.RESOURCE, PermissionTypeEnum.CREATE, List.of("*")),
           new Permissions(
               ResourceTypeEnum.PROCESS_DEFINITION,
               PermissionTypeEnum.READ_PROCESS_DEFINITION,

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistCompleteUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistCompleteUserTaskAuthorizationIT.java
@@ -76,7 +76,7 @@ public class TasklistCompleteUserTaskAuthorizationIT {
       intermediateAuthClient.createUserWithPermissions(
           ADMIN_USER_NAME,
           ADMIN_USER_PASSWORD,
-          new Permissions(ResourceTypeEnum.DEPLOYMENT, PermissionTypeEnum.CREATE, List.of("*")),
+          new Permissions(ResourceTypeEnum.RESOURCE, PermissionTypeEnum.CREATE, List.of("*")),
           new Permissions(
               ResourceTypeEnum.PROCESS_DEFINITION,
               PermissionTypeEnum.READ_PROCESS_DEFINITION,

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistCreateProcessInstanceAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistCreateProcessInstanceAuthorizationIT.java
@@ -67,7 +67,7 @@ public class TasklistCreateProcessInstanceAuthorizationIT {
       intermediateAuthClient.createUserWithPermissions(
           ADMIN_USER_NAME,
           ADMIN_USER_PASSWORD,
-          new Permissions(ResourceTypeEnum.DEPLOYMENT, PermissionTypeEnum.CREATE, List.of("*")),
+          new Permissions(ResourceTypeEnum.RESOURCE, PermissionTypeEnum.CREATE, List.of("*")),
           new Permissions(
               ResourceTypeEnum.PROCESS_DEFINITION,
               PermissionTypeEnum.READ_PROCESS_DEFINITION,

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistProcessDefinitionAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistProcessDefinitionAuthorizationIT.java
@@ -71,7 +71,7 @@ public class TasklistProcessDefinitionAuthorizationIT {
       intermediateAuthClient.createUserWithPermissions(
           ADMIN_USER_NAME,
           ADMIN_USER_PASSWORD,
-          new Permissions(ResourceTypeEnum.DEPLOYMENT, PermissionTypeEnum.CREATE, List.of("*")),
+          new Permissions(ResourceTypeEnum.RESOURCE, PermissionTypeEnum.CREATE, List.of("*")),
           new Permissions(
               ResourceTypeEnum.PROCESS_DEFINITION,
               PermissionTypeEnum.READ_PROCESS_DEFINITION,

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistUnassignUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistUnassignUserTaskAuthorizationIT.java
@@ -76,7 +76,7 @@ public class TasklistUnassignUserTaskAuthorizationIT {
       intermediateAuthClient.createUserWithPermissions(
           ADMIN_USER_NAME,
           ADMIN_USER_PASSWORD,
-          new Permissions(ResourceTypeEnum.DEPLOYMENT, PermissionTypeEnum.CREATE, List.of("*")),
+          new Permissions(ResourceTypeEnum.RESOURCE, PermissionTypeEnum.CREATE, List.of("*")),
           new Permissions(
               ResourceTypeEnum.PROCESS_DEFINITION,
               PermissionTypeEnum.READ_PROCESS_DEFINITION,

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistAssignUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistAssignUserTaskAuthorizationIT.java
@@ -79,7 +79,7 @@ public class CompatibilityTasklistAssignUserTaskAuthorizationIT {
       intermediateAuthClient.createUserWithPermissions(
           ADMIN_USER_NAME,
           ADMIN_USER_PASSWORD,
-          new Permissions(ResourceTypeEnum.DEPLOYMENT, PermissionTypeEnum.CREATE, List.of("*")),
+          new Permissions(ResourceTypeEnum.RESOURCE, PermissionTypeEnum.CREATE, List.of("*")),
           new Permissions(
               ResourceTypeEnum.PROCESS_DEFINITION,
               PermissionTypeEnum.READ_PROCESS_DEFINITION,

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistCompleteUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistCompleteUserTaskAuthorizationIT.java
@@ -76,7 +76,7 @@ public class CompatibilityTasklistCompleteUserTaskAuthorizationIT {
       intermediateAuthClient.createUserWithPermissions(
           ADMIN_USER_NAME,
           ADMIN_USER_PASSWORD,
-          new Permissions(ResourceTypeEnum.DEPLOYMENT, PermissionTypeEnum.CREATE, List.of("*")),
+          new Permissions(ResourceTypeEnum.RESOURCE, PermissionTypeEnum.CREATE, List.of("*")),
           new Permissions(
               ResourceTypeEnum.PROCESS_DEFINITION,
               PermissionTypeEnum.READ_PROCESS_DEFINITION,

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistCreateProcessInstanceAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistCreateProcessInstanceAuthorizationIT.java
@@ -68,7 +68,7 @@ public class CompatibilityTasklistCreateProcessInstanceAuthorizationIT {
       intermediateAuthClient.createUserWithPermissions(
           ADMIN_USER_NAME,
           ADMIN_USER_PASSWORD,
-          new Permissions(ResourceTypeEnum.DEPLOYMENT, PermissionTypeEnum.CREATE, List.of("*")),
+          new Permissions(ResourceTypeEnum.RESOURCE, PermissionTypeEnum.CREATE, List.of("*")),
           new Permissions(
               ResourceTypeEnum.PROCESS_DEFINITION,
               PermissionTypeEnum.READ_PROCESS_DEFINITION,

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistUnassignUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistUnassignUserTaskAuthorizationIT.java
@@ -76,7 +76,7 @@ public class CompatibilityTasklistUnassignUserTaskAuthorizationIT {
       intermediateAuthClient.createUserWithPermissions(
           ADMIN_USER_NAME,
           ADMIN_USER_PASSWORD,
-          new Permissions(ResourceTypeEnum.DEPLOYMENT, PermissionTypeEnum.CREATE, List.of("*")),
+          new Permissions(ResourceTypeEnum.RESOURCE, PermissionTypeEnum.CREATE, List.of("*")),
           new Permissions(
               ResourceTypeEnum.PROCESS_DEFINITION,
               PermissionTypeEnum.READ_PROCESS_DEFINITION,

--- a/security/security-core/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationResourceType.java
+++ b/security/security-core/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationResourceType.java
@@ -20,7 +20,7 @@ public enum AuthorizationResourceType {
   APPLICATION(PermissionType.ACCESS),
   SYSTEM(PermissionType.READ, PermissionType.UPDATE),
   TENANT(PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE),
-  DEPLOYMENT(
+  RESOURCE(
       PermissionType.CREATE,
       PermissionType.DELETE_FORM,
       PermissionType.DELETE_PROCESS,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -132,7 +132,7 @@ public final class DeploymentCreateProcessor
     final var authorizationRequest =
         new AuthorizationRequest(
             command,
-            AuthorizationResourceType.DEPLOYMENT,
+            AuthorizationResourceType.RESOURCE,
             PermissionType.CREATE,
             command.getValue().getTenantId());
     final var isAuthorized = authCheckBehavior.isAuthorized(authorizationRequest);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -188,7 +188,7 @@ public class ResourceDeletionDeleteProcessor
       final var process = processOptional.get();
       checkAuthorization(
           command,
-          AuthorizationResourceType.DEPLOYMENT,
+          AuthorizationResourceType.RESOURCE,
           PermissionType.DELETE_PROCESS,
           bufferAsString(process.getBpmnProcessId()));
       setTenantId(command, tenantId);
@@ -202,7 +202,7 @@ public class ResourceDeletionDeleteProcessor
       final var drg = drgOptional.get();
       checkAuthorization(
           command,
-          AuthorizationResourceType.DEPLOYMENT,
+          AuthorizationResourceType.RESOURCE,
           PermissionType.DELETE_DRD,
           bufferAsString(drg.getDecisionRequirementsId()));
       setTenantId(command, tenantId);
@@ -215,7 +215,7 @@ public class ResourceDeletionDeleteProcessor
       final var form = formOptional.get();
       checkAuthorization(
           command,
-          AuthorizationResourceType.DEPLOYMENT,
+          AuthorizationResourceType.RESOURCE,
           PermissionType.DELETE_FORM,
           bufferAsString(form.getFormId()));
       setTenantId(command, tenantId);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationMultiPartitionTest.java
@@ -54,7 +54,7 @@ public class AddPermissionAuthorizationMultiPartitionTest {
         .authorization()
         .permission()
         .withOwnerKey(ownerKey)
-        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+        .withResourceType(AuthorizationResourceType.RESOURCE)
         .withPermission(PermissionType.CREATE, "foo")
         .add();
 
@@ -121,7 +121,7 @@ public class AddPermissionAuthorizationMultiPartitionTest {
         .authorization()
         .permission()
         .withOwnerKey(ownerKey)
-        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+        .withResourceType(AuthorizationResourceType.RESOURCE)
         .withPermission(PermissionType.CREATE, "foo")
         .add();
 
@@ -156,7 +156,7 @@ public class AddPermissionAuthorizationMultiPartitionTest {
         .authorization()
         .permission()
         .withOwnerKey(ownerKey)
-        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+        .withResourceType(AuthorizationResourceType.RESOURCE)
         .withPermission(PermissionType.CREATE, "foo")
         .add();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationTest.java
@@ -50,7 +50,7 @@ public class AddPermissionAuthorizationTest {
             .authorization()
             .permission()
             .withOwnerKey(ownerKey)
-            .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+            .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermission(PermissionType.CREATE, "foo")
             .withPermission(PermissionType.DELETE_PROCESS, "bar")
             .add()
@@ -62,8 +62,7 @@ public class AddPermissionAuthorizationTest {
             AuthorizationRecordValue::getOwnerKey,
             AuthorizationRecordValue::getOwnerType,
             AuthorizationRecordValue::getResourceType)
-        .containsExactly(
-            ownerKey, AuthorizationOwnerType.USER, AuthorizationResourceType.DEPLOYMENT);
+        .containsExactly(ownerKey, AuthorizationOwnerType.USER, AuthorizationResourceType.RESOURCE);
     assertThat(response.getPermissions())
         .extracting(PermissionValue::getPermissionType, PermissionValue::getResourceIds)
         .containsExactly(
@@ -82,7 +81,7 @@ public class AddPermissionAuthorizationTest {
             .authorization()
             .permission()
             .withOwnerKey(ownerKey)
-            .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+            .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermission(PermissionType.CREATE, "foo")
             .expectRejection()
             .add();
@@ -111,7 +110,7 @@ public class AddPermissionAuthorizationTest {
         .authorization()
         .permission()
         .withOwnerKey(ownerKey)
-        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+        .withResourceType(AuthorizationResourceType.RESOURCE)
         .withPermission(PermissionType.CREATE, "foo")
         .withPermission(PermissionType.DELETE_PROCESS, "bar", "baz")
         .add()
@@ -123,7 +122,7 @@ public class AddPermissionAuthorizationTest {
             .authorization()
             .permission()
             .withOwnerKey(ownerKey)
-            .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+            .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermission(PermissionType.DELETE_PROCESS, "foo", "bar")
             .expectRejection()
             .add();
@@ -136,7 +135,7 @@ public class AddPermissionAuthorizationTest {
             "Expected to add '%s' permission for resource '%s' and resource identifiers '%s' for owner '%s', but this permission for resource identifiers '%s' already exist. Existing resource ids are: '%s'"
                 .formatted(
                     PermissionType.DELETE_PROCESS,
-                    AuthorizationResourceType.DEPLOYMENT,
+                    AuthorizationResourceType.RESOURCE,
                     "[bar, foo]",
                     ownerKey,
                     "[bar]",
@@ -161,7 +160,7 @@ public class AddPermissionAuthorizationTest {
         .authorization()
         .permission()
         .withOwnerKey(roleKey)
-        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+        .withResourceType(AuthorizationResourceType.RESOURCE)
         .withPermission(PermissionType.CREATE, "foo")
         .withPermission(PermissionType.DELETE_PROCESS, "bar", "baz")
         .add()
@@ -173,7 +172,7 @@ public class AddPermissionAuthorizationTest {
             .authorization()
             .permission()
             .withOwnerKey(ownerKey)
-            .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+            .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermission(PermissionType.DELETE_PROCESS, "foo", "bar")
             .add();
 
@@ -183,8 +182,7 @@ public class AddPermissionAuthorizationTest {
             AuthorizationRecordValue::getOwnerKey,
             AuthorizationRecordValue::getOwnerType,
             AuthorizationRecordValue::getResourceType)
-        .containsExactly(
-            ownerKey, AuthorizationOwnerType.USER, AuthorizationResourceType.DEPLOYMENT);
+        .containsExactly(ownerKey, AuthorizationOwnerType.USER, AuthorizationResourceType.RESOURCE);
   }
 
   @Test
@@ -210,7 +208,7 @@ public class AddPermissionAuthorizationTest {
         .authorization()
         .permission()
         .withOwnerKey(groupKey)
-        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+        .withResourceType(AuthorizationResourceType.RESOURCE)
         .withPermission(PermissionType.CREATE, "foo")
         .withPermission(PermissionType.DELETE_PROCESS, "bar", "baz")
         .add()
@@ -222,7 +220,7 @@ public class AddPermissionAuthorizationTest {
             .authorization()
             .permission()
             .withOwnerKey(ownerKey)
-            .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+            .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermission(PermissionType.DELETE_PROCESS, "foo", "bar")
             .add();
 
@@ -232,8 +230,7 @@ public class AddPermissionAuthorizationTest {
             AuthorizationRecordValue::getOwnerKey,
             AuthorizationRecordValue::getOwnerType,
             AuthorizationRecordValue::getResourceType)
-        .containsExactly(
-            ownerKey, AuthorizationOwnerType.USER, AuthorizationResourceType.DEPLOYMENT);
+        .containsExactly(ownerKey, AuthorizationOwnerType.USER, AuthorizationResourceType.RESOURCE);
   }
 
   @Test
@@ -248,7 +245,7 @@ public class AddPermissionAuthorizationTest {
             .withPassword("zabraboof")
             .create()
             .getKey();
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
 
     // when
     final var rejection =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AnonymousAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AnonymousAuthorizationTest.java
@@ -75,7 +75,7 @@ public class AnonymousAuthorizationTest {
         .authorization()
         .permission()
         .withPermission(PermissionType.CREATE, "*")
-        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+        .withResourceType(AuthorizationResourceType.RESOURCE)
         .withOwnerKey(user.getUserKey())
         .withOwnerType(AuthorizationOwnerType.USER)
         .add();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationAddPermissionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationAddPermissionAuthorizationTest.java
@@ -52,7 +52,7 @@ public class AuthorizationAddPermissionAuthorizationTest {
         .authorization()
         .permission()
         .withOwnerKey(user.getUserKey())
-        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+        .withResourceType(AuthorizationResourceType.RESOURCE)
         .withPermission(PermissionType.CREATE, "*")
         .add(DEFAULT_USER.getUsername());
 
@@ -76,7 +76,7 @@ public class AuthorizationAddPermissionAuthorizationTest {
         .authorization()
         .permission()
         .withOwnerKey(user.getUserKey())
-        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+        .withResourceType(AuthorizationResourceType.RESOURCE)
         .withPermission(PermissionType.CREATE, "*")
         .add(user.getUsername());
 
@@ -99,7 +99,7 @@ public class AuthorizationAddPermissionAuthorizationTest {
             .authorization()
             .permission()
             .withOwnerKey(user.getUserKey())
-            .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+            .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermission(PermissionType.DELETE, "*")
             .expectRejection()
             .add(user.getUsername());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -55,7 +55,7 @@ public class AuthorizationCheckBehaviorTest {
   public void shouldBeAuthorizedWhenUserHasPermission() {
     // given
     final var user = createUser();
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(user.getUserKey(), resourceType, permissionType, resourceId);
@@ -74,7 +74,7 @@ public class AuthorizationCheckBehaviorTest {
   public void shouldNotBeAuthorizedWhenUserHasNoPermission() {
     // given
     final var user = createUser();
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.DELETE;
     final var resourceId = UUID.randomUUID().toString();
     final var command = mockCommand(user.getUsername());
@@ -92,7 +92,7 @@ public class AuthorizationCheckBehaviorTest {
   public void shouldGetResourceIdentifiersWhenUserHasPermissions() {
     // given
     final var user = createUser();
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId1 = UUID.randomUUID().toString();
     final var resourceId2 = UUID.randomUUID().toString();
@@ -112,7 +112,7 @@ public class AuthorizationCheckBehaviorTest {
   public void shouldGetEmptySetWhenUserHasNoPermissions() {
     // given
     final var user = createUser();
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.DELETE;
     final var command = mockCommand(user.getUsername());
 
@@ -130,7 +130,7 @@ public class AuthorizationCheckBehaviorTest {
     // given
     final var user = createUser();
     final var roleKey = createRole(user.getUserKey());
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(roleKey, resourceType, permissionType, resourceId);
@@ -150,7 +150,7 @@ public class AuthorizationCheckBehaviorTest {
     // given
     final var user = createUser();
     final var roleKey = createRole(user.getUserKey());
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId1 = UUID.randomUUID().toString();
     final var resourceId2 = UUID.randomUUID().toString();
@@ -171,7 +171,7 @@ public class AuthorizationCheckBehaviorTest {
     // given
     final var user = createUser();
     final var groupKey = createGroup(user.getUserKey(), EntityType.USER);
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(groupKey, resourceType, permissionType, resourceId);
@@ -191,7 +191,7 @@ public class AuthorizationCheckBehaviorTest {
     // given
     final var user = createUser();
     final var groupKey = createGroup(user.getUserKey(), EntityType.USER);
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId1 = UUID.randomUUID().toString();
     final var resourceId2 = UUID.randomUUID().toString();
@@ -211,7 +211,7 @@ public class AuthorizationCheckBehaviorTest {
   public void shouldBeAuthorizedForUserTenant() {
     // given
     final var user = createUser();
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(user.getUserKey(), resourceType, permissionType, resourceId);
@@ -232,7 +232,7 @@ public class AuthorizationCheckBehaviorTest {
   public void shouldBeAuthorizedForUserTenantThroughGroup() {
     // given
     final var user = createUser();
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(user.getUserKey(), resourceType, permissionType, resourceId);
@@ -254,7 +254,7 @@ public class AuthorizationCheckBehaviorTest {
   public void shouldBeUnauthorizedForUserTenant() {
     // given
     final var user = createUser();
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(user.getUserKey(), resourceType, permissionType, resourceId);
@@ -278,7 +278,7 @@ public class AuthorizationCheckBehaviorTest {
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
     final var mappingKey = createMapping(claimName, claimValue);
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(mappingKey, resourceType, permissionType, resourceId);
@@ -301,7 +301,7 @@ public class AuthorizationCheckBehaviorTest {
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
     final var mappingKey = createMapping(claimName, claimValue);
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(mappingKey, resourceType, permissionType, resourceId);
@@ -325,7 +325,7 @@ public class AuthorizationCheckBehaviorTest {
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
     final var mappingKey = createMapping(claimName, claimValue);
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(mappingKey, resourceType, permissionType, resourceId);
@@ -474,7 +474,7 @@ public class AuthorizationCheckBehaviorTest {
   public void shouldBeAuthorizedWhenAnonymousAuthenticationProvided() {
     // given
     final var user = createUser();
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(user.getUserKey(), resourceType, permissionType, resourceId);
@@ -507,7 +507,7 @@ public class AuthorizationCheckBehaviorTest {
     final var claimValue = UUID.randomUUID().toString();
     final var mapping =
         engine.mapping().newMapping(claimName).withClaimValue(claimValue).create().getValue();
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(mapping.getMappingKey(), resourceType, permissionType, resourceId);
@@ -538,7 +538,7 @@ public class AuthorizationCheckBehaviorTest {
         .withEntityType(EntityType.MAPPING)
         .withEntityKey(mappingKey)
         .add();
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(mappingKey, resourceType, permissionType, resourceId);
@@ -570,7 +570,7 @@ public class AuthorizationCheckBehaviorTest {
         .withEntityType(EntityType.MAPPING)
         .withEntityKey(mappingKey)
         .add();
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(mappingKey, resourceType, permissionType, resourceId);
@@ -600,7 +600,7 @@ public class AuthorizationCheckBehaviorTest {
         .withEntityType(EntityType.MAPPING)
         .withEntityKey(mappingKey)
         .add();
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     engine
@@ -635,7 +635,7 @@ public class AuthorizationCheckBehaviorTest {
         .withEntityType(EntityType.MAPPING)
         .withEntityKey(mappingKey)
         .add();
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     engine
@@ -666,8 +666,7 @@ public class AuthorizationCheckBehaviorTest {
 
     // when
     final var request =
-        new AuthorizationRequest(
-                command, AuthorizationResourceType.DEPLOYMENT, PermissionType.DELETE)
+        new AuthorizationRequest(command, AuthorizationResourceType.RESOURCE, PermissionType.DELETE)
             .addResourceId(UUID.randomUUID().toString());
     final var authorized = authorizationCheckBehavior.isAuthorized(request);
 
@@ -697,7 +696,7 @@ public class AuthorizationCheckBehaviorTest {
             .create()
             .getKey();
 
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var firstResourceId = UUID.randomUUID().toString();
     final var secondResourceId = UUID.randomUUID().toString();
@@ -751,7 +750,7 @@ public class AuthorizationCheckBehaviorTest {
     final var secondMappingKey =
         engine.mapping().newMapping(claimName).withClaimValue(secondClaimValue).create().getKey();
 
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var firstResourceId = UUID.randomUUID().toString();
     final var secondResourceId = UUID.randomUUID().toString();
@@ -798,7 +797,7 @@ public class AuthorizationCheckBehaviorTest {
     final var claimValue = UUID.randomUUID().toString();
     final var mapping =
         engine.mapping().newMapping(claimName).withClaimValue(claimValue).create().getValue();
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(mapping.getMappingKey(), resourceType, permissionType, resourceId);
@@ -829,7 +828,7 @@ public class AuthorizationCheckBehaviorTest {
         .withEntityType(EntityType.MAPPING)
         .withEntityKey(mappingKey)
         .add();
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(roleKey, resourceType, permissionType, resourceId);
@@ -860,7 +859,7 @@ public class AuthorizationCheckBehaviorTest {
         .withEntityType(EntityType.MAPPING)
         .withEntityKey(mappingKey)
         .add();
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(groupKey, resourceType, permissionType, resourceId);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationRemovePermissionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationRemovePermissionAuthorizationTest.java
@@ -32,7 +32,6 @@ public class AuthorizationRemovePermissionAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
-  private static final long defaultUserKey = -1L;
 
   @Rule
   public final EngineRule engine =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationRemovePermissionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationRemovePermissionAuthorizationTest.java
@@ -32,7 +32,7 @@ public class AuthorizationRemovePermissionAuthorizationTest {
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
-  private static long defaultUserKey = -1L;
+  private static final long defaultUserKey = -1L;
 
   @Rule
   public final EngineRule engine =
@@ -46,7 +46,7 @@ public class AuthorizationRemovePermissionAuthorizationTest {
   public void shouldBeAuthorizedToRemovePermissionsWithDefaultUser() {
     // given
     final var resourceId = "resourceId";
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var user = createUser();
     addPermissionsToUser(user.getUserKey(), resourceType, permissionType, resourceId);
@@ -105,7 +105,7 @@ public class AuthorizationRemovePermissionAuthorizationTest {
             .authorization()
             .permission()
             .withOwnerKey(user.getUserKey())
-            .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+            .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermission(PermissionType.DELETE, "*")
             .expectRejection()
             .remove(user.getUsername());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RemovePermissionAuthorizationMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RemovePermissionAuthorizationMultiPartitionTest.java
@@ -41,7 +41,7 @@ public class RemovePermissionAuthorizationMultiPartitionTest {
   @Test
   public void shouldTestLifecycle() {
     // when
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     final var ownerKey = createUserWithPermission(resourceId, resourceType, permissionType);
@@ -104,7 +104,7 @@ public class RemovePermissionAuthorizationMultiPartitionTest {
   @Test
   public void shouldDistributeInIdentityQueue() {
     // given
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     final var ownerKey = createUserWithPermission(resourceId, resourceType, permissionType);
@@ -134,7 +134,7 @@ public class RemovePermissionAuthorizationMultiPartitionTest {
       interceptUserCreateForPartition(partitionId);
     }
 
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     final var ownerKey = createUserWithPermission(resourceId, resourceType, permissionType);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RemovePermissionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RemovePermissionAuthorizationTest.java
@@ -46,7 +46,7 @@ public class RemovePermissionAuthorizationTest {
         .authorization()
         .permission()
         .withOwnerKey(ownerKey)
-        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+        .withResourceType(AuthorizationResourceType.RESOURCE)
         .withPermission(PermissionType.CREATE, "foo")
         .withPermission(PermissionType.DELETE_PROCESS, "bar")
         .add()
@@ -58,7 +58,7 @@ public class RemovePermissionAuthorizationTest {
             .authorization()
             .permission()
             .withOwnerKey(ownerKey)
-            .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+            .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermission(PermissionType.CREATE, "foo")
             .withPermission(PermissionType.DELETE_PROCESS, "bar")
             .remove()
@@ -70,8 +70,7 @@ public class RemovePermissionAuthorizationTest {
             AuthorizationRecordValue::getOwnerKey,
             AuthorizationRecordValue::getOwnerType,
             AuthorizationRecordValue::getResourceType)
-        .containsExactly(
-            ownerKey, AuthorizationOwnerType.USER, AuthorizationResourceType.DEPLOYMENT);
+        .containsExactly(ownerKey, AuthorizationOwnerType.USER, AuthorizationResourceType.RESOURCE);
     assertThat(response.getPermissions())
         .extracting(PermissionValue::getPermissionType, PermissionValue::getResourceIds)
         .containsExactly(
@@ -90,7 +89,7 @@ public class RemovePermissionAuthorizationTest {
             .authorization()
             .permission()
             .withOwnerKey(ownerKey)
-            .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+            .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermission(PermissionType.CREATE, "foo")
             .expectRejection()
             .remove();
@@ -119,7 +118,7 @@ public class RemovePermissionAuthorizationTest {
         .authorization()
         .permission()
         .withOwnerKey(ownerKey)
-        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+        .withResourceType(AuthorizationResourceType.RESOURCE)
         .withPermission(PermissionType.CREATE, "foo")
         .withPermission(PermissionType.DELETE_PROCESS, "bar")
         .add()
@@ -131,7 +130,7 @@ public class RemovePermissionAuthorizationTest {
             .authorization()
             .permission()
             .withOwnerKey(ownerKey)
-            .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+            .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermission(PermissionType.DELETE_PROCESS, "foo", "bar")
             .expectRejection()
             .remove();
@@ -144,7 +143,7 @@ public class RemovePermissionAuthorizationTest {
             "Expected to remove '%s' permission for resource '%s' and resource identifiers '%s' for owner '%s', but this permission for resource identifiers '%s' is not found. Existing resource ids are: '%s'"
                 .formatted(
                     PermissionType.DELETE_PROCESS,
-                    AuthorizationResourceType.DEPLOYMENT,
+                    AuthorizationResourceType.RESOURCE,
                     "[bar, foo]",
                     ownerKey,
                     "[foo]",
@@ -169,7 +168,7 @@ public class RemovePermissionAuthorizationTest {
         .authorization()
         .permission()
         .withOwnerKey(roleKey)
-        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+        .withResourceType(AuthorizationResourceType.RESOURCE)
         .withPermission(PermissionType.CREATE, "foo")
         .withPermission(PermissionType.DELETE_PROCESS, "bar")
         .add()
@@ -182,7 +181,7 @@ public class RemovePermissionAuthorizationTest {
             .authorization()
             .permission()
             .withOwnerKey(userKey)
-            .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+            .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermission(PermissionType.DELETE_PROCESS, "foo", "bar")
             .expectRejection()
             .remove();
@@ -195,7 +194,7 @@ public class RemovePermissionAuthorizationTest {
             "Expected to remove '%s' permission for resource '%s' and resource identifiers '%s' for owner '%s', but this permission for resource identifiers '%s' is not found. Existing resource ids are: '%s'"
                 .formatted(
                     PermissionType.DELETE_PROCESS,
-                    AuthorizationResourceType.DEPLOYMENT,
+                    AuthorizationResourceType.RESOURCE,
                     "[bar, foo]",
                     userKey,
                     "[bar, foo]",
@@ -220,7 +219,7 @@ public class RemovePermissionAuthorizationTest {
         .authorization()
         .permission()
         .withOwnerKey(groupKey)
-        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+        .withResourceType(AuthorizationResourceType.RESOURCE)
         .withPermission(PermissionType.CREATE, "foo")
         .withPermission(PermissionType.DELETE_PROCESS, "bar")
         .add()
@@ -233,7 +232,7 @@ public class RemovePermissionAuthorizationTest {
             .authorization()
             .permission()
             .withOwnerKey(userKey)
-            .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+            .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermission(PermissionType.DELETE_PROCESS, "foo", "bar")
             .expectRejection()
             .remove();
@@ -246,7 +245,7 @@ public class RemovePermissionAuthorizationTest {
             "Expected to remove '%s' permission for resource '%s' and resource identifiers '%s' for owner '%s', but this permission for resource identifiers '%s' is not found. Existing resource ids are: '%s'"
                 .formatted(
                     PermissionType.DELETE_PROCESS,
-                    AuthorizationResourceType.DEPLOYMENT,
+                    AuthorizationResourceType.RESOURCE,
                     "[bar, foo]",
                     userKey,
                     "[bar, foo]",

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateAuthorizationTest.java
@@ -106,7 +106,7 @@ public class DeploymentCreateAuthorizationTest {
     Assertions.assertThat(rejection)
         .hasRejectionType(RejectionType.FORBIDDEN)
         .hasRejectionReason(
-            "Insufficient permissions to perform operation 'CREATE' on resource 'DEPLOYMENT'");
+            "Insufficient permissions to perform operation 'CREATE' on resource 'RESOURCE'");
   }
 
   private UserRecordValue createUser() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateAuthorizationTest.java
@@ -69,7 +69,7 @@ public class DeploymentCreateAuthorizationTest {
     final var processId = Strings.newRandomValidBpmnId();
     final var user = createUser();
     addPermissionsToUser(
-        user.getUserKey(), AuthorizationResourceType.DEPLOYMENT, PermissionType.CREATE);
+        user.getUserKey(), AuthorizationResourceType.RESOURCE, PermissionType.CREATE);
 
     // when
     engine

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationTest.java
@@ -106,7 +106,7 @@ public class ResourceDeletionAuthorizationTest {
                 .getFirst())
         .hasRejectionType(RejectionType.FORBIDDEN)
         .hasRejectionReason(
-            "Insufficient permissions to perform operation 'DELETE_PROCESS' on resource 'DEPLOYMENT', required resource identifiers are one of '[*, %s]'"
+            "Insufficient permissions to perform operation 'DELETE_PROCESS' on resource 'RESOURCE', required resource identifiers are one of '[*, %s]'"
                 .formatted(processId));
   }
 
@@ -163,7 +163,7 @@ public class ResourceDeletionAuthorizationTest {
                 .getFirst())
         .hasRejectionType(RejectionType.FORBIDDEN)
         .hasRejectionReason(
-            "Insufficient permissions to perform operation 'DELETE_DRD' on resource 'DEPLOYMENT', required resource identifiers are one of '[*, %s]'"
+            "Insufficient permissions to perform operation 'DELETE_DRD' on resource 'RESOURCE', required resource identifiers are one of '[*, %s]'"
                 .formatted(drdId));
   }
 
@@ -220,7 +220,7 @@ public class ResourceDeletionAuthorizationTest {
                 .getFirst())
         .hasRejectionType(RejectionType.FORBIDDEN)
         .hasRejectionReason(
-            "Insufficient permissions to perform operation 'DELETE_FORM' on resource 'DEPLOYMENT', required resource identifiers are one of '[*, %s]'"
+            "Insufficient permissions to perform operation 'DELETE_FORM' on resource 'RESOURCE', required resource identifiers are one of '[*, %s]'"
                 .formatted(formId));
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationTest.java
@@ -70,7 +70,7 @@ public class ResourceDeletionAuthorizationTest {
     final var user = createUser();
     addPermissionsToUser(
         user.getUserKey(),
-        AuthorizationResourceType.DEPLOYMENT,
+        AuthorizationResourceType.RESOURCE,
         PermissionType.DELETE_PROCESS,
         processId);
 
@@ -133,7 +133,7 @@ public class ResourceDeletionAuthorizationTest {
     final var drdKey = deployDrd();
     final var user = createUser();
     addPermissionsToUser(
-        user.getUserKey(), AuthorizationResourceType.DEPLOYMENT, PermissionType.DELETE_DRD, drdId);
+        user.getUserKey(), AuthorizationResourceType.RESOURCE, PermissionType.DELETE_DRD, drdId);
 
     // when
     engine.resourceDeletion().withResourceKey(drdKey).delete(user.getUsername());
@@ -190,10 +190,7 @@ public class ResourceDeletionAuthorizationTest {
     final var formKey = deployForm();
     final var user = createUser();
     addPermissionsToUser(
-        user.getUserKey(),
-        AuthorizationResourceType.DEPLOYMENT,
-        PermissionType.DELETE_FORM,
-        formId);
+        user.getUserKey(), AuthorizationResourceType.RESOURCE, PermissionType.DELETE_FORM, formId);
 
     // when
     engine.resourceDeletion().withResourceKey(formKey).delete(user.getUsername());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
@@ -52,7 +52,7 @@ public class AuthorizationStateTest {
     final String ownerId = "ownerId";
     final AuthorizationOwnerType ownerType = AuthorizationOwnerType.USER;
     final String resourceId = "resourceId";
-    final AuthorizationResourceType resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final AuthorizationResourceType resourceType = AuthorizationResourceType.RESOURCE;
     final Set<PermissionType> permissions = Set.of(PermissionType.CREATE, PermissionType.DELETE);
     final var authorizationRecord =
         new AuthorizationRecord()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
@@ -40,7 +40,7 @@ public class AuthorizationStateTest {
     // when
     final var persistedAuth =
         authorizationState.getResourceIdentifiers(
-            1L, AuthorizationResourceType.DEPLOYMENT, PermissionType.CREATE);
+            1L, AuthorizationResourceType.RESOURCE, PermissionType.CREATE);
     // then
     assertThat(persistedAuth).isEmpty();
   }
@@ -82,7 +82,7 @@ public class AuthorizationStateTest {
   void shouldCreatePermissions() {
     // given
     final var ownerKey = 1L;
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceIds = Set.of("foo", "bar");
 
@@ -99,7 +99,7 @@ public class AuthorizationStateTest {
   void shouldUpdatePermissionsIfAlreadyExists() {
     // given
     final var ownerKey = 1L;
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceIds = Set.of("foo", "bar");
     authorizationState.createOrAddPermission(ownerKey, resourceType, permissionType, resourceIds);
@@ -118,7 +118,7 @@ public class AuthorizationStateTest {
     // given
     final var ownerKey1 = 1L;
     final var ownerKey2 = 2L;
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     authorizationState.createOrAddPermission(
         ownerKey1, resourceType, permissionType, Set.of("foo"));
@@ -139,7 +139,7 @@ public class AuthorizationStateTest {
   void shouldStorePermissionsByResourceType() {
     // given
     final var ownerKey = 1L;
-    final var resourceType1 = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType1 = AuthorizationResourceType.RESOURCE;
     final var resourceType2 = AuthorizationResourceType.PROCESS_DEFINITION;
     final var permissionType = PermissionType.CREATE;
     authorizationState.createOrAddPermission(
@@ -161,7 +161,7 @@ public class AuthorizationStateTest {
   void shouldStorePermissionsByPermissionType() {
     // given
     final var ownerKey = 1L;
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType1 = PermissionType.CREATE;
     final var permissionType2 = PermissionType.UPDATE;
     authorizationState.createOrAddPermission(
@@ -229,7 +229,7 @@ public class AuthorizationStateTest {
     // given
     final var ownerKey1 = 1L;
     final var ownerKey2 = 2L;
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId1 = "foo";
     final var resourceId2 = "bar";
@@ -252,7 +252,7 @@ public class AuthorizationStateTest {
   void shouldRemoveSinglePermissionsByOwnerKey() {
     // given
     final var ownerKey = 1L;
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId1 = "foo";
     final var resourceId2 = "bar";
@@ -272,7 +272,7 @@ public class AuthorizationStateTest {
   void shouldRemoveAllPermissionsByOwnerKey() {
     // given
     final var ownerKey = 1L;
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId1 = "foo";
     final var resourceId2 = "bar";

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5762,7 +5762,7 @@ components:
         - APPLICATION
         - SYSTEM
         - TENANT
-        - DEPLOYMENT
+        - RESOURCE
         - PROCESS_DEFINITION
         - DECISION_REQUIREMENTS_DEFINITION
         - DECISION_DEFINITION

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/AuthorizationRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/AuthorizationRequestValidator.java
@@ -28,9 +28,9 @@ public final class AuthorizationRequestValidator {
   private static final Map<PermissionTypeEnum, ResourceTypeEnum>
       RESOURCE_SPECIFIC_PERMISSION_TYPES =
           Map.of(
-              PermissionTypeEnum.DELETE_PROCESS, ResourceTypeEnum.DEPLOYMENT,
-              PermissionTypeEnum.DELETE_DRD, ResourceTypeEnum.DEPLOYMENT,
-              PermissionTypeEnum.DELETE_FORM, ResourceTypeEnum.DEPLOYMENT);
+              PermissionTypeEnum.DELETE_PROCESS, ResourceTypeEnum.RESOURCE,
+              PermissionTypeEnum.DELETE_DRD, ResourceTypeEnum.RESOURCE,
+              PermissionTypeEnum.DELETE_FORM, ResourceTypeEnum.RESOURCE);
 
   public static Optional<ProblemDetail> validateAuthorizationCreateRequest(
       final AuthorizationCreateRequest request) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
@@ -147,7 +147,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
             new AuthorizationCreateRequest()
                 .ownerType(OwnerTypeEnum.USER)
                 .resourceId("resourceId")
-                .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                .resourceType(ResourceTypeEnum.RESOURCE)
                 .permissions(permissions),
             "No ownerId provided."),
         Arguments.of(
@@ -155,21 +155,21 @@ public class AuthorizationControllerTest extends RestControllerTest {
                 .ownerId("")
                 .ownerType(OwnerTypeEnum.USER)
                 .resourceId("resourceId")
-                .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                .resourceType(ResourceTypeEnum.RESOURCE)
                 .permissions(permissions),
             "No ownerId provided."),
         Arguments.of(
             new AuthorizationCreateRequest()
                 .ownerId("ownerId")
                 .resourceId("resourceId")
-                .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                .resourceType(ResourceTypeEnum.RESOURCE)
                 .permissions(permissions),
             "No ownerType provided."),
         Arguments.of(
             new AuthorizationCreateRequest()
                 .ownerId("ownerId")
                 .ownerType(OwnerTypeEnum.USER)
-                .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                .resourceType(ResourceTypeEnum.RESOURCE)
                 .permissions(permissions),
             "No resourceId provided."),
         Arguments.of(
@@ -177,7 +177,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
                 .ownerId("ownerId")
                 .ownerType(OwnerTypeEnum.USER)
                 .resourceId("")
-                .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                .resourceType(ResourceTypeEnum.RESOURCE)
                 .permissions(permissions),
             "No resourceId provided."),
         Arguments.of(
@@ -192,14 +192,14 @@ public class AuthorizationControllerTest extends RestControllerTest {
                 .ownerId("ownerId")
                 .ownerType(OwnerTypeEnum.USER)
                 .resourceId("resourceId")
-                .resourceType(ResourceTypeEnum.DEPLOYMENT),
+                .resourceType(ResourceTypeEnum.RESOURCE),
             "No permissions provided."),
         Arguments.of(
             new AuthorizationCreateRequest()
                 .ownerId("ownerId")
                 .ownerType(OwnerTypeEnum.USER)
                 .resourceId("resourceId")
-                .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                .resourceType(ResourceTypeEnum.RESOURCE)
                 .permissions(List.of()),
             "No permissions provided."));
   }
@@ -237,7 +237,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
     final var request =
         new AuthorizationPatchRequest()
             .action(action)
-            .resourceType(ResourceTypeEnum.DEPLOYMENT)
+            .resourceType(ResourceTypeEnum.RESOURCE)
             .permissions(List.of(permissions));
 
     final var permission =
@@ -283,7 +283,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
     final var request =
         new AuthorizationPatchRequest()
             .action(action)
-            .resourceType(ResourceTypeEnum.DEPLOYMENT)
+            .resourceType(ResourceTypeEnum.RESOURCE)
             .permissions(List.of(permissions));
 
     when(authorizationServices.patchAuthorization(any(PatchAuthorizationRequest.class)))
@@ -344,7 +344,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
     return Stream.of(
         Arguments.of(
             new AuthorizationPatchRequest()
-                .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                .resourceType(ResourceTypeEnum.RESOURCE)
                 .permissions(validPermissions),
             "No action provided."),
         Arguments.of(
@@ -353,31 +353,31 @@ public class AuthorizationControllerTest extends RestControllerTest {
         Arguments.of(
             new AuthorizationPatchRequest()
                 .action(ActionEnum.ADD)
-                .resourceType(ResourceTypeEnum.DEPLOYMENT),
+                .resourceType(ResourceTypeEnum.RESOURCE),
             "No permissions provided."),
         Arguments.of(
             new AuthorizationPatchRequest()
                 .action(ActionEnum.ADD)
-                .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                .resourceType(ResourceTypeEnum.RESOURCE)
                 .permissions(List.of()),
             "No permissions provided."),
         Arguments.of(
             new AuthorizationPatchRequest()
                 .action(ActionEnum.ADD)
-                .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                .resourceType(ResourceTypeEnum.RESOURCE)
                 .permissions(List.of(new PermissionDTO().resourceIds(Set.of("resourceId")))),
             "No permissionType provided."),
         Arguments.of(
             new AuthorizationPatchRequest()
                 .action(ActionEnum.ADD)
-                .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                .resourceType(ResourceTypeEnum.RESOURCE)
                 .permissions(
                     List.of(new PermissionDTO().permissionType(PermissionTypeEnum.CREATE))),
             "No resourceIds provided in 'CREATE'."),
         Arguments.of(
             new AuthorizationPatchRequest()
                 .action(ActionEnum.ADD)
-                .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                .resourceType(ResourceTypeEnum.RESOURCE)
                 .permissions(
                     List.of(
                         new PermissionDTO()

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2706,7 +2706,7 @@ final class JsonSerializableToJsonTest {
                     .setOwnerId("ownerId")
                     .setOwnerType(AuthorizationOwnerType.USER)
                     .setResourceId("resourceId")
-                    .setResourceType(AuthorizationResourceType.DEPLOYMENT)
+                    .setResourceType(AuthorizationResourceType.RESOURCE)
                     .addPermission(
                         new Permission()
                             .setPermissionType(PermissionType.CREATE)
@@ -2722,7 +2722,7 @@ final class JsonSerializableToJsonTest {
           "ownerId": "ownerId",
           "ownerType": "USER",
           "resourceId": "resourceId",
-          "resourceType": "DEPLOYMENT",
+          "resourceType": "RESOURCE",
           "permissions": [
             {
               "permissionType": "CREATE",
@@ -2748,7 +2748,7 @@ final class JsonSerializableToJsonTest {
             () ->
                 new AuthorizationRecord()
                     .setOwnerKey(1L)
-                    .setResourceType(AuthorizationResourceType.DEPLOYMENT),
+                    .setResourceType(AuthorizationResourceType.RESOURCE),
         """
         {
           "authorizationKey": -1,
@@ -2756,7 +2756,7 @@ final class JsonSerializableToJsonTest {
           "ownerKey": 1,
           "ownerType": "UNSPECIFIED",
           "resourceId": "",
-          "resourceType": "DEPLOYMENT",
+          "resourceType": "RESOURCE",
           "permissions": [],
           "authorizationPermissions": []
         }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/BasicAuthOverGrpcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/BasicAuthOverGrpcIT.java
@@ -138,7 +138,7 @@ public class BasicAuthOverGrpcIT {
           .isInstanceOf(ClientStatusException.class)
           .hasMessageContaining("FORBIDDEN")
           .hasMessageContaining(
-              "Insufficient permissions to perform operation 'CREATE' on resource 'DEPLOYMENT'");
+              "Insufficient permissions to perform operation 'CREATE' on resource 'RESOURCE'");
     }
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/BasicAuthOverGrpcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/BasicAuthOverGrpcIT.java
@@ -97,7 +97,7 @@ public class BasicAuthOverGrpcIT {
     authUtil.createUserWithPermissions(
         username,
         password,
-        new Permissions(ResourceTypeEnum.DEPLOYMENT, PermissionTypeEnum.CREATE, List.of("*")));
+        new Permissions(ResourceTypeEnum.RESOURCE, PermissionTypeEnum.CREATE, List.of("*")));
 
     try (final var client = authUtil.createClientGrpc(username, password)) {
       // when

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/BasicAuthOverRestIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/BasicAuthOverRestIT.java
@@ -90,7 +90,7 @@ final class BasicAuthOverRestIT {
     authUtil.createUserWithPermissions(
         username,
         password,
-        new Permissions(ResourceTypeEnum.DEPLOYMENT, PermissionTypeEnum.CREATE, List.of("*")));
+        new Permissions(ResourceTypeEnum.RESOURCE, PermissionTypeEnum.CREATE, List.of("*")));
 
     try (final var client = authUtil.createClient(username, password)) {
       // when

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/BasicAuthOverRestIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/BasicAuthOverRestIT.java
@@ -132,7 +132,7 @@ final class BasicAuthOverRestIT {
           .hasMessageContaining("title: FORBIDDEN")
           .hasMessageContaining("status: 403")
           .hasMessageContaining(
-              "Insufficient permissions to perform operation 'CREATE' on resource 'DEPLOYMENT'");
+              "Insufficient permissions to perform operation 'CREATE' on resource 'RESOURCE'");
     }
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AddPermissionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AddPermissionsTest.java
@@ -51,7 +51,7 @@ public class AddPermissionsTest {
     // when
     client
         .newAddPermissionsCommand(ownerKey)
-        .resourceType(ResourceTypeEnum.DEPLOYMENT)
+        .resourceType(ResourceTypeEnum.RESOURCE)
         .permission(PermissionTypeEnum.CREATE)
         .resourceId("resourceId")
         .send()
@@ -80,7 +80,7 @@ public class AddPermissionsTest {
     final var future =
         client
             .newAddPermissionsCommand(nonExistingOwnerKey)
-            .resourceType(ResourceTypeEnum.DEPLOYMENT)
+            .resourceType(ResourceTypeEnum.RESOURCE)
             .permission(PermissionTypeEnum.CREATE)
             .resourceId("resourceId")
             .send();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AddPermissionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AddPermissionsTest.java
@@ -64,7 +64,7 @@ public class AddPermissionsTest {
             .limit(2)
             .getLast()
             .getValue();
-    assertThat(recordValue.getResourceType()).isEqualTo(AuthorizationResourceType.DEPLOYMENT);
+    assertThat(recordValue.getResourceType()).isEqualTo(AuthorizationResourceType.RESOURCE);
     assertThat(recordValue.getOwnerType()).isEqualTo(AuthorizationOwnerType.USER);
     final var permission = recordValue.getPermissions().getFirst();
     assertThat(permission.getPermissionType()).isEqualTo(PermissionType.CREATE);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RemovePermissionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RemovePermissionsTest.java
@@ -69,7 +69,7 @@ public class RemovePermissionsTest {
             .limit(1)
             .getFirst()
             .getValue();
-    assertThat(recordValue.getResourceType()).isEqualTo(AuthorizationResourceType.DEPLOYMENT);
+    assertThat(recordValue.getResourceType()).isEqualTo(AuthorizationResourceType.RESOURCE);
     assertThat(recordValue.getOwnerType()).isEqualTo(AuthorizationOwnerType.USER);
     final var permission = recordValue.getPermissions().getFirst();
     assertThat(permission.getPermissionType()).isEqualTo(PermissionType.CREATE);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RemovePermissionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RemovePermissionsTest.java
@@ -48,7 +48,7 @@ public class RemovePermissionsTest {
   void shouldRemovePermissionsFromOwner() {
     // given
     final long ownerKey = createUser();
-    final var resourceType = ResourceTypeEnum.DEPLOYMENT;
+    final var resourceType = ResourceTypeEnum.RESOURCE;
     final var permissionType = PermissionTypeEnum.CREATE;
     final var resourceId = "resourceId";
     addPermissionToOwner(ownerKey, resourceType, permissionType, resourceId);
@@ -85,7 +85,7 @@ public class RemovePermissionsTest {
     final var future =
         client
             .newRemovePermissionsCommand(nonExistingOwnerKey)
-            .resourceType(ResourceTypeEnum.DEPLOYMENT)
+            .resourceType(ResourceTypeEnum.RESOURCE)
             .permission(PermissionTypeEnum.CREATE)
             .resourceId("resourceId")
             .send();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

User are familiar with the term resource from creating/deleting resources. It makes sense to name the authorization resource type the same way.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #27067 
