### PR TITLE
feat: create a backward-compatible ConnectConfiguration that uses legacy config as default

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/property/ElasticsearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ElasticsearchProperties.java
@@ -9,7 +9,6 @@ package io.camunda.operate.property;
 
 import static io.camunda.operate.util.ConversionUtils.stringIsEmpty;
 
-import io.camunda.operate.connect.OperateDateTimeFormatter;
 import io.camunda.search.connect.plugin.PluginConfiguration;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -22,31 +21,31 @@ public class ElasticsearchProperties {
 
   public static final int BULK_REQUEST_MAX_SIZE_IN_BYTES_DEFAULT = 1024 * 1024 * 90; // 90 MB
 
-  private String clusterName = "elasticsearch";
+  private String clusterName; // = "elasticsearch";
 
-  @Deprecated private String host = "localhost";
+  @Deprecated private String host; // = "localhost";
 
-  @Deprecated private int port = 9200;
+  @Deprecated private int port = -1; // 9200;
 
-  private String dateFormat = OperateDateTimeFormatter.DATE_FORMAT_DEFAULT;
+  private String dateFormat; // = OperateDateTimeFormatter.DATE_FORMAT_DEFAULT;
 
-  private String elsDateFormat = ELS_DATE_FORMAT_DEFAULT;
+  private String elsDateFormat; // = ELS_DATE_FORMAT_DEFAULT;
 
-  private int batchSize = 200;
+  private int batchSize = -1; // = 200;
 
   private Integer socketTimeout;
   private Integer connectTimeout;
 
-  private boolean createSchema = true;
+  private Boolean createSchema; // = true;
 
   /** Indicates whether operate does a proper health check for ES clusters. */
-  private boolean healthCheckEnabled = true;
+  private Boolean healthCheckEnabled; // = true;
 
   private String url;
   private String username;
   private String password;
 
-  private int bulkRequestMaxSizeInBytes = BULK_REQUEST_MAX_SIZE_IN_BYTES_DEFAULT;
+  private int bulkRequestMaxSizeInBytes = -1; // = BULK_REQUEST_MAX_SIZE_IN_BYTES_DEFAULT;
 
   @NestedConfigurationProperty private SslProperties ssl;
 
@@ -115,7 +114,7 @@ public class ElasticsearchProperties {
     this.batchSize = batchSize;
   }
 
-  public boolean isCreateSchema() {
+  public Boolean isCreateSchema() {
     return createSchema;
   }
 
@@ -123,7 +122,7 @@ public class ElasticsearchProperties {
     this.createSchema = createSchema;
   }
 
-  public boolean isHealthCheckEnabled() {
+  public Boolean isHealthCheckEnabled() {
     return healthCheckEnabled;
   }
 
@@ -148,10 +147,15 @@ public class ElasticsearchProperties {
   }
 
   public String getUrl() {
-    if (stringIsEmpty(url)) {
-      return String.format("http://%s:%d", getHost(), getPort());
+    if (getHost() != null && getPort() > 1) {
+      if (stringIsEmpty(url)) {
+        return String.format("http://%s:%d", getHost(), getPort());
+      } else {
+        return url;
+      }
+    } else {
+      return null;
     }
-    return url;
   }
 
   public void setUrl(final String url) {

--- a/operate/common/src/main/java/io/camunda/operate/property/OperateConnectConfiguration.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateConnectConfiguration.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.property;
+
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.search.connect.configuration.SecurityConfiguration;
+import io.camunda.zeebe.util.ReflectUtil;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.IntConsumer;
+import java.util.function.IntSupplier;
+import java.util.function.Supplier;
+
+public class OperateConnectConfiguration extends ConnectConfiguration {
+  private int numberOfShards;
+  private int numberOfReplicas;
+  private int batchSize;
+  private Boolean createSchema;
+  private Boolean healthCheckEnabled;
+
+  public OperateConnectConfiguration(
+      final ConnectConfiguration connectConfiguration,
+      final OperateElasticsearchProperties elasticsearchProperties,
+      final OperateOpensearchProperties opensearchProperties) {
+    super();
+    // set the defaults from the operate properties
+    switch (connectConfiguration.getTypeEnum()) {
+      case ELASTICSEARCH -> mergeWithElasticProperties(elasticsearchProperties);
+      case OPENSEARCH -> mergeWithOpensearchProperties(opensearchProperties);
+    }
+    // merge the configured settings from ConnectConfiguration
+    mergeWithConnectConfiguration(connectConfiguration);
+  }
+
+  private void mergeWithConnectConfiguration(final ConnectConfiguration connectConfiguration) {
+    final var defaultInstance = new ConnectConfiguration();
+    final var fields =
+        Arrays.stream(ConnectConfiguration.class.getDeclaredFields())
+            .filter(f -> !Modifier.isStatic(f.getModifiers()))
+            .toList();
+
+    for (final var field : fields) {
+      try {
+        ReflectUtil.makeAccessible(field, connectConfiguration);
+        ReflectUtil.makeAccessible(field, defaultInstance);
+        final var defaultValue = field.get(defaultInstance);
+        final var setValue = field.get(connectConfiguration);
+        // set value only if it's not the same as the default
+        // if value is primitive, compare with ==
+        if (field.getType().isPrimitive()) {
+          if (setValue != defaultValue) {
+            field.set(this, setValue);
+          }
+        } else {
+          // compare with .equals()
+          if (!Objects.equals(setValue, defaultValue)) {
+            field.set(this, setValue);
+          }
+        }
+      } catch (final IllegalAccessException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  private void mergeWithElasticProperties(final OperateElasticsearchProperties props) {
+    setIfConfigured(props::getIndexPrefix, this::setIndexPrefix);
+    setIfConfiguredInt(props::getNumberOfShards, this::setNumberOfShards);
+    setIfConfiguredInt(props::getNumberOfReplicas, this::setNumberOfReplicas);
+    setIfConfigured(props::getClusterName, this::setClusterName);
+    setIfConfigured(props::getDateFormat, this::setDateFormat);
+    setIfConfigured(props::getElsDateFormat, this::setFieldDateFormat);
+    setIfConfiguredInt(props::getBatchSize, this::setBatchSize);
+    setIfConfigured(props::getSocketTimeout, this::setSocketTimeout);
+    setIfConfigured(props::getConnectTimeout, this::setConnectTimeout);
+    setIfConfigured(props::isCreateSchema, this::setCreateSchema);
+    setIfConfigured(props::isHealthCheckEnabled, this::setHealthCheckEnabled);
+    setIfConfigured(props::getUrl, this::setUrl);
+    setIfConfigured(props::getUsername, this::setUsername);
+    setIfConfigured(props::getPassword, this::setPassword);
+    setIfConfigured(
+        props::getSsl,
+        this::setSecurity,
+        ssl -> {
+          final var security = new SecurityConfiguration();
+          // fixme
+          return security;
+        });
+    setIfConfigured(props::getInterceptorPlugins, this::setInterceptorPlugins);
+  }
+
+  private void mergeWithOpensearchProperties(final OperateOpensearchProperties props) {
+    setIfConfigured(props::getIndexPrefix, this::setIndexPrefix);
+    setIfConfiguredInt(props::getNumberOfShards, this::setNumberOfShards);
+    setIfConfiguredInt(props::getNumberOfReplicas, this::setNumberOfReplicas);
+    setIfConfigured(props::getClusterName, this::setClusterName);
+    setIfConfigured(props::getDateFormat, this::setDateFormat);
+    setIfConfigured(props::getOsDateFormat, this::setFieldDateFormat);
+    setIfConfiguredInt(props::getBatchSize, this::setBatchSize);
+    setIfConfigured(props::getSocketTimeout, this::setSocketTimeout);
+    setIfConfigured(props::getConnectTimeout, this::setConnectTimeout);
+    setIfConfigured(props::isCreateSchema, this::setCreateSchema);
+    setIfConfigured(props::isHealthCheckEnabled, this::setHealthCheckEnabled);
+    setIfConfigured(props::getUrl, this::setUrl);
+    setIfConfigured(props::getUsername, this::setUsername);
+    setIfConfigured(props::getPassword, this::setPassword);
+    setIfConfigured(
+        props::getSsl,
+        this::setSecurity,
+        ssl -> {
+          final var security = new SecurityConfiguration();
+          // fixme
+          return security;
+        });
+    setIfConfigured(props::getInterceptorPlugins, this::setInterceptorPlugins);
+  }
+
+  private <A, B> void setIfConfigured(
+      final Supplier<A> getter, final Consumer<B> setter, final Function<A, B> converter) {
+    if (getter.get() != null) {
+      final B converted = converter.apply(getter.get());
+      setter.accept(converted);
+    }
+  }
+
+  private <A> void setIfConfigured(final Supplier<A> getter, final Consumer<A> setter) {
+    setIfConfigured(getter, setter, Function.identity());
+  }
+
+  private void setIfConfiguredInt(final IntSupplier getter, final IntConsumer setter) {
+    if (getter.getAsInt() >= 0) {
+      setter.accept(getter.getAsInt());
+    }
+  }
+
+  public int getBatchSize() {
+    return batchSize;
+  }
+
+  public void setBatchSize(final int batchSize) {
+    this.batchSize = batchSize;
+  }
+
+  public Boolean getCreateSchema() {
+    return createSchema;
+  }
+
+  public void setCreateSchema(final Boolean createSchema) {
+    this.createSchema = createSchema;
+  }
+
+  public Boolean isHealthCheckEnabled() {
+    return healthCheckEnabled;
+  }
+
+  public void setHealthCheckEnabled(final Boolean healthCheckEnabled) {
+    this.healthCheckEnabled = healthCheckEnabled;
+  }
+
+  public int getNumberOfShards() {
+    return numberOfShards;
+  }
+
+  public void setNumberOfShards(final int numberOfShards) {
+    this.numberOfShards = numberOfShards;
+  }
+
+  public int getNumberOfReplicas() {
+    return numberOfReplicas;
+  }
+
+  public void setNumberOfReplicas(final int numberOfReplicas) {
+    this.numberOfReplicas = numberOfReplicas;
+  }
+}

--- a/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
@@ -9,10 +9,12 @@ package io.camunda.operate.property;
 
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.conditions.DatabaseType;
+import io.camunda.search.connect.configuration.ConnectConfiguration;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Component;
@@ -97,6 +99,11 @@ public class OperateProperties {
 
   @NestedConfigurationProperty
   private WebSecurityProperties webSecurity = new WebSecurityProperties();
+
+  @Bean
+  public OperateConnectConfiguration mergedConfig(final ConnectConfiguration connectConfiguration) {
+    return new OperateConnectConfiguration(connectConfiguration, elasticsearch, opensearch);
+  }
 
   public boolean isImporterEnabled() {
     return importerEnabled;

--- a/operate/common/src/test/java/io/camunda/operate/property/OperateConnectConfigurationTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/property/OperateConnectConfigurationTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.property;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import org.junit.jupiter.api.Test;
+
+public class OperateConnectConfigurationTest {
+
+  @Test
+  public void shouldUseValuesConfiguredInLegacyConfigIfNotOverridden() {
+    final var legacyES = new OperateElasticsearchProperties();
+    final var connectConfiguration = new ConnectConfiguration();
+
+    // given
+    // some overrides in the new config
+    connectConfiguration.setUrl("http://my-cluster:9300");
+    connectConfiguration.setUsername("admin");
+    connectConfiguration.setPassword("admin23");
+    connectConfiguration.setIndexPrefix("camunda");
+
+    // some legacy values
+    legacyES.setIndexPrefix("");
+    legacyES.setNumberOfReplicas(3);
+    legacyES.setNumberOfShards(2);
+    legacyES.setClusterName("clusterName1");
+
+    // when
+    final var merged = new OperateConnectConfiguration(connectConfiguration, legacyES, null);
+
+    // then
+    assertThat(merged.getUrl()).isEqualTo("http://my-cluster:9300");
+    assertThat(merged.getUsername()).isEqualTo("admin");
+    assertThat(merged.getPassword()).isEqualTo("admin23");
+    assertThat(merged.getIndexPrefix()).isEqualTo("camunda");
+    assertThat(merged.getNumberOfShards()).isEqualTo(2);
+    assertThat(merged.getNumberOfReplicas()).isEqualTo(3);
+    assertThat(merged.getClusterName()).isEqualTo("clusterName1");
+  }
+}

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/configuration/ConnectConfiguration.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/configuration/ConnectConfiguration.java
@@ -13,11 +13,11 @@ import java.util.List;
 
 public class ConnectConfiguration {
 
-  private static final DatabaseType DATABASE_TYPE_DEFAULT = DatabaseType.ELASTICSEARCH;
-  private static final String CLUSTER_NAME_DEFAULT = "elasticsearch";
-  private static final String DATE_FORMAT_FIELD = "yyyy-MM-dd'T'HH:mm:ss.SSSZZ";
-  private static final String FIELD_DATE_FORMAT_DEFAULT = "date_time";
-  private static final String URL_DEFAULT = "http://localhost:9200";
+  protected static final DatabaseType DATABASE_TYPE_DEFAULT = DatabaseType.ELASTICSEARCH;
+  protected static final String CLUSTER_NAME_DEFAULT = "elasticsearch";
+  protected static final String DATE_FORMAT_FIELD = "yyyy-MM-dd'T'HH:mm:ss.SSSZZ";
+  protected static final String FIELD_DATE_FORMAT_DEFAULT = "date_time";
+  protected static final String URL_DEFAULT = "http://localhost:9200";
   private String type = DATABASE_TYPE_DEFAULT.toString();
   private String clusterName = CLUSTER_NAME_DEFAULT;
   private String dateFormat = DATE_FORMAT_FIELD;


### PR DESCRIPTION
## Description
POC has been done for operate,  but tasklist is almost identical.
### Objective
Being able to use `ConnectConfiguration` everywhere instead of `ElasticsearchProperties` or `OpensearchProperties` while keeping backward compatibility with the configurations set in those classes


### General idea
An app specific `ConnectConfiguration` is created, because those config classes contains some extra settings compare to the global `ConnectConfiguration`.
Individual keys are overridden in this order

```
ConnectConfiguration(defaults) -> ElasticsearchProperties(settings by user) -> ConnectConfiguration(settings by user)
```

### Implementation
Fields in `ElasticsearchProperties` and `OpensearchProperties`  defaults are all initialized to null instead of a real default value, so it's easy to check if they are set or not. There are some small differences in naming of parameters that make reflection a bit harder to use here.
All fields from `ConnectConfiguration` that are not equal to the default value are individually set.
For `ConnectConfiguration` it's easier to just use reflection, because the class itself extends `ConnectConfiguration` so all the fields must be checked. Moreover, ConnectConfiguration may change over time, while `ElasticsearchProperties` is there just for backward compatibility so it will be frozen.




