### PR TITLE
docs: create an entity relationship diagram for identity

### DIFF
--- a/docs/identity.md
+++ b/docs/identity.md
@@ -1,0 +1,44 @@
+# Identity
+
+## Data model
+
+```mermaid
+erDiagram
+  User {
+    string username PK
+    string name
+    string email
+    string password
+  }
+  Role {
+    string id PK
+    string name
+  }
+  Group {
+    string id PK
+    string name
+  }
+  Tenant {
+    string id PK
+    string name
+  }
+  Authorization {
+    enum ownerType
+    enum resourceType
+  }
+  Permission {
+    enum permissionType
+    string[] resourceIds
+  }
+
+  User }o..o{ Tenant: "assigned"
+  User }o..o{ Group: "member"
+  User ||--o{ Authorization: "granted"
+  Authorization ||--|{ Permission: "granted"
+  Group }o..o{ Tenant: "assigned"
+  Group }o..o{ Role: "assigned"
+  User }o..o{ Role: "assigned"
+  Group ||--o{ Authorization: "granted"
+  Role ||--o{ Authorization: "granted"
+```
+

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -23,6 +23,7 @@ erDiagram
     string name
   }
   Authorization {
+    string ownerId
     enum ownerType
     enum resourceType
   }


### PR DESCRIPTION
This adds an initial diagram describing the _desired_ data model of the Identity entities.

Rendered version: https://github.com/camunda/camunda/blob/ls/identity-er-diagram/docs/identity.md
