### PR TITLE
Migrated backup metrics from prometheus to micrometer

### DIFF
--- a/zeebe/backup/pom.xml
+++ b/zeebe/backup/pom.xml
@@ -108,6 +108,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/metrics/BackupManagerMetrics.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/metrics/BackupManagerMetrics.java
@@ -7,12 +7,12 @@
  */
 package io.camunda.zeebe.backup.metrics;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.Timer.Sample;
-import io.prometheus.client.Counter;
-import io.prometheus.client.Gauge;
-import io.prometheus.client.Histogram;
-import io.prometheus.client.Histogram.Timer;
 import java.time.Duration;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -31,51 +31,27 @@ public class BackupManagerMetrics {
   private static final String LIST_OPERATION = "list";
   private static final String DELETE_OPERATION = "delete";
 
-  private static final io.micrometer.core.instrument.MeterRegistry METER_REGISTRY =
-      Metrics.globalRegistry;
-
-  private static final Counter TOTAL_OPERATIONS =
-      Counter.build()
-          .namespace(NAMESPACE)
-          .name("backup_operations_total")
-          .help("Total number of backup operations")
-          .labelNames(LABEL_NAME_PARTITION, LABEL_NAME_OPERATION, LABEL_NAME_RESULT)
-          .register();
-
-  private static final io.micrometer.core.instrument.Counter.Builder TOTAL_OPERATIONS_BUILDER =
-      io.micrometer.core.instrument.Counter.builder(NAMESPACE + "_backup_operations_total_micro")
+  private static final String BACKUP_OPERATIONS_TIMER_NAME =
+      NAMESPACE + "_backup_operations_latency";
+  private static final String BACKUP_OPERATIONS_IN_PROGRESS_NAME =
+      NAMESPACE + "_backup_operations_in_progress";
+  private static final MeterRegistry METER_REGISTRY = Metrics.globalRegistry;
+  private static final Counter.Builder TOTAL_OPERATIONS_BUILDER =
+      Counter.builder(NAMESPACE + "_backup_operations_total")
           .description("Total number of backup operations");
-
-  private static final Gauge OPERATIONS_IN_PROGRESS =
-      Gauge.build()
-          .namespace(NAMESPACE)
-          .name("backup_operations_in_progress")
-          .help("Number of backup operations that are in progress")
-          .labelNames(LABEL_NAME_PARTITION, LABEL_NAME_OPERATION)
-          .register();
-
-  private static final ConcurrentHashMap<String, AtomicLong>
-      OPERATIONS_IN_PROGRESS_MICROMETER_GAUGES = new ConcurrentHashMap<>();
-
-  private static final Histogram BACKUP_OPERATION_LATENCY =
-      Histogram.build()
-          .namespace(NAMESPACE)
-          .name("backup_operations_latency")
-          .help("Latency of backup operations")
-          .labelNames(LABEL_NAME_PARTITION, LABEL_NAME_OPERATION)
-          .buckets(0.01, 0.1, 1, 10, 60, 5 * 60)
-          .register();
-
+  private static final ConcurrentHashMap<String, AtomicLong> OPERATIONS_IN_PROGRESS_GAUGES =
+      new ConcurrentHashMap<>();
   private static final Duration[] BACKUP_OPERATION_LATENCY_BUCKETS =
       Stream.of(10, 100, 1000, 10000, 60000, 5 * 60000)
-          .map(Duration::ofMillis) // TODO Verify unit
+          .map(Duration::ofMillis)
           .toArray(Duration[]::new);
 
-  private static final io.micrometer.core.instrument.Timer BACKUP_OPERATION_LATENCY_MICROMETER =
-      io.micrometer.core.instrument.Timer.builder(NAMESPACE + "_backup_operations_latency_micro")
-          .description("Latency of backup operations")
-          .sla(BACKUP_OPERATION_LATENCY_BUCKETS)
-          .register(METER_REGISTRY);
+  static {
+    Timer.builder(BACKUP_OPERATIONS_TIMER_NAME)
+        .description("Latency of backup operations")
+        .sla(BACKUP_OPERATION_LATENCY_BUCKETS)
+        .register(METER_REGISTRY);
+  }
 
   private final String partitionId;
 
@@ -100,10 +76,6 @@ public class BackupManagerMetrics {
   }
 
   public void cancelInProgressOperations() {
-    OPERATIONS_IN_PROGRESS.labels(partitionId, TAKE_OPERATION).set(0);
-    OPERATIONS_IN_PROGRESS.labels(partitionId, DELETE_OPERATION).set(0);
-    OPERATIONS_IN_PROGRESS.labels(partitionId, STATUS_OPERATION).set(0);
-    OPERATIONS_IN_PROGRESS.labels(partitionId, LIST_OPERATION).set(0);
     getOperationsInProgressGauge(partitionId, TAKE_OPERATION).set(0);
     getOperationsInProgressGauge(partitionId, DELETE_OPERATION).set(0);
     getOperationsInProgressGauge(partitionId, STATUS_OPERATION).set(0);
@@ -113,14 +85,11 @@ public class BackupManagerMetrics {
   private static AtomicLong getOperationsInProgressGauge(
       final String partitionId, final String operation) {
     final String key = operation + "_" + partitionId;
-    return OPERATIONS_IN_PROGRESS_MICROMETER_GAUGES.computeIfAbsent(
+    return OPERATIONS_IN_PROGRESS_GAUGES.computeIfAbsent(
         key,
         k -> {
           final AtomicLong newGaugeValue = new AtomicLong(0);
-          io.micrometer.core.instrument.Gauge.builder(
-                  NAMESPACE + "_backup_operations_in_progress_micro",
-                  newGaugeValue,
-                  AtomicLong::get)
+          Gauge.builder(BACKUP_OPERATIONS_IN_PROGRESS_NAME, newGaugeValue, AtomicLong::get)
               .description("Number of backup operations that are in progress")
               .tag(LABEL_NAME_PARTITION, partitionId)
               .tag(LABEL_NAME_OPERATION, operation)
@@ -131,46 +100,34 @@ public class BackupManagerMetrics {
 
   public static final class OperationMetrics {
     final String partitionId;
-    final Histogram.Timer timer;
     final Sample timerSample;
     final String operation;
 
     private OperationMetrics(
-        final String partitionId,
-        final Timer timer,
-        final Sample timerSample,
-        final String operation) {
+        final String partitionId, final Sample timerSample, final String operation) {
       this.partitionId = partitionId;
-      this.timer = timer;
       this.timerSample = timerSample;
       this.operation = operation;
     }
 
     private static OperationMetrics start(final String partitionId, final String operation) {
-      final var timer = BACKUP_OPERATION_LATENCY.labels(partitionId, operation).startTimer();
-      final io.micrometer.core.instrument.Timer.Sample timerSample =
-          io.micrometer.core.instrument.Timer.start(METER_REGISTRY);
-      OPERATIONS_IN_PROGRESS.labels(partitionId, operation).inc();
+      final Timer.Sample timerSample = Timer.start(METER_REGISTRY);
       getOperationsInProgressGauge(partitionId, operation).incrementAndGet();
-      return new OperationMetrics(partitionId, timer, timerSample, operation);
+      return new OperationMetrics(partitionId, timerSample, operation);
     }
 
     public <T> void complete(final T ignored, final Throwable throwable) {
-      timer.close();
       if (timerSample != null) {
-        final var microTimer =
+        final var timer =
             METER_REGISTRY.timer(
-                NAMESPACE + "_backup_operations_latency_micro",
+                BACKUP_OPERATIONS_TIMER_NAME,
                 LABEL_NAME_PARTITION,
                 partitionId,
                 LABEL_NAME_OPERATION,
                 operation);
-        if (microTimer != null) {
-          timerSample.stop(microTimer);
-        }
+        timerSample.stop(timer);
       }
 
-      OPERATIONS_IN_PROGRESS.labels(partitionId, operation).dec();
       getOperationsInProgressGauge(partitionId, operation).decrementAndGet();
       if (throwable != null) {
         TOTAL_OPERATIONS_BUILDER
@@ -183,7 +140,6 @@ public class BackupManagerMetrics {
                 FAILED)
             .register(METER_REGISTRY)
             .increment();
-        TOTAL_OPERATIONS.labels(partitionId, operation, FAILED).inc();
       } else {
         TOTAL_OPERATIONS_BUILDER
             .tags(
@@ -195,7 +151,6 @@ public class BackupManagerMetrics {
                 COMPLETED)
             .register(METER_REGISTRY)
             .increment();
-        TOTAL_OPERATIONS.labels(partitionId, operation, COMPLETED).inc();
       }
     }
   }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/metrics/BackupManagerMetrics.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/metrics/BackupManagerMetrics.java
@@ -7,10 +7,16 @@
  */
 package io.camunda.zeebe.backup.metrics;
 
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer.Sample;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.Histogram;
 import io.prometheus.client.Histogram.Timer;
+import java.time.Duration;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
 
 public class BackupManagerMetrics {
   private static final String NAMESPACE = "zeebe";
@@ -25,6 +31,9 @@ public class BackupManagerMetrics {
   private static final String LIST_OPERATION = "list";
   private static final String DELETE_OPERATION = "delete";
 
+  private static final io.micrometer.core.instrument.MeterRegistry METER_REGISTRY =
+      Metrics.globalRegistry;
+
   private static final Counter TOTAL_OPERATIONS =
       Counter.build()
           .namespace(NAMESPACE)
@@ -32,6 +41,11 @@ public class BackupManagerMetrics {
           .help("Total number of backup operations")
           .labelNames(LABEL_NAME_PARTITION, LABEL_NAME_OPERATION, LABEL_NAME_RESULT)
           .register();
+
+  private static final io.micrometer.core.instrument.Counter.Builder TOTAL_OPERATIONS_BUILDER =
+      io.micrometer.core.instrument.Counter.builder(NAMESPACE + "_backup_operations_total_micro")
+          .description("Total number of backup operations");
+
   private static final Gauge OPERATIONS_IN_PROGRESS =
       Gauge.build()
           .namespace(NAMESPACE)
@@ -39,6 +53,9 @@ public class BackupManagerMetrics {
           .help("Number of backup operations that are in progress")
           .labelNames(LABEL_NAME_PARTITION, LABEL_NAME_OPERATION)
           .register();
+
+  private static final ConcurrentHashMap<String, AtomicLong>
+      OPERATIONS_IN_PROGRESS_MICROMETER_GAUGES = new ConcurrentHashMap<>();
 
   private static final Histogram BACKUP_OPERATION_LATENCY =
       Histogram.build()
@@ -48,6 +65,17 @@ public class BackupManagerMetrics {
           .labelNames(LABEL_NAME_PARTITION, LABEL_NAME_OPERATION)
           .buckets(0.01, 0.1, 1, 10, 60, 5 * 60)
           .register();
+
+  private static final Duration[] BACKUP_OPERATION_LATENCY_BUCKETS =
+      Stream.of(10, 100, 1000, 10000, 60000, 5 * 60000)
+          .map(Duration::ofMillis) // TODO Verify unit
+          .toArray(Duration[]::new);
+
+  private static final io.micrometer.core.instrument.Timer BACKUP_OPERATION_LATENCY_MICROMETER =
+      io.micrometer.core.instrument.Timer.builder(NAMESPACE + "_backup_operations_latency_micro")
+          .description("Latency of backup operations")
+          .sla(BACKUP_OPERATION_LATENCY_BUCKETS)
+          .register(METER_REGISTRY);
 
   private final String partitionId;
 
@@ -76,31 +104,97 @@ public class BackupManagerMetrics {
     OPERATIONS_IN_PROGRESS.labels(partitionId, DELETE_OPERATION).set(0);
     OPERATIONS_IN_PROGRESS.labels(partitionId, STATUS_OPERATION).set(0);
     OPERATIONS_IN_PROGRESS.labels(partitionId, LIST_OPERATION).set(0);
+    getOperationsInProgressGauge(partitionId, TAKE_OPERATION).set(0);
+    getOperationsInProgressGauge(partitionId, DELETE_OPERATION).set(0);
+    getOperationsInProgressGauge(partitionId, STATUS_OPERATION).set(0);
+    getOperationsInProgressGauge(partitionId, LIST_OPERATION).set(0);
+  }
+
+  private static AtomicLong getOperationsInProgressGauge(
+      final String partitionId, final String operation) {
+    final String key = operation + "_" + partitionId;
+    return OPERATIONS_IN_PROGRESS_MICROMETER_GAUGES.computeIfAbsent(
+        key,
+        k -> {
+          final AtomicLong newGaugeValue = new AtomicLong(0);
+          io.micrometer.core.instrument.Gauge.builder(
+                  NAMESPACE + "_backup_operations_in_progress_micro",
+                  newGaugeValue,
+                  AtomicLong::get)
+              .description("Number of backup operations that are in progress")
+              .tag(LABEL_NAME_PARTITION, partitionId)
+              .tag(LABEL_NAME_OPERATION, operation)
+              .register(METER_REGISTRY);
+          return newGaugeValue;
+        });
   }
 
   public static final class OperationMetrics {
     final String partitionId;
     final Histogram.Timer timer;
+    final Sample timerSample;
     final String operation;
 
-    private OperationMetrics(final String partitionId, final Timer timer, final String operation) {
+    private OperationMetrics(
+        final String partitionId,
+        final Timer timer,
+        final Sample timerSample,
+        final String operation) {
       this.partitionId = partitionId;
       this.timer = timer;
+      this.timerSample = timerSample;
       this.operation = operation;
     }
 
     private static OperationMetrics start(final String partitionId, final String operation) {
       final var timer = BACKUP_OPERATION_LATENCY.labels(partitionId, operation).startTimer();
+      final io.micrometer.core.instrument.Timer.Sample timerSample =
+          io.micrometer.core.instrument.Timer.start(METER_REGISTRY);
       OPERATIONS_IN_PROGRESS.labels(partitionId, operation).inc();
-      return new OperationMetrics(partitionId, timer, operation);
+      getOperationsInProgressGauge(partitionId, operation).incrementAndGet();
+      return new OperationMetrics(partitionId, timer, timerSample, operation);
     }
 
     public <T> void complete(final T ignored, final Throwable throwable) {
       timer.close();
+      if (timerSample != null) {
+        final var microTimer =
+            METER_REGISTRY.timer(
+                NAMESPACE + "_backup_operations_latency_micro",
+                LABEL_NAME_PARTITION,
+                partitionId,
+                LABEL_NAME_OPERATION,
+                operation);
+        if (microTimer != null) {
+          timerSample.stop(microTimer);
+        }
+      }
+
       OPERATIONS_IN_PROGRESS.labels(partitionId, operation).dec();
+      getOperationsInProgressGauge(partitionId, operation).decrementAndGet();
       if (throwable != null) {
+        TOTAL_OPERATIONS_BUILDER
+            .tags(
+                LABEL_NAME_PARTITION,
+                partitionId,
+                LABEL_NAME_OPERATION,
+                operation,
+                LABEL_NAME_RESULT,
+                FAILED)
+            .register(METER_REGISTRY)
+            .increment();
         TOTAL_OPERATIONS.labels(partitionId, operation, FAILED).inc();
       } else {
+        TOTAL_OPERATIONS_BUILDER
+            .tags(
+                LABEL_NAME_PARTITION,
+                partitionId,
+                LABEL_NAME_OPERATION,
+                operation,
+                LABEL_NAME_RESULT,
+                COMPLETED)
+            .register(METER_REGISTRY)
+            .increment();
         TOTAL_OPERATIONS.labels(partitionId, operation, COMPLETED).inc();
       }
     }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/metrics/CheckpointMetrics.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/metrics/CheckpointMetrics.java
@@ -7,14 +7,25 @@
  */
 package io.camunda.zeebe.backup.metrics;
 
+import io.micrometer.core.instrument.Metrics;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class CheckpointMetrics {
 
   private static final String NAMESPACE = "zeebe";
   private static final String LABEL_NAME_PARTITION = "partition";
   private static final String LABEL_NAME_RESULT = "result";
+
+  private static final io.micrometer.core.instrument.MeterRegistry METER_REGISTRY =
+      Metrics.globalRegistry;
+
+  private static final io.micrometer.core.instrument.Counter.Builder CHECKPOINT_RECORDS_BUILDER =
+      io.micrometer.core.instrument.Counter.builder(NAMESPACE + "_checkpoint_records_total_micro")
+          .description(
+              "Number of checkpoint records processed by stream processor. Processing can result in either creating a new checkpoint or ignoring the record. This can be observed by filtering for label 'result'.");
 
   private static final Counter CHECKPOINT_RECORDS =
       Counter.build()
@@ -24,6 +35,11 @@ public class CheckpointMetrics {
               "Number of checkpoint records processed by stream processor. Processing can result in either creating a new checkpoint or ignoring the record. This can be observed by filtering for label 'result'.")
           .labelNames(LABEL_NAME_RESULT, LABEL_NAME_PARTITION)
           .register();
+
+  private static final ConcurrentHashMap<String, AtomicLong> GAUGES = new ConcurrentHashMap<>();
+
+  private static final String CHECKPOINT_POSITION_NAME = NAMESPACE + "_checkpoint_position_micro";
+  private static final String CHECKPOINT_ID_NAME = NAMESPACE + "_checkpoint_id_micro";
 
   private static final Gauge CHECKPOINT_POSITION =
       Gauge.build()
@@ -50,14 +66,51 @@ public class CheckpointMetrics {
   public void created(final long checkpointId, final long checkpointPosition) {
     setCheckpointId(checkpointId, checkpointPosition);
     CHECKPOINT_RECORDS.labels("created", partitionId).inc();
+    CHECKPOINT_RECORDS_BUILDER
+        .tags(LABEL_NAME_RESULT, "created", LABEL_NAME_PARTITION, partitionId)
+        .register(METER_REGISTRY)
+        .increment();
   }
 
   public void setCheckpointId(final long checkpointId, final long checkpointPosition) {
     CHECKPOINT_ID.labels(partitionId).set(checkpointId);
+    final String idKey = CHECKPOINT_ID_NAME + "_" + partitionId;
+    final AtomicLong newCheckpointId =
+        GAUGES.computeIfAbsent(
+            idKey,
+            k -> {
+              final AtomicLong newGaugeValue = new AtomicLong(0);
+              io.micrometer.core.instrument.Gauge.builder(
+                      CHECKPOINT_ID_NAME, newGaugeValue, AtomicLong::get)
+                  .description("Id of the last checkpoint")
+                  .tag(LABEL_NAME_PARTITION, partitionId)
+                  .register(METER_REGISTRY);
+              return newGaugeValue;
+            });
+    newCheckpointId.set(checkpointId);
+
     CHECKPOINT_POSITION.labels(partitionId).set(checkpointPosition);
+    final String positionKey = CHECKPOINT_POSITION_NAME + "_" + partitionId;
+    final AtomicLong newCheckpointPosition =
+        GAUGES.computeIfAbsent(
+            positionKey,
+            k -> {
+              final AtomicLong newGaugeValue = new AtomicLong(0);
+              io.micrometer.core.instrument.Gauge.builder(
+                      CHECKPOINT_POSITION_NAME, newGaugeValue, AtomicLong::get)
+                  .description("Position of the last checkpoint")
+                  .tag(LABEL_NAME_PARTITION, partitionId)
+                  .register(METER_REGISTRY);
+              return newGaugeValue;
+            });
+    newCheckpointPosition.set(checkpointPosition);
   }
 
   public void ignored() {
     CHECKPOINT_RECORDS.labels("ignored", partitionId).inc();
+    CHECKPOINT_RECORDS_BUILDER
+        .tags(LABEL_NAME_RESULT, "ignored", LABEL_NAME_PARTITION, partitionId)
+        .register(METER_REGISTRY)
+        .increment();
   }
 }


### PR DESCRIPTION
## Description

Converted the existing Prometheus metrics into Micrometer ones.

## Checklist

TODO BEFORE MERGING

- [ ] Duplicate timers metrics without time units to match the Prometheus histogram ones or update the Grafana dashboard

## Related issues

closes #27083
