### PR TITLE
pg-26966-unbind-process-migration-from-tasklist

### DIFF
--- a/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
@@ -10,7 +10,6 @@ package io.camunda.application;
 import static org.springframework.core.env.AbstractEnvironment.ACTIVE_PROFILES_PROPERTY_NAME;
 
 import io.camunda.application.commons.CommonsModuleConfiguration;
-import io.camunda.application.commons.migration.MigrationsRunner;
 import io.camunda.application.initializers.DefaultAuthenticationInitializer;
 import io.camunda.application.initializers.HealthConfigurationInitializer;
 import io.camunda.application.initializers.WebappsConfigurationInitializer;
@@ -47,8 +46,7 @@ public class StandaloneCamunda {
                 IdentityModuleConfiguration.class,
                 WebappsModuleConfiguration.class,
                 BrokerModuleConfiguration.class,
-                GatewayModuleConfiguration.class,
-                MigrationsRunner.class)
+                GatewayModuleConfiguration.class)
             .properties(defaultActiveProfiles)
             .initializers(
                 new DefaultAuthenticationInitializer(),

--- a/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
@@ -10,6 +10,7 @@ package io.camunda.application;
 import static org.springframework.core.env.AbstractEnvironment.ACTIVE_PROFILES_PROPERTY_NAME;
 
 import io.camunda.application.commons.CommonsModuleConfiguration;
+import io.camunda.application.commons.migration.MigrationsRunner;
 import io.camunda.application.initializers.DefaultAuthenticationInitializer;
 import io.camunda.application.initializers.HealthConfigurationInitializer;
 import io.camunda.application.initializers.WebappsConfigurationInitializer;
@@ -46,7 +47,8 @@ public class StandaloneCamunda {
                 IdentityModuleConfiguration.class,
                 WebappsModuleConfiguration.class,
                 BrokerModuleConfiguration.class,
-                GatewayModuleConfiguration.class)
+                GatewayModuleConfiguration.class,
+                MigrationsRunner.class)
             .properties(defaultActiveProfiles)
             .initializers(
                 new DefaultAuthenticationInitializer(),

--- a/dist/src/main/java/io/camunda/application/commons/migration/MigrationProfilePostProcessor.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/MigrationProfilePostProcessor.java
@@ -22,14 +22,6 @@ public class MigrationProfilePostProcessor implements EnvironmentPostProcessor {
     if (environment.acceptsProfiles(Profiles.of(Profile.MIGRATION.getId()))) {
       environment.addActiveProfile(Profile.PROCESS_MIGRATION.getId());
       environment.addActiveProfile(Profile.IDENTITY_MIGRATION.getId());
-    } else if (shouldEnableProcessMigration(environment)) {
-      /* Enable 'process-migration' when Tasklist is enabled on non Test setups  */
-      environment.addActiveProfile(Profile.PROCESS_MIGRATION.getId());
     }
-  }
-
-  private boolean shouldEnableProcessMigration(final ConfigurableEnvironment environment) {
-    return environment.acceptsProfiles(Profiles.of(Profile.TASKLIST.getId()))
-        && !environment.acceptsProfiles(Profiles.of(Profile.TEST.getId()));
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- Tasklist profile no longer runs process-migration
- Include migration modules in StandaloneCamunda
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #26966
