### PR TITLE
refactor: identity client changes for tenant ui

### DIFF
--- a/identity/client/src/pages/tenants/List.tsx
+++ b/identity/client/src/pages/tenants/List.tsx
@@ -88,14 +88,14 @@ const List: FC = () => {
             label: t("Rename"),
             icon: Edit,
             onClick: (tenant) =>
-              editTenant({ tenantKey: tenant.tenantKey, name: tenant.name }),
+              editTenant({ tenantId: tenant.tenantId, name: tenant.name }),
           },
           {
             label: t("Delete"),
             icon: TrashCan,
             isDangerous: true,
             onClick: (tenant) =>
-              deleteTenant({ tenantKey: tenant.tenantKey, name: tenant.name }),
+              deleteTenant({ tenantId: tenant.tenantId, name: tenant.name }),
           },
         ]}
       />

--- a/identity/client/src/pages/tenants/modals/DeleteModal.tsx
+++ b/identity/client/src/pages/tenants/modals/DeleteModal.tsx
@@ -18,14 +18,14 @@ const DeleteTenantModal: FC<UseEntityModalProps<DeleteTenantParams>> = ({
   open,
   onClose,
   onSuccess,
-  entity: { tenantKey, name },
+  entity: { tenantId, name },
 }) => {
   const { t } = useTranslate();
   const { enqueueNotification } = useNotifications();
   const [apiCall, { loading }] = useApiCall(deleteTenant);
 
   const handleSubmit = async () => {
-    const { success } = await apiCall({ tenantKey });
+    const { success } = await apiCall({ tenantId });
 
     if (success) {
       enqueueNotification({

--- a/identity/client/src/pages/tenants/modals/EditModal.tsx
+++ b/identity/client/src/pages/tenants/modals/EditModal.tsx
@@ -17,7 +17,7 @@ const EditTenantModal: FC<UseEntityModalProps<UpdateTenantParams>> = ({
   open,
   onClose,
   onSuccess,
-  entity: { tenantKey, name: currentName },
+  entity: { tenantId, name: currentName },
 }) => {
   const { t } = useTranslate();
   const { enqueueNotification } = useNotifications();
@@ -26,7 +26,7 @@ const EditTenantModal: FC<UseEntityModalProps<UpdateTenantParams>> = ({
 
   const handleSubmit = async () => {
     const { success } = await apiCall({
-      tenantKey,
+      tenantId,
       name,
     });
 

--- a/identity/client/src/utility/api/tenants/index.ts
+++ b/identity/client/src/utility/api/tenants/index.ts
@@ -41,17 +41,17 @@ export const createTenant: ApiDefinition<undefined, CreateTenantParams> = (
 ) => apiPost(TENANTS_ENDPOINT, tenant);
 
 export type UpdateTenantParams = {
-  tenantKey: string;
+  tenantId: string;
   name: string;
 };
 
 export type DeleteTenantParams = UpdateTenantParams;
 
 export const updateTenant: ApiDefinition<undefined, UpdateTenantParams> = ({
-  tenantKey,
+  tenantId,
   name,
-}) => apiPatch(`${TENANTS_ENDPOINT}/${tenantKey}`, { name });
+}) => apiPatch(`${TENANTS_ENDPOINT}/${tenantId}`, { name });
 
-export const deleteTenant: ApiDefinition<undefined, { tenantKey: string }> = ({
-  tenantKey,
-}) => apiDelete(`${TENANTS_ENDPOINT}/${tenantKey}`);
+export const deleteTenant: ApiDefinition<undefined, { tenantId: string }> = ({
+  tenantId,
+}) => apiDelete(`${TENANTS_ENDPOINT}/${tenantId}`);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR achieves three aims:
1. Refactor the tenants ui to use the tenant id instead of key
2. Add the edit option to the tenant details to match the user details page
3. Add the delete option to the tenant details page to match the user details page

## Related issues

closes #27167
closes #27168
