### PR TITLE
feat: Improve `changedAttributes` handling for (`UPDATING`, `UPDATED`, `CORRECTED`)  user task events

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -100,10 +100,10 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
     final var userTaskElementInstance = getUserTaskElementInstance(intermediateUserTaskRecord);
     final var context = buildContext(userTaskElementInstance);
 
-    if (!command.getValue().getChangedAttributes().isEmpty()) {
+    if (command.getValue().hasChangedAttributes()) {
       intermediateUserTaskRecord.wrapChangedAttributesIfValueChanged(command.getValue());
 
-      if (!intermediateUserTaskRecord.getChangedAttributes().isEmpty()) {
+      if (intermediateUserTaskRecord.hasChangedAttributes()) {
         stateWriter.appendFollowUpEvent(
             command.getKey(), UserTaskIntent.CORRECTED, intermediateUserTaskRecord);
       }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -102,8 +102,11 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
 
     if (!command.getValue().getChangedAttributes().isEmpty()) {
       intermediateUserTaskRecord.wrapChangedAttributesIfValueChanged(command.getValue());
-      stateWriter.appendFollowUpEvent(
-          command.getKey(), UserTaskIntent.CORRECTED, intermediateUserTaskRecord);
+
+      if (!intermediateUserTaskRecord.getChangedAttributes().isEmpty()) {
+        stateWriter.appendFollowUpEvent(
+            command.getKey(), UserTaskIntent.CORRECTED, intermediateUserTaskRecord);
+      }
     }
 
     findNextTaskListener(listenerEventType, userTaskElement, userTaskElementInstance)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -101,7 +101,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
     final var context = buildContext(userTaskElementInstance);
 
     if (!command.getValue().getChangedAttributes().isEmpty()) {
-      intermediateUserTaskRecord.wrapChangedAttributes(command.getValue(), true);
+      intermediateUserTaskRecord.wrapChangedAttributesIfValueChanged(command.getValue());
       stateWriter.appendFollowUpEvent(
           command.getKey(), UserTaskIntent.CORRECTED, intermediateUserTaskRecord);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
@@ -53,7 +53,7 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
 
     final UserTaskRecord updateRecord = new UserTaskRecord();
     updateRecord.wrap(BufferUtil.createCopy(userTaskRecord));
-    updateRecord.wrapChangedAttributes(command.getValue(), true);
+    updateRecord.wrapChangedAttributesIfValueChanged(command.getValue());
     updateRecord.setAction(command.getValue().getActionOrDefault(DEFAULT_ACTION));
 
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.UPDATING, updateRecord);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UpdateUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UpdateUserTaskTest.java
@@ -33,6 +33,13 @@ public final class UpdateUserTaskTest {
   private static final String PROCESS_ID = "process";
   private static final String DEFAULT_ACTION = "update";
   private static final int DEFAULT_PRIORITY = 50;
+  private static final List<String> ALL_UPDATABLE_ATTRIBUTES =
+      List.of(
+          UserTaskRecord.CANDIDATE_GROUPS,
+          UserTaskRecord.CANDIDATE_USERS,
+          UserTaskRecord.DUE_DATE,
+          UserTaskRecord.FOLLOW_UP_DATE,
+          UserTaskRecord.PRIORITY);
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
@@ -82,7 +89,8 @@ public final class UpdateUserTaskTest {
                     .hasUserTaskKey(userTaskKey)
                     .hasAction(DEFAULT_ACTION)
                     .hasPriority(DEFAULT_PRIORITY)
-                    .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
+                    .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+                    .hasOnlyChangedAttributes(ALL_UPDATABLE_ATTRIBUTES));
   }
 
   @Test
@@ -120,7 +128,8 @@ public final class UpdateUserTaskTest {
                 Assertions.assertThat(recordValue)
                     .hasUserTaskKey(userTaskKey)
                     .hasAction("customAction")
-                    .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
+                    .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+                    .hasOnlyChangedAttributes(ALL_UPDATABLE_ATTRIBUTES));
   }
 
   @Test
@@ -180,7 +189,8 @@ public final class UpdateUserTaskTest {
                     .hasCandidateUsersList("initial_user_A", "initial_user_B")
                     .hasDueDate("2023-03-02T15:35+02:00")
                     .hasFollowUpDate("2023-03-02T16:35+02:00")
-                    .hasPriority(20));
+                    .hasPriority(20)
+                    .hasOnlyChangedAttributes(UserTaskRecord.CANDIDATE_GROUPS));
   }
 
   @Test
