### PR TITLE
docs: remove JIRA link from Operate's github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/operate-epic.md
+++ b/.github/ISSUE_TEMPLATE/operate-epic.md
@@ -38,5 +38,5 @@ assignees: ''
 ### Links
 
 <!--
-- https://jira.camunda.com/browse/SUPPORT-12398
+- Link to JIRA support case
 -->

--- a/.github/ISSUE_TEMPLATE/operate-feature.md
+++ b/.github/ISSUE_TEMPLATE/operate-feature.md
@@ -46,7 +46,7 @@ Scenario: As an Operate user
 ### Links
 
 <!--
-- https://jira.camunda.com/browse/SUPPORT-12398
+- Link to JIRA support case
 -->
 
 ### Breakdown

--- a/.github/ISSUE_TEMPLATE/operate-task.md
+++ b/.github/ISSUE_TEMPLATE/operate-task.md
@@ -8,7 +8,7 @@ assignees: ''
 
 ---
 
-<!-- For anything that is not a feature request or a bug reeport.-->
+<!-- For anything that is not a feature request or a bug report.-->
 
 ### Description (required on creation)
 
@@ -21,7 +21,7 @@ assignees: ''
 ### Links
 
 <!--
-- https://jira.camunda.com/browse/SUPPORT-12398
+- Link to JIRA support case
 -->
 
 ```[tasklist]

--- a/.github/ISSUE_TEMPLATE/operate_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/operate_bug_report.md
@@ -32,7 +32,7 @@ assignees: ''
 - Operate Version: [e.g. 8.1]
 - Database: [e.g. Elasticsearch X.Y, Opensearch X.Z]
 
-### Rootcause (required on prioritization)
+### Root cause (required on prioritization)
 
 ### Solution ideas
 
@@ -57,7 +57,7 @@ assignees: ''
 ### Links
 
 <!--
-- https://jira.camunda.com/browse/SUPPORT-12398
+- Link to JIRA support case
 -->
 
 ```[tasklist]


### PR DESCRIPTION
This prevents that a support label is added to the issue automatically by accident on non-support issues.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
