### PR TITLE
Migrate all Prometheus metrics in zeebe-db

### DIFF
--- a/zeebe/zb-db/pom.xml
+++ b/zeebe/zb-db/pom.xml
@@ -79,11 +79,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>

--- a/zeebe/zb-db/pom.xml
+++ b/zeebe/zb-db/pom.xml
@@ -88,5 +88,9 @@
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamilyMetrics.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamilyMetrics.java
@@ -7,14 +7,14 @@
  */
 package io.camunda.zeebe.db;
 
-import io.prometheus.client.Histogram.Timer;
+import io.camunda.zeebe.db.impl.FineGrainedColumnFamilyMetrics.TimerContext;
 
 public interface ColumnFamilyMetrics {
-  Timer measureGetLatency();
+  TimerContext measureGetLatency();
 
-  Timer measurePutLatency();
+  TimerContext measurePutLatency();
 
-  Timer measureDeleteLatency();
+  TimerContext measureDeleteLatency();
 
-  Timer measureIterateLatency();
+  TimerContext measureIterateLatency();
 }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/FineGrainedColumnFamilyMetrics.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/FineGrainedColumnFamilyMetrics.java
@@ -9,53 +9,73 @@ package io.camunda.zeebe.db.impl;
 
 import io.camunda.zeebe.db.ColumnFamilyMetrics;
 import io.camunda.zeebe.protocol.EnumValue;
-import io.prometheus.client.Histogram;
-import io.prometheus.client.Histogram.Child;
-import io.prometheus.client.Histogram.Timer;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import java.time.Duration;
+import java.util.Arrays;
 
 public final class FineGrainedColumnFamilyMetrics implements ColumnFamilyMetrics {
+  private static final MeterRegistry METER_REGISTRY = Metrics.globalRegistry;
 
-  private static final Histogram LATENCY =
-      Histogram.build()
-          .namespace("zeebe")
-          .name("rocksdb_latency")
-          .exponentialBuckets(0.00001, 2, 15)
-          .labelNames("partition", "columnFamily", "operation")
-          .help("Latency of RocksDB operations per column family")
-          .register();
+  private static final Duration[] LATENCY_DURATION_BUCKETS =
+      Arrays.stream(exponentialBuckets(0.00001, 2, 15))
+          .mapToObj(Duration::ofMillis)
+          .toArray(Duration[]::new);
 
-  private final Child getLatency;
-  private final Child putLatency;
-  private final Child deleteLatency;
-  private final Child iterateLatency;
+  private final Timer getLatency;
+  private final Timer putLatency;
+  private final Timer deleteLatency;
+  private final Timer iterateLatency;
 
   public <ColumnFamilyNames extends Enum<? extends EnumValue> & EnumValue>
       FineGrainedColumnFamilyMetrics(final int partitionId, final ColumnFamilyNames columnFamily) {
     final var partitionLabel = String.valueOf(partitionId);
     final var columnFamilyLabel = columnFamily.name();
-    getLatency = LATENCY.labels(partitionLabel, columnFamilyLabel, "get");
-    putLatency = LATENCY.labels(partitionLabel, columnFamilyLabel, "put");
-    deleteLatency = LATENCY.labels(partitionLabel, columnFamilyLabel, "delete");
-    iterateLatency = LATENCY.labels(partitionLabel, columnFamilyLabel, "iterate");
+    getLatency = createTimer(METER_REGISTRY, "get", partitionLabel, columnFamilyLabel);
+    putLatency = createTimer(METER_REGISTRY, "put", partitionLabel, columnFamilyLabel);
+    deleteLatency = createTimer(METER_REGISTRY, "delete", partitionLabel, columnFamilyLabel);
+    iterateLatency = createTimer(METER_REGISTRY, "iterate", partitionLabel, columnFamilyLabel);
+  }
+
+  private Timer createTimer(
+      final MeterRegistry registry,
+      final String operation,
+      final String partition,
+      final String columnFamily) {
+    return io.micrometer.core.instrument.Timer.builder("zeebe.rocksdb.latency")
+        .description("Latency of RocksDB operations per column family")
+        .tags("partition", partition, "columnFamily", columnFamily, "operation", operation)
+        .publishPercentileHistogram() // Enables histogram generation
+        .serviceLevelObjectives(LATENCY_DURATION_BUCKETS)
+        .register(registry);
+  }
+
+  private static long[] exponentialBuckets(final double start, final int factor, final int count) {
+    final long[] buckets = new long[count];
+    for (int i = 0; i < count; i++) {
+      buckets[i] = (long) (start * Math.pow(factor, i));
+    }
+    return buckets;
   }
 
   @Override
   public Timer measureGetLatency() {
-    return getLatency.startTimer();
+    return getLatency;
   }
 
   @Override
   public Timer measurePutLatency() {
-    return putLatency.startTimer();
+    return putLatency;
   }
 
   @Override
   public Timer measureDeleteLatency() {
-    return deleteLatency.startTimer();
+    return deleteLatency;
   }
 
   @Override
   public Timer measureIterateLatency() {
-    return iterateLatency.startTimer();
+    return iterateLatency;
   }
 }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/FineGrainedColumnFamilyMetrics.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/FineGrainedColumnFamilyMetrics.java
