### PR TITLE
build: remove Optimize's web server port customization

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/AbstractIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/AbstractIT.java
@@ -32,7 +32,7 @@ import org.springframework.context.annotation.Configuration;
     webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
     properties = {
         INTEGRATION_TESTS + "=true",
-        "useLegacyPort=true"
+        "useLegacyPort=true" // TODO: Remove once we read the configuration from the single application
     })
 @Configuration
 public abstract class AbstractIT {

--- a/optimize/backend/src/it/java/io/camunda/optimize/AbstractIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/AbstractIT.java
@@ -23,16 +23,19 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
     properties = {
-        INTEGRATION_TESTS + "=true",
-        "useLegacyPort=true" // TODO: Remove once we read the configuration from the single application
+      INTEGRATION_TESTS + "=true",
+      "useLegacyPort=true" // TODO: Remove once we read the configuration from the single
+      // application
     })
 @Configuration
 public abstract class AbstractIT {
@@ -46,6 +49,8 @@ public abstract class AbstractIT {
   // due to a bug. They
   // are ignored by the 'OpenSearch passing' CI pipeline, but need to be addressed soon
   public static final String OPENSEARCH_SHOULD_BE_PASSING = "openSearchShouldBePassing";
+
+  @Autowired private Environment environment;
 
   @RegisterExtension
   @Order(1)
@@ -84,7 +89,13 @@ public abstract class AbstractIT {
 
   private String[] prepareArgs(final Map<String, String> argMap) {
     final String httpsPort = getPortArg(HTTPS_PORT_KEY);
-    final String httpPort = getPortArg(HTTP_PORT_KEY);
+
+    String httpPort = getPortArg(HTTP_PORT_KEY);
+    if ("true".equals(environment.getProperty("useLegacyPort"))) {
+      // TODO: Remove this if block once the configuration is read from the single application.
+      httpPort = "8090";
+    }
+
     final String actuatorPort =
         getArg(
             ACTUATOR_PORT_PROPERTY_KEY,

--- a/optimize/backend/src/it/java/io/camunda/optimize/AbstractIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/AbstractIT.java
@@ -30,7 +30,10 @@ import org.springframework.context.annotation.Configuration;
 
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT,
-    properties = {INTEGRATION_TESTS + "=true"})
+    properties = {
+        INTEGRATION_TESTS + "=true",
+        "useLegacyPort=true"
+    })
 @Configuration
 public abstract class AbstractIT {
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/Main.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/Main.java
@@ -24,6 +24,8 @@ public class Main {
   private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(Main.class);
 
   public static void main(final String[] args) {
+    System.setProperty("integrationTest", "true");
+
     final SpringApplication optimize = new SpringApplication(Main.class);
 
     final ConfigurationService configurationService = ConfigurationService.createDefault();

--- a/optimize/backend/src/main/java/io/camunda/optimize/Main.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/Main.java
@@ -11,6 +11,8 @@ import static io.camunda.optimize.tomcat.OptimizeResourceConstants.ACTUATOR_PORT
 
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -24,14 +26,15 @@ public class Main {
   private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(Main.class);
 
   public static void main(final String[] args) {
-    System.setProperty("integrationTest", "true");
-
     final SpringApplication optimize = new SpringApplication(Main.class);
 
     final ConfigurationService configurationService = ConfigurationService.createDefault();
-    optimize.setDefaultProperties(
-        Collections.singletonMap(
-            ACTUATOR_PORT_PROPERTY_KEY, configurationService.getActuatorPort()));
+
+    final Map<String, Object> defaultProperties = new HashMap<>();
+    defaultProperties.put(ACTUATOR_PORT_PROPERTY_KEY, configurationService.getActuatorPort());
+    defaultProperties.put("useLegacyPort", "true");
+
+    optimize.setDefaultProperties(defaultProperties);
 
     optimize.run(args);
   }

--- a/optimize/backend/src/main/java/io/camunda/optimize/Main.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/Main.java
@@ -32,6 +32,8 @@ public class Main {
 
     final Map<String, Object> defaultProperties = new HashMap<>();
     defaultProperties.put(ACTUATOR_PORT_PROPERTY_KEY, configurationService.getActuatorPort());
+
+    // TODO: Remove once we read the configuration from the single application
     defaultProperties.put("useLegacyPort", "true");
 
     optimize.setDefaultProperties(defaultProperties);

--- a/optimize/backend/src/main/java/io/camunda/optimize/Main.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/Main.java
@@ -10,7 +10,6 @@ package io.camunda.optimize;
 import static io.camunda.optimize.tomcat.OptimizeResourceConstants.ACTUATOR_PORT_PROPERTY_KEY;
 
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.slf4j.Logger;

--- a/optimize/backend/src/main/java/io/camunda/optimize/OptimizeTomcatConfig.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/OptimizeTomcatConfig.java
@@ -21,11 +21,6 @@ import io.camunda.optimize.tomcat.OptimizeResourceConstants;
 import io.camunda.optimize.tomcat.ResponseSecurityHeaderFilter;
 import io.camunda.optimize.tomcat.URLRedirectFilter;
 import java.util.Optional;
-import org.apache.catalina.connector.Connector;
-import org.apache.coyote.http2.Http2Protocol;
-import org.apache.tomcat.util.net.SSLHostConfig;
-import org.apache.tomcat.util.net.SSLHostConfigCertificate;
-import org.apache.tomcat.util.net.SSLHostConfigCertificate.Type;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,7 +38,7 @@ public class OptimizeTomcatConfig {
   private static final Logger LOG = LoggerFactory.getLogger(OptimizeTomcatConfig.class);
 
   private static final String[] COMPRESSED_MIME_TYPES = {
-      "application/json", "text/html", "application/x-font-ttf", "image/svg+xml"
+    "application/json", "text/html", "application/x-font-ttf", "image/svg+xml"
   };
 
   private static final String LOGIN_ENDPOINT = "/login";
@@ -53,32 +48,30 @@ public class OptimizeTomcatConfig {
   public static final String ALLOWED_URL_EXTENSION =
       String.join(
           "|",
-          new String[]{
-              URL_BASE,
-              LOGIN_ENDPOINT,
-              METRICS_ENDPOINT,
-              CCSaasAuth0WebSecurityConfig.OAUTH_AUTH_ENDPOINT,
-              CCSaasAuth0WebSecurityConfig.OAUTH_REDIRECT_ENDPOINT,
-              CCSaasAuth0WebSecurityConfig.AUTH0_JWKS_ENDPOINT,
-              CCSaasAuth0WebSecurityConfig.AUTH0_AUTH_ENDPOINT,
-              CCSaasAuth0WebSecurityConfig.AUTH0_TOKEN_ENDPOINT,
-              CCSaasAuth0WebSecurityConfig.AUTH0_USERINFO_ENDPOINT,
-              HealthRestService.READYZ_PATH,
-              LocalizationRestService.LOCALIZATION_PATH,
-              OptimizeTomcatConfig.EXTERNAL_SUB_PATH,
-              OptimizeResourceConstants.REST_API_PATH,
-              OptimizeResourceConstants.STATIC_RESOURCE_PATH,
-              OptimizeResourceConstants.ACTUATOR_ENDPOINT,
-              PanelNotificationConstants.SEND_NOTIFICATION_TO_ALL_ORG_USERS_ENDPOINT,
-              UIConfigurationRestService.UI_CONFIGURATION_PATH
+          new String[] {
+            URL_BASE,
+            LOGIN_ENDPOINT,
+            METRICS_ENDPOINT,
+            CCSaasAuth0WebSecurityConfig.OAUTH_AUTH_ENDPOINT,
+            CCSaasAuth0WebSecurityConfig.OAUTH_REDIRECT_ENDPOINT,
+            CCSaasAuth0WebSecurityConfig.AUTH0_JWKS_ENDPOINT,
+            CCSaasAuth0WebSecurityConfig.AUTH0_AUTH_ENDPOINT,
+            CCSaasAuth0WebSecurityConfig.AUTH0_TOKEN_ENDPOINT,
+            CCSaasAuth0WebSecurityConfig.AUTH0_USERINFO_ENDPOINT,
+            HealthRestService.READYZ_PATH,
+            LocalizationRestService.LOCALIZATION_PATH,
+            OptimizeTomcatConfig.EXTERNAL_SUB_PATH,
+            OptimizeResourceConstants.REST_API_PATH,
+            OptimizeResourceConstants.STATIC_RESOURCE_PATH,
+            OptimizeResourceConstants.ACTUATOR_ENDPOINT,
+            PanelNotificationConstants.SEND_NOTIFICATION_TO_ALL_ORG_USERS_ENDPOINT,
+            UIConfigurationRestService.UI_CONFIGURATION_PATH
           });
 
   private static final String HTTP11_NIO_PROTOCOL = "org.apache.coyote.http11.Http11Nio2Protocol";
 
-  @Autowired
-  private ConfigurationService configurationService;
-  @Autowired
-  private Environment environment;
+  @Autowired private ConfigurationService configurationService;
+  @Autowired private Environment environment;
 
   @Bean
   WebServerFactoryCustomizer<TomcatServletWebServerFactory> tomcatFactoryCustomizer() {
@@ -93,7 +86,7 @@ public class OptimizeTomcatConfig {
 
         factory.addConnectorCustomizers(
             connector -> {
-              if("true".equals(System.getProperty("integrationTest", "false"))) {
+              if ("true".equals(environment.getProperty("useLegacyPort"))) {
                 connector.setPort(8090);
               }
 
@@ -109,7 +102,7 @@ public class OptimizeTomcatConfig {
   }
 
   @Bean
-    /* redirect to /# when the endpoint is not valid. do this rather than showing an error page */
+  /* redirect to /# when the endpoint is not valid. do this rather than showing an error page */
   FilterRegistrationBean<URLRedirectFilter> urlRedirector() {
     LOG.debug("Registering filter 'urlRedirector'...");
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/OptimizeTomcatConfig.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/OptimizeTomcatConfig.java
@@ -86,6 +86,7 @@ public class OptimizeTomcatConfig {
 
         factory.addConnectorCustomizers(
             connector -> {
+              // TODO: Remove once we read the configuration from the single application
               if ("true".equals(environment.getProperty("useLegacyPort"))) {
                 connector.setPort(8090);
               }

--- a/optimize/docker-compose.ccsm-with-optimize.yml
+++ b/optimize/docker-compose.ccsm-with-optimize.yml
@@ -7,7 +7,7 @@ services:
       - elasticsearch
       - identity
     ports:
-      - "8090:8090"
+      - "8080:8080"
       - "8092:8092"
     environment:
       - SPRING_PROFILES_ACTIVE=ccsm
@@ -38,7 +38,7 @@ services:
     depends_on:
       - identity
     ports:
-      - "8090:8090"
+      - "8080:8080"
       - "8092:8092"
     environment:
       - SPRING_PROFILES_ACTIVE=ccsm
@@ -94,7 +94,7 @@ services:
       KEYCLOAK_URL: http://keycloak:8080/auth
       IDENTITY_AUTH_PROVIDER_BACKEND_URL: http://keycloak:8080/auth/realms/camunda-platform
       KEYCLOAK_INIT_OPTIMIZE_SECRET: XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
-      KEYCLOAK_INIT_OPTIMIZE_ROOT_URL: http://localhost:8090
+      KEYCLOAK_INIT_OPTIMIZE_ROOT_URL: http://localhost:8080
       KEYCLOAK_USERS_0_USERNAME: "demo"
       KEYCLOAK_USERS_0_PASSWORD: "demo"
       KEYCLOAK_USERS_0_FIRST_NAME: "demo"

--- a/optimize/docker-compose.ccsm-without-optimize.yml
+++ b/optimize/docker-compose.ccsm-without-optimize.yml
@@ -77,7 +77,7 @@ services:
       KEYCLOAK_URL: http://keycloak:8080/auth
       IDENTITY_AUTH_PROVIDER_BACKEND_URL: http://keycloak:8080/auth/realms/camunda-platform
       KEYCLOAK_INIT_OPTIMIZE_SECRET: XALaRPl5qwTEItdwCMiPS62nVpKs7dL7
-      KEYCLOAK_INIT_OPTIMIZE_ROOT_URL: http://localhost:8090
+      KEYCLOAK_INIT_OPTIMIZE_ROOT_URL: http://localhost:8080
       KEYCLOAK_USERS_0_USERNAME: "demo"
       KEYCLOAK_USERS_0_PASSWORD: "demo"
       KEYCLOAK_USERS_0_FIRST_NAME: "demo"


### PR DESCRIPTION
## Description

As Optimize is going to become part of the single application, the web server customization it is installing need to be removed. With this PR, we are still supporting the legacy default port because, currently, integration tests are being executing using `optimize-distro`. Once they are also migrated to the single JAR distribution, the support for the legacy default port can also be removed.

In addition to that, Optimize is currently opening an extra port, configured with SSL. Even that behavior is supposed to change, leaving the entire configuration in the hands of the common web server used in the single application instead.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

* part of #25686
