### PR TITLE
feat: add description field to tenants in Identity client

### DIFF
--- a/identity/client/src/pages/tenants/List.tsx
+++ b/identity/client/src/pages/tenants/List.tsx
@@ -88,14 +88,22 @@ const List: FC = () => {
             label: t("Rename"),
             icon: Edit,
             onClick: (tenant) =>
-              editTenant({ tenantId: tenant.tenantId, name: tenant.name }),
+              editTenant({
+                tenantId: tenant.tenantId,
+                name: tenant.name,
+                description: tenant.description,
+              }),
           },
           {
             label: t("Delete"),
             icon: TrashCan,
             isDangerous: true,
             onClick: (tenant) =>
-              deleteTenant({ tenantId: tenant.tenantId, name: tenant.name }),
+              deleteTenant({
+                tenantId: tenant.tenantId,
+                name: tenant.name,
+                description: tenant.description,
+              }),
           },
         ]}
       />

--- a/identity/client/src/pages/tenants/detail/TenantDetailsTab.tsx
+++ b/identity/client/src/pages/tenants/detail/TenantDetailsTab.tsx
@@ -49,6 +49,10 @@ const Details: FC<DetailsProps> = ({ tenant, loading }) => {
             </StyledCodeSnippet>
           ),
         },
+        {
+          label: t("Description"),
+          value: tenant.description,
+        },
       ]}
     />
   );

--- a/identity/client/src/pages/tenants/modals/AddModal.tsx
+++ b/identity/client/src/pages/tenants/modals/AddModal.tsx
@@ -19,6 +19,7 @@ const AddTenantModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
   const [apiCall, { loading, namedErrors }] = useApiCall(createTenant);
   const [name, setName] = useState("");
   const [tenantId, setTenantId] = useState("");
+  const [description, setDescription] = useState("");
 
   const submitDisabled = loading || !name || !tenantId;
 
@@ -26,6 +27,7 @@ const AddTenantModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
     const { success } = await apiCall({
       name,
       tenantId,
+      description,
     });
 
     if (success) {
@@ -64,6 +66,13 @@ const AddTenantModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
         onChange={setTenantId}
         value={tenantId}
         errors={namedErrors?.tenantId}
+      />
+      <TextField
+        label={t("Description")}
+        value={description}
+        placeholder={t("Enter a tenant description")}
+        onChange={setDescription}
+        errors={namedErrors?.description}
       />
     </FormModal>
   );

--- a/identity/client/src/pages/tenants/modals/EditModal.tsx
+++ b/identity/client/src/pages/tenants/modals/EditModal.tsx
@@ -17,17 +17,19 @@ const EditTenantModal: FC<UseEntityModalProps<UpdateTenantParams>> = ({
   open,
   onClose,
   onSuccess,
-  entity: { tenantId, name: currentName },
+  entity: { tenantId, name: currentName, description: currentDescription },
 }) => {
   const { t } = useTranslate();
   const { enqueueNotification } = useNotifications();
   const [apiCall, { loading, namedErrors }] = useApiCall(updateTenant);
   const [name, setName] = useState(currentName);
+  const [description, setDescription] = useState(currentDescription);
 
   const handleSubmit = async () => {
     const { success } = await apiCall({
-      tenantId,
-      name,
+      tenantId: tenantId,
+      name: name,
+      description: description ?? "",
     });
 
     if (success) {
@@ -59,6 +61,13 @@ const EditTenantModal: FC<UseEntityModalProps<UpdateTenantParams>> = ({
         onChange={setName}
         errors={namedErrors?.name}
         autoFocus
+      />
+      <TextField
+        label={t("Description")}
+        value={description}
+        placeholder={t("Tenant description")}
+        onChange={setDescription}
+        errors={namedErrors?.description}
       />
     </FormModal>
   );

--- a/identity/client/src/utility/api/tenants/index.ts
+++ b/identity/client/src/utility/api/tenants/index.ts
@@ -16,6 +16,7 @@ export type Tenant = EntityData & {
   tenantKey: string;
   tenantId: string;
   name: string;
+  description: string;
 };
 
 export const searchTenant: ApiDefinition<SearchResponse<Tenant>> = () =>
@@ -24,6 +25,7 @@ export const searchTenant: ApiDefinition<SearchResponse<Tenant>> = () =>
 type GetTenantParams = {
   tenantId?: string;
   name?: string;
+  description?: string;
 };
 
 export const getTenantDetails: ApiDefinition<
@@ -43,6 +45,7 @@ export const createTenant: ApiDefinition<undefined, CreateTenantParams> = (
 export type UpdateTenantParams = {
   tenantId: string;
   name: string;
+  description: string;
 };
 
 export type DeleteTenantParams = UpdateTenantParams;
@@ -50,7 +53,8 @@ export type DeleteTenantParams = UpdateTenantParams;
 export const updateTenant: ApiDefinition<undefined, UpdateTenantParams> = ({
   tenantId,
   name,
-}) => apiPatch(`${TENANTS_ENDPOINT}/${tenantId}`, { name });
+  description,
+}) => apiPatch(`${TENANTS_ENDPOINT}/${tenantId}`, { name, description });
 
 export const deleteTenant: ApiDefinition<undefined, { tenantId: string }> = ({
   tenantId,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
@@ -104,7 +104,7 @@ public class TenantUpdateProcessor implements DistributedTypedRecordProcessor<Te
       existingTenant.setName(updatedName);
     }
     final var updatedDescription = updateRecord.getDescription();
-    if (!updatedDescription.isEmpty()) {
+    if (!existingTenant.getDescription().equals(updatedDescription)) {
       existingTenant.setDescription(updatedDescription);
     }
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/TenantRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/TenantRequestValidator.java
@@ -39,7 +39,7 @@ public final class TenantRequestValidator {
           if (request.getName() == null || request.getName().isBlank()) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("name"));
           }
-          if (request.getDescription() == null || request.getDescription().isBlank()) {
+          if (request.getDescription() == null) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("description"));
           }
         });


### PR DESCRIPTION
**Requires the backend implementation adding a description to a Tenant**

## Description

<!-- Describe the goal and purpose of this PR. -->
This PR adds in the description field for a Tenant in the Identity UI, the Figma designs for the Tenant pages can be found [here](https://www.figma.com/design/0FhSUskdeATmYkEyXAj9S4/Identity-%26-Console-8.7?node-id=239-175225&t=5yKzr15ZbTVBvzHq-0)

## Related issues

This PR is the UI parts of https://github.com/camunda/camunda/issues/27166
