### PR TITLE
Migrate prometheus metrics to micrometer in TopologyMetrics

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/clustering/DynamicClusterServices.java
+++ b/dist/src/main/java/io/camunda/application/commons/clustering/DynamicClusterServices.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
@@ -45,7 +46,8 @@ public class DynamicClusterServices {
         new GatewayClusterConfigurationService(
             clusterCommunicationService,
             clusterMembershipService,
-            gatewayCfg.getCluster().getConfigManager().gossip());
+            gatewayCfg.getCluster().getConfigManager().gossip(),
+            new SimpleMeterRegistry()); // TODO GET metricsRegistry
     scheduler.submitActor(service).join();
     service.addUpdateListener(brokerTopologyManager);
     return service;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
@@ -165,6 +165,7 @@ public class DynamicClusterConfigurationService implements ClusterConfigurationS
             .getExperimental()
             .getFeatures()
             .isEnablePartitionScaling(),
+        brokerStartupContext.getMeterRegistry(),
         clusterChangeExecutor);
   }
 }

--- a/zeebe/dynamic-config/pom.xml
+++ b/zeebe/dynamic-config/pom.xml
@@ -133,6 +133,11 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <version>1.13.1</version>
+    </dependency>
 
   </dependencies>
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/GatewayClusterConfigurationService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/GatewayClusterConfigurationService.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.scheduler.Actor;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +36,8 @@ public class GatewayClusterConfigurationService extends Actor
   public GatewayClusterConfigurationService(
       final ClusterCommunicationService communicationService,
       final ClusterMembershipService memberShipService,
-      final ClusterConfigurationGossiperConfig config) {
+      final ClusterConfigurationGossiperConfig config,
+      final MeterRegistry meterRegistry) {
     clusterConfigurationGossiper =
         new ClusterConfigurationGossiper(
             this,
@@ -43,7 +45,8 @@ public class GatewayClusterConfigurationService extends Actor
             memberShipService,
             new ProtoBufSerializer(),
             config,
-            this::updateClusterTopology);
+            this::updateClusterTopology,
+            meterRegistry);
   }
 
   private void updateClusterTopology(final ClusterConfiguration clusterConfiguration) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiper.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiper.java
@@ -181,7 +181,7 @@ public final class ClusterConfigurationGossiper
     LOGGER.trace("Updated local gossipState to {}", updatedConfiguration);
     gossip();
     notifyListeners(updatedConfiguration);
-    TopologyMetrics.updateFromTopology(updatedConfiguration, meterRegistry);
+    TopologyMetrics.updateFromTopology(updatedConfiguration);
   }
 
   private void notifyListeners(final ClusterConfiguration updatedTopology) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/metrics/TopologyMetrics.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/metrics/TopologyMetrics.java
@@ -85,12 +85,22 @@ public final class TopologyMetrics {
   private static final ConcurrentHashMap<String, io.micrometer.core.instrument.Counter>
       operationAttempts = new ConcurrentHashMap<>();
 
+  //  @Autowired
+  //  private MeterRegistry registry;
   private static io.micrometer.core.instrument.MeterRegistry meterRegistry;
+
+  private static io.micrometer.core.instrument.Gauge MICROMETER_TOPOLOGY_VERSION;
 
   public static void updateFromTopology(
       final ClusterConfiguration topology, final MeterRegistry meterRegistry) {
     TopologyMetrics.meterRegistry = meterRegistry;
     TOPOLOGY_VERSION.set(topology.version());
+    MICROMETER_TOPOLOGY_VERSION =
+        io.micrometer.core.instrument.Gauge.builder(
+                NAMESPACE + "_cluster_topology_version_micro", () -> topology.version())
+            .description("The version of the cluster topology")
+            .register(meterRegistry);
+
     CHANGE_STATUS.state(
         topology
             .pendingChanges()

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/metrics/TopologyMetrics.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/metrics/TopologyMetrics.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CompletedChange;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tag;
 import io.prometheus.client.Enumeration;
@@ -192,6 +193,9 @@ public final class TopologyMetrics {
   }
 
   public static final class OperationObserver {
+    final Counter.Builder counterBuilder =
+        Counter.builder(NAMESPACE + "_cluster_changes_operation_attempts_micro")
+            .description("Number of attempts to apply an operation");
     private final ClusterConfigurationChangeOperation operation;
     private final Timer timer;
     private final io.micrometer.core.instrument.Timer.Sample clusterChangeOperationTimerSample;
@@ -252,6 +256,12 @@ public final class TopologyMetrics {
                         operation.getClass().getSimpleName(),
                         "failed"));
         counter.increment();
+        final Counter c =
+            counterBuilder
+                .tags(LABEL_OPERATION, operation.getClass().getSimpleName())
+                .tags(LABEL_OUTCOME, "failed")
+                .register(meterRegistry);
+        c.increment();
       }
     }
 
@@ -275,6 +285,12 @@ public final class TopologyMetrics {
                         operation.getClass().getSimpleName(),
                         "applied"));
         counter.increment();
