### PR TITLE
Fix RDBMS Tenant members + IT tests

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -9,12 +9,8 @@
 <databaseChangeLog
   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
-  xmlns:pro="http://www.liquibase.org/xml/ns/pro"
   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
-        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
-        http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-latest.xsd">
+        http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
   <changeSet id="create_exporter_position_table" author="pwunderlich">
     <createTable tableName="EXPORTER_POSITION">
@@ -353,7 +349,7 @@
 
   <changeSet id="tenant_members_table" author="cthiel">
     <createTable tableName="TENANT_MEMBER">
-      <column name="TENANT_KEY" type="BIGINT" >
+      <column name="TENANT_ID" type="VARCHAR(255)">
         <constraints primaryKey="true"/>
       </column>
       <column name="ENTITY_KEY" type="BIGINT" >

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/TenantDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/TenantDbModel.java
@@ -21,8 +21,8 @@ public class TenantDbModel implements DbModel<TenantDbModel> {
   public TenantDbModel() {}
 
   private TenantDbModel(
-      final Long tenantKey,
       final String tenantId,
+      final Long tenantKey,
       final String name,
       final List<TenantMemberDbModel> members) {
     this.tenantKey = tenantKey;
@@ -104,7 +104,7 @@ public class TenantDbModel implements DbModel<TenantDbModel> {
 
     @Override
     public TenantDbModel build() {
-      return new TenantDbModel(tenantKey, tenantId, name, members);
+      return new TenantDbModel(tenantId, tenantKey, name, members);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/TenantMemberDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/TenantMemberDbModel.java
@@ -9,16 +9,16 @@ package io.camunda.db.rdbms.write.domain;
 
 import io.camunda.util.ObjectBuilder;
 
-public record TenantMemberDbModel(Long tenantKey, Long entityKey, String entityType) {
+public record TenantMemberDbModel(String tenantId, Long entityKey, String entityType) {
 
   public static class Builder implements ObjectBuilder<TenantMemberDbModel> {
 
-    private Long tenantKey;
+    private String tenantId;
     private Long entityKey;
     private String entityType;
 
-    public Builder tenantKey(final Long tenantKey) {
-      this.tenantKey = tenantKey;
+    public Builder tenantId(final String tenantId) {
+      this.tenantId = tenantId;
       return this;
     }
 
@@ -34,7 +34,7 @@ public record TenantMemberDbModel(Long tenantKey, Long entityKey, String entityT
 
     @Override
     public TenantMemberDbModel build() {
-      return new TenantMemberDbModel(tenantKey, entityKey, entityType);
+      return new TenantMemberDbModel(tenantId, entityKey, entityType);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/TenantWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/TenantWriter.java
@@ -27,7 +27,7 @@ public class TenantWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.TENANT,
-            tenant.tenantKey(),
+            tenant.tenantId(),
             "io.camunda.db.rdbms.sql.TenantMapper.insert",
             tenant));
   }
@@ -50,7 +50,7 @@ public class TenantWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.TENANT,
-            member.tenantKey(),
+            member.tenantId(),
             "io.camunda.db.rdbms.sql.TenantMapper.insertMember",
             member));
   }
@@ -59,7 +59,7 @@ public class TenantWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.TENANT,
-            member.tenantKey(),
+            member.tenantId(),
             "io.camunda.db.rdbms.sql.TenantMapper.deleteMember",
             member));
   }
@@ -76,7 +76,7 @@ public class TenantWriter {
             ContextType.TENANT,
             tenant.tenantId(),
             "io.camunda.db.rdbms.sql.TenantMapper.deleteAllMembers",
-            tenant.tenantKey()));
+            tenant.tenantId()));
   }
 
   private boolean mergeToQueue(

--- a/db/rdbms/src/main/resources/mapper/TenantMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/TenantMapper.xml
@@ -23,11 +23,11 @@
     t.TENANT_KEY,
     t.TENANT_ID,
     t.NAME,
-    tm.TENANT_KEY AS MEMBER_TENANT_KEY,
+    tm.TENANT_ID AS MEMBER_TENANT_ID,
     tm.ENTITY_KEY AS MEMBER_ENTITY_KEY,
     tm.ENTITY_TYPE AS MEMBER_ENTITY_TYPE
     FROM TENANT t
-    LEFT JOIN TENANT_MEMBER tm ON t.TENANT_KEY = tm.TENANT_KEY
+    LEFT JOIN TENANT_MEMBER tm ON t.TENANT_ID = tm.TENANT_ID
     <include refid="io.camunda.db.rdbms.sql.TenantMapper.searchFilter"/>
     ) t
     <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
