### PR TITLE
Migrate the first integration test to external db foundation

### DIFF
--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -433,7 +433,7 @@
               <value>${version.identity}</value>
             </property>
           </systemProperties>
-          <groups>!rdbms</groups>
+          <groups>!rdbms,!multi-db-test</groups>
         </configuration>
         <dependencies>
           <dependency>
@@ -490,7 +490,7 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
               <failIfNoTests>false</failIfNoTests>
-              <groups>multiDbTest</groups>
+              <groups>multi-db-test</groups>
             </configuration>
           </plugin>
         </plugins>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -433,7 +433,7 @@
               <value>${version.identity}</value>
             </property>
           </systemProperties>
-          <groups>!rdbms & !multi-db-test</groups>
+          <excludedGroups>rdbms, multi-db-test</excludedGroups>
         </configuration>
         <dependencies>
           <dependency>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -467,6 +467,7 @@
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
               <groups>rdbms</groups>
+              <excludedGroups>multi-db-test</excludedGroups>
             </configuration>
           </plugin>
         </plugins>
@@ -491,6 +492,7 @@
             <configuration>
               <failIfNoTests>false</failIfNoTests>
               <groups>multi-db-test</groups>
+              <excludedGroups>rdbms</excludedGroups>
             </configuration>
           </plugin>
         </plugins>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -433,7 +433,7 @@
               <value>${version.identity}</value>
             </property>
           </systemProperties>
-          <groups>!rdbms,!multi-db-test</groups>
+          <groups>!rdbms & !multi-db-test</groups>
         </configuration>
         <dependencies>
           <dependency>

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceQueryTest.java
@@ -26,9 +26,7 @@ import io.camunda.client.api.search.response.FlowNodeInstance;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.protocol.rest.ProcessInstanceStateEnum;
 import io.camunda.client.protocol.rest.ProcessInstanceVariableFilterRequest;
-import io.camunda.qa.util.cluster.TestStandaloneCamunda;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.it.utils.MultiDbTest;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
@@ -36,31 +34,19 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-@ZeebeIntegration
+@MultiDbTest
 public class ProcessInstanceAndFlowNodeInstanceQueryTest {
 
   static final List<Process> DEPLOYED_PROCESSES = new ArrayList<>();
   static final List<ProcessInstanceEvent> PROCESS_INSTANCES = new ArrayList<>();
 
-  private static CamundaClient camundaClient;
-
-  @TestZeebe(initMethod = "initTestStandaloneCamunda")
-  private static TestStandaloneCamunda testStandaloneCamunda;
-
   private static FlowNodeInstance flowNodeInstance;
   private static FlowNodeInstance flowNodeInstanceWithIncident;
-
-  @SuppressWarnings("unused")
-  static void initTestStandaloneCamunda() {
-    testStandaloneCamunda =
-        new TestStandaloneCamunda().withElasticsearchExporter(false).withCamundaExporter();
-  }
+  private static CamundaClient camundaClient;
 
   @BeforeAll
   public static void beforeAll() {
-
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
-
+    Objects.requireNonNull(camundaClient);
     final List<String> processes =
         List.of(
             "service_tasks_v1.bpmn",


### PR DESCRIPTION
## Description

> This is part of https://github.com/camunda/camunda/issues/26896
> Preparation work to provide the foundation for future IT

 Took ProcessInstanceAndFlowNodeInstanceQueryTest as example test to migrate to new external database approach and new extension

Note:

 * Locally I was able to run it against ES AND OS container 🚀 

<!-- Describe the goal and purpose of this PR. -->

## See in action

To see it in action please take a look at the POC https://github.com/camunda/camunda/pull/26852 and for example this gha run https://github.com/camunda/camunda/actions/runs/12831203732/job/35781068144

## Related issues

related https://github.com/camunda/camunda/issues/26896