### PR TITLE
build: optimize calls the API with the absolute URL

### DIFF
--- a/optimize/client/src/components/Analysis/BranchAnalysis/service.js
+++ b/optimize/client/src/components/Analysis/BranchAnalysis/service.js
@@ -7,6 +7,7 @@
  */
 
 import {post} from 'request';
+import { getAbsoluteURL } from '../../../modules/api';
 
 export async function loadFrequencyData(
   processDefinitionKey,
@@ -16,7 +17,7 @@ export async function loadFrequencyData(
   filter
 ) {
   const response = await post(
-    'api/report/evaluate',
+    getAbsoluteURL('api/report/evaluate'),
     createFlowNodeFrequencyReport(
       processDefinitionKey,
       processDefinitionVersions,
@@ -56,7 +57,7 @@ export async function loadCorrelationData(
   gateway,
   end
 ) {
-  const response = await post('api/analysis/correlation', {
+  const response = await post(getAbsoluteURL('api/analysis/correlation'), {
     processDefinitionKey,
     processDefinitionVersions,
     tenantIds,

--- a/optimize/client/src/components/Analysis/BranchAnalysis/service.js
+++ b/optimize/client/src/components/Analysis/BranchAnalysis/service.js
@@ -7,7 +7,7 @@
  */
 
 import {post} from 'request';
-import { getAbsoluteURL } from '../../../modules/api';
+import { getFullURL } from '../../../modules/api';
 
 export async function loadFrequencyData(
   processDefinitionKey,
@@ -17,7 +17,7 @@ export async function loadFrequencyData(
   filter
 ) {
   const response = await post(
-    getAbsoluteURL('api/report/evaluate'),
+    getFullURL('api/report/evaluate'),
     createFlowNodeFrequencyReport(
       processDefinitionKey,
       processDefinitionVersions,
@@ -57,7 +57,7 @@ export async function loadCorrelationData(
   gateway,
   end
 ) {
-  const response = await post(getAbsoluteURL('api/analysis/correlation'), {
+  const response = await post(getFullURL('api/analysis/correlation'), {
     processDefinitionKey,
     processDefinitionVersions,
     tenantIds,

--- a/optimize/client/src/components/Analysis/TaskAnalysis/service.js
+++ b/optimize/client/src/components/Analysis/TaskAnalysis/service.js
@@ -7,9 +7,10 @@
  */
 
 import {post} from 'request';
+import { getAbsoluteURL } from '../../../modules/api.ts';
 
 export async function loadNodesOutliers(config) {
-  const response = await post('api/analysis/flowNodeOutliers', config);
+  const response = await post(getAbsoluteURL('api/analysis/flowNodeOutliers'), config);
   return await response.json();
 }
 

--- a/optimize/client/src/components/Analysis/TaskAnalysis/service.js
+++ b/optimize/client/src/components/Analysis/TaskAnalysis/service.js
@@ -7,10 +7,10 @@
  */
 
 import {post} from 'request';
-import { getAbsoluteURL } from '../../../modules/api.ts';
+import { getFullURL } from '../../../modules/api.ts';
 
 export async function loadNodesOutliers(config) {
-  const response = await post(getAbsoluteURL('api/analysis/flowNodeOutliers'), config);
+  const response = await post(getFullURL('api/analysis/flowNodeOutliers'), config);
   return await response.json();
 }
 

--- a/optimize/client/src/components/Analysis/TaskAnalysis/service.ts
+++ b/optimize/client/src/components/Analysis/TaskAnalysis/service.ts
@@ -9,6 +9,7 @@
 import {t} from 'translation';
 import {post} from 'request';
 import {AnalysisDurationChartEntry} from 'types';
+import { getAbsoluteURL } from 'modules/api';
 
 export interface OutliersVariable {
   variableName: string;
@@ -48,14 +49,14 @@ export type OutlierNode = {
 export async function loadCommonOutliersVariables(
   params: AnalysisFlowNodeOutlierParameters
 ): Promise<OutliersVariable[]> {
-  const response = await post('api/analysis/significantOutlierVariableTerms', params);
+  const response = await post(getAbsoluteURL('api/analysis/significantOutlierVariableTerms'), params);
   return await response.json();
 }
 
 export async function loadDurationData(
   params: AnalysisFlowNodeOutlierParameters
 ): Promise<AnalysisDurationChartEntry[]> {
-  const response = await post('api/analysis/durationChart', params);
+  const response = await post(getAbsoluteURL('api/analysis/durationChart'), params);
   return await response.json();
 }
 

--- a/optimize/client/src/components/Analysis/TaskAnalysis/service.ts
+++ b/optimize/client/src/components/Analysis/TaskAnalysis/service.ts
@@ -9,7 +9,7 @@
 import {t} from 'translation';
 import {post} from 'request';
 import {AnalysisDurationChartEntry} from 'types';
-import { getAbsoluteURL } from 'modules/api';
+import { getAbsoluteURL } from '../../../modules/api';
 
 export interface OutliersVariable {
   variableName: string;

--- a/optimize/client/src/components/Analysis/TaskAnalysis/service.ts
+++ b/optimize/client/src/components/Analysis/TaskAnalysis/service.ts
@@ -9,7 +9,7 @@
 import {t} from 'translation';
 import {post} from 'request';
 import {AnalysisDurationChartEntry} from 'types';
-import { getAbsoluteURL } from '../../../modules/api';
+import { getFullURL } from '../../../modules/api';
 
 export interface OutliersVariable {
   variableName: string;
@@ -49,14 +49,14 @@ export type OutlierNode = {
 export async function loadCommonOutliersVariables(
   params: AnalysisFlowNodeOutlierParameters
 ): Promise<OutliersVariable[]> {
-  const response = await post(getAbsoluteURL('api/analysis/significantOutlierVariableTerms'), params);
+  const response = await post(getFullURL('api/analysis/significantOutlierVariableTerms'), params);
   return await response.json();
 }
 
 export async function loadDurationData(
   params: AnalysisFlowNodeOutlierParameters
 ): Promise<AnalysisDurationChartEntry[]> {
-  const response = await post(getAbsoluteURL('api/analysis/durationChart'), params);
+  const response = await post(getFullURL('api/analysis/durationChart'), params);
   return await response.json();
 }
 

--- a/optimize/client/src/components/Dashboards/filters/service.js
+++ b/optimize/client/src/components/Dashboards/filters/service.js
@@ -7,15 +7,16 @@
  */
 
 import {post, get} from 'request';
+import { getAbsoluteURL } from '../../../modules/api';
 
 export async function getVariableNames(reportIds) {
-  const response = await post('api/variables/reports', {reportIds});
+  const response = await post(getAbsoluteURL('api/variables/reports'), {reportIds});
 
   return await response.json();
 }
 
 export async function getVariableValues(reportIds, name, type, numResults, valueFilter) {
-  const response = await post('api/variables/values/reports', {
+  const response = await post(getAbsoluteURL('api/variables/values/reports'), {
     reportIds,
     name,
     type,
@@ -28,13 +29,13 @@ export async function getVariableValues(reportIds, name, type, numResults, value
 }
 
 export async function loadUsersByReportIds(type, payload) {
-  const response = await post(`api/${type}/search/reports`, payload);
+  const response = await post(getAbsoluteURL(`api/${type}/search/reports`), payload);
 
   return await response.json();
 }
 
 export async function getAssigneeNames(type, listOfIds) {
-  const response = await get('api/' + type, {idIn: listOfIds.join(',')});
+  const response = await get(getAbsoluteURL('api/' + type), {idIn: listOfIds.join(',')});
 
   return await response.json();
 }

--- a/optimize/client/src/components/Dashboards/filters/service.js
+++ b/optimize/client/src/components/Dashboards/filters/service.js
@@ -7,16 +7,16 @@
  */
 
 import {post, get} from 'request';
-import { getAbsoluteURL } from '../../../modules/api';
+import { getFullURL } from '../../../modules/api';
 
 export async function getVariableNames(reportIds) {
-  const response = await post(getAbsoluteURL('api/variables/reports'), {reportIds});
+  const response = await post(getFullURL('api/variables/reports'), {reportIds});
 
   return await response.json();
 }
 
 export async function getVariableValues(reportIds, name, type, numResults, valueFilter) {
-  const response = await post(getAbsoluteURL('api/variables/values/reports'), {
+  const response = await post(getFullURL('api/variables/values/reports'), {
     reportIds,
     name,
     type,
@@ -29,13 +29,13 @@ export async function getVariableValues(reportIds, name, type, numResults, value
 }
 
 export async function loadUsersByReportIds(type, payload) {
-  const response = await post(getAbsoluteURL(`api/${type}/search/reports`), payload);
+  const response = await post(getFullURL(`api/${type}/search/reports`), payload);
 
   return await response.json();
 }
 
 export async function getAssigneeNames(type, listOfIds) {
-  const response = await get(getAbsoluteURL('api/' + type), {idIn: listOfIds.join(',')});
+  const response = await get(getFullURL('api/' + type), {idIn: listOfIds.join(',')});
 
   return await response.json();
 }

--- a/optimize/client/src/components/Dashboards/service.js
+++ b/optimize/client/src/components/Dashboards/service.js
@@ -7,20 +7,20 @@
  */
 
 import {get, del, post} from 'request';
-import { getAbsoluteURL } from '../../modules/api';
+import { getFullURL } from '../../modules/api';
 
 export async function shareDashboard(dashboardId) {
   const body = {
     dashboardId,
   };
-  const response = await post(getAbsoluteURL(`api/share/dashboard`), body);
+  const response = await post(getFullURL(`api/share/dashboard`), body);
 
   const json = await response.json();
   return json.id;
 }
 
 export async function getSharedDashboard(reportId) {
-  const response = await get(getAbsoluteURL(`api/share/dashboard/${reportId}`));
+  const response = await get(getFullURL(`api/share/dashboard/${reportId}`));
 
   if (response.status > 201) {
     return '';
@@ -31,12 +31,12 @@ export async function getSharedDashboard(reportId) {
 }
 
 export async function revokeDashboardSharing(id) {
-  return await del(getAbsoluteURL(`api/share/dashboard/${id}`));
+  return await del(getFullURL(`api/share/dashboard/${id}`));
 }
 
 export async function isAuthorizedToShareDashboard(dashboardId) {
   try {
-    const response = await get(getAbsoluteURL(`api/share/dashboard/${dashboardId}/isAuthorizedToShare`));
+    const response = await get(getFullURL(`api/share/dashboard/${dashboardId}/isAuthorizedToShare`));
     return response.status === 200;
   } catch (_error) {
     return false;

--- a/optimize/client/src/components/Dashboards/service.js
+++ b/optimize/client/src/components/Dashboards/service.js
@@ -7,19 +7,20 @@
  */
 
 import {get, del, post} from 'request';
+import { getAbsoluteURL } from '../../modules/api';
 
 export async function shareDashboard(dashboardId) {
   const body = {
     dashboardId,
   };
-  const response = await post(`api/share/dashboard`, body);
+  const response = await post(getAbsoluteURL(`api/share/dashboard`), body);
 
   const json = await response.json();
   return json.id;
 }
 
 export async function getSharedDashboard(reportId) {
-  const response = await get(`api/share/dashboard/${reportId}`);
+  const response = await get(getAbsoluteURL(`api/share/dashboard/${reportId}`));
 
   if (response.status > 201) {
     return '';
@@ -30,12 +31,12 @@ export async function getSharedDashboard(reportId) {
 }
 
 export async function revokeDashboardSharing(id) {
-  return await del(`api/share/dashboard/${id}`);
+  return await del(getAbsoluteURL(`api/share/dashboard/${id}`));
 }
 
 export async function isAuthorizedToShareDashboard(dashboardId) {
   try {
-    const response = await get(`api/share/dashboard/${dashboardId}/isAuthorizedToShare`);
+    const response = await get(getAbsoluteURL(`api/share/dashboard/${dashboardId}/isAuthorizedToShare`));
     return response.status === 200;
   } catch (_error) {
     return false;

--- a/optimize/client/src/components/Header/service.ts
+++ b/optimize/client/src/components/Header/service.ts
@@ -7,9 +7,10 @@
  */
 
 import {get} from 'request';
+import {getAbsoluteURL} from '../../modules/api';
 
 export async function getUserToken(): Promise<string> {
-  const response = await get('api/token');
+  const response = await get(getAbsoluteURL('api/token'));
   const value = (await response.json()) as {token: string};
   return value.token;
 }

--- a/optimize/client/src/components/Header/service.ts
+++ b/optimize/client/src/components/Header/service.ts
@@ -7,10 +7,10 @@
  */
 
 import {get} from 'request';
-import {getAbsoluteURL} from '../../modules/api';
+import {getFullURL} from '../../modules/api';
 
 export async function getUserToken(): Promise<string> {
-  const response = await get(getAbsoluteURL('api/token'));
+  const response = await get(getFullURL('api/token'));
   const value = (await response.json()) as {token: string};
   return value.token;
 }

--- a/optimize/client/src/components/Home/CollectionEnitiesList.js
+++ b/optimize/client/src/components/Home/CollectionEnitiesList.js
@@ -32,7 +32,7 @@ import {checkConflicts, importEntity, removeEntities} from './service';
 import {formatLink, formatSubEntities, formatType} from './formatters';
 
 import './CollectionEnitiesList.scss';
-import { getAbsoluteURL } from '../../modules/api';
+import { getFullURL } from '../../modules/api';
 
 export default function CollectionEnitiesList({
   collection,
@@ -175,7 +175,7 @@ export default function CollectionEnitiesList({
                   icon: <Save />,
                   text: t('common.export'),
                   action: () => {
-                    window.location.href = getAbsoluteURL(`api/export/${entityType}/json/${
+                    window.location.href = getFullURL(`api/export/${entityType}/json/${
                       entity.id
                     }/${encodeURIComponent(formatters.formatFileName(entity.name))}.json`);
                   },

--- a/optimize/client/src/components/Home/CollectionEnitiesList.js
+++ b/optimize/client/src/components/Home/CollectionEnitiesList.js
@@ -32,6 +32,7 @@ import {checkConflicts, importEntity, removeEntities} from './service';
 import {formatLink, formatSubEntities, formatType} from './formatters';
 
 import './CollectionEnitiesList.scss';
+import { getAbsoluteURL } from '../../modules/api';
 
 export default function CollectionEnitiesList({
   collection,
@@ -174,9 +175,9 @@ export default function CollectionEnitiesList({
                   icon: <Save />,
                   text: t('common.export'),
                   action: () => {
-                    window.location.href = `api/export/${entityType}/json/${
+                    window.location.href = getAbsoluteURL(`api/export/${entityType}/json/${
                       entity.id
-                    }/${encodeURIComponent(formatters.formatFileName(entity.name))}.json`;
+                    }/${encodeURIComponent(formatters.formatFileName(entity.name))}.json`);
                   },
                 }
               );

--- a/optimize/client/src/components/Home/Home.js
+++ b/optimize/client/src/components/Home/Home.js
@@ -43,7 +43,7 @@ import {importEntity, removeEntities, checkConflicts} from './service';
 import {formatLink, formatType, formatSubEntities} from './formatters';
 
 import './Home.scss';
-import { getAbsoluteURL } from '../../modules/api';
+import { getFullURL } from '../../modules/api';
 
 export function Home({mightFail, user}) {
   const [entities, setEntities] = useState(null);
@@ -209,7 +209,7 @@ export function Home({mightFail, user}) {
                   icon: <Save />,
                   text: t('common.export'),
                   action: () => {
-                    window.location.href = getAbsoluteURL(`api/export/${entityType}/json/${
+                    window.location.href = getFullURL(`api/export/${entityType}/json/${
                       entity.id
                     }/${encodeURIComponent(formatters.formatFileName(entity.name))}.json`);
                   },

--- a/optimize/client/src/components/Home/Home.js
+++ b/optimize/client/src/components/Home/Home.js
@@ -43,6 +43,7 @@ import {importEntity, removeEntities, checkConflicts} from './service';
 import {formatLink, formatType, formatSubEntities} from './formatters';
 
 import './Home.scss';
+import { getAbsoluteURL } from '../../modules/api';
 
 export function Home({mightFail, user}) {
   const [entities, setEntities] = useState(null);
@@ -208,9 +209,9 @@ export function Home({mightFail, user}) {
                   icon: <Save />,
                   text: t('common.export'),
                   action: () => {
-                    window.location.href = `api/export/${entityType}/json/${
+                    window.location.href = getAbsoluteURL(`api/export/${entityType}/json/${
                       entity.id
-                    }/${encodeURIComponent(formatters.formatFileName(entity.name))}.json`;
+                    }/${encodeURIComponent(formatters.formatFileName(entity.name))}.json`);
                   },
                 });
               }

--- a/optimize/client/src/components/Home/modals/service.ts
+++ b/optimize/client/src/components/Home/modals/service.ts
@@ -10,6 +10,7 @@ import {get} from 'request';
 import {Definition, Tenant} from 'types';
 import {formatters, UNAUTHORIZED_TENANT_ID} from 'services';
 import {t} from 'translation';
+import {getAbsoluteURL} from '../../../modules/api';
 
 const {formatTenantName} = formatters;
 
@@ -18,13 +19,13 @@ export type TenantWithDefinitions = Tenant & {definitions: Definition};
 export type DefinitionWithTenants = Omit<Definition, 'key'> & {tenants: Tenant[]; key: string};
 
 export async function getDefinitionsWithTenants(): Promise<DefinitionWithTenants[]> {
-  const response = await get('api/definition');
+  const response = await get(getAbsoluteURL('api/definition'));
 
   return await response.json();
 }
 
 export async function getTenantsWithDefinitions(): Promise<TenantWithDefinitions[]> {
-  const response = await get('api/definition/_groupByTenant');
+  const response = await get(getAbsoluteURL('api/definition/_groupByTenant'));
 
   return await response.json();
 }
@@ -33,7 +34,7 @@ export async function getDefinitionTenants(
   defintionKey: string,
   defintionType: string
 ): Promise<DefinitionWithTenants> {
-  const response = await get(`api/definition/${defintionType}/${defintionKey}`);
+  const response = await get(getAbsoluteURL(`api/definition/${defintionType}/${defintionKey}`));
 
   return await response.json();
 }

--- a/optimize/client/src/components/Home/modals/service.ts
+++ b/optimize/client/src/components/Home/modals/service.ts
@@ -10,7 +10,7 @@ import {get} from 'request';
 import {Definition, Tenant} from 'types';
 import {formatters, UNAUTHORIZED_TENANT_ID} from 'services';
 import {t} from 'translation';
-import {getAbsoluteURL} from '../../../modules/api';
+import {getFullURL} from '../../../modules/api';
 
 const {formatTenantName} = formatters;
 
@@ -19,13 +19,13 @@ export type TenantWithDefinitions = Tenant & {definitions: Definition};
 export type DefinitionWithTenants = Omit<Definition, 'key'> & {tenants: Tenant[]; key: string};
 
 export async function getDefinitionsWithTenants(): Promise<DefinitionWithTenants[]> {
-  const response = await get(getAbsoluteURL('api/definition'));
+  const response = await get(getFullURL('api/definition'));
 
   return await response.json();
 }
 
 export async function getTenantsWithDefinitions(): Promise<TenantWithDefinitions[]> {
-  const response = await get(getAbsoluteURL('api/definition/_groupByTenant'));
+  const response = await get(getFullURL('api/definition/_groupByTenant'));
 
   return await response.json();
 }
@@ -34,7 +34,7 @@ export async function getDefinitionTenants(
   defintionKey: string,
   defintionType: string
 ): Promise<DefinitionWithTenants> {
-  const response = await get(getAbsoluteURL(`api/definition/${defintionType}/${defintionKey}`));
+  const response = await get(getFullURL(`api/definition/${defintionType}/${defintionKey}`));
 
   return await response.json();
 }

--- a/optimize/client/src/components/Home/service.js
+++ b/optimize/client/src/components/Home/service.js
@@ -7,6 +7,7 @@
  */
 
 import {get, post, put, del} from 'request';
+import { getAbsoluteURL } from '../../modules/api';
 
 export async function loadCollectionEntities(id, sortBy, sortOrder) {
   const params = {};
@@ -15,42 +16,42 @@ export async function loadCollectionEntities(id, sortBy, sortOrder) {
     params.sortOrder = sortOrder;
   }
 
-  const response = await get(`api/collection/${id}/entities`, params);
+  const response = await get(getAbsoluteURL(`api/collection/${id}/entities`), params);
   return await response.json();
 }
 
 export async function getUsers(collection) {
-  const response = await get(`api/collection/${collection}/role`);
+  const response = await get(getAbsoluteURL(`api/collection/${collection}/role`));
   return await response.json();
 }
 
 export async function addUser(collection, roles) {
-  return await post(`api/collection/${collection}/role`, roles);
+  return await post(getAbsoluteURL(`api/collection/${collection}/role`), roles);
 }
 
 export async function editUser(collection, id, role) {
-  return await put(`api/collection/${collection}/role/${id}`, {role});
+  return await put(getAbsoluteURL(`api/collection/${collection}/role/${id}`), {role});
 }
 
 export async function removeUser(collection, id) {
-  return await del(`api/collection/${collection}/role/${id}`);
+  return await del(getAbsoluteURL(`api/collection/${collection}/role/${id}`));
 }
 
 export async function getSources(collection) {
-  const response = await get(`api/collection/${collection}/scope`);
+  const response = await get(getAbsoluteURL(`api/collection/${collection}/scope`));
   return await response.json();
 }
 
 export async function editSource(collection, scopeId, tenants, force = false) {
-  return await put(`api/collection/${collection}/scope/${scopeId}`, {tenants}, {query: {force}});
+  return await put(getAbsoluteURL(`api/collection/${collection}/scope/${scopeId}`), {tenants}, {query: {force}});
 }
 
 export async function removeSource(collection, scopeId) {
-  return await del(`api/collection/${collection}/scope/${scopeId}?force=true`);
+  return await del(getAbsoluteURL(`api/collection/${collection}/scope/${scopeId}?force=true`));
 }
 
 export async function checkDeleteSourceConflicts(collection, scopeId) {
-  const response = await get(`api/collection/${collection}/scope/${scopeId}/delete-conflicts`);
+  const response = await get(getAbsoluteURL(`api/collection/${collection}/scope/${scopeId}/delete-conflicts`));
   return await response.json();
 }
 
@@ -59,7 +60,7 @@ export async function importEntity(json, collectionId) {
   if (collectionId) {
     query.collectionId = collectionId;
   }
-  return await post('api/import', json, {query});
+  return await post(getAbsoluteURL('api/import'), json, {query});
 }
 
 export async function removeEntities(entities, collectionId) {
@@ -68,7 +69,7 @@ export async function removeEntities(entities, collectionId) {
     query.collectionId = collectionId;
   }
 
-  return await post(`api/entities/delete`, formatRequest(entities));
+  return await post(getAbsoluteURL(`api/entities/delete`), formatRequest(entities));
 }
 
 export async function checkConflicts(entities, collectionId) {
@@ -77,22 +78,22 @@ export async function checkConflicts(entities, collectionId) {
     query.collectionId = collectionId;
   }
 
-  const response = await post(`api/entities/delete-conflicts`, formatRequest(entities));
+  const response = await post(getAbsoluteURL(`api/entities/delete-conflicts`), formatRequest(entities));
 
   return await response.json();
 }
 
 export async function removeAlerts(alerts) {
-  return await post('api/alert/delete', getIds(alerts));
+  return await post(getAbsoluteURL('api/alert/delete'), getIds(alerts));
 }
 
 export async function removeSources(collectionId, scopes) {
-  return await post(`api/collection/${collectionId}/scope/delete`, getIds(scopes));
+  return await post(getAbsoluteURL(`api/collection/${collectionId}/scope/delete`), getIds(scopes));
 }
 
 export async function checkSourcesConflicts(collectionId, scopes) {
   const response = await post(
-    `api/collection/${collectionId}/scope/delete-conflicts`,
+    getAbsoluteURL(`api/collection/${collectionId}/scope/delete-conflicts`),
     getIds(scopes)
   );
 
@@ -100,7 +101,7 @@ export async function checkSourcesConflicts(collectionId, scopes) {
 }
 
 export async function removeUsers(collectionId, users) {
-  return await post(`api/collection/${collectionId}/roles/delete`, getIds(users));
+  return await post(getAbsoluteURL(`api/collection/${collectionId}/roles/delete`), getIds(users));
 }
 
 function getIds(entities) {

--- a/optimize/client/src/components/Home/service.js
+++ b/optimize/client/src/components/Home/service.js
@@ -7,7 +7,7 @@
  */
 
 import {get, post, put, del} from 'request';
-import { getAbsoluteURL } from '../../modules/api';
+import { getFullURL } from '../../modules/api';
 
 export async function loadCollectionEntities(id, sortBy, sortOrder) {
   const params = {};
@@ -16,42 +16,42 @@ export async function loadCollectionEntities(id, sortBy, sortOrder) {
     params.sortOrder = sortOrder;
   }
 
-  const response = await get(getAbsoluteURL(`api/collection/${id}/entities`), params);
+  const response = await get(getFullURL(`api/collection/${id}/entities`), params);
   return await response.json();
 }
 
 export async function getUsers(collection) {
-  const response = await get(getAbsoluteURL(`api/collection/${collection}/role`));
+  const response = await get(getFullURL(`api/collection/${collection}/role`));
   return await response.json();
 }
 
 export async function addUser(collection, roles) {
-  return await post(getAbsoluteURL(`api/collection/${collection}/role`), roles);
+  return await post(getFullURL(`api/collection/${collection}/role`), roles);
 }
 
 export async function editUser(collection, id, role) {
-  return await put(getAbsoluteURL(`api/collection/${collection}/role/${id}`), {role});
+  return await put(getFullURL(`api/collection/${collection}/role/${id}`), {role});
 }
 
 export async function removeUser(collection, id) {
-  return await del(getAbsoluteURL(`api/collection/${collection}/role/${id}`));
+  return await del(getFullURL(`api/collection/${collection}/role/${id}`));
 }
 
 export async function getSources(collection) {
-  const response = await get(getAbsoluteURL(`api/collection/${collection}/scope`));
+  const response = await get(getFullURL(`api/collection/${collection}/scope`));
   return await response.json();
 }
 
 export async function editSource(collection, scopeId, tenants, force = false) {
-  return await put(getAbsoluteURL(`api/collection/${collection}/scope/${scopeId}`), {tenants}, {query: {force}});
+  return await put(getFullURL(`api/collection/${collection}/scope/${scopeId}`), {tenants}, {query: {force}});
 }
 
 export async function removeSource(collection, scopeId) {
-  return await del(getAbsoluteURL(`api/collection/${collection}/scope/${scopeId}?force=true`));
+  return await del(getFullURL(`api/collection/${collection}/scope/${scopeId}?force=true`));
 }
 
 export async function checkDeleteSourceConflicts(collection, scopeId) {
-  const response = await get(getAbsoluteURL(`api/collection/${collection}/scope/${scopeId}/delete-conflicts`));
+  const response = await get(getFullURL(`api/collection/${collection}/scope/${scopeId}/delete-conflicts`));
   return await response.json();
 }
 
@@ -60,7 +60,7 @@ export async function importEntity(json, collectionId) {
   if (collectionId) {
     query.collectionId = collectionId;
   }
-  return await post(getAbsoluteURL('api/import'), json, {query});
+  return await post(getFullURL('api/import'), json, {query});
 }
 
 export async function removeEntities(entities, collectionId) {
@@ -69,7 +69,7 @@ export async function removeEntities(entities, collectionId) {
     query.collectionId = collectionId;
   }
 
-  return await post(getAbsoluteURL(`api/entities/delete`), formatRequest(entities));
+  return await post(getFullURL(`api/entities/delete`), formatRequest(entities));
 }
 
 export async function checkConflicts(entities, collectionId) {
@@ -78,22 +78,22 @@ export async function checkConflicts(entities, collectionId) {
     query.collectionId = collectionId;
   }
 
-  const response = await post(getAbsoluteURL(`api/entities/delete-conflicts`), formatRequest(entities));
+  const response = await post(getFullURL(`api/entities/delete-conflicts`), formatRequest(entities));
 
   return await response.json();
 }
 
 export async function removeAlerts(alerts) {
-  return await post(getAbsoluteURL('api/alert/delete'), getIds(alerts));
+  return await post(getFullURL('api/alert/delete'), getIds(alerts));
 }
 
 export async function removeSources(collectionId, scopes) {
-  return await post(getAbsoluteURL(`api/collection/${collectionId}/scope/delete`), getIds(scopes));
+  return await post(getFullURL(`api/collection/${collectionId}/scope/delete`), getIds(scopes));
 }
 
 export async function checkSourcesConflicts(collectionId, scopes) {
   const response = await post(
-    getAbsoluteURL(`api/collection/${collectionId}/scope/delete-conflicts`),
+    getFullURL(`api/collection/${collectionId}/scope/delete-conflicts`),
     getIds(scopes)
   );
 
@@ -101,7 +101,7 @@ export async function checkSourcesConflicts(collectionId, scopes) {
 }
 
 export async function removeUsers(collectionId, users) {
-  return await post(getAbsoluteURL(`api/collection/${collectionId}/roles/delete`), getIds(users));
+  return await post(getFullURL(`api/collection/${collectionId}/roles/delete`), getIds(users));
 }
 
 function getIds(entities) {

--- a/optimize/client/src/components/Logout.js
+++ b/optimize/client/src/components/Logout.js
@@ -12,12 +12,13 @@ import {get} from 'request';
 import {withErrorHandling} from 'HOC';
 import {addNotification} from 'notifications';
 import {t} from 'translation';
+import { getAbsoluteURL } from '../modules/api';
 
 export function Logout({mightFail, history}) {
   useEffect(() => {
     (async () => {
       await mightFail(
-        get('api/authentication/logout'),
+        get(getAbsoluteURL('api/authentication/logout')),
         () => addNotification({text: t('navigation.logoutSuccess')}),
         () => addNotification({text: t('navigation.logoutFailed'), type: 'error'})
       );

--- a/optimize/client/src/components/Logout.js
+++ b/optimize/client/src/components/Logout.js
@@ -12,13 +12,13 @@ import {get} from 'request';
 import {withErrorHandling} from 'HOC';
 import {addNotification} from 'notifications';
 import {t} from 'translation';
-import { getAbsoluteURL } from '../modules/api';
+import { getFullURL } from '../modules/api';
 
 export function Logout({mightFail, history}) {
   useEffect(() => {
     (async () => {
       await mightFail(
-        get(getAbsoluteURL('api/authentication/logout')),
+        get(getFullURL('api/authentication/logout')),
         () => addNotification({text: t('navigation.logoutSuccess')}),
         () => addNotification({text: t('navigation.logoutFailed'), type: 'error'})
       );

--- a/optimize/client/src/components/Logout.test.js
+++ b/optimize/client/src/components/Logout.test.js
@@ -26,7 +26,7 @@ it('should logout from server', () => {
   shallow(<Logout {...props} />);
   runLastEffect();
 
-  expect(get).toHaveBeenCalledWith('api/authentication/logout');
+  expect(get).toHaveBeenCalledWith('http://localhost/api/authentication/logout');
 });
 
 it('should redirect to the index page', async () => {

--- a/optimize/client/src/components/Processes/service.js
+++ b/optimize/client/src/components/Processes/service.js
@@ -8,7 +8,7 @@
 
 import {get, put} from 'request';
 import {formatters} from 'services';
-import { getAbsoluteURL } from '../../modules/api';
+import { getFullURL } from '../../modules/api';
 
 export async function loadProcesses(sortBy, sortOrder) {
   const params = {};
@@ -17,16 +17,16 @@ export async function loadProcesses(sortBy, sortOrder) {
     params.sortOrder = sortOrder;
   }
 
-  const response = await get(getAbsoluteURL('api/process/overview'), params);
+  const response = await get(getFullURL('api/process/overview'), params);
   return await response.json();
 }
 
 export function updateProcess(processDefinitionKey, payload) {
-  return put(getAbsoluteURL(`api/process/${processDefinitionKey}`), payload);
+  return put(getFullURL(`api/process/${processDefinitionKey}`), payload);
 }
 
 export async function loadManagementDashboard() {
-  const response = await get(getAbsoluteURL(`api/dashboard/management`));
+  const response = await get(getFullURL(`api/dashboard/management`));
 
   return await response.json();
 }

--- a/optimize/client/src/components/Processes/service.js
+++ b/optimize/client/src/components/Processes/service.js
@@ -7,8 +7,8 @@
  */
 
 import {get, put} from 'request';
-
 import {formatters} from 'services';
+import { getAbsoluteURL } from '../../modules/api';
 
 export async function loadProcesses(sortBy, sortOrder) {
   const params = {};
@@ -17,16 +17,16 @@ export async function loadProcesses(sortBy, sortOrder) {
     params.sortOrder = sortOrder;
   }
 
-  const response = await get('api/process/overview', params);
+  const response = await get(getAbsoluteURL('api/process/overview'), params);
   return await response.json();
 }
 
 export function updateProcess(processDefinitionKey, payload) {
-  return put(`api/process/${processDefinitionKey}`, payload);
+  return put(getAbsoluteURL(`api/process/${processDefinitionKey}`), payload);
 }
 
 export async function loadManagementDashboard() {
-  const response = await get(`api/dashboard/management`);
+  const response = await get(getAbsoluteURL(`api/dashboard/management`));
 
   return await response.json();
 }

--- a/optimize/client/src/components/Reports/controlPanels/DefinitionList/service.js
+++ b/optimize/client/src/components/Reports/controlPanels/DefinitionList/service.js
@@ -7,6 +7,7 @@
  */
 
 import {get, post} from 'request';
+import { getAbsoluteURL } from '../../../../modules/api.ts';
 
 export async function loadTenants(type, definitions, collectionId) {
   const payload = {definitions};
@@ -14,7 +15,7 @@ export async function loadTenants(type, definitions, collectionId) {
     payload.filterByCollectionScope = collectionId;
   }
 
-  const response = await post(`api/definition/${type}/_resolveTenantsForVersions`, payload);
+  const response = await post(getAbsoluteURL(`api/definition/${type}/_resolveTenantsForVersions`), payload);
 
   return await response.json();
 }
@@ -25,7 +26,7 @@ export async function loadVersions(type, collectionId, key) {
     params.filterByCollectionScope = collectionId;
   }
 
-  const response = await get(`api/definition/${type}/${key}/versions`, params);
+  const response = await get(getAbsoluteURL(`api/definition/${type}/${key}/versions`), params);
 
   return await response.json();
 }

--- a/optimize/client/src/components/Reports/controlPanels/DefinitionList/service.js
+++ b/optimize/client/src/components/Reports/controlPanels/DefinitionList/service.js
@@ -7,7 +7,7 @@
  */
 
 import {get, post} from 'request';
-import { getAbsoluteURL } from '../../../../modules/api.ts';
+import { getFullURL } from '../../../../modules/api.ts';
 
 export async function loadTenants(type, definitions, collectionId) {
   const payload = {definitions};
@@ -15,7 +15,7 @@ export async function loadTenants(type, definitions, collectionId) {
     payload.filterByCollectionScope = collectionId;
   }
 
-  const response = await post(getAbsoluteURL(`api/definition/${type}/_resolveTenantsForVersions`), payload);
+  const response = await post(getFullURL(`api/definition/${type}/_resolveTenantsForVersions`), payload);
 
   return await response.json();
 }
@@ -26,7 +26,7 @@ export async function loadVersions(type, collectionId, key) {
     params.filterByCollectionScope = collectionId;
   }
 
-  const response = await get(getAbsoluteURL(`api/definition/${type}/${key}/versions`), params);
+  const response = await get(getFullURL(`api/definition/${type}/${key}/versions`), params);
 
   return await response.json();
 }

--- a/optimize/client/src/components/Reports/controlPanels/DefinitionList/service.ts
+++ b/optimize/client/src/components/Reports/controlPanels/DefinitionList/service.ts
@@ -6,8 +6,9 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import { getAbsoluteURL } from 'modules/api';
 import {post} from 'request';
 
 export function updateVariables(definitionKey: string, labels: string[]) {
-  return post('api/variables/labels', {definitionKey, labels});
+  return post(getAbsoluteURL('api/variables/labels'), {definitionKey, labels});
 }

--- a/optimize/client/src/components/Reports/controlPanels/DefinitionList/service.ts
+++ b/optimize/client/src/components/Reports/controlPanels/DefinitionList/service.ts
@@ -6,9 +6,9 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { getAbsoluteURL } from '../../../../modules/api';
+import { getFullURL } from '../../../../modules/api';
 import {post} from 'request';
 
 export function updateVariables(definitionKey: string, labels: string[]) {
-  return post(getAbsoluteURL('api/variables/labels'), {definitionKey, labels});
+  return post(getFullURL('api/variables/labels'), {definitionKey, labels});
 }

--- a/optimize/client/src/components/Reports/controlPanels/DefinitionList/service.ts
+++ b/optimize/client/src/components/Reports/controlPanels/DefinitionList/service.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { getAbsoluteURL } from 'modules/api';
+import { getAbsoluteURL } from '../../../../modules/api';
 import {post} from 'request';
 
 export function updateVariables(definitionKey: string, labels: string[]) {

--- a/optimize/client/src/components/Reports/controlPanels/service.js
+++ b/optimize/client/src/components/Reports/controlPanels/service.js
@@ -7,7 +7,7 @@
  */
 
 import {post} from 'request';
-import { getAbsoluteURL } from '../../../modules/api';
+import { getFullURL } from '../../../modules/api';
 
 export function isDurationHeatmap({view, visualization, definitions}) {
   return (
@@ -30,7 +30,7 @@ export async function loadTenants(type, definitions, collectionId) {
     payload.filterByCollectionScope = collectionId;
   }
 
-  const response = await post(getAbsoluteURL(`api/definition/${type}/_resolveTenantsForVersions`), payload);
+  const response = await post(getFullURL(`api/definition/${type}/_resolveTenantsForVersions`), payload);
 
   return await response.json();
 }

--- a/optimize/client/src/components/Reports/controlPanels/service.js
+++ b/optimize/client/src/components/Reports/controlPanels/service.js
@@ -7,6 +7,7 @@
  */
 
 import {post} from 'request';
+import { getAbsoluteURL } from '../../../modules/api';
 
 export function isDurationHeatmap({view, visualization, definitions}) {
   return (
@@ -29,7 +30,7 @@ export async function loadTenants(type, definitions, collectionId) {
     payload.filterByCollectionScope = collectionId;
   }
 
-  const response = await post(`api/definition/${type}/_resolveTenantsForVersions`, payload);
+  const response = await post(getAbsoluteURL(`api/definition/${type}/_resolveTenantsForVersions`), payload);
 
   return await response.json();
 }

--- a/optimize/client/src/components/Reports/service.js
+++ b/optimize/client/src/components/Reports/service.js
@@ -7,20 +7,20 @@
  */
 
 import {get, del, post} from 'request';
-import { getAbsoluteURL } from '../../modules/api';
+import { getFullURL } from '../../modules/api';
 
 export async function shareReport(reportId) {
   const body = {
     reportId,
   };
-  const response = await post(getAbsoluteURL(`api/share/report`), body);
+  const response = await post(getFullURL(`api/share/report`), body);
 
   const json = await response.json();
   return json.id;
 }
 
 export async function getSharedReport(reportId) {
-  const response = await get(getAbsoluteURL(`api/share/report/${reportId}`));
+  const response = await get(getFullURL(`api/share/report/${reportId}`));
 
   if (response.status > 201) {
     return '';
@@ -31,5 +31,5 @@ export async function getSharedReport(reportId) {
 }
 
 export async function revokeReportSharing(id) {
-  return await del(getAbsoluteURL(`api/share/report/${id}`));
+  return await del(getFullURL(`api/share/report/${id}`));
 }

--- a/optimize/client/src/components/Reports/service.js
+++ b/optimize/client/src/components/Reports/service.js
@@ -7,19 +7,20 @@
  */
 
 import {get, del, post} from 'request';
+import { getAbsoluteURL } from '../../modules/api';
 
 export async function shareReport(reportId) {
   const body = {
     reportId,
   };
-  const response = await post(`api/share/report`, body);
+  const response = await post(getAbsoluteURL(`api/share/report`), body);
 
   const json = await response.json();
   return json.id;
 }
 
 export async function getSharedReport(reportId) {
-  const response = await get(`api/share/report/${reportId}`);
+  const response = await get(getAbsoluteURL(`api/share/report/${reportId}`));
 
   if (response.status > 201) {
     return '';
@@ -30,5 +31,5 @@ export async function getSharedReport(reportId) {
 }
 
 export async function revokeReportSharing(id) {
-  return await del(`api/share/report/${id}`);
+  return await del(getAbsoluteURL(`api/share/report/${id}`));
 }

--- a/optimize/client/src/components/Sharing/service.js
+++ b/optimize/client/src/components/Sharing/service.js
@@ -7,10 +7,11 @@
  */
 
 import {get, post} from 'request';
+import { getAbsoluteURL } from '../../modules/api';
 
 export async function evaluateEntity(id, type, query = {}) {
   const request = type === 'dashboard' ? get : post;
-  const response = await request(`api/share/${type}/${id}/evaluate`, {}, {query});
+  const response = await request(getAbsoluteURL(`api/share/${type}/${id}/evaluate`), {}, {query});
 
   return await response.json();
 }
@@ -18,7 +19,7 @@ export async function evaluateEntity(id, type, query = {}) {
 export function createLoadReportCallback(dashboardShareId) {
   return async (reportId, filter, query) => {
     const response = await post(
-      `api/share/dashboard/${dashboardShareId}/report/${reportId}/evaluate`,
+      getAbsoluteURL(`api/share/dashboard/${dashboardShareId}/report/${reportId}/evaluate`),
       {filter},
       {query}
     );

--- a/optimize/client/src/components/Sharing/service.js
+++ b/optimize/client/src/components/Sharing/service.js
@@ -7,11 +7,11 @@
  */
 
 import {get, post} from 'request';
-import { getAbsoluteURL } from '../../modules/api';
+import { getFullURL } from '../../modules/api';
 
 export async function evaluateEntity(id, type, query = {}) {
   const request = type === 'dashboard' ? get : post;
-  const response = await request(getAbsoluteURL(`api/share/${type}/${id}/evaluate`), {}, {query});
+  const response = await request(getFullURL(`api/share/${type}/${id}/evaluate`), {}, {query});
 
   return await response.json();
 }
@@ -19,7 +19,7 @@ export async function evaluateEntity(id, type, query = {}) {
 export function createLoadReportCallback(dashboardShareId) {
   return async (reportId, filter, query) => {
     const response = await post(
-      getAbsoluteURL(`api/share/dashboard/${dashboardShareId}/report/${reportId}/evaluate`),
+      getFullURL(`api/share/dashboard/${dashboardShareId}/report/${reportId}/evaluate`),
       {filter},
       {query}
     );

--- a/optimize/client/src/modules/HOC/withUser.tsx
+++ b/optimize/client/src/modules/HOC/withUser.tsx
@@ -9,7 +9,7 @@
 import {ReactNode, createContext, useState, useEffect, ComponentType} from 'react';
 import {get} from 'request';
 import {useUser} from 'hooks';
-import {getAbsoluteURL} from '../api';
+import {getFullURL} from '../api';
 
 export interface User {
   id: string;
@@ -35,7 +35,7 @@ export function UserProvider({children}: {children: ReactNode}): JSX.Element {
   const [user, setUser] = useState<User>();
 
   const refreshUser = async () => {
-    const response = await get(getAbsoluteURL('api/identity/current/user'));
+    const response = await get(getFullURL('api/identity/current/user'));
     const user = await response.json();
 
     resolveWithUser.forEach((resolve) => resolve(user));

--- a/optimize/client/src/modules/HOC/withUser.tsx
+++ b/optimize/client/src/modules/HOC/withUser.tsx
@@ -7,9 +7,9 @@
  */
 
 import {ReactNode, createContext, useState, useEffect, ComponentType} from 'react';
-
 import {get} from 'request';
 import {useUser} from 'hooks';
+import {getAbsoluteURL} from '../api';
 
 export interface User {
   id: string;
@@ -35,7 +35,7 @@ export function UserProvider({children}: {children: ReactNode}): JSX.Element {
   const [user, setUser] = useState<User>();
 
   const refreshUser = async () => {
-    const response = await get('api/identity/current/user');
+    const response = await get(getAbsoluteURL('api/identity/current/user'));
     const user = await response.json();
 
     resolveWithUser.forEach((resolve) => resolve(user));

--- a/optimize/client/src/modules/api.test.ts
+++ b/optimize/client/src/modules/api.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { getFullURL } from './api';
+
+beforeAll(() => {
+  Object.defineProperty(window, 'location', {
+    value: {
+      origin: 'http://localhost:3000',
+    },
+    writable: true,
+  });
+});
+
+describe('getFullURL', () => {
+  it('should return the same absolute URL when passed an absolute URL', () => {
+    const absoluteURL = 'https://example.com/path/to/resource';
+    const result = getFullURL(absoluteURL);
+    expect(result).toBe(absoluteURL);
+  });
+
+  it('should return the full URL when passed a relative URL that starts with /', () => {
+    const relativeURL = '/path/to/resource';
+    const result = getFullURL(relativeURL);
+    expect(result).toBe('http://localhost:3000/path/to/resource');
+  });
+
+  it('should return the full URL when passed a relative URL that does not start with /', () => {
+    const relativeURL = 'path/to/resource';
+    const result = getFullURL(relativeURL);
+    expect(result).toBe('http://localhost:3000/path/to/resource');
+  });
+});

--- a/optimize/client/src/modules/api.ts
+++ b/optimize/client/src/modules/api.ts
@@ -6,12 +6,10 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-export function getAbsoluteURL(url: string) {
-  try {
-    const absoluteURL = new URL(url);
-    return absoluteURL.toString();
-  } catch {
-    const baseURL = `${window.location.protocol}//${window.location.host}`;
-    return `${baseURL}/${url}`;
+export function getFullURL(url: string) {
+  if (typeof window.location.origin !== 'string') {
+    throw new Error('window.location.origin is not a set');
   }
+
+  return new URL(url, window.location.origin).toString();
 }

--- a/optimize/client/src/modules/api.ts
+++ b/optimize/client/src/modules/api.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+export function getAbsoluteURL(url: string) {
+  try {
+    const absoluteURL = new URL(url);
+    return absoluteURL.toString();
+  } catch {
+    const baseURL = `${window.location.protocol}//${window.location.host}`;
+    return `${baseURL}/${url}`;
+  }
+}

--- a/optimize/client/src/modules/components/Breadcrumbs/service.ts
+++ b/optimize/client/src/modules/components/Breadcrumbs/service.ts
@@ -7,6 +7,7 @@
  */
 
 import {get} from 'request';
+import {getAbsoluteURL} from '../../../modules/api';
 
 export type EntityNamesResponse = {
   reportName: string | null;
@@ -19,7 +20,7 @@ export async function loadEntitiesNames(entitiesIds: {
   dashboardId?: string | null;
   collectionId?: string | null;
 }): Promise<EntityNamesResponse> {
-  const res = await get('api/entities/names', entitiesIds);
+  const res = await get(getAbsoluteURL('api/entities/names'), entitiesIds);
 
   return await res.json();
 }

--- a/optimize/client/src/modules/components/Breadcrumbs/service.ts
+++ b/optimize/client/src/modules/components/Breadcrumbs/service.ts
@@ -7,7 +7,7 @@
  */
 
 import {get} from 'request';
-import {getAbsoluteURL} from '../../../modules/api';
+import {getFullURL} from '../../../modules/api';
 
 export type EntityNamesResponse = {
   reportName: string | null;
@@ -20,7 +20,7 @@ export async function loadEntitiesNames(entitiesIds: {
   dashboardId?: string | null;
   collectionId?: string | null;
 }): Promise<EntityNamesResponse> {
-  const res = await get(getAbsoluteURL('api/entities/names'), entitiesIds);
+  const res = await get(getFullURL('api/entities/names'), entitiesIds);
 
   return await res.json();
 }

--- a/optimize/client/src/modules/components/DefinitionSelection/service.ts
+++ b/optimize/client/src/modules/components/DefinitionSelection/service.ts
@@ -8,6 +8,7 @@
 
 import {Tenant} from 'types';
 import {get, post} from 'request';
+import { getAbsoluteURL } from '../../api';
 
 export type Version = {
   version: string;
@@ -32,7 +33,7 @@ export async function loadVersions(
     params.filterByCollectionScope = collectionId;
   }
 
-  const response = await get(`api/definition/${type}/${key}/versions`, params);
+  const response = await get(getAbsoluteURL(`api/definition/${type}/${key}/versions`), params);
 
   return response.json();
 }
@@ -49,7 +50,7 @@ export async function loadTenants(
     payload.filterByCollectionScope = collectionId;
   }
 
-  const response = await post(`api/definition/${type}/_resolveTenantsForVersions`, payload);
+  const response = await post(getAbsoluteURL(`api/definition/${type}/_resolveTenantsForVersions`), payload);
 
   return response.json();
 }

--- a/optimize/client/src/modules/components/DefinitionSelection/service.ts
+++ b/optimize/client/src/modules/components/DefinitionSelection/service.ts
@@ -8,7 +8,7 @@
 
 import {Tenant} from 'types';
 import {get, post} from 'request';
-import { getAbsoluteURL } from '../../api';
+import { getFullURL } from '../../api';
 
 export type Version = {
   version: string;
@@ -33,7 +33,7 @@ export async function loadVersions(
     params.filterByCollectionScope = collectionId;
   }
 
-  const response = await get(getAbsoluteURL(`api/definition/${type}/${key}/versions`), params);
+  const response = await get(getFullURL(`api/definition/${type}/${key}/versions`), params);
 
   return response.json();
 }
@@ -50,7 +50,7 @@ export async function loadTenants(
     payload.filterByCollectionScope = collectionId;
   }
 
-  const response = await post(getAbsoluteURL(`api/definition/${type}/_resolveTenantsForVersions`), payload);
+  const response = await post(getFullURL(`api/definition/${type}/_resolveTenantsForVersions`), payload);
 
   return response.json();
 }

--- a/optimize/client/src/modules/components/ReportDetails/service.js
+++ b/optimize/client/src/modules/components/ReportDetails/service.js
@@ -7,10 +7,11 @@
  */
 
 import {post} from 'request';
+import { getAbsoluteURL } from '../../api';
 
 export async function loadTenants(definitions) {
   const params = {definitions};
-  const response = await post(`api/definition/process/_resolveTenantsForVersions`, params);
+  const response = await post(getAbsoluteURL(`api/definition/process/_resolveTenantsForVersions`), params);
 
   return await response.json();
 }

--- a/optimize/client/src/modules/components/ReportDetails/service.js
+++ b/optimize/client/src/modules/components/ReportDetails/service.js
@@ -7,11 +7,11 @@
  */
 
 import {post} from 'request';
-import { getAbsoluteURL } from '../../api';
+import { getFullURL } from '../../api';
 
 export async function loadTenants(definitions) {
   const params = {definitions};
-  const response = await post(getAbsoluteURL(`api/definition/process/_resolveTenantsForVersions`), params);
+  const response = await post(getFullURL(`api/definition/process/_resolveTenantsForVersions`), params);
 
   return await response.json();
 }

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Table/service.ts
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Table/service.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { getAbsoluteURL } from '../../../../api';
+import { getFullURL } from '../../../../api';
 import {post} from 'request';
 
 export async function loadObjectValues(
@@ -16,7 +16,7 @@ export async function loadObjectValues(
   processDefinitionVersions: string[],
   tenantIds: (string | null)[]
 ): Promise<string> {
-  const response = await post(getAbsoluteURL(`api/variables/values`), {
+  const response = await post(getFullURL(`api/variables/values`), {
     name,
     processInstanceId,
     processDefinitionKey,

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Table/service.ts
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Table/service.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { getAbsoluteURL } from 'modules/api';
+import { getAbsoluteURL } from '../../../../api';
 import {post} from 'request';
 
 export async function loadObjectValues(

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Table/service.ts
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Table/service.ts
@@ -6,6 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import { getAbsoluteURL } from 'modules/api';
 import {post} from 'request';
 
 export async function loadObjectValues(
@@ -15,7 +16,7 @@ export async function loadObjectValues(
   processDefinitionVersions: string[],
   tenantIds: (string | null)[]
 ): Promise<string> {
-  const response = await post(`api/variables/values`, {
+  const response = await post(getAbsoluteURL(`api/variables/values`), {
     name,
     processInstanceId,
     processDefinitionKey,

--- a/optimize/client/src/modules/components/UserTypeahead/service.test.tsx
+++ b/optimize/client/src/modules/components/UserTypeahead/service.test.tsx
@@ -30,7 +30,7 @@ describe('UserTypeahead service', () => {
 
       const result = await searchIdentities('John', false);
 
-      expect(get).toHaveBeenCalledWith('api/identity/search', {
+      expect(get).toHaveBeenCalledWith('http://localhost/api/identity/search', {
         terms: 'John',
         excludeUserGroups: false,
       });
@@ -45,7 +45,7 @@ describe('UserTypeahead service', () => {
 
       const result = await getUser('1');
 
-      expect(get).toHaveBeenCalledWith('api/identity/1');
+      expect(get).toHaveBeenCalledWith('http://localhost/api/identity/1');
       expect(result).toEqual({id: '1', name: 'John Doe'});
     });
   });

--- a/optimize/client/src/modules/components/UserTypeahead/service.tsx
+++ b/optimize/client/src/modules/components/UserTypeahead/service.tsx
@@ -8,6 +8,7 @@
 
 import {get} from 'request';
 import {formatters} from 'services';
+import { getAbsoluteURL } from '../../api';
 
 export interface Identity {
   id: string | null;
@@ -33,12 +34,12 @@ export async function searchIdentities(
   terms: string,
   excludeUserGroups: boolean
 ): Promise<{total: number; result: Identity[]}> {
-  const response = await get('api/identity/search', {terms, excludeUserGroups});
+  const response = await get(getAbsoluteURL('api/identity/search'), {terms, excludeUserGroups});
   return await response.json();
 }
 
 export async function getUser(id: string): Promise<Identity> {
-  const response = await get(`api/identity/${id}`);
+  const response = await get(getAbsoluteURL(`api/identity/${id}`));
   return await response.json();
 }
 

--- a/optimize/client/src/modules/components/UserTypeahead/service.tsx
+++ b/optimize/client/src/modules/components/UserTypeahead/service.tsx
@@ -8,7 +8,7 @@
 
 import {get} from 'request';
 import {formatters} from 'services';
-import { getAbsoluteURL } from '../../api';
+import { getFullURL } from '../../api';
 
 export interface Identity {
   id: string | null;
@@ -34,12 +34,12 @@ export async function searchIdentities(
   terms: string,
   excludeUserGroups: boolean
 ): Promise<{total: number; result: Identity[]}> {
-  const response = await get(getAbsoluteURL('api/identity/search'), {terms, excludeUserGroups});
+  const response = await get(getFullURL('api/identity/search'), {terms, excludeUserGroups});
   return await response.json();
 }
 
 export async function getUser(id: string): Promise<Identity> {
-  const response = await get(getAbsoluteURL(`api/identity/${id}`));
+  const response = await get(getFullURL(`api/identity/${id}`));
   return await response.json();
 }
 

--- a/optimize/client/src/modules/config.tsx
+++ b/optimize/client/src/modules/config.tsx
@@ -8,6 +8,7 @@
 
 import {ReactNode, createContext, useEffect, useState} from 'react';
 import {Loading} from '@carbon/react';
+import { getAbsoluteURL } from './api';
 
 import {get, ErrorResponse} from 'request';
 import {showError} from 'notifications';
@@ -81,7 +82,7 @@ export function ConfigProvider({children}: {children: ReactNode}): JSX.Element {
 
   const loadConfig = async () => {
     try {
-      const response = await get('api/ui-configuration');
+      const response = await get(getAbsoluteURL('api/ui-configuration'));
       const config = await response.json();
 
       setConfig(config);

--- a/optimize/client/src/modules/config.tsx
+++ b/optimize/client/src/modules/config.tsx
@@ -8,7 +8,7 @@
 
 import {ReactNode, createContext, useEffect, useState} from 'react';
 import {Loading} from '@carbon/react';
-import { getAbsoluteURL } from './api';
+import { getFullURL } from './api';
 
 import {get, ErrorResponse} from 'request';
 import {showError} from 'notifications';
@@ -82,7 +82,7 @@ export function ConfigProvider({children}: {children: ReactNode}): JSX.Element {
 
   const loadConfig = async () => {
     try {
-      const response = await get(getAbsoluteURL('api/ui-configuration'));
+      const response = await get(getFullURL('api/ui-configuration'));
       const config = await response.json();
 
       setConfig(config);

--- a/optimize/client/src/modules/filter/modals/assignee/service.ts
+++ b/optimize/client/src/modules/filter/modals/assignee/service.ts
@@ -9,7 +9,7 @@
 import {User} from 'components';
 import {post, get} from 'request';
 import {Definition} from 'types';
-import { getAbsoluteURL } from '../../../api';
+import { getFullURL } from '../../../api';
 
 export async function loadUsersByDefinition(
   type: string,
@@ -19,7 +19,7 @@ export async function loadUsersByDefinition(
     terms: string;
   }
 ) {
-  const response = await post(getAbsoluteURL(`api/${type}/search`), payload);
+  const response = await post(getFullURL(`api/${type}/search`), payload);
 
   return await response.json();
 }
@@ -31,13 +31,13 @@ export async function loadUsersByReportIds(
     terms: string;
   }
 ) {
-  const response = await post(getAbsoluteURL(`api/${type}/search/reports`), payload);
+  const response = await post(getFullURL(`api/${type}/search/reports`), payload);
 
   return await response.json();
 }
 
 export async function getUsersById(type: string, ids: (string | null)[]): Promise<User[]> {
-  const response = await get(getAbsoluteURL(`api/${type}`), {idIn: ids.join(',')});
+  const response = await get(getFullURL(`api/${type}`), {idIn: ids.join(',')});
 
   return await response.json();
 }

--- a/optimize/client/src/modules/filter/modals/assignee/service.ts
+++ b/optimize/client/src/modules/filter/modals/assignee/service.ts
@@ -9,6 +9,7 @@
 import {User} from 'components';
 import {post, get} from 'request';
 import {Definition} from 'types';
+import { getAbsoluteURL } from '../../../api';
 
 export async function loadUsersByDefinition(
   type: string,
@@ -18,7 +19,7 @@ export async function loadUsersByDefinition(
     terms: string;
   }
 ) {
-  const response = await post(`api/${type}/search`, payload);
+  const response = await post(getAbsoluteURL(`api/${type}/search`), payload);
 
   return await response.json();
 }
@@ -30,13 +31,13 @@ export async function loadUsersByReportIds(
     terms: string;
   }
 ) {
-  const response = await post(`api/${type}/search/reports`, payload);
+  const response = await post(getAbsoluteURL(`api/${type}/search/reports`), payload);
 
   return await response.json();
 }
 
 export async function getUsersById(type: string, ids: (string | null)[]): Promise<User[]> {
-  const response = await get(`api/${type}`, {idIn: ids.join(',')});
+  const response = await get(getAbsoluteURL(`api/${type}`), {idIn: ids.join(',')});
 
   return await response.json();
 }

--- a/optimize/client/src/modules/filter/service.js
+++ b/optimize/client/src/modules/filter/service.js
@@ -8,6 +8,7 @@
 
 import {post, get} from 'request';
 import equal from 'fast-deep-equal';
+import { getAbsoluteURL } from '../api';
 
 export async function loadValues(
   processDefinitionKey,
@@ -19,7 +20,7 @@ export async function loadValues(
   numResults,
   valueFilter
 ) {
-  const response = await post(`api/variables/values`, {
+  const response = await post(getAbsoluteURL(`api/variables/values`), {
     processDefinitionKey,
     processDefinitionVersions,
     tenantIds,
@@ -64,7 +65,7 @@ export function filterSameTypeExistingFilters(filters, newFilter) {
 }
 
 export async function loadUserNames(type, ids) {
-  const response = await get(`api/${type}`, {idIn: ids.join(',')});
+  const response = await get(getAbsoluteURL(`api/${type}`), {idIn: ids.join(',')});
 
   return await response.json();
 }

--- a/optimize/client/src/modules/filter/service.js
+++ b/optimize/client/src/modules/filter/service.js
@@ -8,7 +8,7 @@
 
 import {post, get} from 'request';
 import equal from 'fast-deep-equal';
-import { getAbsoluteURL } from '../api';
+import { getFullURL } from '../api';
 
 export async function loadValues(
   processDefinitionKey,
@@ -20,7 +20,7 @@ export async function loadValues(
   numResults,
   valueFilter
 ) {
-  const response = await post(getAbsoluteURL(`api/variables/values`), {
+  const response = await post(getFullURL(`api/variables/values`), {
     processDefinitionKey,
     processDefinitionVersions,
     tenantIds,
@@ -65,7 +65,7 @@ export function filterSameTypeExistingFilters(filters, newFilter) {
 }
 
 export async function loadUserNames(type, ids) {
-  const response = await get(getAbsoluteURL(`api/${type}`), {idIn: ids.join(',')});
+  const response = await get(getFullURL(`api/${type}`), {idIn: ids.join(',')});
 
   return await response.json();
 }

--- a/optimize/client/src/modules/services/alertService.js
+++ b/optimize/client/src/modules/services/alertService.js
@@ -8,27 +8,28 @@
 
 import {del, get, post, put} from 'request';
 import {track} from 'tracking';
+import { getAbsoluteURL } from '../api';
 
 export async function loadAlerts(collection) {
-  const response = await get(`api/collection/${collection}/alerts`);
+  const response = await get(getAbsoluteURL(`api/collection/${collection}/alerts`));
   return await response.json();
 }
 
 export async function addAlert(alert) {
-  const response = await post(`api/alert`, alert);
+  const response = await post(getAbsoluteURL(`api/alert`), alert);
   const json = await response.json();
   track('createAlert', {entityId: json.id});
   return response;
 }
 
 export async function editAlert(id, alert) {
-  const response = await put(`api/alert/${id}`, alert);
+  const response = await put(getAbsoluteURL(`api/alert/${id}`), alert);
   track('updateAlert', {entityId: id});
   return response;
 }
 
 export async function removeAlert(id) {
-  const response = await del(`api/alert/${id}`);
+  const response = await del(getAbsoluteURL(`api/alert/${id}`));
   track('deleteAlert', {entityId: id});
   return response;
 }

--- a/optimize/client/src/modules/services/alertService.js
+++ b/optimize/client/src/modules/services/alertService.js
@@ -8,28 +8,28 @@
 
 import {del, get, post, put} from 'request';
 import {track} from 'tracking';
-import { getAbsoluteURL } from '../api';
+import { getFullURL } from '../api';
 
 export async function loadAlerts(collection) {
-  const response = await get(getAbsoluteURL(`api/collection/${collection}/alerts`));
+  const response = await get(getFullURL(`api/collection/${collection}/alerts`));
   return await response.json();
 }
 
 export async function addAlert(alert) {
-  const response = await post(getAbsoluteURL(`api/alert`), alert);
+  const response = await post(getFullURL(`api/alert`), alert);
   const json = await response.json();
   track('createAlert', {entityId: json.id});
   return response;
 }
 
 export async function editAlert(id, alert) {
-  const response = await put(getAbsoluteURL(`api/alert/${id}`), alert);
+  const response = await put(getFullURL(`api/alert/${id}`), alert);
   track('updateAlert', {entityId: id});
   return response;
 }
 
 export async function removeAlert(id) {
-  const response = await del(getAbsoluteURL(`api/alert/${id}`));
+  const response = await del(getFullURL(`api/alert/${id}`));
   track('deleteAlert', {entityId: id});
   return response;
 }

--- a/optimize/client/src/modules/services/collectionService.ts
+++ b/optimize/client/src/modules/services/collectionService.ts
@@ -8,10 +8,10 @@
 
 import {Source} from 'types';
 import {put} from 'request';
-import { getAbsoluteURL } from '../api';
+import { getFullURL } from '../api';
 
 export async function addSources(collectionId: string, sources: Source[]) {
-  return await put(getAbsoluteURL(`api/collection/${collectionId}/scope`), sources);
+  return await put(getFullURL(`api/collection/${collectionId}/scope`), sources);
 }
 
 export function getCollection(path: string) {

--- a/optimize/client/src/modules/services/collectionService.ts
+++ b/optimize/client/src/modules/services/collectionService.ts
@@ -8,7 +8,7 @@
 
 import {Source} from 'types';
 import {put} from 'request';
-import { getAbsoluteURL } from 'modules/api';
+import { getAbsoluteURL } from '../modules/api';
 
 export async function addSources(collectionId: string, sources: Source[]) {
   return await put(getAbsoluteURL(`api/collection/${collectionId}/scope`), sources);

--- a/optimize/client/src/modules/services/collectionService.ts
+++ b/optimize/client/src/modules/services/collectionService.ts
@@ -8,9 +8,10 @@
 
 import {Source} from 'types';
 import {put} from 'request';
+import { getAbsoluteURL } from 'modules/api';
 
 export async function addSources(collectionId: string, sources: Source[]) {
-  return await put(`api/collection/${collectionId}/scope`, sources);
+  return await put(getAbsoluteURL(`api/collection/${collectionId}/scope`), sources);
 }
 
 export function getCollection(path: string) {

--- a/optimize/client/src/modules/services/collectionService.ts
+++ b/optimize/client/src/modules/services/collectionService.ts
@@ -8,7 +8,7 @@
 
 import {Source} from 'types';
 import {put} from 'request';
-import { getAbsoluteURL } from '../modules/api';
+import { getAbsoluteURL } from '../api';
 
 export async function addSources(collectionId: string, sources: Source[]) {
   return await put(getAbsoluteURL(`api/collection/${collectionId}/scope`), sources);

--- a/optimize/client/src/modules/services/dataLoaders.js
+++ b/optimize/client/src/modules/services/dataLoaders.js
@@ -7,6 +7,7 @@
  */
 
 import {get, post} from 'request';
+import { getAbsoluteURL } from '../api.ts';
 
 export {loadProcessDefinitionXml, loadVariables} from './dataLoaders.ts';
 
@@ -21,7 +22,7 @@ export async function getFlowNodeNames(processDefinitionKey, processDefinitionVe
       payload.tenantId = tenantId;
     }
 
-    const response = await post(`api/flow-node/flowNodeNames`, payload);
+    const response = await post(getAbsoluteURL(`api/flow-node/flowNodeNames`), payload);
 
     const json = await response.json();
 
@@ -32,6 +33,6 @@ export async function getFlowNodeNames(processDefinitionKey, processDefinitionVe
 }
 
 export async function checkDeleteConflict(id, entity) {
-  const response = await get(`api/${entity}/${id}/delete-conflicts`);
+  const response = await get(getAbsoluteURL(`api/${entity}/${id}/delete-conflicts`));
   return await response.json();
 }

--- a/optimize/client/src/modules/services/dataLoaders.js
+++ b/optimize/client/src/modules/services/dataLoaders.js
@@ -7,7 +7,7 @@
  */
 
 import {get, post} from 'request';
-import { getAbsoluteURL } from '../api.ts';
+import { getFullURL } from '../api.ts';
 
 export {loadProcessDefinitionXml, loadVariables} from './dataLoaders.ts';
 
@@ -22,7 +22,7 @@ export async function getFlowNodeNames(processDefinitionKey, processDefinitionVe
       payload.tenantId = tenantId;
     }
 
-    const response = await post(getAbsoluteURL(`api/flow-node/flowNodeNames`), payload);
+    const response = await post(getFullURL(`api/flow-node/flowNodeNames`), payload);
 
     const json = await response.json();
 
@@ -33,6 +33,6 @@ export async function getFlowNodeNames(processDefinitionKey, processDefinitionVe
 }
 
 export async function checkDeleteConflict(id, entity) {
-  const response = await get(getAbsoluteURL(`api/${entity}/${id}/delete-conflicts`));
+  const response = await get(getFullURL(`api/${entity}/${id}/delete-conflicts`));
   return await response.json();
 }

--- a/optimize/client/src/modules/services/dataLoaders.ts
+++ b/optimize/client/src/modules/services/dataLoaders.ts
@@ -8,7 +8,7 @@
 
 import {ProcessFilter, Variable} from 'types';
 import {get, post} from 'request';
-import { getAbsoluteURL } from '../api';
+import { getFullURL } from '../api';
 
 export async function loadProcessDefinitionXml(
   key?: string,
@@ -21,7 +21,7 @@ export async function loadProcessDefinitionXml(
   }
 
   try {
-    const response = await get(getAbsoluteURL('api/definition/process/xml'), payload);
+    const response = await get(getFullURL('api/definition/process/xml'), payload);
 
     return await response.text();
   } catch (_e) {
@@ -41,7 +41,7 @@ type LoadVariablesPayload = {
 };
 
 export const loadVariables = async (payload: LoadVariablesPayload) => {
-  const response = await post(getAbsoluteURL('api/variables'), payload);
+  const response = await post(getFullURL('api/variables'), payload);
 
   return (await response.json()) as Variable[];
 };

--- a/optimize/client/src/modules/services/dataLoaders.ts
+++ b/optimize/client/src/modules/services/dataLoaders.ts
@@ -8,6 +8,7 @@
 
 import {ProcessFilter, Variable} from 'types';
 import {get, post} from 'request';
+import { getAbsoluteURL } from '../api';
 
 export async function loadProcessDefinitionXml(
   key?: string,
@@ -20,7 +21,7 @@ export async function loadProcessDefinitionXml(
   }
 
   try {
-    const response = await get('api/definition/process/xml', payload);
+    const response = await get(getAbsoluteURL('api/definition/process/xml'), payload);
 
     return await response.text();
   } catch (_e) {
@@ -40,7 +41,7 @@ type LoadVariablesPayload = {
 };
 
 export const loadVariables = async (payload: LoadVariablesPayload) => {
-  const response = await post('api/variables', payload);
+  const response = await post(getAbsoluteURL('api/variables'), payload);
 
   return (await response.json()) as Variable[];
 };

--- a/optimize/client/src/modules/services/entityService.js
+++ b/optimize/client/src/modules/services/entityService.js
@@ -10,10 +10,10 @@ import {get, post, put} from 'request';
 import {track} from 'tracking';
 import {createEventName} from './entityService.tsx';
 export {deleteEntity} from './entityService.tsx';
-import { getAbsoluteURL } from '../api.ts';
+import { getFullURL } from '../api.ts';
 
 export async function loadEntity(type, id, query) {
-  const response = await get(getAbsoluteURL(`api/${type}/` + id), query);
+  const response = await get(getFullURL(`api/${type}/` + id), query);
   const json = await response.json();
   track(createEventName('view', type), {
     entityId: id,
@@ -23,21 +23,21 @@ export async function loadEntity(type, id, query) {
 }
 
 export async function copyReport(id) {
-  const response = await post(getAbsoluteURL(`api/report/${id}/copy`));
+  const response = await post(getFullURL(`api/report/${id}/copy`));
   const json = await response.json();
   return json.id;
 }
 
 export async function updateEntity(type, id, data, options = {}) {
-  const response = await put(getAbsoluteURL(`api/${type}/${id}`), data, options);
+  const response = await put(getFullURL(`api/${type}/${id}`), data, options);
   track(createEventName('update', type), {entityId: id});
   return response;
 }
 
 export async function loadReports(collection) {
-  let url = getAbsoluteURL('api/report');
+  let url = getFullURL('api/report');
   if (collection) {
-    url = getAbsoluteURL(`api/collection/${collection}/reports`);
+    url = getFullURL(`api/collection/${collection}/reports`);
   }
   const response = await get(url);
   return await response.json();

--- a/optimize/client/src/modules/services/entityService.js
+++ b/optimize/client/src/modules/services/entityService.js
@@ -8,12 +8,12 @@
 
 import {get, post, put} from 'request';
 import {track} from 'tracking';
-
 import {createEventName} from './entityService.tsx';
 export {deleteEntity} from './entityService.tsx';
+import { getAbsoluteURL } from '../api.ts';
 
 export async function loadEntity(type, id, query) {
-  const response = await get(`api/${type}/` + id, query);
+  const response = await get(getAbsoluteURL(`api/${type}/` + id), query);
   const json = await response.json();
   track(createEventName('view', type), {
     entityId: id,
@@ -23,21 +23,21 @@ export async function loadEntity(type, id, query) {
 }
 
 export async function copyReport(id) {
-  const response = await post(`api/report/${id}/copy`);
+  const response = await post(getAbsoluteURL(`api/report/${id}/copy`));
   const json = await response.json();
   return json.id;
 }
 
 export async function updateEntity(type, id, data, options = {}) {
-  const response = await put(`api/${type}/${id}`, data, options);
+  const response = await put(getAbsoluteURL(`api/${type}/${id}`), data, options);
   track(createEventName('update', type), {entityId: id});
   return response;
 }
 
 export async function loadReports(collection) {
-  let url = 'api/report';
+  let url = getAbsoluteURL('api/report');
   if (collection) {
-    url = `api/collection/${collection}/reports`;
+    url = getAbsoluteURL(`api/collection/${collection}/reports`);
   }
   const response = await get(url);
   return await response.json();

--- a/optimize/client/src/modules/services/entityService.tsx
+++ b/optimize/client/src/modules/services/entityService.tsx
@@ -11,11 +11,12 @@ import {ChartColumn, Dashboard, Folder} from '@carbon/icons-react';
 import {del, get, post} from 'request';
 import {EntityListEntity, GenericReport} from 'types';
 import {track} from 'tracking';
+import { getAbsoluteURL } from '../api';
 
 export async function loadReports(collection?: string | null): Promise<GenericReport[]> {
-  let url = 'api/report';
+  let url = getAbsoluteURL('api/report');
   if (collection) {
-    url = `api/collection/${collection}/reports`;
+    url = getAbsoluteURL(`api/collection/${collection}/reports`);
   }
   const response = await get(url);
   return await response.json();
@@ -31,12 +32,12 @@ export async function loadEntities(
     params.sortOrder = sortOrder;
   }
 
-  const response = await get('api/entities', params);
+  const response = await get(getAbsoluteURL('api/entities'), params);
   return await response.json();
 }
 
 export async function deleteEntity(type: string, id: string): Promise<Response> {
-  const response = await del(`api/${type}/${id}`, {force: true});
+  const response = await del(getAbsoluteURL(`api/${type}/${id}`), {force: true});
   track(createEventName('delete', type), {entityId: id});
   return response;
 }
@@ -66,7 +67,7 @@ export async function copyEntity(
     query.collectionId = collectionId;
   }
 
-  const response = await post(`api/${type}/${id}/copy`, undefined, {query});
+  const response = await post(getAbsoluteURL(`api/${type}/${id}/copy`), undefined, {query});
   const json = await response.json();
 
   return json.id as string;
@@ -77,7 +78,7 @@ export async function createEntity(
   initialValues = {},
   context?: string
 ): Promise<GenericReport> {
-  const response = await post('api/' + type, initialValues);
+  const response = await post(getAbsoluteURL('api/' + type), initialValues);
   const json = await response.json();
   track(createEventName('create', type), {entityId: json.id, context});
   return json.id;

--- a/optimize/client/src/modules/services/entityService.tsx
+++ b/optimize/client/src/modules/services/entityService.tsx
@@ -11,12 +11,12 @@ import {ChartColumn, Dashboard, Folder} from '@carbon/icons-react';
 import {del, get, post} from 'request';
 import {EntityListEntity, GenericReport} from 'types';
 import {track} from 'tracking';
-import { getAbsoluteURL } from '../api';
+import { getFullURL } from '../api';
 
 export async function loadReports(collection?: string | null): Promise<GenericReport[]> {
-  let url = getAbsoluteURL('api/report');
+  let url = getFullURL('api/report');
   if (collection) {
-    url = getAbsoluteURL(`api/collection/${collection}/reports`);
+    url = getFullURL(`api/collection/${collection}/reports`);
   }
   const response = await get(url);
   return await response.json();
@@ -32,12 +32,12 @@ export async function loadEntities(
     params.sortOrder = sortOrder;
   }
 
-  const response = await get(getAbsoluteURL('api/entities'), params);
+  const response = await get(getFullURL('api/entities'), params);
   return await response.json();
 }
 
 export async function deleteEntity(type: string, id: string): Promise<Response> {
-  const response = await del(getAbsoluteURL(`api/${type}/${id}`), {force: true});
+  const response = await del(getFullURL(`api/${type}/${id}`), {force: true});
   track(createEventName('delete', type), {entityId: id});
   return response;
 }
@@ -67,7 +67,7 @@ export async function copyEntity(
     query.collectionId = collectionId;
   }
 
-  const response = await post(getAbsoluteURL(`api/${type}/${id}/copy`), undefined, {query});
+  const response = await post(getFullURL(`api/${type}/${id}/copy`), undefined, {query});
   const json = await response.json();
 
   return json.id as string;
@@ -78,7 +78,7 @@ export async function createEntity(
   initialValues = {},
   context?: string
 ): Promise<GenericReport> {
-  const response = await post(getAbsoluteURL('api/' + type), initialValues);
+  const response = await post(getFullURL('api/' + type), initialValues);
   const json = await response.json();
   track(createEventName('create', type), {entityId: json.id, context});
   return json.id;

--- a/optimize/client/src/modules/services/loadDefinitions.ts
+++ b/optimize/client/src/modules/services/loadDefinitions.ts
@@ -7,6 +7,7 @@
  */
 
 import {get} from 'request';
+import { getAbsoluteURL } from '../api';
 
 export type Definition = {
   key: string;
@@ -23,7 +24,7 @@ export async function loadDefinitions(
     params.filterByCollectionScope = collectionId;
   }
 
-  const response = await get(`api/definition/${type}/keys`, params);
+  const response = await get(getAbsoluteURL(`api/definition/${type}/keys`), params);
 
   return response.json();
 }

--- a/optimize/client/src/modules/services/loadDefinitions.ts
+++ b/optimize/client/src/modules/services/loadDefinitions.ts
@@ -7,7 +7,7 @@
  */
 
 import {get} from 'request';
-import { getAbsoluteURL } from '../api';
+import { getFullURL } from '../api';
 
 export type Definition = {
   key: string;
@@ -24,7 +24,7 @@ export async function loadDefinitions(
     params.filterByCollectionScope = collectionId;
   }
 
-  const response = await get(getAbsoluteURL(`api/definition/${type}/keys`), params);
+  const response = await get(getFullURL(`api/definition/${type}/keys`), params);
 
   return response.json();
 }

--- a/optimize/client/src/modules/services/reportService.ts
+++ b/optimize/client/src/modules/services/reportService.ts
@@ -8,7 +8,7 @@
 
 import {post} from 'request';
 import {Report, ReportType} from 'types';
-import { getAbsoluteURL } from '../api';
+import { getFullURL } from '../api';
 
 interface ConfigParams {
   processDefinitionKey: string;
@@ -32,7 +32,7 @@ export function isTextTileTooLong(
 }
 
 export async function loadRawData(config: ConfigParams): Promise<Blob> {
-  const response = await post(getAbsoluteURL('api/export/csv/process/rawData/data'), config);
+  const response = await post(getFullURL('api/export/csv/process/rawData/data'), config);
 
   return await response.blob();
 }
@@ -54,12 +54,12 @@ export async function evaluateReport<T extends ReportType>(
 
   if (typeof payload !== 'object') {
     // evaluate saved report
-    response = await post(getAbsoluteURL(`api/report/${payload}/evaluate`), {filter}, {query});
+    response = await post(getFullURL(`api/report/${payload}/evaluate`), {filter}, {query});
   } else {
     // evaluate unsaved report
     // we dont want to send report result in payload to prevent exceedeing request size limit
     const {result: _result, ...evaluationPayload} = payload;
-    response = await post(getAbsoluteURL(`api/report/evaluate/`), evaluationPayload, {query});
+    response = await post(getFullURL(`api/report/evaluate/`), evaluationPayload, {query});
   }
 
   return await response.json();

--- a/optimize/client/src/modules/services/reportService.ts
+++ b/optimize/client/src/modules/services/reportService.ts
@@ -7,8 +7,8 @@
  */
 
 import {post} from 'request';
-
 import {Report, ReportType} from 'types';
+import { getAbsoluteURL } from '../api';
 
 interface ConfigParams {
   processDefinitionKey: string;
@@ -32,7 +32,7 @@ export function isTextTileTooLong(
 }
 
 export async function loadRawData(config: ConfigParams): Promise<Blob> {
-  const response = await post('api/export/csv/process/rawData/data', config);
+  const response = await post(getAbsoluteURL('api/export/csv/process/rawData/data'), config);
 
   return await response.blob();
 }
@@ -54,12 +54,12 @@ export async function evaluateReport<T extends ReportType>(
 
   if (typeof payload !== 'object') {
     // evaluate saved report
-    response = await post(`api/report/${payload}/evaluate`, {filter}, {query});
+    response = await post(getAbsoluteURL(`api/report/${payload}/evaluate`), {filter}, {query});
   } else {
     // evaluate unsaved report
     // we dont want to send report result in payload to prevent exceedeing request size limit
     const {result: _result, ...evaluationPayload} = payload;
-    response = await post(`api/report/evaluate/`, evaluationPayload, {query});
+    response = await post(getAbsoluteURL(`api/report/evaluate/`), evaluationPayload, {query});
   }
 
   return await response.json();

--- a/optimize/client/src/modules/translation/service.ts
+++ b/optimize/client/src/modules/translation/service.ts
@@ -7,9 +7,10 @@
  */
 
 import {get} from 'request';
+import { getAbsoluteURL } from '../api';
 
 export async function loadTranslation(version: string, localeCode: string) {
-  const response = await get(`api/localization`, {
+  const response = await get(getAbsoluteURL(`api/localization`), {
     version,
     localeCode,
   });

--- a/optimize/client/src/modules/translation/service.ts
+++ b/optimize/client/src/modules/translation/service.ts
@@ -7,10 +7,10 @@
  */
 
 import {get} from 'request';
-import { getAbsoluteURL } from '../api';
+import { getFullURL } from '../api';
 
 export async function loadTranslation(version: string, localeCode: string) {
-  const response = await get(getAbsoluteURL(`api/localization`), {
+  const response = await get(getFullURL(`api/localization`), {
     version,
     localeCode,
   });


### PR DESCRIPTION
## Description

As the single application will introduce the `/optimize` context path, we need to make sure that the calls to the API are done against the server hostname without such context path. This is doable by calling the API URIs with an absolute URL, instead of appending a relative URL to the current path.

For more context:
https://github.com/camunda/camunda/issues/22347

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Part of:
* https://github.com/camunda/camunda/issues/22347
* https://github.com/camunda/product-hub/issues/2289
