### PR TITLE
ci: preview-env teardown delete deployment and environment

### DIFF
--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -36,6 +36,21 @@ jobs:
           secret/data/products/camunda/ci/camunda ARGOCD_TOKEN;
 
     #########################################################################
+    # Setup: Generate Github Token for the Github App
+    - name: Generate a GitHub token
+      id: github-token
+      uses: camunda/infra-global-github-actions/generate-github-app-token-from-vault-secrets@main
+      with:
+        github-app-id-vault-key: GITHUB_PREVIEW_ENVIRONMENTS_APP_ID
+        github-app-id-vault-path: secret/data/products/camunda/ci/camunda
+        github-app-private-key-vault-key: GITHUB_PREVIEW_ENVIRONMENTS_APP_PRIVATE_KEY
+        github-app-private-key-vault-path: secret/data/products/camunda/ci/camunda
+        vault-auth-method: approle
+        vault-auth-role-id: ${{ secrets.VAULT_ROLE_ID }}
+        vault-auth-secret-id: ${{ secrets.VAULT_SECRET_ID}}
+        vault-url: ${{ secrets.VAULT_ADDR }}
+
+    #########################################################################
     # Setup: checkout code. This is required because we are using
     # composite actions and deployment manifests.
     - name: Checkout
@@ -50,6 +65,7 @@ jobs:
         argocd_token: ${{ steps.secrets.outputs.ARGOCD_TOKEN }}
         app_name: camunda-${{ steps.sanitize.outputs.branch_name }}
         argocd_server: argocd.int.camunda.com
+        github_token: ${{ steps.github-token.outputs.token }}
 
   clean:
     if: always() && needs.teardown-preview.result != 'skipped'


### PR DESCRIPTION
## Description

This PR adds to the `preview-env-teardown` GitHub action a step to generate a personal access token using the preview-env GitHub app necessary to delete GitHub environment and deployments associated with a preview environment

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues
- camunda/team-infrastructure#456
