### PR TITLE
refactor: remove login and test from auth service

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/AuthenticationRestService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/AuthenticationRestService.java
@@ -10,7 +10,6 @@ package io.camunda.optimize.rest;
 import static io.camunda.optimize.tomcat.OptimizeResourceConstants.REST_API_PATH;
 
 import io.camunda.identity.sdk.authentication.dto.AuthCodeDto;
-import io.camunda.optimize.dto.optimize.query.security.CredentialsRequestDto;
 import io.camunda.optimize.service.security.authentication.AbstractAuthenticationService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -18,7 +17,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,23 +27,12 @@ public class AuthenticationRestService {
 
   public static final String AUTHENTICATION_PATH = "/authentication";
   public static final String LOGOUT = "/logout";
-  public static final String TEST = "/test";
   public static final String CALLBACK = "/callback";
 
   private final AbstractAuthenticationService authenticationService;
 
   public AuthenticationRestService(final AbstractAuthenticationService authenticationService) {
     this.authenticationService = authenticationService;
-  }
-
-  @PostMapping()
-  public void authenticateUser(final CredentialsRequestDto credentials) {
-    authenticationService.authenticateUser(credentials);
-  }
-
-  @GetMapping(path = TEST)
-  public String testAuthentication() {
-    return authenticationService.testAuthentication();
   }
 
   @GetMapping(path = CALLBACK)


### PR DESCRIPTION
## Description

This PR removes the following leftover rest endpoints from `optimize-backend` authentication service :
- POST /authentication
- GET /authentication/test.

My full investigation can be found [here](https://github.com/camunda/camunda-optimize/issues/13405#issuecomment-2601422311)

## Related issues

related to https://github.com/camunda/camunda-optimize/issues/13405
