### PR TITLE
[Backport stable/8.4] fix: avoid actor call to unregister handlers when it is closing

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImpl.java
@@ -64,7 +64,7 @@ public final class CommandApiServiceImpl extends Actor
   @Override
   protected void onActorClosing() {
     for (final Integer leadPartition : leadPartitions) {
-      unregisterHandlers(leadPartition);
+      unregisterHandlersActorless(leadPartition);
     }
     leadPartitions.clear();
     actor.runOnCompletion(
@@ -133,14 +133,15 @@ public final class CommandApiServiceImpl extends Actor
 
   @Override
   public ActorFuture<Void> unregisterHandlers(final int partitionId) {
-    return actor.call(
-        () -> {
-          commandHandler.removePartition(partitionId);
-          queryHandler.removePartition(partitionId);
-          leadPartitions.remove(partitionId);
-          serverTransport.unsubscribe(partitionId, RequestType.COMMAND);
-          serverTransport.unsubscribe(partitionId, RequestType.QUERY);
-        });
+    return actor.call(() -> unregisterHandlersActorless(partitionId));
+  }
+
+  private void unregisterHandlersActorless(final int partitionId) {
+    commandHandler.removePartition(partitionId);
+    queryHandler.removePartition(partitionId);
+    leadPartitions.remove(partitionId);
+    serverTransport.unsubscribe(partitionId, RequestType.COMMAND);
+    serverTransport.unsubscribe(partitionId, RequestType.QUERY);
   }
 
   @Override

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImplTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.broker.system.configuration.QueryApiCfg;
@@ -25,16 +26,20 @@ import io.camunda.zeebe.broker.transport.backpressure.RequestLimiter;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
 import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.transport.ServerTransport;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.Mock;
+import org.mockito.Mock.Strictness;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -43,20 +48,29 @@ public class CommandApiServiceImplTest {
   @Mock private ServerTransport serverTransport;
   @Mock private QueryApiCfg queryApi;
   private CommandApiServiceImpl commandApiService;
-  @Mock private PartitionTransitionContext transitionContext;
-  @Mock private LogStream logStream;
+
+  @Mock(strictness = Strictness.LENIENT)
+  private PartitionTransitionContext transitionContext;
+
+  @Mock(strictness = Strictness.LENIENT)
+  private LogStream logStream;
 
   @RegisterExtension
-  private ControlledActorSchedulerExtension scheduler = new ControlledActorSchedulerExtension();
+  private final ControlledActorSchedulerExtension scheduler =
+      new ControlledActorSchedulerExtension();
 
   @BeforeEach
   public void setup() {
-    final ConcurrencyControl cc = mock();
+    final ConcurrencyControl cc =
+        mock(
+            ConcurrencyControl.class,
+            withSettings().strictness(org.mockito.quality.Strictness.LENIENT));
     when(cc.createCompletedFuture()).thenReturn(CompletableActorFuture.completed(null));
 
     final RequestLimiter<Intent> requestLimiter = mock();
 
-    final PartitionAwareRequestLimiter limiter = mock();
+    final PartitionAwareRequestLimiter limiter =
+        mock(withSettings().strictness(org.mockito.quality.Strictness.LENIENT));
     when(limiter.getLimiter(anyInt())).thenReturn(requestLimiter);
 
     commandApiService =
@@ -109,5 +123,64 @@ public class CommandApiServiceImplTest {
     transitionFollowerFuture.join();
     verify(serverTransport, never()).unsubscribe(eq(1), eq(RequestType.QUERY));
     verify(serverTransport, never()).unsubscribe(eq(1), eq(RequestType.COMMAND));
+  }
+
+  @RegressionTest("https://github.com/camunda/camunda/issues/25897")
+  public void shouldUnsubscribeTwiceWhenTransitioningFromFollowerToInactive() {
+    // given
+    when(transitionContext.getPartitionId()).thenReturn(1);
+    final var transitionStep = new CommandApiServiceTransitionStep();
+    final var prepareFollowerFuture =
+        transitionStep.prepareTransition(transitionContext, 1, Role.FOLLOWER);
+    scheduler.workUntilDone();
+    prepareFollowerFuture.join();
+
+    // when - transitions to FOLLOWER
+    final var transitionFollowerFuture =
+        transitionStep.transitionTo(transitionContext, 1, Role.FOLLOWER);
+    scheduler.workUntilDone();
+    transitionFollowerFuture.join();
+
+    // then - subscriptions are cleaned up
+    verify(serverTransport, times(1)).unsubscribe(eq(1), eq(RequestType.QUERY));
+    verify(serverTransport, times(1)).unsubscribe(eq(1), eq(RequestType.COMMAND));
+
+    clearInvocations(serverTransport);
+    final var unregisterFuture =
+        transitionStep.prepareTransition(transitionContext, 2, Role.INACTIVE);
+    scheduler.workUntilDone();
+    unregisterFuture.join();
+
+    // when - transitions to INACTIVE
+    final var transitionInactiveFuture =
+        transitionStep.transitionTo(transitionContext, 2, Role.INACTIVE);
+    scheduler.workUntilDone();
+    transitionInactiveFuture.join();
+
+    // then - subscriptions are cleaned up
+    verify(serverTransport, times(1)).unsubscribe(eq(1), eq(RequestType.QUERY));
+    verify(serverTransport, times(1)).unsubscribe(eq(1), eq(RequestType.COMMAND));
+  }
+
+  @RegressionTest("https://github.com/camunda/camunda/issues/25897")
+  public void shouldUnsubscribeOnActorClosing() {
+    // given
+    when(logStream.newLogStreamWriter()).thenReturn(CompletableActorFuture.completed(mock()));
+    when(transitionContext.getQueryService()).thenReturn(mock());
+
+    commandApiService.registerHandlers(1, logStream, transitionContext.getQueryService());
+    scheduler.workUntilDone();
+
+    verify(serverTransport).subscribe(eq(1), eq(RequestType.QUERY), any());
+    verify(serverTransport).subscribe(eq(1), eq(RequestType.COMMAND), any());
+
+    // when - closing the actor
+    final ActorFuture<Void> closeFuture = commandApiService.closeAsync();
+    scheduler.workUntilDone();
+    closeFuture.join(10, TimeUnit.SECONDS);
+
+    // then - subscriptions are cleaned up
+    verify(serverTransport).unsubscribe(eq(1), eq(RequestType.QUERY));
+    verify(serverTransport).unsubscribe(eq(1), eq(RequestType.COMMAND));
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImplTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImplTest.java
@@ -32,8 +32,8 @@ import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
 import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.transport.ServerTransport;
-import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -126,6 +126,7 @@ public class CommandApiServiceImplTest {
   }
 
   @RegressionTest("https://github.com/camunda/camunda/issues/25897")
+  @Timeout(value = 10)
   public void shouldUnsubscribeTwiceWhenTransitioningFromFollowerToInactive() {
     // given
     when(transitionContext.getPartitionId()).thenReturn(1);
@@ -163,6 +164,7 @@ public class CommandApiServiceImplTest {
   }
 
   @RegressionTest("https://github.com/camunda/camunda/issues/25897")
+  @Timeout(value = 10)
   public void shouldUnsubscribeOnActorClosing() {
     // given
     when(logStream.newLogStreamWriter()).thenReturn(CompletableActorFuture.completed(mock()));
@@ -177,7 +179,7 @@ public class CommandApiServiceImplTest {
     // when - closing the actor
     final ActorFuture<Void> closeFuture = commandApiService.closeAsync();
     scheduler.workUntilDone();
-    closeFuture.join(10, TimeUnit.SECONDS);
+    closeFuture.join();
 
     // then - subscriptions are cleaned up
     verify(serverTransport).unsubscribe(eq(1), eq(RequestType.QUERY));


### PR DESCRIPTION
# Description
Backport of #26759 to `stable/8.4`.

relates to #25897
original author: @filipecampos