### PR TITLE
ci: test using bigger runner to avoid OOM kills

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
             maven-modules: "'!qa/integration-tests,!qa/update-tests' -f zeebe"
             maven-build-threads: 2
             maven-test-fork-count: 7
-            runs-on: gcp-perf-core-8-longrunning
+            runs-on: gcp-perf-core-16-longrunning
           - group: qa-integration
             name: "Zeebe QA - Integration Tests"
             maven-modules: "zeebe/qa/integration-tests"


### PR DESCRIPTION
## Description

It was identified in INC-2230 that the `Zeebe Module Integration Tests` frequently leads to OOM kills (of processes like `java`, `Runner.Listener`, `Runner.Worker` and `run.sh`) so trying with more CPU cores (and more RAM) to try to fix the instability.

If we confirm that this fixes, we can find a less costly way of achieving the same.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Related to INC-2230
