### PR TITLE
Implement CamundaExporter::purge and parameterize ClusterPurgeIT

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/schema/SchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/SchemaManager.java
@@ -52,6 +52,8 @@ public interface SchemaManager {
 
   boolean deleteTemplatesFor(final String deleteTemplatePattern);
 
+  boolean deleteDefaults();
+
   void removePipeline(String pipelineName);
 
   boolean addPipeline(String name, String pipelineDefinition);

--- a/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.elasticsearch.action.admin.indices.alias.Alias;
 import org.elasticsearch.client.indices.CreateIndexRequest;
+import org.elasticsearch.client.indices.DeleteComponentTemplateRequest;
 import org.elasticsearch.client.indices.PutComponentTemplateRequest;
 import org.elasticsearch.client.indices.PutComposableIndexTemplateRequest;
 import org.elasticsearch.client.indices.PutIndexTemplateRequest;
@@ -184,6 +185,12 @@ public class ElasticsearchSchemaManager implements SchemaManager {
   @Override
   public boolean deleteTemplatesFor(final String deleteTemplatePattern) {
     return retryElasticsearchClient.deleteTemplatesFor(deleteTemplatePattern);
+  }
+
+  @Override
+  public boolean deleteDefaults() {
+    final var request = new DeleteComponentTemplateRequest(settingsTemplateName());
+    return retryElasticsearchClient.deleteComponentTemplate(request);
   }
 
   @Override

--- a/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchSchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchSchemaManager.java
@@ -39,6 +39,7 @@ import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.mapping.Property;
 import org.opensearch.client.opensearch._types.mapping.TypeMapping;
+import org.opensearch.client.opensearch.cluster.DeleteComponentTemplateRequest;
 import org.opensearch.client.opensearch.cluster.PutComponentTemplateRequest;
 import org.opensearch.client.opensearch.indices.Alias;
 import org.opensearch.client.opensearch.indices.CreateIndexRequest;
@@ -223,6 +224,17 @@ public class OpensearchSchemaManager implements SchemaManager {
   @Override
   public boolean deleteTemplatesFor(final String deleteTemplatePattern) {
     return richOpenSearchClient.template().deleteTemplatesWithRetries(deleteTemplatePattern);
+  }
+
+  @Override
+  public boolean deleteDefaults() {
+    final String settingsTemplateName = settingsTemplateName();
+    LOGGER.info("Delete default settings '{}'.", settingsTemplateName);
+
+    return richOpenSearchClient
+        .template()
+        .deleteComponentTemplateWithRetries(
+            new DeleteComponentTemplateRequest.Builder().name(settingsTemplateName).build());
   }
 
   @Override

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/RetryElasticsearchClient.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/RetryElasticsearchClient.java
@@ -59,6 +59,7 @@ import org.elasticsearch.client.core.CountRequest;
 import org.elasticsearch.client.indexlifecycle.PutLifecyclePolicyRequest;
 import org.elasticsearch.client.indices.ComposableIndexTemplateExistRequest;
 import org.elasticsearch.client.indices.CreateIndexRequest;
+import org.elasticsearch.client.indices.DeleteComponentTemplateRequest;
 import org.elasticsearch.client.indices.DeleteComposableIndexTemplateRequest;
 import org.elasticsearch.client.indices.GetIndexRequest;
 import org.elasticsearch.client.indices.GetIndexResponse;
@@ -386,6 +387,12 @@ public class RetryElasticsearchClient {
           }
           return true;
         });
+  }
+
+  public boolean deleteComponentTemplate(final DeleteComponentTemplateRequest request) {
+    return executeWithRetries(
+        "DeleteComponentTemplate " + request.getName(),
+        () -> esClient.cluster().deleteComponentTemplate(request, requestOptions).isAcknowledged());
   }
 
   public boolean createTemplate(final PutComposableIndexTemplateRequest request) {

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchTemplateOperations.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchTemplateOperations.java
@@ -13,12 +13,14 @@ import java.util.stream.Collectors;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch.cluster.ComponentTemplate;
 import org.opensearch.client.opensearch.cluster.ComponentTemplateNode;
+import org.opensearch.client.opensearch.cluster.DeleteComponentTemplateRequest;
 import org.opensearch.client.opensearch.cluster.PutComponentTemplateRequest;
 import org.opensearch.client.opensearch.indices.PutIndexTemplateRequest;
 import org.slf4j.Logger;
 
 public class OpenSearchTemplateOperations extends OpenSearchRetryOperation {
-  public OpenSearchTemplateOperations(Logger logger, OpenSearchClient openSearchClient) {
+  public OpenSearchTemplateOperations(
+      final Logger logger, final OpenSearchClient openSearchClient) {
     super(logger, openSearchClient);
   }
 
@@ -26,7 +28,8 @@ public class OpenSearchTemplateOperations extends OpenSearchRetryOperation {
     return openSearchClient.indices().existsIndexTemplate(it -> it.name(templatePattern)).value();
   }
 
-  public boolean createTemplateWithRetries(PutIndexTemplateRequest request, boolean overwrite) {
+  public boolean createTemplateWithRetries(
+      final PutIndexTemplateRequest request, final boolean overwrite) {
     return executeWithRetries(
         "CreateTemplate " + request.name(),
         () -> {
@@ -59,6 +62,17 @@ public class OpenSearchTemplateOperations extends OpenSearchRetryOperation {
             return openSearchClient.cluster().putComponentTemplate(request).acknowledged();
           }
           return false;
+        });
+  }
+
+  public boolean deleteComponentTemplateWithRetries(final DeleteComponentTemplateRequest request) {
+    return executeWithRetries(
+        "DeleteComponentTemplate " + request.name(),
+        () -> {
+          if (templatesExist(request.name())) {
+            return openSearchClient.cluster().deleteComponentTemplate(request).acknowledged();
+          }
+          return true;
         });
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/CamundaMultiDBExtension.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/CamundaMultiDBExtension.java
@@ -206,7 +206,8 @@ public class CamundaMultiDBExtension
   }
 
   private CamundaClient createCamundaClient() {
-    final CamundaClient camundaClient = testApplication.newClientBuilder().build();
+    final CamundaClient camundaClient =
+        testApplication.newClientBuilder().preferRestOverGrpc(true).build();
     closeables.add(camundaClient);
     return camundaClient;
   }

--- a/zeebe/broker/pom.xml
+++ b/zeebe/broker/pom.xml
@@ -220,6 +220,16 @@
       <artifactId>camunda-service</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>operate-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>operate-schema</artifactId>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterChangeExecutorImpl.java
@@ -18,8 +18,14 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.stream.api.StreamClock;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class ClusterChangeExecutorImpl implements ClusterChangeExecutor {
+  private static final Logger LOG = LoggerFactory.getLogger(ClusterChangeExecutorImpl.class);
 
   private final ConcurrencyControl concurrencyControl;
   private final ExporterRepository exporterRepository;
@@ -36,18 +42,40 @@ public final class ClusterChangeExecutorImpl implements ClusterChangeExecutor {
 
   @Override
   public ActorFuture<Void> deleteHistory() {
-    final ActorFuture<Void> result = concurrencyControl.createFuture();
-    concurrencyControl.run(() -> purgeExporters(result));
-    return result;
-  }
 
-  private void purgeExporters(final ActorFuture<Void> result) {
-    try {
-      exporterRepository.getExporters().forEach(this::purgeExporter);
-      result.complete(null);
-    } catch (final Exception e) {
-      result.completeExceptionally(e);
-    }
+    final ActorFuture<Void> result = concurrencyControl.createFuture();
+    concurrencyControl.run(
+        () -> {
+          try {
+            exporterRepository.getExporters().forEach(this::purgeExporter);
+            final var failed =
+                SchemaManagerProvider.purgeUsingSchemaManager()
+                    .thenAccept(
+                        schemaManager -> {
+                          Stream.of("operate-*", "tasklist-*")
+                              .forEach(
+                                  name ->
+                                      schemaManager.deleteIndicesFor(
+                                          prefixedName(schemaManager.getIndexPrefix(), name)));
+                          Stream.of("operate-*", "tasklist-*")
+                              .forEach(
+                                  name ->
+                                      schemaManager.deleteTemplatesFor(
+                                          prefixedName(schemaManager.getIndexPrefix(), name)));
+                          schemaManager.deleteDefaults();
+                          schemaManager.createDefaults(); // TODO temporary workaround
+                        })
+                    .isCompletedExceptionally();
+            if (failed) {
+              LOG.info("SchemaManager not found");
+            }
+            result.complete(null);
+          } catch (final Exception e) {
+            result.completeExceptionally(e);
+          }
+        });
+
+    return result;
   }
 
   private void purgeExporter(final String id, final ExporterDescriptor descriptor) {
@@ -71,5 +99,14 @@ public final class ClusterChangeExecutorImpl implements ClusterChangeExecutor {
               .formatted(id, exporter.getClass()),
           e);
     }
+  }
+
+  private List<String> prefixedNames(final String prefix, final String... names) {
+    final var indexPrefix = prefix.isBlank() ? "" : prefix + "-";
+    return Arrays.stream(names).map(s -> indexPrefix + s).toList();
+  }
+
+  private String prefixedName(final String prefix, final String name) {
+    return prefix.isBlank() ? name : prefix + "-" + name;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/SchemaManagerProvider.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/SchemaManagerProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.partitioning.topology;
+
+import io.camunda.operate.schema.SchemaManager;
+import io.camunda.operate.util.RetryOperation;
+import io.camunda.operate.util.SpringContextHolder;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SchemaManagerProvider {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SchemaManagerProvider.class);
+  private static final int RETRY_COUNT = 5;
+
+  public static CompletableFuture<SchemaManager> purgeUsingSchemaManager() {
+    final CompletableFuture<SchemaManager> future = new CompletableFuture<>();
+    tryFetchingBean(future);
+    return future;
+  }
+
+  // need to wait and retry as transitions steps starts before the SpringContextHolder gets its
+  // context set
+  private static void tryFetchingBean(final CompletableFuture<SchemaManager> future) {
+    try {
+      RetryOperation.newBuilder()
+          .noOfRetry(RETRY_COUNT)
+          .retryOn(NullPointerException.class)
+          .delayInterval(1, TimeUnit.SECONDS)
+          .message("Fetching SchemaManager bean")
+          .retryConsumer(
+              () -> {
+                LOG.info("Fetching SchemaManager ...");
+                final SchemaManager schemaManager =
+                    SpringContextHolder.getBean(SchemaManager.class);
+                future.complete(schemaManager); // Successfully retrieved the bean
+                return true;
+              })
+          .build()
+          .retry();
+    } catch (final Exception e) {
+      LOG.error("FAILED TO GET THE BEAN, retrying...", e);
+      future.completeExceptionally(e);
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SearchEngineClient.java
@@ -44,4 +44,12 @@ public interface SearchEngineClient {
 
   boolean importersCompleted(
       final int partitionId, final List<IndexDescriptor> importPositionIndices);
+
+  void deleteIndex(final String indexName);
+
+  void deleteIndexTemplate(final String indexTemplateName);
+
+  void deleteIndexLifeCyclePolicy(final String policyName);
+
+  void deleteComponentTemplate(final String templateName);
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/opensearch/OpensearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/opensearch/OpensearchEngineClient.java
@@ -44,6 +44,7 @@ import org.opensearch.client.opensearch.generic.Body;
 import org.opensearch.client.opensearch.generic.Request;
 import org.opensearch.client.opensearch.generic.Requests;
 import org.opensearch.client.opensearch.indices.CreateIndexRequest;
+import org.opensearch.client.opensearch.indices.DeleteIndexRequest;
 import org.opensearch.client.opensearch.indices.PutIndexTemplateRequest;
 import org.opensearch.client.opensearch.indices.PutIndicesSettingsRequest;
 import org.opensearch.client.opensearch.indices.PutMappingRequest;
@@ -238,6 +239,63 @@ public class OpensearchEngineClient implements SearchEngineClient {
               partitionId);
       LOG.error(errMsg, e);
       return false;
+    }
+  }
+
+  @Override
+  public void deleteIndex(final String indexName) {
+    final DeleteIndexRequest request = new DeleteIndexRequest.Builder().index(indexName).build();
+
+    try {
+      client.indices().delete(request);
+      LOG.debug("Index [{}] was successfully deleted", indexName);
+    } catch (final IOException ioe) {
+      final var errMsg = String.format("Index [%s] was not deleted", indexName);
+      LOG.error(errMsg, ioe);
+      throw new OpensearchExporterException(errMsg, ioe);
+    }
+  }
+
+  @Override
+  public void deleteIndexTemplate(final String indexTemplateName) {
+    try {
+      client.indices().deleteIndexTemplate(req -> req.name(indexTemplateName));
+      LOG.debug("Index template [{}] was successfully deleted", indexTemplateName);
+    } catch (final IOException ioe) {
+      final var errMsg = String.format("Index template [%s] was not deleted", indexTemplateName);
+      LOG.error(errMsg, ioe);
+      throw new OpensearchExporterException(errMsg, ioe);
+    }
+  }
+
+  @Override
+  public void deleteIndexLifeCyclePolicy(final String policyName) {
+    try {
+      client
+          .generic()
+          .execute(
+              Requests.builder()
+                  .method("DELETE")
+                  .endpoint("_plugins/_ism/policies/" + policyName)
+                  .build());
+      LOG.debug("Index state management policy [{}] was successfully deleted", policyName);
+    } catch (final IOException | OpenSearchException e) {
+      final var errMsg =
+          String.format("Index state management policy [%s] was not deleted", policyName);
+      LOG.error(errMsg, e);
+      throw new OpensearchExporterException(errMsg, e);
+    }
+  }
+
+  @Override
+  public void deleteComponentTemplate(final String templateName) {
+    try {
+      client.cluster().deleteComponentTemplate(req -> req.name(templateName));
+      LOG.debug("Component template [{}] was successfully deleted", templateName);
+    } catch (final IOException ioe) {
+      final var errMsg = String.format("Component template [%s] was not deleted", templateName);
+      LOG.error(errMsg, ioe);
+      throw new OpensearchExporterException(errMsg, ioe);
     }
   }
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -246,12 +247,22 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
   }
 
   public TestStandaloneBroker withCamundaExporter(final String elasticSearchUrl) {
+    return withCamundaExporter(elasticSearchUrl, null);
+  }
+
+  public TestStandaloneBroker withCamundaExporter(
+      final String elasticSearchUrl, final String retentionPolicyName) {
+    final var exporterConfigArgs =
+        new HashMap<String, Object>(
+            Map.of("connect", Map.of("url", elasticSearchUrl), "bulk", Map.of("size", 1)));
+    if (retentionPolicyName != null) {
+      exporterConfigArgs.put("retention", Map.of("enabled", true, "policyName", "test-policy"));
+    }
     withExporter(
         "CamundaExporter",
         cfg -> {
           cfg.setClassName("io.camunda.exporter.CamundaExporter");
-          cfg.setArgs(
-              Map.of("connect", Map.of("url", elasticSearchUrl), "bulk", Map.of("size", 1)));
+          cfg.setArgs(exporterConfigArgs);
         });
     final var searchClient = new SearchClientProperties();
     searchClient.setUrl(elasticSearchUrl);


### PR DESCRIPTION
## Description

Implement `purge()` for the Camunda Exporter using ES.

- Delete indices
- Delete index templates
- Delete ILM policies

## Related issues

closes #26043
