### PR TITLE
fix: Failing to deserialize GetRepositoryResponse with AWS opensearch

### DIFF
--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearchTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearchTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.webapp.es.backup.os;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.tasklist.property.TasklistProperties;
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.transport.OpenSearchTransport;
+import org.opensearch.client.transport.endpoints.SimpleEndpoint;
+
+@ExtendWith(MockitoExtension.class)
+class BackupManagerOpenSearchTest {
+
+  @Mock private OpenSearchAsyncClient openSearchAsyncClient;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private TasklistProperties tasklistProperties;
+
+  @InjectMocks private BackupManagerOpenSearch backupManagerOpenSearch;
+
+  @Test
+  void shouldValidateRepositoryExistsDoNotDeserializeOpenSearchResponse() throws IOException {
+    final OpenSearchTransport openSearchTransport = mock(OpenSearchTransport.class);
+    when(openSearchAsyncClient._transport()).thenReturn(openSearchTransport);
+    when(openSearchTransport.performRequestAsync(any(), any(), any()))
+        .thenReturn(mock(CompletableFuture.class));
+
+    backupManagerOpenSearch.validateRepositoryExists();
+
+    final ArgumentCaptor<SimpleEndpoint> endpointArgumentCaptor =
+        ArgumentCaptor.forClass(SimpleEndpoint.class);
+    verify(openSearchTransport).performRequestAsync(any(), endpointArgumentCaptor.capture(), any());
+    assertThat(endpointArgumentCaptor.getValue().responseDeserializer()).isNull();
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
When S3 is used as backup repository , AWS opensearch returns a response without a mandatory `location` field in `org.opensearch.client.opensearch.snapshot.RepositorySettings`.

```
> GET /_snapshot/backupRepo

{
  "backupRepo": {
    "type": "s3",
    "settings": {
      "bucket": "bucket-qa-s3",
      "base_path": "backup/andreas/opensearch",
      "region": "eu-central-1",
      "role_arn": "arn:aws:iam::613365526843:role/TestOpenSearchAndreas"
    }
  }
}
```

which causes this exception when deserializing the response
```
Caused by: org.opensearch.client.util.MissingRequiredPropertyException: Missing required property 'RepositorySettings.location'
	at org.opensearch.client.util.ApiTypeHelper.requireNonNull(ApiTypeHelper.java:89) ~[opensearch-java-2.9.0.jar:?]
	at org.opensearch.client.opensearch.snapshot.RepositorySettings.<init>(RepositorySettings.java:73) ~[opensearch-java-2.9.0.jar:?]
```

In this pull request, we skip the deserialization of the response as it is not needed in the code.

Tested in local targeting an AWS opensearch instance
```
> curl --location 'http://localhost:9600/actuator/backups' \
--header 'Content-Type: application/json' \
--data '{"backupId": 1}'

{
    "scheduledSnapshots": [
        "camunda_tasklist_1_8.6.8-snapshot_part_1_of_6",
        "camunda_tasklist_1_8.6.8-snapshot_part_2_of_6",
        "camunda_tasklist_1_8.6.8-snapshot_part_3_of_6",
        "camunda_tasklist_1_8.6.8-snapshot_part_4_of_6",
        "camunda_tasklist_1_8.6.8-snapshot_part_5_of_6",
        "camunda_tasklist_1_8.6.8-snapshot_part_6_of_6"
    ]
}
```


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/tasklist/issues/5125
