### PR TITLE
Add new IT job for externalize ES database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,7 +292,7 @@ jobs:
           -D skipUTs -D skipChecks
           -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
           -P parallel-tests,extract-flaky-tests,skipFrontendBuild,multi-db-test
-          -D camunda.it.database.type=es
+          -D test.integration.camunda.database.type=es
           -pl 'qa/integration-tests'
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,96 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
+  elasticsearch-integration-tests:
+    name: "[IT] Elasticsearch"
+    timeout-minutes: 25
+    permissions: {}  # GITHUB_TOKEN unused in this job
+    runs-on: gcp-perf-core-8-default
+    env:
+      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
+    services:
+      # Set up an elastic search service container
+      # https://docs.github.com/en/actions/use-cases-and-examples/using-containerized-services/about-service-containers
+      elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.17.0
+        # Exposing the ports allow to be accessible via http://localhost:9200 in the runner
+        ports:
+          - 9200:9200
+        env:
+          # Disabling the security to make sure we can access without tls in our tests
+          # https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#general-security-settings
+          xpack.security.enabled: "false"
+          # We run a single node for our integration tests
+          discovery.type: "single-node"
+          # Disabling to make sure we can delete indices via wildcards
+          # https://www.elastic.co/guide/en/elasticsearch/reference/current/index-management-settings.html
+          action.destructive_requires_name: "false"
+      # Set up a registry service container to host our custom docker image
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-build
+        with:
+          maven-cache-key-modifier: it-elasticsearch
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      # Build the platform before running the integration tests; skipping frontend
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: -T1C -PskipFrontendBuild
+      - name: Create build output log file
+        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
+      # To fail early if set up with service container doesn't work and ES is not accessible
+      - name: Validate connection with ES
+        run: curl http://localhost:9200
+      # Run specific integration tests with ES service container
+      # During the migration of tests we run only specific package, where classes moved into
+      #
+      # To communicate to the IT what database to expect and run against:
+      # -Dcamunda.it.database.type=es
+      #
+      - name: Run integration test with externalized ES
+        run: >
+          ./mvnw -B -T 2 --no-snapshot-updates
+          -D forkCount=7
+          -D maven.javadoc.skip=true
+          -D skipUTs -D skipChecks
+          -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
+          -P parallel-tests,extract-flaky-tests,skipFrontendBuild
+          -Dit.test=io/camunda/v2/**
+          -Dcamunda.it.database.type=es
+          -pl 'qa/integration-tests'
+          verify
+          | tee "${BUILD_OUTPUT_FILE_PATH}"
+      - name: Analyze Test Runs
+        id: analyze-test-run
+        if: always()
+        uses: ./.github/actions/analyze-test-runs
+        with:
+          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
+      - name: Upload test artifacts
+        uses: ./.github/actions/collect-test-artifacts
+        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
+        with:
+          name: "[IT] Elasticsearch"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "integration-tests/elasticsearch"
+          build_status: ${{ job.status }}
+          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
+          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
   integration-tests:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     name: "[IT] ${{ matrix.name }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -834,6 +834,7 @@ jobs:
       - build-tasklist-backend
       - docker-checks
       - identity-frontend-tests
+      - elasticsearch-integration-tests
       - integration-tests
       - java-checks
       - java-unit-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -312,7 +312,6 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
-          job_name: "integration-tests/elasticsearch"
           build_status: ${{ job.status }}
           user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
           user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,6 +244,11 @@ jobs:
         # Exposing the ports allow to be accessible via http://localhost:9200 in the runner
         ports:
           - 9200:9200
+        options: >-
+          --health-cmd "curl --silent --fail http://localhost:9200/_cluster/health"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
         env:
           # Disabling the security to make sure we can access without tls in our tests
           # https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#general-security-settings
@@ -273,9 +278,6 @@ jobs:
           maven-extra-args: -T1C -PskipFrontendBuild
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
-      # To fail early if set up with service container doesn't work and ES is not accessible
-      - name: Validate connection with ES
-        run: curl http://localhost:9200
       # Run specific integration tests with ES service container
       # During the migration of tests we run only specific package, where classes moved into
       #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,8 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   elasticsearch-integration-tests:
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
+    needs: [ detect-changes ]
     name: "[IT] Elasticsearch"
     timeout-minutes: 25
     permissions: {}  # GITHUB_TOKEN unused in this job

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,10 +291,8 @@ jobs:
           -D maven.javadoc.skip=true
           -D skipUTs -D skipChecks
           -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
-          -P parallel-tests,extract-flaky-tests,skipFrontendBuild
-          -Dit.test=io/camunda/v2/**
-          -Dcamunda.it.database.type=es
-          -Dfailsafe.failIfNoSpecifiedTests=false
+          -P parallel-tests,extract-flaky-tests,skipFrontendBuild,multi-db-test
+          -D camunda.it.database.type=es
           -pl 'qa/integration-tests'
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,6 +292,7 @@ jobs:
           -P parallel-tests,extract-flaky-tests,skipFrontendBuild
           -Dit.test=io/camunda/v2/**
           -Dcamunda.it.database.type=es
+          -Dfailsafe.failIfNoSpecifiedTests=false
           -pl 'qa/integration-tests'
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [ detect-changes ]
     name: "[IT] Elasticsearch"
-    timeout-minutes: 25
+    timeout-minutes: 10
     permissions: {}  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-8-default
     env:

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -442,6 +442,30 @@
         </plugins>
       </build>
     </profile>
+
+    <!--
+    This profile will run all tests annotated with @Tag("multiDbTest").
+    The profile is mainly used to run tests, that can be executed against multiple different
+    databases.
+
+    For example against:
+    Elasticsearch, OpenSearch, AWS OpenSearch, PostGreSQL, etc.
+    -->
+    <profile>
+      <id>multi-db-test</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <failIfNoTests>false</failIfNoTests>
+              <groups>multiDbTest</groups>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>


### PR DESCRIPTION
## Description

> This is part of https://github.com/camunda/camunda/issues/26896
> Preparation work to provide the foundation for future IT

* Add a new IT job to run with the ES service container
* Service containers are hosted/maintained by GH
* IT is run against external ES, reducing set-up time for individual tests and sharing ES instances
* This setup allows to add more similar jobs, to run tests parallel against external different database types
<!-- Describe the goal and purpose of this PR. -->

## See in action

To see it in action please take a look at the POC https://github.com/camunda/camunda/pull/26852 and for example this gha run https://github.com/camunda/camunda/actions/runs/12831203732/job/35781068144

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related https://github.com/camunda/camunda/issues/26896
