### PR TITLE
[CPT] feat: Configure the BPMN element selector

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import org.assertj.core.api.AbstractAssert;
 import org.awaitility.Awaitility;
@@ -41,23 +42,29 @@ public class ProcessInstanceAssertj
     implements ProcessInstanceAssert {
 
   private final CamundaDataSource dataSource;
+
   private final ElementAssertj elementAssertj;
   private final VariableAssertj variableAssertj;
   private final String failureMessagePrefix;
 
   private final AtomicReference<ProcessInstanceDto> actualProcessInstance = new AtomicReference<>();
 
-  public ProcessInstanceAssertj(final CamundaDataSource dataSource, final long processInstanceKey) {
-    this(dataSource, ProcessInstanceSelectors.byKey(processInstanceKey));
+  public ProcessInstanceAssertj(
+      final CamundaDataSource dataSource,
+      final long processInstanceKey,
+      final Function<String, ElementSelector> elementSelector) {
+    this(dataSource, ProcessInstanceSelectors.byKey(processInstanceKey), elementSelector);
   }
 
   public ProcessInstanceAssertj(
-      final CamundaDataSource dataSource, final ProcessInstanceSelector processInstanceSelector) {
+      final CamundaDataSource dataSource,
+      final ProcessInstanceSelector processInstanceSelector,
+      final Function<String, ElementSelector> elementSelector) {
     super(processInstanceSelector, ProcessInstanceAssertj.class);
     this.dataSource = dataSource;
     failureMessagePrefix =
         String.format("Process instance [%s]", processInstanceSelector.describe());
-    elementAssertj = new ElementAssertj(dataSource, failureMessagePrefix);
+    elementAssertj = new ElementAssertj(dataSource, failureMessagePrefix, elementSelector);
     variableAssertj = new VariableAssertj(dataSource, failureMessagePrefix);
   }
 

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ElementAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ElementAssertTest.java
@@ -107,6 +107,11 @@ public class ElementAssertTest {
           .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB, flowNodeInstanceC));
     }
 
+    @AfterEach
+    void reset() {
+      CamundaAssert.setElementSelector(CamundaAssert.DEFAULT_ELEMENT_SELECTOR);
+    }
+
     @Test
     void shouldUseStringSelector() {
       // when
@@ -129,6 +134,18 @@ public class ElementAssertTest {
                   + "\t- 'C': completed\n"
                   + "\t- 'D': not activated",
               PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldChangeStringSelector() {
+      // given
+      CamundaAssert.setElementSelector(ElementSelectors::byName);
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThat(processInstanceEvent).hasActiveElements("element_A", "element_B");
     }
 
     @Test


### PR DESCRIPTION
## Description

Add an option to configure the element selector used for the BPMN element assertions. The default selector is the
by-element-id selector.

This is a follow-up task of #26704 to ease the migration from 8.6. Instead of changing all assertions from BPMN element name to element ID, you need to set only the default selector and keep the test cases as before. 

```
CamundaAssert.setElementSelector(ElementSelectors::byName);
```

## Related issues

related to #26704 
