### PR TITLE
feat: add tenant descriptions

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
@@ -60,7 +60,10 @@ public class CamundaUserDetailsService implements UserDetailsService {
 
     final var tenants =
         tenantServices.getTenantsByMemberKey(userKey).stream()
-            .map(entity -> new TenantDTO(entity.key(), entity.tenantId(), entity.name()))
+            .map(
+                entity ->
+                    new TenantDTO(
+                        entity.key(), entity.tenantId(), entity.name(), entity.description()))
             .toList();
 
     return aCamundaUser()

--- a/authentication/src/test/java/io/camunda/authentication/filters/TenantRequestAttributeFilterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/filters/TenantRequestAttributeFilterTest.java
@@ -43,7 +43,9 @@ public class TenantRequestAttributeFilterTest {
   private final UserEntity user =
       new UserEntity(100L, "u1", "Test User", "u1@camunda.test", "secret");
   private final List<TenantDTO> tenants =
-      List.of(new TenantDTO(1L, "T1", "Tenant 1"), new TenantDTO(2L, "T2", "Tenant 2"));
+      List.of(
+          new TenantDTO(1L, "T1", "Tenant 1", "Tenant 1 description"),
+          new TenantDTO(2L, "T2", "Tenant 2", "Tenant 2 description"));
   private final CamundaUser camundaUser =
       CamundaUser.CamundaUserBuilder.aCamundaUser()
           .withUserKey(user.userKey())

--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateTenantCommandStep1.java
@@ -33,4 +33,7 @@ public interface CreateTenantCommandStep1 extends FinalCommandStep<CreateTenantR
    * @return the builder for this command
    */
   CreateTenantCommandStep1 name(String name);
+
+  /** Set the description for the tenant to be created. */
+  CreateTenantCommandStep1 description(String description);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/command/UpdateTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/UpdateTenantCommandStep1.java
@@ -26,4 +26,7 @@ public interface UpdateTenantCommandStep1 extends FinalCommandStep<UpdateTenantR
    * @return the builder for this command
    */
   UpdateTenantCommandStep1 name(String name);
+
+  /** Set the new description for the tenant. */
+  UpdateTenantCommandStep1 description(String description);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/response/CreateTenantResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/CreateTenantResponse.java
@@ -28,4 +28,7 @@ public interface CreateTenantResponse {
 
   /** Returns the name of the created tenant. */
   String getName();
+
+  /** Returns the description of the created tenant. */
+  String getDescription();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/response/UpdateTenantResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/UpdateTenantResponse.java
@@ -42,4 +42,7 @@ public interface UpdateTenantResponse {
    * @return the tenant name.
    */
   String getName();
+
+  /** Returns the description of the updated tenant. */
+  String getDescription();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateTenantCommandImpl.java
@@ -55,6 +55,12 @@ public final class CreateTenantCommandImpl implements CreateTenantCommandStep1 {
   }
 
   @Override
+  public CreateTenantCommandStep1 description(final String description) {
+    request.setDescription(description);
+    return this;
+  }
+
+  @Override
   public FinalCommandStep<CreateTenantResponse> requestTimeout(final Duration requestTimeout) {
     httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
     return this;

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateTenantCommandImpl.java
@@ -52,6 +52,12 @@ public final class UpdateTenantCommandImpl implements UpdateTenantCommandStep1 {
   }
 
   @Override
+  public UpdateTenantCommandStep1 description(final String description) {
+    request.setDescription(description);
+    return this;
+  }
+
+  @Override
   public FinalCommandStep<UpdateTenantResponse> requestTimeout(final Duration requestTimeout) {
     httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
     return this;
@@ -59,7 +65,6 @@ public final class UpdateTenantCommandImpl implements UpdateTenantCommandStep1 {
 
   @Override
   public CamundaFuture<UpdateTenantResponse> send() {
-    ArgumentUtil.ensureNotNull("name", request.getName());
     final HttpCamundaFuture<UpdateTenantResponse> result = new HttpCamundaFuture<>();
     final UpdateTenantResponseImpl response = new UpdateTenantResponseImpl();
 

--- a/clients/java/src/main/java/io/camunda/client/impl/response/CreateTenantResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/CreateTenantResponseImpl.java
@@ -22,6 +22,7 @@ public class CreateTenantResponseImpl implements CreateTenantResponse {
   private long tenantKey;
   private String tenantId;
   private String name;
+  private String description;
 
   @Override
   public long getTenantKey() {
@@ -38,10 +39,16 @@ public class CreateTenantResponseImpl implements CreateTenantResponse {
     return name;
   }
 
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
   public CreateTenantResponseImpl setResponse(final TenantCreateResult response) {
     tenantKey = Long.parseLong(response.getTenantKey());
     tenantId = response.getTenantId();
     name = response.getName();
+    description = response.getDescription();
     return this;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/UpdateTenantResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/UpdateTenantResponseImpl.java
@@ -22,6 +22,7 @@ public final class UpdateTenantResponseImpl implements UpdateTenantResponse {
   private long tenantKey;
   private String tenantId;
   private String name;
+  private String description;
 
   @Override
   public long getTenantKey() {
@@ -38,10 +39,16 @@ public final class UpdateTenantResponseImpl implements UpdateTenantResponse {
     return name;
   }
 
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
   public UpdateTenantResponseImpl setResponse(final TenantUpdateResult response) {
     tenantKey = Long.parseLong(response.getTenantKey());
     tenantId = response.getTenantId();
     name = response.getName();
+    description = response.getDescription();
     return this;
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/tenant/CreateTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/CreateTenantTest.java
@@ -29,16 +29,24 @@ public class CreateTenantTest extends ClientRestTest {
 
   public static final String TENANT_ID = "tenant-id";
   public static final String NAME = "Tenant Name";
+  public static final String DESCRIPTION = "Tenant Description";
 
   @Test
   void shouldCreateTenant() {
     // when
-    client.newCreateTenantCommand().tenantId(TENANT_ID).name(NAME).send().join();
+    client
+        .newCreateTenantCommand()
+        .tenantId(TENANT_ID)
+        .name(NAME)
+        .description(DESCRIPTION)
+        .send()
+        .join();
 
     // then
     final TenantCreateRequest request = gatewayService.getLastRequest(TenantCreateRequest.class);
     assertThat(request.getTenantId()).isEqualTo(TENANT_ID);
     assertThat(request.getName()).isEqualTo(NAME);
+    assertThat(request.getDescription()).isEqualTo(DESCRIPTION);
   }
 
   @Test

--- a/clients/java/src/test/java/io/camunda/client/tenant/UpdateTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/UpdateTenantTest.java
@@ -29,9 +29,10 @@ public class UpdateTenantTest extends ClientRestTest {
 
   private static final String TENANT_ID = "my-tenant-id";
   private static final String UPDATED_NAME = "Updated Tenant Name";
+  private static final String UPDATED_DESCRIPTION = "Updated Tenant Description";
 
   @Test
-  void shouldUpdateTenant() {
+  void shouldUpdateTenantName() {
     // when
     client.newUpdateTenantCommand(TENANT_ID).name(UPDATED_NAME).send().join();
 
@@ -41,11 +42,29 @@ public class UpdateTenantTest extends ClientRestTest {
   }
 
   @Test
-  void shouldRaiseExceptionOnNullName() {
-    // when / then
-    assertThatThrownBy(() -> client.newUpdateTenantCommand(TENANT_ID).name(null).send().join())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("name must not be null");
+  void shouldUpdateTenantDescription() {
+    // when
+    client.newUpdateTenantCommand(TENANT_ID).description(UPDATED_DESCRIPTION).send().join();
+
+    // then
+    final TenantUpdateRequest request = gatewayService.getLastRequest(TenantUpdateRequest.class);
+    assertThat(request.getDescription()).isEqualTo(UPDATED_DESCRIPTION);
+  }
+
+  @Test
+  void shouldUpdateTenantNameAndDescription() {
+    // when
+    client
+        .newUpdateTenantCommand(TENANT_ID)
+        .name(UPDATED_NAME)
+        .description(UPDATED_DESCRIPTION)
+        .send()
+        .join();
+
+    // then
+    final TenantUpdateRequest request = gatewayService.getLastRequest(TenantUpdateRequest.class);
+    assertThat(request.getName()).isEqualTo(UPDATED_NAME);
+    assertThat(request.getDescription()).isEqualTo(UPDATED_DESCRIPTION);
   }
 
   @Test

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -344,6 +344,7 @@
       </column>
       <column name="TENANT_KEY" type="BIGINT"/>
       <column name="NAME" type="VARCHAR(255)" />
+      <column name="DESCRIPTION" type="VARCHAR(255)" />
     </createTable>
   </changeSet>
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantReader.java
@@ -53,6 +53,7 @@ public class TenantReader extends AbstractEntityReader<TenantEntity> {
         model.tenantKey(),
         model.tenantId(),
         model.name(),
+        model.description(),
         model.members().stream().map(TenantMemberDbModel::entityKey).collect(Collectors.toSet()));
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/TenantDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/TenantDbModel.java
@@ -16,6 +16,7 @@ public class TenantDbModel implements DbModel<TenantDbModel> {
   private Long tenantKey;
   private String tenantId;
   private String name;
+  private String description;
   private List<TenantMemberDbModel> members;
 
   public TenantDbModel() {}
@@ -24,10 +25,12 @@ public class TenantDbModel implements DbModel<TenantDbModel> {
       final String tenantId,
       final Long tenantKey,
       final String name,
+      final String description,
       final List<TenantMemberDbModel> members) {
     this.tenantKey = tenantKey;
     this.tenantId = tenantId;
     this.name = name;
+    this.description = description;
     this.members = members;
   }
 
@@ -35,7 +38,12 @@ public class TenantDbModel implements DbModel<TenantDbModel> {
   public TenantDbModel copy(
       final Function<ObjectBuilder<TenantDbModel>, ObjectBuilder<TenantDbModel>> builderFunction) {
     return builderFunction
-        .apply(new Builder().tenantKey(tenantKey).tenantId(tenantId).name(name))
+        .apply(
+            new Builder()
+                .tenantKey(tenantKey)
+                .tenantId(tenantId)
+                .name(name)
+                .description(description))
         .build();
   }
 
@@ -63,6 +71,14 @@ public class TenantDbModel implements DbModel<TenantDbModel> {
     this.name = name;
   }
 
+  public String description() {
+    return description;
+  }
+
+  public void description(final String description) {
+    this.description = description;
+  }
+
   public List<TenantMemberDbModel> members() {
     return members;
   }
@@ -76,6 +92,7 @@ public class TenantDbModel implements DbModel<TenantDbModel> {
     private Long tenantKey;
     private String tenantId;
     private String name;
+    private String description;
     private List<TenantMemberDbModel> members;
 
     // Public constructor to initialize the builder
@@ -97,6 +114,11 @@ public class TenantDbModel implements DbModel<TenantDbModel> {
       return this;
     }
 
+    public Builder description(final String description) {
+      this.description = description;
+      return this;
+    }
+
     public Builder members(final List<TenantMemberDbModel> members) {
       this.members = members;
       return this;
@@ -104,7 +126,7 @@ public class TenantDbModel implements DbModel<TenantDbModel> {
 
     @Override
     public TenantDbModel build() {
-      return new TenantDbModel(tenantId, tenantKey, name, members);
+      return new TenantDbModel(tenantId, tenantKey, name, description, members);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/TenantWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/TenantWriter.java
@@ -34,7 +34,12 @@ public class TenantWriter {
 
   public void update(final TenantDbModel tenant) {
     final boolean wasMerged =
-        mergeToQueue(tenant.tenantId(), b -> b.tenantId(tenant.tenantId()).name(tenant.name()));
+        mergeToQueue(
+            tenant.tenantId(),
+            b ->
+                b.tenantId(tenant.tenantId())
+                    .name(tenant.name())
+                    .description(tenant.description()));
 
     if (!wasMerged) {
       executionQueue.executeInQueue(

--- a/db/rdbms/src/main/resources/mapper/TenantMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/TenantMapper.xml
@@ -23,6 +23,7 @@
     t.TENANT_KEY,
     t.TENANT_ID,
     t.NAME,
+    t.DESCRIPTION,
     tm.TENANT_ID AS MEMBER_TENANT_ID,
     tm.ENTITY_KEY AS MEMBER_ENTITY_KEY,
     tm.ENTITY_TYPE AS MEMBER_ENTITY_TYPE
@@ -46,6 +47,7 @@
     <id column="TENANT_ID" property="tenantId"/>
     <result column="TENANT_KEY" property="tenantKey"/>
     <result column="NAME" property="name"/>
+    <result column="DESCRIPTION" property="description"/>
     <collection property="members" ofType="io.camunda.db.rdbms.write.domain.TenantMemberDbModel"
       javaType="java.util.List">
       <constructor>
@@ -60,8 +62,8 @@
     id="insert"
     parameterType="io.camunda.db.rdbms.write.domain.TenantDbModel"
     flushCache="true">
-    INSERT INTO TENANT (TENANT_KEY, TENANT_ID, NAME)
-    VALUES (#{tenantKey}, #{tenantId}, #{name})
+    INSERT INTO TENANT (TENANT_KEY, TENANT_ID, NAME, DESCRIPTION)
+    VALUES (#{tenantKey}, #{tenantId}, #{name}, #{description})
   </insert>
 
   <update
@@ -70,7 +72,8 @@
     flushCache="true">
     UPDATE TENANT SET
                     TENANT_ID = #{tenantId},
-                    NAME = #{name}
+                    NAME = #{name},
+                    DESCRIPTION = #{description}
     WHERE TENANT_ID = #{tenantId}
   </update>
 

--- a/docs/identity.md
+++ b/docs/identity.md
@@ -21,6 +21,7 @@ erDiagram
   Tenant {
     string id PK
     string name
+    string description
   }
   Authorization {
     string ownerId

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/TenantMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/TenantMigrationHandler.java
@@ -46,7 +46,9 @@ public class TenantMigrationHandler extends MigrationHandler<Tenant> {
 
   protected MigrationStatusUpdateRequest processTask(final Tenant tenant) {
     try {
-      tenantServices.createTenant(new TenantDTO(null, tenant.tenantId(), tenant.name())).join();
+      tenantServices
+          .createTenant(new TenantDTO(null, tenant.tenantId(), tenant.name(), null))
+          .join();
     } catch (final Exception e) {
       if (!isConflictError(e)) {
         return managementIdentityTransformer.toMigrationStatusUpdateRequest(tenant, e);

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/TenantMappingRuleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/TenantMappingRuleMigrationHandlerTest.java
@@ -89,7 +89,7 @@ final class TenantMappingRuleMigrationHandlerTest {
     // given
     givenMappingRules();
     when(tenantServices.getById(any()))
-        .thenReturn(new TenantEntity(1L, "", "", Collections.emptySet()));
+        .thenReturn(new TenantEntity(1L, "", "", null, Collections.emptySet()));
     when(mappingServices.createMapping(any()))
         .thenAnswer(invocation -> CompletableFuture.completedFuture(new MappingRecord()));
     when(tenantServices.addMember(any(), any(), anyLong()))
@@ -157,7 +157,7 @@ final class TenantMappingRuleMigrationHandlerTest {
     // given
     givenMappingRules();
     when(tenantServices.getById(any()))
-        .thenReturn(new TenantEntity(1L, "", "", Collections.emptySet()));
+        .thenReturn(new TenantEntity(1L, "", "", null, Collections.emptySet()));
     when(mappingServices.createMapping(any()))
         .thenAnswer(invocation -> CompletableFuture.completedFuture(new MappingRecord()));
     when(tenantServices.addMember(any(), any(), anyLong()))

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/UserTenantsMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/UserTenantsMigrationHandlerTest.java
@@ -94,7 +94,7 @@ final class UserTenantsMigrationHandlerTest {
     // given
     givenUserTenants();
     when(tenantServices.getById(any()))
-        .thenReturn(new TenantEntity(1L, "", "", Collections.emptySet()));
+        .thenReturn(new TenantEntity(1L, "", "", null, Collections.emptySet()));
     when(tenantServices.createTenant(any()))
         .thenReturn(CompletableFuture.completedFuture(new TenantRecord()));
     when(mappingServices.createMapping(any()))
@@ -163,7 +163,7 @@ final class UserTenantsMigrationHandlerTest {
     // given
     givenUserTenants();
     when(tenantServices.getById(any()))
-        .thenReturn(new TenantEntity(1L, "", "", Collections.emptySet()));
+        .thenReturn(new TenantEntity(1L, "", "", null, Collections.emptySet()));
     doThrow(
             new BrokerRejectionException(
                 new BrokerRejection(TenantIntent.ADD_ENTITY, -1, RejectionType.ALREADY_EXISTS, "")))

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
@@ -81,7 +81,8 @@ public class BasicAuthIT {
                 null,
                 null));
     when(tenantServices.getTenantsByMemberKey(anyLong()))
-        .thenReturn(List.of(new TenantEntity(9L, "T1", "Tenant 1", Set.of())));
+        .thenReturn(
+            List.of(new TenantEntity(9L, "T1", "Tenant 1", "Tenant 1 description", Set.of())));
 
     when(authorizationServices.findAll(any()))
         .thenReturn(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/TenantEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/TenantEntityTransformer.java
@@ -22,6 +22,7 @@ public class TenantEntityTransformer
         source.getKey(),
         source.getTenantId(),
         source.getName(),
+        source.getDescription(),
         source.getJoin().parent() != null ? Set.of(source.getJoin().parent()) : Set.of());
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/TenantEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/TenantEntity.java
@@ -11,4 +11,5 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.Set;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record TenantEntity(Long key, String tenantId, String name, Set<Long> assignedMemberKeys) {}
+public record TenantEntity(
+    Long key, String tenantId, String name, String description, Set<Long> assignedMemberKeys) {}

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -68,12 +68,17 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
 
   public CompletableFuture<TenantRecord> createTenant(final TenantDTO request) {
     return sendBrokerRequest(
-        new BrokerTenantCreateRequest().setTenantId(request.tenantId()).setName(request.name()));
+        new BrokerTenantCreateRequest()
+            .setTenantId(request.tenantId())
+            .setName(request.name())
+            .setDescription(request.description()));
   }
 
   public CompletableFuture<TenantRecord> updateTenant(final TenantDTO request) {
     return sendBrokerRequest(
-        new BrokerTenantUpdateRequest(request.tenantId()).setName(request.name()));
+        new BrokerTenantUpdateRequest(request.tenantId())
+            .setName(request.name())
+            .setDescription(request.description()));
   }
 
   public CompletableFuture<TenantRecord> deleteTenant(final String tenantId) {
@@ -136,9 +141,9 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
     return tenantEntity;
   }
 
-  public record TenantDTO(Long key, String tenantId, String name) {
+  public record TenantDTO(Long key, String tenantId, String name, String description) {
     public static TenantDTO fromEntity(final TenantEntity entity) {
-      return new TenantDTO(entity.key(), entity.tenantId(), entity.name());
+      return new TenantDTO(entity.key(), entity.tenantId(), entity.name(), entity.description());
     }
   }
 }

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -140,8 +140,6 @@ public class TenantServiceTest {
   public void shouldUpdateTenantName() {
 
     // given
-    final var result =
-        new SearchQueryResult<>(1, List.of(tenantEntity), Arrays.array(), Arrays.array());
     final var tenantDTO =
         new TenantDTO(tenantEntity.key(), tenantEntity.tenantId(), "UpdatedTenantId", null);
 
@@ -155,6 +153,26 @@ public class TenantServiceTest {
     final TenantRecord brokerRequestValue = request.getRequestWriter();
     assertThat(brokerRequestValue.getTenantId()).isEqualTo(tenantDTO.tenantId());
     assertThat(brokerRequestValue.getName()).isEqualTo(tenantDTO.name());
+  }
+
+  @Test
+  public void shouldUpdateTenantDescription() {
+
+    // given
+    final var tenantDTO =
+        new TenantDTO(
+            tenantEntity.key(), tenantEntity.tenantId(), "TenantName", "UpdatedTenantDescription");
+
+    // when
+    services.updateTenant(tenantDTO);
+
+    // then
+    final BrokerTenantUpdateRequest request = stubbedBrokerClient.getSingleBrokerRequest();
+    assertThat(request.getIntent()).isEqualTo(TenantIntent.UPDATE);
+    assertThat(request.getValueType()).isEqualTo(ValueType.TENANT);
+    final TenantRecord brokerRequestValue = request.getRequestWriter();
+    assertThat(brokerRequestValue.getTenantId()).isEqualTo(tenantDTO.tenantId());
+    assertThat(brokerRequestValue.getDescription()).isEqualTo(tenantDTO.description());
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -46,7 +46,7 @@ public class TenantServiceTest {
   private TenantSearchClient client;
   private StubbedBrokerClient stubbedBrokerClient;
   private final TenantEntity tenantEntity =
-      new TenantEntity(100L, "tenant-id", "Tenant name", Set.of());
+      new TenantEntity(100L, "tenant-id", "Tenant name", "Tenant description", Set.of());
 
   @BeforeEach
   public void before() {
@@ -121,7 +121,8 @@ public class TenantServiceTest {
   @Test
   public void shouldCreateTenant() {
     // given
-    final var tenantDTO = new TenantDTO(100L, "NewTenantName", "NewTenantId");
+    final var tenantDTO =
+        new TenantDTO(100L, "NewTenantName", "NewTenantId", "NewTenantDescription");
 
     // when
     services.createTenant(tenantDTO);
@@ -142,7 +143,7 @@ public class TenantServiceTest {
     final var result =
         new SearchQueryResult<>(1, List.of(tenantEntity), Arrays.array(), Arrays.array());
     final var tenantDTO =
-        new TenantDTO(tenantEntity.key(), tenantEntity.tenantId(), "UpdatedTenantId");
+        new TenantDTO(tenantEntity.key(), tenantEntity.tenantId(), "UpdatedTenantId", null);
 
     // when
     services.updateTenant(tenantDTO);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantEntity.java
@@ -14,6 +14,7 @@ public class TenantEntity extends AbstractExporterEntity<TenantEntity> {
   private Long key;
   private String tenantId;
   private String name;
+  private String description;
   private Long memberKey;
 
   private EntityJoinRelation join;
@@ -42,6 +43,15 @@ public class TenantEntity extends AbstractExporterEntity<TenantEntity> {
 
   public TenantEntity setName(final String name) {
     this.name = name;
+    return this;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public TenantEntity setDescription(final String description) {
+    this.description = description;
     return this;
   }
 

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-tenant.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-tenant.json
@@ -14,6 +14,9 @@
       "name": {
         "type": "keyword"
       },
+      "description": {
+        "type": "text"
+      },
       "memberKey": {
         "type": "long"
       },

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-tenant.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-tenant.json
@@ -14,6 +14,9 @@
       "name": {
         "type": "keyword"
       },
+      "description": {
+        "type": "text"
+      },
       "memberKey": {
         "type": "long"
       },

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
@@ -103,6 +103,10 @@ public class TenantUpdateProcessor implements DistributedTypedRecordProcessor<Te
     if (!updatedName.isEmpty()) {
       existingTenant.setName(updatedName);
     }
+    final var updatedDescription = updateRecord.getDescription();
+    if (!updatedDescription.isEmpty()) {
+      existingTenant.setDescription(updatedDescription);
+    }
   }
 
   private void updateStateAndDistribute(
@@ -111,7 +115,8 @@ public class TenantUpdateProcessor implements DistributedTypedRecordProcessor<Te
         new TenantRecord()
             .setTenantKey(persistedTenant.getTenantKey())
             .setTenantId(persistedTenant.getTenantId())
-            .setName(persistedTenant.getName());
+            .setName(persistedTenant.getName())
+            .setDescription(persistedTenant.getDescription());
 
     stateWriter.appendFollowUpEvent(
         persistedTenant.getTenantKey(), TenantIntent.UPDATED, updatedRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/DbTenantState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/DbTenantState.java
@@ -74,6 +74,7 @@ public class DbTenantState implements MutableTenantState {
     tenantKey.wrapLong(updatedTenantRecord.getTenantKey());
     final var persistedTenant = tenantsColumnFamily.get(tenantKey);
     persistedTenant.setName(updatedTenantRecord.getName());
+    persistedTenant.setDescription(updatedTenantRecord.getDescription());
     tenantsColumnFamily.update(tenantKey, persistedTenant);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/PersistedTenant.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/PersistedTenant.java
@@ -19,12 +19,14 @@ public class PersistedTenant extends UnpackedObject implements DbValue {
   private final LongProperty tenantKeyProp = new LongProperty("tenantKey");
   private final StringProperty tenantIdProp = new StringProperty("tenantId");
   private final StringProperty nameProp = new StringProperty("name", "");
+  private final StringProperty descriptionProp = new StringProperty("description", "");
 
   public PersistedTenant() {
-    super(3);
+    super(4);
     declareProperty(tenantKeyProp);
     declareProperty(tenantIdProp);
     declareProperty(nameProp);
+    declareProperty(descriptionProp);
   }
 
   public PersistedTenant copy() {
@@ -93,6 +95,15 @@ public class PersistedTenant extends UnpackedObject implements DbValue {
     return this;
   }
 
+  public String getDescription() {
+    return BufferUtil.bufferAsString(descriptionProp.getValue());
+  }
+
+  public PersistedTenant setDescription(final String description) {
+    descriptionProp.setValue(description);
+    return this;
+  }
+
   /**
    * Wraps the provided TenantRecord into this PersistedTenant instance. Copies the tenant key,
    * tenant ID, and tenant name from the TenantRecord to the corresponding properties of this
@@ -104,5 +115,6 @@ public class PersistedTenant extends UnpackedObject implements DbValue {
     tenantKeyProp.setValue(tenantRecord.getTenantKey());
     tenantIdProp.setValue(tenantRecord.getTenantId());
     nameProp.setValue(tenantRecord.getName());
+    descriptionProp.setValue(tenantRecord.getDescription());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantCreateUpdateHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantCreateUpdateHandler.java
@@ -62,6 +62,7 @@ public class TenantCreateUpdateHandler implements ExportHandler<TenantEntity, Te
         .setKey(value.getTenantKey())
         .setTenantId(value.getTenantId())
         .setName(value.getName())
+        .setDescription(value.getDescription())
         .setJoin(joinRelation);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantDeletedHandler.java
@@ -55,7 +55,11 @@ public class TenantDeletedHandler implements ExportHandler<TenantEntity, TenantR
   @Override
   public void updateEntity(final Record<TenantRecordValue> record, final TenantEntity entity) {
     final TenantRecordValue value = record.getValue();
-    entity.setKey(value.getTenantKey()).setTenantId(value.getTenantId()).setName(value.getName());
+    entity
+        .setKey(value.getTenantKey())
+        .setTenantId(value.getTenantId())
+        .setName(value.getName())
+        .setDescription(value.getDescription());
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/TenantExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/TenantExportHandler.java
@@ -73,6 +73,7 @@ public class TenantExportHandler implements RdbmsExportHandler<TenantRecordValue
         .tenantKey(recordValue.getTenantKey())
         .tenantId(recordValue.getTenantId())
         .name(recordValue.getName())
+        .description(recordValue.getDescription())
         .build();
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4016,6 +4016,9 @@ components:
         description:
           type: string
           description: The new description of the tenant.
+      required:
+        - name
+        - description
 
     TenantUpdateResponseBase:
       description: Base properties for TenantUpdateResponse.

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3985,6 +3985,9 @@ components:
         name:
           type: string
           description: The name of the tenant.
+        description:
+          type: string
+          description: The description of the tenant.
       required:
         - tenantId
 
@@ -4000,6 +4003,9 @@ components:
         name:
           type: string
           description: The name of the tenant.
+        description:
+          type: string
+          description: The description of the tenant.
 
     TenantUpdateRequest:
       type: object
@@ -4007,8 +4013,9 @@ components:
         name:
           type: string
           description: The new name of the tenant.
-      required:
-        - name
+        description:
+          type: string
+          description: The new description of the tenant.
 
     TenantUpdateResponseBase:
       description: Base properties for TenantUpdateResponse.
@@ -4020,6 +4027,9 @@ components:
         name:
           type: string
           description: The name of the tenant.
+        description:
+          type: string
+          description: The description of the tenant.
     TenantUpdateResponse:
       deprecated: true
       type: object
@@ -4049,6 +4059,9 @@ components:
         tenantId:
           type: string
           description: The unique external tenant ID.
+        description:
+          type: string
+          description: The tenant description.
     TenantItem:
       description: Tenant search response item. Key attributes as numeric values.
       deprecated: true

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3990,6 +3990,7 @@ components:
           description: The description of the tenant.
       required:
         - tenantId
+        - name
 
     TenantCreateResult:
       type: object

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -775,14 +775,23 @@ public class RequestMapper {
     return getResult(
         TenantRequestValidator.validateTenantCreateRequest(tenantCreateRequest),
         () ->
-            new TenantDTO(null, tenantCreateRequest.getTenantId(), tenantCreateRequest.getName()));
+            new TenantDTO(
+                null,
+                tenantCreateRequest.getTenantId(),
+                tenantCreateRequest.getName(),
+                tenantCreateRequest.getDescription()));
   }
 
   public static Either<ProblemDetail, TenantDTO> toTenantUpdateDto(
       final String tenantId, final TenantUpdateRequest tenantUpdateRequest) {
     return getResult(
         TenantRequestValidator.validateTenantUpdateRequest(tenantUpdateRequest),
-        () -> new TenantDTO(null, tenantId, tenantUpdateRequest.getName()));
+        () ->
+            new TenantDTO(
+                null,
+                tenantId,
+                tenantUpdateRequest.getName(),
+                tenantUpdateRequest.getDescription()));
   }
 
   private static List<ProcessInstanceModificationActivateInstruction>

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -488,7 +488,8 @@ public final class ResponseMapper {
         new TenantCreateResult()
             .tenantKey(Long.toString(record.getTenantKey()))
             .tenantId(record.getTenantId())
-            .name(record.getName());
+            .name(record.getName())
+            .description(record.getDescription());
     return new ResponseEntity<>(response, HttpStatus.CREATED);
   }
 
@@ -497,7 +498,8 @@ public final class ResponseMapper {
         new TenantUpdateResponse()
             .tenantKey(record.getTenantKey())
             .tenantId(record.getTenantId())
-            .name(record.getName());
+            .name(record.getName())
+            .description(record.getDescription());
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -314,6 +314,7 @@ public final class SearchQueryResponseMapper {
     return new TenantItem()
         .tenantKey(tenantEntity.key())
         .name(tenantEntity.name())
+        .description(tenantEntity.description())
         .tenantId(tenantEntity.tenantId())
         .assignedMemberKeys(
             tenantEntity.assignedMemberKeys() == null

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/TenantRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/TenantRequestValidator.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest.validator;
 
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_AT_LEAST_ONE_FIELD;
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
 
@@ -36,8 +37,11 @@ public final class TenantRequestValidator {
       final TenantUpdateRequest request) {
     return validate(
         violations -> {
-          if (request.getName() == null || request.getName().isBlank()) {
-            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("name"));
+          final var noDescription =
+              request.getDescription() == null || request.getDescription().isBlank();
+          final var noName = request.getName() == null || request.getName().isBlank();
+          if (noDescription && noName) {
+            violations.add(ERROR_MESSAGE_AT_LEAST_ONE_FIELD.formatted("description, name"));
           }
         });
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/TenantRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/TenantRequestValidator.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.gateway.rest.validator;
 
-import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_AT_LEAST_ONE_FIELD;
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
 
@@ -37,11 +36,11 @@ public final class TenantRequestValidator {
       final TenantUpdateRequest request) {
     return validate(
         violations -> {
-          final var noDescription =
-              request.getDescription() == null || request.getDescription().isBlank();
-          final var noName = request.getName() == null || request.getName().isBlank();
-          if (noDescription && noName) {
-            violations.add(ERROR_MESSAGE_AT_LEAST_ONE_FIELD.formatted("description, name"));
+          if (request.getName() == null || request.getName().isBlank()) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("name"));
+          }
+          if (request.getDescription() == null || request.getDescription().isBlank()) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("description"));
           }
         });
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -205,6 +205,85 @@ public class TenantControllerTest extends RestControllerTest {
   }
 
   @Test
+  void updateTenantNameWithoutDescription() {
+    // given
+    final var tenantKey = 100L;
+    final var tenantName = "Updated Tenant Name";
+    final var tenantId = "tenant-test-id";
+    when(tenantServices.updateTenant(new TenantDTO(null, tenantId, tenantName, null)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new TenantRecord()
+                    .setName(tenantName)
+                    .setTenantKey(tenantKey)
+                    .setTenantId(tenantId)));
+
+    // when
+    webClient
+        .patch()
+        .uri("%s/%s".formatted(TENANT_BASE_URL, tenantId))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(new TenantUpdateRequest().name(tenantName))
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            {
+              "tenantKey": "%d",
+              "tenantId": "%s",
+              "name": "%s"
+            }
+            """
+                .formatted(tenantKey, tenantId, tenantName));
+
+    // then
+    verify(tenantServices, times(1)).updateTenant(new TenantDTO(null, tenantId, tenantName, null));
+  }
+
+  @Test
+  void updateTenantDescriptionWithoutName() {
+    // given
+    final var tenantKey = 100L;
+    final var tenantId = "tenant-test-id";
+    final var tenantDescription = "Updated description";
+    when(tenantServices.updateTenant(new TenantDTO(null, tenantId, null, tenantDescription)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new TenantRecord()
+                    .setDescription(tenantDescription)
+                    .setTenantKey(tenantKey)
+                    .setTenantId(tenantId)));
+
+    // when
+    webClient
+        .patch()
+        .uri("%s/%s".formatted(TENANT_BASE_URL, tenantId))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(new TenantUpdateRequest().description(tenantDescription))
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            {
+              "tenantKey": "%d",
+              "tenantId": "%s",
+              "description": "%s"
+            }
+            """
+                .formatted(tenantKey, tenantId, tenantDescription));
+
+    // then
+    verify(tenantServices, times(1))
+        .updateTenant(new TenantDTO(null, tenantId, null, tenantDescription));
+  }
+
+  @Test
   void updateTenantWithoutNameAndDescriptionShouldFail() {
     // given
     final var tenantId = 100L;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -53,38 +53,14 @@ public class TenantControllerTest extends RestControllerTest {
     // given
     final var tenantName = "Test Tenant";
     final var tenantId = "tenant-test-id";
-    when(tenantServices.createTenant(new TenantDTO(null, tenantId, tenantName)))
-        .thenReturn(
-            CompletableFuture.completedFuture(
-                new TenantRecord().setTenantKey(100L).setName(tenantName).setTenantId(tenantId)));
-
-    // when
-    webClient
-        .post()
-        .uri(TENANT_BASE_URL)
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(new TenantCreateRequest().name(tenantName).tenantId(tenantId))
-        .exchange()
-        .expectStatus()
-        .isCreated();
-
-    // then
-    verify(tenantServices, times(1)).createTenant(new TenantDTO(null, tenantId, tenantName));
-  }
-
-  @Test
-  void createTenantShouldReturnAllDetails() {
-    // given
-    final var tenantName = "Test Tenant";
-    final var tenantId = "tenant-test-id";
-    final var tenantKey = 100L;
-    when(tenantServices.createTenant(new TenantDTO(null, tenantId, tenantName)))
+    final var tenantDescription = "Test description";
+    when(tenantServices.createTenant(new TenantDTO(null, tenantId, tenantName, tenantDescription)))
         .thenReturn(
             CompletableFuture.completedFuture(
                 new TenantRecord()
-                    .setTenantKey(tenantKey)
+                    .setTenantKey(100L)
                     .setName(tenantName)
+                    .setDescription(tenantDescription)
                     .setTenantId(tenantId)));
 
     // when
@@ -93,7 +69,47 @@ public class TenantControllerTest extends RestControllerTest {
         .uri(TENANT_BASE_URL)
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(new TenantCreateRequest().name(tenantName).tenantId(tenantId))
+        .bodyValue(
+            new TenantCreateRequest()
+                .name(tenantName)
+                .description(tenantDescription)
+                .tenantId(tenantId))
+        .exchange()
+        .expectStatus()
+        .isCreated();
+
+    // then
+    verify(tenantServices, times(1))
+        .createTenant(new TenantDTO(null, tenantId, tenantName, tenantDescription));
+  }
+
+  @Test
+  void createTenantShouldReturnAllDetails() {
+    // given
+    final var tenantName = "Test Tenant";
+    final var tenantId = "tenant-test-id";
+    final var tenantDescription = "Test description";
+    final var tenantKey = 100L;
+    when(tenantServices.createTenant(new TenantDTO(null, tenantId, tenantName, tenantDescription)))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new TenantRecord()
+                    .setTenantKey(tenantKey)
+                    .setName(tenantName)
+                    .setDescription(tenantDescription)
+                    .setTenantId(tenantId)));
+
+    // when
+    webClient
+        .post()
+        .uri(TENANT_BASE_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            new TenantCreateRequest()
+                .name(tenantName)
+                .tenantId(tenantId)
+                .description(tenantDescription))
         .exchange()
         .expectStatus()
         .isCreated()
@@ -103,13 +119,15 @@ public class TenantControllerTest extends RestControllerTest {
             {
               "tenantKey": "%d",
               "tenantId": "%s",
-              "name": "%s"
+              "name": "%s",
+              "description": "%s"
             }
             """
-                .formatted(tenantKey, tenantId, tenantName));
+                .formatted(tenantKey, tenantId, tenantName, tenantDescription));
 
     // then
-    verify(tenantServices, times(1)).createTenant(new TenantDTO(null, tenantId, tenantName));
+    verify(tenantServices, times(1))
+        .createTenant(new TenantDTO(null, tenantId, tenantName, tenantDescription));
   }
 
   @Test
@@ -149,11 +167,13 @@ public class TenantControllerTest extends RestControllerTest {
     final var tenantKey = 100L;
     final var tenantName = "Updated Tenant Name";
     final var tenantId = "tenant-test-id";
-    when(tenantServices.updateTenant(new TenantDTO(null, tenantId, tenantName)))
+    final var tenantDescription = "Updated description";
+    when(tenantServices.updateTenant(new TenantDTO(null, tenantId, tenantName, tenantDescription)))
         .thenReturn(
             CompletableFuture.completedFuture(
                 new TenantRecord()
                     .setName(tenantName)
+                    .setDescription(tenantDescription)
                     .setTenantKey(tenantKey)
                     .setTenantId(tenantId)));
 
@@ -163,7 +183,7 @@ public class TenantControllerTest extends RestControllerTest {
         .uri("%s/%s".formatted(TENANT_BASE_URL, tenantId))
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(new TenantUpdateRequest().name(tenantName))
+        .bodyValue(new TenantUpdateRequest().name(tenantName).description(tenantDescription))
         .exchange()
         .expectStatus()
         .isOk()
@@ -173,17 +193,19 @@ public class TenantControllerTest extends RestControllerTest {
             {
               "tenantKey": "%d",
               "tenantId": "%s",
-              "name": "%s"
+              "name": "%s",
+              "description": "%s"
             }
             """
-                .formatted(tenantKey, tenantId, tenantName));
+                .formatted(tenantKey, tenantId, tenantName, tenantDescription));
 
     // then
-    verify(tenantServices, times(1)).updateTenant(new TenantDTO(null, tenantId, tenantName));
+    verify(tenantServices, times(1))
+        .updateTenant(new TenantDTO(null, tenantId, tenantName, tenantDescription));
   }
 
   @Test
-  void updateTenantWithEmptyNameShouldFail() {
+  void updateTenantWithoutNameAndDescriptionShouldFail() {
     // given
     final var tenantId = 100L;
     final var tenantName = "";
@@ -206,7 +228,7 @@ public class TenantControllerTest extends RestControllerTest {
               "type": "about:blank",
               "status": 400,
               "title": "INVALID_ARGUMENT",
-              "detail": "No name provided.",
+              "detail": "At least one of description, name is required.",
               "instance": "%s"
             }"""
                 .formatted(uri));
@@ -221,7 +243,7 @@ public class TenantControllerTest extends RestControllerTest {
     final var tenantName = "My tenant";
     final var tenantKey = 100L;
     final var path = "%s/%s".formatted(TENANT_BASE_URL, tenantId);
-    when(tenantServices.updateTenant(new TenantDTO(null, tenantId, tenantName)))
+    when(tenantServices.updateTenant(new TenantDTO(null, tenantId, tenantName, null)))
         .thenReturn(
             CompletableFuture.failedFuture(
                 new CamundaBrokerException(
@@ -242,7 +264,7 @@ public class TenantControllerTest extends RestControllerTest {
         .expectStatus()
         .isNotFound();
 
-    verify(tenantServices, times(1)).updateTenant(new TenantDTO(null, tenantId, tenantName));
+    verify(tenantServices, times(1)).updateTenant(new TenantDTO(null, tenantId, tenantName, null));
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -53,18 +53,21 @@ public class TenantQueryControllerTest extends RestControllerTest {
            {
              "tenantKey": %s,
              "name": "%s",
+             "description": "%s",
              "tenantId": "%s",
              "assignedMemberKeys": %s
            },
            {
              "tenantKey": %s,
              "name": "%s",
+             "description": "%s",
              "tenantId": "%s",
              "assignedMemberKeys": %s
            },
            {
              "tenantKey": %s,
              "name": "%s",
+             "description": "%s",
              "tenantId": "%s",
              "assignedMemberKeys": %s
            }
@@ -80,14 +83,17 @@ public class TenantQueryControllerTest extends RestControllerTest {
       RESPONSE.formatted(
           "\"%s\"".formatted(TENANT_ENTITIES.get(0).key()),
           TENANT_ENTITIES.get(0).name(),
+          TENANT_ENTITIES.get(0).description(),
           TENANT_ENTITIES.get(0).tenantId(),
           formatSet(TENANT_ENTITIES.get(0).assignedMemberKeys(), true),
           "\"%s\"".formatted(TENANT_ENTITIES.get(1).key()),
           TENANT_ENTITIES.get(1).name(),
+          TENANT_ENTITIES.get(1).description(),
           TENANT_ENTITIES.get(1).tenantId(),
           formatSet(TENANT_ENTITIES.get(1).assignedMemberKeys(), true),
           "\"%s\"".formatted(TENANT_ENTITIES.get(2).key()),
           TENANT_ENTITIES.get(2).name(),
+          TENANT_ENTITIES.get(2).description(),
           TENANT_ENTITIES.get(2).tenantId(),
           formatSet(TENANT_ENTITIES.get(2).assignedMemberKeys(), true),
           TENANT_ENTITIES.size());
@@ -95,14 +101,17 @@ public class TenantQueryControllerTest extends RestControllerTest {
       RESPONSE.formatted(
           TENANT_ENTITIES.get(0).key(),
           TENANT_ENTITIES.get(0).name(),
+          TENANT_ENTITIES.get(0).description(),
           TENANT_ENTITIES.get(0).tenantId(),
           formatSet(TENANT_ENTITIES.get(0).assignedMemberKeys(), false),
           TENANT_ENTITIES.get(1).key(),
           TENANT_ENTITIES.get(1).name(),
+          TENANT_ENTITIES.get(1).description(),
           TENANT_ENTITIES.get(1).tenantId(),
           formatSet(TENANT_ENTITIES.get(1).assignedMemberKeys(), false),
           TENANT_ENTITIES.get(2).key(),
           TENANT_ENTITIES.get(2).name(),
+          TENANT_ENTITIES.get(2).description(),
           TENANT_ENTITIES.get(2).tenantId(),
           formatSet(TENANT_ENTITIES.get(2).assignedMemberKeys(), false),
           TENANT_ENTITIES.size());

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -42,9 +42,9 @@ public class TenantQueryControllerTest extends RestControllerTest {
 
   private static final List<TenantEntity> TENANT_ENTITIES =
       List.of(
-          new TenantEntity(100L, "tenant-id-1", "Tenant 1", Set.of()),
-          new TenantEntity(200L, "tenant-id-2", "Tenant 2", Set.of(1L, 2L)),
-          new TenantEntity(300L, "tenant-id-3", "Tenant 12", Set.of(3L)));
+          new TenantEntity(100L, "tenant-id-1", "Tenant 1", "Description 1", Set.of()),
+          new TenantEntity(200L, "tenant-id-2", "Tenant 2", "Description 2", Set.of(1L, 2L)),
+          new TenantEntity(300L, "tenant-id-3", "Tenant 12", "Description 3", Set.of(3L)));
 
   private static final String RESPONSE =
       """
@@ -128,7 +128,8 @@ public class TenantQueryControllerTest extends RestControllerTest {
     // given
     final var tenantName = "Tenant Name";
     final var tenantId = "tenant-id";
-    final var tenant = new TenantEntity(100L, tenantId, tenantName, Set.of());
+    final var tenantDescription = "Tenant Description";
+    final var tenant = new TenantEntity(100L, tenantId, tenantName, tenantDescription, Set.of());
     when(tenantServices.getById(tenant.tenantId())).thenReturn(tenant);
 
     // when
@@ -145,11 +146,12 @@ public class TenantQueryControllerTest extends RestControllerTest {
             {
               "tenantKey": "%d",
               "name": "%s",
+              "description": "%s",
               "tenantId": "%s",
               "assignedMemberKeys": []
             }
             """
-                .formatted(tenant.key(), tenantName, tenantId));
+                .formatted(tenant.key(), tenantName, tenantDescription, tenantId));
 
     // then
     verify(tenantServices, times(1)).getById(tenant.tenantId());

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/tenant/BrokerTenantCreateRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/tenant/BrokerTenantCreateRequest.java
@@ -33,6 +33,11 @@ public class BrokerTenantCreateRequest extends BrokerExecuteCommand<TenantRecord
     return this;
   }
 
+  public BrokerTenantCreateRequest setDescription(final String description) {
+    requestDto.setDescription(description);
+    return this;
+  }
+
   @Override
   public TenantRecord getRequestWriter() {
     return requestDto;

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/tenant/BrokerTenantUpdateRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/tenant/BrokerTenantUpdateRequest.java
@@ -28,6 +28,11 @@ public class BrokerTenantUpdateRequest extends BrokerExecuteCommand<TenantRecord
     return this;
   }
 
+  public BrokerTenantUpdateRequest setDescription(final String description) {
+    tenantDto.setDescription(description);
+    return this;
+  }
+
   @Override
   public TenantRecord getRequestWriter() {
     return tenantDto;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/tenant/TenantRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/tenant/TenantRecord.java
@@ -92,6 +92,11 @@ public final class TenantRecord extends UnifiedRecordValue implements TenantReco
   }
 
   public TenantRecord setDescription(final String description) {
+    if (description == null) {
+      descriptionProp.reset();
+      return this;
+    }
+
     descriptionProp.setValue(description);
     return this;
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/tenant/TenantRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/tenant/TenantRecord.java
@@ -23,16 +23,18 @@ public final class TenantRecord extends UnifiedRecordValue implements TenantReco
   private final LongProperty tenantKeyProp = new LongProperty("tenantKey", DEFAULT_KEY);
   private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
   private final StringProperty nameProp = new StringProperty("name", "");
+  private final StringProperty descriptionProp = new StringProperty("description", "");
   private final LongProperty entityKeyProp = new LongProperty("entityKey", DEFAULT_KEY);
   private final StringProperty entityIdProp = new StringProperty("entityId", "");
   private final EnumProperty<EntityType> entityTypeProp =
       new EnumProperty<>("entityType", EntityType.class, EntityType.UNSPECIFIED);
 
   public TenantRecord() {
-    super(6);
+    super(7);
     declareProperty(tenantKeyProp)
         .declareProperty(tenantIdProp)
         .declareProperty(nameProp)
+        .declareProperty(descriptionProp)
         .declareProperty(entityKeyProp)
         .declareProperty(entityIdProp)
         .declareProperty(entityTypeProp);
@@ -81,6 +83,16 @@ public final class TenantRecord extends UnifiedRecordValue implements TenantReco
 
   public TenantRecord setName(final DirectBuffer name) {
     nameProp.setValue(name);
+    return this;
+  }
+
+  @Override
+  public String getDescription() {
+    return bufferAsString(descriptionProp.getValue());
+  }
+
+  public TenantRecord setDescription(final String description) {
+    descriptionProp.setValue(description);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2837,6 +2837,7 @@ final class JsonSerializableToJsonTest {
                     .setTenantKey(123L)
                     .setTenantId("tenant-abc")
                     .setName("Test Tenant")
+                    .setDescription("Test Description")
                     .setEntityKey(456L)
                     .setEntityId("entity-xyz")
                     .setEntityType(EntityType.USER),
@@ -2845,6 +2846,7 @@ final class JsonSerializableToJsonTest {
           "tenantKey": 123,
           "tenantId": "tenant-abc",
           "name": "Test Tenant",
+          "description": "Test Description",
           "entityKey": 456,
           "entityId": "entity-xyz",
           "entityType": "USER"
@@ -2862,6 +2864,7 @@ final class JsonSerializableToJsonTest {
             "tenantKey": -1,
             "tenantId": "",
             "name": "",
+            "description": "",
             "entityKey": -1,
             "entityId": "",
             "entityType": "UNSPECIFIED"
@@ -3064,6 +3067,7 @@ final class JsonSerializableToJsonTest {
           "tenantKey": 5,
           "tenantId": "id",
           "name": "name",
+          "description": "",
           "entityKey": -1,
           "entityId": "",
           "entityType": "UNSPECIFIED"
@@ -3104,6 +3108,7 @@ final class JsonSerializableToJsonTest {
               "tenantKey": -1,
               "tenantId": "",
               "name": "",
+              "description": "",
               "entityKey": -1,
               "entityId": "",
               "entityType": "UNSPECIFIED"

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/TenantRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/TenantRecordValue.java
@@ -33,6 +33,8 @@ public interface TenantRecordValue extends RecordValue {
   /** Name of the tenant. */
   String getName();
 
+  String getDescription();
+
   /** Key of the entity associated with this tenant. */
   long getEntityKey();
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateTenantTest.java
@@ -38,6 +38,28 @@ class CreateTenantTest {
   void shouldCreateTenant() {
     // when
     final var response =
+        client
+            .newCreateTenantCommand()
+            .tenantId("tenant-id")
+            .name("Tenant Name")
+            .description("Tenant Description")
+            .send()
+            .join();
+
+    // then
+    assertThat(response.getTenantKey()).isGreaterThan(0);
+    ZeebeAssertHelper.assertTenantCreated(
+        "tenant-id",
+        (tenant) -> {
+          assertThat(tenant.getName()).isEqualTo("Tenant Name");
+          assertThat(tenant.getDescription()).isEqualTo("Tenant Description");
+        });
+  }
+
+  @Test
+  void shouldCreateTenantWithoutDescription() {
+    // when
+    final var response =
         client.newCreateTenantCommand().tenantId("tenant-id").name("Tenant Name").send().join();
 
     // then
@@ -46,6 +68,7 @@ class CreateTenantTest {
         "tenant-id",
         (tenant) -> {
           assertThat(tenant.getName()).isEqualTo("Tenant Name");
+          assertThat(tenant.getDescription()).isEmpty();
         });
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UpdateTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UpdateTenantTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 class UpdateTenantTest {
 
   private static final String UPDATED_TENANT_NAME = "Updated Tenant Name";
+  private static final String UPDATED_TENANT_DESCRIPTION = "Updated Tenant Description";
   private static final String TENANT_ID = "tenant-id";
 
   @TestZeebe
@@ -32,25 +33,27 @@ class UpdateTenantTest {
 
   @AutoClose private CamundaClient client;
 
-  private long tenantKey;
-
   @BeforeEach
   void initClientAndInstances() {
     client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
-    tenantKey =
-        client
-            .newCreateTenantCommand()
-            .tenantId(TENANT_ID)
-            .name("Initial Tenant Name")
-            .send()
-            .join()
-            .getTenantKey();
+    client
+        .newCreateTenantCommand()
+        .tenantId(TENANT_ID)
+        .name("Initial Tenant Name")
+        .send()
+        .join()
+        .getTenantKey();
   }
 
   @Test
-  void shouldUpdateTenantName() {
+  void shouldUpdateTenantNameAndDescription() {
     // when
-    client.newUpdateTenantCommand(TENANT_ID).name(UPDATED_TENANT_NAME).send().join();
+    client
+        .newUpdateTenantCommand(TENANT_ID)
+        .name(UPDATED_TENANT_NAME)
+        .description(UPDATED_TENANT_DESCRIPTION)
+        .send()
+        .join();
 
     // then
     ZeebeAssertHelper.assertTenantUpdated(
@@ -60,9 +63,24 @@ class UpdateTenantTest {
   @Test
   void shouldRejectUpdateIfNameIsNull() {
     // when / then
-    assertThatThrownBy(() -> client.newUpdateTenantCommand(TENANT_ID).name(null).send().join())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("name must not be null");
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUpdateTenantCommand(TENANT_ID)
+                    .description("new description")
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("No name provided");
+  }
+
+  @Test
+  void shouldRejectUpdateIfDescriptionIsNull() {
+    // when / then
+    assertThatThrownBy(
+            () -> client.newUpdateTenantCommand(TENANT_ID).name("new name").send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("No description provided");
   }
 
   @Test
@@ -74,6 +92,7 @@ class UpdateTenantTest {
                 client
                     .newUpdateTenantCommand(notExistingTenantId)
                     .name("Non-Existent Tenant Name")
+                    .description("Some Description")
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)


### PR DESCRIPTION
This adds a description field to the Tenant entity.
Tenants can be created without specifying a description, the description is set to `""` internally.
Tenants can be updated but both name and description have to be provided, we don't support partial updates.
We do not support filtering or sorting based on the description.

The description is exported as a `text` field on ES/OS and as a `varchar(255)` on RDBMS.

relates to https://github.com/camunda/camunda/issues/27166
