### PR TITLE
ci: upload 8.7 Docker SNAPSHOTs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -630,7 +630,7 @@ jobs:
     name: Deploy snapshot Camunda Docker image
     needs: [ docker-checks, check-results ]
     runs-on: ubuntu-latest
-    if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
+    if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/stable/8.7'
     concurrency:
       group: deploy-camunda-docker-snapshot
       cancel-in-progress: false
@@ -663,7 +663,7 @@ jobs:
         id: build-camunda-docker
         with:
           repository: camunda/camunda
-          version: SNAPSHOT
+          version: 8.7.0-SNAPSHOT
           distball: ${{ steps.build-camunda.outputs.distball }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
           dockerfile: camunda.Dockerfile

--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -38,6 +38,7 @@ defaults:
 env:
   BRANCH_NAME: ${{ inputs.branch }}
   IS_DEFAULT_BRANCH: ${{ inputs.branch == 'main' }}
+  SHOULD_PUSH_DOCKER_SNAPSHOT: ${{ inputs.branch == 'stable/8.7' }}
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
 
 jobs:
@@ -126,7 +127,7 @@ jobs:
       #########################################################################
       # Docker login for snapshot deployment
       - name: Login to docker hub
-        if: ${{ env.IS_DEFAULT_BRANCH == 'true' }}
+        if: ${{ env.SHOULD_PUSH_DOCKER_SNAPSHOT == 'true' }}
         uses: docker/login-action@v3
         with:
           username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
@@ -135,11 +136,11 @@ jobs:
       #########################################################################
       # Build SNAPSHOT Docker image
       - name: Build SNAPSHOT Docker image
-        if: ${{ env.IS_DEFAULT_BRANCH == 'true' }}
+        if: ${{ env.SHOULD_PUSH_DOCKER_SNAPSHOT == 'true' }}
         uses: ./.github/actions/build-platform-docker
         with:
           repository: camunda/operate
-          version: SNAPSHOT
+          version: 8.7.0-SNAPSHOT
           push: true
           platforms: ${{ env.DOCKER_PLATFORMS }}
           dockerfile: operate.Dockerfile

--- a/.github/workflows/tasklist-ci-build-reusable.yml
+++ b/.github/workflows/tasklist-ci-build-reusable.yml
@@ -38,6 +38,7 @@ defaults:
 env:
   BRANCH_NAME: ${{ inputs.branch }}
   IS_DEFAULT_BRANCH: ${{ inputs.branch == 'main' }}
+  SHOULD_PUSH_DOCKER_SNAPSHOT: ${{ inputs.branch == 'stable/8.7' }}
   DOCKER_PLATFORMS: "linux/amd64,linux/arm64"
 
 jobs:
@@ -124,7 +125,7 @@ jobs:
       #########################################################################
       # Docker login for snapshot deployment
       - name: Login to docker hub
-        if: ${{ env.IS_DEFAULT_BRANCH == 'true' }}
+        if: ${{ env.SHOULD_PUSH_DOCKER_SNAPSHOT == 'true' }}
         uses: docker/login-action@v3
         with:
           username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
@@ -133,11 +134,11 @@ jobs:
       #########################################################################
       # Build SNAPSHOT Docker image
       - name: Build SNAPSHOT Docker image
-        if: ${{ env.IS_DEFAULT_BRANCH == 'true' }}
+        if: ${{ env.SHOULD_PUSH_DOCKER_SNAPSHOT == 'true' }}
         uses: ./.github/actions/build-platform-docker
         with:
           repository: camunda/tasklist
-          version: SNAPSHOT
+          version: 8.7.0-SNAPSHOT
           push: true
           platforms: ${{ env.DOCKER_PLATFORMS }}
           dockerfile: tasklist.Dockerfile


### PR DESCRIPTION
## Description

This PR adjusts the Docker SNAPSHOT image deploy jobs for Operate, Tasklist, Zeebe to publish DockerHub with the `8.7.0-SNAPSHOT` tag.

✔️ This PR needs CI fixes from https://github.com/camunda/camunda/pull/27216 and https://github.com/camunda/camunda/pull/27224

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Related to https://github.com/camunda/camunda/issues/27193
