### PR TITLE
refactor: support generic key types in entityjoinrelation

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -358,7 +358,7 @@
       <column name="TENANT_ID" type="VARCHAR(255)">
         <constraints primaryKey="true"/>
       </column>
-      <column name="ENTITY_KEY" type="BIGINT" >
+      <column name="ENTITY_ID" type="VARCHAR(255)" >
         <constraints primaryKey="true"/>
       </column>
       <column name="ENTITY_TYPE" type="VARCHAR(255)" />

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantReader.java
@@ -47,10 +47,6 @@ public class TenantReader extends AbstractEntityReader<TenantEntity> {
   }
 
   private TenantEntity map(final TenantDbModel model) {
-    return new TenantEntity(
-        model.tenantKey(),
-        model.tenantId(),
-        model.name(),
-        model.description());
+    return new TenantEntity(model.tenantKey(), model.tenantId(), model.name(), model.description());
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantReader.java
@@ -11,12 +11,10 @@ import io.camunda.db.rdbms.read.domain.TenantDbQuery;
 import io.camunda.db.rdbms.sql.TenantMapper;
 import io.camunda.db.rdbms.sql.columns.TenantSearchColumn;
 import io.camunda.db.rdbms.write.domain.TenantDbModel;
-import io.camunda.db.rdbms.write.domain.TenantMemberDbModel;
 import io.camunda.search.entities.TenantEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.TenantQuery;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +51,6 @@ public class TenantReader extends AbstractEntityReader<TenantEntity> {
         model.tenantKey(),
         model.tenantId(),
         model.name(),
-        model.description(),
-        model.members().stream().map(TenantMemberDbModel::entityKey).collect(Collectors.toSet()));
+        model.description());
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/TenantMemberDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/TenantMemberDbModel.java
@@ -9,12 +9,12 @@ package io.camunda.db.rdbms.write.domain;
 
 import io.camunda.util.ObjectBuilder;
 
