### PR TITLE
[Backport stable/8.6] fix: ignore MIGRATED variable records

### DIFF
--- a/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/v8_5/processors/ListViewZeebeRecordProcessor.java
+++ b/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/v8_5/processors/ListViewZeebeRecordProcessor.java
@@ -50,6 +50,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.*;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -184,15 +185,15 @@ public class ListViewZeebeRecordProcessor {
       final var scopedVariables = variableRecords.getValue();
 
       for (final var scopedVariable : scopedVariables) {
+        if (!shouldProcessVariableRecord(scopedVariable)) {
+          continue;
+        }
         final var intent = scopedVariable.getIntent();
         final var variableValue = scopedVariable.getValue();
         final var variableName = variableValue.getName();
         final var cachedVariable =
             temporaryVariableCache.computeIfAbsent(
-                variableName,
-                (k) -> {
-                  return Tuple.of(intent, new VariableForListViewEntity());
-                });
+                variableName, (k) -> Tuple.of(intent, new VariableForListViewEntity()));
         final var variableEntity = cachedVariable.getRight();
         processVariableRecord(scopedVariable, variableEntity);
       }
@@ -457,6 +458,12 @@ public class ListViewZeebeRecordProcessor {
     return PI_AND_AI_START_STATES.contains(intent)
         || PI_AND_AI_FINISH_STATES.contains(intent)
         || ELEMENT_MIGRATED.name().equals(intent);
+  }
+
+  private boolean shouldProcessVariableRecord(final Record<VariableRecordValue> record) {
+    final var intent = record.getIntent().name();
+    // skip variable migrated record as it always has null in value field
+    return !VariableIntent.MIGRATED.name().equals(intent);
   }
 
   private boolean isProcessInstanceTerminated(final Record<ProcessInstanceRecordValue> record) {

--- a/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/ListViewZeebeRecordProcessor.java
+++ b/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/ListViewZeebeRecordProcessor.java
@@ -51,6 +51,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.*;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -197,6 +198,9 @@ public class ListViewZeebeRecordProcessor {
       final var scopedVariables = variableRecords.getValue();
 
       for (final var scopedVariable : scopedVariables) {
+        if (!shouldProcessVariableRecord(scopedVariable)) {
+          continue;
+        }
         final var intent = scopedVariable.getIntent();
         final var variableValue = scopedVariable.getValue();
         final var variableName = variableValue.getName();
@@ -491,6 +495,12 @@ public class ListViewZeebeRecordProcessor {
     return PI_AND_AI_START_STATES.contains(intent)
         || PI_AND_AI_FINISH_STATES.contains(intent)
         || ELEMENT_MIGRATED.name().equals(intent);
+  }
+
+  private boolean shouldProcessVariableRecord(final Record<VariableRecordValue> record) {
+    final var intent = record.getIntent().name();
+    // skip variable migrated record as it always has null in value field
+    return !VariableIntent.MIGRATED.name().equals(intent);
   }
 
   private boolean isProcessInstanceTerminated(final Record<ProcessInstanceRecordValue> record) {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/processors/ListViewZeebeRecordProcessorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/processors/ListViewZeebeRecordProcessorIT.java
@@ -707,6 +707,48 @@ public class ListViewZeebeRecordProcessorIT extends OperateSearchAbstractIT {
     assertThat(updatedFni.getPositionJob()).isEqualTo(2L);
   }
 
+  @Test
+  public void shouldNotClearVariableValueDuringMigration()
+      throws PersistenceException, IOException {
+    // having
+    final long processInstanceKey = 333L;
+    final VariableForListViewEntity variableEntity = createVariableForListView(processInstanceKey);
+
+    final String variableValue = "varValue";
+    variableEntity.setVarValue(variableValue);
+    testSearchRepository.createOrUpdateDocumentFromObject(
+        listViewTemplate.getFullQualifiedName(),
+        variableEntity.getId(),
+        variableEntity,
+        String.valueOf(processInstanceKey));
+
+    final Record<VariableRecordValue> zeebeRecord =
+        (Record)
+            ImmutableRecord.builder()
+                .withKey(variableEntity.getKey())
+                .withPosition(1L)
+                .withIntent(VariableIntent.MIGRATED)
+                .withValue(
+                    ImmutableVariableRecordValue.builder()
+                        .withBpmnProcessId("bpmnId")
+                        .withName(variableEntity.getVarName())
+                        .withProcessDefinitionKey(123L)
+                        .withProcessInstanceKey(processInstanceKey)
+                        .withScopeKey(processInstanceKey)
+                        .withValue(null) // migrated Zeebe variable records have a null value
+                        .build())
+                .build();
+
+    // when
+    importVariableZeebeRecord(zeebeRecord);
+
+    // then
+    // the variable value has not been set to null but is still the old value
+    final VariableForListViewEntity persistedVariable = variableById(variableEntity.getId());
+    // old values
+    assertThat(persistedVariable.getVarValue()).isEqualTo(variableValue);
+  }
+
   @NotNull
   private ProcessInstanceForListViewEntity findProcessInstanceByKey(final long key)
       throws IOException {


### PR DESCRIPTION
# Description
Backport of #26914 to `stable/8.6`.

relates to #26490
original author: @sdorokhova