### PR TITLE
refactor: adjust Camunda Exporter-specific versioning to 8.8

### DIFF
--- a/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
@@ -216,13 +216,13 @@ class BackupPrioritiesTest {
             "operate-process-8.3.0_",
             "tasklist-form-8.4.0_",
             "tasklist-metric-8.3.0_",
-            "camunda-authorization-8.7.0_",
-            "camunda-group-8.7.0_",
-            "camunda-mapping-8.7.0_",
-            "camunda-web-session-8.7.0_",
-            "camunda-role-8.7.0_",
-            "camunda-tenant-8.7.0_",
-            "camunda-user-8.7.0_");
+            "camunda-authorization-8.8.0_",
+            "camunda-group-8.8.0_",
+            "camunda-mapping-8.8.0_",
+            "camunda-web-session-8.8.0_",
+            "camunda-role-8.8.0_",
+            "camunda-tenant-8.8.0_",
+            "camunda-user-8.8.0_");
 
     // PRIO6
     assertThat(indices.get(7).allIndices())

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/AuthorizationIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/AuthorizationIndex.java
@@ -12,7 +12,7 @@ import io.camunda.webapps.schema.descriptors.usermanagement.UserManagementIndexD
 
 public class AuthorizationIndex extends UserManagementIndexDescriptor implements Prio5Backup {
   public static final String INDEX_NAME = "authorization";
-  public static final String INDEX_VERSION = "8.7.0";
+  public static final String INDEX_VERSION = "8.8.0";
 
   public static final String ID = "id";
   public static final String OWNER_KEY = "ownerKey";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/GroupIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/GroupIndex.java
@@ -15,7 +15,7 @@ import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.Iden
 public class GroupIndex extends UserManagementIndexDescriptor implements Prio5Backup {
 
   public static final String INDEX_NAME = "group";
-  public static final String INDEX_VERSION = "8.7.0";
+  public static final String INDEX_VERSION = "8.8.0";
   public static final String KEY = "key";
   public static final String MEMBER_KEY = "memberKey";
   public static final String NAME = "name";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/MappingIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/MappingIndex.java
@@ -12,7 +12,7 @@ import io.camunda.webapps.schema.descriptors.usermanagement.UserManagementIndexD
 
 public class MappingIndex extends UserManagementIndexDescriptor implements Prio5Backup {
   public static final String INDEX_NAME = "mapping";
-  public static final String INDEX_VERSION = "8.7.0";
+  public static final String INDEX_VERSION = "8.8.0";
 
   public static final String MAPPING_KEY = "mappingKey";
   public static final String CLAIM_NAME = "claimName";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/PersistentWebSessionIndexDescriptor.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/PersistentWebSessionIndexDescriptor.java
@@ -14,7 +14,7 @@ public class PersistentWebSessionIndexDescriptor extends UserManagementIndexDesc
     implements Prio5Backup {
 
   public static final String INDEX_NAME = "web-session";
-  public static final String INDEX_VERSION = "8.7.0";
+  public static final String INDEX_VERSION = "8.8.0";
 
   public PersistentWebSessionIndexDescriptor(
       final String indexPrefix, final boolean isElasticsearch) {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/RoleIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/RoleIndex.java
@@ -14,7 +14,7 @@ import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.Iden
 
 public class RoleIndex extends UserManagementIndexDescriptor implements Prio5Backup {
   public static final String INDEX_NAME = "role";
-  public static final String INDEX_VERSION = "8.7.0";
+  public static final String INDEX_VERSION = "8.8.0";
 
   public static final String KEY = "key";
   public static final String NAME = "name";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/TenantIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/TenantIndex.java
@@ -15,7 +15,7 @@ import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.Enti
 public class TenantIndex extends UserManagementIndexDescriptor implements Prio5Backup {
 
   public static final String INDEX_NAME = "tenant";
-  public static final String INDEX_VERSION = "8.7.0";
+  public static final String INDEX_VERSION = "8.8.0";
 
   public static final String KEY = "key";
   public static final String TENANT_ID = "tenantId";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/UserIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/UserIndex.java
@@ -12,7 +12,7 @@ import io.camunda.webapps.schema.descriptors.usermanagement.UserManagementIndexD
 
 public class UserIndex extends UserManagementIndexDescriptor implements Prio5Backup {
   public static final String INDEX_NAME = "user";
-  public static final String INDEX_VERSION = "8.7.0";
+  public static final String INDEX_VERSION = "8.8.0";
 
   public static final String ID = "id";
   public static final String KEY = "key";

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -165,7 +165,7 @@ public class CamundaExporter implements Exporter {
 
     final var recordVersion = getVersion(record.getBrokerVersion());
 
-    if (recordVersion.major() == 8 && recordVersion.minor() < 7) {
+    if (recordVersion.major() == 8 && recordVersion.minor() < 8) {
       LOG.debug(
           "Skip record with broker version '{}'. Last exported position will be updated to '{}'",
           record.getBrokerVersion(),

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -328,13 +328,13 @@ final class CamundaExporterIT {
         // we verify the names hard coded on purpose
         // to make sure no index will be accidentally dropped, names are changed or added
         .containsExactlyInAnyOrder(
-            "custom-prefix-camunda-authorization-8.7.0_",
-            "custom-prefix-camunda-group-8.7.0_",
-            "custom-prefix-camunda-mapping-8.7.0_",
-            "custom-prefix-camunda-role-8.7.0_",
-            "custom-prefix-camunda-tenant-8.7.0_",
-            "custom-prefix-camunda-user-8.7.0_",
-            "custom-prefix-camunda-web-session-8.7.0_",
+            "custom-prefix-camunda-authorization-8.8.0_",
+            "custom-prefix-camunda-group-8.8.0_",
+            "custom-prefix-camunda-mapping-8.8.0_",
+            "custom-prefix-camunda-role-8.8.0_",
+            "custom-prefix-camunda-tenant-8.8.0_",
+            "custom-prefix-camunda-user-8.8.0_",
+            "custom-prefix-camunda-web-session-8.8.0_",
             "custom-prefix-operate-batch-operation-1.0.0_",
             "custom-prefix-operate-decision-8.3.0_",
             "custom-prefix-operate-decision-instance-8.3.0_",
@@ -424,7 +424,7 @@ final class CamundaExporterIT {
         factory.generateRecord(
             valueType,
             r ->
-                r.withBrokerVersion("8.7.0")
+                r.withBrokerVersion("8.8.0")
                     .withIntent(IncidentIntent.RESOLVED)
                     .withTimestamp(System.currentTimeMillis())
                     .withOperationReference(notExistingOperationReference));
@@ -457,7 +457,7 @@ final class CamundaExporterIT {
         factory.generateRecord(
             valueType,
             r ->
-                r.withBrokerVersion("8.7.0")
+                r.withBrokerVersion("8.8.0")
                     .withIntent(IncidentIntent.RESOLVED)
                     .withTimestamp(invalidTimestamp));
     final var resourceProvider = new DefaultExporterResourceProvider();
@@ -483,7 +483,7 @@ final class CamundaExporterIT {
   }
 
   @TestTemplate
-  void shouldNotExport860RecordButStillUpdateLastExportedPosition(
+  void shouldNotExport870RecordButStillUpdateLastExportedPosition(
       final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
       throws IOException {
     // given
@@ -491,7 +491,7 @@ final class CamundaExporterIT {
     final var record =
         factory.generateRecord(
             ValueType.AUTHORIZATION,
-            r -> r.withBrokerVersion("8.6.0").withPosition(recordPosition));
+            r -> r.withBrokerVersion("8.7.0").withPosition(recordPosition));
 
     final CamundaExporter camundaExporter = new CamundaExporter();
     final var controller = new ExporterTestController();
@@ -549,7 +549,7 @@ final class CamundaExporterIT {
   }
 
   private Record<?> generateRecordWithSupportedBrokerVersion(final ValueType valueType) {
-    return factory.generateRecord(valueType, r -> r.withBrokerVersion("8.7.0"));
+    return factory.generateRecord(valueType, r -> r.withBrokerVersion("8.8.0"));
   }
 
   private static Stream<Arguments> containerProvider() {
@@ -650,7 +650,7 @@ final class CamundaExporterIT {
       final var record =
           factory.generateRecord(
               ValueType.AUTHORIZATION,
-              r -> r.withBrokerVersion("8.7.0").withTimestamp(System.currentTimeMillis()));
+              r -> r.withBrokerVersion("8.8.0").withTimestamp(System.currentTimeMillis()));
 
       camundaExporter.export(record);
 
@@ -691,7 +691,7 @@ final class CamundaExporterIT {
       final var record =
           factory.generateRecord(
               ValueType.AUTHORIZATION,
-              r -> r.withBrokerVersion("8.7.0").withTimestamp(System.currentTimeMillis()));
+              r -> r.withBrokerVersion("8.8.0").withTimestamp(System.currentTimeMillis()));
 
       camundaExporter.export(record);
 
@@ -736,14 +736,14 @@ final class CamundaExporterIT {
       final var record =
           factory.generateRecord(
               ValueType.AUTHORIZATION,
-              r -> r.withBrokerVersion("8.7.0").withTimestamp(System.currentTimeMillis()));
+              r -> r.withBrokerVersion("8.8.0").withTimestamp(System.currentTimeMillis()));
 
       camundaExporter.export(record);
 
       final var record2 =
           factory.generateRecord(
               ValueType.AUTHORIZATION,
-              r -> r.withBrokerVersion("8.7.0").withTimestamp(System.currentTimeMillis()));
+              r -> r.withBrokerVersion("8.8.0").withTimestamp(System.currentTimeMillis()));
 
       // then
       assertThatThrownBy(() -> camundaExporter.export(record2))


### PR DESCRIPTION
## Description

* Changes version of Identity-related entities from 8.7.0 to 8.8.0 - as they will be released with 8.8
* Ensure that the Camunda Exporter exports only records with version >= 8.8

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
