### PR TITLE
feat: move spring datasource properties to camunda.database

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -37,6 +37,7 @@ import org.mybatis.spring.SqlSessionFactoryBean;
 import org.mybatis.spring.mapper.MapperFactoryBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -48,7 +49,12 @@ public class MyBatisConfiguration {
   private static final Logger LOGGER = LoggerFactory.getLogger(MyBatisConfiguration.class);
 
   @Bean
-  public MultiTenantSpringLiquibase customerLiquibase(final DataSource dataSource) {
+  @ConditionalOnProperty(
+      prefix = "camunda.database",
+      name = "auto-ddl",
+      havingValue = "true",
+      matchIfMissing = true)
+  public MultiTenantSpringLiquibase rdbmsExporterLiquibase(final DataSource dataSource) {
     LOGGER.info("Initializing Liquibase for RDBMS.");
     final var moduleConfig = new MultiTenantSpringLiquibase();
     moduleConfig.setDataSource(dataSource);

--- a/dist/src/main/resources/application-rdbmsH2.yaml
+++ b/dist/src/main/resources/application-rdbmsH2.yaml
@@ -97,6 +97,9 @@ camunda:
     # Controls which database must be used, possible values: elasticsearch, opensearch
     # This setting can also be overridden using the environment variable CAMUNDA_DATABASE_TYPE
     type: rdbms
+    url: jdbc:h2:mem:camunda
+    username: sa
+    password:
   # Operate configuration properties
   operate:
     # Set operate username and password.
@@ -151,13 +154,3 @@ logging:
   level:
     io:
       camunda: DEBUG
-
-spring:
-  datasource:
-    driverClassName: org.h2.Driver
-    url: jdbc:h2:mem:camunda
-    username: sa
-    password:
-
-mybatis:
-  mapper-locations: classpath:mapper/**/*-mapper.xml

--- a/dist/src/main/resources/application-rdbmsMariaDB.yaml
+++ b/dist/src/main/resources/application-rdbmsMariaDB.yaml
@@ -95,6 +95,9 @@ camunda:
     # Controls which database must be used, possible values: elasticsearch, opensearch
     # This setting can also be overridden using the environment variable CAMUNDA_DATABASE_TYPE
     type: rdbms
+    url: jdbc:mariadb://localhost:3306/camunda
+    username: camunda
+    password: demo
   # Operate configuration properties
   operate:
     # Set operate username and password.
@@ -149,17 +152,3 @@ logging:
   level:
     io:
       camunda: DEBUG
-
-spring:
-  datasource:
-    url: jdbc:mariadb://localhost:3306/camunda
-    username: camunda
-    password: demo
-    #driverClassName: org.h2.Driver
-  #  url: jdbc:h2:file:./camunda;AUTO_SERVER=TRUE;MODE=PostgreSQL
-  #  username: sa
-  #  password:
-  #  driverClassName: org.h2.Driver
-
-mybatis:
-  mapper-locations: classpath:mapper/**/*-mapper.xml

--- a/dist/src/main/resources/application-rdbmsOracle.yaml
+++ b/dist/src/main/resources/application-rdbmsOracle.yaml
@@ -95,6 +95,9 @@ camunda:
     # Controls which database must be used, possible values: elasticsearch, opensearch
     # This setting can also be overridden using the environment variable CAMUNDA_DATABASE_TYPE
     type: rdbms
+    url: jdbc:oracle:thin:@localhost:1521/FREEPDB1
+    username: camunda
+    password: demo
   # Operate configuration properties
   operate:
     # Set operate username and password.
@@ -149,17 +152,3 @@ logging:
   level:
     io:
       camunda: DEBUG
-
-spring:
-  datasource:
-    url: jdbc:oracle:thin:@localhost:1521/FREEPDB1
-    username: camunda
-    password: demo
-    #driverClassName: org.h2.Driver
-  #  url: jdbc:h2:file:./camunda;AUTO_SERVER=TRUE;MODE=PostgreSQL
-  #  username: sa
-  #  password:
-  #  driverClassName: org.h2.Driver
-
-mybatis:
-  mapper-locations: classpath:mapper/**/*-mapper.xml

--- a/dist/src/main/resources/application-rdbmsPostgres.yaml
+++ b/dist/src/main/resources/application-rdbmsPostgres.yaml
@@ -98,6 +98,9 @@ camunda:
     # Controls which database must be used, possible values: elasticsearch, opensearch
     # This setting can also be overridden using the environment variable CAMUNDA_DATABASE_TYPE
     type: rdbms
+    url: jdbc:postgresql:camunda
+    username: camunda
+    password: demo
   # Operate configuration properties
   operate:
     # Set operate username and password.
@@ -152,17 +155,3 @@ logging:
   level:
     io:
       camunda: DEBUG
-
-spring:
-  datasource:
-    url: jdbc:postgresql:camunda
-    username: camunda
-    password: demo
-    #driverClassName: org.h2.Driver
-  #  url: jdbc:h2:file:./camunda;AUTO_SERVER=TRUE;MODE=PostgreSQL
-  #  username: sa
-  #  password:
-  #  driverClassName: org.h2.Driver
-
-mybatis:
-  mapper-locations: classpath:mapper/**/*-mapper.xml

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -60,12 +60,20 @@ camunda.security.initialization.users[0].username=demo
 camunda.security.initialization.users[0].password=demo
 camunda.security.initialization.users[0].name=Demo
 camunda.security.initialization.users[0].email=demo@demo.com
-spring.jpa.generate-ddl=false
-spring.jpa.hibernate.ddl-auto=validate
 
 # Multipart file uploads
 spring.servlet.multipart.max-file-size=4MB
 spring.servlet.multipart.max-request-size=4MB
 
-# disable global Liquibase setup to only opt-in to module-specific liquibase schemas
+#
+# RDBMS extension default properties
+#
+spring.jpa.generate-ddl=false
+spring.jpa.hibernate.ddl-auto=validate
 spring.liquibase.enabled=false
+
+# forward spring datasource properties
+spring.datasource.url=${camunda.database.url:}
+spring.datasource.username=${camunda.database.username:}
+spring.datasource.password=${camunda.database.password:}
+mybatis.mapper-locations: classpath:mapper/**/*-mapper.xml

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
@@ -45,10 +45,9 @@ public final class CamundaRdbmsTestApplication
 
   public CamundaRdbmsTestApplication withH2() {
     super.withProperty(
-            "spring.datasource.url", "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL")
-        .withProperty("spring.datasource.driver-class-name", "org.h2.Driver")
-        .withProperty("spring.datasource.username", "sa")
-        .withProperty("spring.datasource.password", "");
+            "camunda.database.url", "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL")
+        .withProperty("camunda.database.username", "sa")
+        .withProperty("camunda.database.password", "");
     return this;
   }
 
@@ -59,9 +58,9 @@ public final class CamundaRdbmsTestApplication
       databaseContainer.start();
 
       if (databaseContainer instanceof final JdbcDatabaseContainer<?> jdbcDatabaseContainer) {
-        super.withProperty("spring.datasource.url", jdbcDatabaseContainer.getJdbcUrl())
-            .withProperty("spring.datasource.username", jdbcDatabaseContainer.getUsername())
-            .withProperty("spring.datasource.password", jdbcDatabaseContainer.getPassword());
+        super.withProperty("camunda.database.url", jdbcDatabaseContainer.getJdbcUrl())
+            .withProperty("camunda.database.username", jdbcDatabaseContainer.getUsername())
+            .withProperty("camunda.database.password", jdbcDatabaseContainer.getPassword());
       }
     }
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -251,11 +251,10 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
   public TestStandaloneBroker withRdbmsExporter() {
     withProperty("camunda.database.type", "rdbms");
     withProperty(
-        "spring.datasource.url",
+        "camunda.database.url",
         "jdbc:h2:mem:testdb+" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL");
-    withProperty("spring.datasource.driver-class-name", "org.h2.Driver");
-    withProperty("spring.datasource.username", "sa");
-    withProperty("spring.datasource.password", "");
+    withProperty("camunda.database.username", "sa");
+    withProperty("camunda.database.password", "");
     withProperty("logging.level.io.camunda.db.rdbms", "DEBUG");
     withProperty("logging.level.org.mybatis", "DEBUG");
     withExporter(


### PR DESCRIPTION
## Description

Currently the user needs to specify Spring datasource properties to define the database connection. With this PR the properties are moved to camunda.database.* to hide the Spring dependency.