@@ -227,7 +237,8 @@ public final class UpdateUserTaskTest {
                     .hasCandidateUsersList("updated_user_C", "updated_user_D")
                     .hasDueDate("2023-03-02T15:35+02:00")
                     .hasFollowUpDate("2023-03-02T16:35+02:00")
-                    .hasPriority(20));
+                    .hasPriority(20)
+                    .hasOnlyChangedAttributes(UserTaskRecord.CANDIDATE_USERS));
   }
 
   @Test
@@ -271,7 +282,8 @@ public final class UpdateUserTaskTest {
                     .hasCandidateUsersList("initial_user_A", "initial_user_B")
                     .hasDueDate("updated_dueDate")
                     .hasFollowUpDate("2023-03-02T16:35+02:00")
-                    .hasPriority(20));
+                    .hasPriority(20)
+                    .hasOnlyChangedAttributes(UserTaskRecord.DUE_DATE));
   }
 
   @Test
@@ -318,7 +330,8 @@ public final class UpdateUserTaskTest {
                     .hasCandidateUsersList("initial_user_A", "initial_user_B")
                     .hasDueDate("2023-03-02T15:35+02:00")
                     .hasFollowUpDate("updated_followUpDate")
-                    .hasPriority(20));
+                    .hasPriority(20)
+                    .hasOnlyChangedAttributes(UserTaskRecord.FOLLOW_UP_DATE));
   }
 
   @Test
@@ -363,7 +376,8 @@ public final class UpdateUserTaskTest {
                     .hasCandidateUsersList("initial_user_A", "initial_user_B")
                     .hasDueDate("2023-03-02T15:35+02:00")
                     .hasFollowUpDate("2023-03-02T16:35+02:00")
-                    .hasPriority(newPriority));
+                    .hasPriority(newPriority)
+                    .hasOnlyChangedAttributes(UserTaskRecord.PRIORITY));
   }
 
   @Test