-public record TenantMemberDbModel(String tenantId, Long entityKey, String entityType) {
+public record TenantMemberDbModel(String tenantId, String entityId, String entityType) {
 
   public static class Builder implements ObjectBuilder<TenantMemberDbModel> {
 
     private String tenantId;
-    private Long entityKey;
+    private String entityId;
     private String entityType;
 
     public Builder tenantId(final String tenantId) {
@@ -22,8 +22,8 @@ public record TenantMemberDbModel(String tenantId, Long entityKey, String entity
       return this;
     }
 
-    public Builder entityKey(final Long entityKey) {
-      this.entityKey = entityKey;
+    public Builder entityId(final String entityId) {
+      this.entityId = entityId;
       return this;
     }
 
@@ -34,7 +34,7 @@ public record TenantMemberDbModel(String tenantId, Long entityKey, String entity
 
     @Override
     public TenantMemberDbModel build() {
-      return new TenantMemberDbModel(tenantId, entityKey, entityType);
+      return new TenantMemberDbModel(tenantId, entityId, entityType);
     }
   }
 }

--- a/db/rdbms/src/main/resources/mapper/TenantMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/TenantMapper.xml
@@ -20,15 +20,11 @@
     resultMap="io.camunda.db.rdbms.sql.TenantMapper.tenantResultMap">
     SELECT * FROM (
     SELECT
-    t.TENANT_KEY,
-    t.TENANT_ID,
-    t.NAME,
-    t.DESCRIPTION,
-    tm.TENANT_ID AS MEMBER_TENANT_ID,
-    tm.ENTITY_KEY AS MEMBER_ENTITY_KEY,
-    tm.ENTITY_TYPE AS MEMBER_ENTITY_TYPE
+    TENANT_KEY,
+    TENANT_ID,
+    NAME,
+    DESCRIPTION
     FROM TENANT t
-    LEFT JOIN TENANT_MEMBER tm ON t.TENANT_ID = tm.TENANT_ID
     <include refid="io.camunda.db.rdbms.sql.TenantMapper.searchFilter"/>
     ) t
     <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
@@ -48,14 +44,6 @@
     <result column="TENANT_KEY" property="tenantKey"/>
     <result column="NAME" property="name"/>
     <result column="DESCRIPTION" property="description"/>
-    <collection property="members" ofType="io.camunda.db.rdbms.write.domain.TenantMemberDbModel"
-      javaType="java.util.List">
-      <constructor>
-        <idArg column="MEMBER_TENANT_ID" javaType="java.lang.String"/>
-        <idArg column="MEMBER_ENTITY_KEY" javaType="java.lang.Long"/>
-        <arg column="MEMBER_ENTITY_TYPE" javaType="java.lang.String"/>
-      </constructor>
-    </collection>
   </resultMap>
 
   <insert

--- a/db/rdbms/src/main/resources/mapper/TenantMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/TenantMapper.xml
@@ -24,7 +24,7 @@
     TENANT_ID,
     NAME,
     DESCRIPTION
-    FROM TENANT t
+    FROM TENANT
     <include refid="io.camunda.db.rdbms.sql.TenantMapper.searchFilter"/>
     ) t
     <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
@@ -34,9 +34,9 @@
 
   <sql id="searchFilter">
     WHERE 1 = 1
-    <if test="filter.key != null">AND t.TENANT_KEY = #{filter.key}</if>
-    <if test="filter.tenantId != null">AND t.TENANT_ID = #{filter.tenantId}</if>
-    <if test="filter.name != null">AND t.NAME = #{filter.name}</if>
+    <if test="filter.key != null">AND TENANT_KEY = #{filter.key}</if>
+    <if test="filter.tenantId != null">AND TENANT_ID = #{filter.tenantId}</if>
+    <if test="filter.name != null">AND NAME = #{filter.name}</if>
   </sql>
 
   <resultMap id="tenantResultMap" type="io.camunda.db.rdbms.write.domain.TenantDbModel">

--- a/db/rdbms/src/main/resources/mapper/TenantMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/TenantMapper.xml
@@ -75,8 +75,8 @@
     id="insertMember"
     parameterType="io.camunda.db.rdbms.write.domain.TenantMemberDbModel"
     flushCache="true">
-    INSERT INTO TENANT_MEMBER (TENANT_ID, ENTITY_KEY, ENTITY_TYPE)
-    VALUES (#{tenantId}, #{entityKey}, #{entityType})
+    INSERT INTO TENANT_MEMBER (TENANT_ID, ENTITY_ID, ENTITY_TYPE)
+    VALUES (#{tenantId}, #{entityID}, #{entityType})
   </insert>
 
   <delete
@@ -86,7 +86,7 @@
     DELETE
     FROM TENANT_MEMBER
     WHERE TENANT_ID = #{tenantId}
-      AND ENTITY_KEY = #{entityKey}
+      AND ENTITY_ID = #{entityId}
       AND ENTITY_TYPE = #{entityType}
   </delete>
 

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/TenantMappingRuleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/TenantMappingRuleMigrationHandlerTest.java
@@ -87,8 +87,7 @@ final class TenantMappingRuleMigrationHandlerTest {
   void stopWhenNoMoreRecords() {
     // given
     givenMappingRules();
-    when(tenantServices.getById(any()))
-        .thenReturn(new TenantEntity(1L, "", "", null));
+    when(tenantServices.getById(any())).thenReturn(new TenantEntity(1L, "", "", null));
     when(mappingServices.createMapping(any()))
         .thenAnswer(invocation -> CompletableFuture.completedFuture(new MappingRecord()));
     when(tenantServices.addMember(any(), any(), anyLong()))
@@ -155,8 +154,7 @@ final class TenantMappingRuleMigrationHandlerTest {
   void ignoreWhenMappingAlreadyAssigned() {
     // given
     givenMappingRules();
-    when(tenantServices.getById(any()))
-        .thenReturn(new TenantEntity(1L, "", "", null));
+    when(tenantServices.getById(any())).thenReturn(new TenantEntity(1L, "", "", null));
     when(mappingServices.createMapping(any()))
         .thenAnswer(invocation -> CompletableFuture.completedFuture(new MappingRecord()));
     when(tenantServices.addMember(any(), any(), anyLong()))

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/TenantMappingRuleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/TenantMappingRuleMigrationHandlerTest.java
@@ -36,7 +36,6 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -89,7 +88,7 @@ final class TenantMappingRuleMigrationHandlerTest {
     // given
     givenMappingRules();
     when(tenantServices.getById(any()))
-        .thenReturn(new TenantEntity(1L, "", "", null, Collections.emptySet()));
+        .thenReturn(new TenantEntity(1L, "", "", null));
     when(mappingServices.createMapping(any()))
         .thenAnswer(invocation -> CompletableFuture.completedFuture(new MappingRecord()));
     when(tenantServices.addMember(any(), any(), anyLong()))
@@ -157,7 +156,7 @@ final class TenantMappingRuleMigrationHandlerTest {
     // given
     givenMappingRules();
     when(tenantServices.getById(any()))
-        .thenReturn(new TenantEntity(1L, "", "", null, Collections.emptySet()));
+        .thenReturn(new TenantEntity(1L, "", "", null));
     when(mappingServices.createMapping(any()))
         .thenAnswer(invocation -> CompletableFuture.completedFuture(new MappingRecord()));
     when(tenantServices.addMember(any(), any(), anyLong()))

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/UserTenantsMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/UserTenantsMigrationHandlerTest.java
@@ -92,8 +92,7 @@ final class UserTenantsMigrationHandlerTest {
   void stopWhenNoMoreRecords() {
     // given
     givenUserTenants();
-    when(tenantServices.getById(any()))
-        .thenReturn(new TenantEntity(1L, "", "", null));
+    when(tenantServices.getById(any())).thenReturn(new TenantEntity(1L, "", "", null));
     when(tenantServices.createTenant(any()))
         .thenReturn(CompletableFuture.completedFuture(new TenantRecord()));
     when(mappingServices.createMapping(any()))
@@ -161,8 +160,7 @@ final class UserTenantsMigrationHandlerTest {
   void ignoreWhenUserAlreadyAssigned() {
     // given
     givenUserTenants();
-    when(tenantServices.getById(any()))
-        .thenReturn(new TenantEntity(1L, "", "", null));
+    when(tenantServices.getById(any())).thenReturn(new TenantEntity(1L, "", "", null));
     doThrow(
             new BrokerRejectionException(
                 new BrokerRejection(TenantIntent.ADD_ENTITY, -1, RejectionType.ALREADY_EXISTS, "")))

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/UserTenantsMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/UserTenantsMigrationHandlerTest.java
@@ -34,7 +34,6 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -94,7 +93,7 @@ final class UserTenantsMigrationHandlerTest {
     // given
     givenUserTenants();
     when(tenantServices.getById(any()))
-        .thenReturn(new TenantEntity(1L, "", "", null, Collections.emptySet()));
+        .thenReturn(new TenantEntity(1L, "", "", null));
     when(tenantServices.createTenant(any()))
         .thenReturn(CompletableFuture.completedFuture(new TenantRecord()));
     when(mappingServices.createMapping(any()))
@@ -163,7 +162,7 @@ final class UserTenantsMigrationHandlerTest {
     // given
     givenUserTenants();
     when(tenantServices.getById(any()))
-        .thenReturn(new TenantEntity(1L, "", "", null, Collections.emptySet()));
+        .thenReturn(new TenantEntity(1L, "", "", null));
     doThrow(
             new BrokerRejectionException(
                 new BrokerRejection(TenantIntent.ADD_ENTITY, -1, RejectionType.ALREADY_EXISTS, "")))

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
@@ -10,7 +10,6 @@ package io.camunda.it.auth;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -82,7 +81,7 @@ public class BasicAuthIT {
                 null));
     when(tenantServices.getTenantsByMemberKey(anyLong()))
         .thenReturn(
-            List.of(new TenantEntity(9L, "T1", "Tenant 1", "Tenant 1 description", Set.of())));
+            List.of(new TenantEntity(9L, "T1", "Tenant 1", "Tenant 1 description")));
 
     when(authorizationServices.findAll(any()))
         .thenReturn(

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
@@ -80,8 +80,7 @@ public class BasicAuthIT {
                 null,
                 null));
     when(tenantServices.getTenantsByMemberKey(anyLong()))
-        .thenReturn(
-            List.of(new TenantEntity(9L, "T1", "Tenant 1", "Tenant 1 description")));
+        .thenReturn(List.of(new TenantEntity(9L, "T1", "Tenant 1", "Tenant 1 description")));
 
     when(authorizationServices.findAll(any()))
         .thenReturn(

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantIT.java
@@ -16,7 +16,6 @@ import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.TenantReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.TenantDbModel;
-import io.camunda.db.rdbms.write.domain.TenantMemberDbModel;
 import io.camunda.it.rdbms.db.fixtures.TenantFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
@@ -104,32 +103,6 @@ public class TenantIT {
 
     final var deletedInstance = tenantReader.findOne(tenant.tenantId()).orElse(null);
     assertThat(deletedInstance).isNull();
-  }
-
-  @TestTemplate
-  public void shouldAddAndRemoveMember(final CamundaRdbmsTestApplication testApplication) {
-    final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
-    final TenantReader tenantReader = rdbmsService.getTenantReader();
-
-    final var tenant = TenantFixtures.createRandomized(b -> b);
-    createAndSaveTenant(rdbmsWriter, tenant);
-
-    rdbmsWriter
-        .getTenantWriter()
-        .addMember(new TenantMemberDbModel(tenant.tenantId(), 1337L, "USER"));
-    rdbmsWriter.flush();
-
-    final var addedMemberInstance = tenantReader.findOne(tenant.tenantId()).orElse(null);
-    assertThat(addedMemberInstance.assignedMemberKeys()).containsExactly(1337L);
-
-    rdbmsWriter
-        .getTenantWriter()
-        .removeMember(new TenantMemberDbModel(tenant.tenantId(), 1337L, "USER"));
-    rdbmsWriter.flush();
-
-    final var removedMemberInstance = tenantReader.findOne(tenant.tenantId()).orElse(null);
-    assertThat(removedMemberInstance.assignedMemberKeys()).isEmpty();
   }
 
   @TestTemplate

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -345,48 +345,6 @@ class RdbmsExporterIT {
   }
 
   @Test
-  public void shouldExportTenantAndAddAndDeleteMember() {
-    final var tenantId = "tenant=" + nextKey();
-    // given
-    final var tenantRecord = getTenantRecord(43L, tenantId, TenantIntent.CREATED);
-    final var tenantRecordValue = ((TenantRecordValue) tenantRecord.getValue());
-
-    // when
-    exporter.export(tenantRecord);
-
-    // then
-    final var tenant =
-        rdbmsService
-            .getTenantReader()
-            .findOne(((TenantRecordValue) tenantRecord.getValue()).getTenantId());
-    assertThat(tenant).isNotEmpty();
-    assertThat(tenant.get().key()).isEqualTo(tenantRecordValue.getTenantKey());
-    assertThat(tenant.get().name()).isEqualTo(tenantRecordValue.getName());
-
-    // when
-    exporter.export(getTenantRecord(43L, tenantId, TenantIntent.ENTITY_ADDED, 1337L));
-
-    // then
-    final var updatedTenant =
-        rdbmsService
-            .getTenantReader()
-            .findOne(((TenantRecordValue) tenantRecord.getValue()).getTenantId())
-            .orElseThrow();
-    assertThat(updatedTenant.assignedMemberKeys()).containsExactly(1337L);
-
-    // when
-    exporter.export(getTenantRecord(43L, tenantId, TenantIntent.ENTITY_REMOVED, 1337L));
-
-    // then
-    final var deletedTenant =
-        rdbmsService
-            .getTenantReader()
-            .findOne(((TenantRecordValue) tenantRecord.getValue()).getTenantId())
-            .orElseThrow();
-    assertThat(deletedTenant.assignedMemberKeys()).isEmpty();
-  }
-
-  @Test
   public void shouldExportUpdateAndDeleteRole() {
     // given
     final var roleRecord = getRoleRecord(42L, RoleIntent.CREATED);

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/TenantEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/TenantEntityTransformer.java
@@ -9,7 +9,6 @@ package io.camunda.search.clients.transformers.entity;
 
 import io.camunda.search.clients.transformers.ServiceTransformer;
 import io.camunda.search.entities.TenantEntity;
-import java.util.Set;
 
 public class TenantEntityTransformer
     implements ServiceTransformer<
@@ -22,7 +21,6 @@ public class TenantEntityTransformer
         source.getKey(),
         source.getTenantId(),
         source.getName(),
-        source.getDescription(),
-        source.getJoin().parent() != null ? Set.of(source.getJoin().parent()) : Set.of());
+        source.getDescription());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/TenantEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/TenantEntityTransformer.java
@@ -18,9 +18,6 @@ public class TenantEntityTransformer
   public TenantEntity apply(
       final io.camunda.webapps.schema.entities.usermanagement.TenantEntity source) {
     return new TenantEntity(
-        source.getKey(),
-        source.getTenantId(),
-        source.getName(),
-        source.getDescription());
+        source.getKey(), source.getTenantId(), source.getName(), source.getDescription());
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/TenantEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/TenantEntity.java
@@ -10,5 +10,4 @@ package io.camunda.search.entities;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record TenantEntity(
-    Long key, String tenantId, String name, String description) {}
+public record TenantEntity(Long key, String tenantId, String name, String description) {}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/TenantEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/TenantEntity.java
@@ -8,8 +8,7 @@
 package io.camunda.search.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import java.util.Set;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record TenantEntity(
-    Long key, String tenantId, String name, String description, Set<Long> assignedMemberKeys) {}
+    Long key, String tenantId, String name, String description) {}

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -33,7 +33,6 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.List;
-import java.util.Set;
 import org.assertj.core.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,7 +45,7 @@ public class TenantServiceTest {
   private TenantSearchClient client;
   private StubbedBrokerClient stubbedBrokerClient;
   private final TenantEntity tenantEntity =
-      new TenantEntity(100L, "tenant-id", "Tenant name", "Tenant description", Set.of());
+      new TenantEntity(100L, "tenant-id", "Tenant name", "Tenant description");
 
   @BeforeEach
   public void before() {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/GroupIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/GroupIndex.java
@@ -21,8 +21,8 @@ public class GroupIndex extends UserManagementIndexDescriptor implements Prio5Ba
   public static final String NAME = "name";
   public static final String JOIN = "join";
 
-  public static final EntityJoinRelationFactory JOIN_RELATION_FACTORY =
-      new EntityJoinRelationFactory(
+  public static final EntityJoinRelationFactory<Long> JOIN_RELATION_FACTORY =
+      new EntityJoinRelationFactory<>(
           IdentityJoinRelationshipType.GROUP, IdentityJoinRelationshipType.MEMBER);
 
   public GroupIndex(final String indexPrefix, final boolean isElasticsearch) {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/RoleIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/RoleIndex.java
@@ -21,8 +21,8 @@ public class RoleIndex extends UserManagementIndexDescriptor implements Prio5Bac
   public static final String MEMBER_KEY = "memberKey";
   public static final String JOIN = "join";
 
-  public static final EntityJoinRelationFactory JOIN_RELATION_FACTORY =
-      new EntityJoinRelationFactory(
+  public static final EntityJoinRelationFactory<Long> JOIN_RELATION_FACTORY =
+      new EntityJoinRelationFactory<>(
           IdentityJoinRelationshipType.ROLE, IdentityJoinRelationshipType.MEMBER);
 
   public RoleIndex(final String indexPrefix, final boolean isElasticsearch) {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/TenantIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/TenantIndex.java
@@ -23,8 +23,8 @@ public class TenantIndex extends UserManagementIndexDescriptor implements Prio5B
   public static final String JOIN = "join";
   public static final String MEMBER_KEY = "memberKey";
 
-  public static final EntityJoinRelationFactory JOIN_RELATION_FACTORY =
-      new EntityJoinRelationFactory(
+  public static final EntityJoinRelationFactory<String> JOIN_RELATION_FACTORY =
+      new EntityJoinRelationFactory<>(
           EntityJoinRelation.IdentityJoinRelationshipType.TENANT,
           EntityJoinRelation.IdentityJoinRelationshipType.MEMBER);
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/EntityJoinRelation.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/EntityJoinRelation.java
@@ -9,7 +9,7 @@ package io.camunda.webapps.schema.entities.usermanagement;
 
 public record EntityJoinRelation<T>(String name, T parent) {
 
-  public static class EntityJoinRelationFactory {
+  public static class EntityJoinRelationFactory<T> {
 
     private final IdentityJoinRelationshipType parent;
     private final IdentityJoinRelationshipType child;
@@ -20,15 +20,11 @@ public record EntityJoinRelation<T>(String name, T parent) {
       this.child = child;
     }
 
-    public EntityJoinRelation<?> createParent() {
+    public EntityJoinRelation<T> createParent() {
       return new EntityJoinRelation<>(parent.getType(), null);
     }
 
-    public EntityJoinRelation<Long> createChild(final long parentKey) {
-      return new EntityJoinRelation<>(child.getType(), parentKey);
-    }
-
-    public EntityJoinRelation<String> createChild(final String parentId) {
+    public EntityJoinRelation<T> createChild(final T parentId) {
       return new EntityJoinRelation<>(child.getType(), parentId);
     }
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/EntityJoinRelation.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/EntityJoinRelation.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.webapps.schema.entities.usermanagement;
 
-public record EntityJoinRelation(String name, Long parent) {
+public record EntityJoinRelation<T>(String name, T parent) {
 
   public static class EntityJoinRelationFactory {
 
@@ -20,12 +20,16 @@ public record EntityJoinRelation(String name, Long parent) {
       this.child = child;
     }
 
-    public EntityJoinRelation createParent() {
-      return new EntityJoinRelation(parent.getType(), null);
+    public EntityJoinRelation<?> createParent() {
+      return new EntityJoinRelation<>(parent.getType(), null);
     }
 
-    public EntityJoinRelation createChild(final long parentKey) {
-      return new EntityJoinRelation(child.getType(), parentKey);
+    public EntityJoinRelation<Long> createChild(final long parentKey) {
+      return new EntityJoinRelation<>(child.getType(), parentKey);
+    }
+
+    public EntityJoinRelation<String> createChild(final String parentId) {
+      return new EntityJoinRelation<>(child.getType(), parentId);
     }
   }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupEntity.java
@@ -15,7 +15,7 @@ public class GroupEntity extends AbstractExporterEntity<GroupEntity> {
   private String name;
   private Long memberKey;
 
-  private EntityJoinRelation join;
+  private EntityJoinRelation<Long> join;
 
   public Long getKey() {
     return key;
@@ -44,11 +44,11 @@ public class GroupEntity extends AbstractExporterEntity<GroupEntity> {
     return this;
   }
 
-  public EntityJoinRelation getJoin() {
+  public EntityJoinRelation<Long> getJoin() {
     return join;
   }
 
-  public GroupEntity setJoin(final EntityJoinRelation join) {
+  public GroupEntity setJoin(final EntityJoinRelation<Long> join) {
     this.join = join;
     return this;
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleEntity.java
@@ -14,7 +14,7 @@ public class RoleEntity extends AbstractExporterEntity<RoleEntity> {
   private Long key;
   private String name;
   private Long memberKey;
-  private EntityJoinRelation join;
+  private EntityJoinRelation<Long> join;
 
   public Long getKey() {
     return key;
@@ -43,11 +43,11 @@ public class RoleEntity extends AbstractExporterEntity<RoleEntity> {
     return this;
   }
 
-  public EntityJoinRelation getJoin() {
+  public EntityJoinRelation<Long> getJoin() {
     return join;
   }
 
-  public RoleEntity setJoin(final EntityJoinRelation join) {
+  public RoleEntity setJoin(final EntityJoinRelation<Long> join) {
     this.join = join;
     return this;
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantEntity.java
@@ -17,7 +17,7 @@ public class TenantEntity extends AbstractExporterEntity<TenantEntity> {
   private String description;
   private Long memberKey;
 
-  private EntityJoinRelation join;
+  private EntityJoinRelation<String> join;
 
   public Long getKey() {
     return key;
@@ -64,11 +64,11 @@ public class TenantEntity extends AbstractExporterEntity<TenantEntity> {
     return this;
   }
 
-  public EntityJoinRelation getJoin() {
+  public EntityJoinRelation<String> getJoin() {
     return join;
   }
 
-  public TenantEntity setJoin(final EntityJoinRelation join) {
+  public TenantEntity setJoin(final EntityJoinRelation<String> join) {
     this.join = join;
     return this;
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantEntity.java
@@ -16,6 +16,7 @@ public class TenantEntity extends AbstractExporterEntity<TenantEntity> {
   private String name;
   private String description;
   private Long memberKey;
+  private String memberId;
 
   private EntityJoinRelation<String> join;
 
@@ -73,7 +74,12 @@ public class TenantEntity extends AbstractExporterEntity<TenantEntity> {
     return this;
   }
 
-  public static String getChildKey(final long tenantKey, final long memberKey) {
-    return String.format("%d-%d", tenantKey, memberKey);
+  public TenantEntity setMemberId(final String memberId) {
+    this.memberId = memberId;
+    return this;
+  }
+
+  public static String getChildKey(final String tenantId, final String memberId) {
+    return String.format("%s-%s", tenantId, memberId);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityAddedHandler.java
@@ -44,7 +44,7 @@ public class TenantEntityAddedHandler implements ExportHandler<TenantEntity, Ten
   public List<String> generateIds(final Record<TenantRecordValue> record) {
     final var tenantRecord = record.getValue();
     return List.of(
-        TenantEntity.getChildKey(tenantRecord.getTenantKey(), tenantRecord.getEntityKey()));
+        TenantEntity.getChildKey(tenantRecord.getTenantId(), tenantRecord.getEntityId()));
   }
 
   @Override
@@ -56,14 +56,14 @@ public class TenantEntityAddedHandler implements ExportHandler<TenantEntity, Ten
   public void updateEntity(final Record<TenantRecordValue> record, final TenantEntity entity) {
     final TenantRecordValue value = record.getValue();
     entity
-        .setMemberKey(value.getEntityKey())
-        .setJoin(TenantIndex.JOIN_RELATION_FACTORY.createChild(value.getTenantKey()));
+        .setMemberId(value.getEntityId())
+        .setJoin(TenantIndex.JOIN_RELATION_FACTORY.createChild(value.getTenantId()));
   }
 
   @Override
   public void flush(final TenantEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.addWithRouting(indexName, entity, String.valueOf(entity.getJoin().parent()));
+    batchRequest.addWithRouting(indexName, entity, entity.getJoin().parent());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityRemovedHandler.java
@@ -45,7 +45,7 @@ public class TenantEntityRemovedHandler implements ExportHandler<TenantEntity, T
   public List<String> generateIds(final Record<TenantRecordValue> record) {
     final var tenantRecord = record.getValue();
     return List.of(
-        TenantEntity.getChildKey(tenantRecord.getTenantKey(), tenantRecord.getEntityKey()));
+        TenantEntity.getChildKey(tenantRecord.getTenantId(), tenantRecord.getEntityId()));
   }
 
   @Override
@@ -56,8 +56,8 @@ public class TenantEntityRemovedHandler implements ExportHandler<TenantEntity, T
   @Override
   public void updateEntity(final Record<TenantRecordValue> record, final TenantEntity entity) {
     final TenantRecordValue value = record.getValue();
-    final var joinRelation = TenantIndex.JOIN_RELATION_FACTORY.createChild(value.getTenantKey());
-    entity.setMemberKey(value.getEntityKey()).setJoin(joinRelation);
+    final var joinRelation = TenantIndex.JOIN_RELATION_FACTORY.createChild(value.getTenantId());
+    entity.setMemberId(value.getEntityId()).setJoin(joinRelation);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityAddedHandlerTest.java
@@ -59,7 +59,7 @@ public class TenantEntityAddedHandlerTest {
     // then
     final var value = tenantRecord.getValue();
     assertThat(idList)
-        .containsExactly(TenantEntity.getChildKey(value.getTenantKey(), value.getEntityKey()));
+        .containsExactly(TenantEntity.getChildKey(value.getTenantId(), value.getEntityId()));
   }
 
   @Test
@@ -75,7 +75,7 @@ public class TenantEntityAddedHandlerTest {
   @Test
   void shouldUpdateTenantEntityOnFlush() throws PersistenceException {
     // given
-    final var joinRelation = TenantIndex.JOIN_RELATION_FACTORY.createChild(111L);
+    final var joinRelation = TenantIndex.JOIN_RELATION_FACTORY.createChild("111");
     final TenantEntity inputEntity =
         new TenantEntity().setId("111").setMemberKey(222L).setJoin(joinRelation);
     final BatchRequest mockRequest = mock(BatchRequest.class);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityRemovedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityRemovedHandlerTest.java
@@ -61,7 +61,7 @@ public class TenantEntityRemovedHandlerTest {
     // then
     final var value = tenantRecord.getValue();
     assertThat(idList)
-        .containsExactly(TenantEntity.getChildKey(value.getTenantKey(), value.getEntityKey()));
+        .containsExactly(TenantEntity.getChildKey(value.getTenantId(), value.getEntityId()));
   }
 
   @Test
@@ -77,7 +77,7 @@ public class TenantEntityRemovedHandlerTest {
   @Test
   void shouldUpdateTenantEntityOnFlush() throws PersistenceException {
     // given
-    final var joinRelation = TenantIndex.JOIN_RELATION_FACTORY.createChild(111L);
+    final var joinRelation = TenantIndex.JOIN_RELATION_FACTORY.createChild("111");
     final TenantEntity inputEntity =
         new TenantEntity().setId("111").setMemberKey(222L).setJoin(joinRelation);
     final BatchRequest mockRequest = mock(BatchRequest.class);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/TenantExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/TenantExportHandler.java
@@ -54,14 +54,14 @@ public class TenantExportHandler implements RdbmsExportHandler<TenantRecordValue
           tenantWriter.addMember(
               new TenantMemberDbModel.Builder()
                   .tenantId(value.getTenantId())
-                  .entityKey(value.getEntityKey())
+                  .entityId(value.getEntityId())
                   .entityType(value.getEntityType().name())
                   .build());
       case TenantIntent.ENTITY_REMOVED ->
           tenantWriter.removeMember(
               new TenantMemberDbModel.Builder()
                   .tenantId(value.getTenantId())
-                  .entityKey(value.getEntityKey())
+                  .entityId(value.getEntityId())
                   .entityType(value.getEntityType().name())
                   .build());
       default -> LOG.warn("Unexpected intent {} for tenant record", record.getIntent());

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -315,11 +315,7 @@ public final class SearchQueryResponseMapper {
         .tenantKey(tenantEntity.key())
         .name(tenantEntity.name())
         .description(tenantEntity.description())
-        .tenantId(tenantEntity.tenantId())
-        .assignedMemberKeys(
-            tenantEntity.assignedMemberKeys() == null
-                ? null
-                : tenantEntity.assignedMemberKeys().stream().sorted().toList());
+        .tenantId(tenantEntity.tenantId());
   }
 
   private static List<MappingItem> toMappings(final List<MappingEntity> mappings) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -54,7 +54,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
              "tenantKey": %s,
              "name": "%s",
              "description": "%s",
-             "tenantId": "%s",
+             "tenantId": "%s"
            },
            {
              "tenantKey": %s,

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -42,9 +42,9 @@ public class TenantQueryControllerTest extends RestControllerTest {
 
   private static final List<TenantEntity> TENANT_ENTITIES =
       List.of(
-          new TenantEntity(100L, "tenant-id-1", "Tenant 1", "Description 1", Set.of()),
-          new TenantEntity(200L, "tenant-id-2", "Tenant 2", "Description 2", Set.of(1L, 2L)),
-          new TenantEntity(300L, "tenant-id-3", "Tenant 12", "Description 3", Set.of(3L)));
+          new TenantEntity(100L, "tenant-id-1", "Tenant 1", "Description 1"),
+          new TenantEntity(200L, "tenant-id-2", "Tenant 2", "Description 2"),
+          new TenantEntity(300L, "tenant-id-3", "Tenant 12", "Description 3"));
 
   private static final String RESPONSE =
       """
@@ -55,21 +55,18 @@ public class TenantQueryControllerTest extends RestControllerTest {
              "name": "%s",
              "description": "%s",
              "tenantId": "%s",
-             "assignedMemberKeys": %s
            },
            {
              "tenantKey": %s,
              "name": "%s",
              "description": "%s",
-             "tenantId": "%s",
-             "assignedMemberKeys": %s
+             "tenantId": "%s"
            },
            {
              "tenantKey": %s,
              "name": "%s",
              "description": "%s",
-             "tenantId": "%s",
-             "assignedMemberKeys": %s
+             "tenantId": "%s"
            }
          ],
          "page": {
@@ -85,17 +82,14 @@ public class TenantQueryControllerTest extends RestControllerTest {
           TENANT_ENTITIES.get(0).name(),
           TENANT_ENTITIES.get(0).description(),
           TENANT_ENTITIES.get(0).tenantId(),
-          formatSet(TENANT_ENTITIES.get(0).assignedMemberKeys(), true),
           "\"%s\"".formatted(TENANT_ENTITIES.get(1).key()),
           TENANT_ENTITIES.get(1).name(),
           TENANT_ENTITIES.get(1).description(),
           TENANT_ENTITIES.get(1).tenantId(),
-          formatSet(TENANT_ENTITIES.get(1).assignedMemberKeys(), true),
           "\"%s\"".formatted(TENANT_ENTITIES.get(2).key()),
           TENANT_ENTITIES.get(2).name(),
           TENANT_ENTITIES.get(2).description(),
           TENANT_ENTITIES.get(2).tenantId(),
-          formatSet(TENANT_ENTITIES.get(2).assignedMemberKeys(), true),
           TENANT_ENTITIES.size());
   private static final String EXPECTED_RESPONSE_NUMBER_KEYS =
       RESPONSE.formatted(
@@ -103,17 +97,14 @@ public class TenantQueryControllerTest extends RestControllerTest {
           TENANT_ENTITIES.get(0).name(),
           TENANT_ENTITIES.get(0).description(),
           TENANT_ENTITIES.get(0).tenantId(),
-          formatSet(TENANT_ENTITIES.get(0).assignedMemberKeys(), false),
           TENANT_ENTITIES.get(1).key(),
           TENANT_ENTITIES.get(1).name(),
           TENANT_ENTITIES.get(1).description(),
           TENANT_ENTITIES.get(1).tenantId(),
-          formatSet(TENANT_ENTITIES.get(1).assignedMemberKeys(), false),
           TENANT_ENTITIES.get(2).key(),
           TENANT_ENTITIES.get(2).name(),
           TENANT_ENTITIES.get(2).description(),
           TENANT_ENTITIES.get(2).tenantId(),
-          formatSet(TENANT_ENTITIES.get(2).assignedMemberKeys(), false),
           TENANT_ENTITIES.size());
 
   @MockBean private TenantServices tenantServices;
@@ -138,7 +129,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
     final var tenantName = "Tenant Name";
     final var tenantId = "tenant-id";
     final var tenantDescription = "Tenant Description";
-    final var tenant = new TenantEntity(100L, tenantId, tenantName, tenantDescription, Set.of());
+    final var tenant = new TenantEntity(100L, tenantId, tenantName, tenantDescription);
     when(tenantServices.getById(tenant.tenantId())).thenReturn(tenant);
 
     // when
@@ -156,8 +147,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
               "tenantKey": "%d",
               "name": "%s",
               "description": "%s",
-              "tenantId": "%s",
-              "assignedMemberKeys": []
+              "tenantId": "%s"
             }
             """
                 .formatted(tenant.key(), tenantName, tenantDescription, tenantId));


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The intention of this PR is to refactor three things:
1. Enable a smoother transition from keys to ids by switching the EntityJoinRelation to use generics, this allows the parent key to be a `String` in the case of a tenant, or a 'long` in the case of the other entities yet to be moved.
2. Remove the `assignedMemberKeys` from the `TenantEntity` object for clarity. This field is not populated when using ES/OS due to the document structures so we would have to populate them in different ways, although we can map them when using the RDBMS side, we would likely prefer a consistent approach (such as accessing the members of a tenant in a targeted call i.e. `/tenant/{id}/members?memberType=user`
3. Use entityId in the tenant member mappings instead of entityKey

For 2, I'm aware that we are removing a field however the functionality will be reintroduced with https://github.com/camunda/camunda/issues/27217 (the same will be true for other entities where memberships are resolved)

Closes https://github.com/camunda/camunda/issues/27326
Closes https://github.com/camunda/camunda/issues/27266
