### PR TITLE
[Backport stable/8.5] fix: avoid actor call to unregister handlers when it is closing

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImpl.java
@@ -66,7 +66,7 @@ public final class CommandApiServiceImpl extends Actor
   @Override
   protected void onActorClosing() {
     for (final Integer leadPartition : leadPartitions) {
-      unregisterHandlers(leadPartition);
+      unregisterHandlersActorless(leadPartition);
     }
     leadPartitions.clear();
     actor.runOnCompletion(
@@ -135,14 +135,15 @@ public final class CommandApiServiceImpl extends Actor
 
   @Override
   public ActorFuture<Void> unregisterHandlers(final int partitionId) {
-    return actor.call(
-        () -> {
-          commandHandler.removePartition(partitionId);
-          queryHandler.removePartition(partitionId);
-          leadPartitions.remove(partitionId);
-          serverTransport.unsubscribe(partitionId, RequestType.COMMAND);
-          serverTransport.unsubscribe(partitionId, RequestType.QUERY);
-        });
+    return actor.call(() -> unregisterHandlersActorless(partitionId));
+  }
+
+  private void unregisterHandlersActorless(final int partitionId) {
+    commandHandler.removePartition(partitionId);
+    queryHandler.removePartition(partitionId);
+    leadPartitions.remove(partitionId);
+    serverTransport.unsubscribe(partitionId, RequestType.COMMAND);
+    serverTransport.unsubscribe(partitionId, RequestType.QUERY);
   }
 
   @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImplTest.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.transport.RequestType;
 import io.camunda.zeebe.transport.ServerTransport;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -130,6 +131,7 @@ public class CommandApiServiceImplTest {
   }
 
   @RegressionTest("https://github.com/camunda/camunda/issues/25897")
+  @Timeout(value = 10)
   public void shouldUnsubscribeTwiceWhenTransitioningFromFollowerToInactive() {
     // given
     when(transitionContext.getPartitionId()).thenReturn(1);
@@ -167,6 +169,7 @@ public class CommandApiServiceImplTest {
   }
 
   @RegressionTest("https://github.com/camunda/camunda/issues/25897")
+  @Timeout(value = 10)
   public void shouldUnsubscribeOnActorClosing() {
     // given
     when(logStream.newLogStreamWriter()).thenReturn(CompletableActorFuture.completed(mock()));
@@ -183,7 +186,7 @@ public class CommandApiServiceImplTest {
     // when - closing the actor
     final ActorFuture<Void> closeFuture = commandApiService.closeAsync();
     scheduler.workUntilDone();
-    closeFuture.join(10, TimeUnit.SECONDS);
+    closeFuture.join();
 
     // then - subscriptions are cleaned up
     verify(serverTransport).unsubscribe(eq(1), eq(RequestType.QUERY));


### PR DESCRIPTION
# Description
Backport of #26759 to `stable/8.5`.

relates to #25897
original author: @filipecampos