### PR TITLE
feat: Allow Camunda Exporter index descriptors to decide how their persistence errors are handled

### DIFF
--- a/migration/process-migration/src/main/java/io/camunda/migration/process/adapter/MigrationRepositoryIndex.java
+++ b/migration/process-migration/src/main/java/io/camunda/migration/process/adapter/MigrationRepositoryIndex.java
@@ -7,10 +7,11 @@
  */
 package io.camunda.migration.process.adapter;
 
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.operate.OperateIndexDescriptor;
 
 /* Fork of Operate's MigrationRepositoryIndex descriptor for correct prefixing */
-public class MigrationRepositoryIndex extends OperateIndexDescriptor {
+public class MigrationRepositoryIndex extends OperateIndexDescriptor implements ErrorThrowing {
 
   public static final String INDEX_NAME = "migration-steps-repository";
   public static final String VERSION = "1.1.0";

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/util/TestDynamicIndex.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/util/TestDynamicIndex.java
@@ -7,9 +7,10 @@
  */
 package io.camunda.operate.schema.util;
 
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.operate.OperateIndexDescriptor;
 
-public class TestDynamicIndex extends OperateIndexDescriptor {
+public class TestDynamicIndex extends OperateIndexDescriptor implements ErrorThrowing {
 
   public TestDynamicIndex(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/util/elasticsearch/ElasticsearchSchemaTestHelper.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/util/elasticsearch/ElasticsearchSchemaTestHelper.java
@@ -109,6 +109,11 @@ public class ElasticsearchSchemaTestHelper implements SchemaTestHelper {
     schemaManager.createIndex(
         new OperateIndexDescriptor(properties.getElasticsearch().getIndexPrefix(), true) {
           @Override
+          public ErrorHandling getErrorHandlingBehavior() {
+            return ErrorHandling.THROW;
+          }
+
+          @Override
           public String getIndexName() {
             return indexDescriptor.getIndexName();
           }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/util/opensearch/OpenSearchSchemaTestHelper.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/util/opensearch/OpenSearchSchemaTestHelper.java
@@ -104,6 +104,11 @@ public class OpenSearchSchemaTestHelper implements SchemaTestHelper {
     schemaManager.createIndex(
         new OperateIndexDescriptor(properties.getOpensearch().getIndexPrefix(), false) {
           @Override
+          public ErrorHandling getErrorHandlingBehavior() {
+            return ErrorHandling.THROW;
+          }
+
+          @Override
           public String getIndexName() {
             return indexDescriptor.getIndexName();
           }

--- a/operate/schema/src/main/java/io/camunda/operate/schema/indices/UserIndex.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/indices/UserIndex.java
@@ -10,13 +10,14 @@ package io.camunda.operate.schema.indices;
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.operate.OperateIndexDescriptor;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-public class UserIndex extends OperateIndexDescriptor implements Prio5Backup {
+public class UserIndex extends OperateIndexDescriptor implements Prio5Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "user";
   public static final String ID = "id";

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/indices/UserIndex.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/indices/UserIndex.java
@@ -8,9 +8,10 @@
 package io.camunda.tasklist.schema.indices;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.tasklist.TasklistIndexDescriptor;
 
-public class UserIndex extends TasklistIndexDescriptor implements Prio5Backup {
+public class UserIndex extends TasklistIndexDescriptor implements Prio5Backup, ErrorThrowing {
 
   public static final String ID = "id";
   public static final String USER_ID = "userId";

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticSearchSchemaManagementIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticSearchSchemaManagementIT.java
@@ -179,6 +179,11 @@ public class ElasticSearchSchemaManagementIT extends TasklistZeebeIntegrationTes
   private IndexDescriptor createIndexDescriptor() {
     return new IndexDescriptor() {
       @Override
+      public ErrorHandling getErrorHandlingBehavior() {
+        return ErrorHandling.THROW;
+      }
+
+      @Override
       public String getFullQualifiedName() {
         return getFullIndexName();
       }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/IndexSchemaValidatorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/IndexSchemaValidatorIT.java
@@ -132,6 +132,11 @@ public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
   private IndexDescriptor createIndexDescriptor() {
     return new IndexDescriptor() {
       @Override
+      public ErrorHandling getErrorHandlingBehavior() {
+        return ErrorHandling.THROW;
+      }
+
+      @Override
       public String getFullQualifiedName() {
         return getFullIndexName();
       }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/IndexSchemaValidatorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/IndexSchemaValidatorIT.java
@@ -122,6 +122,11 @@ public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
   private IndexDescriptor createIndexDescriptor() {
     return new IndexDescriptor() {
       @Override
+      public ErrorHandling getErrorHandlingBehavior() {
+        return ErrorHandling.THROW;
+      }
+
+      @Override
       public String getFullQualifiedName() {
         return getFullIndexName();
       }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchSchemaManagementIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchSchemaManagementIT.java
@@ -176,6 +176,11 @@ public class OpenSearchSchemaManagementIT extends TasklistZeebeIntegrationTest {
   private IndexDescriptor createIndexDescriptor() {
     return new IndexDescriptor() {
       @Override
+      public ErrorHandling getErrorHandlingBehavior() {
+        return ErrorHandling.THROW;
+      }
+
+      @Override
       public String getFullQualifiedName() {
         return getFullIndexName();
       }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptor.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/IndexDescriptor.java
@@ -7,9 +7,10 @@
  */
 package io.camunda.webapps.schema.descriptors;
 
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorHandlingBehavior;
 import java.util.Optional;
 
-public interface IndexDescriptor {
+public interface IndexDescriptor extends ErrorHandlingBehavior {
 
   String TENANT_ID = "tenantId";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/errorHandling/ErrorHandlingBehavior.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/errorHandling/ErrorHandlingBehavior.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.descriptors.errorHandling;
+
+public interface ErrorHandlingBehavior {
+  ErrorHandling getErrorHandlingBehavior();
+
+  enum ErrorHandling {
+    THROW,
+    SWALLOW
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/errorHandling/ErrorSwallowing.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/errorHandling/ErrorSwallowing.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.descriptors.errorHandling;
+
+public interface ErrorSwallowing extends ErrorHandlingBehavior {
+
+  @Override
+  default ErrorHandling getErrorHandlingBehavior() {
+    return ErrorHandling.SWALLOW;
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/errorHandling/ErrorThrowing.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/errorHandling/ErrorThrowing.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.descriptors.errorHandling;
+
+public interface ErrorThrowing extends ErrorHandlingBehavior {
+
+  @Override
+  default ErrorHandling getErrorHandlingBehavior() {
+    return ErrorHandling.THROW;
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/index/DecisionIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/index/DecisionIndex.java
@@ -8,10 +8,11 @@
 package io.camunda.webapps.schema.descriptors.operate.index;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.operate.OperateIndexDescriptor;
 import java.util.Optional;
 
-public class DecisionIndex extends OperateIndexDescriptor implements Prio4Backup {
+public class DecisionIndex extends OperateIndexDescriptor implements Prio4Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "decision";
   public static final String ID = "id";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/index/DecisionRequirementsIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/index/DecisionRequirementsIndex.java
@@ -8,10 +8,12 @@
 package io.camunda.webapps.schema.descriptors.operate.index;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.operate.OperateIndexDescriptor;
 import java.util.Optional;
 
-public class DecisionRequirementsIndex extends OperateIndexDescriptor implements Prio5Backup {
+public class DecisionRequirementsIndex extends OperateIndexDescriptor
+    implements Prio5Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "decision-requirements";
   public static final String ID = "id";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/index/ImportPositionIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/index/ImportPositionIndex.java
@@ -8,9 +8,11 @@
 package io.camunda.webapps.schema.descriptors.operate.index;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio1Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.operate.OperateIndexDescriptor;
 
-public class ImportPositionIndex extends OperateIndexDescriptor implements Prio1Backup {
+public class ImportPositionIndex extends OperateIndexDescriptor
+    implements Prio1Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "import-position";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/index/MetricIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/index/MetricIndex.java
@@ -8,10 +8,11 @@
 package io.camunda.webapps.schema.descriptors.operate.index;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.operate.OperateIndexDescriptor;
 import java.util.Optional;
 
-public class MetricIndex extends OperateIndexDescriptor implements Prio5Backup {
+public class MetricIndex extends OperateIndexDescriptor implements Prio5Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "metric";
   public static final String ID = "id";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/index/ProcessIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/index/ProcessIndex.java
@@ -8,10 +8,11 @@
 package io.camunda.webapps.schema.descriptors.operate.index;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.operate.OperateIndexDescriptor;
 import java.util.Optional;
 
-public class ProcessIndex extends OperateIndexDescriptor implements Prio5Backup {
+public class ProcessIndex extends OperateIndexDescriptor implements Prio5Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "process";
   public static final String ID = "id";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/BatchOperationTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/BatchOperationTemplate.java
@@ -8,9 +8,11 @@
 package io.camunda.webapps.schema.descriptors.operate.template;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 
-public class BatchOperationTemplate extends OperateTemplateDescriptor implements Prio3Backup {
+public class BatchOperationTemplate extends OperateTemplateDescriptor
+    implements Prio3Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "batch-operation";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/DecisionInstanceTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/DecisionInstanceTemplate.java
@@ -8,12 +8,13 @@
 package io.camunda.webapps.schema.descriptors.operate.template;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 import java.util.Optional;
 
 public class DecisionInstanceTemplate extends OperateTemplateDescriptor
-    implements ProcessInstanceDependant, Prio4Backup {
+    implements ProcessInstanceDependant, Prio4Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "decision-instance";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/EventTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/EventTemplate.java
@@ -8,12 +8,13 @@
 package io.camunda.webapps.schema.descriptors.operate.template;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 import java.util.Optional;
 
 public class EventTemplate extends OperateTemplateDescriptor
-    implements ProcessInstanceDependant, Prio4Backup {
+    implements ProcessInstanceDependant, Prio4Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "event";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/FlowNodeInstanceTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/FlowNodeInstanceTemplate.java
@@ -8,12 +8,13 @@
 package io.camunda.webapps.schema.descriptors.operate.template;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 import java.util.Optional;
 
 public class FlowNodeInstanceTemplate extends OperateTemplateDescriptor
-    implements ProcessInstanceDependant, Prio4Backup {
+    implements ProcessInstanceDependant, Prio4Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "flownode-instance";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/IncidentTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/IncidentTemplate.java
@@ -8,12 +8,13 @@
 package io.camunda.webapps.schema.descriptors.operate.template;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 import java.util.Optional;
 
 public class IncidentTemplate extends OperateTemplateDescriptor
-    implements ProcessInstanceDependant, Prio4Backup {
+    implements ProcessInstanceDependant, Prio4Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "incident";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/JobTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/JobTemplate.java
@@ -8,12 +8,13 @@
 package io.camunda.webapps.schema.descriptors.operate.template;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 import java.util.Optional;
 
 public class JobTemplate extends OperateTemplateDescriptor
-    implements ProcessInstanceDependant, Prio4Backup {
+    implements ProcessInstanceDependant, Prio4Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "job";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/ListViewTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/ListViewTemplate.java
@@ -8,10 +8,12 @@
 package io.camunda.webapps.schema.descriptors.operate.template;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio2Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 import java.util.Optional;
 
-public class ListViewTemplate extends OperateTemplateDescriptor implements Prio2Backup {
+public class ListViewTemplate extends OperateTemplateDescriptor
+    implements Prio2Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "list-view";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/MessageTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/MessageTemplate.java
@@ -8,10 +8,12 @@
 package io.camunda.webapps.schema.descriptors.operate.template;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 import java.util.Optional;
 
-public class MessageTemplate extends OperateTemplateDescriptor implements Prio4Backup {
+public class MessageTemplate extends OperateTemplateDescriptor
+    implements Prio4Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "message";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/OperationTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/OperationTemplate.java
@@ -8,11 +8,12 @@
 package io.camunda.webapps.schema.descriptors.operate.template;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorSwallowing;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 
 public class OperationTemplate extends OperateTemplateDescriptor
-    implements ProcessInstanceDependant, Prio3Backup {
+    implements ProcessInstanceDependant, Prio3Backup, ErrorSwallowing {
 
   public static final String INDEX_NAME = "operation";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/PostImporterQueueTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/PostImporterQueueTemplate.java
@@ -8,11 +8,12 @@
 package io.camunda.webapps.schema.descriptors.operate.template;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 
 public class PostImporterQueueTemplate extends OperateTemplateDescriptor
-    implements ProcessInstanceDependant, Prio4Backup {
+    implements ProcessInstanceDependant, Prio4Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "post-importer-queue";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/SequenceFlowTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/SequenceFlowTemplate.java
@@ -8,12 +8,13 @@
 package io.camunda.webapps.schema.descriptors.operate.template;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 import java.util.Optional;
 
 public class SequenceFlowTemplate extends OperateTemplateDescriptor
-    implements ProcessInstanceDependant, Prio4Backup {
+    implements ProcessInstanceDependant, Prio4Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "sequence-flow";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/VariableTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/VariableTemplate.java
@@ -8,12 +8,13 @@
 package io.camunda.webapps.schema.descriptors.operate.template;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 import java.util.Optional;
 
 public class VariableTemplate extends OperateTemplateDescriptor
-    implements ProcessInstanceDependant, Prio4Backup {
+    implements ProcessInstanceDependant, Prio4Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "variable";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/index/FormIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/index/FormIndex.java
@@ -9,10 +9,11 @@ package io.camunda.webapps.schema.descriptors.tasklist.index;
 
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.tasklist.TasklistIndexDescriptor;
 import java.util.Optional;
 
-public class FormIndex extends TasklistIndexDescriptor implements Prio5Backup {
+public class FormIndex extends TasklistIndexDescriptor implements Prio5Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "form";
   public static final String INDEX_VERSION = "8.4.0";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/index/TasklistImportPositionIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/index/TasklistImportPositionIndex.java
@@ -8,9 +8,11 @@
 package io.camunda.webapps.schema.descriptors.tasklist.index;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio1Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.tasklist.TasklistIndexDescriptor;
 
-public class TasklistImportPositionIndex extends TasklistIndexDescriptor implements Prio1Backup {
+public class TasklistImportPositionIndex extends TasklistIndexDescriptor
+    implements Prio1Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "import-position";
   public static final String INDEX_VERSION = "8.2.0";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/index/TasklistMetricIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/index/TasklistMetricIndex.java
@@ -9,10 +9,12 @@ package io.camunda.webapps.schema.descriptors.tasklist.index;
 
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.tasklist.TasklistIndexDescriptor;
 import java.util.Optional;
 
-public class TasklistMetricIndex extends TasklistIndexDescriptor implements Prio5Backup {
+public class TasklistMetricIndex extends TasklistIndexDescriptor
+    implements Prio5Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "metric";
   public static final String INDEX_VERSION = "8.3.0";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/template/DraftTaskVariableTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/template/DraftTaskVariableTemplate.java
@@ -8,10 +8,12 @@
 package io.camunda.webapps.schema.descriptors.tasklist.template;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.tasklist.TasklistTemplateDescriptor;
 import java.util.Optional;
 
-public class DraftTaskVariableTemplate extends TasklistTemplateDescriptor implements Prio4Backup {
+public class DraftTaskVariableTemplate extends TasklistTemplateDescriptor
+    implements Prio4Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "draft-task-variable";
   public static final String INDEX_VERSION = "8.3.0";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/template/SnapshotTaskVariableTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/template/SnapshotTaskVariableTemplate.java
@@ -8,12 +8,13 @@
 package io.camunda.webapps.schema.descriptors.tasklist.template;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.tasklist.TasklistTemplateDescriptor;
 import java.util.Optional;
 
 public class SnapshotTaskVariableTemplate extends TasklistTemplateDescriptor
-    implements ProcessInstanceDependant, Prio4Backup {
+    implements ProcessInstanceDependant, Prio4Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "task-variable";
   public static final String INDEX_VERSION = "8.3.0";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/template/TaskTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/template/TaskTemplate.java
@@ -8,12 +8,13 @@
 package io.camunda.webapps.schema.descriptors.tasklist.template;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio2Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.tasklist.TasklistTemplateDescriptor;
 import java.util.Optional;
 
 public class TaskTemplate extends TasklistTemplateDescriptor
-    implements Prio2Backup, ProcessInstanceDependant {
+    implements Prio2Backup, ProcessInstanceDependant, ErrorThrowing {
 
   public static final String INDEX_NAME = "task";
   public static final String INDEX_VERSION = "8.5.0";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/AuthorizationIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/AuthorizationIndex.java
@@ -8,9 +8,11 @@
 package io.camunda.webapps.schema.descriptors.usermanagement.index;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.usermanagement.UserManagementIndexDescriptor;
 
-public class AuthorizationIndex extends UserManagementIndexDescriptor implements Prio5Backup {
+public class AuthorizationIndex extends UserManagementIndexDescriptor
+    implements Prio5Backup, ErrorThrowing {
   public static final String INDEX_NAME = "authorization";
   public static final String INDEX_VERSION = "8.7.0";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/GroupIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/GroupIndex.java
@@ -8,11 +8,13 @@
 package io.camunda.webapps.schema.descriptors.usermanagement.index;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.usermanagement.UserManagementIndexDescriptor;
 import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.EntityJoinRelationFactory;
 import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.IdentityJoinRelationshipType;
 
-public class GroupIndex extends UserManagementIndexDescriptor implements Prio5Backup {
+public class GroupIndex extends UserManagementIndexDescriptor
+    implements Prio5Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "group";
   public static final String INDEX_VERSION = "8.7.0";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/MappingIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/MappingIndex.java
@@ -8,9 +8,11 @@
 package io.camunda.webapps.schema.descriptors.usermanagement.index;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.usermanagement.UserManagementIndexDescriptor;
 
-public class MappingIndex extends UserManagementIndexDescriptor implements Prio5Backup {
+public class MappingIndex extends UserManagementIndexDescriptor
+    implements Prio5Backup, ErrorThrowing {
   public static final String INDEX_NAME = "mapping";
   public static final String INDEX_VERSION = "8.7.0";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/PersistentWebSessionIndexDescriptor.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/PersistentWebSessionIndexDescriptor.java
@@ -8,10 +8,11 @@
 package io.camunda.webapps.schema.descriptors.usermanagement.index;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.usermanagement.UserManagementIndexDescriptor;
 
 public class PersistentWebSessionIndexDescriptor extends UserManagementIndexDescriptor
-    implements Prio5Backup {
+    implements Prio5Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "web-session";
   public static final String INDEX_VERSION = "8.7.0";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/RoleIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/RoleIndex.java
@@ -8,11 +8,12 @@
 package io.camunda.webapps.schema.descriptors.usermanagement.index;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.usermanagement.UserManagementIndexDescriptor;
 import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.EntityJoinRelationFactory;
 import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.IdentityJoinRelationshipType;
 
-public class RoleIndex extends UserManagementIndexDescriptor implements Prio5Backup {
+public class RoleIndex extends UserManagementIndexDescriptor implements Prio5Backup, ErrorThrowing {
   public static final String INDEX_NAME = "role";
   public static final String INDEX_VERSION = "8.7.0";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/TenantIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/TenantIndex.java
@@ -8,11 +8,13 @@
 package io.camunda.webapps.schema.descriptors.usermanagement.index;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.usermanagement.UserManagementIndexDescriptor;
 import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation;
 import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.EntityJoinRelationFactory;
 
-public class TenantIndex extends UserManagementIndexDescriptor implements Prio5Backup {
+public class TenantIndex extends UserManagementIndexDescriptor
+    implements Prio5Backup, ErrorThrowing {
 
   public static final String INDEX_NAME = "tenant";
   public static final String INDEX_VERSION = "8.7.0";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/UserIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/UserIndex.java
@@ -8,9 +8,10 @@
 package io.camunda.webapps.schema.descriptors.usermanagement.index;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
+import io.camunda.webapps.schema.descriptors.errorHandling.ErrorThrowing;
 import io.camunda.webapps.schema.descriptors.usermanagement.UserManagementIndexDescriptor;
 
-public class UserIndex extends UserManagementIndexDescriptor implements Prio5Backup {
+public class UserIndex extends UserManagementIndexDescriptor implements Prio5Backup, ErrorThrowing {
   public static final String INDEX_NAME = "user";
   public static final String INDEX_VERSION = "8.7.0";
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -135,110 +135,71 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
 
     exportHandlers =
         Set.of(
-            new RoleCreateUpdateHandler(
-                indexDescriptors.get(RoleIndex.class).getFullQualifiedName()),
-            new RoleDeletedHandler(indexDescriptors.get(RoleIndex.class).getFullQualifiedName()),
-            new RoleMemberAddedHandler(
-                indexDescriptors.get(RoleIndex.class).getFullQualifiedName()),
-            new RoleMemberRemovedHandler(
-                indexDescriptors.get(RoleIndex.class).getFullQualifiedName()),
-            new RoleDeletedHandler(indexDescriptors.get(RoleIndex.class).getFullQualifiedName()),
-            new UserCreatedUpdatedHandler(
-                indexDescriptors.get(UserIndex.class).getFullQualifiedName()),
-            new UserDeletedHandler(indexDescriptors.get(UserIndex.class).getFullQualifiedName()),
-            new AuthorizationHandler(
-                indexDescriptors.get(AuthorizationIndex.class).getFullQualifiedName()),
-            new TenantCreateUpdateHandler(
-                indexDescriptors.get(TenantIndex.class).getFullQualifiedName()),
-            new TenantDeletedHandler(
-                indexDescriptors.get(TenantIndex.class).getFullQualifiedName()),
-            new TenantEntityAddedHandler(
-                indexDescriptors.get(TenantIndex.class).getFullQualifiedName()),
-            new TenantEntityRemovedHandler(
-                indexDescriptors.get(TenantIndex.class).getFullQualifiedName()),
-            new GroupCreatedUpdatedHandler(
-                indexDescriptors.get(GroupIndex.class).getFullQualifiedName()),
-            new GroupEntityAddedHandler(
-                indexDescriptors.get(GroupIndex.class).getFullQualifiedName()),
-            new GroupEntityRemovedHandler(
-                indexDescriptors.get(GroupIndex.class).getFullQualifiedName()),
-            new GroupDeletedHandler(indexDescriptors.get(GroupIndex.class).getFullQualifiedName()),
-            new DecisionHandler(indexDescriptors.get(DecisionIndex.class).getFullQualifiedName()),
+            new RoleCreateUpdateHandler(indexDescriptors.get(RoleIndex.class)),
+            new RoleDeletedHandler(indexDescriptors.get(RoleIndex.class)),
+            new RoleMemberAddedHandler(indexDescriptors.get(RoleIndex.class)),
+            new RoleMemberRemovedHandler(indexDescriptors.get(RoleIndex.class)),
+            new UserCreatedUpdatedHandler(indexDescriptors.get(UserIndex.class)),
+            new UserDeletedHandler(indexDescriptors.get(UserIndex.class)),
+            new AuthorizationHandler(indexDescriptors.get(AuthorizationIndex.class)),
+            new TenantCreateUpdateHandler(indexDescriptors.get(TenantIndex.class)),
+            new TenantDeletedHandler(indexDescriptors.get(TenantIndex.class)),
+            new TenantEntityAddedHandler(indexDescriptors.get(TenantIndex.class)),
+            new TenantEntityRemovedHandler(indexDescriptors.get(TenantIndex.class)),
+            new GroupCreatedUpdatedHandler(indexDescriptors.get(GroupIndex.class)),
+            new GroupEntityAddedHandler(indexDescriptors.get(GroupIndex.class)),
+            new GroupEntityRemovedHandler(indexDescriptors.get(GroupIndex.class)),
+            new GroupDeletedHandler(indexDescriptors.get(GroupIndex.class)),
+            new DecisionHandler(indexDescriptors.get(DecisionIndex.class)),
             new ListViewProcessInstanceFromProcessInstanceHandler(
-                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName(), processCache),
-            new ListViewFlowNodeFromIncidentHandler(
-                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
-            new ListViewFlowNodeFromJobHandler(
-                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
+                indexDescriptors.get(ListViewTemplate.class), processCache),
+            new ListViewFlowNodeFromIncidentHandler(indexDescriptors.get(ListViewTemplate.class)),
+            new ListViewFlowNodeFromJobHandler(indexDescriptors.get(ListViewTemplate.class)),
             new ListViewFlowNodeFromProcessInstanceHandler(
-                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
-            new ListViewVariableFromVariableHandler(
-                indexDescriptors.get(ListViewTemplate.class).getFullQualifiedName()),
+                indexDescriptors.get(ListViewTemplate.class)),
+            new ListViewVariableFromVariableHandler(indexDescriptors.get(ListViewTemplate.class)),
             new VariableHandler(
-                indexDescriptors.get(VariableTemplate.class).getFullQualifiedName(),
+                indexDescriptors.get(VariableTemplate.class),
                 configuration.getIndex().getVariableSizeThreshold()),
-            new DecisionRequirementsHandler(
-                indexDescriptors.get(DecisionRequirementsIndex.class).getFullQualifiedName()),
+            new DecisionRequirementsHandler(indexDescriptors.get(DecisionRequirementsIndex.class)),
             new PostImporterQueueFromIncidentHandler(
-                indexDescriptors.get(PostImporterQueueTemplate.class).getFullQualifiedName()),
+                indexDescriptors.get(PostImporterQueueTemplate.class)),
             new FlowNodeInstanceFromIncidentHandler(
-                indexDescriptors.get(FlowNodeInstanceTemplate.class).getFullQualifiedName()),
+                indexDescriptors.get(FlowNodeInstanceTemplate.class)),
             new FlowNodeInstanceFromProcessInstanceHandler(
-                indexDescriptors.get(FlowNodeInstanceTemplate.class).getFullQualifiedName()),
-            new IncidentHandler(
-                indexDescriptors.get(IncidentTemplate.class).getFullQualifiedName(), processCache),
-            new SequenceFlowHandler(
-                indexDescriptors.get(SequenceFlowTemplate.class).getFullQualifiedName()),
-            new DecisionEvaluationHandler(
-                indexDescriptors.get(DecisionInstanceTemplate.class).getFullQualifiedName()),
-            new ProcessHandler(
-                indexDescriptors.get(ProcessIndex.class).getFullQualifiedName(), processCache),
-            new MetricFromProcessInstanceHandler(
-                indexDescriptors.get(MetricIndex.class).getFullQualifiedName()),
-            new TaskCompletedMetricHandler(
-                indexDescriptors.get(TasklistMetricIndex.class).getFullQualifiedName()),
-            new EmbeddedFormHandler(indexDescriptors.get(FormIndex.class).getFullQualifiedName()),
-            new FormHandler(
-                indexDescriptors.get(FormIndex.class).getFullQualifiedName(), formCache),
-            new EventFromIncidentHandler(
-                indexDescriptors.get(EventTemplate.class).getFullQualifiedName()),
-            new EventFromJobHandler(
-                indexDescriptors.get(EventTemplate.class).getFullQualifiedName()),
-            new EventFromProcessInstanceHandler(
-                indexDescriptors.get(EventTemplate.class).getFullQualifiedName()),
+                indexDescriptors.get(FlowNodeInstanceTemplate.class)),
+            new IncidentHandler(indexDescriptors.get(IncidentTemplate.class), processCache),
+            new SequenceFlowHandler(indexDescriptors.get(SequenceFlowTemplate.class)),
+            new DecisionEvaluationHandler(indexDescriptors.get(DecisionInstanceTemplate.class)),
+            new ProcessHandler(indexDescriptors.get(ProcessIndex.class), processCache),
+            new MetricFromProcessInstanceHandler(indexDescriptors.get(MetricIndex.class)),
+            new TaskCompletedMetricHandler(indexDescriptors.get(TasklistMetricIndex.class)),
+            new EmbeddedFormHandler(indexDescriptors.get(FormIndex.class)),
+            new FormHandler(indexDescriptors.get(FormIndex.class), formCache),
+            new EventFromIncidentHandler(indexDescriptors.get(EventTemplate.class)),
+            new EventFromJobHandler(indexDescriptors.get(EventTemplate.class)),
+            new EventFromProcessInstanceHandler(indexDescriptors.get(EventTemplate.class)),
             new EventFromProcessMessageSubscriptionHandler(
-                indexDescriptors.get(EventTemplate.class).getFullQualifiedName()),
+                indexDescriptors.get(EventTemplate.class)),
             new UserTaskHandler(
-                indexDescriptors.get(TaskTemplate.class).getFullQualifiedName(),
-                formCache,
-                exporterMetadata),
+                indexDescriptors.get(TaskTemplate.class), formCache, exporterMetadata),
             new UserTaskJobBasedHandler(
-                indexDescriptors.get(TaskTemplate.class).getFullQualifiedName(),
-                formCache,
-                exporterMetadata),
-            new UserTaskProcessInstanceHandler(
-                indexDescriptors.get(TaskTemplate.class).getFullQualifiedName()),
+                indexDescriptors.get(TaskTemplate.class), formCache, exporterMetadata),
+            new UserTaskProcessInstanceHandler(indexDescriptors.get(TaskTemplate.class)),
             new UserTaskVariableHandler(
-                indexDescriptors.get(TaskTemplate.class).getFullQualifiedName(),
+                indexDescriptors.get(TaskTemplate.class),
                 configuration.getIndex().getVariableSizeThreshold()),
             new UserTaskCompletionVariableHandler(
-                indexDescriptors.get(SnapshotTaskVariableTemplate.class).getFullQualifiedName(),
+                indexDescriptors.get(SnapshotTaskVariableTemplate.class),
                 configuration.getIndex().getVariableSizeThreshold()),
-            new OperationFromProcessInstanceHandler(
-                indexDescriptors.get(OperationTemplate.class).getFullQualifiedName()),
-            new OperationFromVariableDocumentHandler(
-                indexDescriptors.get(OperationTemplate.class).getFullQualifiedName()),
-            new OperationFromIncidentHandler(
-                indexDescriptors.get(OperationTemplate.class).getFullQualifiedName()),
-            new MappingCreatedHandler(
-                indexDescriptors.get(MappingIndex.class).getFullQualifiedName()),
-            new MappingDeletedHandler(
-                indexDescriptors.get(MappingIndex.class).getFullQualifiedName()),
-            new MetricFromDecisionEvaluationHandler(
-                indexDescriptors.get(MetricIndex.class).getFullQualifiedName()),
-            new JobHandler(indexDescriptors.get(JobTemplate.class).getFullQualifiedName()),
-            new MigratedVariableHandler(
-                indexDescriptors.get(VariableTemplate.class).getFullQualifiedName()));
+            new OperationFromProcessInstanceHandler(indexDescriptors.get(OperationTemplate.class)),
+            new OperationFromVariableDocumentHandler(indexDescriptors.get(OperationTemplate.class)),
+            new OperationFromIncidentHandler(indexDescriptors.get(OperationTemplate.class)),
+            new MappingCreatedHandler(indexDescriptors.get(MappingIndex.class)),
+            new MappingDeletedHandler(indexDescriptors.get(MappingIndex.class)),
+            new MetricFromDecisionEvaluationHandler(indexDescriptors.get(MetricIndex.class)),
+            new JobHandler(indexDescriptors.get(JobTemplate.class)),
+            new MigratedVariableHandler(indexDescriptors.get(VariableTemplate.class)));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/exceptions/PersistenceException.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/exceptions/PersistenceException.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.exporter.exceptions;
 
-public class PersistenceException extends Exception {
+public class PersistenceException extends RuntimeException {
 
   private static final long serialVersionUID = 1L;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AbstractEventHandler.java
@@ -27,6 +27,7 @@ import static io.camunda.webapps.schema.descriptors.operate.template.EventTempla
 import static io.camunda.webapps.schema.descriptors.operate.template.EventTemplate.PROCESS_KEY;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.operate.EventEntity;
 import io.camunda.webapps.schema.entities.operate.EventSourceType;
 import io.camunda.webapps.schema.entities.operate.EventType;
@@ -39,10 +40,10 @@ import java.util.Map;
 public abstract class AbstractEventHandler<R extends RecordValue>
     implements ExportHandler<EventEntity, R> {
   protected static final String ID_PATTERN = "%s_%s";
-  protected final String indexName;
+  protected final IndexDescriptor index;
 
-  public AbstractEventHandler(final String indexName) {
-    this.indexName = indexName;
+  public AbstractEventHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -56,8 +57,8 @@ public abstract class AbstractEventHandler<R extends RecordValue>
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 
   protected void loadEventGeneralData(final Record<R> record, final EventEntity eventEntity) {
@@ -110,6 +111,6 @@ public abstract class AbstractEventHandler<R extends RecordValue>
     }
 
     // write event
-    batchRequest.upsert(indexName, entity.getId(), entity, jsonMap);
+    batchRequest.upsert(index.getIndexName(), entity.getId(), entity, jsonMap);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationHandler.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.handlers;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.security.entity.Permission;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.usermanagement.AuthorizationEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -20,10 +21,10 @@ import java.util.stream.Collectors;
 
 public class AuthorizationHandler
     implements ExportHandler<AuthorizationEntity, AuthorizationRecordValue> {
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public AuthorizationHandler(final String indexName) {
-    this.indexName = indexName;
+  public AuthorizationHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -65,12 +66,12 @@ public class AuthorizationHandler
   @Override
   public void flush(final AuthorizationEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index.getIndexName(), entity);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 
   private List<Permission> getPermissions(final List<PermissionValue> permissionValues) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DecisionEvaluationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DecisionEvaluationHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.operate.dmn.DecisionInstanceEntity;
 import io.camunda.webapps.schema.entities.operate.dmn.DecisionInstanceInputEntity;
 import io.camunda.webapps.schema.entities.operate.dmn.DecisionInstanceOutputEntity;
@@ -36,10 +37,10 @@ public class DecisionEvaluationHandler
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DecisionEvaluationHandler.class);
   private static final String ID_PATTERN = "%s-%d";
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public DecisionEvaluationHandler(final String indexName) {
-    this.indexName = indexName;
+  public DecisionEvaluationHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -117,12 +118,12 @@ public class DecisionEvaluationHandler
 
   @Override
   public void flush(final DecisionInstanceEntity entity, final BatchRequest batchRequest) {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index.getIndexName(), entity);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 
   private int getEvaluatedDecisionValueIndex(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DecisionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DecisionHandler.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.handlers;
 import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.operate.dmn.definition.DecisionDefinitionEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -22,10 +23,10 @@ public class DecisionHandler
     implements ExportHandler<DecisionDefinitionEntity, DecisionRecordValue> {
 
   private static final Set<String> STATES = Set.of(ProcessIntent.CREATED.name());
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public DecisionHandler(final String indexName) {
-    this.indexName = indexName;
+  public DecisionHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -71,11 +72,11 @@ public class DecisionHandler
 
   @Override
   public void flush(final DecisionDefinitionEntity entity, final BatchRequest batchRequest) {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index.getIndexName(), entity);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DecisionRequirementsHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DecisionRequirementsHandler.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.handlers;
 import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.operate.dmn.definition.DecisionRequirementsEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -23,10 +24,10 @@ public class DecisionRequirementsHandler
     implements ExportHandler<DecisionRequirementsEntity, DecisionRequirementsRecordValue> {
   private static final Charset CHARSET = StandardCharsets.UTF_8;
 
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public DecisionRequirementsHandler(final String indexName) {
-    this.indexName = indexName;
+  public DecisionRequirementsHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -74,11 +75,11 @@ public class DecisionRequirementsHandler
 
   @Override
   public void flush(final DecisionRequirementsEntity entity, final BatchRequest batchRequest) {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index.getIndexName(), entity);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/EmbeddedFormHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/EmbeddedFormHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.tasklist.EmbeddedFormBatch;
 import io.camunda.webapps.schema.entities.tasklist.FormEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -22,10 +23,10 @@ import java.util.Optional;
 public class EmbeddedFormHandler implements ExportHandler<EmbeddedFormBatch, Process> {
 
   private static final String FORM_ID_PATTERN = "%s_%s";
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public EmbeddedFormHandler(final String indexName) {
-    this.indexName = indexName;
+  public EmbeddedFormHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -67,12 +68,13 @@ public class EmbeddedFormHandler implements ExportHandler<EmbeddedFormBatch, Pro
   @Override
   public void flush(final EmbeddedFormBatch entity, final BatchRequest batchRequest) {
     final var forms = entity.getForms();
-    Optional.ofNullable(forms).ifPresent(l -> l.forEach(f -> batchRequest.add(indexName, f)));
+    Optional.ofNullable(forms)
+        .ifPresent(l -> l.forEach(f -> batchRequest.add(index.getIndexName(), f)));
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 
   private List<FormEntity> mapToFormEntities(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/EventFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/EventFromIncidentHandler.java
@@ -12,6 +12,7 @@ import static io.camunda.exporter.utils.ExporterUtil.trimWhitespace;
 import static io.camunda.webapps.schema.descriptors.operate.template.EventTemplate.*;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.operate.ErrorType;
 import io.camunda.webapps.schema.entities.operate.EventEntity;
 import io.camunda.webapps.schema.entities.operate.EventMetadataEntity;
@@ -23,8 +24,8 @@ import java.util.List;
 
 public class EventFromIncidentHandler extends AbstractEventHandler<IncidentRecordValue> {
 
-  public EventFromIncidentHandler(final String indexName) {
-    super(indexName);
+  public EventFromIncidentHandler(final IndexDescriptor index) {
+    super(index);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/EventFromJobHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/EventFromJobHandler.java
@@ -11,6 +11,7 @@ import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 import static io.camunda.exporter.utils.ExporterUtil.toOffsetDateTime;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.template.EventTemplate;
 import io.camunda.webapps.schema.entities.operate.EventEntity;
 import io.camunda.webapps.schema.entities.operate.EventMetadataEntity;
@@ -33,8 +34,8 @@ public class EventFromJobHandler extends AbstractEventHandler<JobRecordValue> {
           JobIntent.CANCELED,
           JobIntent.MIGRATED);
 
-  public EventFromJobHandler(final String indexName) {
-    super(indexName);
+  public EventFromJobHandler(final IndexDescriptor index) {
+    super(index);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/EventFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/EventFromProcessInstanceHandler.java
@@ -11,6 +11,7 @@ import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 import static io.camunda.webapps.schema.descriptors.operate.template.EventTemplate.*;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.template.EventTemplate;
 import io.camunda.webapps.schema.entities.operate.EventEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -32,8 +33,8 @@ public class EventFromProcessInstanceHandler
           ProcessInstanceIntent.ELEMENT_COMPLETED,
           ProcessInstanceIntent.ELEMENT_TERMINATED);
 
-  public EventFromProcessInstanceHandler(final String indexName) {
-    super(indexName);
+  public EventFromProcessInstanceHandler(final IndexDescriptor index) {
+    super(index);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/EventFromProcessMessageSubscriptionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/EventFromProcessMessageSubscriptionHandler.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.handlers;
 import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.template.EventTemplate;
 import io.camunda.webapps.schema.entities.operate.EventEntity;
 import io.camunda.webapps.schema.entities.operate.EventMetadataEntity;
@@ -27,8 +28,8 @@ public class EventFromProcessMessageSubscriptionHandler
   public static final Set<Intent> STATES =
       Set.of(ProcessMessageSubscriptionIntent.CREATED, ProcessMessageSubscriptionIntent.MIGRATED);
 
-  public EventFromProcessMessageSubscriptionHandler(final String indexName) {
-    super(indexName);
+  public EventFromProcessMessageSubscriptionHandler(final IndexDescriptor index) {
+    super(index);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ExportHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ExportHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
@@ -76,8 +77,5 @@ public interface ExportHandler<T extends ExporterEntity<T>, R extends RecordValu
    */
   void flush(T entity, BatchRequest batchRequest) throws PersistenceException;
 
-  /**
-   * @return the index name that the handler entities are flushed to.
-   */
-  String getIndexName();
+  IndexDescriptor getIndex();
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.entities.operate.FlowNodeInstanceEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -26,10 +27,10 @@ public class FlowNodeInstanceFromIncidentHandler
   private static final Logger LOGGER =
       LoggerFactory.getLogger(FlowNodeInstanceFromIncidentHandler.class);
 
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public FlowNodeInstanceFromIncidentHandler(final String indexName) {
-    this.indexName = indexName;
+  public FlowNodeInstanceFromIncidentHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -72,11 +73,11 @@ public class FlowNodeInstanceFromIncidentHandler
   public void flush(final FlowNodeInstanceEntity entity, final BatchRequest batchRequest) {
     final Map<String, Object> updateFields = new HashMap<>();
     updateFields.put(FlowNodeInstanceTemplate.INCIDENT_KEY, entity.getIncidentKey());
-    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
+    batchRequest.upsert(index.getIndexName(), entity.getId(), entity, updateFields);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
@@ -14,6 +14,7 @@ import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEM
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_TERMINATED;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.entities.operate.FlowNodeInstanceEntity;
 import io.camunda.webapps.schema.entities.operate.FlowNodeState;
@@ -40,10 +41,10 @@ public class FlowNodeInstanceFromProcessInstanceHandler
   private static final Set<Intent> AI_FINISH_STATES = Set.of(ELEMENT_COMPLETED, ELEMENT_TERMINATED);
   private static final Set<Intent> AI_START_STATES = Set.of(ELEMENT_ACTIVATING);
 
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public FlowNodeInstanceFromProcessInstanceHandler(final String indexName) {
-    this.indexName = indexName;
+  public FlowNodeInstanceFromProcessInstanceHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -167,12 +168,12 @@ public class FlowNodeInstanceFromProcessInstanceHandler
     if (entity.getPosition() != null) {
       updateFields.put(FlowNodeInstanceTemplate.POSITION, entity.getPosition());
     }
-    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
+    batchRequest.upsert(index.getIndexName(), entity.getId(), entity, updateFields);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 
   private boolean isOfType(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FormHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FormHandler.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.handlers;
 import io.camunda.exporter.cache.ExporterEntityCache;
 import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.tasklist.FormEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -20,12 +21,12 @@ import java.util.List;
 
 public class FormHandler implements ExportHandler<FormEntity, Form> {
 
-  private final String indexName;
+  private final IndexDescriptor index;
   private final ExporterEntityCache<String, CachedFormEntity> formCache;
 
   public FormHandler(
-      final String indexName, final ExporterEntityCache<String, CachedFormEntity> formCache) {
-    this.indexName = indexName;
+      final IndexDescriptor index, final ExporterEntityCache<String, CachedFormEntity> formCache) {
+    this.index = index;
     this.formCache = formCache;
   }
 
@@ -79,11 +80,11 @@ public class FormHandler implements ExportHandler<FormEntity, Form> {
 
   @Override
   public void flush(final FormEntity entity, final BatchRequest batchRequest) {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index.getIndexName(), entity);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.GroupIndex;
 import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -23,10 +24,10 @@ public class GroupCreatedUpdatedHandler implements ExportHandler<GroupEntity, Gr
 
   private static final Set<Intent> SUPPORTED_INTENTS =
       Set.of(GroupIntent.CREATED, GroupIntent.UPDATED);
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public GroupCreatedUpdatedHandler(final String indexName) {
-    this.indexName = indexName;
+  public GroupCreatedUpdatedHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -65,11 +66,11 @@ public class GroupCreatedUpdatedHandler implements ExportHandler<GroupEntity, Gr
   @Override
   public void flush(final GroupEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index.getIndexName(), entity);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupDeletedHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.GroupIndex;
 import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -19,10 +20,10 @@ import java.util.List;
 
 public class GroupDeletedHandler implements ExportHandler<GroupEntity, GroupRecordValue> {
 
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public GroupDeletedHandler(final String indexName) {
-    this.indexName = indexName;
+  public GroupDeletedHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -61,11 +62,11 @@ public class GroupDeletedHandler implements ExportHandler<GroupEntity, GroupReco
   @Override
   public void flush(final GroupEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.delete(indexName, entity.getId());
+    batchRequest.delete(index.getIndexName(), entity.getId());
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.GroupIndex;
 import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -19,10 +20,10 @@ import java.util.List;
 
 public class GroupEntityAddedHandler implements ExportHandler<GroupEntity, GroupRecordValue> {
 
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public GroupEntityAddedHandler(final String indexName) {
-    this.indexName = indexName;
+  public GroupEntityAddedHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -66,11 +67,12 @@ public class GroupEntityAddedHandler implements ExportHandler<GroupEntity, Group
   @Override
   public void flush(final GroupEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.addWithRouting(indexName, entity, String.valueOf(entity.getJoin().parent()));
+    batchRequest.addWithRouting(
+        index.getIndexName(), entity, String.valueOf(entity.getJoin().parent()));
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityRemovedHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.GroupIndex;
 import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -19,10 +20,10 @@ import java.util.List;
 
 public class GroupEntityRemovedHandler implements ExportHandler<GroupEntity, GroupRecordValue> {
 
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public GroupEntityRemovedHandler(final String indexName) {
-    this.indexName = indexName;
+  public GroupEntityRemovedHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -63,11 +64,11 @@ public class GroupEntityRemovedHandler implements ExportHandler<GroupEntity, Gro
   public void flush(final GroupEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
     batchRequest.deleteWithRouting(
-        indexName, entity.getId(), String.valueOf(entity.getJoin().parent()));
+        index.getIndexName(), entity.getId(), String.valueOf(entity.getJoin().parent()));
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
@@ -15,6 +15,7 @@ import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.exporter.utils.ProcessCacheUtil;
 import io.camunda.webapps.operate.TreePath;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.operate.ErrorType;
 import io.camunda.webapps.schema.entities.operate.IncidentEntity;
 import io.camunda.webapps.schema.entities.operate.IncidentState;
@@ -36,12 +37,13 @@ public class IncidentHandler implements ExportHandler<IncidentEntity, IncidentRe
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IncidentHandler.class);
   private final Map<String, Record<IncidentRecordValue>> recordsMap = new HashMap<>();
-  private final String indexName;
+  private final IndexDescriptor index;
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
 
   public IncidentHandler(
-      final String indexName, final ExporterEntityCache<Long, CachedProcessEntity> processCache) {
-    this.indexName = indexName;
+      final IndexDescriptor index,
+      final ExporterEntityCache<Long, CachedProcessEntity> processCache) {
+    this.index = index;
     this.processCache = processCache;
   }
 
@@ -121,12 +123,13 @@ public class IncidentHandler implements ExportHandler<IncidentEntity, IncidentRe
     }
     final Map<String, Object> updateFields = getUpdateFieldsMapByIntent(intentStr, entity);
     updateFields.put(POSITION, entity.getPosition());
-    batchRequest.upsert(indexName, String.valueOf(entity.getKey()), entity, updateFields);
+    batchRequest.upsert(
+        index.getIndexName(), String.valueOf(entity.getKey()), entity, updateFields);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 
   private String buildTreePath(final Record<IncidentRecordValue> record) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
@@ -21,6 +21,7 @@ import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate
 import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.TIME;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.operate.JobEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -47,10 +48,10 @@ public class JobHandler implements ExportHandler<JobEntity, JobRecordValue> {
   private static final Set<JobIntent> FAILED_JOB_EVENTS =
       Set.of(JobIntent.FAILED, JobIntent.ERROR_THROWN);
 
-  protected final String indexName;
+  protected final IndexDescriptor index;
 
-  public JobHandler(final String indexName) {
-    this.indexName = indexName;
+  public JobHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -140,11 +141,11 @@ public class JobHandler implements ExportHandler<JobEntity, JobRecordValue> {
     if (FAILED_JOB_EVENTS.stream().anyMatch(i -> jobEntity.getState().equals(i.name()))) {
       updateFields.put(JOB_FAILED_WITH_RETRIES_LEFT, jobEntity.isJobFailedWithRetriesLeft());
     }
-    batchRequest.upsert(indexName, jobEntity.getId(), jobEntity, updateFields);
+    batchRequest.upsert(index.getIndexName(), jobEntity.getId(), jobEntity, updateFields);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandler.java
@@ -12,6 +12,7 @@ import static io.camunda.webapps.schema.descriptors.operate.template.ListViewTem
 import static io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate.INCIDENT_POSITION;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.operate.listview.FlowNodeInstanceForListViewEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -29,10 +30,10 @@ public class ListViewFlowNodeFromIncidentHandler
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ListViewFlowNodeFromIncidentHandler.class);
 
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public ListViewFlowNodeFromIncidentHandler(final String indexName) {
-    this.indexName = indexName;
+  public ListViewFlowNodeFromIncidentHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -100,12 +101,16 @@ public class ListViewFlowNodeFromIncidentHandler
     final Long processInstanceKey = entity.getProcessInstanceKey();
 
     batchRequest.upsertWithRouting(
-        indexName, entity.getId(), entity, updateFields, String.valueOf(processInstanceKey));
+        index.getIndexName(),
+        entity.getId(),
+        entity,
+        updateFields,
+        String.valueOf(processInstanceKey));
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 
   public String trimWhitespace(final String str) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromJobHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromJobHandler.java
@@ -12,6 +12,7 @@ import static io.camunda.webapps.schema.descriptors.operate.template.ListViewTem
 import static io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate.JOB_POSITION;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.operate.listview.FlowNodeInstanceForListViewEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -30,10 +31,10 @@ public class ListViewFlowNodeFromJobHandler
 
   private static final Set<Intent> FAILED_JOB_EVENTS = Set.of(JobIntent.FAIL, JobIntent.FAILED);
 
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public ListViewFlowNodeFromJobHandler(final String indexName) {
-    this.indexName = indexName;
+  public ListViewFlowNodeFromJobHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -101,11 +102,15 @@ public class ListViewFlowNodeFromJobHandler
     final Long processInstanceKey = entity.getProcessInstanceKey();
 
     batchRequest.upsertWithRouting(
-        indexName, entity.getId(), entity, updateFields, String.valueOf(processInstanceKey));
+        index.getIndexName(),
+        entity.getId(),
+        entity,
+        updateFields,
+        String.valueOf(processInstanceKey));
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromProcessInstanceHandler.java
@@ -16,6 +16,7 @@ import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.*;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_TERMINATED;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.operate.FlowNodeState;
 import io.camunda.webapps.schema.entities.operate.FlowNodeType;
 import io.camunda.webapps.schema.entities.operate.listview.FlowNodeInstanceForListViewEntity;
@@ -38,10 +39,10 @@ public class ListViewFlowNodeFromProcessInstanceHandler
   private static final Set<Intent> PI_AND_AI_FINISH_STATES =
       Set.of(ELEMENT_COMPLETED, ELEMENT_TERMINATED);
 
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public ListViewFlowNodeFromProcessInstanceHandler(final String indexName) {
-    this.indexName = indexName;
+  public ListViewFlowNodeFromProcessInstanceHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -130,12 +131,12 @@ public class ListViewFlowNodeFromProcessInstanceHandler
     final Long processInstanceKey = entity.getProcessInstanceKey();
 
     batchRequest.upsertWithRouting(
-        indexName, entity.getId(), entity, updateFields, processInstanceKey.toString());
+        index.getIndexName(), entity.getId(), entity, updateFields, processInstanceKey.toString());
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 
   private boolean isProcessEvent(final ProcessInstanceRecordValue recordValue) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
@@ -16,6 +16,7 @@ import io.camunda.exporter.cache.process.CachedProcessEntity;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ProcessCacheUtil;
 import io.camunda.webapps.operate.TreePath;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.operate.listview.ProcessInstanceForListViewEntity;
 import io.camunda.webapps.schema.entities.operate.listview.ProcessInstanceState;
@@ -47,11 +48,12 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
       Set.of(ELEMENT_COMPLETED, ELEMENT_TERMINATED);
 
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
-  private final String indexName;
+  private final IndexDescriptor index;
 
   public ListViewProcessInstanceFromProcessInstanceHandler(
-      final String indexName, final ExporterEntityCache<Long, CachedProcessEntity> processCache) {
-    this.indexName = indexName;
+      final IndexDescriptor index,
+      final ExporterEntityCache<Long, CachedProcessEntity> processCache) {
+    this.index = index;
     this.processCache = processCache;
   }
 
@@ -178,12 +180,12 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
       updateFields.put(ListViewTemplate.STATE, entity.getState());
     }
 
-    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
+    batchRequest.upsert(index.getIndexName(), entity.getId(), entity, updateFields);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 
   private boolean isProcessEvent(final ProcessInstanceRecordValue recordValue) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandler.java
@@ -13,6 +13,7 @@ import static io.camunda.webapps.schema.descriptors.operate.template.ListViewTem
 import static io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate.VAR_VALUE;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.operate.listview.VariableForListViewEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -29,10 +30,10 @@ public class ListViewVariableFromVariableHandler
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ListViewVariableFromVariableHandler.class);
 
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public ListViewVariableFromVariableHandler(final String indexName) {
-    this.indexName = indexName;
+  public ListViewVariableFromVariableHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -94,11 +95,15 @@ public class ListViewVariableFromVariableHandler
     final Long processInstanceKey = entity.getProcessInstanceKey();
 
     batchRequest.upsertWithRouting(
-        indexName, entity.getId(), entity, updateFields, String.valueOf(processInstanceKey));
+        index.getIndexName(),
+        entity.getId(),
+        entity,
+        updateFields,
+        String.valueOf(processInstanceKey));
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingCreatedHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.usermanagement.MappingEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -17,10 +18,10 @@ import io.camunda.zeebe.protocol.record.value.MappingRecordValue;
 import java.util.List;
 
 public class MappingCreatedHandler implements ExportHandler<MappingEntity, MappingRecordValue> {
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public MappingCreatedHandler(final String indexName) {
-    this.indexName = indexName;
+  public MappingCreatedHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -61,11 +62,11 @@ public class MappingCreatedHandler implements ExportHandler<MappingEntity, Mappi
   @Override
   public void flush(final MappingEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index.getIndexName(), entity);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingDeletedHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.usermanagement.MappingEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -17,10 +18,10 @@ import io.camunda.zeebe.protocol.record.value.MappingRecordValue;
 import java.util.List;
 
 public class MappingDeletedHandler implements ExportHandler<MappingEntity, MappingRecordValue> {
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public MappingDeletedHandler(final String indexName) {
-    this.indexName = indexName;
+  public MappingDeletedHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -61,11 +62,11 @@ public class MappingDeletedHandler implements ExportHandler<MappingEntity, Mappi
   @Override
   public void flush(final MappingEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.delete(indexName, entity.getId());
+    batchRequest.delete(index.getIndexName(), entity.getId());
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MetricFromDecisionEvaluationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MetricFromDecisionEvaluationHandler.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.handlers;
 import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.MetricEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -28,10 +29,10 @@ public class MetricFromDecisionEvaluationHandler
       "EVENT_DECISION_INSTANCE_EVALUATED";
   private static final String ID_PATTERN = "%d-%d";
 
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public MetricFromDecisionEvaluationHandler(final String indexName) {
-    this.indexName = indexName;
+  public MetricFromDecisionEvaluationHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -82,11 +83,11 @@ public class MetricFromDecisionEvaluationHandler
 
   @Override
   public void flush(final MetricEntity entity, final BatchRequest batchRequest) {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index.getIndexName(), entity);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MetricFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MetricFromProcessInstanceHandler.java
@@ -11,6 +11,7 @@ import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATING;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.MetricEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -25,10 +26,10 @@ public class MetricFromProcessInstanceHandler
   protected static final int EMPTY_PARENT_PROCESS_INSTANCE_ID = -1;
   protected static final String EVENT_PROCESS_INSTANCE_STARTED = "EVENT_PROCESS_INSTANCE_STARTED";
 
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public MetricFromProcessInstanceHandler(final String indexName) {
-    this.indexName = indexName;
+  public MetricFromProcessInstanceHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -76,11 +77,11 @@ public class MetricFromProcessInstanceHandler
 
   @Override
   public void flush(final MetricEntity entity, final BatchRequest batchRequest) {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index.getIndexName(), entity);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MigratedVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MigratedVariableHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.template.VariableTemplate;
 import io.camunda.webapps.schema.entities.operate.VariableEntity;
 import io.camunda.webapps.schema.entities.operate.listview.VariableForListViewEntity;
@@ -21,10 +22,10 @@ import java.util.Map;
 
 public class MigratedVariableHandler implements ExportHandler<VariableEntity, VariableRecordValue> {
 
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public MigratedVariableHandler(final String indexName) {
-    this.indexName = indexName;
+  public MigratedVariableHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -73,11 +74,11 @@ public class MigratedVariableHandler implements ExportHandler<VariableEntity, Va
     updateFields.put(VariableTemplate.BPMN_PROCESS_ID, entity.getBpmnProcessId());
     updateFields.put(VariableTemplate.POSITION, entity.getPosition());
 
-    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
+    batchRequest.upsert(index.getIndexName(), entity.getId(), entity, updateFields);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.operate.post.PostImporterActionType;
 import io.camunda.webapps.schema.entities.operate.post.PostImporterQueueEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -21,10 +22,10 @@ import java.util.List;
 public class PostImporterQueueFromIncidentHandler
     implements ExportHandler<PostImporterQueueEntity, IncidentRecordValue> {
 
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public PostImporterQueueFromIncidentHandler(final String indexName) {
-    this.indexName = indexName;
+  public PostImporterQueueFromIncidentHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -77,11 +78,11 @@ public class PostImporterQueueFromIncidentHandler
 
   @Override
   public void flush(final PostImporterQueueEntity entity, final BatchRequest batchRequest) {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index.getIndexName(), entity);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
@@ -12,6 +12,7 @@ import io.camunda.exporter.cache.process.CachedProcessEntity;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.exporter.utils.ProcessCacheUtil;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.operate.ProcessEntity;
 import io.camunda.webapps.schema.entities.operate.ProcessFlowNodeEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -24,12 +25,13 @@ import java.util.List;
 
 public class ProcessHandler implements ExportHandler<ProcessEntity, Process> {
 
-  private final String indexName;
+  private final IndexDescriptor index;
   private final ExporterEntityCache<Long, CachedProcessEntity> processCache;
 
   public ProcessHandler(
-      final String indexName, final ExporterEntityCache<Long, CachedProcessEntity> processCache) {
-    this.indexName = indexName;
+      final IndexDescriptor index,
+      final ExporterEntityCache<Long, CachedProcessEntity> processCache) {
+    this.index = index;
     this.processCache = processCache;
   }
 
@@ -92,12 +94,12 @@ public class ProcessHandler implements ExportHandler<ProcessEntity, Process> {
 
   @Override
   public void flush(final ProcessEntity entity, final BatchRequest batchRequest) {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index.getIndexName(), entity);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 
   private void extractProcessModelData(final Process process, final ProcessEntity entity) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleCreateUpdateHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleCreateUpdateHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.RoleIndex;
 import io.camunda.webapps.schema.entities.usermanagement.RoleEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -18,10 +19,10 @@ import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
 import java.util.List;
 
 public class RoleCreateUpdateHandler implements ExportHandler<RoleEntity, RoleRecordValue> {
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public RoleCreateUpdateHandler(final String indexName) {
-    this.indexName = indexName;
+  public RoleCreateUpdateHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -63,11 +64,11 @@ public class RoleCreateUpdateHandler implements ExportHandler<RoleEntity, RoleRe
   @Override
   public void flush(final RoleEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index.getIndexName(), entity);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleDeletedHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.usermanagement.RoleEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -20,10 +21,10 @@ import java.util.Set;
 
 public class RoleDeletedHandler implements ExportHandler<RoleEntity, RoleRecordValue> {
   private static final Set<Intent> SUPPORTED_INTENTS = Set.of(RoleIntent.DELETED);
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public RoleDeletedHandler(final String indexName) {
-    this.indexName = indexName;
+  public RoleDeletedHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -61,11 +62,11 @@ public class RoleDeletedHandler implements ExportHandler<RoleEntity, RoleRecordV
   @Override
   public void flush(final RoleEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.delete(indexName, entity.getId());
+    batchRequest.delete(index.getIndexName(), entity.getId());
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberAddedHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.RoleIndex;
 import io.camunda.webapps.schema.entities.usermanagement.RoleEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -19,10 +20,10 @@ import java.util.List;
 
 public class RoleMemberAddedHandler implements ExportHandler<RoleEntity, RoleRecordValue> {
 
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public RoleMemberAddedHandler(final String indexName) {
-    this.indexName = indexName;
+  public RoleMemberAddedHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -62,11 +63,11 @@ public class RoleMemberAddedHandler implements ExportHandler<RoleEntity, RoleRec
   @Override
   public void flush(final RoleEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.addWithRouting(indexName, entity, entity.getJoin().parent().toString());
+    batchRequest.addWithRouting(index.getIndexName(), entity, entity.getJoin().parent().toString());
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberRemovedHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.RoleIndex;
 import io.camunda.webapps.schema.entities.usermanagement.RoleEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -18,10 +19,10 @@ import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
 import java.util.List;
 
 public class RoleMemberRemovedHandler implements ExportHandler<RoleEntity, RoleRecordValue> {
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public RoleMemberRemovedHandler(final String indexName) {
-    this.indexName = indexName;
+  public RoleMemberRemovedHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -61,11 +62,12 @@ public class RoleMemberRemovedHandler implements ExportHandler<RoleEntity, RoleR
   @Override
   public void flush(final RoleEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.deleteWithRouting(indexName, entity.getId(), entity.getJoin().parent().toString());
+    batchRequest.deleteWithRouting(
+        index.getIndexName(), entity.getId(), entity.getJoin().parent().toString());
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/SequenceFlowHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.operate.SequenceFlowEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -20,10 +21,10 @@ public class SequenceFlowHandler
     implements ExportHandler<SequenceFlowEntity, ProcessInstanceRecordValue> {
 
   private static final String ID_PATTERN = "%s_%s";
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public SequenceFlowHandler(final String indexName) {
-    this.indexName = indexName;
+  public SequenceFlowHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -70,11 +71,11 @@ public class SequenceFlowHandler
 
   @Override
   public void flush(final SequenceFlowEntity entity, final BatchRequest batchRequest) {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index.getIndexName(), entity);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TaskCompletedMetricHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TaskCompletedMetricHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.MetricEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -21,10 +22,10 @@ public class TaskCompletedMetricHandler
     implements ExportHandler<MetricEntity, UserTaskRecordValue> {
 
   protected static final String EVENT_TASK_COMPLETED_BY_ASSIGNEE = "task_completed_by_assignee";
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public TaskCompletedMetricHandler(final String indexName) {
-    this.indexName = indexName;
+  public TaskCompletedMetricHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -63,11 +64,11 @@ public class TaskCompletedMetricHandler
 
   @Override
   public void flush(final MetricEntity entity, final BatchRequest batchRequest) {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index.getIndexName(), entity);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantCreateUpdateHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantCreateUpdateHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex;
 import io.camunda.webapps.schema.entities.usermanagement.TenantEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -22,10 +23,10 @@ import java.util.Set;
 public class TenantCreateUpdateHandler implements ExportHandler<TenantEntity, TenantRecordValue> {
   private static final Set<Intent> SUPPORTED_INTENTS =
       Set.of(TenantIntent.CREATED, TenantIntent.UPDATED);
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public TenantCreateUpdateHandler(final String indexName) {
-    this.indexName = indexName;
+  public TenantCreateUpdateHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -68,11 +69,11 @@ public class TenantCreateUpdateHandler implements ExportHandler<TenantEntity, Te
   @Override
   public void flush(final TenantEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index.getIndexName(), entity);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantDeletedHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.usermanagement.TenantEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -20,10 +21,10 @@ import java.util.Set;
 
 public class TenantDeletedHandler implements ExportHandler<TenantEntity, TenantRecordValue> {
   private static final Set<Intent> SUPPORTED_INTENTS = Set.of(TenantIntent.DELETED);
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public TenantDeletedHandler(final String indexName) {
-    this.indexName = indexName;
+  public TenantDeletedHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -61,11 +62,11 @@ public class TenantDeletedHandler implements ExportHandler<TenantEntity, TenantR
   @Override
   public void flush(final TenantEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.delete(indexName, entity.getId());
+    batchRequest.delete(index.getIndexName(), entity.getId());
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityAddedHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex;
 import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
 import io.camunda.webapps.schema.entities.usermanagement.TenantEntity;
@@ -20,10 +21,10 @@ import java.util.List;
 
 public class TenantEntityAddedHandler implements ExportHandler<TenantEntity, TenantRecordValue> {
 
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public TenantEntityAddedHandler(final String indexName) {
-    this.indexName = indexName;
+  public TenantEntityAddedHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -64,11 +65,12 @@ public class TenantEntityAddedHandler implements ExportHandler<TenantEntity, Ten
   @Override
   public void flush(final TenantEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.addWithRouting(indexName, entity, String.valueOf(entity.getJoin().parent()));
+    batchRequest.addWithRouting(
+        index.getIndexName(), entity, String.valueOf(entity.getJoin().parent()));
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityRemovedHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex;
 import io.camunda.webapps.schema.entities.usermanagement.TenantEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -19,10 +20,10 @@ import java.util.List;
 
 public class TenantEntityRemovedHandler implements ExportHandler<TenantEntity, TenantRecordValue> {
 
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public TenantEntityRemovedHandler(final String indexName) {
-    this.indexName = indexName;
+  public TenantEntityRemovedHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -64,11 +65,11 @@ public class TenantEntityRemovedHandler implements ExportHandler<TenantEntity, T
   public void flush(final TenantEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
     batchRequest.deleteWithRouting(
-        indexName, entity.getId(), String.valueOf(entity.getJoin().parent()));
+        index.getIndexName(), entity.getId(), String.valueOf(entity.getJoin().parent()));
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserCreatedUpdatedHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.usermanagement.UserEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -21,10 +22,10 @@ import java.util.Set;
 public class UserCreatedUpdatedHandler implements ExportHandler<UserEntity, UserRecordValue> {
   private static final Set<Intent> SUPPORTED_INTENTS =
       Set.of(UserIntent.CREATED, UserIntent.UPDATED);
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public UserCreatedUpdatedHandler(final String indexName) {
-    this.indexName = indexName;
+  public UserCreatedUpdatedHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -67,11 +68,11 @@ public class UserCreatedUpdatedHandler implements ExportHandler<UserEntity, User
   @Override
   public void flush(final UserEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index.getIndexName(), entity);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserDeletedHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.usermanagement.UserEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -20,10 +21,10 @@ import java.util.Set;
 
 public class UserDeletedHandler implements ExportHandler<UserEntity, UserRecordValue> {
   private static final Set<Intent> SUPPORTED_INTENTS = Set.of(UserIntent.DELETED);
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public UserDeletedHandler(final String indexName) {
-    this.indexName = indexName;
+  public UserDeletedHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -66,11 +67,11 @@ public class UserDeletedHandler implements ExportHandler<UserEntity, UserRecordV
   @Override
   public void flush(final UserEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.delete(indexName, entity.getId());
+    batchRequest.delete(index.getIndexName(), entity.getId());
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandler.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.handlers.UserTaskCompletionVariableHandler.SnapshotTaskVariableBatch;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.tasklist.template.SnapshotTaskVariableTemplate;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.webapps.schema.entities.tasklist.SnapshotTaskVariableEntity;
@@ -34,11 +35,11 @@ public class UserTaskCompletionVariableHandler
   private static final String ID_PATTERN = "%s-%s";
   private static final ObjectMapper MAPPER = new ObjectMapper();
   protected final int variableSizeThreshold;
-  private final String indexName;
+  private final IndexDescriptor index;
 
   public UserTaskCompletionVariableHandler(
-      final String indexName, final int variableSizeThreshold) {
-    this.indexName = indexName;
+      final IndexDescriptor index, final int variableSizeThreshold) {
+    this.index = index;
     this.variableSizeThreshold = variableSizeThreshold;
   }
 
@@ -86,8 +87,8 @@ public class UserTaskCompletionVariableHandler
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 
   private void flushSnapshotTaskVariableEntity(
@@ -96,7 +97,7 @@ public class UserTaskCompletionVariableHandler
     updateFields.put(SnapshotTaskVariableTemplate.VALUE, entity.getValue());
     updateFields.put(SnapshotTaskVariableTemplate.FULL_VALUE, entity.getFullValue());
     updateFields.put(SnapshotTaskVariableTemplate.IS_PREVIEW, entity.getIsPreview());
-    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
+    batchRequest.upsert(index.getIndexName(), entity.getId(), entity, updateFields);
   }
 
   private SnapshotTaskVariableEntity createSnapshotVariableEntity(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -12,6 +12,7 @@ import io.camunda.exporter.cache.ExporterEntityCache;
 import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
 import io.camunda.webapps.schema.entities.tasklist.TaskEntity;
 import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
@@ -46,15 +47,15 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
   private static final String UNMAPPED_USER_TASK_ATTRIBUTE_WARNING =
       "Attribute update not mapped while importing ZEEBE_USER_TASKS: {}";
 
-  private final String indexName;
+  private final IndexDescriptor index;
   private final ExporterEntityCache<String, CachedFormEntity> formCache;
   private final ExporterMetadata exporterMetadata;
 
   public UserTaskHandler(
-      final String indexName,
+      final IndexDescriptor index,
       final ExporterEntityCache<String, CachedFormEntity> formCache,
       final ExporterMetadata exporterMetadata) {
-    this.indexName = indexName;
+    this.index = index;
     this.formCache = formCache;
     this.exporterMetadata = exporterMetadata;
   }
@@ -121,7 +122,7 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
     final boolean previousVersionRecord = refersToPreviousVersionRecord(entity.getKey());
 
     batchRequest.upsertWithRouting(
-        indexName,
+        index.getIndexName(),
         previousVersionRecord ? String.valueOf(entity.getKey()) : entity.getId(),
         entity,
         updateFields,
@@ -129,8 +130,8 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 
   private Map<String, Object> getUpdatedFields(final TaskEntity entity) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskJobBasedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskJobBasedHandler.java
@@ -18,6 +18,7 @@ import io.camunda.exporter.cache.ExporterEntityCache;
 import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
 import io.camunda.webapps.schema.entities.tasklist.TaskEntity;
 import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
@@ -53,15 +54,15 @@ public class UserTaskJobBasedHandler implements ExportHandler<TaskEntity, JobRec
           JobIntent.RECURRED_AFTER_BACKOFF,
           JobIntent.FAILED);
 
-  private final String indexName;
+  private final IndexDescriptor index;
   private final ExporterEntityCache<String, CachedFormEntity> formCache;
   private final ExporterMetadata exporterMetadata;
 
   public UserTaskJobBasedHandler(
-      final String indexName,
+      final IndexDescriptor index,
       final ExporterEntityCache<String, CachedFormEntity> formCache,
       final ExporterMetadata exporterMetadata) {
-    this.indexName = indexName;
+    this.index = index;
     this.formCache = formCache;
     this.exporterMetadata = exporterMetadata;
   }
@@ -145,7 +146,7 @@ public class UserTaskJobBasedHandler implements ExportHandler<TaskEntity, JobRec
     final boolean previousVersionRecord = refersToPreviousVersionRecord(entity.getKey());
 
     batchRequest.upsertWithRouting(
-        indexName,
+        index.getIndexName(),
         previousVersionRecord ? String.valueOf(entity.getKey()) : taskEntityId,
         entity,
         updateFields,
@@ -153,8 +154,8 @@ public class UserTaskJobBasedHandler implements ExportHandler<TaskEntity, JobRec
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 
   private Map<String, Object> getUpdatedFields(final TaskEntity entity) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandler.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.handlers;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATING;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship;
 import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship.TaskJoinRelationshipType;
 import io.camunda.webapps.schema.entities.tasklist.TaskProcessInstanceEntity;
@@ -22,10 +23,10 @@ import java.util.List;
 public class UserTaskProcessInstanceHandler
     implements ExportHandler<TaskProcessInstanceEntity, ProcessInstanceRecordValue> {
 
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public UserTaskProcessInstanceHandler(final String indexName) {
-    this.indexName = indexName;
+  public UserTaskProcessInstanceHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -68,11 +69,11 @@ public class UserTaskProcessInstanceHandler
 
   @Override
   public void flush(final TaskProcessInstanceEntity entity, final BatchRequest batchRequest) {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index.getIndexName(), entity);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskVariableHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.handlers.UserTaskVariableHandler.UserTaskVariableBatch;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
 import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship;
@@ -32,10 +33,10 @@ public class UserTaskVariableHandler
 
   private static final String ID_PATTERN = "%s-%s";
   protected final int variableSizeThreshold;
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public UserTaskVariableHandler(final String indexName, final int variableSizeThreshold) {
-    this.indexName = indexName;
+  public UserTaskVariableHandler(final IndexDescriptor index, final int variableSizeThreshold) {
+    this.index = index;
     this.variableSizeThreshold = variableSizeThreshold;
   }
 
@@ -104,13 +105,17 @@ public class UserTaskVariableHandler
               updateFields.put(TaskTemplate.VARIABLE_FULL_VALUE, v.getFullValue());
               updateFields.put(TaskTemplate.IS_TRUNCATED, v.getIsTruncated());
               batchRequest.upsertWithRouting(
-                  indexName, v.getId(), v, updateFields, String.valueOf(v.getProcessInstanceId()));
+                  index.getIndexName(),
+                  v.getId(),
+                  v,
+                  updateFields,
+                  String.valueOf(v.getProcessInstanceId()));
             });
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 
   private TaskVariableEntity createVariableFromRecord(final Record<VariableRecordValue> record) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/VariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/VariableHandler.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.handlers;
 import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.operate.VariableEntity;
 import io.camunda.webapps.schema.entities.operate.listview.VariableForListViewEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -21,10 +22,10 @@ import java.util.List;
 public class VariableHandler implements ExportHandler<VariableEntity, VariableRecordValue> {
 
   private final int variableSizeThreshold;
-  private final String indexName;
+  private final IndexDescriptor index;
 
-  public VariableHandler(final String indexName, final int variableSizeThreshold) {
-    this.indexName = indexName;
+  public VariableHandler(final IndexDescriptor index, final int variableSizeThreshold) {
+    this.index = index;
     this.variableSizeThreshold = variableSizeThreshold;
   }
 
@@ -84,11 +85,11 @@ public class VariableHandler implements ExportHandler<VariableEntity, VariableRe
 
   @Override
   public void flush(final VariableEntity entity, final BatchRequest batchRequest) {
-    batchRequest.add(indexName, entity);
+    batchRequest.add(index.getIndexName(), entity);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/operation/AbstractOperationHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/operation/AbstractOperationHandler.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.handlers.operation;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.template.OperationTemplate;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationState;
@@ -23,10 +24,10 @@ import java.util.Map;
 public abstract class AbstractOperationHandler<R extends RecordValue>
     implements ExportHandler<OperationEntity, R> {
 
-  protected final String indexName;
+  protected final IndexDescriptor index;
 
-  public AbstractOperationHandler(final String indexName) {
-    this.indexName = indexName;
+  public AbstractOperationHandler(final IndexDescriptor index) {
+    this.index = index;
   }
 
   @Override
@@ -66,11 +67,11 @@ public abstract class AbstractOperationHandler<R extends RecordValue>
     updateFields.put(OperationTemplate.LOCK_OWNER, entity.getLockOwner());
     updateFields.put(OperationTemplate.LOCK_EXPIRATION_TIME, entity.getLockExpirationTime());
 
-    batchRequest.update(indexName, entity.getId(), updateFields);
+    batchRequest.update(index.getIndexName(), entity.getId(), updateFields);
   }
 
   @Override
-  public String getIndexName() {
-    return indexName;
+  public IndexDescriptor getIndex() {
+    return index;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/operation/OperationFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/operation/OperationFromIncidentHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers.operation;
 
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -14,8 +15,8 @@ import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 
 public class OperationFromIncidentHandler extends AbstractOperationHandler<IncidentRecordValue> {
 
-  public OperationFromIncidentHandler(final String indexName) {
-    super(indexName);
+  public OperationFromIncidentHandler(final IndexDescriptor index) {
+    super(index);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/operation/OperationFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/operation/OperationFromProcessInstanceHandler.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.handlers.operation;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_MIGRATED;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_TERMINATED;
 
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -21,8 +22,8 @@ public class OperationFromProcessInstanceHandler
     extends AbstractOperationHandler<ProcessInstanceRecordValue> {
   protected static final Set<Intent> ELIGIBLE_STATES = Set.of(ELEMENT_MIGRATED, ELEMENT_TERMINATED);
 
-  public OperationFromProcessInstanceHandler(final String indexName) {
-    super(indexName);
+  public OperationFromProcessInstanceHandler(final IndexDescriptor index) {
+    super(index);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/operation/OperationFromVariableDocumentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/operation/OperationFromVariableDocumentHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers.operation;
 
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
@@ -15,8 +16,8 @@ import io.camunda.zeebe.protocol.record.value.VariableDocumentRecordValue;
 public class OperationFromVariableDocumentHandler
     extends AbstractOperationHandler<VariableDocumentRecordValue> {
 
-  public OperationFromVariableDocumentHandler(final String indexName) {
-    super(indexName);
+  public OperationFromVariableDocumentHandler(final IndexDescriptor index) {
+    super(index);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/BatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/BatchRequest.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.store;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import java.util.Map;
+import java.util.function.Consumer;
 
 /** A {@link BatchRequest} contains updates to one or more {@link ExporterEntity} */
 @SuppressWarnings("rawtypes")
@@ -65,4 +66,13 @@ public interface BatchRequest {
   void execute() throws PersistenceException;
 
   void executeWithRefresh() throws PersistenceException;
+
+  /**
+   * Adds an error handler to the batch request. The error handler is called when an error occurs
+   *
+   * @param index the index name that this specific error handler should be used to handle errors
+   *     for.
+   * @param errorHandler the error handler to call when an error occurs
+   */
+  void onError(String index, Consumer<String> errorHandler);
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
@@ -17,8 +17,11 @@ import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.utils.ElasticsearchScriptBuilder;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,6 +33,7 @@ public class ElasticsearchBatchRequest implements BatchRequest {
   private final ElasticsearchClient esClient;
   private final BulkRequest.Builder bulkRequestBuilder;
   private final ElasticsearchScriptBuilder scriptBuilder;
+  private final Map<String, Consumer<String>> errorHandlers;
 
   public ElasticsearchBatchRequest(
       final ElasticsearchClient esClient,
@@ -38,6 +42,7 @@ public class ElasticsearchBatchRequest implements BatchRequest {
     this.esClient = esClient;
     this.bulkRequestBuilder = bulkRequestBuilder;
     this.scriptBuilder = scriptBuilder;
+    errorHandlers = new HashMap<>();
   }
 
   @Override
@@ -230,6 +235,11 @@ public class ElasticsearchBatchRequest implements BatchRequest {
     execute(true);
   }
 
+  @Override
+  public void onError(final String index, final Consumer<String> errorHandler) {
+    errorHandlers.put(index, errorHandler);
+  }
+
   private void execute(final boolean shouldRefresh) throws PersistenceException {
     if (shouldRefresh) {
       bulkRequestBuilder.refresh(Refresh.True);
@@ -241,15 +251,41 @@ public class ElasticsearchBatchRequest implements BatchRequest {
     try {
       final BulkResponse bulkResponse = esClient.bulk(bulkRequest);
       final List<BulkResponseItem> items = bulkResponse.items();
-      for (final BulkResponseItem item : items) {
-        if (item.error() != null) {
-          LOGGER.warn("Bulk request execution failed. {}. Cause: {}.", item, item.error().reason());
-          throw new PersistenceException("Operation failed: " + item.error().reason());
-        }
-      }
+      validateNoErrors(items);
     } catch (final IOException | ElasticsearchException ex) {
       throw new PersistenceException(
           "Error when processing bulk request against Elasticsearch: " + ex.getMessage(), ex);
     }
+  }
+
+  private void validateNoErrors(final List<BulkResponseItem> items) {
+    final var errorItems = items.stream().filter(item -> item.error() != null).toList();
+    if (errorItems.isEmpty()) {
+      return;
+    }
+
+    final String errorMessages =
+        errorItems.stream()
+            .map(
+                item ->
+                    String.format(
+                        "%s failed for type [%s] and id [%s]: %s",
+                        item.operationType(), item.index(), item.id(), item.error().reason()))
+            .collect(Collectors.joining(", \n"));
+    LOGGER.warn("Bulk request execution failed: \n[{}]", errorMessages);
+
+    errorItems.forEach(
+        item -> {
+          final var errorHandler = errorHandlers.get(item.index());
+          final String message =
+              String.format(
+                  "%s failed for type [%s] and id [%s]: %s",
+                  item.operationType(), item.index(), item.id(), item.error().reason());
+          if (errorHandler != null) {
+            errorHandler.accept(message);
+          } else {
+            throw new PersistenceException(message);
+          }
+        });
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/OpensearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/OpensearchBatchRequest.java
@@ -11,8 +11,11 @@ import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.utils.OpensearchScriptBuilder;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.Refresh;
@@ -30,6 +33,7 @@ public class OpensearchBatchRequest implements BatchRequest {
   private final OpenSearchClient osClient;
   private final BulkRequest.Builder bulkRequestBuilder;
   private final OpensearchScriptBuilder scriptBuilder;
+  private final Map<String, Consumer<String>> errorHandlers;
 
   public OpensearchBatchRequest(
       final OpenSearchClient osClient,
@@ -38,6 +42,7 @@ public class OpensearchBatchRequest implements BatchRequest {
     this.osClient = osClient;
     this.bulkRequestBuilder = bulkRequestBuilder;
     this.scriptBuilder = scriptBuilder;
+    errorHandlers = new HashMap<>();
   }
 
   @Override
@@ -223,6 +228,11 @@ public class OpensearchBatchRequest implements BatchRequest {
     execute(true);
   }
 
+  @Override
+  public void onError(final String index, final Consumer<String> errorHandler) {
+    errorHandlers.put(index, errorHandler);
+  }
+
   private void execute(final boolean shouldRefresh) throws PersistenceException {
     if (shouldRefresh) {
       bulkRequestBuilder.refresh(Refresh.True);
@@ -238,22 +248,41 @@ public class OpensearchBatchRequest implements BatchRequest {
     try {
       final BulkResponse bulkItemResponses = osClient.bulk(bulkRequest);
       final List<BulkResponseItem> items = bulkItemResponses.items();
-      for (final BulkResponseItem responseItem : items) {
-        if (responseItem.error() != null) {
-          LOGGER.warn(
-              String.format(
-                  "%s failed for type [%s] and id [%s]: %s",
-                  responseItem.operationType(),
-                  responseItem.index(),
-                  responseItem.id(),
-                  responseItem.error().reason()),
-              "error on OpenSearch BulkRequest");
-          throw new PersistenceException("Operation failed: " + responseItem.error().reason());
-        }
-      }
+      validateNoErrors(items);
     } catch (final IOException | OpenSearchException ex) {
       throw new PersistenceException(
           "Error when processing bulk request against OpenSearch: " + ex.getMessage(), ex);
     }
+  }
+
+  private void validateNoErrors(final List<BulkResponseItem> items) {
+    final var errorItems = items.stream().filter(item -> item.error() != null).toList();
+    if (errorItems.isEmpty()) {
+      return;
+    }
+
+    final String errorMessages =
+        errorItems.stream()
+            .map(
+                item ->
+                    String.format(
+                        "%s failed for type [%s] and id [%s]: %s",
+                        item.operationType(), item.index(), item.id(), item.error().reason()))
+            .collect(Collectors.joining(", \n"));
+    LOGGER.warn("Bulk request execution failed: \n[{}]", errorMessages);
+
+    errorItems.forEach(
+        item -> {
+          final var errorHandler = errorHandlers.get(item.index());
+          final String message =
+              String.format(
+                  "%s failed for type [%s] and id [%s]: %s",
+                  item.operationType(), item.index(), item.id(), item.error().reason());
+          if (errorHandler != null) {
+            errorHandler.accept(message);
+          } else {
+            throw new PersistenceException(message);
+          }
+        });
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -11,6 +11,7 @@ import static io.camunda.exporter.config.ConnectionTypes.ELASTICSEARCH;
 import static io.camunda.exporter.schema.SchemaTestUtil.mappingsMatch;
 import static io.camunda.exporter.utils.CamundaExporterITInvocationProvider.CONFIG_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -48,6 +49,7 @@ import io.camunda.zeebe.exporter.test.ExporterTestController;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -396,7 +398,7 @@ final class CamundaExporterIT {
             responseEntity =
                 clientAdapter.get(
                     expectedEntity.getId(),
-                    exportHandler.getIndexName(),
+                    exportHandler.getIndex().getIndexName(),
                     exportHandler.getEntityType());
           } catch (final IOException e) {
             fail("Failed to find expected entity " + expectedEntity, e);
@@ -409,6 +411,37 @@ final class CamundaExporterIT {
                   exportHandler.getClass().getSimpleName(), exportHandler.getHandledValueType())
               .isEqualTo(expectedEntity);
         });
+  }
+
+  @TestTemplate
+  void shouldNotFailWhenUpdatingOperationWithNoDocument(
+      final ExporterConfiguration config, final SearchClientAdapter clientAdapter) {
+    // given
+    final ValueType valueType = ValueType.INCIDENT;
+    final Record record =
+        factory.generateRecord(
+            valueType,
+            r ->
+                r.withBrokerVersion("8.7.0")
+                    .withIntent(IncidentIntent.RESOLVED)
+                    .withTimestamp(System.currentTimeMillis()));
+    final var resourceProvider = new DefaultExporterResourceProvider();
+    resourceProvider.init(
+        config,
+        mock(ExporterEntityCacheProvider.class),
+        new SimpleMeterRegistry(),
+        new ExporterMetadata());
+
+    final CamundaExporter camundaExporter = new CamundaExporter();
+    final ExporterTestContext exporterTestContext =
+        new ExporterTestContext()
+            .setConfiguration(new ExporterTestConfiguration<>("camundaExporter", config));
+
+    camundaExporter.configure(exporterTestContext);
+    camundaExporter.open(new ExporterTestController());
+
+    // act
+    assertThatCode(() -> camundaExporter.export(record)).doesNotThrowAnyException();
   }
 
   @TestTemplate
@@ -447,7 +480,9 @@ final class CamundaExporterIT {
       final var handler = entry.getKey();
       final var entityId = entry.getValue();
 
-      assertThat(clientAdapter.get(entityId, handler.getIndexName(), handler.getEntityType()))
+      assertThat(
+              clientAdapter.get(
+                  entityId, handler.getIndex().getIndexName(), handler.getEntityType()))
           .isNull();
     }
   }
@@ -600,7 +635,8 @@ final class CamundaExporterIT {
       final var recordId = authHandler.generateIds(record).getFirst();
 
       assertThat(
-              clientAdapter.get(recordId, authHandler.getIndexName(), authHandler.getEntityType()))
+              clientAdapter.get(
+                  recordId, authHandler.getIndex().getIndexName(), authHandler.getEntityType()))
           .isNull();
     }
 
@@ -638,7 +674,8 @@ final class CamundaExporterIT {
       final var recordId = authHandler.generateIds(record).getFirst();
 
       assertThat(
-              clientAdapter.get(recordId, authHandler.getIndexName(), authHandler.getEntityType()))
+              clientAdapter.get(
+                  recordId, authHandler.getIndex().getIndexName(), authHandler.getEntityType()))
           .isNotNull();
     }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionEvaluationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionEvaluationHandlerTest.java
@@ -13,6 +13,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.entities.operate.dmn.DecisionInstanceEntity;
 import io.camunda.webapps.schema.entities.operate.dmn.DecisionInstanceState;
 import io.camunda.webapps.schema.entities.operate.dmn.DecisionType;
@@ -38,8 +40,8 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 public class DecisionEvaluationHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-decision-evaluation";
-  private final DecisionEvaluationHandler underTest = new DecisionEvaluationHandler(indexName);
+  private final IndexDescriptor index = new DecisionInstanceTemplate("", true);
+  private final DecisionEvaluationHandler underTest = new DecisionEvaluationHandler(index);
 
   @Test
   void testGetHandledValueType() {
@@ -111,7 +113,7 @@ public class DecisionEvaluationHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index.getIndexName(), inputEntity);
   }
 
   @ParameterizedTest

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionHandlerTest.java
@@ -11,6 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.operate.index.DecisionIndex;
 import io.camunda.webapps.schema.entities.operate.dmn.definition.DecisionDefinitionEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -26,8 +28,8 @@ import org.junit.jupiter.api.Test;
 final class DecisionHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-decision";
-  private final DecisionHandler underTest = new DecisionHandler(indexName);
+  private final IndexDescriptor index = new DecisionIndex("", true);
+  private final DecisionHandler underTest = new DecisionHandler(index);
 
   @Test
   void testGetHandledValueType() {
@@ -111,7 +113,7 @@ final class DecisionHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index.getIndexName(), inputEntity);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionRequirementsHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionRequirementsHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.entities.operate.dmn.definition.DecisionRequirementsEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -28,9 +29,9 @@ import org.junit.jupiter.api.Test;
 
 final class DecisionRequirementsHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = DecisionRequirementsIndex.INDEX_NAME;
+  private final IndexDescriptor index = new DecisionRequirementsIndex("", true);
 
-  private final DecisionRequirementsHandler underTest = new DecisionRequirementsHandler(indexName);
+  private final DecisionRequirementsHandler underTest = new DecisionRequirementsHandler(index);
 
   @Test
   void testGetHandledValueType() {
@@ -144,7 +145,7 @@ final class DecisionRequirementsHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index.getIndexName(), inputEntity);
   }
 
   private Record<DecisionRequirementsRecordValue> generateRecord(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/EmbeddedFormHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/EmbeddedFormHandlerTest.java
@@ -14,6 +14,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.tasklist.index.FormIndex;
 import io.camunda.webapps.schema.entities.tasklist.EmbeddedFormBatch;
 import io.camunda.webapps.schema.entities.tasklist.FormEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -32,8 +34,8 @@ import org.junit.jupiter.api.Test;
 public class EmbeddedFormHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-form";
-  private final EmbeddedFormHandler underTest = new EmbeddedFormHandler(indexName);
+  private final IndexDescriptor index = new FormIndex("", true);
+  private final EmbeddedFormHandler underTest = new EmbeddedFormHandler(index);
 
   @Test
   void testGetHandledValueType() {
@@ -105,7 +107,7 @@ public class EmbeddedFormHandlerTest {
     underTest.flush(batch, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index.getIndexName(), inputEntity);
   }
 
   @Test
@@ -122,8 +124,8 @@ public class EmbeddedFormHandlerTest {
     underTest.flush(batch, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, firstInputEntity);
-    verify(mockRequest, times(1)).add(indexName, secondInputEntity);
+    verify(mockRequest, times(1)).add(index.getIndexName(), firstInputEntity);
+    verify(mockRequest, times(1)).add(index.getIndexName(), secondInputEntity);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/EventFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/EventFromIncidentHandlerTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.template.EventTemplate;
 import io.camunda.webapps.schema.entities.operate.ErrorType;
 import io.camunda.webapps.schema.entities.operate.EventEntity;
@@ -37,9 +38,9 @@ import org.mockito.Mockito;
 
 final class EventFromIncidentHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = EventTemplate.INDEX_NAME;
+  private final IndexDescriptor index = new EventTemplate("", true);
 
-  private final EventFromIncidentHandler underTest = new EventFromIncidentHandler(indexName);
+  private final EventFromIncidentHandler underTest = new EventFromIncidentHandler(index);
 
   @Test
   void testGetHandledValueType() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/EventFromJobHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/EventFromJobHandlerTest.java
@@ -19,6 +19,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.template.EventTemplate;
 import io.camunda.webapps.schema.entities.operate.EventEntity;
 import io.camunda.webapps.schema.entities.operate.EventMetadataEntity;
@@ -38,9 +39,9 @@ import org.mockito.Mockito;
 
 final class EventFromJobHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = EventTemplate.INDEX_NAME;
+  private final IndexDescriptor index = new EventTemplate("", true);
 
-  private final EventFromJobHandler underTest = new EventFromJobHandler(indexName);
+  private final EventFromJobHandler underTest = new EventFromJobHandler(index);
 
   @Test
   void testGetHandledValueType() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/EventFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/EventFromProcessInstanceHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.template.EventTemplate;
 import io.camunda.webapps.schema.entities.operate.EventEntity;
 import io.camunda.webapps.schema.entities.operate.EventSourceType;
@@ -33,10 +34,10 @@ import org.mockito.Mockito;
 
 final class EventFromProcessInstanceHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = EventTemplate.INDEX_NAME;
+  private final IndexDescriptor index = new EventTemplate("", true);
 
   private final EventFromProcessInstanceHandler underTest =
-      new EventFromProcessInstanceHandler(indexName);
+      new EventFromProcessInstanceHandler(index);
 
   @Test
   void testGetHandledValueType() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/EventFromProcessMessageSubscriptionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/EventFromProcessMessageSubscriptionHandlerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.template.EventTemplate;
 import io.camunda.webapps.schema.entities.operate.EventEntity;
 import io.camunda.webapps.schema.entities.operate.EventMetadataEntity;
@@ -37,10 +38,10 @@ import org.mockito.Mockito;
 
 final class EventFromProcessMessageSubscriptionHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = EventTemplate.INDEX_NAME;
+  private final IndexDescriptor index = new EventTemplate("", true);
 
   private final EventFromProcessMessageSubscriptionHandler underTest =
-      new EventFromProcessMessageSubscriptionHandler(indexName);
+      new EventFromProcessMessageSubscriptionHandler(index);
 
   @Test
   void testGetHandledValueType() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.entities.operate.FlowNodeInstanceEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -29,9 +30,9 @@ import org.junit.jupiter.api.Test;
 public class FlowNodeInstanceFromIncidentHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-flownode-instance";
+  private final IndexDescriptor index = new FlowNodeInstanceTemplate("", true);
   private final FlowNodeInstanceFromIncidentHandler underTest =
-      new FlowNodeInstanceFromIncidentHandler(indexName);
+      new FlowNodeInstanceFromIncidentHandler(index);
 
   @Test
   public void testGetHandledValueType() {
@@ -99,7 +100,7 @@ public class FlowNodeInstanceFromIncidentHandlerTest {
 
     // then
     verify(mockRequest, times(1))
-        .upsert(indexName, inputEntity.getId(), inputEntity, expectedUpdateFields);
+        .upsert(index.getIndexName(), inputEntity.getId(), inputEntity, expectedUpdateFields);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.entities.operate.FlowNodeInstanceEntity;
 import io.camunda.webapps.schema.entities.operate.FlowNodeState;
@@ -38,9 +39,9 @@ import org.junit.jupiter.api.Test;
 
 public class FlowNodeInstanceFromProcessInstanceHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-list-view";
+  private final IndexDescriptor index = new FlowNodeInstanceTemplate("", true);
   private final FlowNodeInstanceFromProcessInstanceHandler underTest =
-      new FlowNodeInstanceFromProcessInstanceHandler(indexName);
+      new FlowNodeInstanceFromProcessInstanceHandler(index);
 
   @Test
   public void testGetHandledValueType() {
@@ -185,7 +186,7 @@ public class FlowNodeInstanceFromProcessInstanceHandlerTest {
     underTest.flush(inputEntity, mockRequest);
     // then
     verify(mockRequest, times(1))
-        .upsert(indexName, inputEntity.getId(), inputEntity, expectedUpdateFields);
+        .upsert(index.getIndexName(), inputEntity.getId(), inputEntity, expectedUpdateFields);
   }
 
   @Test
@@ -218,7 +219,7 @@ public class FlowNodeInstanceFromProcessInstanceHandlerTest {
     underTest.flush(inputEntity, mockRequest);
     // then
     verify(mockRequest, times(1))
-        .upsert(indexName, inputEntity.getId(), inputEntity, expectedUpdateFields);
+        .upsert(index.getIndexName(), inputEntity.getId(), inputEntity, expectedUpdateFields);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FormHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FormHandlerTest.java
@@ -15,6 +15,8 @@ import static org.mockito.Mockito.verify;
 import io.camunda.exporter.cache.TestFormCache;
 import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.tasklist.index.FormIndex;
 import io.camunda.webapps.schema.entities.tasklist.FormEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -29,9 +31,9 @@ import org.junit.jupiter.api.Test;
 public class FormHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-form";
+  private final IndexDescriptor index = new FormIndex("", true);
   private final TestFormCache formCache = new TestFormCache();
-  private final FormHandler underTest = new FormHandler(indexName, formCache);
+  private final FormHandler underTest = new FormHandler(index, formCache);
 
   @Test
   void testGetHandledValueType() {
@@ -97,7 +99,7 @@ public class FormHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index.getIndexName(), inputEntity);
   }
 
   @Test
@@ -110,7 +112,7 @@ public class FormHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index.getIndexName(), inputEntity);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandlerTest.java
@@ -14,6 +14,8 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.usermanagement.index.GroupIndex;
 import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -29,8 +31,8 @@ import org.junit.jupiter.params.provider.EnumSource.Mode;
 public class GroupCreatedUpdatedHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-group";
-  private final GroupCreatedUpdatedHandler underTest = new GroupCreatedUpdatedHandler(indexName);
+  private final IndexDescriptor index = new GroupIndex("", true);
+  private final GroupCreatedUpdatedHandler underTest = new GroupCreatedUpdatedHandler(index);
 
   @Test
   void testGetHandledValueType() {
@@ -117,6 +119,6 @@ public class GroupCreatedUpdatedHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index.getIndexName(), inputEntity);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupDeletedHandlerTest.java
@@ -14,6 +14,8 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.usermanagement.index.GroupIndex;
 import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -25,8 +27,8 @@ import org.junit.jupiter.api.Test;
 public class GroupDeletedHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-group";
-  private final GroupDeletedHandler underTest = new GroupDeletedHandler(indexName);
+  private final IndexDescriptor index = new GroupIndex("", true);
+  private final GroupDeletedHandler underTest = new GroupDeletedHandler(index);
 
   @Test
   void testGetHandledValueType() {
@@ -81,6 +83,6 @@ public class GroupDeletedHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).delete(indexName, inputEntity.getId());
+    verify(mockRequest, times(1)).delete(index.getIndexName(), inputEntity.getId());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityAddedHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.GroupIndex;
 import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -26,8 +27,8 @@ import org.junit.jupiter.api.Test;
 public class GroupEntityAddedHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-group";
-  private final GroupEntityAddedHandler underTest = new GroupEntityAddedHandler(indexName);
+  private final IndexDescriptor index = new GroupIndex("", true);
+  private final GroupEntityAddedHandler underTest = new GroupEntityAddedHandler(index);
 
   @Test
   void testGetHandledValueType() {
@@ -87,6 +88,6 @@ public class GroupEntityAddedHandlerTest {
 
     // then
     verify(mockRequest, times(1))
-        .addWithRouting(indexName, inputEntity, String.valueOf(joinRelation.parent()));
+        .addWithRouting(index.getIndexName(), inputEntity, String.valueOf(joinRelation.parent()));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityRemovedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityRemovedHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.GroupIndex;
 import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -26,8 +27,8 @@ import org.junit.jupiter.api.Test;
 public class GroupEntityRemovedHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-group";
-  private final GroupEntityRemovedHandler underTest = new GroupEntityRemovedHandler(indexName);
+  private final IndexDescriptor index = new GroupIndex("", true);
+  private final GroupEntityRemovedHandler underTest = new GroupEntityRemovedHandler(index);
 
   @Test
   void testGetHandledValueType() {
@@ -87,6 +88,7 @@ public class GroupEntityRemovedHandlerTest {
 
     // then
     verify(mockRequest, times(1))
-        .deleteWithRouting(indexName, inputEntity.getId(), String.valueOf(joinRelation.parent()));
+        .deleteWithRouting(
+            index.getIndexName(), inputEntity.getId(), String.valueOf(joinRelation.parent()));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
@@ -20,6 +20,8 @@ import io.camunda.exporter.cache.TestProcessCache;
 import io.camunda.exporter.cache.process.CachedProcessEntity;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.operate.template.IncidentTemplate;
 import io.camunda.webapps.schema.entities.operate.IncidentEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -38,9 +40,9 @@ import org.junit.jupiter.api.Test;
 
 public class IncidentHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-incident";
+  private final IndexDescriptor index = new IncidentTemplate("", true);
   private final TestProcessCache processCache = new TestProcessCache();
-  private final IncidentHandler underTest = new IncidentHandler(indexName, processCache);
+  private final IncidentHandler underTest = new IncidentHandler(index, processCache);
 
   @Test
   void testGetHandledValueType() {
@@ -117,7 +119,8 @@ public class IncidentHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).upsert(indexName, "0", inputEntity, Map.of("position", 1L));
+    verify(mockRequest, times(1))
+        .upsert(index.getIndexName(), "0", inputEntity, Map.of("position", 1L));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.template.JobTemplate;
 import io.camunda.webapps.schema.entities.operate.JobEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -48,9 +49,9 @@ import org.mockito.Mockito;
 
 final class JobHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = JobTemplate.INDEX_NAME;
+  private final IndexDescriptor index = new JobTemplate("", true);
 
-  private final JobHandler underTest = new JobHandler(indexName);
+  private final JobHandler underTest = new JobHandler(index);
 
   @Test
   void testGetHandledValueType() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromIncidentHandlerTest.java
@@ -13,6 +13,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.operate.listview.FlowNodeInstanceForListViewEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -27,9 +29,9 @@ import org.mockito.Mockito;
 public class ListViewFlowNodeFromIncidentHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-list-view";
+  private final IndexDescriptor index = new ListViewTemplate("", true);
   private final ListViewFlowNodeFromIncidentHandler underTest =
-      new ListViewFlowNodeFromIncidentHandler(indexName);
+      new ListViewFlowNodeFromIncidentHandler(index);
 
   @Test
   public void testGetHandledValueType() {
@@ -89,7 +91,7 @@ public class ListViewFlowNodeFromIncidentHandlerTest {
     // then
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index.getIndexName(),
             inputEntity.getId(),
             inputEntity,
             expectedUpdateFields,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromJobHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromJobHandlerTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.operate.listview.FlowNodeInstanceForListViewEntity;
 import io.camunda.webapps.schema.entities.operate.listview.ListViewJoinRelation;
@@ -28,9 +29,9 @@ import org.junit.jupiter.api.Test;
 public class ListViewFlowNodeFromJobHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-list-view";
+  private final IndexDescriptor index = new ListViewTemplate("", true);
   private final ListViewFlowNodeFromJobHandler underTest =
-      new ListViewFlowNodeFromJobHandler(indexName);
+      new ListViewFlowNodeFromJobHandler(index);
 
   @Test
   public void testGetHandledValueType() {
@@ -99,7 +100,7 @@ public class ListViewFlowNodeFromJobHandlerTest {
     // then
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index.getIndexName(),
             inputEntity.getId(),
             inputEntity,
             expectedUpdateFields,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromProcesInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromProcesInstanceHandlerTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.operate.FlowNodeState;
 import io.camunda.webapps.schema.entities.operate.FlowNodeType;
@@ -35,9 +36,9 @@ import org.junit.jupiter.api.Test;
 public class ListViewFlowNodeFromProcesInstanceHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-list-view";
+  private final IndexDescriptor index = new ListViewTemplate("", true);
   private final ListViewFlowNodeFromProcessInstanceHandler underTest =
-      new ListViewFlowNodeFromProcessInstanceHandler(indexName);
+      new ListViewFlowNodeFromProcessInstanceHandler(index);
 
   @Test
   public void testGetHandledValueType() {
@@ -183,7 +184,7 @@ public class ListViewFlowNodeFromProcesInstanceHandlerTest {
     // then
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index.getIndexName(),
             inputEntity.getId(),
             inputEntity,
             expectedUpdateFields,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.verify;
 import io.camunda.exporter.cache.TestProcessCache;
 import io.camunda.exporter.cache.process.CachedProcessEntity;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.operate.listview.ListViewJoinRelation;
 import io.camunda.webapps.schema.entities.operate.listview.ProcessInstanceForListViewEntity;
@@ -45,10 +46,10 @@ import org.junit.jupiter.api.Test;
 public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-list-view";
+  private final IndexDescriptor index = new ListViewTemplate("", true);
   private final TestProcessCache processCache = new TestProcessCache();
   private final ListViewProcessInstanceFromProcessInstanceHandler underTest =
-      new ListViewProcessInstanceFromProcessInstanceHandler(indexName, processCache);
+      new ListViewProcessInstanceFromProcessInstanceHandler(index, processCache);
 
   @Test
   public void testGetHandledValueType() {
@@ -200,7 +201,8 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).upsert(indexName, "111", inputEntity, expectedUpdateFields);
+    verify(mockRequest, times(1))
+        .upsert(index.getIndexName(), "111", inputEntity, expectedUpdateFields);
   }
 
   @Test
@@ -229,7 +231,8 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).upsert(indexName, "111", inputEntity, expectedUpdateFields);
+    verify(mockRequest, times(1))
+        .upsert(index.getIndexName(), "111", inputEntity, expectedUpdateFields);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewVariableFromVariableHandlerTest.java
@@ -16,6 +16,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.operate.listview.VariableForListViewEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -29,9 +31,9 @@ import org.junit.jupiter.api.Test;
 public class ListViewVariableFromVariableHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-list-view";
+  private final IndexDescriptor index = new ListViewTemplate("", true);
   private final ListViewVariableFromVariableHandler underTest =
-      new ListViewVariableFromVariableHandler(indexName);
+      new ListViewVariableFromVariableHandler(index);
 
   @Test
   public void testGetHandledValueType() {
@@ -90,7 +92,7 @@ public class ListViewVariableFromVariableHandlerTest {
     // then
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index.getIndexName(),
             inputEntity.getId(),
             inputEntity,
             expectedUpdateFields,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MappingCreatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MappingCreatedHandlerTest.java
@@ -14,6 +14,8 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.usermanagement.index.MappingIndex;
 import io.camunda.webapps.schema.entities.usermanagement.MappingEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -24,8 +26,8 @@ import org.junit.jupiter.api.Test;
 
 public class MappingCreatedHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-mapping";
-  private final MappingCreatedHandler underTest = new MappingCreatedHandler(indexName);
+  private final IndexDescriptor index = new MappingIndex("", true);
+  private final MappingCreatedHandler underTest = new MappingCreatedHandler(index);
 
   @Test
   void testGetHandledValueType() {
@@ -80,6 +82,6 @@ public class MappingCreatedHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index.getIndexName(), inputEntity);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MappingDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MappingDeletedHandlerTest.java
@@ -14,6 +14,8 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.usermanagement.index.MappingIndex;
 import io.camunda.webapps.schema.entities.usermanagement.MappingEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -24,8 +26,8 @@ import org.junit.jupiter.api.Test;
 
 public class MappingDeletedHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-mapping";
-  private final MappingDeletedHandler underTest = new MappingDeletedHandler(indexName);
+  private final IndexDescriptor index = new MappingIndex("", true);
+  private final MappingDeletedHandler underTest = new MappingDeletedHandler(index);
 
   @Test
   void testGetHandledValueType() {
@@ -80,6 +82,6 @@ public class MappingDeletedHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).delete(indexName, inputEntity.getId());
+    verify(mockRequest, times(1)).delete(index.getIndexName(), inputEntity.getId());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MetricFromDecisionEvaluationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MetricFromDecisionEvaluationHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.index.MetricIndex;
 import io.camunda.webapps.schema.entities.MetricEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -33,10 +34,10 @@ import org.junit.jupiter.api.Test;
 
 public class MetricFromDecisionEvaluationHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = MetricIndex.INDEX_NAME;
+  private final IndexDescriptor index = new MetricIndex("", true);
 
   private final MetricFromDecisionEvaluationHandler underTest =
-      new MetricFromDecisionEvaluationHandler(indexName);
+      new MetricFromDecisionEvaluationHandler(index);
 
   @Test
   void testGetHandledValueType() {
@@ -160,6 +161,6 @@ public class MetricFromDecisionEvaluationHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index.getIndexName(), inputEntity);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MetricFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MetricFromProcessInstanceHandlerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.index.MetricIndex;
 import io.camunda.webapps.schema.entities.MetricEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -32,10 +33,10 @@ import org.junit.jupiter.api.Test;
 
 final class MetricFromProcessInstanceHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = MetricIndex.INDEX_NAME;
+  private final IndexDescriptor index = new MetricIndex("", true);
 
   private final MetricFromProcessInstanceHandler underTest =
-      new MetricFromProcessInstanceHandler(indexName);
+      new MetricFromProcessInstanceHandler(index);
 
   @Test
   void testGetHandledValueType() {
@@ -143,7 +144,7 @@ final class MetricFromProcessInstanceHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index.getIndexName(), inputEntity);
   }
 
   private void assertShouldNotHandleRecordWithIntent(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MigratedVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MigratedVariableHandlerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.template.VariableTemplate;
 import io.camunda.webapps.schema.entities.operate.VariableEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -30,8 +31,8 @@ import org.junit.jupiter.params.provider.EnumSource.Mode;
 
 public class MigratedVariableHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "variable";
-  private final MigratedVariableHandler underTest = new MigratedVariableHandler(indexName);
+  private final IndexDescriptor index = new VariableTemplate("", true);
+  private final MigratedVariableHandler underTest = new MigratedVariableHandler(index);
 
   @Test
   void testGetHandledValueType() {
@@ -119,7 +120,8 @@ public class MigratedVariableHandlerTest {
     updateFields.put(VariableTemplate.POSITION, inputEntity.getPosition());
 
     // then
-    verify(mockRequest, times(1)).upsert(indexName, inputEntity.getId(), inputEntity, updateFields);
+    verify(mockRequest, times(1))
+        .upsert(index.getIndexName(), inputEntity.getId(), inputEntity, updateFields);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandlerTest.java
@@ -13,6 +13,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.operate.template.PostImporterQueueTemplate;
 import io.camunda.webapps.schema.entities.operate.post.PostImporterActionType;
 import io.camunda.webapps.schema.entities.operate.post.PostImporterQueueEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -26,9 +28,9 @@ import org.junit.jupiter.api.Test;
 public class PostImporterQueueFromIncidentHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-post-import-queue";
+  private final IndexDescriptor index = new PostImporterQueueTemplate("", true);
   private final PostImporterQueueFromIncidentHandler underTest =
-      new PostImporterQueueFromIncidentHandler(indexName);
+      new PostImporterQueueFromIncidentHandler(index);
 
   @Test
   void testGetHandledValueType() {
@@ -118,7 +120,7 @@ public class PostImporterQueueFromIncidentHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index.getIndexName(), inputEntity);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessHandlerTest.java
@@ -15,6 +15,8 @@ import static org.mockito.Mockito.verify;
 import io.camunda.exporter.cache.TestProcessCache;
 import io.camunda.exporter.cache.process.CachedProcessEntity;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.operate.index.ProcessIndex;
 import io.camunda.webapps.schema.entities.operate.ProcessEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -31,9 +33,9 @@ import org.junit.jupiter.api.Test;
 
 public class ProcessHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-process";
+  private final IndexDescriptor index = new ProcessIndex("", true);
   private final TestProcessCache processCache = new TestProcessCache();
-  private final ProcessHandler underTest = new ProcessHandler(indexName, processCache);
+  private final ProcessHandler underTest = new ProcessHandler(index, processCache);
 
   @Test
   void testGetHandledValueType() {
@@ -99,7 +101,7 @@ public class ProcessHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index.getIndexName(), inputEntity);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/RoleDeletedHandlerTest.java
@@ -14,6 +14,8 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.usermanagement.index.RoleIndex;
 import io.camunda.webapps.schema.entities.usermanagement.RoleEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -24,8 +26,8 @@ import org.junit.jupiter.api.Test;
 
 public class RoleDeletedHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-role";
-  private final RoleDeletedHandler underTest = new RoleDeletedHandler(indexName);
+  private final IndexDescriptor index = new RoleIndex("", true);
+  private final RoleDeletedHandler underTest = new RoleDeletedHandler(index);
 
   @Test
   void testGetHandledValueType() {
@@ -80,6 +82,6 @@ public class RoleDeletedHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).delete(indexName, inputEntity.getId());
+    verify(mockRequest, times(1)).delete(index.getIndexName(), inputEntity.getId());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/SequenceFlowHandlerTest.java
@@ -13,6 +13,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.operate.template.SequenceFlowTemplate;
 import io.camunda.webapps.schema.entities.operate.SequenceFlowEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -25,8 +27,8 @@ import org.junit.jupiter.api.Test;
 
 public class SequenceFlowHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "sequence-flow";
-  private final SequenceFlowHandler underTest = new SequenceFlowHandler(indexName);
+  private final IndexDescriptor index = new SequenceFlowTemplate("", true);
+  private final SequenceFlowHandler underTest = new SequenceFlowHandler(index);
 
   @Test
   void testGetHandledValueType() {
@@ -108,7 +110,7 @@ public class SequenceFlowHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index.getIndexName(), inputEntity);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TaskCompletedMetricHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TaskCompletedMetricHandlerTest.java
@@ -14,7 +14,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.store.BatchRequest;
-import io.camunda.webapps.schema.descriptors.operate.index.MetricIndex;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.tasklist.index.TasklistMetricIndex;
 import io.camunda.webapps.schema.entities.MetricEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -30,9 +31,9 @@ import org.junit.jupiter.api.Test;
 
 public class TaskCompletedMetricHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-" + MetricIndex.INDEX_NAME;
+  private final IndexDescriptor index = new TasklistMetricIndex("", true);
 
-  private final TaskCompletedMetricHandler underTest = new TaskCompletedMetricHandler(indexName);
+  private final TaskCompletedMetricHandler underTest = new TaskCompletedMetricHandler(index);
 
   @Test
   void testGetHandledValueType() {
@@ -125,7 +126,7 @@ public class TaskCompletedMetricHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index.getIndexName(), inputEntity);
   }
 
   private Record<UserTaskRecordValue> generateRecord(final UserTaskIntent intent) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantCreateUpdateHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantCreateUpdateHandlerTest.java
@@ -14,6 +14,8 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex;
 import io.camunda.webapps.schema.entities.usermanagement.TenantEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -25,8 +27,8 @@ import org.junit.jupiter.api.Test;
 
 public class TenantCreateUpdateHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-tenant";
-  private final TenantCreateUpdateHandler underTest = new TenantCreateUpdateHandler(indexName);
+  private final IndexDescriptor index = new TenantIndex("", true);
+  private final TenantCreateUpdateHandler underTest = new TenantCreateUpdateHandler(index);
 
   @Test
   void testGetHandledValueType() {
@@ -112,6 +114,6 @@ public class TenantCreateUpdateHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index.getIndexName(), inputEntity);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantDeletedHandlerTest.java
@@ -14,6 +14,8 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex;
 import io.camunda.webapps.schema.entities.usermanagement.TenantEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -24,8 +26,8 @@ import org.junit.jupiter.api.Test;
 
 public class TenantDeletedHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-tenant";
-  private final TenantDeletedHandler underTest = new TenantDeletedHandler(indexName);
+  private final IndexDescriptor index = new TenantIndex("", true);
+  private final TenantDeletedHandler underTest = new TenantDeletedHandler(index);
 
   @Test
   void testGetHandledValueType() {
@@ -80,6 +82,6 @@ public class TenantDeletedHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).delete(indexName, inputEntity.getId());
+    verify(mockRequest, times(1)).delete(index.getIndexName(), inputEntity.getId());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityAddedHandlerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.*;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex;
 import io.camunda.webapps.schema.entities.usermanagement.TenantEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -24,8 +25,8 @@ import org.junit.jupiter.api.Test;
 public class TenantEntityAddedHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-tenant";
-  private final TenantEntityAddedHandler underTest = new TenantEntityAddedHandler(indexName);
+  private final IndexDescriptor index = new TenantIndex("", true);
+  private final TenantEntityAddedHandler underTest = new TenantEntityAddedHandler(index);
 
   @Test
   void testGetHandledValueType() {
@@ -85,6 +86,6 @@ public class TenantEntityAddedHandlerTest {
 
     // then
     verify(mockRequest, times(1))
-        .addWithRouting(indexName, inputEntity, String.valueOf(joinRelation.parent()));
+        .addWithRouting(index.getIndexName(), inputEntity, String.valueOf(joinRelation.parent()));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityRemovedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityRemovedHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex;
 import io.camunda.webapps.schema.entities.usermanagement.TenantEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -26,8 +27,8 @@ import org.junit.jupiter.api.Test;
 public class TenantEntityRemovedHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-tenant";
-  private final TenantEntityRemovedHandler underTest = new TenantEntityRemovedHandler(indexName);
+  private final IndexDescriptor index = new TenantIndex("", true);
+  private final TenantEntityRemovedHandler underTest = new TenantEntityRemovedHandler(index);
 
   @Test
   void testGetHandledValueType() {
@@ -87,6 +88,7 @@ public class TenantEntityRemovedHandlerTest {
 
     // then
     verify(mockRequest, times(1))
-        .deleteWithRouting(indexName, inputEntity.getId(), String.valueOf(joinRelation.parent()));
+        .deleteWithRouting(
+            index.getIndexName(), inputEntity.getId(), String.valueOf(joinRelation.parent()));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserCreatedUpdatedHandlerTest.java
@@ -14,6 +14,8 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.usermanagement.index.UserIndex;
 import io.camunda.webapps.schema.entities.usermanagement.UserEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -25,8 +27,8 @@ import org.junit.jupiter.api.Test;
 
 public class UserCreatedUpdatedHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-user";
-  private final UserCreatedUpdatedHandler underTest = new UserCreatedUpdatedHandler(indexName);
+  private final IndexDescriptor index = new UserIndex("", true);
+  private final UserCreatedUpdatedHandler underTest = new UserCreatedUpdatedHandler(index);
 
   @Test
   void testGetHandledValueType() {
@@ -116,6 +118,6 @@ public class UserCreatedUpdatedHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index.getIndexName(), inputEntity);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserDeletedHandlerTest.java
@@ -14,6 +14,8 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.usermanagement.index.UserIndex;
 import io.camunda.webapps.schema.entities.usermanagement.UserEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -24,8 +26,8 @@ import org.junit.jupiter.api.Test;
 
 public class UserDeletedHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-user";
-  private final UserDeletedHandler underTest = new UserDeletedHandler(indexName);
+  private final IndexDescriptor index = new UserIndex("", true);
+  private final UserDeletedHandler underTest = new UserDeletedHandler(index);
 
   @Test
   void testGetHandledValueType() {
@@ -80,6 +82,6 @@ public class UserDeletedHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).delete(indexName, inputEntity.getId());
+    verify(mockRequest, times(1)).delete(index.getIndexName(), inputEntity.getId());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandlerTest.java
@@ -14,7 +14,9 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.handlers.UserTaskCompletionVariableHandler.SnapshotTaskVariableBatch;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.tasklist.template.SnapshotTaskVariableTemplate;
+import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
 import io.camunda.webapps.schema.entities.tasklist.SnapshotTaskVariableEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -32,9 +34,9 @@ import org.junit.jupiter.api.Test;
 public class UserTaskCompletionVariableHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-tasklist-task";
+  private final IndexDescriptor index = new TaskTemplate("", true);
   private final UserTaskCompletionVariableHandler underTest =
-      new UserTaskCompletionVariableHandler(indexName, 100);
+      new UserTaskCompletionVariableHandler(index, 100);
 
   @Test
   void testGetHandledValueType() {
@@ -144,7 +146,7 @@ public class UserTaskCompletionVariableHandlerTest {
     updateFieldsMap.put(SnapshotTaskVariableTemplate.IS_PREVIEW, inputEntity.getIsPreview());
 
     verify(mockRequest, times(1))
-        .upsert(indexName, inputEntity.getId(), inputEntity, updateFieldsMap);
+        .upsert(index.getIndexName(), inputEntity.getId(), inputEntity, updateFieldsMap);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
@@ -17,6 +17,7 @@ import io.camunda.exporter.cache.TestFormCache;
 import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
 import io.camunda.webapps.schema.entities.tasklist.TaskEntity;
 import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
@@ -51,11 +52,10 @@ public class UserTaskHandlerTest {
           UserTaskIntent.UPDATED);
 
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-tasklist-task";
+  private final IndexDescriptor index = new TaskTemplate("", true);
   private final TestFormCache formCache = new TestFormCache();
   private final ExporterMetadata exporterMetadata = new ExporterMetadata();
-  private final UserTaskHandler underTest =
-      new UserTaskHandler(indexName, formCache, exporterMetadata);
+  private final UserTaskHandler underTest = new UserTaskHandler(index, formCache, exporterMetadata);
 
   @BeforeEach
   void resetMetadata() {
@@ -193,7 +193,7 @@ public class UserTaskHandlerTest {
 
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index.getIndexName(),
             String.valueOf(flowNodeInstanceKey),
             inputEntity,
             updateFieldsMap,
@@ -225,7 +225,7 @@ public class UserTaskHandlerTest {
 
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index.getIndexName(),
             String.valueOf(recordKey),
             inputEntity,
             updateFieldsMap,
@@ -600,7 +600,7 @@ public class UserTaskHandlerTest {
     assertThat(taskEntity.getBpmnProcessId()).isEqualTo(taskRecordValue.getBpmnProcessId());
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index.getIndexName(),
             taskEntity.getId(),
             taskEntity,
             expectedUpdates,
@@ -639,7 +639,7 @@ public class UserTaskHandlerTest {
     assertThat(taskEntity.getAssignee()).isEqualTo(taskRecordValue.getAssignee());
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index.getIndexName(),
             taskEntity.getId(),
             taskEntity,
             expectedUpdates,
@@ -679,7 +679,7 @@ public class UserTaskHandlerTest {
     assertThat(taskEntity.getAssignee()).isEqualTo(null);
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index.getIndexName(),
             taskEntity.getId(),
             taskEntity,
             expectedUpdates,
@@ -716,7 +716,7 @@ public class UserTaskHandlerTest {
 
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index.getIndexName(),
             taskEntity.getId(),
             taskEntity,
             expectedUpdates,
@@ -786,7 +786,7 @@ public class UserTaskHandlerTest {
         .isEqualTo(taskRecordValue.getCandidateUsersList());
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index.getIndexName(),
             String.valueOf(recordKey),
             taskEntity,
             expectedUpdates,
@@ -843,7 +843,7 @@ public class UserTaskHandlerTest {
     assertThat(taskEntity.getAssignee()).isEqualTo(assignTaskRecordValue.getAssignee());
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index.getIndexName(),
             taskEntity.getId(),
             taskEntity,
             expectedUpdates,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
@@ -17,6 +17,7 @@ import io.camunda.exporter.cache.TestFormCache;
 import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
 import io.camunda.webapps.schema.entities.tasklist.TaskEntity;
 import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
@@ -51,11 +52,11 @@ public class UserTaskJobBasedHandlerTest {
           JobIntent.FAILED);
 
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-tasklist-task";
+  private final IndexDescriptor index = new TaskTemplate("", true);
   private final TestFormCache formCache = new TestFormCache();
   private final ExporterMetadata exporterMetadata = new ExporterMetadata();
   private final UserTaskJobBasedHandler underTest =
-      new UserTaskJobBasedHandler(indexName, formCache, exporterMetadata);
+      new UserTaskJobBasedHandler(index, formCache, exporterMetadata);
 
   @BeforeEach
   void resetMetadata() {
@@ -215,7 +216,7 @@ public class UserTaskJobBasedHandlerTest {
 
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index.getIndexName(),
             String.valueOf(flowNodeInstanceKey),
             inputEntity,
             updateFieldsMap,
@@ -247,7 +248,7 @@ public class UserTaskJobBasedHandlerTest {
 
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index.getIndexName(),
             String.valueOf(recordKey),
             inputEntity,
             updateFieldsMap,
@@ -493,7 +494,7 @@ public class UserTaskJobBasedHandlerTest {
     assertThat(taskEntity.getBpmnProcessId()).isEqualTo(jobRecordValue.getBpmnProcessId());
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index.getIndexName(),
             taskEntity.getId(),
             taskEntity,
             expectedUpdates,
@@ -529,7 +530,7 @@ public class UserTaskJobBasedHandlerTest {
 
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index.getIndexName(),
             taskEntity.getId(),
             taskEntity,
             expectedUpdates,
@@ -593,7 +594,7 @@ public class UserTaskJobBasedHandlerTest {
 
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index.getIndexName(),
             taskEntity.getId(),
             taskEntity,
             expectedUpdates,
@@ -659,7 +660,7 @@ public class UserTaskJobBasedHandlerTest {
 
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index.getIndexName(),
             taskEntity.getId(),
             taskEntity,
             expectedUpdates,
@@ -725,7 +726,7 @@ public class UserTaskJobBasedHandlerTest {
 
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index.getIndexName(),
             taskEntity.getId(),
             taskEntity,
             expectedUpdates,
@@ -783,7 +784,7 @@ public class UserTaskJobBasedHandlerTest {
 
     verify(mockRequest, times(1))
         .upsertWithRouting(
-            indexName,
+            index.getIndexName(),
             taskEntity.getId(),
             taskEntity,
             expectedUpdates,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskProcessInstanceHandlerTest.java
@@ -13,6 +13,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
 import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship.TaskJoinRelationshipType;
 import io.camunda.webapps.schema.entities.tasklist.TaskProcessInstanceEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -37,9 +39,9 @@ public class UserTaskProcessInstanceHandlerTest {
           BpmnElementType.USER_TASK,
           BpmnElementType.MULTI_INSTANCE_BODY);
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-tasklist-task";
+  private final IndexDescriptor index = new TaskTemplate("", true);
   private final UserTaskProcessInstanceHandler underTest =
-      new UserTaskProcessInstanceHandler(indexName);
+      new UserTaskProcessInstanceHandler(index);
 
   @Test
   void testGetHandledValueType() {
@@ -125,7 +127,7 @@ public class UserTaskProcessInstanceHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index.getIndexName(), inputEntity);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskVariableHandlerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.handlers.UserTaskVariableHandler.UserTaskVariableBatch;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
 import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship.TaskJoinRelationshipType;
 import io.camunda.webapps.schema.entities.tasklist.TaskVariableEntity;
@@ -36,8 +37,8 @@ import org.mockito.ArgumentCaptor;
 public class UserTaskVariableHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "test-tasklist-task";
-  private final UserTaskVariableHandler underTest = new UserTaskVariableHandler(indexName, 100);
+  private final IndexDescriptor index = new TaskTemplate("", true);
+  private final UserTaskVariableHandler underTest = new UserTaskVariableHandler(index, 100);
 
   @Test
   void testGetHandledValueType() {
@@ -146,7 +147,7 @@ public class UserTaskVariableHandlerTest {
     assertThat(variableBatch.getVariables()).hasSize(2);
     verify(mockRequest, times(2))
         .upsertWithRouting(
-            eq(indexName),
+            eq(index.getIndexName()),
             idCaptor.capture(),
             entityCaptor.capture(),
             updateFieldsCaptor.capture(),

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/VariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/VariableHandlerTest.java
@@ -13,6 +13,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.operate.template.VariableTemplate;
 import io.camunda.webapps.schema.entities.operate.VariableEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -27,9 +29,9 @@ import org.junit.jupiter.params.provider.EnumSource.Mode;
 
 public class VariableHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
-  private final String indexName = "variable";
+  private final IndexDescriptor index = new VariableTemplate("", true);
   private final int variableSizeThreshold = 10;
-  private final VariableHandler underTest = new VariableHandler(indexName, variableSizeThreshold);
+  private final VariableHandler underTest = new VariableHandler(index, variableSizeThreshold);
 
   @Test
   void testGetHandledValueType() {
@@ -111,7 +113,7 @@ public class VariableHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index.getIndexName(), inputEntity);
   }
 
   @Test
@@ -129,7 +131,7 @@ public class VariableHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1)).add(index.getIndexName(), inputEntity);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/operation/AbstractOperationHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/operation/AbstractOperationHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.template.OperationTemplate;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationState;
@@ -31,7 +32,7 @@ import org.junit.jupiter.api.Test;
 abstract class AbstractOperationHandlerTest<R extends RecordValue> {
   protected AbstractOperationHandler<R> underTest;
   protected final ProtocolFactory factory = new ProtocolFactory();
-  protected final String indexName = OperationTemplate.INDEX_NAME;
+  protected final IndexDescriptor index = new OperationTemplate("", true);
   protected ValueType valueType;
 
   @Test
@@ -121,7 +122,7 @@ abstract class AbstractOperationHandlerTest<R extends RecordValue> {
     underTest.flush(entity, mockRequest);
 
     // then
-    verify(mockRequest).update(indexName, entity.getId(), expectedUpdateFields);
+    verify(mockRequest).update(index.getIndexName(), entity.getId(), expectedUpdateFields);
   }
 
   protected Record<R> generateRecord(final Intent intent) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/operation/OperationFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/operation/OperationFromIncidentHandlerTest.java
@@ -21,7 +21,7 @@ class OperationFromIncidentHandlerTest extends AbstractOperationHandlerTest<Inci
 
   @BeforeEach
   void setUp() {
-    underTest = new OperationFromIncidentHandler(indexName);
+    underTest = new OperationFromIncidentHandler(index);
     valueType = ValueType.INCIDENT;
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/operation/OperationFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/operation/OperationFromProcessInstanceHandlerTest.java
@@ -24,7 +24,7 @@ class OperationFromProcessInstanceHandlerTest
 
   @BeforeEach
   void setUp() {
-    underTest = new OperationFromProcessInstanceHandler(indexName);
+    underTest = new OperationFromProcessInstanceHandler(index);
     valueType = ValueType.PROCESS_INSTANCE;
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/operation/OperationFromVariableDocumentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/operation/OperationFromVariableDocumentHandlerTest.java
@@ -21,7 +21,7 @@ class OperationFromVariableDocumentHandlerTest
 
   @BeforeEach
   void setUp() {
-    underTest = new OperationFromVariableDocumentHandler(indexName);
+    underTest = new OperationFromVariableDocumentHandler(index);
     valueType = ValueType.VARIABLE_DOCUMENT;
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterMultipleHandlersTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterMultipleHandlersTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.verify;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.store.ExporterBatchWriter.Builder;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -308,7 +309,7 @@ public class ExporterBatchWriterMultipleHandlersTest {
     }
 
     @Override
-    public String getIndexName() {
+    public IndexDescriptor getIndex() {
       return null;
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/OpensearchBatchRequestTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/OpensearchBatchRequestTest.java
@@ -20,6 +20,7 @@ import io.camunda.exporter.utils.OpensearchScriptBuilder;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,6 +43,7 @@ class OpensearchBatchRequestTest {
 
   private static final String ID = "id";
   private static final String INDEX = "index";
+  private static final String INDEX_WITH_HANDLER = "indexWithHandler";
   private OpensearchBatchRequest batchRequest;
   private OpenSearchClient osClient;
   private Builder requestBuilder;
@@ -433,5 +435,32 @@ class OpensearchBatchRequestTest {
     // Then
     assertThatThrownBy(callable).isInstanceOf(PersistenceException.class);
     verify(osClient).bulk(any(BulkRequest.class));
+  }
+
+  @Test
+  void shouldUseCustomErrorHandlerIfProvided() throws IOException {
+    // Given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+
+    final Consumer<String> errorHandler = mock(Consumer.class);
+    batchRequest.onError(INDEX_WITH_HANDLER, errorHandler);
+
+    final BulkResponseItem item = mock(BulkResponseItem.class);
+    when(item.id()).thenReturn("1");
+    when(item.error())
+        .thenReturn(new ErrorCause.Builder().type("string_error").reason("error").build());
+    when(item.index()).thenReturn(INDEX_WITH_HANDLER);
+
+    final BulkResponse bulkResponse = mock(BulkResponse.class);
+    when(bulkResponse.items()).thenReturn(List.of(item));
+
+    when(osClient.bulk(any(BulkRequest.class))).thenReturn(bulkResponse);
+
+    // When
+    batchRequest.add(INDEX_WITH_HANDLER, entity);
+    batchRequest.execute();
+
+    // Then
+    verify(errorHandler).accept(any());
   }
 }


### PR DESCRIPTION
## Description
- Added ErrorHandlingBehavior interfaces
- IndexDescriptor interface implements ErrorHandlingBehavior
- Operate OperationTemplate implements ErrorSwallowing
- Mark all current indices and templates as ErrorThrowing
- refactor: handlers receive their respective IndexDescriptor as a constructor parameter
- BatchRequest can register how to handle errors for certain indices, and use the behavior for persistence errors
- pass error handling behavior to batchRequest when flushing entities to be exported

## Related issues

closes #27090
