### PR TITLE
ci: Modify camunda-helm-dir to camunda-platform-alpha-8.8

### DIFF
--- a/.github/workflows/camunda-helm-integration.yml
+++ b/.github/workflows/camunda-helm-integration.yml
@@ -12,7 +12,7 @@ jobs:
     secrets: inherit
     with:
       identifier: camunda-helm-int
-      camunda-helm-dir: camunda-platform-alpha
+      camunda-helm-dir: camunda-platform-alpha-8.8
       test-enabled: true
       caller-git-ref: main
       extra-values: |

--- a/.github/workflows/camunda-helm-integration.yml
+++ b/.github/workflows/camunda-helm-integration.yml
@@ -3,6 +3,9 @@ name: Camunda Helm Chart Integration Test
 on:
   schedule:
     - cron: "0 5 * * *"
+  pull_request:
+    paths:
+      - ".github/workflows/camunda-helm-integration.yml"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The directory in the camunda-platform-helm repo got changed. We must modify the directory in our CI as well.

For `stable/8.7` we don't need to change anything. This already points to the `camunda-platform-alpha` directory, which is correct.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

N/A
