### PR TITLE
[Backport stable/operate-8.5] fix: ignore MIGRATED variable records

### DIFF
--- a/operate/importer-8_4/src/main/java/io/camunda/operate/zeebeimport/v8_4/processors/ListViewZeebeRecordProcessor.java
+++ b/operate/importer-8_4/src/main/java/io/camunda/operate/zeebeimport/v8_4/processors/ListViewZeebeRecordProcessor.java
@@ -59,6 +59,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.*;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -193,15 +194,15 @@ public class ListViewZeebeRecordProcessor {
       final var scopedVariables = variableRecords.getValue();
 
       for (final var scopedVariable : scopedVariables) {
+        if (!shouldProcessVariableRecord(scopedVariable)) {
+          continue;
+        }
         final var intent = scopedVariable.getIntent();
         final var variableValue = scopedVariable.getValue();
         final var variableName = variableValue.getName();
         final var cachedVariable =
             temporaryVariableCache.computeIfAbsent(
-                variableName,
-                (k) -> {
-                  return Tuple.of(intent, new VariableForListViewEntity());
-                });
+                variableName, (k) -> Tuple.of(intent, new VariableForListViewEntity()));
         final var variableEntity = cachedVariable.getRight();
         processVariableRecord(scopedVariable, variableEntity);
       }
@@ -466,6 +467,12 @@ public class ListViewZeebeRecordProcessor {
     return PI_AND_AI_START_STATES.contains(intent)
         || PI_AND_AI_FINISH_STATES.contains(intent)
         || ELEMENT_MIGRATED.name().equals(intent);
+  }
+
+  private boolean shouldProcessVariableRecord(final Record<VariableRecordValue> record) {
+    final var intent = record.getIntent().name();
+    // skip variable migrated record as it always has null in value field
+    return !VariableIntent.MIGRATED.name().equals(intent);
   }
 
   private boolean isProcessInstanceTerminated(final Record<ProcessInstanceRecordValue> record) {

--- a/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/processors/ListViewZeebeRecordProcessor.java
+++ b/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/processors/ListViewZeebeRecordProcessor.java
@@ -59,6 +59,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.*;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -205,6 +206,9 @@ public class ListViewZeebeRecordProcessor {
       final var scopedVariables = variableRecords.getValue();
 
       for (final var scopedVariable : scopedVariables) {
+        if (!shouldProcessVariableRecord(scopedVariable)) {
+          continue;
+        }
         final var intent = scopedVariable.getIntent();
         final var variableValue = scopedVariable.getValue();
         final var variableName = variableValue.getName();
@@ -492,6 +496,12 @@ public class ListViewZeebeRecordProcessor {
     return PI_AND_AI_START_STATES.contains(intent)
         || PI_AND_AI_FINISH_STATES.contains(intent)
         || ELEMENT_MIGRATED.name().equals(intent);
+  }
+
+  private boolean shouldProcessVariableRecord(final Record<VariableRecordValue> record) {
+    final var intent = record.getIntent().name();
+    // skip variable migrated record as it always has null in value field
+    return !VariableIntent.MIGRATED.name().equals(intent);
   }
 
   private boolean isProcessInstanceTerminated(final Record<ProcessInstanceRecordValue> record) {


### PR DESCRIPTION
# Description
Backport of #26914 to `stable/operate-8.5`.

relates to #26490
original author: @sdorokhova