+        final Counter c =
+            counterBuilder
+                .tags(LABEL_OPERATION, operation.getClass().getSimpleName())
+                .tags(LABEL_OUTCOME, "applied")
+                .register(meterRegistry);
+        c.increment();
       }
     }
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/metrics/TopologyMetrics.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/metrics/TopologyMetrics.java
@@ -14,13 +14,11 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.CompletedChange;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
-import io.micrometer.core.instrument.Tag;
 import io.prometheus.client.Enumeration;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.Histogram;
 import io.prometheus.client.Histogram.Timer;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -194,7 +192,7 @@ public final class TopologyMetrics {
 
   public static final class OperationObserver {
     final Counter.Builder counterBuilder =
-        Counter.builder(NAMESPACE + "_cluster_changes_operation_attempts_micro")
+        Counter.builder(NAMESPACE + "_cluster_changes_operation_attempts")
             .description("Number of attempts to apply an operation");
     private final ClusterConfigurationChangeOperation operation;
     private final Timer timer;
@@ -224,17 +222,17 @@ public final class TopologyMetrics {
           io.micrometer.core.instrument.Timer.start(meterRegistry));
     }
 
-    protected io.micrometer.core.instrument.Counter newCounter(
-        final String metricName, final String operation, final String outcome) {
-      final List<Tag> tags = new ArrayList<>();
-      if (operation != null && !operation.isEmpty()) {
-        tags.add(Tag.of(LABEL_OPERATION, operation));
-      }
-      if (outcome != null && !outcome.isEmpty()) {
-        tags.add(Tag.of(LABEL_OUTCOME, outcome));
-      }
-      return meterRegistry.counter(metricName, tags);
-    }
+    //    protected io.micrometer.core.instrument.Counter newCounter(
+    //        final String metricName, final String operation, final String outcome) {
+    //      final List<Tag> tags = new ArrayList<>();
+    //      if (operation != null && !operation.isEmpty()) {
+    //        tags.add(Tag.of(LABEL_OPERATION, operation));
+    //      }
+    //      if (outcome != null && !outcome.isEmpty()) {
+    //        tags.add(Tag.of(LABEL_OUTCOME, outcome));
+    //      }
+    //      return meterRegistry.counter(metricName, tags);
+    //    }
 
     public void failed() {
       if (clusterChangeOperationTimer != null && clusterChangeOperationTimerSample != null) {
@@ -242,20 +240,20 @@ public final class TopologyMetrics {
       }
       if (timer != null) {
         timer.close();
-        final String key =
-            NAMESPACE
-                + "_cluster_changes_operation_attempts#"
-                + operation.getClass().getSimpleName()
-                + "#failed";
-        final io.micrometer.core.instrument.Counter counter =
-            operationAttempts.computeIfAbsent(
-                key,
-                k ->
-                    newCounter(
-                        NAMESPACE + "_cluster_changes_operation_attempts",
-                        operation.getClass().getSimpleName(),
-                        "failed"));
-        counter.increment();
+        //        final String key =
+        //            NAMESPACE
+        //                + "_cluster_changes_operation_attempts#"
+        //                + operation.getClass().getSimpleName()
+        //                + "#failed";
+        //        final io.micrometer.core.instrument.Counter counter =
+        //            operationAttempts.computeIfAbsent(
+        //                key,
+        //                k ->
+        //                    newCounter(
+        //                        NAMESPACE + "_cluster_changes_operation_attempts",
+        //                        operation.getClass().getSimpleName(),
+        //                        "failed"));
+        //        counter.increment();
         final Counter c =
             counterBuilder
                 .tags(LABEL_OPERATION, operation.getClass().getSimpleName())
@@ -271,20 +269,20 @@ public final class TopologyMetrics {
       }
       if (timer != null) {
         timer.close();
-        final String key =
-            NAMESPACE
-                + "_cluster_changes_operation_attempts#"
-                + operation.getClass().getSimpleName()
-                + "#applied";
-        final io.micrometer.core.instrument.Counter counter =
-            operationAttempts.computeIfAbsent(
-                key,
-                k ->
-                    newCounter(
-                        NAMESPACE + "_cluster_changes_operation_attempts",
-                        operation.getClass().getSimpleName(),
-                        "applied"));
-        counter.increment();
+        //        final String key =
+        //            NAMESPACE
+        //                + "_cluster_changes_operation_attempts#"
+        //                + operation.getClass().getSimpleName()
+        //                + "#applied";
+        //        final io.micrometer.core.instrument.Counter counter =
+        //            operationAttempts.computeIfAbsent(
+        //                key,
+        //                k ->
+        //                    newCounter(
+        //                        NAMESPACE + "_cluster_changes_operation_attempts",
+        //                        operation.getClass().getSimpleName(),
+        //                        "applied"));
+        //        counter.increment();
         final Counter c =
             counterBuilder
                 .tags(LABEL_OPERATION, operation.getClass().getSimpleName())

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.FileUtil;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -253,6 +254,7 @@ class ClusterConfigurationManagementIntegrationTest {
             new ClusterConfigurationGossiperConfig(
                 Duration.ofSeconds(1), Duration.ofMillis(100), 2),
             true,
+            new SimpleMeterRegistry(),
             new NoopClusterChangeExecutor());
     return new TestNode(cluster, service);
   }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiperTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiperTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
@@ -105,7 +106,8 @@ final class ClusterConfigurationGossiperTest {
               atomixCluster.getMembershipService(),
               new ProtoBufSerializer(),
               config,
-              this::mergeTopology);
+              this::mergeTopology,
+              new SimpleMeterRegistry());
       this.atomixCluster = atomixCluster;
     }
 


### PR DESCRIPTION
## Description
This PR targeted `TopologyMetrics` as it contains several types of Prometheus metrics and the idea was to replace them with Micrometer corresponding metrics.

## TODO

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] Remove Histogram when metric name is modified to the new Timer in grafana dashboard 
- [ ] Replace Enumeration

## Related issues

closes #26909, #27085