@@ -404,7 +418,8 @@ public final class UpdateUserTaskTest {
                     .hasNoCandidateUsersList()
                     .hasDueDate("")
                     .hasFollowUpDate("")
-                    .hasPriority(DEFAULT_PRIORITY));
+                    .hasPriority(DEFAULT_PRIORITY)
+                    .hasOnlyChangedAttributes(ALL_UPDATABLE_ATTRIBUTES));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UpdateUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UpdateUserTaskTest.java
@@ -153,7 +153,10 @@ public final class UpdateUserTaskTest {
         ENGINE
             .userTask()
             .ofInstance(processInstanceKey)
-            .update(List.of("updated_group_C", "updated_group_D"), null, null, null);
+            .update(
+                new UserTaskRecord()
+                    .setCandidateGroupsList(List.of("updated_group_C", "updated_group_D"))
+                    .setCandidateGroupsChanged());
 
     // then
     Assertions.assertThat(updatingRecord)
@@ -195,7 +198,10 @@ public final class UpdateUserTaskTest {
         ENGINE
             .userTask()
             .ofInstance(processInstanceKey)
-            .update(null, List.of("updated_user_C", "updated_user_D"), null, null);
+            .update(
+                new UserTaskRecord()
+                    .setCandidateUsersList(List.of("updated_user_C", "updated_user_D"))
+                    .setCandidateUsersChanged());
 
     // then
     Assertions.assertThat(updatingRecord)
@@ -237,7 +243,7 @@ public final class UpdateUserTaskTest {
         ENGINE
             .userTask()
             .ofInstance(processInstanceKey)
-            .update(null, null, "updated_dueDate", null);
+            .update(new UserTaskRecord().setDueDate("updated_dueDate").setDueDateChanged());
 
     // then
     Assertions.assertThat(updatingRecord)
@@ -279,7 +285,10 @@ public final class UpdateUserTaskTest {
         ENGINE
             .userTask()
             .ofInstance(processInstanceKey)
-            .update(null, null, null, "updated_followUpDate");
+            .update(
+                new UserTaskRecord()
+                    .setFollowUpDate("updated_followUpDate")
+                    .setFollowUpDateChanged());
 
     // then
     Assertions.assertThat(updatingRecord)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UpdateUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UpdateUserTaskTest.java
@@ -141,8 +141,8 @@ public final class UpdateUserTaskTest {
         .withXmlResource(
             process(
                 t ->
-                    t.zeebeCandidateGroups("foo, bar")
-                        .zeebeCandidateUsers("oof, rab")
+                    t.zeebeCandidateGroups("initial_group_A, initial_group_B")
+                        .zeebeCandidateUsers("initial_user_A, initial_user_B")
                         .zeebeDueDate("2023-03-02T15:35+02:00")
                         .zeebeFollowUpDate("2023-03-02T16:35+02:00")))
         .deploy();
@@ -153,7 +153,7 @@ public final class UpdateUserTaskTest {
         ENGINE
             .userTask()
             .ofInstance(processInstanceKey)
-            .update(List.of("baz", "foobar"), null, null, null);
+            .update(List.of("updated_group_C", "updated_group_D"), null, null, null);
 
     // then
     Assertions.assertThat(updatingRecord)
@@ -169,8 +169,8 @@ public final class UpdateUserTaskTest {
         .allSatisfy(
             recordValue ->
                 Assertions.assertThat(recordValue)
-                    .hasCandidateGroupsList("baz", "foobar")
-                    .hasCandidateUsersList("oof", "rab")
+                    .hasCandidateGroupsList("updated_group_C", "updated_group_C")
+                    .hasCandidateUsersList("initial_user_A", "initial_user_B")
                     .hasDueDate("2023-03-02T15:35+02:00")
                     .hasFollowUpDate("2023-03-02T16:35+02:00"));
   }
@@ -183,8 +183,8 @@ public final class UpdateUserTaskTest {
         .withXmlResource(
             process(
                 t ->
-                    t.zeebeCandidateGroups("foo, bar")
-                        .zeebeCandidateUsers("oof, rab")
+                    t.zeebeCandidateGroups("initial_group_A, initial_group_B")
+                        .zeebeCandidateUsers("initial_user_A, initial_user_B")
                         .zeebeDueDate("2023-03-02T15:35+02:00")
                         .zeebeFollowUpDate("2023-03-02T16:35+02:00")))
         .deploy();
@@ -195,7 +195,7 @@ public final class UpdateUserTaskTest {
         ENGINE
             .userTask()
             .ofInstance(processInstanceKey)
-            .update(null, List.of("baz", "foobar"), null, null);
+            .update(null, List.of("updated_user_C", "updated_user_D"), null, null);
 
     // then
     Assertions.assertThat(updatingRecord)
@@ -211,8 +211,8 @@ public final class UpdateUserTaskTest {
         .allSatisfy(
             recordValue ->
                 Assertions.assertThat(recordValue)
-                    .hasCandidateGroupsList("foo", "bar")
-                    .hasCandidateUsersList("baz", "foobar")
+                    .hasCandidateGroupsList("initial_group_A", "initial_group_B")
+                    .hasCandidateUsersList("updated_user_C", "updated_user_D")
                     .hasDueDate("2023-03-02T15:35+02:00")
                     .hasFollowUpDate("2023-03-02T16:35+02:00"));
   }
@@ -225,8 +225,8 @@ public final class UpdateUserTaskTest {
         .withXmlResource(
             process(
                 t ->
-                    t.zeebeCandidateGroups("foo, bar")
-                        .zeebeCandidateUsers("oof, rab")
+                    t.zeebeCandidateGroups("initial_group_A, initial_group_B")
+                        .zeebeCandidateUsers("initial_user_A, initial_user_B")
                         .zeebeDueDate("2023-03-02T15:35+02:00")
                         .zeebeFollowUpDate("2023-03-02T16:35+02:00")))
         .deploy();
@@ -234,7 +234,10 @@ public final class UpdateUserTaskTest {
 
     // when
     final var updatingRecord =
-        ENGINE.userTask().ofInstance(processInstanceKey).update(null, null, "abc", null);
+        ENGINE
+            .userTask()
+            .ofInstance(processInstanceKey)
+            .update(null, null, "updated_dueDate", null);
 
     // then
     Assertions.assertThat(updatingRecord)
@@ -250,9 +253,9 @@ public final class UpdateUserTaskTest {
         .allSatisfy(
             recordValue ->
                 Assertions.assertThat(recordValue)
-                    .hasCandidateGroupsList("foo", "bar")
-                    .hasCandidateUsersList("oof", "rab")
-                    .hasDueDate("abc")
+                    .hasCandidateGroupsList("initial_group_A", "initial_group_B")
+                    .hasCandidateUsersList("initial_user_A", "initial_user_B")
+                    .hasDueDate("updated_dueDate")
                     .hasFollowUpDate("2023-03-02T16:35+02:00"));
   }
 
@@ -264,8 +267,8 @@ public final class UpdateUserTaskTest {
         .withXmlResource(
             process(
                 t ->
-                    t.zeebeCandidateGroups("foo, bar")
-                        .zeebeCandidateUsers("oof, rab")
+                    t.zeebeCandidateGroups("initial_group_A, initial_group_B")
+                        .zeebeCandidateUsers("initial_user_A, initial_user_B")
                         .zeebeDueDate("2023-03-02T15:35+02:00")
                         .zeebeFollowUpDate("2023-03-02T16:35+02:00")))
         .deploy();
@@ -273,7 +276,10 @@ public final class UpdateUserTaskTest {
 
     // when
     final var updatingRecord =
-        ENGINE.userTask().ofInstance(processInstanceKey).update(null, null, null, "abc");
+        ENGINE
+            .userTask()
+            .ofInstance(processInstanceKey)
+            .update(null, null, null, "updated_followUpDate");
 
     // then
     Assertions.assertThat(updatingRecord)
@@ -289,10 +295,10 @@ public final class UpdateUserTaskTest {
         .allSatisfy(
             recordValue ->
                 Assertions.assertThat(recordValue)
-                    .hasCandidateGroupsList("foo", "bar")
-                    .hasCandidateUsersList("oof", "rab")
+                    .hasCandidateGroupsList("initial_group_A", "initial_group_B")
+                    .hasCandidateUsersList("initial_user_A", "initial_user_B")
                     .hasDueDate("2023-03-02T15:35+02:00")
-                    .hasFollowUpDate("abc"));
+                    .hasFollowUpDate("updated_followUpDate"));
   }
 
   @Test
@@ -303,10 +309,10 @@ public final class UpdateUserTaskTest {
         .withXmlResource(
             process(
                 t ->
-                    t.zeebeCandidateGroups("foo, bar")
-                        .zeebeCandidateUsers("oof, rab")
-                        .zeebeFollowUpDate("2023-03-02T15:35+02:00")
-                        .zeebeDueDate("2023-03-02T16:35+02:00")))
+                    t.zeebeCandidateGroups("initial_group_A, initial_group_B")
+                        .zeebeCandidateUsers("initial_user_A, initial_user_B")
+                        .zeebeDueDate("2023-03-02T15:35+02:00")
+                        .zeebeFollowUpDate("2023-03-02T16:35+02:00")))
         .deploy();
     final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
@@ -220,36 +220,6 @@ public final class UserTaskClient {
     return expectation.apply(position);
   }
 
-  public Record<UserTaskRecordValue> update(
-      final List<String> candidateGroups,
-      final List<String> candidateUsers,
-      final String dueDate,
-      final String followUpDate) {
-    if (candidateGroups != null) {
-      userTaskRecord.setCandidateGroupsList(candidateGroups).setCandidateGroupsChanged();
-    }
-    if (candidateUsers != null) {
-      userTaskRecord.setCandidateUsersList(candidateUsers).setCandidateUsersChanged();
-    }
-    if (dueDate != null) {
-      userTaskRecord.setDueDate(dueDate).setDueDateChanged();
-    }
-    if (followUpDate != null) {
-      userTaskRecord.setFollowUpDate(followUpDate).setFollowUpDateChanged();
-    }
-
-    final long userTaskKey = findUserTaskKey();
-    final long position =
-        writer.writeCommand(
-            userTaskKey,
-            DEFAULT_REQUEST_STREAM_ID,
-            DEFAULT_REQUEST_ID,
-            UserTaskIntent.UPDATE,
-            userTaskRecord.setUserTaskKey(userTaskKey),
-            authorizedTenantIds.toArray(new String[0]));
-    return expectation.apply(position);
-  }
-
   public Record<UserTaskRecordValue> update(final UserTaskRecord changes) {
     if (changes.getChangedAttributesProp().isEmpty()) {
       // assume all attributes have been changed

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
@@ -251,12 +251,15 @@ public final class UserTaskClient {
   }
 
   public Record<UserTaskRecordValue> update(final UserTaskRecord changes) {
-    changes
-        .setCandidateGroupsChanged()
-        .setCandidateUsersChanged()
-        .setDueDateChanged()
-        .setFollowUpDateChanged()
-        .setPriorityChanged();
+    if (changes.getChangedAttributesProp().isEmpty()) {
+      // assume all attributes have been changed
+      changes
+          .setCandidateGroupsChanged()
+          .setCandidateUsersChanged()
+          .setDueDateChanged()
+          .setFollowUpDateChanged()
+          .setPriorityChanged();
+    }
     userTaskRecord.wrapChangedAttributes(changes, true);
 
     final long userTaskKey = findUserTaskKey();
@@ -272,11 +275,15 @@ public final class UserTaskClient {
   }
 
   public Record<UserTaskRecordValue> update(final UserTaskRecord changes, final String username) {
-    changes
-        .setCandidateGroupsChanged()
-        .setCandidateUsersChanged()
-        .setDueDateChanged()
-        .setFollowUpDateChanged();
+    if (changes.getChangedAttributesProp().isEmpty()) {
+      // assume all attributes have been changed
+      changes
+          .setCandidateGroupsChanged()
+          .setCandidateUsersChanged()
+          .setDueDateChanged()
+          .setFollowUpDateChanged()
+          .setPriorityChanged();
+    }
     userTaskRecord.wrapChangedAttributes(changes, true);
 
     final long userTaskKey = findUserTaskKey();

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -177,13 +177,31 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     return copy;
   }
 
+  /**
+   * Updates the attributes of this {@link UserTaskRecord} based on the given record.
+   *
+   * @apiNote If {@code includeTrackingProperties} is {@code true}, all attributes in the given
+   *     record's `changedAttributes` list will be added to this record's `changedAttributesProp`,
+   *     even if their values match the existing values. To update attributes and track only truly
+   *     changed attributes, use the {@link #wrapChangedAttributesIfValueChanged} method instead.
+   * @param record the record containing the changed attributes list and new attribute values
+   * @param includeTrackingProperties whether to include all changed attributes in the tracking list
+   */
   public void wrapChangedAttributes(
       final UserTaskRecord record, final boolean includeTrackingProperties) {
-    record.getChangedAttributesProp().stream()
-        .forEach(attribute -> updateAttribute(bufferAsString(attribute.getValue()), record));
     if (includeTrackingProperties) {
-      setChangedAttributesProp(record.getChangedAttributesProp());
+      changedAttributesProp.reset();
     }
+
+    record
+        .getChangedAttributes()
+        .forEach(
+            attribute -> {
+              updateAttribute(attribute, record);
+              if (includeTrackingProperties) {
+                addChangedAttribute(attribute);
+              }
+            });
   }
 
   /**

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -589,18 +589,14 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   }
 
   private boolean isAttributeValueChanged(final String attribute, final UserTaskRecord other) {
-    final var attributeGetter = resolveAttributeGetter(attribute);
+    final var attributeGetter = ATTRIBUTE_GETTER_MAP.get(attribute);
+    if (attributeGetter == null) {
+      return false;
+    }
+
     final var thisAttributeValue = attributeGetter.apply(this);
     final var otherAttributeValue = attributeGetter.apply(other);
     return !Objects.equals(thisAttributeValue, otherAttributeValue);
-  }
-
-  private Function<UserTaskRecord, ?> resolveAttributeGetter(final String attribute) {
-    final Function<UserTaskRecord, ?> getter = ATTRIBUTE_GETTER_MAP.get(attribute);
-    if (getter == null) {
-      throw new IllegalArgumentException("Unknown attribute: " + attribute);
-    }
-    return getter;
   }
 
   @JsonIgnore

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -105,23 +105,23 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   /**
-   * Tracks the names of user task attributes that have been modified.
+   * Tracks the names of user task attributes that are intended to be modified (e.g. on `UPDATE`),
+   * or have been modified (e.g. on `UPDATED` or `CORRECTED`).
    *
-   * <p>This property was introduced to enable tracking of attributes that were truly modified.
-   * Since our `msgpack` implementation doesn't support `null` values, all record attributes have
-   * default non-null values. As a result, without `changedAttributesProp`, it would be impossible
-   * to determine whether an attribute was explicitly modified or simply retained its default value.
+   * <p>Since our `msgpack` implementation doesn't support `null` values, all record attributes have
+   * default non-null values. As a result, without `changedAttributes`, it would be impossible to
+   * determine whether an attribute was explicitly modified or simply retained its default value.
    * This property solves that issue by explicitly listing attributes that were changed.
    *
-   * <p>The content of `changedAttributesProp` field depend on the type of event being processed:
+   * <p>The content of `changedAttributes` field depend on the type of record:
    *
    * <ul>
    *   <li><b>UPDATE command:</b> Specifies which attributes are intended to be updated, allowing
    *       explicit changes (including clearing values to default). The presence of an attribute in
    *       this list indicates that it was explicitly modified by the update request.
    *   <li><b>UPDATING and UPDATED events:</b> Contains only attributes whose values differ from the
-   *       persisted state or, in the case of `UPDATED`, from the intermediate user task record
-   *       state if task listeners were executed, including any corrections made by listeners.
+   *       persisted state. In the case of `UPDATED` this can include any corrections made by
+   *       listeners, unless they corrected them back to the prior state.
    *   <li><b>CORRECTED event:</b> Contains only attributes that were modified by a listener,
    *       comparing them to the previous event that triggered the listener or a prior listener
    *       correction. It doesn't include the original attributes that caused the listener to

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -578,18 +578,10 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
 
   public void setDiffAsChangedAttributes(final UserTaskRecord other) {
     changedAttributesProp.reset();
-    addIfAttributeChanged(ASSIGNEE, other);
-    addIfAttributeChanged(CANDIDATE_GROUPS, other);
-    addIfAttributeChanged(CANDIDATE_USERS, other);
-    addIfAttributeChanged(DUE_DATE, other);
-    addIfAttributeChanged(FOLLOW_UP_DATE, other);
-    addIfAttributeChanged(PRIORITY, other);
-  }
-
-  private void addIfAttributeChanged(final String attribute, final UserTaskRecord other) {
-    if (isAttributeValueChanged(attribute, other)) {
-      addChangedAttribute(attribute);
-    }
+    ATTRIBUTE_GETTER_MAP.keySet().stream()
+        .sorted()
+        .filter(attribute -> isAttributeValueChanged(attribute, other))
+        .forEach(this::addChangedAttribute);
   }
 
   private boolean isAttributeValueChanged(final String attribute, final UserTaskRecord other) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -584,6 +584,10 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
         .forEach(this::addChangedAttribute);
   }
 
+  public boolean hasChangedAttributes() {
+    return !changedAttributesProp.isEmpty();
+  }
+
   private boolean isAttributeValueChanged(final String attribute, final UserTaskRecord other) {
     final var attributeGetter = resolveAttributeGetter(attribute);
     final var thisAttributeValue = attributeGetter.apply(this);


### PR DESCRIPTION
## Description
This PR refactors the mechanism for populating the `changedAttributes` field in user task events (`UPDATING`, `UPDATED`, and `CORRECTED`) to ensure it accurately tracks only the attributes that have been genuinely modified.  
Previously, the `changedAttributes` list could include attributes that were set to the same value as their persisted state or unknown attributes, leading to unnecessary updates and redundant tracking.

### Key improvements  
- The `changedAttributes` field now includes only attributes that were actually changed:  
  - For `UPDATING` events, it contains only attributes whose values differ from the [persisted state](https://github.com/camunda/camunda/blob/ad03aca0e7baef3a33a1177455233829304b179c/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbUserTaskState.java#L181).  
  - For `UPDATED` events, it contains only attributes whose values differ either from the [persisted state](https://github.com/camunda/camunda/blob/ad03aca0e7baef3a33a1177455233829304b179c/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbUserTaskState.java#L181) or from the [intermediate state](https://github.com/camunda/camunda/blob/ad03aca0e7baef3a33a1177455233829304b179c/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbUserTaskState.java#L190), if any task listeners were executed during the update process.  
  - For `CORRECTED` events, it contains only attributes that differ from the previous event (either the event that triggered the listener or a prior listener correction), stored in the [intermediate user task record state](https://github.com/camunda/camunda/blob/ad03aca0e7baef3a33a1177455233829304b179c/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbUserTaskState.java#L190).  
- Attributes updated/corrected to the same value as the current persisted/intermediate state are excluded.
- The `CORRECTED` intent is emitted only when meaningful corrections are applied.  
- Ensures unknown attributes are ignored during updates, preventing them from being included in the `changedAttributes` list.  
- Comprehensive tests validate the behavior of `changedAttributes` tracking across all relevant scenarios, including updates, corrections, and handling of unknown attributes.  

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #27212 