@@ -46,7 +46,7 @@ public final class FineGrainedColumnFamilyMetrics implements ColumnFamilyMetrics
       final String operation,
       final String partition,
       final String columnFamily) {
-    return Timer.builder(NAMESPACE + "rocksdb_latency")
+    return Timer.builder(NAMESPACE + "_rocksdb_latency")
         .description("Latency of RocksDB operations per column family")
         .tags("partition", partition, "columnFamily", columnFamily, "operation", operation)
         .publishPercentileHistogram() // Enables histogram generation

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/FineGrainedColumnFamilyMetrics.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/FineGrainedColumnFamilyMetrics.java
@@ -60,22 +60,38 @@ public final class FineGrainedColumnFamilyMetrics implements ColumnFamilyMetrics
   }
 
   @Override
-  public Timer measureGetLatency() {
-    return getLatency;
+  public TimerContext measureGetLatency() {
+    return new TimerContext(getLatency);
   }
 
   @Override
-  public Timer measurePutLatency() {
-    return putLatency;
+  public TimerContext measurePutLatency() {
+    return new TimerContext(putLatency);
   }
 
   @Override
-  public Timer measureDeleteLatency() {
-    return deleteLatency;
+  public TimerContext measureDeleteLatency() {
+    return new TimerContext(deleteLatency);
   }
 
   @Override
-  public Timer measureIterateLatency() {
-    return iterateLatency;
+  public TimerContext measureIterateLatency() {
+    return new TimerContext(iterateLatency);
+  }
+
+  /** A helper class for handling AutoCloseable Timer measurement. */
+  public static class TimerContext implements AutoCloseable {
+    private final Timer timer;
+    private final Timer.Sample sample;
+
+    public TimerContext(final Timer timer) {
+      this.timer = timer;
+      sample = Timer.start();
+    }
+
+    @Override
+    public void close() {
+      sample.stop(timer);
+    }
   }
 }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/NoopColumnFamilyMetrics.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/NoopColumnFamilyMetrics.java
@@ -8,27 +8,27 @@
 package io.camunda.zeebe.db.impl;
 
 import io.camunda.zeebe.db.ColumnFamilyMetrics;
-import io.prometheus.client.Histogram.Timer;
+import io.camunda.zeebe.db.impl.FineGrainedColumnFamilyMetrics.TimerContext;
 
 public class NoopColumnFamilyMetrics implements ColumnFamilyMetrics {
 
   @Override
-  public Timer measureGetLatency() {
+  public TimerContext measureGetLatency() {
     return null;
   }
 
   @Override
-  public Timer measurePutLatency() {
+  public TimerContext measurePutLatency() {
     return null;
   }
 
   @Override
-  public Timer measureDeleteLatency() {
+  public TimerContext measureDeleteLatency() {
     return null;
   }
 
   @Override
-  public Timer measureIterateLatency() {
+  public TimerContext measureIterateLatency() {
     return null;
   }
 }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDBMetricExporter.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDBMetricExporter.java
@@ -26,8 +26,7 @@ public final class ZeebeRocksDBMetricExporter<
   private static final Logger LOG =
       LoggerFactory.getLogger(ZeebeRocksDBMetricExporter.class.getName());
 
-  private static final MeterRegistry METER_REGISTRY =
-      Metrics.globalRegistry;
+  private static final MeterRegistry METER_REGISTRY = Metrics.globalRegistry;
 
   private static final ConcurrentHashMap<String, AtomicReference<Double>> GAUGES =
       new ConcurrentHashMap<>();

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDBMetricExporter.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDBMetricExporter.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.db.impl.rocksdb;
 
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.protocol.EnumValue;
-import io.prometheus.client.Gauge;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -119,22 +118,13 @@ public final class ZeebeRocksDBMetricExporter<
 
   private static final class RocksDBMetric {
     private final String propertyName;
-    private final Gauge gauge;
     private final String gaugeName;
     private final String help;
 
     private RocksDBMetric(final String propertyName, final String namePrefix, final String help) {
       this.propertyName = Objects.requireNonNull(propertyName);
-      gaugeName = ZEEBE_NAMESPACE + "_" + namePrefix + gaugeSuffix() + "_micro";
+      gaugeName = ZEEBE_NAMESPACE + "_" + namePrefix + gaugeSuffix();
       this.help = help;
-
-      gauge =
-          Gauge.build()
-              .namespace(ZEEBE_NAMESPACE)
-              .name(namePrefix + gaugeSuffix())
-              .help(help)
-              .labelNames(PARTITION)
-              .register();
     }
 
     public String getPropertyName() {
@@ -148,8 +138,6 @@ public final class ZeebeRocksDBMetricExporter<
     }
 
     public void exportValue(final String partitionID, final Double value) {
-      gauge.labels(partitionID).set(value);
-
       final String key = gaugeName + "_" + partitionID;
       final AtomicReference<Double> newValue =
           GAUGES.computeIfAbsent(

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDBMetricExporter.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDBMetricExporter.java
@@ -9,6 +9,9 @@ package io.camunda.zeebe.db.impl.rocksdb;
 
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.protocol.EnumValue;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
@@ -23,8 +26,8 @@ public final class ZeebeRocksDBMetricExporter<
   private static final Logger LOG =
       LoggerFactory.getLogger(ZeebeRocksDBMetricExporter.class.getName());
 
-  private static final io.micrometer.core.instrument.MeterRegistry METER_REGISTRY =
-      io.micrometer.core.instrument.Metrics.globalRegistry;
+  private static final MeterRegistry METER_REGISTRY =
+      Metrics.globalRegistry;
 
   private static final ConcurrentHashMap<String, AtomicReference<Double>> GAUGES =
       new ConcurrentHashMap<>();
@@ -144,8 +147,7 @@ public final class ZeebeRocksDBMetricExporter<
               key,
               k -> {
                 final AtomicReference<Double> newGaugeValue = new AtomicReference<>(0.0);
-                io.micrometer.core.instrument.Gauge.builder(
-                        gaugeName, newGaugeValue, AtomicReference::get)
+                Gauge.builder(gaugeName, newGaugeValue, AtomicReference::get)
                     .description(help)
                     .tags(PARTITION, partitionID)
                     .register(METER_REGISTRY);


### PR DESCRIPTION
## Description

Convert all Prometheus metrics to Micrometer.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] ColumnFamilyMetrics
- [x] FineGrainedColumnFamilyMetrics
- [x] NoopColumnFamilyMetrics
- [x] ZeebeRocksDBMetricExporter
- [ ] Given that with the micrometer timers these get published with the automatic sufix "_seconds" plus "_buckets", "_count", "_max" and "_sum", we need to see if we can change this in some configuration or change the dashboards.

<img width="270" alt="image" src="https://github.com/user-attachments/assets/a80db948-b78c-4272-a1de-00e3902029c0" />


## Related issues

closes #27153 
