### PR TITLE
ci: upload 8.7 Maven SNAPSHOTs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -576,7 +576,7 @@ jobs:
     name: Deploy snapshot artifacts
     needs: [ check-results ]
     runs-on: ubuntu-latest
-    if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
+    if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/stable/8.7'
     concurrency:
       group: deploy-maven-snapshot
       cancel-in-progress: false


### PR DESCRIPTION
## Description

This PR adjusts the `ci.yml` Maven deploy job (that should include Operate, Tasklist, Zeebe artifact) to allow it to publish Maven SNAPSHOTs to Artifactory. Those will be `8.7.0-SNAPSHOT` version.

✔️ This PR needs CI fixes from https://github.com/camunda/camunda/pull/27216 and https://github.com/camunda/camunda/pull/27224

✔️ This PR needs to be merged after https://github.com/camunda/camunda/pull/27210 to avoid overwriting same-name artifacts from `main`:

* https://github.com/camunda/camunda/pull/27210

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Related to https://github.com/camunda/camunda/issues/27193
