### PR TITLE
fix: Process instances are sometimes not visible in the Operate UI

### DIFF
--- a/operate/importer-8_7/src/main/java/io/camunda/operate/zeebeimport/v8_7/processors/processors/ListViewZeebeRecordProcessor.java
+++ b/operate/importer-8_7/src/main/java/io/camunda/operate/zeebeimport/v8_7/processors/processors/ListViewZeebeRecordProcessor.java
@@ -475,6 +475,11 @@ public class ListViewZeebeRecordProcessor {
     final FlowNodeInstanceForListViewEntity entity = new FlowNodeInstanceForListViewEntity();
 
     final var recordValue = record.getValue();
+    // only execute update if job is on a flownode (not on a process)
+    if (recordValue.getElementInstanceKey() == recordValue.getProcessInstanceKey()) {
+      return;
+    }
+
     final var intentStr = record.getIntent().name();
 
     entity.setKey(record.getValue().getElementInstanceKey());

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateZeebeAbstractIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateZeebeAbstractIT.java
@@ -182,6 +182,10 @@ public abstract class OperateZeebeAbstractIT extends OperateAbstractIT {
   protected Predicate<Object[]> processInstancesAreStartedByProcessId;
 
   @Autowired
+  @Qualifier("listenerJobIsCreated")
+  protected Predicate<Object[]> listenerJobIsCreated;
+
+  @Autowired
   @Qualifier("userTasksAreCreated")
   protected Predicate<Object[]> userTasksAreCreated;
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/ProcessInstanceZeebeImportIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/ProcessInstanceZeebeImportIT.java
@@ -28,6 +28,7 @@ import io.camunda.operate.webapp.rest.dto.listview.ListViewRequestDto;
 import io.camunda.operate.webapp.rest.dto.listview.ListViewResponseDto;
 import io.camunda.operate.webapp.rest.dto.listview.ProcessInstanceStateDto;
 import io.camunda.operate.webapp.rest.dto.listview.VariablesQueryDto;
+import io.camunda.operate.zeebe.ImportValueType;
 import io.camunda.webapps.schema.descriptors.operate.template.VariableTemplate;
 import io.camunda.webapps.schema.entities.operate.FlowNodeInstanceEntity;
 import io.camunda.webapps.schema.entities.operate.FlowNodeState;
@@ -105,6 +106,21 @@ public class ProcessInstanceZeebeImportIT extends OperateZeebeAbstractIT {
     assertThat(allFlowNodeInstances).hasSize(2);
     assertStartFlowNodeCompleted(allFlowNodeInstances.get(0));
     assertFlowNodeIsActive(allFlowNodeInstances.get(1), "taskA");
+  }
+
+  @Test
+  public void processInstanceCreatedIfJobRecordProcessedFirst() {
+    final String processId = "Process_Start_Listener";
+    final Long processDefinitionKey = deployProcess("process-start-listener.bpmn");
+
+    // when
+    final Long processInstanceKey =
+        ZeebeTestUtil.startProcessInstance(camundaClient, processId, null);
+    searchTestRule.processRecordsWithTypeAndWait(
+        ImportValueType.JOB, listenerJobIsCreated, processInstanceKey, processId);
+    searchTestRule.processAllRecordsAndWait(processInstanceIsCreatedCheck, processInstanceKey);
+    final ListViewProcessInstanceDto dto = getSingleProcessInstanceForListView();
+    assertThat(dto.getBpmnProcessId()).isEqualTo(processId);
   }
 
   @Test

--- a/operate/qa/integration-tests/src/test/resources/process-start-listener.bpmn
+++ b/operate/qa/integration-tests/src/test/resources/process-start-listener.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1cl7qw0" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.32.0-nightly.20250116" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="Process_Start_Listener" name="Process Start Listener" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:executionListeners>
+        <zeebe:executionListener eventType="start" type="process_start_listener" />
+      </zeebe:executionListeners>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1qx1uix</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="taskA" name="TaskA">
+      <bpmn:extensionElements />
+      <bpmn:incoming>Flow_1qx1uix</bpmn:incoming>
+      <bpmn:outgoing>Flow_0oy1sg0</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1qx1uix" sourceRef="StartEvent_1" targetRef="taskA" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_0oy1sg0</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0oy1sg0" sourceRef="taskA" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_Start_Listener">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ynw1f5_di" bpmnElement="taskA">
+        <dc:Bounds x="260" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_07a7fy8_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="402" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1qx1uix_di" bpmnElement="Flow_1qx1uix">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="260" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0oy1sg0_di" bpmnElement="Flow_0oy1sg0">
+        <di:waypoint x="360" y="120" />
+        <di:waypoint x="402" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromJobHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewFlowNodeFromJobHandler.java
@@ -48,6 +48,13 @@ public class ListViewFlowNodeFromJobHandler
 
   @Override
   public boolean handlesRecord(final Record<JobRecordValue> record) {
+    // do not handle record if the job is executed on a process instance instead of a flow node
+    // instance
+    final var recordValue = record.getValue();
+    // only execute update if job is on a flownode (not on a process)
+    if (recordValue.getElementInstanceKey() == recordValue.getProcessInstanceKey()) {
+      return false;
+    }
     return true;
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromJobHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewFlowNodeFromJobHandlerTest.java
@@ -45,9 +45,37 @@ public class ListViewFlowNodeFromJobHandlerTest {
   @Test
   public void shouldHandlesRecord() {
     // given
-    final Record<JobRecordValue> jobRecord = factory.generateRecord(ValueType.JOB);
+    final Record<JobRecordValue> jobRecord =
+        factory.generateRecord(
+            r ->
+                r.withValueType(ValueType.JOB)
+                    .withValue(
+                        ImmutableJobRecordValue.builder()
+                            .withProcessDefinitionKey(1L)
+                            .withElementInstanceKey(111L)
+                            .withProcessInstanceKey(222L)
+                            .build())
+                    .withKey(111L));
     // when - then
     assertThat(underTest.handlesRecord(jobRecord)).isTrue();
+  }
+
+  @Test
+  public void shouldNotHandlesRecord() {
+    // given
+    final Record<JobRecordValue> jobRecord =
+        factory.generateRecord(
+            r ->
+                r.withValueType(ValueType.JOB)
+                    .withValue(
+                        ImmutableJobRecordValue.builder()
+                            .withProcessDefinitionKey(1L)
+                            .withElementInstanceKey(111L)
+                            .withProcessInstanceKey(111L)
+                            .build())
+                    .withKey(111L));
+    // when - then
+    assertThat(underTest.handlesRecord(jobRecord)).isFalse();
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Added a check to handlers that update the list-view index from zeebe job records to only do so for jobs that are executed on flow nodes, not on process level.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates to https://github.com/camunda/camunda/issues/24744
