### PR TITLE
Process and apply Authrozation.CREATE command

### DIFF
--- a/security/security-core/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationResourceType.java
+++ b/security/security-core/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationResourceType.java
@@ -12,7 +12,8 @@ import java.util.HashSet;
 import java.util.Set;
 
 public enum AuthorizationResourceType {
-  AUTHORIZATION(PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE, PermissionType.CREATE),
+  AUTHORIZATION(
+      PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE, PermissionType.CREATE),
   MAPPING_RULE(
       PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE),
   MESSAGE(PermissionType.CREATE, PermissionType.READ),

--- a/security/security-core/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationResourceType.java
+++ b/security/security-core/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationResourceType.java
@@ -12,7 +12,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 public enum AuthorizationResourceType {
-  AUTHORIZATION(PermissionType.READ, PermissionType.UPDATE),
+  AUTHORIZATION(PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE, PermissionType.CREATE),
   MAPPING_RULE(
       PermissionType.CREATE, PermissionType.READ, PermissionType.UPDATE, PermissionType.DELETE),
   MESSAGE(PermissionType.CREATE, PermissionType.READ),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
@@ -66,7 +66,7 @@ public class AuthorizationCreateProcessor
   @Override
   public void processDistributedCommand(final TypedRecord<AuthorizationRecord> command) {
     permissionsBehavior
-        .permissionAlreadyExists(command.getValue())
+        .authorizationAlreadyExists(command.getValue())
         .ifRightOrLeft(
             ignored ->
                 stateWriter.appendFollowUpEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity;
+
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+public class AuthorizationCreateProcessor
+    implements DistributedTypedRecordProcessor<AuthorizationRecord> {
+
+  private final KeyGenerator keyGenerator;
+  private final CommandDistributionBehavior distributionBehavior;
+  private final StateWriter stateWriter;
+  private final TypedResponseWriter responseWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final PermissionsBehavior permissionsBehavior;
+
+  public AuthorizationCreateProcessor(
+      final Writers writers,
+      final KeyGenerator keyGenerator,
+      final ProcessingState processingState,
+      final CommandDistributionBehavior distributionBehavior,
+      final AuthorizationCheckBehavior authCheckBehavior) {
+    this.keyGenerator = keyGenerator;
+    this.distributionBehavior = distributionBehavior;
+    stateWriter = writers.state();
+    responseWriter = writers.response();
+    rejectionWriter = writers.rejection();
+    permissionsBehavior = new PermissionsBehavior(processingState, authCheckBehavior);
+  }
+
+  @Override
+  public void processNewCommand(final TypedRecord<AuthorizationRecord> command) {
+    permissionsBehavior
+        .isAuthorized(command, PermissionType.CREATE)
+        .flatMap(
+            record ->
+                permissionsBehavior.hasValidPermissionTypes(
+                    record,
+                    "Expected to create authorization with permission types '%s' and resource type '%s', but these permissions are not supported. Supported permission types are: '%s'"))
+        .flatMap(permissionsBehavior::authorizationAlreadyExists)
+        .ifRightOrLeft(
+            authorizationRecord -> writeEventAndDistribute(command, authorizationRecord),
+            (rejection) -> {
+              rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
+              responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
+            });
+  }
+
+  @Override
+  public void processDistributedCommand(final TypedRecord<AuthorizationRecord> command) {
+    permissionsBehavior
+        .permissionAlreadyExists(command.getValue())
+        .ifRightOrLeft(
+            ignored ->
+                stateWriter.appendFollowUpEvent(
+                    command.getKey(), AuthorizationIntent.CREATED, command.getValue()),
+            rejection ->
+                rejectionWriter.appendRejection(command, rejection.type(), rejection.reason()));
+
+    distributionBehavior.acknowledgeCommand(command);
+  }
+
+  private void writeEventAndDistribute(
+      final TypedRecord<AuthorizationRecord> command,
+      final AuthorizationRecord authorizationRecord) {
+    final long key = keyGenerator.nextKey();
+    authorizationRecord.setAuthorizationKey(key);
+    stateWriter.appendFollowUpEvent(key, AuthorizationIntent.CREATED, authorizationRecord);
+    responseWriter.writeEventOnCommand(
+        key, AuthorizationIntent.CREATED, authorizationRecord, command);
+    distributionBehavior
+        .withKey(key)
+        .inQueue(DistributionQueue.IDENTITY.getQueueId())
+        .distribute(command);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationProcessors.java
@@ -26,6 +26,11 @@ public final class AuthorizationProcessors {
       final AuthorizationCheckBehavior authCheckBehavior) {
     typedRecordProcessors.onCommand(
         ValueType.AUTHORIZATION,
+        AuthorizationIntent.CREATE,
+        new AuthorizationCreateProcessor(
+            writers, keyGenerator, processingState, distributionBehavior, authCheckBehavior));
+    typedRecordProcessors.onCommand(
+        ValueType.AUTHORIZATION,
         AuthorizationIntent.ADD_PERMISSION,
         new AuthorizationAddPermissionProcessor(
             writers, keyGenerator, processingState, distributionBehavior, authCheckBehavior));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -99,15 +99,13 @@ public class PermissionsBehavior {
     return Either.right(record);
   }
 
-  // TODO: we need to provide also the ownerType here when
-  // https://github.com/camunda/camunda/issues/27036 is implemented
   public Either<Rejection, AuthorizationRecord> authorizationAlreadyExists(
       final AuthorizationRecord record) {
     for (final PermissionType permission : record.getAuthorizationPermissions()) {
       final var addedResourceId = record.getResourceId();
       final var currentResourceIds =
           authCheckBehavior.getDirectAuthorizedResourceIdentifiers(
-              record.getOwnerKey(), record.getResourceType(), permission);
+              record.getOwnerType(), record.getOwnerId(), record.getResourceType(), permission);
 
       if (currentResourceIds.contains(addedResourceId)) {
         return Either.left(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 import java.util.HashSet;
-import java.util.stream.Collectors;
 
 public class PermissionsBehavior {
 
@@ -158,24 +157,9 @@ public class PermissionsBehavior {
 
   public Either<Rejection, AuthorizationRecord> hasValidPermissionTypes(
       final AuthorizationRecord record) {
-    final var resourceType = record.getResourceType();
-    final var permissionTypes =
-        record.getPermissions().stream()
-            .map(PermissionValue::getPermissionType)
-            .collect(Collectors.toList());
-
-    if (resourceType.getSupportedPermissionTypes().containsAll(permissionTypes)) {
-      return Either.right(record);
-    }
-
-    permissionTypes.removeAll(resourceType.getSupportedPermissionTypes());
-
-    return Either.left(
-        new Rejection(
-            RejectionType.INVALID_ARGUMENT,
-            "Expected to add permission types '%s' for resource type '%s', but these permissions are not supported. Supported permission types are: '%s'"
-                .formatted(
-                    permissionTypes, resourceType, resourceType.getSupportedPermissionTypes())));
+    return hasValidPermissionTypes(
+        record,
+        "Expected to add permission types '%s' for resource type '%s', but these permissions are not supported. Supported permission types are: '%s'");
   }
 
   public Either<Rejection, AuthorizationRecord> hasValidPermissionTypes(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -100,7 +100,8 @@ public class PermissionsBehavior {
     return Either.right(record);
   }
 
-  // TODO: we need to provide also the ownerType here when https://github.com/camunda/camunda/issues/27036 is implemented
+  // TODO: we need to provide also the ownerType here when
+  // https://github.com/camunda/camunda/issues/27036 is implemented
   public Either<Rejection, AuthorizationRecord> authorizationAlreadyExists(
       final AuthorizationRecord record) {
     for (final PermissionType permission : record.getAuthorizationPermissions()) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AuthorizationCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AuthorizationCreatedApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableAuthorizationState;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+
+public class AuthorizationCreatedApplier
+    implements TypedEventApplier<AuthorizationIntent, AuthorizationRecord> {
+
+  private final MutableAuthorizationState authorizationState;
+
+  public AuthorizationCreatedApplier(final MutableAuthorizationState state) {
+    authorizationState = state;
+  }
+
+  @Override
+  public void applyState(final long key, final AuthorizationRecord value) {
+    authorizationState.create(key, value);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -484,6 +484,9 @@ public final class EventAppliers implements EventApplier {
     register(AuthorizationIntent.PERMISSION_ADDED, new AuthorizationPermissionAddedApplier(state));
     register(
         AuthorizationIntent.PERMISSION_REMOVED, new AuthorizationPermissionRemovedApplier(state));
+    register(
+        AuthorizationIntent.CREATED,
+        new AuthorizationCreatedApplier(state.getAuthorizationState()));
   }
 
   private void registerEscalationAppliers() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/Permissions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/Permissions.java
@@ -56,6 +56,13 @@ public class Permissions extends UnpackedObject implements DbValue {
     setPermissions(permissions);
   }
 
+  public void addResourceIdentifier(
+      final PermissionType permissionType, final String resourceIdentifier) {
+    final var permissions = getPermissions();
+    permissions.computeIfAbsent(permissionType, ignored -> new HashSet<>()).add(resourceIdentifier);
+    setPermissions(permissions);
+  }
+
   @Override
   public boolean isEmpty() {
     return getPermissions().isEmpty();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.Set;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -253,6 +254,7 @@ public class AddPermissionAuthorizationTest {
   }
 
   @Test
+  @Ignore("This test will be removed")
   public void shouldRejectAddingUnsupportedPermission() {
     // given
     final var owner =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationArchTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationArchTest.java
@@ -31,6 +31,8 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCommandPreconditionChecker;
 import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCommandProcessor;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 @AnalyzeClasses(
@@ -107,6 +109,9 @@ public class AuthorizationArchTest {
             .or(
                 ArchConditions.callMethod(
                     PermissionsBehavior.class, "isAuthorized", TypedRecord.class))
+            .or(
+                ArchConditions.callMethod(
+                    PermissionsBehavior.class, "isAuthorized", TypedRecord.class, PermissionType.class))
             .check(item, events);
       }
     };

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationArchTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationArchTest.java
@@ -31,7 +31,6 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCommandPreconditionChecker;
 import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCommandProcessor;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
-import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
@@ -111,7 +110,10 @@ public class AuthorizationArchTest {
                     PermissionsBehavior.class, "isAuthorized", TypedRecord.class))
             .or(
                 ArchConditions.callMethod(
-                    PermissionsBehavior.class, "isAuthorized", TypedRecord.class, PermissionType.class))
+                    PermissionsBehavior.class,
+                    "isAuthorized",
+                    TypedRecord.class,
+                    PermissionType.class))
             .check(item, events);
       }
     };

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationMultipartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationMultipartitionTest.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.authorization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class CreateAuthorizationMultipartitionTest {
+
+  private static final int PARTITION_COUNT = 3;
+
+  @Rule public final EngineRule engine = EngineRule.multiplePartition(PARTITION_COUNT);
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldTestLifecycle() {
+    // when
+    engine
+        .authorization()
+        .newAuthorization()
+        // TODO: remove with https://github.com/camunda/camunda/issues/26883
+        .withOwnerKey(1L)
+        .withOwnerId("ownerId")
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceId("resourceId")
+        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+        .withPermissions(PermissionType.CREATE)
+        .create();
+
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .withPartitionId(1)
+                .limit(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED))
+                .filter(
+                    record ->
+                        record.getValueType() == ValueType.AUTHORIZATION
+                            || (record.getValueType() == ValueType.COMMAND_DISTRIBUTION
+                                && ((CommandDistributionRecordValue) record.getValue()).getIntent()
+                                    == AuthorizationIntent.CREATE)))
+        .extracting(
+            io.camunda.zeebe.protocol.record.Record::getIntent,
+            io.camunda.zeebe.protocol.record.Record::getRecordType,
+            r ->
+                // We want to verify the partition id where the deletion was distributing to and
+                // where it was completed. Since only the CommandDistribution records have a
+                // value that contains the partition id, we use the partition id the record was
+                // written on for the other records.
+                r.getValue() instanceof CommandDistributionRecordValue
+                    ? ((CommandDistributionRecordValue) r.getValue()).getPartitionId()
+                    : r.getPartitionId())
+        .containsSubsequence(
+            tuple(AuthorizationIntent.CREATE, RecordType.COMMAND, 1),
+            tuple(AuthorizationIntent.CREATED, RecordType.EVENT, 1),
+            tuple(CommandDistributionIntent.STARTED, RecordType.EVENT, 1))
+        .containsSubsequence(
+            tuple(CommandDistributionIntent.DISTRIBUTING, RecordType.EVENT, 2),
+            tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 2),
+            tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 2))
+        .containsSubsequence(
+            tuple(CommandDistributionIntent.DISTRIBUTING, RecordType.EVENT, 3),
+            tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
+            tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
+        .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
+
+    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+      assertThat(
+              RecordingExporter.records()
+                  .withPartitionId(partitionId)
+                  .limit(r -> r.getIntent().equals(AuthorizationIntent.CREATED))
+                  .collect(Collectors.toList()))
+          .extracting(Record::getIntent)
+          .endsWith(AuthorizationIntent.CREATE, AuthorizationIntent.CREATED);
+    }
+  }
+
+  @Test
+  public void shouldDistributeInIdentityQueue() {
+    // when
+    engine
+        .authorization()
+        .newAuthorization()
+        // TODO: remove with https://github.com/camunda/camunda/issues/26883
+        .withOwnerKey(1L)
+        .withOwnerId("ownerId")
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceId("resourceId")
+        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+        .withPermissions(PermissionType.CREATE)
+        .create();
+
+    // then
+    assertThat(
+            RecordingExporter.commandDistributionRecords()
+                .limit(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED))
+                .withIntent(CommandDistributionIntent.ENQUEUED))
+        .extracting(r -> r.getValue().getQueueId())
+        .containsOnly(DistributionQueue.IDENTITY.getQueueId());
+  }
+
+  @Test
+  public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
+    // given the user creation distribution is intercepted
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      interceptUserCreateForPartition(partitionId);
+    }
+    engine
+        .user()
+        .newUser("foo")
+        .withEmail("foo@bar")
+        .withName("Foo Bar")
+        .withPassword("zabraboof")
+        .create()
+        .getKey();
+
+    // when
+    engine
+        .authorization()
+        .newAuthorization()
+        // TODO: remove with https://github.com/camunda/camunda/issues/26883
+        .withOwnerKey(1L)
+        .withOwnerId("ownerId")
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceId("resourceId")
+        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+        .withPermissions(PermissionType.CREATE)
+        .create();
+
+    // Increase time to trigger a redistribution
+    engine.increaseTime(Duration.ofMinutes(1));
+
+    // then
+    assertThat(
+            RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
+                .limit(2))
+        .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
+        .containsExactly(
+            tuple(ValueType.USER, UserIntent.CREATE),
+            tuple(ValueType.AUTHORIZATION, AuthorizationIntent.CREATE));
+  }
+
+  private void interceptUserCreateForPartition(final int partitionId) {
+    final var hasInterceptedPartition = new AtomicBoolean(false);
+    engine.interceptInterPartitionCommands(
+        (receiverPartitionId, valueType, intent, recordKey, command) -> {
+          if (hasInterceptedPartition.get()) {
+            return true;
+          }
+          hasInterceptedPartition.set(true);
+          return !(receiverPartitionId == partitionId && intent == UserIntent.CREATE);
+        });
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationMultipartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationMultipartitionTest.java
@@ -49,7 +49,7 @@ public class CreateAuthorizationMultipartitionTest {
         .withOwnerId("ownerId")
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceId("resourceId")
-        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+        .withResourceType(AuthorizationResourceType.RESOURCE)
         .withPermissions(PermissionType.CREATE)
         .create();
 
@@ -111,7 +111,7 @@ public class CreateAuthorizationMultipartitionTest {
         .withOwnerId("ownerId")
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceId("resourceId")
-        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+        .withResourceType(AuthorizationResourceType.RESOURCE)
         .withPermissions(PermissionType.CREATE)
         .create();
 
@@ -148,7 +148,7 @@ public class CreateAuthorizationMultipartitionTest {
         .withOwnerId("ownerId")
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceId("resourceId")
-        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+        .withResourceType(AuthorizationResourceType.RESOURCE)
         .withPermissions(PermissionType.CREATE)
         .create();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.authorization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.Set;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class CreateAuthorizationTest {
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldCreateAuthorization() {
+    // when
+    final var response =
+        engine
+            .authorization()
+            .newAuthorization()
+            // TODO: remove with https://github.com/camunda/camunda/issues/26883
+            .withOwnerKey(1L)
+            .withOwnerId("ownerId")
+            .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceId("resourceId")
+            .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+            .withPermissions(PermissionType.CREATE)
+            .create()
+            .getValue();
+
+    // then
+    assertThat(response)
+        .extracting(
+            AuthorizationRecordValue::getOwnerId,
+            AuthorizationRecordValue::getOwnerType,
+            AuthorizationRecordValue::getResourceId,
+            AuthorizationRecordValue::getResourceType,
+            AuthorizationRecordValue::getAuthorizationPermissions)
+        .containsExactly(
+            "ownerId",
+            AuthorizationOwnerType.USER,
+            "resourceId",
+            AuthorizationResourceType.DEPLOYMENT,
+            Set.of(PermissionType.CREATE));
+  }
+
+  @Test
+  @Ignore(
+      "This test needs to be enabled once this feature: https://github.com/camunda/camunda/issues/27036 is implemented")
+  public void shouldRejectIfPermissionAlreadyExistsDirectly() {
+    // given
+    engine
+        .authorization()
+        .newAuthorization()
+        // TODO: remove with https://github.com/camunda/camunda/issues/26883
+        .withOwnerKey(1L)
+        .withOwnerId("ownerId")
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceId("resourceId")
+        .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+        .withPermissions(PermissionType.CREATE)
+        .create();
+
+    engine
+        .authorization()
+        .newAuthorization()
+        // TODO: remove with https://github.com/camunda/camunda/issues/26883
+        .withOwnerKey(1L)
+        .withOwnerId("ownerId")
+        .withOwnerType(AuthorizationOwnerType.USER)
+        .withResourceId("anotherResourceId")
+        .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+        .withPermissions(PermissionType.CREATE)
+        .create();
+
+    // when
+    final var rejection =
+        engine
+            .authorization()
+            .newAuthorization()
+            // TODO: remove with https://github.com/camunda/camunda/issues/26883
+            .withOwnerKey(1L)
+            .withOwnerId("ownerId")
+            .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceId("resourceId")
+            .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+            .withPermissions(PermissionType.CREATE)
+            .expectRejection()
+            .create();
+
+    // then
+    Assertions.assertThat(rejection)
+        .describedAs("Authorization already exists")
+        .hasRejectionType(RejectionType.ALREADY_EXISTS)
+        .hasRejectionReason(
+            "Expected to create authorization for owner '%s' with permission type '%s' and resource type '%s', but this permission for resource identifiers '%s' already exist. Existing resource ids are: '%s'"
+                .formatted(
+                    "ownerId",
+                    PermissionType.CREATE,
+                    AuthorizationResourceType.PROCESS_DEFINITION,
+                    "resourceId",
+                    "[resourceId, anotherResourceId]"));
+  }
+
+  @Test
+  public void shouldRejectCreateUnsupportedPermission() {
+    // given
+    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+
+    // when
+    final var rejection =
+        engine
+            .authorization()
+            .newAuthorization()
+            // TODO: remove with https://github.com/camunda/camunda/issues/26883
+            .withOwnerKey(1L)
+            .withOwnerId("ownerId")
+            .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceId("resourceId")
+            .withResourceType(resourceType)
+            .withPermissions(
+                PermissionType.CREATE, PermissionType.DELETE_PROCESS, PermissionType.ACCESS)
+            .expectRejection()
+            .create();
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason(
+            "Expected to create authorization with permission types '%s' and resource type '%s', but these permissions are not supported. Supported permission types are: '%s'"
+                .formatted(
+                    List.of(PermissionType.ACCESS),
+                    resourceType,
+                    resourceType.getSupportedPermissionTypes()));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationTest.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.Set;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -63,8 +62,6 @@ public class CreateAuthorizationTest {
   }
 
   @Test
-  @Ignore(
-      "This test needs to be enabled once this feature: https://github.com/camunda/camunda/issues/27036 is implemented")
   public void shouldRejectIfPermissionAlreadyExistsDirectly() {
     // given
     engine
@@ -75,7 +72,7 @@ public class CreateAuthorizationTest {
         .withOwnerId("ownerId")
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceId("resourceId")
-        .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+        .withResourceType(AuthorizationResourceType.RESOURCE)
         .withPermissions(PermissionType.CREATE)
         .create();
 
@@ -87,7 +84,7 @@ public class CreateAuthorizationTest {
         .withOwnerId("ownerId")
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceId("anotherResourceId")
-        .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+        .withResourceType(AuthorizationResourceType.RESOURCE)
         .withPermissions(PermissionType.CREATE)
         .create();
 
@@ -101,7 +98,7 @@ public class CreateAuthorizationTest {
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceId("resourceId")
-            .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
+            .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermissions(PermissionType.CREATE)
             .expectRejection()
             .create();
@@ -115,7 +112,7 @@ public class CreateAuthorizationTest {
                 .formatted(
                     "ownerId",
                     PermissionType.CREATE,
-                    AuthorizationResourceType.PROCESS_DEFINITION,
+                    AuthorizationResourceType.RESOURCE,
                     "resourceId",
                     "[resourceId, anotherResourceId]"));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationTest.java
@@ -41,7 +41,7 @@ public class CreateAuthorizationTest {
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceId("resourceId")
-            .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+            .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermissions(PermissionType.CREATE)
             .create()
             .getValue();
@@ -58,7 +58,7 @@ public class CreateAuthorizationTest {
             "ownerId",
             AuthorizationOwnerType.USER,
             "resourceId",
-            AuthorizationResourceType.DEPLOYMENT,
+            AuthorizationResourceType.RESOURCE,
             Set.of(PermissionType.CREATE));
   }
 
@@ -123,7 +123,7 @@ public class CreateAuthorizationTest {
   @Test
   public void shouldRejectCreateUnsupportedPermission() {
     // given
-    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var resourceType = AuthorizationResourceType.RESOURCE;
 
     // when
     final var rejection =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -131,6 +131,26 @@ public class CommandDistributionIdempotencyTest {
   public static Collection<Object[]> scenarios() {
     return Arrays.asList(
         new Object[][] {
+            {
+                "Authorization.CREATE is idempotent",
+                new Scenario(
+                    ValueType.AUTHORIZATION,
+                    AuthorizationIntent.CREATE,
+                    () -> {
+                      final var user = createUser();
+                      ENGINE
+                          .authorization()
+                          .newAuthorization()
+                          .withOwnerKey(user.getKey())
+                          .withOwnerId(user.getValue().getUsername())
+                          .withResourceId("*")
+                          .withResourceType(AuthorizationResourceType.USER)
+                          .withPermissions(PermissionType.READ)
+                          .create();
+                    },
+                    2),
+                AuthorizationAddPermissionProcessor.class
+            },
           {
             "Authorization.ADD_PERMISSION is idempotent",
             new Scenario(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.fail;
 import io.camunda.zeebe.engine.processing.clock.ClockProcessor;
 import io.camunda.zeebe.engine.processing.deployment.DeploymentCreateProcessor;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationAddPermissionProcessor;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCreateProcessor;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationRemovePermissionProcessor;
 import io.camunda.zeebe.engine.processing.identity.GroupAddEntityProcessor;
 import io.camunda.zeebe.engine.processing.identity.GroupCreateProcessor;
@@ -131,26 +132,26 @@ public class CommandDistributionIdempotencyTest {
   public static Collection<Object[]> scenarios() {
     return Arrays.asList(
         new Object[][] {
-            {
-                "Authorization.CREATE is idempotent",
-                new Scenario(
-                    ValueType.AUTHORIZATION,
-                    AuthorizationIntent.CREATE,
-                    () -> {
-                      final var user = createUser();
-                      ENGINE
-                          .authorization()
-                          .newAuthorization()
-                          .withOwnerKey(user.getKey())
-                          .withOwnerId(user.getValue().getUsername())
-                          .withResourceId("*")
-                          .withResourceType(AuthorizationResourceType.USER)
-                          .withPermissions(PermissionType.READ)
-                          .create();
-                    },
-                    2),
-                AuthorizationAddPermissionProcessor.class
-            },
+          {
+            "Authorization.CREATE is idempotent",
+            new Scenario(
+                ValueType.AUTHORIZATION,
+                AuthorizationIntent.CREATE,
+                () -> {
+                  final var user = createUser();
+                  ENGINE
+                      .authorization()
+                      .newAuthorization()
+                      .withOwnerKey(user.getKey())
+                      .withOwnerId(user.getValue().getUsername())
+                      .withResourceId("*")
+                      .withResourceType(AuthorizationResourceType.USER)
+                      .withPermissions(PermissionType.READ)
+                      .create();
+                },
+                2),
+            AuthorizationCreateProcessor.class
+          },
           {
             "Authorization.ADD_PERMISSION is idempotent",
             new Scenario(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.engine.state.mutable.MutableAuthorizationState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
-import io.camunda.zeebe.protocol.impl.record.value.authorization.Permission;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -65,9 +64,7 @@ public class AuthorizationStateTest {
             .setOwnerType(ownerType)
             .setResourceId(resourceId)
             .setResourceType(resourceType)
-            .setAuthorizationPermissions(permissions)
-            .addPermission(
-                new Permission().setPermissionType(PermissionType.CREATE).addResourceId("test"));
+            .setAuthorizationPermissions(permissions);
 
     // when
     authorizationState.create(authorizationKey, authorizationRecord);
@@ -85,7 +82,7 @@ public class AuthorizationStateTest {
     final var resourceIdentifiers =
         authorizationState.getResourceIdentifiers(
             ownerType, ownerId, resourceType, PermissionType.CREATE);
-    assertThat(resourceIdentifiers).containsExactly("test");
+    assertThat(resourceIdentifiers).containsExactly("resourceId");
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AuthorizationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AuthorizationClient.java
@@ -27,6 +27,10 @@ public final class AuthorizationClient {
     this.writer = writer;
   }
 
+  public AuthorizationCreateClient newAuthorization() {
+    return new AuthorizationCreateClient(writer);
+  }
+
   public AuthorizationPermissionClient permission() {
     return new AuthorizationPermissionClient(writer);
   }
@@ -137,6 +141,83 @@ public final class AuthorizationClient {
       final long position =
           writer.writeCommand(
               AuthorizationIntent.REMOVE_PERMISSION, username, authorizationCreationRecord);
+      return expectation.apply(position);
+    }
+  }
+
+  public static class AuthorizationCreateClient {
+    private static final Function<Long, Record<AuthorizationRecordValue>> CREATE_SUCCESS_SUPPLIER =
+        (position) ->
+            RecordingExporter.authorizationRecords()
+                .withIntent(AuthorizationIntent.CREATED)
+                .withSourceRecordPosition(position)
+                .getFirst();
+    private static final Function<Long, Record<AuthorizationRecordValue>>
+        CREATE_REJECTION_SUPPLIER =
+            (position) ->
+                RecordingExporter.authorizationRecords()
+                    .onlyCommandRejections()
+                    .withIntent(AuthorizationIntent.CREATE)
+                    .withSourceRecordPosition(position)
+                    .getFirst();
+
+    private Function<Long, Record<AuthorizationRecordValue>> expectation = CREATE_SUCCESS_SUPPLIER;
+    private final CommandWriter writer;
+    private final AuthorizationRecord authorizationCreationRecord;
+    private boolean expectRejection = false;
+
+    public AuthorizationCreateClient(final CommandWriter writer) {
+      this.writer = writer;
+      authorizationCreationRecord = new AuthorizationRecord();
+    }
+
+    public AuthorizationCreateClient withOwnerKey(final Long ownerKey) {
+      authorizationCreationRecord.setOwnerKey(ownerKey);
+      return this;
+    }
+
+    public AuthorizationCreateClient withOwnerId(final String ownerId) {
+      authorizationCreationRecord.setOwnerId(ownerId);
+      return this;
+    }
+
+    public AuthorizationCreateClient withOwnerType(final AuthorizationOwnerType ownerType) {
+      authorizationCreationRecord.setOwnerType(ownerType);
+      return this;
+    }
+
+    public AuthorizationCreateClient withResourceId(final String resourceId) {
+      authorizationCreationRecord.setResourceId(resourceId);
+      return this;
+    }
+
+    public AuthorizationCreateClient withResourceType(
+        final AuthorizationResourceType resourceType) {
+      authorizationCreationRecord.setResourceType(resourceType);
+      return this;
+    }
+
+    public AuthorizationCreateClient withPermissions(final PermissionType... permissions) {
+      authorizationCreationRecord.setAuthorizationPermissions(Set.of(permissions));
+      return this;
+    }
+
+    public AuthorizationCreateClient expectRejection() {
+      expectRejection = true;
+      return this;
+    }
+
+    public Record<AuthorizationRecordValue> create() {
+      expectation = expectRejection ? CREATE_REJECTION_SUPPLIER : CREATE_SUCCESS_SUPPLIER;
+      final long position =
+          writer.writeCommand(AuthorizationIntent.CREATE, authorizationCreationRecord);
+      return expectation.apply(position);
+    }
+
+    public Record<AuthorizationRecordValue> create(final String username) {
+      expectation = expectRejection ? CREATE_REJECTION_SUPPLIER : CREATE_SUCCESS_SUPPLIER;
+      final long position =
+          writer.writeCommand(AuthorizationIntent.CREATE, username, authorizationCreationRecord);
       return expectation.apply(position);
     }
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/AuthorizationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/AuthorizationRecord.java
@@ -26,8 +26,8 @@ import java.util.stream.Collectors;
 
 public final class AuthorizationRecord extends UnifiedRecordValue
     implements AuthorizationRecordValue {
-  // TODO: remove default value in: https://github.com/camunda/camunda/issues/26883
   private final LongProperty authorizationKeyProp = new LongProperty("authorizationKey", -1L);
+  // TODO: remove default value in: https://github.com/camunda/camunda/issues/26883
   private final StringProperty ownerIdProp = new StringProperty("ownerId", "");
   // TODO: remove in: https://github.com/camunda/camunda/issues/26883
   private final LongProperty ownerKeyProp = new LongProperty("ownerKey");


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds:

- A new processor, to process the Authrozation.CREATE
- A new applier, to create in the state a new authorization record
- 2 new permissions to the authrorization resource type (CREATE and DELETE)

## Related issues

closes #27063 
