### PR TITLE
feat: configure custom error handling per index

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -238,6 +238,7 @@ public class CamundaExporter implements Exporter {
   private ExporterBatchWriter createBatchWriter() {
     final var builder = ExporterBatchWriter.Builder.begin();
     provider.getExportHandlers().forEach(builder::withHandler);
+    builder.withCustomErrorHandlers(provider.getCustomErrorHandlers());
     return builder.build();
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
@@ -54,5 +54,12 @@ public interface ExporterResourceProvider {
    */
   Set<ExportHandler<?, ?>> getExportHandlers();
 
+  /**
+   * Possible custom error handlers to be used if certain indices threw persistence errors. The
+   * first parameter is the name of the index that threw the error and the second is the error
+   * details
+   *
+   * @return A {@link BiConsumer} of {@link String} and {@link Error} to handle custom errors
+   */
   BiConsumer<String, Error> getCustomErrorHandlers();
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
@@ -15,6 +15,7 @@ import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collection;
 import java.util.Set;
+import java.util.function.BiConsumer;
 
 public interface ExporterResourceProvider {
 
@@ -51,4 +52,6 @@ public interface ExporterResourceProvider {
    * @return A {@link Set} of {@link ExportHandler} to be registered with the exporter
    */
   Set<ExportHandler<?, ?>> getExportHandlers();
+
+  BiConsumer<String, String> getCustomErrorHandlers();
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
@@ -9,6 +9,7 @@ package io.camunda.exporter;
 
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
 import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
@@ -53,5 +54,5 @@ public interface ExporterResourceProvider {
    */
   Set<ExportHandler<?, ?>> getExportHandlers();
 
-  BiConsumer<String, String> getCustomErrorHandlers();
+  BiConsumer<String, Error> getCustomErrorHandlers();
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/errorhandling/Error.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/errorhandling/Error.java
@@ -7,4 +7,12 @@
  */
 package io.camunda.exporter.errorhandling;
 
+/**
+ * Represents error details for Elasticsearch/Opensearch persistence errors when executing batch
+ * requests in the exporter.
+ *
+ * @param message the error message
+ * @param type the error type communicated by the search engine
+ * @param status the HTTP status code of the error
+ */
 public record Error(String message, String type, int status) {}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/errorhandling/Error.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/errorhandling/Error.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.errorhandling;
+
+public record Error(String message, String type, int status) {}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/errorhandling/ErrorHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/errorhandling/ErrorHandler.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.errorhandling;
+
+@FunctionalInterface
+public interface ErrorHandler {
+  void handle(Error error);
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/errorhandling/ErrorHandlers.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/errorhandling/ErrorHandlers.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.errorhandling;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+
+public enum ErrorHandlers implements ErrorHandler {
+  IGNORE_DOCUMENT_DOES_NOT_EXIST {
+    @Override
+    public void handle(final Error error) {
+      if (error.status() == 404 || error.type().equals("document_missing_exception")) {
+        return;
+      }
+      throw new PersistenceException(error.message());
+    }
+  },
+  THROWING {
+    @Override
+    public void handle(final Error error) {
+      throw new PersistenceException(error.message());
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/errorhandling/ErrorHandlers.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/errorhandling/ErrorHandlers.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.errorhandling;
 import io.camunda.exporter.exceptions.PersistenceException;
 
 public enum ErrorHandlers implements ErrorHandler {
+  /** Ignore the error if the document does not exist, otherwise, throw. */
   IGNORE_DOCUMENT_DOES_NOT_EXIST {
     @Override
     public void handle(final Error error) {
@@ -19,6 +20,7 @@ public enum ErrorHandlers implements ErrorHandler {
       throw new PersistenceException(error.message());
     }
   },
+  /** Always throw when an error occurs */
   THROWING {
     @Override
     public void handle(final Error error) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/exceptions/PersistenceException.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/exceptions/PersistenceException.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.exporter.exceptions;
 
-public class PersistenceException extends Exception {
+public class PersistenceException extends RuntimeException {
 
   private static final long serialVersionUID = 1L;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/BatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/BatchRequest.java
@@ -64,10 +64,14 @@ public interface BatchRequest {
    *
    * @param customErrorHandlers possible custom error handlers to be used if certain indices threw
    *     persistence errors. The first parameter is the index name and the second is the error
-   *     detail
+   *     detail if not passed, a PersistenceException will be thrown by default in case of error
    * @throws PersistenceException if an error occurs during the execution
    */
   void execute(final BiConsumer<String, Error> customErrorHandlers) throws PersistenceException;
+
+  default void execute() throws PersistenceException {
+    execute(null);
+  }
 
   void executeWithRefresh() throws PersistenceException;
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/BatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/BatchRequest.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.store;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 /** A {@link BatchRequest} contains updates to one or more {@link ExporterEntity} */
 @SuppressWarnings("rawtypes")
@@ -60,9 +61,12 @@ public interface BatchRequest {
   /**
    * Applies all updates in this batch.
    *
+   * @param customErrorHandlers possible custom error handlers to be used if certain indices threw
+   *     persistence errors. The first parameter is the index name and the second is the error
+   *     message
    * @throws PersistenceException if an error occurs during the execution
    */
-  void execute() throws PersistenceException;
+  void execute(final BiConsumer<String, String> customErrorHandlers) throws PersistenceException;
 
   void executeWithRefresh() throws PersistenceException;
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/BatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/BatchRequest.java
@@ -64,7 +64,7 @@ public interface BatchRequest {
    *
    * @param customErrorHandlers possible custom error handlers to be used if certain indices threw
    *     persistence errors. The first parameter is the index name and the second is the error
-   *     message
+   *     detail
    * @throws PersistenceException if an error occurs during the execution
    */
   void execute(final BiConsumer<String, Error> customErrorHandlers) throws PersistenceException;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/BatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/BatchRequest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.store;
 
+import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import java.util.Map;
@@ -66,7 +67,7 @@ public interface BatchRequest {
    *     message
    * @throws PersistenceException if an error occurs during the execution
    */
-  void execute(final BiConsumer<String, String> customErrorHandlers) throws PersistenceException;
+  void execute(final BiConsumer<String, Error> customErrorHandlers) throws PersistenceException;
 
   void executeWithRefresh() throws PersistenceException;
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
@@ -19,6 +19,8 @@ import io.camunda.webapps.schema.entities.ExporterEntity;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -221,16 +223,19 @@ public class ElasticsearchBatchRequest implements BatchRequest {
   }
 
   @Override
-  public void execute() throws PersistenceException {
-    execute(false);
+  public void execute(final BiConsumer<String, String> customErrorHandlers)
+      throws PersistenceException {
+    execute(customErrorHandlers, false);
   }
 
   @Override
   public void executeWithRefresh() throws PersistenceException {
-    execute(true);
+    execute(null, true);
   }
 
-  private void execute(final boolean shouldRefresh) throws PersistenceException {
+  private void execute(
+      final BiConsumer<String, String> customErrorHandlers, final boolean shouldRefresh)
+      throws PersistenceException {
     if (shouldRefresh) {
       bulkRequestBuilder.refresh(Refresh.True);
     }
@@ -241,15 +246,42 @@ public class ElasticsearchBatchRequest implements BatchRequest {
     try {
       final BulkResponse bulkResponse = esClient.bulk(bulkRequest);
       final List<BulkResponseItem> items = bulkResponse.items();
-      for (final BulkResponseItem item : items) {
-        if (item.error() != null) {
-          LOGGER.warn("Bulk request execution failed. {}. Cause: {}.", item, item.error().reason());
-          throw new PersistenceException("Operation failed: " + item.error().reason());
-        }
-      }
+      validateNoErrors(items, customErrorHandlers);
     } catch (final IOException | ElasticsearchException ex) {
+
       throw new PersistenceException(
           "Error when processing bulk request against Elasticsearch: " + ex.getMessage(), ex);
     }
+  }
+
+  private void validateNoErrors(
+      final List<BulkResponseItem> items, final BiConsumer<String, String> customErrorHandlers) {
+    final var errorItems = items.stream().filter(item -> item.error() != null).toList();
+    if (errorItems.isEmpty()) {
+      return;
+    }
+
+    final String errorMessages =
+        errorItems.stream()
+            .map(
+                item ->
+                    String.format(
+                        "%s failed for type [%s] and id [%s]: %s",
+                        item.operationType(), item.index(), item.id(), item.error().reason()))
+            .collect(Collectors.joining(", \n"));
+    LOGGER.warn("Bulk request execution failed: \n[{}]", errorMessages);
+
+    errorItems.forEach(
+        item -> {
+          final String message =
+              String.format(
+                  "%s failed for type [%s] and id [%s]: %s",
+                  item.operationType(), item.index(), item.id(), item.error().reason());
+          if (customErrorHandlers != null) {
+            customErrorHandlers.accept(item.index(), message);
+          } else {
+            throw new PersistenceException(message);
+          }
+        });
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.store;
 
+import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.webapps.schema.entities.ExporterEntity;
@@ -27,7 +28,7 @@ import java.util.function.BiConsumer;
 public class ExporterBatchWriter {
   private final Map<ValueType, List<ExportHandler>> handlers = new HashMap<>();
   private final Map<EntityIdAndEntityType, EntityAndHandlers> cachedEntities = new HashMap<>();
-  private BiConsumer<String, String> customErrorHandlers;
+  private BiConsumer<String, Error> customErrorHandlers;
 
   public void addRecord(final Record<?> record) {
     final ValueType valueType = record.getValueType();
@@ -112,7 +113,7 @@ public class ExporterBatchWriter {
       return writer;
     }
 
-    public void withCustomErrorHandlers(final BiConsumer<String, String> customErrorHandlers) {
+    public void withCustomErrorHandlers(final BiConsumer<String, Error> customErrorHandlers) {
       writer.customErrorHandlers = customErrorHandlers;
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
@@ -20,12 +20,14 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
 
 /** Caches exporter entities of different types and provide the method to flush them in a batch. */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class ExporterBatchWriter {
   private final Map<ValueType, List<ExportHandler>> handlers = new HashMap<>();
   private final Map<EntityIdAndEntityType, EntityAndHandlers> cachedEntities = new HashMap<>();
+  private BiConsumer<String, String> customErrorHandlers;
 
   public void addRecord(final Record<?> record) {
     final ValueType valueType = record.getValueType();
@@ -75,7 +77,7 @@ public class ExporterBatchWriter {
         handler.flush(entity, batchRequest);
       }
     }
-    batchRequest.execute();
+    batchRequest.execute(customErrorHandlers);
     reset();
   }
 
@@ -108,6 +110,10 @@ public class ExporterBatchWriter {
 
     public ExporterBatchWriter build() {
       return writer;
+    }
+
+    public void withCustomErrorHandlers(final BiConsumer<String, String> customErrorHandlers) {
+      writer.customErrorHandlers = customErrorHandlers;
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/OpensearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/OpensearchBatchRequest.java
@@ -13,6 +13,8 @@ import io.camunda.webapps.schema.entities.ExporterEntity;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.Refresh;
@@ -214,46 +216,70 @@ public class OpensearchBatchRequest implements BatchRequest {
   }
 
   @Override
-  public void execute() throws PersistenceException {
-    execute(false);
+  public void execute(final BiConsumer<String, String> customErrorHandlers)
+      throws PersistenceException {
+    execute(customErrorHandlers, false);
   }
 
   @Override
   public void executeWithRefresh() throws PersistenceException {
-    execute(true);
+    execute(null, true);
   }
 
-  private void execute(final boolean shouldRefresh) throws PersistenceException {
+  private void execute(
+      final BiConsumer<String, String> customErrorHandlers, final boolean shouldRefresh)
+      throws PersistenceException {
     if (shouldRefresh) {
       bulkRequestBuilder.refresh(Refresh.True);
     }
     final BulkRequest bulkRequest = bulkRequestBuilder.build();
-    processBulkRequest(bulkRequest);
+    processBulkRequest(bulkRequest, customErrorHandlers);
   }
 
-  private void processBulkRequest(final BulkRequest bulkRequest) throws PersistenceException {
+  private void processBulkRequest(
+      final BulkRequest bulkRequest, final BiConsumer<String, String> customErrorHandlers)
+      throws PersistenceException {
     if (bulkRequest.operations().isEmpty()) {
       return;
     }
     try {
       final BulkResponse bulkItemResponses = osClient.bulk(bulkRequest);
       final List<BulkResponseItem> items = bulkItemResponses.items();
-      for (final BulkResponseItem responseItem : items) {
-        if (responseItem.error() != null) {
-          LOGGER.warn(
-              String.format(
-                  "%s failed for type [%s] and id [%s]: %s",
-                  responseItem.operationType(),
-                  responseItem.index(),
-                  responseItem.id(),
-                  responseItem.error().reason()),
-              "error on OpenSearch BulkRequest");
-          throw new PersistenceException("Operation failed: " + responseItem.error().reason());
-        }
-      }
+      validateNoErrors(items, customErrorHandlers);
     } catch (final IOException | OpenSearchException ex) {
       throw new PersistenceException(
           "Error when processing bulk request against OpenSearch: " + ex.getMessage(), ex);
     }
+  }
+
+  private void validateNoErrors(
+      final List<BulkResponseItem> items, final BiConsumer<String, String> errorHandlers) {
+    final var errorItems = items.stream().filter(item -> item.error() != null).toList();
+    if (errorItems.isEmpty()) {
+      return;
+    }
+
+    final String errorMessages =
+        errorItems.stream()
+            .map(
+                item ->
+                    String.format(
+                        "%s failed for type [%s] and id [%s]: %s",
+                        item.operationType(), item.index(), item.id(), item.error().reason()))
+            .collect(Collectors.joining(", \n"));
+    LOGGER.warn("Bulk request execution failed: \n[{}]", errorMessages);
+
+    errorItems.forEach(
+        item -> {
+          final String message =
+              String.format(
+                  "%s failed for type [%s] and id [%s]: %s",
+                  item.operationType(), item.index(), item.id(), item.error().reason());
+          if (errorHandlers != null) {
+            errorHandlers.accept(item.index(), message);
+          } else {
+            throw new PersistenceException(message);
+          }
+        });
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -419,13 +419,15 @@ final class CamundaExporterIT {
       final ExporterConfiguration config, final SearchClientAdapter clientAdapter) {
     // given
     final ValueType valueType = ValueType.INCIDENT;
+    final long notExistingOperationReference = 9876543210L;
     final Record record =
         factory.generateRecord(
             valueType,
             r ->
                 r.withBrokerVersion("8.7.0")
                     .withIntent(IncidentIntent.RESOLVED)
-                    .withTimestamp(System.currentTimeMillis()));
+                    .withTimestamp(System.currentTimeMillis())
+                    .withOperationReference(notExistingOperationReference));
     final var resourceProvider = new DefaultExporterResourceProvider();
     resourceProvider.init(
         config,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ElasticsearchBatchRequestTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ElasticsearchBatchRequestTest.java
@@ -66,7 +66,7 @@ class ElasticsearchBatchRequestTest {
 
     // When
     batchRequest.add(INDEX, entity);
-    batchRequest.execute();
+    batchRequest.execute(null);
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -93,7 +93,7 @@ class ElasticsearchBatchRequestTest {
     // When
     batchRequest.addWithRouting(INDEX, entity, routing);
 
-    batchRequest.execute();
+    batchRequest.execute(null);
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -121,7 +121,7 @@ class ElasticsearchBatchRequestTest {
 
     // When
     batchRequest.upsert(INDEX, ID, entity, updateFields);
-    batchRequest.execute();
+    batchRequest.execute(null);
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -150,7 +150,7 @@ class ElasticsearchBatchRequestTest {
 
     // When
     batchRequest.upsertWithRouting(INDEX, ID, entity, updateFields, routing);
-    batchRequest.execute();
+    batchRequest.execute(null);
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -183,7 +183,7 @@ class ElasticsearchBatchRequestTest {
 
     // When
     batchRequest.upsertWithScript(INDEX, ID, entity, script, params);
-    batchRequest.execute();
+    batchRequest.execute(null);
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -216,7 +216,7 @@ class ElasticsearchBatchRequestTest {
 
     // When
     batchRequest.upsertWithScriptAndRouting(INDEX, ID, entity, script, params, routing);
-    batchRequest.execute();
+    batchRequest.execute(null);
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -243,7 +243,7 @@ class ElasticsearchBatchRequestTest {
 
     // When
     batchRequest.update(INDEX, ID, updateFields);
-    batchRequest.execute();
+    batchRequest.execute(null);
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -269,7 +269,7 @@ class ElasticsearchBatchRequestTest {
 
     // When
     batchRequest.update(INDEX, ID, entity);
-    batchRequest.execute();
+    batchRequest.execute(null);
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -299,7 +299,7 @@ class ElasticsearchBatchRequestTest {
 
     // When
     batchRequest.updateWithScript(INDEX, ID, script, params);
-    batchRequest.execute();
+    batchRequest.execute(null);
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -322,7 +322,7 @@ class ElasticsearchBatchRequestTest {
   void shouldDeleteEntity() throws IOException, PersistenceException {
     // When
     batchRequest.delete(INDEX, ID);
-    batchRequest.execute();
+    batchRequest.execute(null);
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -347,7 +347,7 @@ class ElasticsearchBatchRequestTest {
 
     // when
     batchRequest.deleteWithRouting(INDEX, ID, routing);
-    batchRequest.execute();
+    batchRequest.execute(null);
 
     // then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -373,7 +373,7 @@ class ElasticsearchBatchRequestTest {
     // When
     batchRequest.add(INDEX, entity);
     batchRequest.update(INDEX, ID, entity);
-    batchRequest.execute();
+    batchRequest.execute(null);
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -412,7 +412,7 @@ class ElasticsearchBatchRequestTest {
     when(elasticsearchClient.bulk(any(BulkRequest.class))).thenThrow(throwable);
 
     // When
-    final ThrowingCallable callable = () -> batchRequest.execute();
+    final ThrowingCallable callable = () -> batchRequest.execute(null);
 
     // Then
     assertThatThrownBy(callable).isInstanceOf(PersistenceException.class);
@@ -434,7 +434,7 @@ class ElasticsearchBatchRequestTest {
 
     // When
     batchRequest.add(INDEX, entity);
-    final ThrowingCallable callable = () -> batchRequest.execute();
+    final ThrowingCallable callable = () -> batchRequest.execute(null);
 
     // Then
     assertThatThrownBy(callable).isInstanceOf(PersistenceException.class);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ElasticsearchBatchRequestTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ElasticsearchBatchRequestTest.java
@@ -70,7 +70,7 @@ class ElasticsearchBatchRequestTest {
 
     // When
     batchRequest.add(INDEX, entity);
-    batchRequest.execute(null);
+    batchRequest.execute();
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -97,7 +97,7 @@ class ElasticsearchBatchRequestTest {
     // When
     batchRequest.addWithRouting(INDEX, entity, routing);
 
-    batchRequest.execute(null);
+    batchRequest.execute();
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -125,7 +125,7 @@ class ElasticsearchBatchRequestTest {
 
     // When
     batchRequest.upsert(INDEX, ID, entity, updateFields);
-    batchRequest.execute(null);
+    batchRequest.execute();
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -154,7 +154,7 @@ class ElasticsearchBatchRequestTest {
 
     // When
     batchRequest.upsertWithRouting(INDEX, ID, entity, updateFields, routing);
-    batchRequest.execute(null);
+    batchRequest.execute();
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -187,7 +187,7 @@ class ElasticsearchBatchRequestTest {
 
     // When
     batchRequest.upsertWithScript(INDEX, ID, entity, script, params);
-    batchRequest.execute(null);
+    batchRequest.execute();
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -220,7 +220,7 @@ class ElasticsearchBatchRequestTest {
 
     // When
     batchRequest.upsertWithScriptAndRouting(INDEX, ID, entity, script, params, routing);
-    batchRequest.execute(null);
+    batchRequest.execute();
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -247,7 +247,7 @@ class ElasticsearchBatchRequestTest {
 
     // When
     batchRequest.update(INDEX, ID, updateFields);
-    batchRequest.execute(null);
+    batchRequest.execute();
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -273,7 +273,7 @@ class ElasticsearchBatchRequestTest {
 
     // When
     batchRequest.update(INDEX, ID, entity);
-    batchRequest.execute(null);
+    batchRequest.execute();
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -303,7 +303,7 @@ class ElasticsearchBatchRequestTest {
 
     // When
     batchRequest.updateWithScript(INDEX, ID, script, params);
-    batchRequest.execute(null);
+    batchRequest.execute();
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -326,7 +326,7 @@ class ElasticsearchBatchRequestTest {
   void shouldDeleteEntity() throws IOException, PersistenceException {
     // When
     batchRequest.delete(INDEX, ID);
-    batchRequest.execute(null);
+    batchRequest.execute();
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -351,7 +351,7 @@ class ElasticsearchBatchRequestTest {
 
     // when
     batchRequest.deleteWithRouting(INDEX, ID, routing);
-    batchRequest.execute(null);
+    batchRequest.execute();
 
     // then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -377,7 +377,7 @@ class ElasticsearchBatchRequestTest {
     // When
     batchRequest.add(INDEX, entity);
     batchRequest.update(INDEX, ID, entity);
-    batchRequest.execute(null);
+    batchRequest.execute();
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -416,7 +416,7 @@ class ElasticsearchBatchRequestTest {
     when(elasticsearchClient.bulk(any(BulkRequest.class))).thenThrow(throwable);
 
     // When
-    final ThrowingCallable callable = () -> batchRequest.execute(null);
+    final ThrowingCallable callable = () -> batchRequest.execute();
 
     // Then
     assertThatThrownBy(callable).isInstanceOf(PersistenceException.class);
@@ -438,7 +438,7 @@ class ElasticsearchBatchRequestTest {
 
     // When
     batchRequest.add(INDEX, entity);
-    final ThrowingCallable callable = () -> batchRequest.execute(null);
+    final ThrowingCallable callable = () -> batchRequest.execute();
 
     // Then
     assertThatThrownBy(callable).isInstanceOf(PersistenceException.class);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ElasticsearchBatchRequestTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ElasticsearchBatchRequestTest.java
@@ -10,7 +10,6 @@ package io.camunda.exporter.store;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -28,6 +27,7 @@ import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
 import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
 import co.elastic.clients.elasticsearch.core.bulk.IndexOperation;
 import io.camunda.exporter.entities.TestExporterEntity;
+import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.utils.ElasticsearchScriptBuilder;
 import java.io.IOException;
@@ -458,13 +458,13 @@ class ElasticsearchBatchRequestTest {
     when(bulkResponse.items()).thenReturn(List.of(item));
 
     when(elasticsearchClient.bulk(any(BulkRequest.class))).thenReturn(bulkResponse);
-    final BiConsumer<String, String> errorHandler = mock(BiConsumer.class);
+    final BiConsumer<String, Error> errorHandler = mock(BiConsumer.class);
 
     // When
     batchRequest.add(INDEX_WITH_HANDLER, entity);
     batchRequest.execute(errorHandler);
 
     // Then
-    verify(errorHandler).accept(eq(INDEX_WITH_HANDLER), anyString());
+    verify(errorHandler).accept(eq(INDEX_WITH_HANDLER), any());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterMultipleHandlersTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterMultipleHandlersTest.java
@@ -96,7 +96,7 @@ public class ExporterBatchWriterMultipleHandlersTest {
     // then
     verify(batchRequest, times(2))
         .update(eq("indexA"), eq(Long.toString(record.getKey())), any(TestEntity.class));
-    verify(batchRequest).execute();
+    verify(batchRequest).execute(any());
   }
 
   @Test
@@ -125,7 +125,7 @@ public class ExporterBatchWriterMultipleHandlersTest {
         .update(eq("indexA"), eq(Long.toString(record.getKey())), any(TestEntity.class));
     verify(batchRequest)
         .update(eq("indexB"), eq(Long.toString(record.getKey())), any(TestEntity.class));
-    verify(batchRequest).execute();
+    verify(batchRequest).execute(any());
   }
 
   @Test
@@ -172,7 +172,7 @@ public class ExporterBatchWriterMultipleHandlersTest {
     inOrder
         .verify(batchRequest)
         .update(eq("indexF"), eq(Long.toString(record.getKey())), any(TestEntity.class));
-    inOrder.verify(batchRequest).execute();
+    inOrder.verify(batchRequest).execute(any());
   }
 
   @Test
@@ -202,7 +202,7 @@ public class ExporterBatchWriterMultipleHandlersTest {
         .update(eq("indexA"), eq(Long.toString(record.getKey())), any(TestEntity.class));
     verify(batchRequest)
         .update(eq("indexA"), eq(Long.toString(record.getKey())), any(OtherTestEntity.class));
-    verify(batchRequest).execute();
+    verify(batchRequest).execute(any());
   }
 
   private static class TestEntity implements ExporterEntity<TestEntity> {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterMultipleHandlersTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterMultipleHandlersTest.java
@@ -96,7 +96,7 @@ public class ExporterBatchWriterMultipleHandlersTest {
     // then
     verify(batchRequest, times(2))
         .update(eq("indexA"), eq(Long.toString(record.getKey())), any(TestEntity.class));
-    verify(batchRequest).execute(null);
+    verify(batchRequest).execute();
   }
 
   @Test
@@ -125,7 +125,7 @@ public class ExporterBatchWriterMultipleHandlersTest {
         .update(eq("indexA"), eq(Long.toString(record.getKey())), any(TestEntity.class));
     verify(batchRequest)
         .update(eq("indexB"), eq(Long.toString(record.getKey())), any(TestEntity.class));
-    verify(batchRequest).execute(null);
+    verify(batchRequest).execute();
   }
 
   @Test
@@ -172,7 +172,7 @@ public class ExporterBatchWriterMultipleHandlersTest {
     inOrder
         .verify(batchRequest)
         .update(eq("indexF"), eq(Long.toString(record.getKey())), any(TestEntity.class));
-    inOrder.verify(batchRequest).execute(null);
+    inOrder.verify(batchRequest).execute();
   }
 
   @Test
@@ -202,7 +202,7 @@ public class ExporterBatchWriterMultipleHandlersTest {
         .update(eq("indexA"), eq(Long.toString(record.getKey())), any(TestEntity.class));
     verify(batchRequest)
         .update(eq("indexA"), eq(Long.toString(record.getKey())), any(OtherTestEntity.class));
-    verify(batchRequest).execute(null);
+    verify(batchRequest).execute();
   }
 
   private static class TestEntity implements ExporterEntity<TestEntity> {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterMultipleHandlersTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterMultipleHandlersTest.java
@@ -96,7 +96,7 @@ public class ExporterBatchWriterMultipleHandlersTest {
     // then
     verify(batchRequest, times(2))
         .update(eq("indexA"), eq(Long.toString(record.getKey())), any(TestEntity.class));
-    verify(batchRequest).execute();
+    verify(batchRequest).execute(null);
   }
 
   @Test
@@ -125,7 +125,7 @@ public class ExporterBatchWriterMultipleHandlersTest {
         .update(eq("indexA"), eq(Long.toString(record.getKey())), any(TestEntity.class));
     verify(batchRequest)
         .update(eq("indexB"), eq(Long.toString(record.getKey())), any(TestEntity.class));
-    verify(batchRequest).execute();
+    verify(batchRequest).execute(null);
   }
 
   @Test
@@ -172,7 +172,7 @@ public class ExporterBatchWriterMultipleHandlersTest {
     inOrder
         .verify(batchRequest)
         .update(eq("indexF"), eq(Long.toString(record.getKey())), any(TestEntity.class));
-    inOrder.verify(batchRequest).execute();
+    inOrder.verify(batchRequest).execute(null);
   }
 
   @Test
@@ -202,7 +202,7 @@ public class ExporterBatchWriterMultipleHandlersTest {
         .update(eq("indexA"), eq(Long.toString(record.getKey())), any(TestEntity.class));
     verify(batchRequest)
         .update(eq("indexA"), eq(Long.toString(record.getKey())), any(OtherTestEntity.class));
-    verify(batchRequest).execute();
+    verify(batchRequest).execute(null);
   }
 
   private static class TestEntity implements ExporterEntity<TestEntity> {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterTest.java
@@ -131,7 +131,7 @@ class ExporterBatchWriterTest {
     // then
 
     verify(handler).flush(entity, batchRequest);
-    verify(batchRequest).execute();
+    verify(batchRequest).execute(any());
     assertThat(batchWriter.getBatchSize()).isEqualTo(0);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterTest.java
@@ -131,7 +131,7 @@ class ExporterBatchWriterTest {
     // then
 
     verify(handler).flush(entity, batchRequest);
-    verify(batchRequest).execute(null);
+    verify(batchRequest).execute();
     assertThat(batchWriter.getBatchSize()).isEqualTo(0);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterTest.java
@@ -131,7 +131,7 @@ class ExporterBatchWriterTest {
     // then
 
     verify(handler).flush(entity, batchRequest);
-    verify(batchRequest).execute();
+    verify(batchRequest).execute(null);
     assertThat(batchWriter.getBatchSize()).isEqualTo(0);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/OpensearchBatchRequestTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/OpensearchBatchRequestTest.java
@@ -69,7 +69,7 @@ class OpensearchBatchRequestTest {
 
     // When
     batchRequest.add(INDEX, entity);
-    batchRequest.execute(null);
+    batchRequest.execute();
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -96,7 +96,7 @@ class OpensearchBatchRequestTest {
     // When
     batchRequest.addWithRouting(INDEX, entity, routing);
 
-    batchRequest.execute(null);
+    batchRequest.execute();
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -124,7 +124,7 @@ class OpensearchBatchRequestTest {
 
     // When
     batchRequest.upsert(INDEX, ID, entity, updateFields);
-    batchRequest.execute(null);
+    batchRequest.execute();
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -152,7 +152,7 @@ class OpensearchBatchRequestTest {
 
     // When
     batchRequest.upsertWithRouting(INDEX, ID, entity, updateFields, routing);
-    batchRequest.execute(null);
+    batchRequest.execute();
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -183,7 +183,7 @@ class OpensearchBatchRequestTest {
 
     // When
     batchRequest.upsertWithScript(INDEX, ID, entity, script, params);
-    batchRequest.execute(null);
+    batchRequest.execute();
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -214,7 +214,7 @@ class OpensearchBatchRequestTest {
 
     // When
     batchRequest.upsertWithScriptAndRouting(INDEX, ID, entity, script, params, routing);
-    batchRequest.execute(null);
+    batchRequest.execute();
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -239,7 +239,7 @@ class OpensearchBatchRequestTest {
 
     // When
     batchRequest.update(INDEX, ID, updateFields);
-    batchRequest.execute(null);
+    batchRequest.execute();
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -264,7 +264,7 @@ class OpensearchBatchRequestTest {
 
     // When
     batchRequest.update(INDEX, ID, entity);
-    batchRequest.execute(null);
+    batchRequest.execute();
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -293,7 +293,7 @@ class OpensearchBatchRequestTest {
 
     // When
     batchRequest.updateWithScript(INDEX, ID, script, params);
-    batchRequest.execute(null);
+    batchRequest.execute();
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -318,7 +318,7 @@ class OpensearchBatchRequestTest {
 
     // When
     batchRequest.delete(INDEX, ID);
-    batchRequest.execute(null);
+    batchRequest.execute();
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -343,7 +343,7 @@ class OpensearchBatchRequestTest {
 
     // when
     batchRequest.deleteWithRouting(INDEX, ID, routing);
-    batchRequest.execute(null);
+    batchRequest.execute();
 
     // then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -369,7 +369,7 @@ class OpensearchBatchRequestTest {
     // When
     batchRequest.add(INDEX, entity);
     batchRequest.update(INDEX, ID, entity);
-    batchRequest.execute(null);
+    batchRequest.execute();
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -408,7 +408,7 @@ class OpensearchBatchRequestTest {
     when(osClient.bulk(any(BulkRequest.class))).thenThrow(throwable);
 
     // When
-    final ThrowingCallable callable = () -> batchRequest.execute(null);
+    final ThrowingCallable callable = () -> batchRequest.execute();
 
     // Then
     assertThatThrownBy(callable).isInstanceOf(PersistenceException.class);
@@ -432,7 +432,7 @@ class OpensearchBatchRequestTest {
 
     // When
     batchRequest.add(INDEX, entity);
-    final ThrowingCallable callable = () -> batchRequest.execute(null);
+    final ThrowingCallable callable = () -> batchRequest.execute();
 
     // Then
     assertThatThrownBy(callable).isInstanceOf(PersistenceException.class);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/OpensearchBatchRequestTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/OpensearchBatchRequestTest.java
@@ -10,13 +10,13 @@ package io.camunda.exporter.store;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.exporter.entities.TestExporterEntity;
+import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.utils.OpensearchScriptBuilder;
 import java.io.IOException;
@@ -454,12 +454,12 @@ class OpensearchBatchRequestTest {
     when(bulkResponse.items()).thenReturn(List.of(item));
 
     when(osClient.bulk(any(BulkRequest.class))).thenReturn(bulkResponse);
-    final BiConsumer<String, String> errorHandler = mock(BiConsumer.class);
+    final BiConsumer<String, Error> errorHandler = mock(BiConsumer.class);
     // When
     batchRequest.add(INDEX_WITH_HANDLER, entity);
     batchRequest.execute(errorHandler);
 
     // Then
-    verify(errorHandler).accept(eq(INDEX_WITH_HANDLER), anyString());
+    verify(errorHandler).accept(eq(INDEX_WITH_HANDLER), any());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/OpensearchBatchRequestTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/OpensearchBatchRequestTest.java
@@ -10,6 +10,8 @@ package io.camunda.exporter.store;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -20,6 +22,7 @@ import io.camunda.exporter.utils.OpensearchScriptBuilder;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,6 +45,7 @@ class OpensearchBatchRequestTest {
 
   private static final String ID = "id";
   private static final String INDEX = "index";
+  private static final String INDEX_WITH_HANDLER = "indexWithHandler";
   private OpensearchBatchRequest batchRequest;
   private OpenSearchClient osClient;
   private Builder requestBuilder;
@@ -433,5 +437,29 @@ class OpensearchBatchRequestTest {
     // Then
     assertThatThrownBy(callable).isInstanceOf(PersistenceException.class);
     verify(osClient).bulk(any(BulkRequest.class));
+  }
+
+  @Test
+  void shouldUseCustomErrorHandlerIfProvided() throws IOException {
+    // Given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+
+    final BulkResponseItem item = mock(BulkResponseItem.class);
+    when(item.id()).thenReturn("1");
+    when(item.error())
+        .thenReturn(new ErrorCause.Builder().type("string_error").reason("error").build());
+    when(item.index()).thenReturn(INDEX_WITH_HANDLER);
+
+    final BulkResponse bulkResponse = mock(BulkResponse.class);
+    when(bulkResponse.items()).thenReturn(List.of(item));
+
+    when(osClient.bulk(any(BulkRequest.class))).thenReturn(bulkResponse);
+    final BiConsumer<String, String> errorHandler = mock(BiConsumer.class);
+    // When
+    batchRequest.add(INDEX_WITH_HANDLER, entity);
+    batchRequest.execute(errorHandler);
+
+    // Then
+    verify(errorHandler).accept(eq(INDEX_WITH_HANDLER), anyString());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/OpensearchBatchRequestTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/OpensearchBatchRequestTest.java
@@ -65,7 +65,7 @@ class OpensearchBatchRequestTest {
 
     // When
     batchRequest.add(INDEX, entity);
-    batchRequest.execute();
+    batchRequest.execute(null);
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -92,7 +92,7 @@ class OpensearchBatchRequestTest {
     // When
     batchRequest.addWithRouting(INDEX, entity, routing);
 
-    batchRequest.execute();
+    batchRequest.execute(null);
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -120,7 +120,7 @@ class OpensearchBatchRequestTest {
 
     // When
     batchRequest.upsert(INDEX, ID, entity, updateFields);
-    batchRequest.execute();
+    batchRequest.execute(null);
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -148,7 +148,7 @@ class OpensearchBatchRequestTest {
 
     // When
     batchRequest.upsertWithRouting(INDEX, ID, entity, updateFields, routing);
-    batchRequest.execute();
+    batchRequest.execute(null);
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -179,7 +179,7 @@ class OpensearchBatchRequestTest {
 
     // When
     batchRequest.upsertWithScript(INDEX, ID, entity, script, params);
-    batchRequest.execute();
+    batchRequest.execute(null);
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -210,7 +210,7 @@ class OpensearchBatchRequestTest {
 
     // When
     batchRequest.upsertWithScriptAndRouting(INDEX, ID, entity, script, params, routing);
-    batchRequest.execute();
+    batchRequest.execute(null);
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -235,7 +235,7 @@ class OpensearchBatchRequestTest {
 
     // When
     batchRequest.update(INDEX, ID, updateFields);
-    batchRequest.execute();
+    batchRequest.execute(null);
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -260,7 +260,7 @@ class OpensearchBatchRequestTest {
 
     // When
     batchRequest.update(INDEX, ID, entity);
-    batchRequest.execute();
+    batchRequest.execute(null);
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -289,7 +289,7 @@ class OpensearchBatchRequestTest {
 
     // When
     batchRequest.updateWithScript(INDEX, ID, script, params);
-    batchRequest.execute();
+    batchRequest.execute(null);
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -314,7 +314,7 @@ class OpensearchBatchRequestTest {
 
     // When
     batchRequest.delete(INDEX, ID);
-    batchRequest.execute();
+    batchRequest.execute(null);
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -339,7 +339,7 @@ class OpensearchBatchRequestTest {
 
     // when
     batchRequest.deleteWithRouting(INDEX, ID, routing);
-    batchRequest.execute();
+    batchRequest.execute(null);
 
     // then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -365,7 +365,7 @@ class OpensearchBatchRequestTest {
     // When
     batchRequest.add(INDEX, entity);
     batchRequest.update(INDEX, ID, entity);
-    batchRequest.execute();
+    batchRequest.execute(null);
 
     // Then
     final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
@@ -404,7 +404,7 @@ class OpensearchBatchRequestTest {
     when(osClient.bulk(any(BulkRequest.class))).thenThrow(throwable);
 
     // When
-    final ThrowingCallable callable = () -> batchRequest.execute();
+    final ThrowingCallable callable = () -> batchRequest.execute(null);
 
     // Then
     assertThatThrownBy(callable).isInstanceOf(PersistenceException.class);
@@ -428,7 +428,7 @@ class OpensearchBatchRequestTest {
 
     // When
     batchRequest.add(INDEX, entity);
-    final ThrowingCallable callable = () -> batchRequest.execute();
+    final ThrowingCallable callable = () -> batchRequest.execute(null);
 
     // Then
     assertThatThrownBy(callable).isInstanceOf(PersistenceException.class);


### PR DESCRIPTION
## Description

- ExporterResourceProvider to provide a map of indices and their custom error handling behavior
- Exporter passes the custom error handlers to the ExporterBatchWriter
- ExporterBatchWriter passes the error handlers through to be used when executing a BatchRequest
- Created ErrorHandler functional interface that receives Error details
- Created an enum with a couple of error handling implementations
- Only ignore operation index errors if the error was document missing

## Related issues

closes #27090
closes #26093
