### PR TITLE
feat: assign users to tenants by id instead of key

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -1577,17 +1577,17 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * <pre>
    * camundaClient
-   *   .newAssignUserToTenantCommand(tenantKey)
-   *   .userKey(userKey)
+   *   .newAssignUserToTenantCommand(tenantId)
+   *   .userKey(userId)
    *   .send();
    * </pre>
    *
    * <p>This command sends an HTTP PUT request to assign the specified user to the given tenant.
    *
-   * @param tenantKey the unique identifier of the tenant
+   * @param tenantId the unique identifier of the tenant
    * @return a builder for the assign user to tenant command
    */
-  AssignUserToTenantCommandStep1 newAssignUserToTenantCommand(long tenantKey);
+  AssignUserToTenantCommandStep1 newAssignUserToTenantCommand(String tenantId);
 
   /**
    * Command to remove a user from a tenant.

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -1578,7 +1578,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * <pre>
    * camundaClient
    *   .newAssignUserToTenantCommand(tenantId)
-   *   .userKey(userId)
+   *   .username(username)
    *   .send();
    * </pre>
    *

--- a/clients/java/src/main/java/io/camunda/client/api/command/AssignUserToTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AssignUserToTenantCommandStep1.java
@@ -24,9 +24,9 @@ public interface AssignUserToTenantCommandStep1
   /**
    * Sets the user key for the assignment.
    *
-   * @param userName the unique identifier for the user
+   * @param username the unique identifier for the user
    * @return the builder for this command. Call {@link #send()} to complete the command and send it
    *     to the broker.
    */
-  AssignUserToTenantCommandStep1 userName(String userName);
+  AssignUserToTenantCommandStep1 username(String username);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/AssignUserToTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/AssignUserToTenantCommandStep1.java
@@ -24,9 +24,9 @@ public interface AssignUserToTenantCommandStep1
   /**
    * Sets the user key for the assignment.
    *
-   * @param userKey the key of the user
+   * @param userName the unique identifier for the user
    * @return the builder for this command. Call {@link #send()} to complete the command and send it
    *     to the broker.
    */
-  AssignUserToTenantCommandStep1 userKey(long userKey);
+  AssignUserToTenantCommandStep1 userName(String userName);
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -884,8 +884,8 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public AssignUserToTenantCommandStep1 newAssignUserToTenantCommand(final long tenantKey) {
-    return new AssignUserToTenantCommandImpl(httpClient, tenantKey);
+  public AssignUserToTenantCommandStep1 newAssignUserToTenantCommand(final String tenantId) {
+    return new AssignUserToTenantCommandImpl(httpClient, tenantId);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignUserToTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignUserToTenantCommandImpl.java
@@ -28,7 +28,7 @@ import org.apache.hc.client5.http.config.RequestConfig;
 public final class AssignUserToTenantCommandImpl implements AssignUserToTenantCommandStep1 {
 
   private final String tenantId;
-  private String userName;
+  private String username;
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
 
@@ -39,8 +39,8 @@ public final class AssignUserToTenantCommandImpl implements AssignUserToTenantCo
   }
 
   @Override
-  public AssignUserToTenantCommandStep1 userName(final String userName) {
-    this.userName = userName;
+  public AssignUserToTenantCommandStep1 username(final String username) {
+    this.username = username;
     return this;
   }
 
@@ -54,7 +54,7 @@ public final class AssignUserToTenantCommandImpl implements AssignUserToTenantCo
   @Override
   public CamundaFuture<AssignUserToTenantResponse> send() {
     final HttpCamundaFuture<AssignUserToTenantResponse> result = new HttpCamundaFuture<>();
-    final String endpoint = String.format("/tenants/%s/users/%s", tenantId, userName);
+    final String endpoint = String.format("/tenants/%s/users/%s", tenantId, username);
     httpClient.put(endpoint, null, httpRequestConfig.build(), result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignUserToTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignUserToTenantCommandImpl.java
@@ -27,20 +27,20 @@ import org.apache.hc.client5.http.config.RequestConfig;
 
 public final class AssignUserToTenantCommandImpl implements AssignUserToTenantCommandStep1 {
 
-  private final long tenantKey;
-  private long userKey;
+  private final String tenantId;
+  private String userName;
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
 
-  public AssignUserToTenantCommandImpl(final HttpClient httpClient, final long tenantKey) {
+  public AssignUserToTenantCommandImpl(final HttpClient httpClient, final String tenantId) {
     this.httpClient = httpClient;
-    this.tenantKey = tenantKey;
+    this.tenantId = tenantId;
     httpRequestConfig = httpClient.newRequestConfig();
   }
 
   @Override
-  public AssignUserToTenantCommandStep1 userKey(final long userKey) {
-    this.userKey = userKey;
+  public AssignUserToTenantCommandStep1 userName(final String userName) {
+    this.userName = userName;
     return this;
   }
 
@@ -54,7 +54,7 @@ public final class AssignUserToTenantCommandImpl implements AssignUserToTenantCo
   @Override
   public CamundaFuture<AssignUserToTenantResponse> send() {
     final HttpCamundaFuture<AssignUserToTenantResponse> result = new HttpCamundaFuture<>();
-    final String endpoint = String.format("/tenants/%d/users/%d", tenantKey, userKey);
+    final String endpoint = String.format("/tenants/%s/users/%s", tenantId, userName);
     httpClient.put(endpoint, null, httpRequestConfig.build(), result);
     return result;
   }

--- a/clients/java/src/test/java/io/camunda/client/tenant/AssignUserToTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/AssignUserToTenantTest.java
@@ -24,23 +24,24 @@ import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.protocol.rest.ProblemDetail;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 public class AssignUserToTenantTest extends ClientRestTest {
 
-  private static final long TENANT_KEY = 123L;
-  private static final long USER_KEY = 456L;
+  private static final String TENANT_ID = UUID.randomUUID().toString();
+  private static final String USER_NAME = UUID.randomUUID().toString();
 
   @Test
   void shouldAssignUserToTenant() {
     // when
-    client.newAssignUserToTenantCommand(TENANT_KEY).userKey(USER_KEY).send().join();
+    client.newAssignUserToTenantCommand(TENANT_ID).userName(USER_NAME).send().join();
 
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();
     final RequestMethod method = RestGatewayService.getLastRequest().getMethod();
     assertThat(requestPath)
-        .isEqualTo(REST_API_PATH + "/tenants/" + TENANT_KEY + "/users/" + USER_KEY);
+        .isEqualTo(REST_API_PATH + "/tenants/" + TENANT_ID + "/users/" + USER_NAME);
     assertThat(method).isEqualTo(RequestMethod.PUT);
   }
 
@@ -48,12 +49,12 @@ public class AssignUserToTenantTest extends ClientRestTest {
   void shouldRaiseExceptionOnNotFoundTenant() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_KEY + "/users/" + USER_KEY,
+        REST_API_PATH + "/tenants/" + TENANT_ID + "/users/" + USER_NAME,
         () -> new ProblemDetail().title("Not Found").status(404));
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignUserToTenantCommand(TENANT_KEY).userKey(USER_KEY).send().join())
+            () -> client.newAssignUserToTenantCommand(TENANT_ID).userName(USER_NAME).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -62,12 +63,12 @@ public class AssignUserToTenantTest extends ClientRestTest {
   void shouldRaiseExceptionOnNotFoundUser() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_KEY + "/users/" + USER_KEY,
+        REST_API_PATH + "/tenants/" + TENANT_ID + "/users/" + USER_NAME,
         () -> new ProblemDetail().title("Not Found").status(404));
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignUserToTenantCommand(TENANT_KEY).userKey(USER_KEY).send().join())
+            () -> client.newAssignUserToTenantCommand(TENANT_ID).userName(USER_NAME).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -76,12 +77,12 @@ public class AssignUserToTenantTest extends ClientRestTest {
   void shouldHandleServerError() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_KEY + "/users/" + USER_KEY,
+        REST_API_PATH + "/tenants/" + TENANT_ID + "/users/" + USER_NAME,
         () -> new ProblemDetail().title("Internal Server Error").status(500));
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignUserToTenantCommand(TENANT_KEY).userKey(USER_KEY).send().join())
+            () -> client.newAssignUserToTenantCommand(TENANT_ID).userName(USER_NAME).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 500: 'Internal Server Error'");
   }
@@ -90,12 +91,12 @@ public class AssignUserToTenantTest extends ClientRestTest {
   void shouldRaiseExceptionOnForbiddenRequest() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_KEY + "/users/" + USER_KEY,
+        REST_API_PATH + "/tenants/" + TENANT_ID + "/users/" + USER_NAME,
         () -> new ProblemDetail().title("Forbidden").status(403));
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignUserToTenantCommand(TENANT_KEY).userKey(USER_KEY).send().join())
+            () -> client.newAssignUserToTenantCommand(TENANT_ID).userName(USER_NAME).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 403: 'Forbidden'");
   }

--- a/clients/java/src/test/java/io/camunda/client/tenant/AssignUserToTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/AssignUserToTenantTest.java
@@ -35,7 +35,7 @@ public class AssignUserToTenantTest extends ClientRestTest {
   @Test
   void shouldAssignUserToTenant() {
     // when
-    client.newAssignUserToTenantCommand(TENANT_ID).userName(USER_NAME).send().join();
+    client.newAssignUserToTenantCommand(TENANT_ID).username(USER_NAME).send().join();
 
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();
@@ -54,7 +54,7 @@ public class AssignUserToTenantTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignUserToTenantCommand(TENANT_ID).userName(USER_NAME).send().join())
+            () -> client.newAssignUserToTenantCommand(TENANT_ID).username(USER_NAME).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -68,7 +68,7 @@ public class AssignUserToTenantTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignUserToTenantCommand(TENANT_ID).userName(USER_NAME).send().join())
+            () -> client.newAssignUserToTenantCommand(TENANT_ID).username(USER_NAME).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -82,7 +82,7 @@ public class AssignUserToTenantTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignUserToTenantCommand(TENANT_ID).userName(USER_NAME).send().join())
+            () -> client.newAssignUserToTenantCommand(TENANT_ID).username(USER_NAME).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 500: 'Internal Server Error'");
   }
@@ -96,7 +96,7 @@ public class AssignUserToTenantTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignUserToTenantCommand(TENANT_ID).userName(USER_NAME).send().join())
+            () -> client.newAssignUserToTenantCommand(TENANT_ID).username(USER_NAME).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 403: 'Forbidden'");
   }