@@ -43,13 +43,13 @@
   </sql>
 
   <resultMap id="tenantResultMap" type="io.camunda.db.rdbms.write.domain.TenantDbModel">
-    <id column="TENANT_KEY" property="tenantKey" />
-    <result column="TENANT_ID" property="tenantId"/>
+    <id column="TENANT_ID" property="tenantId"/>
+    <result column="TENANT_KEY" property="tenantKey"/>
     <result column="NAME" property="name"/>
     <collection property="members" ofType="io.camunda.db.rdbms.write.domain.TenantMemberDbModel"
       javaType="java.util.List">
       <constructor>
-        <idArg column="MEMBER_TENANT_KEY" javaType="java.lang.Long"/>
+        <idArg column="MEMBER_TENANT_ID" javaType="java.lang.String"/>
         <idArg column="MEMBER_ENTITY_KEY" javaType="java.lang.Long"/>
         <arg column="MEMBER_ENTITY_TYPE" javaType="java.lang.String"/>
       </constructor>
@@ -84,8 +84,8 @@
     id="insertMember"
     parameterType="io.camunda.db.rdbms.write.domain.TenantMemberDbModel"
     flushCache="true">
-    INSERT INTO TENANT_MEMBER (TENANT_KEY, ENTITY_KEY, ENTITY_TYPE)
-    VALUES (#{tenantKey}, #{entityKey}, #{entityType})
+    INSERT INTO TENANT_MEMBER (TENANT_ID, ENTITY_KEY, ENTITY_TYPE)
+    VALUES (#{tenantId}, #{entityKey}, #{entityType})
   </insert>
 
   <delete
@@ -94,18 +94,18 @@
     flushCache="true">
     DELETE
     FROM TENANT_MEMBER
-    WHERE TENANT_KEY = #{tenantKey}
+    WHERE TENANT_ID = #{tenantId}
       AND ENTITY_KEY = #{entityKey}
       AND ENTITY_TYPE = #{entityType}
   </delete>
 
   <delete
     id="deleteAllMembers"
-    parameterType="java.lang.Long"
+    parameterType="java.lang.String"
     flushCache="true">
     DELETE
     FROM TENANT_MEMBER
-    WHERE TENANT_KEY = #{tenantKey}
+    WHERE TENANT_ID = #{tenantId}
   </delete>
 
 </mapper>

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantIT.java
@@ -117,7 +117,7 @@ public class TenantIT {
 
     rdbmsWriter
         .getTenantWriter()
-        .addMember(new TenantMemberDbModel(tenant.tenantKey(), 1337L, "USER"));
+        .addMember(new TenantMemberDbModel(tenant.tenantId(), 1337L, "USER"));
     rdbmsWriter.flush();
 
     final var addedMemberInstance = tenantReader.findOne(tenant.tenantId()).orElse(null);
@@ -125,7 +125,7 @@ public class TenantIT {
 
     rdbmsWriter
         .getTenantWriter()
-        .removeMember(new TenantMemberDbModel(tenant.tenantKey(), 1337L, "USER"));
+        .removeMember(new TenantMemberDbModel(tenant.tenantId(), 1337L, "USER"));
     rdbmsWriter.flush();
 
     final var removedMemberInstance = tenantReader.findOne(tenant.tenantId()).orElse(null);

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantSortIT.java
@@ -7,12 +7,15 @@
  */
 package io.camunda.it.rdbms.db.tenant;
 
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
 import static io.camunda.it.rdbms.db.fixtures.TenantFixtures.createAndSaveRandomTenants;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.TenantReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
+import io.camunda.db.rdbms.write.domain.TenantDbModel;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.TenantEntity;
@@ -36,50 +39,72 @@ public class TenantSortIT {
 
   @TestTemplate
   public void shouldSortByTenantKeyAsc(final CamundaRdbmsTestApplication testApplication) {
+    final var aggregator =
+        "AggregatorSortByKeyAsc " + nextStringId(); // Will be used to have isolated test data
+
     testSorting(
         testApplication.getRdbmsService(),
         b -> b.tenantKey().asc(),
-        Comparator.comparing(TenantEntity::key));
+        Comparator.comparing(TenantEntity::key),
+        b -> b.name(aggregator),
+        b -> b.name(aggregator));
   }
 
   @TestTemplate
   public void shouldSortByTenantKeyDesc(final CamundaRdbmsTestApplication testApplication) {
+    final var aggregator =
+        "AggregatorSortByKeyDesc " + nextStringId(); // Will be used to have isolated test data
+
     testSorting(
         testApplication.getRdbmsService(),
         b -> b.tenantKey().desc(),
-        Comparator.comparing(TenantEntity::key).reversed());
+        Comparator.comparing(TenantEntity::key).reversed(),
+        b -> b.name(aggregator),
+        b -> b.name(aggregator));
   }
 
   @TestTemplate
   public void shouldSortByTenantIdAsc(final CamundaRdbmsTestApplication testApplication) {
+    final var aggregator =
+        "AggregatorSortByKeyAsc " + nextStringId(); // Will be used to have isolated test data
+
     testSorting(
         testApplication.getRdbmsService(),
         b -> b.tenantId().asc(),
-        Comparator.comparing(TenantEntity::tenantId));
+        Comparator.comparing(TenantEntity::tenantId),
+        b -> b.name(aggregator),
+        b -> b.name(aggregator));
   }
 
   @TestTemplate
   public void shouldSortByNameAsc(final CamundaRdbmsTestApplication testApplication) {
+    final var aggregator = nextKey(); // Will be used to have isolated test data
+
     testSorting(
         testApplication.getRdbmsService(),
         b -> b.name().asc(),
-        Comparator.comparing(TenantEntity::name));
+        Comparator.comparing(TenantEntity::name),
+        b -> b.tenantKey(aggregator),
+        b -> b.key(aggregator));
   }
 
   private void testSorting(
       final RdbmsService rdbmsService,
       final Function<Builder, ObjectBuilder<TenantSort>> sortBuilder,
-      final Comparator<TenantEntity> comparator) {
+      final Comparator<TenantEntity> comparator,
+      final Function<TenantDbModel.Builder, TenantDbModel.Builder> aggregatorBuilderFunction,
+      final Function<TenantFilter.Builder, TenantFilter.Builder> aggregatorFilterFunction) {
     final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
     final TenantReader reader = rdbmsService.getTenantReader();
 
-    createAndSaveRandomTenants(rdbmsWriter, b -> b.name("test"));
+    aggregatorBuilderFunction.apply(new TenantDbModel.Builder().name("test"));
+    createAndSaveRandomTenants(rdbmsWriter, aggregatorBuilderFunction);
 
     final var searchResult =
         reader
             .search(
                 new TenantQuery(
-                    TenantFilter.of(b -> b),
+                    TenantFilter.of(aggregatorFilterFunction),
                     TenantSort.of(sortBuilder),
                     SearchQueryPage.of(b -> b)))
             .items();

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessExportHandler.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.util.modelreader.ProcessModelReader;
 import io.camunda.zeebe.util.modelreader.ProcessModelReader.StartFormLink;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,7 +65,7 @@ public class ProcessExportHandler implements RdbmsExportHandler<Process> {
         value.getResourceName(),
         processName,
         value.getTenantId(),
-        value.getVersionTag(),
+        StringUtils.defaultIfEmpty(value.getVersionTag(), null),
         value.getVersion(),
         new String(value.getResource(), StandardCharsets.UTF_8),
         formId);

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/TenantExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/TenantExportHandler.java
@@ -53,14 +53,14 @@ public class TenantExportHandler implements RdbmsExportHandler<TenantRecordValue
       case TenantIntent.ENTITY_ADDED ->
           tenantWriter.addMember(
               new TenantMemberDbModel.Builder()
-                  .tenantKey(value.getTenantKey())
+                  .tenantId(value.getTenantId())
                   .entityKey(value.getEntityKey())
                   .entityType(value.getEntityType().name())
                   .build());
       case TenantIntent.ENTITY_REMOVED ->
           tenantWriter.removeMember(
               new TenantMemberDbModel.Builder()
-                  .tenantKey(value.getTenantKey())
+                  .tenantId(value.getTenantId())
                   .entityKey(value.getEntityKey())
                   .entityType(value.getEntityType().name())
                   .build());


### PR DESCRIPTION
## Description

* This fixes the relation between tenants and members (since now the tenantId is the PK, this has also to be used for the member relation)
* Also MyBatis aggregation in result map has been fixed
* Add test isolation to Tenant sort tests
* Make name sort test useful
* Small fix for process definitions ... if version tag is empty, value should be null