--- a/qa/integration-tests/src/test/java/io/camunda/it/operate/OperateMultiTenancyIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/operate/OperateMultiTenancyIT.java
@@ -47,10 +47,10 @@ public class OperateMultiTenancyIT {
   public void beforeEach() {
     try (final var authorizationsUtil =
         AuthorizationsUtil.create(testInstance, testInstance.getElasticSearchHostAddress())) {
-      final var userKey1 = authorizationsUtil.createUser(USERNAME_1, PASSWORD);
-      final var userKey2 = authorizationsUtil.createUser(USERNAME_2, PASSWORD);
-      authorizationsUtil.createTenant(TENANT_ID_1, TENANT_ID_1, userKey1);
-      authorizationsUtil.createTenant(TENANT_ID_2, TENANT_ID_2, userKey2);
+      authorizationsUtil.createUser(USERNAME_1, PASSWORD);
+      authorizationsUtil.createUser(USERNAME_2, PASSWORD);
+      authorizationsUtil.createTenant(TENANT_ID_1, TENANT_ID_1, USERNAME_1);
+      authorizationsUtil.createTenant(TENANT_ID_2, TENANT_ID_2, USERNAME_2);
 
       final var processTenant1 =
           deployResourceForTenant(

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -88,6 +88,14 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
             .setEntity(entityType, entityKey));
   }
 
+  public CompletableFuture<TenantRecord> addMember(
+      final String tenantId, final EntityType entityType, final String entityId) {
+    return sendBrokerRequest(
+        BrokerTenantEntityRequest.createAddRequest()
+            .setTenantId(tenantId)
+            .setEntity(entityType, entityId));
+  }
+
   public CompletableFuture<TenantRecord> removeMember(
       final Long tenantKey, final EntityType entityType, final long entityKey) {
     return sendBrokerRequest(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -210,7 +210,9 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
       final RejectionType type,
       final String errorMessage) {
     rejectionWriter.appendRejection(command, type, errorMessage);
-    responseWriter.writeRejectionOnCommand(command, type, errorMessage);
+    if (command.hasRequestMetadata()) {
+      responseWriter.writeRejectionOnCommand(command, type, errorMessage);
+    }
   }
 
   private void distributeCommand(final TypedRecord<TenantRecord> command) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -22,18 +22,18 @@ import io.camunda.zeebe.engine.state.immutable.MappingState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.TenantState;
 import io.camunda.zeebe.engine.state.immutable.UserState;
+import io.camunda.zeebe.engine.state.tenant.PersistedTenant;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
-import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.Either;
 
 public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor<TenantRecord> {
-  private static final String ENTITY_ALREADY_ASSIGNED_ERROR_MESSAGE =
-      "Expected to add entity with key '%s' to tenant with key '%s', but the entity is already assigned to this tenant.";
+
   private final TenantState tenantState;
   private final UserState userState;
   private final MappingState mappingState;
@@ -67,17 +67,15 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
   public void processNewCommand(final TypedRecord<TenantRecord> command) {
     final var record = command.getValue();
 
-    final var tenantKey = record.getTenantKey();
-    final var persistedTenant = tenantState.getTenantByKey(tenantKey);
-    if (persistedTenant.isEmpty()) {
-      rejectCommand(
-          command,
-          RejectionType.NOT_FOUND,
-          "Expected to add entity to tenant with key '%s', but no tenant with this key exists."
-              .formatted(tenantKey));
+    final var tenantLookup = getPersistedTenant(record);
+    if (tenantLookup.isLeft()) {
+      rejectCommand(command, RejectionType.NOT_FOUND, tenantLookup.getLeft());
       return;
     }
-    final var tenantId = persistedTenant.get().getTenantId();
+
+    final var persistedTenant = tenantLookup.get();
+    final var tenantKey = persistedTenant.getTenantKey();
+    final var tenantId = persistedTenant.getTenantId();
     record.setTenantId(tenantId);
 
     final var authorizationRequest =
@@ -89,8 +87,7 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
       return;
     }
 
-    final var entityKey = record.getEntityKey();
-    if (!isEntityPresentAndNotAssigned(entityKey, record.getEntityType(), command, tenantId)) {
+    if (!validateEntityAssignment(command, tenantId)) {
       return;
     }
 
@@ -103,29 +100,48 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
   @Override
   public void processDistributedCommand(final TypedRecord<TenantRecord> command) {
     final var record = command.getValue();
-    tenantState
-        .getEntityType(record.getTenantKey(), record.getEntityKey())
-        .ifPresentOrElse(
-            entityType ->
-                rejectionWriter.appendRejection(
-                    command,
-                    RejectionType.ALREADY_EXISTS,
-                    ENTITY_ALREADY_ASSIGNED_ERROR_MESSAGE.formatted(
-                        record.getEntityKey(), record.getTenantKey())),
-            () ->
-                stateWriter.appendFollowUpEvent(
-                    command.getKey(), TenantIntent.ENTITY_ADDED, record));
+    if (validateEntityAssignment(command, record.getTenantId())) {
+      stateWriter.appendFollowUpEvent(command.getKey(), TenantIntent.ENTITY_ADDED, record);
+    }
 
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 
-  private boolean isEntityPresentAndNotAssigned(
-      final long entityKey,
-      final EntityType entityType,
-      final TypedRecord<TenantRecord> command,
-      final String tenantId) {
+  /** Loads the persisted tenant by the tenant key if it is set, otherwise by the tenant id. */
+  private Either<String, PersistedTenant> getPersistedTenant(final TenantRecord record) {
+    if (record.hasTenantKey()) {
+      final var tenantKey = record.getTenantKey();
+      return tenantState
+          .getTenantByKey(tenantKey)
+          .<Either<String, PersistedTenant>>map(Either::right)
+          .orElseGet(
+              () ->
+                  Either.left(
+                      "Expected to add entity to tenant with key '%s', but no tenant with this key exists."
+                          .formatted(tenantKey)));
+    }
+
+    final var tenantId = record.getTenantId();
+    return tenantState
+        .getTenantById(tenantId)
+        .<Either<String, PersistedTenant>>map(Either::right)
+        .orElseGet(
+            () ->
+                Either.left(
+                    "Expected to add entity to tenant with id '%s', but no tenant with this id exists."
+                        .formatted(tenantId)));
+  }
+
+  /**
+   * Writes rejection and returns false if the entity does not exist or is already assigned to the
+   * tenant.
+   */
+  private boolean validateEntityAssignment(
+      final TypedRecord<TenantRecord> command, final String tenantId) {
+    final var entityType = command.getValue().getEntityType();
+    final var entityKey = command.getValue().getEntityKey();
     return switch (entityType) {
-      case USER -> checkUserAssignment(entityKey, command, tenantId);
+      case USER -> checkUserAssignment(command, tenantId);
       case MAPPING -> checkMappingAssignment(entityKey, command, tenantId);
       case GROUP -> checkGroupAssignment(entityKey, command, tenantId);
       default ->
@@ -134,14 +150,24 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
   }
 
   private boolean checkUserAssignment(
-      final long entityKey, final TypedRecord<TenantRecord> command, final String tenantId) {
-    final var user = userState.getUser(entityKey);
+      final TypedRecord<TenantRecord> command, final String tenantId) {
+    final var record = command.getValue();
+    final var entityId = record.getEntityId();
+    final var user = userState.getUser(entityId);
     if (user.isEmpty()) {
-      createEntityNotExistRejectCommand(command, entityKey, tenantId);
+      rejectCommand(
+          command,
+          RejectionType.NOT_FOUND,
+          "Expected to add user '%s' to tenant '%s', but the user doesn't exist."
+              .formatted(entityId, tenantId));
       return false;
     }
     if (user.get().getTenantIdsList().contains(tenantId)) {
-      createAlreadyAssignedRejectCommand(command, entityKey, tenantId);
+      rejectCommand(
+          command,
+          RejectionType.INVALID_ARGUMENT,
+          "Expected to add user '%s' to tenant '%s', but the user is already assigned to the tenant."
+              .formatted(entityId, tenantId));
       return false;
     }
     return true;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityAddedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityAddedApplier.java
@@ -37,9 +37,10 @@ public class TenantEntityAddedApplier implements TypedEventApplier<TenantIntent,
       case USER -> {
         final var username = tenant.getEntityId();
         final var userKey = userState.getUser(username).orElseThrow().getUserKey();
+        final var tenantKey = tenantState.getTenantKeyById(tenant.getTenantId()).orElseThrow();
         tenantState.addEntity(
             new TenantRecord()
-                .setTenantKey(tenant.getTenantKey())
+                .setTenantKey(tenantKey)
                 .setEntityType(EntityType.USER)
                 .setEntityKey(userKey));
         userState.addTenantId(username, tenant.getTenantId());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityAddedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityAddedApplier.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableTenantState;
 import io.camunda.zeebe.engine.state.mutable.MutableUserState;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 
 public class TenantEntityAddedApplier implements TypedEventApplier<TenantIntent, TenantRecord> {
 
@@ -32,14 +33,25 @@ public class TenantEntityAddedApplier implements TypedEventApplier<TenantIntent,
 
   @Override
   public void applyState(final long key, final TenantRecord tenant) {
-    tenantState.addEntity(tenant);
     switch (tenant.getEntityType()) {
-      case USER ->
-          userState
-              .getUser(tenant.getEntityKey())
-              .ifPresent(user -> userState.addTenantId(user.getUsername(), tenant.getTenantId()));
-      case MAPPING -> mappingState.addTenant(tenant.getEntityKey(), tenant.getTenantId());
-      case GROUP -> groupState.addTenant(tenant.getEntityKey(), tenant.getTenantId());
+      case USER -> {
+        final var username = tenant.getEntityId();
+        final var userKey = userState.getUser(username).orElseThrow().getUserKey();
+        tenantState.addEntity(
+            new TenantRecord()
+                .setTenantKey(tenant.getTenantKey())
+                .setEntityType(EntityType.USER)
+                .setEntityKey(userKey));
+        userState.addTenantId(username, tenant.getTenantId());
+      }
+      case MAPPING -> {
+        tenantState.addEntity(tenant);
+        mappingState.addTenant(tenant.getEntityKey(), tenant.getTenantId());
+      }
+      case GROUP -> {
+        tenantState.addEntity(tenant);
+        groupState.addTenant(tenant.getEntityKey(), tenant.getTenantId());
+      }
       default ->
           throw new IllegalStateException(
               String.format(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AnonymousAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AnonymousAuthorizationTest.java
@@ -67,7 +67,7 @@ public class AnonymousAuthorizationTest {
     engine
         .tenant()
         .addEntity(tenantKey)
-        .withEntityKey(user.getUserKey())
+        .withEntityId(username)
         .withEntityType(EntityType.USER)
         .add();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -215,7 +215,7 @@ public class AuthorizationCheckBehaviorTest {
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(user.getUserKey(), resourceType, permissionType, resourceId);
-    final var tenantId = createAndAssignTenant(user.getUserKey(), EntityType.USER);
+    final var tenantId = createAndAssignTenant(user.getUsername(), EntityType.USER);
     final var command = mockCommand(user.getUsername());
 
     // when
@@ -259,7 +259,7 @@ public class AuthorizationCheckBehaviorTest {
     final var resourceId = UUID.randomUUID().toString();
     addPermission(user.getUserKey(), resourceType, permissionType, resourceId);
     final var anotherTenantId = "authorizedForAnotherTenant";
-    createAndAssignTenant(user.getUserKey(), EntityType.USER);
+    createAndAssignTenant(user.getUsername(), EntityType.USER);
     final var command = mockCommand(user.getUsername());
 
     // when
@@ -347,8 +347,8 @@ public class AuthorizationCheckBehaviorTest {
   public void shouldGetUserAuthorizedTenantIds() {
     // given
     final var user = createUser();
-    final var tenantId1 = createAndAssignTenant(user.getUserKey(), EntityType.USER);
-    final var tenantId2 = createAndAssignTenant(user.getUserKey(), EntityType.USER);
+    final var tenantId1 = createAndAssignTenant(user.getUsername(), EntityType.USER);
+    final var tenantId2 = createAndAssignTenant(user.getUsername(), EntityType.USER);
     final var command = mockCommand(user.getUsername());
 
     // when
@@ -970,6 +970,13 @@ public class AuthorizationCheckBehaviorTest {
     final var tenantId = UUID.randomUUID().toString();
     final var tenantKey = engine.tenant().newTenant().withTenantId(tenantId).create().getKey();
     engine.tenant().addEntity(tenantKey).withEntityKey(entityKey).withEntityType(entityType).add();
+    return tenantId;
+  }
+
+  private String createAndAssignTenant(final String entityId, final EntityType entityType) {
+    final var tenantId = UUID.randomUUID().toString();
+    engine.tenant().newTenant().withTenantId(tenantId).create();
+    engine.tenant().addEntity(tenantId).withEntityId(entityId).withEntityType(entityType).add();
     return tenantId;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
@@ -54,13 +54,12 @@ public class IdentitySetupInitializeTest {
     final var roleName = "roleName";
     final var role = new RoleRecord().setName(roleName);
     final var username = "username";
-    final var userName = "userName";
     final var password = "password";
     final var mail = "e@mail.com";
     final var user =
         new UserRecord()
             .setUsername(username)
-            .setName(userName)
+            .setName(username)
             .setPassword(password)
             .setEmail(mail);
     final var tenantId = "tenant-id";
@@ -95,7 +94,7 @@ public class IdentitySetupInitializeTest {
                 .getValue())
         .hasUserKey(userKey)
         .hasUsername(username)
-        .hasName(userName)
+        .hasName(username)
         .hasPassword(password)
         .hasEmail(mail);
     assertThat(
@@ -116,20 +115,19 @@ public class IdentitySetupInitializeTest {
     final var roleName = "roleName";
     final var role = new RoleRecord().setName(roleName);
     final var username = "username";
-    final var userName = "userName";
     final var password = "password";
     final var mail = "e@mail.com";
     final var user =
         new UserRecord()
             .setUsername(username)
-            .setName(userName)
+            .setName(username)
             .setPassword(password)
             .setEmail(mail);
     final var userKey =
         engine
             .user()
             .newUser(username)
-            .withName(userName)
+            .withName(username)
             .withPassword(password)
             .withEmail(mail)
             .create()
@@ -151,13 +149,12 @@ public class IdentitySetupInitializeTest {
     final var roleName = "roleName";
     final var role = new RoleRecord().setRoleKey(1).setName(roleName);
     final var username = "username";
-    final var userName = "userName";
     final var password = "password";
     final var mail = "e@mail.com";
     final var user =
         new UserRecord()
             .setUsername(username)
-            .setName(userName)
+            .setName(username)
             .setPassword(password)
             .setEmail(mail);
     final var roleKey = engine.role().newRole(roleName).create().getKey();
@@ -207,14 +204,13 @@ public class IdentitySetupInitializeTest {
     final var roleName = "roleName";
     final var role = new RoleRecord().setRoleKey(1).setName(roleName);
     final var username = "username";
-    final var userName = "userName";
     final var password = "password";
     final var mail = "e@mail.com";
     final var user =
         new UserRecord()
             .setUserKey(2)
             .setUsername(username)
-            .setName(userName)
+            .setName(username)
             .setPassword(password)
             .setEmail(mail);
     final var roleKey = engine.role().newRole(roleName).create().getKey();
@@ -222,7 +218,7 @@ public class IdentitySetupInitializeTest {
         engine
             .user()
             .newUser(username)
-            .withName(userName)
+            .withName(username)
             .withPassword(password)
             .withEmail(mail)
             .create()
@@ -244,14 +240,13 @@ public class IdentitySetupInitializeTest {
     final var roleName = "roleName";
     final var role = new RoleRecord().setRoleKey(1).setName(roleName);
     final var username = "username";
-    final var userName = "userName";
     final var password = "password";
     final var mail = "e@mail.com";
     final var user =
         new UserRecord()
             .setUserKey(2)
             .setUsername(username)
-            .setName(userName)
+            .setName(username)
             .setPassword(password)
             .setEmail(mail);
     final var roleKey = engine.role().newRole(roleName).create().getKey();
@@ -259,7 +254,7 @@ public class IdentitySetupInitializeTest {
         engine
             .user()
             .newUser(username)
-            .withName(userName)
+            .withName(username)
             .withPassword(password)
             .withEmail(mail)
             .create()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -435,8 +435,8 @@ public class CommandDistributionIdempotencyTest {
                   final var user = createUser();
                   ENGINE
                       .tenant()
-                      .addEntity(tenant.getKey())
-                      .withEntityKey(user.getKey())
+                      .addEntity(tenant.getValue().getTenantId())
+                      .withEntityId(user.getValue().getUsername())
                       .withEntityType(EntityType.USER)
                       .add();
                 },
@@ -453,8 +453,8 @@ public class CommandDistributionIdempotencyTest {
                   final var user = createUser();
                   ENGINE
                       .tenant()
-                      .addEntity(tenant.getKey())
-                      .withEntityKey(user.getKey())
+                      .addEntity(tenant.getValue().getTenantId())
+                      .withEntityId(user.getValue().getUsername())
                       .withEntityType(EntityType.USER)
                       .add();
                   ENGINE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
@@ -60,13 +60,12 @@ public final class CompleteJobTest {
     tenantId = UUID.randomUUID().toString();
     username = UUID.randomUUID().toString();
     final var userKey = ENGINE.user().newUser(username).create().getValue().getUserKey();
-    final var tenantKey =
-        ENGINE.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
+    ENGINE.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
     ENGINE
         .tenant()
-        .addEntity(tenantKey)
+        .addEntity(tenantId)
         .withEntityType(EntityType.USER)
-        .withEntityKey(userKey)
+        .withEntityId(username)
         .add();
 
     ENGINE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
@@ -67,13 +67,12 @@ public final class FailJobTest {
     tenantId = UUID.randomUUID().toString();
     username = UUID.randomUUID().toString();
     final var userKey = ENGINE.user().newUser(username).create().getValue().getUserKey();
-    final var tenantKey =
-        ENGINE.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
+    ENGINE.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
     ENGINE
         .tenant()
-        .addEntity(tenantKey)
+        .addEntity(tenantId)
         .withEntityType(EntityType.USER)
-        .withEntityKey(userKey)
+        .withEntityId(username)
         .add();
 
     ENGINE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorTest.java
@@ -56,13 +56,12 @@ public final class JobThrowErrorTest {
     tenantId = UUID.randomUUID().toString();
     username = UUID.randomUUID().toString();
     final var user = ENGINE.user().newUser(username).create().getValue();
-    final var tenantKey =
-        ENGINE.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
+    ENGINE.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
     ENGINE
         .tenant()
-        .addEntity(tenantKey)
+        .addEntity(tenantId)
         .withEntityType(EntityType.USER)
-        .withEntityKey(user.getUserKey())
+        .withEntityId(username)
         .add();
 
     ENGINE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesTest.java
@@ -48,13 +48,12 @@ public final class JobUpdateRetriesTest {
     tenantId = UUID.randomUUID().toString();
     username = UUID.randomUUID().toString();
     final var userKey = ENGINE.user().newUser(username).create().getValue().getUserKey();
-    final var tenantKey =
-        ENGINE.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
+    ENGINE.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
     ENGINE
         .tenant()
-        .addEntity(tenantKey)
+        .addEntity(tenantId)
         .withEntityType(EntityType.USER)
-        .withEntityKey(userKey)
+        .withEntityId(username)
         .add();
 
     ENGINE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutTest.java
@@ -60,9 +60,9 @@ public class JobUpdateTimeoutTest {
         ENGINE.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
     ENGINE
         .tenant()
-        .addEntity(tenantKey)
+        .addEntity(tenantId)
         .withEntityType(EntityType.USER)
-        .withEntityKey(userKey)
+        .withEntityId(username)
         .add();
 
     ENGINE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareActivateJobBatchTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareActivateJobBatchTest.java
@@ -39,9 +39,9 @@ public class TenantAwareActivateJobBatchTest {
         ENGINE.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
     ENGINE
         .tenant()
-        .addEntity(tenantKey)
+        .addEntity(tenantId)
         .withEntityType(EntityType.USER)
-        .withEntityKey(user.getUserKey())
+        .withEntityId(username)
         .add();
 
     // when
@@ -68,13 +68,12 @@ public class TenantAwareActivateJobBatchTest {
     final var username = UUID.randomUUID().toString();
     final var tenantId = UUID.randomUUID().toString();
     final var user = ENGINE.user().newUser(username).create().getValue();
-    final var tenantKey =
-        ENGINE.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
+    ENGINE.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
     ENGINE
         .tenant()
-        .addEntity(tenantKey)
+        .addEntity(tenantId)
         .withEntityType(EntityType.USER)
-        .withEntityKey(user.getUserKey())
+        .withEntityId(username)
         .add();
 
     // when

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareCancelProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareCancelProcessInstanceTest.java
@@ -68,20 +68,15 @@ public class TenantAwareCancelProcessInstanceTest {
   @Test
   public void shouldRejectCancelInstanceForUnauthorizedTenant() {
     // given
-    final var user = ENGINE.user().newUser("username").create().getValue();
-    final var tenantKey =
-        ENGINE
-            .tenant()
-            .newTenant()
-            .withTenantId("another-tenant")
-            .create()
-            .getValue()
-            .getTenantKey();
+    final var tenantId = "another-tenant";
+    final var username = "username";
+    final var user = ENGINE.user().newUser(username).create().getValue();
+    ENGINE.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
     ENGINE
         .tenant()
-        .addEntity(tenantKey)
+        .addEntity(tenantId)
         .withEntityType(EntityType.USER)
-        .withEntityKey(user.getUserKey())
+        .withEntityId(username)
         .add();
 
     ENGINE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareModifyProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareModifyProcessInstanceTest.java
@@ -79,20 +79,16 @@ public class TenantAwareModifyProcessInstanceTest {
   @Test
   public void shouldRejectModifyInstanceForUnauthorizedTenant() {
     // given
-    final var user = ENGINE.user().newUser("username").create().getValue();
+    final var tenantId = "another-tenant";
+    final var username = "username";
+    final var user = ENGINE.user().newUser(username).create().getValue();
     final var tenantKey =
-        ENGINE
-            .tenant()
-            .newTenant()
-            .withTenantId("another-tenant")
-            .create()
-            .getValue()
-            .getTenantKey();
+        ENGINE.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
     ENGINE
         .tenant()
-        .addEntity(tenantKey)
+        .addEntity(tenantId)
         .withEntityType(EntityType.USER)
-        .withEntityKey(user.getUserKey())
+        .withEntityId(username)
         .add();
 
     ENGINE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareUpdateVariablesTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareUpdateVariablesTest.java
@@ -70,20 +70,16 @@ public class TenantAwareUpdateVariablesTest {
   @Test
   public void shouldRejectUpdateVariablesForUnauthorizedTenant() {
     // given
-    final var user = ENGINE.user().newUser("username").create().getValue();
+    final var tenantId = "another-tenant";
+    final var username = "username";
+    final var user = ENGINE.user().newUser(username).create().getValue();
     final var tenantKey =
-        ENGINE
-            .tenant()
-            .newTenant()
-            .withTenantId("another-tenant")
-            .create()
-            .getValue()
-            .getTenantKey();
+        ENGINE.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
     ENGINE
         .tenant()
-        .addEntity(tenantKey)
+        .addEntity(tenantId)
         .withEntityType(EntityType.USER)
-        .withEntityKey(user.getUserKey())
+        .withEntityId(username)
         .add();
 
     ENGINE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantMultiPartitionTest.java
@@ -39,22 +39,22 @@ public class AddEntityTenantMultiPartitionTest {
   @Test
   public void shouldDistributeTenantAddEntityCommand() {
     // when
-    final var userKey =
-        engine
-            .user()
-            .newUser("foo")
-            .withEmail("foo@bar")
-            .withName("Foo Bar")
-            .withPassword("zabraboof")
-            .create()
-            .getKey();
+    final var username = "foo";
+    engine
+        .user()
+        .newUser(username)
+        .withEmail("foo@bar")
+        .withName("Foo Bar")
+        .withPassword("zabraboof")
+        .create()
+        .getKey();
     final var tenantId = UUID.randomUUID().toString();
     final var tenantKey =
         engine.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
     engine
         .tenant()
         .addEntity(tenantKey)
-        .withEntityKey(userKey)
+        .withEntityId(username)
         .withEntityType(EntityType.USER)
         .add();
 
@@ -105,22 +105,22 @@ public class AddEntityTenantMultiPartitionTest {
   @Test
   public void shouldDistributeInIdentityQueue() {
     // when
-    final var userKey =
-        engine
-            .user()
-            .newUser("foo")
-            .withEmail("foo@bar")
-            .withName("Foo Bar")
-            .withPassword("zabraboof")
-            .create()
-            .getKey();
+    final var username = "foo";
+    engine
+        .user()
+        .newUser(username)
+        .withEmail("foo@bar")
+        .withName("Foo Bar")
+        .withPassword("zabraboof")
+        .create()
+        .getKey();
     final var tenantId = UUID.randomUUID().toString();
     final var tenantKey =
         engine.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
     engine
         .tenant()
         .addEntity(tenantKey)
-        .withEntityKey(userKey)
+        .withEntityId(username)
         .withEntityType(EntityType.USER)
         .add();
 
@@ -136,15 +136,15 @@ public class AddEntityTenantMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the tenant creation distribution is intercepted
-    final var userKey =
-        engine
-            .user()
-            .newUser("foo")
-            .withEmail("foo@bar")
-            .withName("Foo Bar")
-            .withPassword("zabraboof")
-            .create()
-            .getKey();
+    final var username = "foo";
+    engine
+        .user()
+        .newUser(username)
+        .withEmail("foo@bar")
+        .withName("Foo Bar")
+        .withPassword("zabraboof")
+        .create()
+        .getKey();
 
     for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       interceptTenantCreateForPartition(partitionId); // Intercept tenant creation
@@ -157,7 +157,7 @@ public class AddEntityTenantMultiPartitionTest {
     engine
         .tenant()
         .addEntity(tenantKey)
-        .withEntityKey(userKey)
+        .withEntityId(username)
         .withEntityType(EntityType.USER)
         .add();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantTest.java
@@ -14,6 +14,7 @@ import static io.camunda.zeebe.protocol.record.value.EntityType.USER;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.UUID;
 import org.assertj.core.api.Assertions;
@@ -69,7 +70,9 @@ public class AddEntityTenantTest {
   public void shouldAddUserToTenant() {
     // given
     final var entityType = USER;
-    final var entityKey = createUser();
+    final var user = createUser();
+    final var userKey = user.getUserKey();
+    final var userName = user.getUsername();
     final var tenantId = UUID.randomUUID().toString();
     final var tenantKey =
         engine
@@ -86,7 +89,7 @@ public class AddEntityTenantTest {
         engine
             .tenant()
             .addEntity(tenantKey)
-            .withEntityKey(entityKey)
+            .withEntityId(userName)
             .withEntityType(entityType)
             .add()
             .getValue();
@@ -95,9 +98,9 @@ public class AddEntityTenantTest {
     Assertions.assertThat(updatedTenant)
         .describedAs(
             "Entity of type %s with key %s should be correctly added to tenant with key %s",
-            entityType, entityKey, tenantKey)
+            entityType, userKey, tenantKey)
         .isNotNull()
-        .hasFieldOrPropertyWithValue("entityKey", entityKey)
+        .hasFieldOrPropertyWithValue("entityId", userName)
         .hasFieldOrPropertyWithValue("tenantKey", tenantKey)
         .hasFieldOrPropertyWithValue("entityType", entityType);
   }
@@ -165,7 +168,7 @@ public class AddEntityTenantTest {
         engine
             .tenant()
             .addEntity(tenantKey)
-            .withEntityKey(1L)
+            .withEntityId("does-not-exist")
             .withEntityType(USER)
             .expectRejection()
             .add();
@@ -174,26 +177,27 @@ public class AddEntityTenantTest {
     assertThat(notPresentUpdateRecord)
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
-            "Expected to add entity with key '1' to tenant with tenantId '%s', but the entity doesn't exist."
+            "Expected to add user 'does-not-exist' to tenant '%s', but the user doesn't exist."
                 .formatted(tenantId));
   }
 
   @Test
   public void shouldRejectIfEntityIsAlreadyAssignedToTenant() {
     // given
-    final var userKey = createUser();
+    final var user = createUser();
     final var tenantId = UUID.randomUUID().toString();
     final var tenantRecord =
         engine.tenant().newTenant().withTenantId(tenantId).withName("Tenant 1").create();
     final var tenantKey = tenantRecord.getValue().getTenantKey();
-    engine.tenant().addEntity(tenantKey).withEntityKey(userKey).withEntityType(USER).add();
+    final var username = user.getUsername();
+    engine.tenant().addEntity(tenantKey).withEntityId(username).withEntityType(USER).add();
 
     // when try adding a non-existent entity to the tenant
     final var alreadyAssignedRecord =
         engine
             .tenant()
             .addEntity(tenantKey)
-            .withEntityKey(userKey)
+            .withEntityId(username)
             .withEntityType(USER)
             .expectRejection()
             .add();
@@ -202,11 +206,11 @@ public class AddEntityTenantTest {
     assertThat(alreadyAssignedRecord)
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason(
-            "Expected to add entity with key '%s' to tenant with tenantId '%s', but the entity is already assigned to the tenant."
-                .formatted(userKey, tenantId));
+            "Expected to add user '%s' to tenant '%s', but the user is already assigned to the tenant."
+                .formatted(username, tenantId));
   }
 
-  private Long createUser() {
+  private UserRecordValue createUser() {
     return engine
         .user()
         .newUser(UUID.randomUUID().toString())
@@ -214,8 +218,7 @@ public class AddEntityTenantTest {
         .withEmail("foo@bar.com")
         .withPassword("password")
         .create()
-        .getValue()
-        .getUserKey();
+        .getValue();
   }
 
   private long createGroup() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantTest.java
@@ -72,7 +72,7 @@ public class AddEntityTenantTest {
     final var entityType = USER;
     final var user = createUser();
     final var userKey = user.getUserKey();
-    final var userName = user.getUsername();
+    final var username = user.getUsername();
     final var tenantId = UUID.randomUUID().toString();
     final var tenantKey =
         engine
@@ -89,7 +89,7 @@ public class AddEntityTenantTest {
         engine
             .tenant()
             .addEntity(tenantKey)
-            .withEntityId(userName)
+            .withEntityId(username)
             .withEntityType(entityType)
             .add()
             .getValue();
@@ -100,7 +100,7 @@ public class AddEntityTenantTest {
             "Entity of type %s with key %s should be correctly added to tenant with key %s",
             entityType, userKey, tenantKey)
         .isNotNull()
-        .hasFieldOrPropertyWithValue("entityId", userName)
+        .hasFieldOrPropertyWithValue("entityId", username)
         .hasFieldOrPropertyWithValue("tenantKey", tenantKey)
         .hasFieldOrPropertyWithValue("entityType", entityType);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/RemoveEntityTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/RemoveEntityTenantMultiPartitionTest.java
@@ -37,10 +37,11 @@ public class RemoveEntityTenantMultiPartitionTest {
   @Rule public final TestWatcher testWatcher = new RecordingExporterTestWatcher();
 
   public void setupTenantWithUserAndRemoveEntity() {
+    final var username = "foo";
     final var userKey =
         engine
             .user()
-            .newUser("foo")
+            .newUser(username)
             .withEmail("foo@bar")
             .withName("Foo Bar")
             .withPassword("zabraboof")
@@ -52,7 +53,7 @@ public class RemoveEntityTenantMultiPartitionTest {
     engine
         .tenant()
         .addEntity(tenantKey)
-        .withEntityKey(userKey)
+        .withEntityId(username)
         .withEntityType(EntityType.USER)
         .add();
     engine

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/RemoveEntityTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/RemoveEntityTenantTest.java
@@ -36,10 +36,11 @@ public class RemoveEntityTenantTest {
             .create()
             .getValue()
             .getTenantKey();
+    final var username = "foo";
     final var userKey =
         engine
             .user()
-            .newUser("foo")
+            .newUser(username)
             .withEmail("foo@bar")
             .withName("Foo Bar")
             .withPassword("zabraboof")
@@ -48,7 +49,7 @@ public class RemoveEntityTenantTest {
     engine
         .tenant()
         .addEntity(tenantKey)
-        .withEntityKey(userKey)
+        .withEntityId(username)
         .withEntityType(EntityType.USER)
         .add();
     final var removedEntity =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessorTest.java
@@ -75,15 +75,15 @@ public class TenantDeleteProcessorTest {
   @Test
   public void shouldDeleteTenantWithAssignedEntities() {
     // Given: create a tenant and assign a user entity to it
-    final var userKey =
-        engine
-            .user()
-            .newUser("foo")
-            .withEmail("foo@bar")
-            .withName("Foo Bar")
-            .withPassword("zabraboof")
-            .create()
-            .getKey();
+    final var username = "foo";
+    engine
+        .user()
+        .newUser(username)
+        .withEmail("foo@bar")
+        .withName("Foo Bar")
+        .withPassword("zabraboof")
+        .create()
+        .getKey();
 
     final var tenantId = UUID.randomUUID().toString();
     final var tenantName = UUID.randomUUID().toString();
@@ -100,7 +100,7 @@ public class TenantDeleteProcessorTest {
     engine
         .tenant()
         .addEntity(tenantKey)
-        .withEntityKey(userKey)
+        .withEntityId(username)
         .withEntityType(EntityType.USER)
         .add();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserTest.java
@@ -50,6 +50,7 @@ public class DeleteUserTest {
   @Test
   public void shouldCleanupMembership() {
     final var username = UUID.randomUUID().toString();
+    final var tenantId = "tenant";
     final var userRecord =
         ENGINE
             .user()
@@ -60,7 +61,7 @@ public class DeleteUserTest {
             .create();
     final var group = ENGINE.group().newGroup("group").create();
     final var role = ENGINE.role().newRole("role").create();
-    final var tenant = ENGINE.tenant().newTenant().withTenantId("tenant").create();
+    final var tenant = ENGINE.tenant().newTenant().withTenantId(tenantId).create();
 
     ENGINE
         .group()
@@ -76,8 +77,8 @@ public class DeleteUserTest {
         .add();
     ENGINE
         .tenant()
-        .addEntity(tenant.getKey())
-        .withEntityKey(userRecord.getKey())
+        .addEntity(tenantId)
+        .withEntityId(username)
         .withEntityType(EntityType.USER)
         .add();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
@@ -58,11 +58,12 @@ public class TenantAppliersTest {
     final long entityKey = UUID.randomUUID().hashCode();
     final long tenantKey = UUID.randomUUID().hashCode();
     final var tenantId = UUID.randomUUID().toString();
+    final var username = "username";
     createTenant(tenantKey, tenantId);
-    createUser(entityKey, "username");
+    createUser(entityKey, username);
 
     // when
-    associateUserWithTenant(tenantKey, tenantId, entityKey);
+    associateUserWithTenant(tenantKey, tenantId, username);
 
     // then
     assertThat(tenantState.getEntitiesByType(tenantKey).get(EntityType.USER))
@@ -126,9 +127,10 @@ public class TenantAppliersTest {
     final long entityKey = UUID.randomUUID().hashCode();
     final long tenantKey = UUID.randomUUID().hashCode();
     final var tenantId = UUID.randomUUID().toString();
+    final var username = "username";
     createTenant(tenantKey, tenantId);
-    createUser(entityKey, "username");
-    associateUserWithTenant(tenantKey, tenantId, entityKey);
+    createUser(entityKey, username);
+    associateUserWithTenant(tenantKey, tenantId, username);
 
     // Ensure the user is associated with the tenant before removal
     assertThat(tenantState.getEntitiesByType(tenantKey).get(EntityType.USER))
@@ -203,12 +205,11 @@ public class TenantAppliersTest {
   }
 
   private void associateUserWithTenant(
-      final long tenantKey, final String tenantId, final long userKey) {
+      final long tenantKey, final String tenantId, final String userName) {
     final var tenantRecord =
         new TenantRecord()
-            .setTenantKey(tenantKey)
             .setTenantId(tenantId)
-            .setEntityKey(userKey)
+            .setEntityId(userName)
             .setEntityType(EntityType.USER);
     tenantEntityAddedApplier.applyState(tenantKey, tenantRecord);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
@@ -205,11 +205,11 @@ public class TenantAppliersTest {
   }
 
   private void associateUserWithTenant(
-      final long tenantKey, final String tenantId, final String userName) {
+      final long tenantKey, final String tenantId, final String username) {
     final var tenantRecord =
         new TenantRecord()
             .setTenantId(tenantId)
-            .setEntityId(userName)
+            .setEntityId(username)
             .setEntityType(EntityType.USER);
     tenantEntityAddedApplier.applyState(tenantKey, tenantRecord);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/TenantClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/TenantClient.java
@@ -56,6 +56,17 @@ public class TenantClient {
   }
 
   /**
+   * Creates a new {@link TenantAddEntityClient} for adding an entity to a tenant. The client uses
+   * the internal command writer to submit the add entity commands.
+   *
+   * @param tenantId the id of the tenant
+   * @return a new instance of {@link TenantAddEntityClient}
+   */
+  public TenantAddEntityClient addEntity(final String tenantId) {
+    return new TenantAddEntityClient(writer, tenantId);
+  }
+
+  /**
    * Creates a new {@link TenantRemoveEntityClient} for removing an entity from a tenant. The client
    * uses the internal command writer to submit the remove entity commands.
    *
@@ -267,6 +278,12 @@ public class TenantClient {
       this.writer = writer;
       tenantRecord = new TenantRecord();
       tenantRecord.setTenantKey(tenantKey);
+    }
+
+    public TenantAddEntityClient(final CommandWriter writer, final String tenantId) {
+      this.writer = writer;
+      tenantRecord = new TenantRecord();
+      tenantRecord.setTenantId(tenantId);
     }
 
     public TenantAddEntityClient withEntityKey(final long entityKey) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/TenantClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/TenantClient.java
@@ -274,6 +274,11 @@ public class TenantClient {
       return this;
     }
 
+    public TenantAddEntityClient withEntityId(final String entityId) {
+      tenantRecord.setEntityId(entityId);
+      return this;
+    }
+
     public TenantAddEntityClient withEntityType(final EntityType entityType) {
       tenantRecord.setEntityType(entityType);
       return this;

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -540,7 +540,7 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
-  /tenants/{tenantId}/users/{userName}:
+  /tenants/{tenantId}/users/{username}:
     put:
       tags:
         - Tenant
@@ -554,7 +554,7 @@ paths:
           description: The unique identifier of the tenant.
           schema:
             type: string
-        - name: userName
+        - name: username
           in: path
           required: true
           description: The username of the user to assign.

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -580,6 +580,7 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /tenants/{tenantKey}/users/{userKey}:
     delete:
       tags:
         - Tenant

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -540,7 +540,7 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
-  /tenants/{tenantKey}/users/{userKey}:
+  /tenants/{tenantId}/users/{userName}:
     put:
       tags:
         - Tenant
@@ -548,20 +548,18 @@ paths:
       summary: Assign a user to a tenant
       description: Assign a single user to a specified tenant.
       parameters:
-        - name: tenantKey
+        - name: tenantId
           in: path
           required: true
           description: The unique identifier of the tenant.
           schema:
-            type: integer
-            format: int64
-        - name: userKey
+            type: string
+        - name: userName
           in: path
           required: true
-          description: The unique identifier of the user.
+          description: The username of the user to assign.
           schema:
-            type: integer
-            format: int64
+            type: string
       responses:
         "202":
           description: The user was successfully assigned to the tenant.

--- a/zeebe/gateway-protocol/vacuum-ignores.yaml
+++ b/zeebe/gateway-protocol/vacuum-ignores.yaml
@@ -1,1 +1,5 @@
 # https://quobix.com/vacuum/ignoring/
+no-ambiguous-paths:
+  - $.paths['/tenants/{tenantKey}/users/{userKey}'] # Temporarily ambiguous until unassign is id-based too
+path-params:
+  - $.paths.['/tenants/{tenantKey}/users/{userKey}'] # Temporarily ambiguous until unassign is id-based too

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -74,14 +74,14 @@ public class TenantController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::updateTenant);
   }
 
-  @CamundaPutMapping(path = "/{tenantId}/users/{userName}")
+  @CamundaPutMapping(path = "/{tenantId}/users/{username}")
   public CompletableFuture<ResponseEntity<Object>> assignUsersToTenant(
-      @PathVariable final String tenantId, @PathVariable final String userName) {
+      @PathVariable final String tenantId, @PathVariable final String username) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             tenantServices
                 .withAuthentication(RequestMapper.getAuthentication())
-                .addMember(tenantId, EntityType.USER, userName));
+                .addMember(tenantId, EntityType.USER, username));
   }
 
   @CamundaDeleteMapping(path = "/{tenantId}")

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -74,14 +74,14 @@ public class TenantController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::updateTenant);
   }
 
-  @CamundaPutMapping(path = "/{tenantKey}/users/{userKey}")
+  @CamundaPutMapping(path = "/{tenantId}/users/{userName}")
   public CompletableFuture<ResponseEntity<Object>> assignUsersToTenant(
-      @PathVariable final long tenantKey, @PathVariable final long userKey) {
+      @PathVariable final String tenantId, @PathVariable final String userName) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             tenantServices
                 .withAuthentication(RequestMapper.getAuthentication())
-                .addMember(tenantKey, EntityType.USER, userKey));
+                .addMember(tenantId, EntityType.USER, userName));
   }
 
   @CamundaDeleteMapping(path = "/{tenantId}")

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -269,8 +269,8 @@ public class TenantControllerTest extends RestControllerTest {
   }
 
   @ParameterizedTest
-  @MethodSource("provideAddMemberTestCases")
-  void testAddMemberToTenant(final EntityType entityType, final String entityPath) {
+  @MethodSource("provideAddMemberByKeyTestCases")
+  void testAddMemberToTenantByKey(final EntityType entityType, final String entityPath) {
     // given
     final var tenantKey = 100L;
     final var entityKey = 42L;
@@ -289,6 +289,29 @@ public class TenantControllerTest extends RestControllerTest {
 
     // then
     verify(tenantServices, times(1)).addMember(tenantKey, entityType, entityKey);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideAddMemberByIdTestCases")
+  void testAddMemberToTenantById(final EntityType entityType, final String entityPath) {
+    // given
+    final var tenantId = "some-tenant-id";
+    final var entityId = "some-entity-id";
+
+    when(tenantServices.addMember(tenantId, entityType, entityId))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    webClient
+        .put()
+        .uri("%s/%s/%s/%s".formatted(TENANT_BASE_URL, tenantId, entityPath, entityId))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    // then
+    verify(tenantServices, times(1)).addMember(tenantId, entityType, entityId);
   }
 
   @ParameterizedTest
@@ -314,11 +337,14 @@ public class TenantControllerTest extends RestControllerTest {
     verify(tenantServices, times(1)).removeMember(tenantKey, entityType, entityKey);
   }
 
-  private static Stream<Arguments> provideAddMemberTestCases() {
+  private static Stream<Arguments> provideAddMemberByKeyTestCases() {
     return Stream.of(
-        Arguments.of(EntityType.USER, "users"),
         Arguments.of(EntityType.MAPPING, "mapping-rules"),
         Arguments.of(EntityType.GROUP, "groups"));
+  }
+
+  private static Stream<Arguments> provideAddMemberByIdTestCases() {
+    return Stream.of(Arguments.of(EntityType.USER, "users"));
   }
 
   private static Stream<Arguments> provideRemoveMemberTestCases() {

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerTenantEntityRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerTenantEntityRequest.java
@@ -12,9 +12,14 @@ import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.EnumSet;
+import java.util.Set;
 import org.agrona.DirectBuffer;
 
 public final class BrokerTenantEntityRequest extends BrokerExecuteCommand<TenantRecord> {
+  private static final Set<EntityType> ALLOWED_ENTITY_TYPES =
+      EnumSet.of(EntityType.USER, EntityType.MAPPING, EntityType.GROUP);
+
   private final TenantRecord tenantDto = new TenantRecord();
 
   private BrokerTenantEntityRequest(final TenantIntent intent) {
@@ -40,11 +45,9 @@ public final class BrokerTenantEntityRequest extends BrokerExecuteCommand<Tenant
   }
 
   public BrokerTenantEntityRequest setEntity(final EntityType entityType, final long entityKey) {
-    if (entityType != EntityType.USER
-        && entityType != EntityType.MAPPING
-        && entityType != EntityType.GROUP) {
+    if (!ALLOWED_ENTITY_TYPES.contains(entityType)) {
       throw new IllegalArgumentException(
-          "For now, tenants can only be assigned to users, groups and mappings");
+          "For now, tenants can only be assigned to %s".formatted(ALLOWED_ENTITY_TYPES));
     }
     tenantDto.setEntityType(entityType);
     tenantDto.setEntityKey(entityKey);
@@ -52,11 +55,9 @@ public final class BrokerTenantEntityRequest extends BrokerExecuteCommand<Tenant
   }
 
   public BrokerTenantEntityRequest setEntity(final EntityType entityType, final String entityId) {
-    if (entityType != EntityType.USER
-        && entityType != EntityType.MAPPING
-        && entityType != EntityType.GROUP) {
+    if (!ALLOWED_ENTITY_TYPES.contains(entityType)) {
       throw new IllegalArgumentException(
-          "For now, tenants can only be assigned to users, groups and mappings");
+          "For now, tenants can only be assigned to %s".formatted(ALLOWED_ENTITY_TYPES));
     }
     tenantDto.setEntityType(entityType);
     tenantDto.setEntityId(entityId);

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerTenantEntityRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerTenantEntityRequest.java
@@ -34,6 +34,11 @@ public final class BrokerTenantEntityRequest extends BrokerExecuteCommand<Tenant
     return this;
   }
 
+  public BrokerTenantEntityRequest setTenantId(final String tenantId) {
+    tenantDto.setTenantId(tenantId);
+    return this;
+  }
+
   public BrokerTenantEntityRequest setEntity(final EntityType entityType, final long entityKey) {
     if (entityType != EntityType.USER
         && entityType != EntityType.MAPPING
@@ -43,6 +48,18 @@ public final class BrokerTenantEntityRequest extends BrokerExecuteCommand<Tenant
     }
     tenantDto.setEntityType(entityType);
     tenantDto.setEntityKey(entityKey);
+    return this;
+  }
+
+  public BrokerTenantEntityRequest setEntity(final EntityType entityType, final String entityId) {
+    if (entityType != EntityType.USER
+        && entityType != EntityType.MAPPING
+        && entityType != EntityType.GROUP) {
+      throw new IllegalArgumentException(
+          "For now, tenants can only be assigned to users, groups and mappings");
+    }
+    tenantDto.setEntityType(entityType);
+    tenantDto.setEntityId(entityId);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/tenant/TenantRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/tenant/TenantRecord.java
@@ -23,15 +23,17 @@ public final class TenantRecord extends UnifiedRecordValue implements TenantReco
   private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
   private final StringProperty nameProp = new StringProperty("name", "");
   private final LongProperty entityKeyProp = new LongProperty("entityKey", -1L);
+  private final StringProperty entityIdProp = new StringProperty("entityId", "");
   private final EnumProperty<EntityType> entityTypeProp =
       new EnumProperty<>("entityType", EntityType.class, EntityType.UNSPECIFIED);
 
   public TenantRecord() {
-    super(5);
+    super(6);
     declareProperty(tenantKeyProp)
         .declareProperty(tenantIdProp)
         .declareProperty(nameProp)
         .declareProperty(entityKeyProp)
+        .declareProperty(entityIdProp)
         .declareProperty(entityTypeProp);
   }
 
@@ -88,6 +90,16 @@ public final class TenantRecord extends UnifiedRecordValue implements TenantReco
 
   public TenantRecord setEntityKey(final long entityKey) {
     entityKeyProp.setValue(entityKey);
+    return this;
+  }
+
+  @Override
+  public String getEntityId() {
+    return bufferAsString(entityIdProp.getValue());
+  }
+
+  public TenantRecord setEntityId(final String entityId) {
+    entityIdProp.setValue(entityId);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/tenant/TenantRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/tenant/TenantRecord.java
@@ -19,10 +19,11 @@ import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
 import org.agrona.DirectBuffer;
 
 public final class TenantRecord extends UnifiedRecordValue implements TenantRecordValue {
-  private final LongProperty tenantKeyProp = new LongProperty("tenantKey", -1L);
+  private static final long DEFAULT_KEY = -1;
+  private final LongProperty tenantKeyProp = new LongProperty("tenantKey", DEFAULT_KEY);
   private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
   private final StringProperty nameProp = new StringProperty("name", "");
-  private final LongProperty entityKeyProp = new LongProperty("entityKey", -1L);
+  private final LongProperty entityKeyProp = new LongProperty("entityKey", DEFAULT_KEY);
   private final StringProperty entityIdProp = new StringProperty("entityId", "");
   private final EnumProperty<EntityType> entityTypeProp =
       new EnumProperty<>("entityType", EntityType.class, EntityType.UNSPECIFIED);
@@ -111,6 +112,10 @@ public final class TenantRecord extends UnifiedRecordValue implements TenantReco
   public TenantRecord setEntityType(final EntityType entityType) {
     entityTypeProp.setValue(entityType);
     return this;
+  }
+
+  public boolean hasTenantKey() {
+    return tenantKeyProp.getValue() != -1L;
   }
 
   @JsonIgnore

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2838,6 +2838,7 @@ final class JsonSerializableToJsonTest {
                     .setTenantId("tenant-abc")
                     .setName("Test Tenant")
                     .setEntityKey(456L)
+                    .setEntityId("entity-xyz")
                     .setEntityType(EntityType.USER),
         """
         {
@@ -2845,6 +2846,7 @@ final class JsonSerializableToJsonTest {
           "tenantId": "tenant-abc",
           "name": "Test Tenant",
           "entityKey": 456,
+          "entityId": "entity-xyz",
           "entityType": "USER"
         }
         """
@@ -2861,6 +2863,7 @@ final class JsonSerializableToJsonTest {
             "tenantId": "",
             "name": "",
             "entityKey": -1,
+            "entityId": "",
             "entityType": "UNSPECIFIED"
           }
           """
@@ -3062,6 +3065,7 @@ final class JsonSerializableToJsonTest {
           "tenantId": "id",
           "name": "name",
           "entityKey": -1,
+          "entityId": "",
           "entityType": "UNSPECIFIED"
         },
         "mappings": [
@@ -3101,6 +3105,7 @@ final class JsonSerializableToJsonTest {
               "tenantId": "",
               "name": "",
               "entityKey": -1,
+              "entityId": "",
               "entityType": "UNSPECIFIED"
           },
           "mappings": []

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/TenantRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/TenantRecordValue.java
@@ -36,6 +36,9 @@ public interface TenantRecordValue extends RecordValue {
   /** Key of the entity associated with this tenant. */
   long getEntityKey();
 
+  /** Identifier of the entity associated with this tenant. */
+  String getEntityId();
+
   /** The type of the entity to assign/remove from a tenant. */
   EntityType getEntityType();
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignUserToTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignUserToTenantTest.java
@@ -7,17 +7,19 @@
  */
 package io.camunda.zeebe.it.client.command;
 
-import static io.camunda.zeebe.protocol.record.value.EntityType.USER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
-import io.camunda.zeebe.it.util.ZeebeAssertHelper;
+import io.camunda.zeebe.protocol.record.intent.TenantIntent;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
+import java.util.UUID;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,6 +28,7 @@ import org.junit.jupiter.api.Test;
 class AssignUserToTenantTest {
 
   private static final String TENANT_ID = "tenant-id";
+  private static final String USERNAME = "username";
 
   @TestZeebe
   private final TestStandaloneBroker zeebe = new TestStandaloneBroker().withRecordingExporter(true);
@@ -53,7 +56,7 @@ class AssignUserToTenantTest {
     userKey =
         client
             .newUserCreateCommand()
-            .username("username")
+            .username(USERNAME)
             .name("name")
             .email("email@example.com")
             .password("password")
@@ -65,50 +68,56 @@ class AssignUserToTenantTest {
   @Test
   void shouldAssignUserToTenant() {
     // When
-    client.newAssignUserToTenantCommand(tenantKey).userKey(userKey).send().join();
+    client.newAssignUserToTenantCommand(TENANT_ID).userName(USERNAME).send().join();
 
     // Then
-    ZeebeAssertHelper.assertEntityAssignedToTenant(
-        tenantKey, userKey, tenant -> assertThat(tenant.getEntityType()).isEqualTo(USER));
+    assertThat(
+            RecordingExporter.tenantRecords()
+                .withIntent(TenantIntent.ENTITY_ADDED)
+                .withTenantId(TENANT_ID)
+                .withEntityType(EntityType.USER)
+                .withEntityId(USERNAME)
+                .exists())
+        .isTrue();
   }
 
   @Test
   void shouldRejectAssignIfTenantDoesNotExist() {
     // Given
-    final long invalidTenantKey = 99999L;
+    final var invalidTenantId = UUID.randomUUID().toString();
 
     // When / Then
     assertThatThrownBy(
             () ->
                 client
-                    .newAssignUserToTenantCommand(invalidTenantKey)
-                    .userKey(userKey)
+                    .newAssignUserToTenantCommand(invalidTenantId)
+                    .userName(USERNAME)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
         .hasMessageContaining(
-            "Command 'ADD_ENTITY' rejected with code 'NOT_FOUND': Expected to add entity to tenant with key '%d', but no tenant with this key exists."
-                .formatted(invalidTenantKey));
+            "Command 'ADD_ENTITY' rejected with code 'NOT_FOUND': Expected to add entity to tenant with id '%s', but no tenant with this id exists."
+                .formatted(invalidTenantId));
   }
 
   @Test
   void shouldRejectAssignIfUserDoesNotExist() {
     // Given
-    final long invalidUserKey = 99999L;
+    final var invalidUserName = UUID.randomUUID().toString();
 
     // When / Then
     assertThatThrownBy(
             () ->
                 client
-                    .newAssignUserToTenantCommand(tenantKey)
-                    .userKey(invalidUserKey)
+                    .newAssignUserToTenantCommand(TENANT_ID)
+                    .userName(invalidUserName)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
         .hasMessageContaining(
-            "Expected to add entity with key '%d' to tenant with tenantId '%s', but the entity doesn't exist."
-                .formatted(invalidUserKey, TENANT_ID));
+            "Expected to add user '%s' to tenant '%s', but the user doesn't exist."
+                .formatted(invalidUserName, TENANT_ID));
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignUserToTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignUserToTenantTest.java
@@ -68,7 +68,7 @@ class AssignUserToTenantTest {
   @Test
   void shouldAssignUserToTenant() {
     // When
-    client.newAssignUserToTenantCommand(TENANT_ID).userName(USERNAME).send().join();
+    client.newAssignUserToTenantCommand(TENANT_ID).username(USERNAME).send().join();
 
     // Then
     assertThat(
@@ -91,7 +91,7 @@ class AssignUserToTenantTest {
             () ->
                 client
                     .newAssignUserToTenantCommand(invalidTenantId)
-                    .userName(USERNAME)
+                    .username(USERNAME)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -111,7 +111,7 @@ class AssignUserToTenantTest {
             () ->
                 client
                     .newAssignUserToTenantCommand(TENANT_ID)
-                    .userName(invalidUserName)
+                    .username(invalidUserName)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RemoveUserFromTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RemoveUserFromTenantTest.java
@@ -50,10 +50,11 @@ class RemoveUserFromTenantTest {
             .getTenantKey();
 
     // Create User
+    final var username = "username";
     userKey =
         client
             .newUserCreateCommand()
-            .username("username")
+            .username(username)
             .name("name")
             .email("email@example.com")
             .password("password")
@@ -62,7 +63,7 @@ class RemoveUserFromTenantTest {
             .getUserKey();
 
     // Assign User to Tenant
-    client.newAssignUserToTenantCommand(tenantKey).userKey(userKey).send().join();
+    client.newAssignUserToTenantCommand(TENANT_ID).userName(username).send().join();
   }
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RemoveUserFromTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RemoveUserFromTenantTest.java
@@ -63,7 +63,7 @@ class RemoveUserFromTenantTest {
             .getUserKey();
 
     // Assign User to Tenant
-    client.newAssignUserToTenantCommand(TENANT_ID).userName(username).send().join();
+    client.newAssignUserToTenantCommand(TENANT_ID).username(username).send().join();
   }
 
   @Test

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/AuthorizationsUtil.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/AuthorizationsUtil.java
@@ -93,20 +93,19 @@ public class AuthorizationsUtil implements CloseableSilently {
     }
   }
 
-  public long createTenant(final String tenantId, final String tenantName, final long... userKeys) {
-    final long tenantKey =
-        client
-            .newCreateTenantCommand()
-            .tenantId(tenantId)
-            .name(tenantName)
-            .send()
-            .join()
-            .getTenantKey();
-    for (final long userKey : userKeys) {
-      client.newAssignUserToTenantCommand(tenantKey).userKey(userKey).send().join();
+  public void createTenant(
+      final String tenantId, final String tenantName, final String... userNames) {
+    client
+        .newCreateTenantCommand()
+        .tenantId(tenantId)
+        .name(tenantName)
+        .send()
+        .join()
+        .getTenantKey();
+    for (final var userName : userNames) {
+      client.newAssignUserToTenantCommand(tenantId).userName(userName).send().join();
     }
     awaitTenantExistsInElasticsearch(tenantId);
-    return tenantKey;
   }
 
   public CamundaClient createClient(final String username, final String password) {

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/AuthorizationsUtil.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/AuthorizationsUtil.java
@@ -94,7 +94,7 @@ public class AuthorizationsUtil implements CloseableSilently {
   }
 
   public void createTenant(
-      final String tenantId, final String tenantName, final String... userNames) {
+      final String tenantId, final String tenantName, final String... usernames) {
     client
         .newCreateTenantCommand()
         .tenantId(tenantId)
@@ -102,8 +102,8 @@ public class AuthorizationsUtil implements CloseableSilently {
         .send()
         .join()
         .getTenantKey();
-    for (final var userName : userNames) {
-      client.newAssignUserToTenantCommand(tenantId).userName(userName).send().join();
+    for (final var username : usernames) {
+      client.newAssignUserToTenantCommand(tenantId).username(username).send().join();
     }
     awaitTenantExistsInElasticsearch(tenantId);
   }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -911,6 +911,8 @@ public class CompactRecordLogger {
         .append(formatId(value.getName()))
         .append(", EntityKey=")
         .append(shortenKey(value.getEntityKey()))
+        .append(", EntityId=")
+        .append(formatId(value.getEntityId()))
         .append("]");
 
     return builder.toString();

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/TenantRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/TenantRecordStream.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.test.util.record;
 
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
 import java.util.stream.Stream;
 
@@ -37,5 +38,13 @@ public class TenantRecordStream
 
   public TenantRecordStream withEntityKey(final long entityKey) {
     return valueFilter(v -> v.getEntityKey() == entityKey);
+  }
+
+  public TenantRecordStream withEntityId(final String entityId) {
+    return valueFilter(v -> v.getEntityId().equals(entityId));
+  }
+
+  public TenantRecordStream withEntityType(final EntityType entityType) {
+    return valueFilter(v -> v.getEntityType() == entityType);
   }
 }


### PR DESCRIPTION
This changes how we assign users to tenants. Instead of the tenant key and user key, we now use tenant id and username.
Tenant assignments are now in a temporary state where groups and mappings are assigned by tenant and entity key while users are assigned by ids only. The `TenantRecord` supports both. Processors and appliers were adjusted to resolve ids to keys as late as possible such that we can eventually [remove tenant keys from the API](https://github.com/camunda/camunda/issues/27059) and [reorganize the runtime state](https://github.com/camunda/camunda/issues/27137) to store things by id, not key.

closes #27186
