### PR TITLE
fix: Process instances sometimes not visible in Operate [Backport stable/8.7]

### DIFF
--- a/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/v8_6/processors/ListViewZeebeRecordProcessor.java
+++ b/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/v8_6/processors/ListViewZeebeRecordProcessor.java
@@ -644,6 +644,11 @@ public class ListViewZeebeRecordProcessor {
     final FlowNodeInstanceForListViewEntity entity = new FlowNodeInstanceForListViewEntity();
 
     final var recordValue = record.getValue();
+    // only execute update if job is on a flownode (not on a process)
+    if (recordValue.getElementInstanceKey() == recordValue.getProcessInstanceKey()) {
+      return;
+    }
+
     final var intentStr = record.getIntent().name();
 
     entity.setKey(record.getValue().getElementInstanceKey());

--- a/operate/importer-8_7/src/main/java/io/camunda/operate/zeebeimport/processors/ListViewZeebeRecordProcessor.java
+++ b/operate/importer-8_7/src/main/java/io/camunda/operate/zeebeimport/processors/ListViewZeebeRecordProcessor.java
@@ -644,6 +644,10 @@ public class ListViewZeebeRecordProcessor {
     final FlowNodeInstanceForListViewEntity entity = new FlowNodeInstanceForListViewEntity();
 
     final var recordValue = record.getValue();
+    // only execute update if job is on a flownode (not on a process)
+    if (recordValue.getElementInstanceKey() == recordValue.getProcessInstanceKey()) {
+      return;
+    }
     final var intentStr = record.getIntent().name();
 
     entity.setKey(record.getValue().getElementInstanceKey());

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchChecks.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchChecks.java
@@ -27,6 +27,7 @@ import io.camunda.operate.store.NotFoundException;
 import io.camunda.operate.store.elasticsearch.ElasticsearchIncidentStore;
 import io.camunda.operate.webapp.elasticsearch.reader.ProcessInstanceReader;
 import io.camunda.operate.webapp.reader.*;
+import io.camunda.operate.webapp.rest.dto.ListenerRequestDto;
 import io.camunda.operate.webapp.rest.dto.VariableDto;
 import io.camunda.operate.webapp.rest.dto.VariableRequestDto;
 import io.camunda.operate.webapp.rest.dto.listview.ListViewProcessInstanceDto;
@@ -70,6 +71,8 @@ public class ElasticsearchChecks {
 
   @Autowired private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
 
+  @Autowired private ListenerReader listenerReader;
+
   @Autowired private EventTemplate eventTemplate;
 
   @Autowired private VariableTemplate variableTemplate;
@@ -102,7 +105,7 @@ public class ElasticsearchChecks {
       try {
         final ProcessEntity process = processReader.getProcess(processDefinitionKey);
         return process != null;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -124,7 +127,7 @@ public class ElasticsearchChecks {
             io.camunda.operate.qa.util.ElasticsearchUtil.getDocCount(
                 esClient, decisionIndex.getAlias());
         return docCount == count;
-      } catch (IOException ex) {
+      } catch (final IOException ex) {
         return false;
       }
     };
@@ -146,7 +149,7 @@ public class ElasticsearchChecks {
             io.camunda.operate.qa.util.ElasticsearchUtil.getDocCount(
                 esClient, decisionInstanceTemplate.getAlias());
         return docCount == count;
-      } catch (IOException ex) {
+      } catch (final IOException ex) {
         return false;
       }
     };
@@ -182,7 +185,7 @@ public class ElasticsearchChecks {
             return flowNodes.get(0).getState().equals(FlowNodeState.ACTIVE);
           }
         }
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -277,7 +280,7 @@ public class ElasticsearchChecks {
           return flowNodes.get(0).getState().equals(FlowNodeState.ACTIVE)
               && flowNodes.get(0).isIncident();
         }
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -310,7 +313,7 @@ public class ElasticsearchChecks {
           return flowNodes.stream()
               .allMatch(flowNode -> flowNode.getState().equals(FlowNodeState.TERMINATED));
         }
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -341,7 +344,7 @@ public class ElasticsearchChecks {
                   .count()
               >= instancesCount;
         }
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -375,7 +378,7 @@ public class ElasticsearchChecks {
               .map(FlowNodeInstanceEntity::getState)
               .anyMatch(fns -> fns.equals(FlowNodeState.COMPLETED));
         }
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -412,7 +415,7 @@ public class ElasticsearchChecks {
                   .count()
               >= instancesCount;
         }
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -441,7 +444,7 @@ public class ElasticsearchChecks {
           return flowNodes.stream().filter(fn -> fn.getState().equals(FlowNodeState.ACTIVE)).count()
               >= instancesCount;
         }
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -465,7 +468,7 @@ public class ElasticsearchChecks {
                 .filter(a -> a.getFlowNodeId().equals(flowNodeId))
                 .collect(Collectors.toList());
         return flowNodes.size() >= instancesCount;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -491,13 +494,13 @@ public class ElasticsearchChecks {
           return flowNodes.stream().filter(fn -> fn.getState().equals(FlowNodeState.ACTIVE)).count()
               >= instancesCount;
         }
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
   }
 
-  public List<FlowNodeInstanceEntity> getAllFlowNodeInstances(Long processInstanceKey) {
+  public List<FlowNodeInstanceEntity> getAllFlowNodeInstances(final Long processInstanceKey) {
     final TermQueryBuilder processInstanceKeyQuery =
         termQuery(FlowNodeInstanceTemplate.PROCESS_INSTANCE_KEY, processInstanceKey);
     final SearchRequest searchRequest =
@@ -508,12 +511,12 @@ public class ElasticsearchChecks {
                     .sort(FlowNodeInstanceTemplate.POSITION, SortOrder.ASC));
     try {
       return scroll(searchRequest, FlowNodeInstanceEntity.class, objectMapper, esClient);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new RuntimeException(e);
     }
   }
 
-  public List<EventEntity> getAllEvents(Long processInstanceKey) {
+  public List<EventEntity> getAllEvents(final Long processInstanceKey) {
     final TermQueryBuilder processInstanceKeyQuery =
         termQuery(FlowNodeInstanceTemplate.PROCESS_INSTANCE_KEY, processInstanceKey);
     final SearchRequest searchRequest =
@@ -521,7 +524,7 @@ public class ElasticsearchChecks {
             .source(new SearchSourceBuilder().query(constantScoreQuery(processInstanceKeyQuery)));
     try {
       return scroll(searchRequest, EventEntity.class, objectMapper, esClient);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new RuntimeException(e);
     }
   }
@@ -535,7 +538,7 @@ public class ElasticsearchChecks {
                     .sort(FlowNodeInstanceTemplate.POSITION, SortOrder.ASC));
     try {
       return scroll(searchRequest, FlowNodeInstanceEntity.class, objectMapper, esClient);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new RuntimeException(e);
     }
   }
@@ -557,7 +560,7 @@ public class ElasticsearchChecks {
       try {
         final List<VariableEntity> variables = getAllVariables(processInstanceKey);
         return variables.stream().anyMatch(v -> v.getName().equals(varName));
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -576,7 +579,7 @@ public class ElasticsearchChecks {
       try {
         return null
             != variableReader.getVariableByName(processInstanceKey + "", scopeKey + "", varName);
-      } catch (OperateRuntimeException ex) {
+      } catch (final OperateRuntimeException ex) {
         return false;
       }
     };
@@ -597,13 +600,13 @@ public class ElasticsearchChecks {
             variableReader
                 .getVariableByName(processInstanceKey + "", "" + scopeKey, varName)
                 .getValue());
-      } catch (OperateRuntimeException ex) {
+      } catch (final OperateRuntimeException ex) {
         return false;
       }
     };
   }
 
-  public List<VariableEntity> getAllVariables(Long processInstanceKey) {
+  public List<VariableEntity> getAllVariables(final Long processInstanceKey) {
     final TermQueryBuilder processInstanceKeyQuery =
         termQuery(VariableTemplate.PROCESS_INSTANCE_KEY, processInstanceKey);
     final SearchRequest searchRequest =
@@ -611,7 +614,7 @@ public class ElasticsearchChecks {
             .source(new SearchSourceBuilder().query(constantScoreQuery(processInstanceKeyQuery)));
     try {
       return scroll(searchRequest, VariableEntity.class, objectMapper, esClient);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new RuntimeException(e);
     }
   }
@@ -638,7 +641,7 @@ public class ElasticsearchChecks {
         final List<VariableDto> variables = getVariables(processInstanceKey, scopeKey);
         return variables.stream()
             .anyMatch(v -> v.getName().equals(varName) && v.getValue().equals(varValue));
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -671,7 +674,7 @@ public class ElasticsearchChecks {
           found = allIncidents.size() > 0;
         }
         return found;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -703,7 +706,7 @@ public class ElasticsearchChecks {
                   > 0;
         }
         return found;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -722,7 +725,7 @@ public class ElasticsearchChecks {
       final Long count = (Long) objects[0];
       try {
         return getActiveIncidentsCount() == count && getPendingIncidentsCount() == 0;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -741,7 +744,7 @@ public class ElasticsearchChecks {
       final Integer count = (Integer) objects[0];
       try {
         return getPostImporterQueueCount() == count;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -755,7 +758,7 @@ public class ElasticsearchChecks {
     try {
       final SearchResponse response = esClient.search(searchRequest, RequestOptions.DEFAULT);
       return response.getHits().getTotalHits().value;
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new RuntimeException(e);
     }
   }
@@ -769,7 +772,7 @@ public class ElasticsearchChecks {
     try {
       final SearchResponse response = esClient.search(searchRequest, RequestOptions.DEFAULT);
       return response.getHits().getTotalHits().value;
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new RuntimeException(e);
     }
   }
@@ -781,12 +784,12 @@ public class ElasticsearchChecks {
     try {
       final SearchResponse response = esClient.search(searchRequest, RequestOptions.DEFAULT);
       return response.getHits().getTotalHits().value;
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new RuntimeException(e);
     }
   }
 
-  public long getActiveIncidentsCount(Long processInstanceKey) {
+  public long getActiveIncidentsCount(final Long processInstanceKey) {
     final SearchRequest searchRequest =
         ElasticsearchUtil.createSearchRequest(incidentTemplate)
             .source(
@@ -798,12 +801,12 @@ public class ElasticsearchChecks {
     try {
       final SearchResponse response = esClient.search(searchRequest, RequestOptions.DEFAULT);
       return response.getHits().getTotalHits().value;
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new RuntimeException(e);
     }
   }
 
-  public long getIncidentsCount(Long processInstanceKey, IncidentState state) {
+  public long getIncidentsCount(final Long processInstanceKey, final IncidentState state) {
     final SearchRequest searchRequest =
         ElasticsearchUtil.createSearchRequest(incidentTemplate)
             .source(
@@ -815,12 +818,12 @@ public class ElasticsearchChecks {
     try {
       final SearchResponse response = esClient.search(searchRequest, RequestOptions.DEFAULT);
       return response.getHits().getTotalHits().value;
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new RuntimeException(e);
     }
   }
 
-  public long getIncidentsCount(String bpmnProcessId, IncidentState state) {
+  public long getIncidentsCount(final String bpmnProcessId, final IncidentState state) {
     final SearchRequest searchRequest =
         ElasticsearchUtil.createSearchRequest(incidentTemplate)
             .source(
@@ -831,7 +834,7 @@ public class ElasticsearchChecks {
     try {
       final SearchResponse response = esClient.search(searchRequest, RequestOptions.DEFAULT);
       return response.getHits().getTotalHits().value;
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new RuntimeException(e);
     }
   }
@@ -842,7 +845,7 @@ public class ElasticsearchChecks {
    * @param processInstanceKey
    * @return
    */
-  public long getIncidentsCount(Long processInstanceKey) {
+  public long getIncidentsCount(final Long processInstanceKey) {
     final SearchRequest searchRequest =
         ElasticsearchUtil.createSearchRequest(incidentTemplate)
             .source(
@@ -851,7 +854,7 @@ public class ElasticsearchChecks {
     try {
       final SearchResponse response = esClient.search(searchRequest, RequestOptions.DEFAULT);
       return response.getHits().getTotalHits().value;
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new RuntimeException(e);
     }
   }
@@ -868,7 +871,7 @@ public class ElasticsearchChecks {
     try {
       final SearchResponse response = esClient.search(searchRequest, RequestOptions.DEFAULT);
       return response.getHits().getTotalHits().value;
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new RuntimeException(e);
     }
   }
@@ -889,7 +892,7 @@ public class ElasticsearchChecks {
       final int incidentsCount = (int) objects[1];
       try {
         return getActiveIncidentsCount(processInstanceKey) == incidentsCount;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -911,7 +914,7 @@ public class ElasticsearchChecks {
       final int incidentsCount = (int) objects[1];
       try {
         return getIncidentsCount(bpmnProcessId, IncidentState.ACTIVE) == incidentsCount;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -933,7 +936,7 @@ public class ElasticsearchChecks {
       final int incidentsCount = (int) objects[1];
       try {
         return getIncidentsCount(processInstanceKey) == incidentsCount;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -953,7 +956,7 @@ public class ElasticsearchChecks {
       final int incidentsCount = (int) objects[0];
       try {
         return getIncidentsCount() == incidentsCount;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -974,7 +977,7 @@ public class ElasticsearchChecks {
         final List<FlowNodeInstanceEntity> allActivityInstances =
             getAllFlowNodeInstances(processInstanceKey);
         return allActivityInstances.stream().noneMatch(ai -> ai.isIncident());
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -996,7 +999,7 @@ public class ElasticsearchChecks {
       try {
         return getIncidentsCount(processInstanceKey, IncidentState.RESOLVED)
             == resolvedIncidentsCount;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -1017,7 +1020,7 @@ public class ElasticsearchChecks {
         final ProcessInstanceForListViewEntity instance =
             processInstanceReader.getProcessInstanceByKey(processInstanceKey);
         return instance.getState().equals(ProcessInstanceState.CANCELED);
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -1037,7 +1040,7 @@ public class ElasticsearchChecks {
       try {
         processInstanceReader.getProcessInstanceByKey(processInstanceKey);
         return true;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -1058,7 +1061,7 @@ public class ElasticsearchChecks {
         final ProcessInstanceForListViewEntity instance =
             processInstanceReader.getProcessInstanceByKey(processInstanceKey);
         return instance.getState().equals(ProcessInstanceState.COMPLETED);
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -1216,9 +1219,25 @@ public class ElasticsearchChecks {
       try {
         final List<UserTaskEntity> userTasks = userTaskReader.getUserTasks();
         return userTasks.size() == count;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
+    };
+  }
+
+  @Bean(name = "listenerJobIsCreated")
+  public Predicate<Object[]> getListenerJobIsCreatedCheck() {
+    return objects -> {
+      assertThat(objects).hasSize(2);
+      assertThat(objects[0]).isInstanceOf(Long.class);
+      assertThat(objects[1]).isInstanceOf(String.class);
+      final long processInstanceId = (long) objects[0];
+      final String flowNodeId = (String) objects[1];
+      final ListenerRequestDto dto = new ListenerRequestDto().setFlowNodeId(flowNodeId);
+      return listenerReader
+              .getListenerExecutions(Long.toString(processInstanceId), dto)
+              .getTotalCount()
+          > 0;
     };
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchChecks.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchChecks.java
@@ -34,6 +34,7 @@ import io.camunda.operate.store.NotFoundException;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
 import io.camunda.operate.webapp.elasticsearch.reader.ProcessInstanceReader;
 import io.camunda.operate.webapp.reader.*;
+import io.camunda.operate.webapp.rest.dto.ListenerRequestDto;
 import io.camunda.operate.webapp.rest.dto.VariableDto;
 import io.camunda.operate.webapp.rest.dto.VariableRequestDto;
 import io.camunda.operate.webapp.rest.dto.listview.ListViewProcessInstanceDto;
@@ -63,6 +64,8 @@ public class OpensearchChecks {
   @Autowired private ProcessReader processReader;
   @Autowired private ProcessInstanceReader processInstanceReader;
   @Autowired private FlowNodeInstanceReader flowNodeInstanceReader;
+
+  @Autowired private ListenerReader listenerReader;
 
   @Autowired private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
 
@@ -98,7 +101,7 @@ public class OpensearchChecks {
       try {
         final ProcessEntity process = processReader.getProcess(processDefinitionKey);
         return process != null;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -170,7 +173,7 @@ public class OpensearchChecks {
             return flowNodes.get(0).getState().equals(FlowNodeState.ACTIVE);
           }
         }
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -242,7 +245,7 @@ public class OpensearchChecks {
           return flowNodes.get(0).getState().equals(FlowNodeState.ACTIVE)
               && flowNodes.get(0).isIncident();
         }
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -275,7 +278,7 @@ public class OpensearchChecks {
           return flowNodes.stream()
               .allMatch(flowNode -> flowNode.getState().equals(FlowNodeState.TERMINATED));
         }
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -306,7 +309,7 @@ public class OpensearchChecks {
                   .count()
               >= instancesCount;
         }
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -340,7 +343,7 @@ public class OpensearchChecks {
               .map(FlowNodeInstanceEntity::getState)
               .anyMatch(fns -> fns.equals(FlowNodeState.COMPLETED));
         }
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -377,7 +380,7 @@ public class OpensearchChecks {
                   .count()
               >= instancesCount;
         }
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -406,7 +409,7 @@ public class OpensearchChecks {
           return flowNodes.stream().filter(fn -> fn.getState().equals(FlowNodeState.ACTIVE)).count()
               >= instancesCount;
         }
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -430,7 +433,7 @@ public class OpensearchChecks {
                 .filter(a -> a.getFlowNodeId().equals(flowNodeId))
                 .collect(Collectors.toList());
         return flowNodes.size() >= instancesCount;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -456,13 +459,13 @@ public class OpensearchChecks {
           return flowNodes.stream().filter(fn -> fn.getState().equals(FlowNodeState.ACTIVE)).count()
               >= instancesCount;
         }
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
   }
 
-  public List<FlowNodeInstanceEntity> getAllFlowNodeInstances(Long processInstanceKey) {
+  public List<FlowNodeInstanceEntity> getAllFlowNodeInstances(final Long processInstanceKey) {
     final var searchRequestBuilder =
         searchRequestBuilder(flowNodeInstanceTemplate)
             .query(
@@ -475,7 +478,7 @@ public class OpensearchChecks {
         .scrollValues(searchRequestBuilder, FlowNodeInstanceEntity.class);
   }
 
-  public List<EventEntity> getAllEvents(Long processInstanceKey) {
+  public List<EventEntity> getAllEvents(final Long processInstanceKey) {
     return richOpenSearchClient
         .doc()
         .scrollValues(
@@ -513,7 +516,7 @@ public class OpensearchChecks {
       try {
         final List<VariableEntity> variables = getAllVariables(processInstanceKey);
         return variables.stream().anyMatch(v -> v.getName().equals(varName));
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -532,7 +535,7 @@ public class OpensearchChecks {
       try {
         return null
             != variableReader.getVariableByName(processInstanceKey + "", scopeKey + "", varName);
-      } catch (OperateRuntimeException ex) {
+      } catch (final OperateRuntimeException ex) {
         return false;
       }
     };
@@ -553,13 +556,13 @@ public class OpensearchChecks {
             variableReader
                 .getVariableByName(processInstanceKey + "", "" + scopeKey, varName)
                 .getValue());
-      } catch (OperateRuntimeException ex) {
+      } catch (final OperateRuntimeException ex) {
         return false;
       }
     };
   }
 
-  public List<VariableEntity> getAllVariables(Long processInstanceKey) {
+  public List<VariableEntity> getAllVariables(final Long processInstanceKey) {
     return richOpenSearchClient
         .doc()
         .scrollValues(
@@ -590,7 +593,7 @@ public class OpensearchChecks {
         final List<VariableDto> variables = getVariables(processInstanceKey, scopeKey);
         return variables.stream()
             .anyMatch(v -> v.getName().equals(varName) && v.getValue().equals(varValue));
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -623,7 +626,7 @@ public class OpensearchChecks {
           found = allIncidents.size() > 0;
         }
         return found;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -655,7 +658,7 @@ public class OpensearchChecks {
                   > 0;
         }
         return found;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -674,7 +677,7 @@ public class OpensearchChecks {
       final Long count = (Long) objects[0];
       try {
         return getActiveIncidentsCount() == count && getPendingIncidentsCount() == 0;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -693,7 +696,7 @@ public class OpensearchChecks {
       final Integer count = (Integer) objects[0];
       try {
         return getPostImporterQueueCount() == count;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -719,7 +722,7 @@ public class OpensearchChecks {
         .docCount(searchRequestBuilder(postImporterQueueTemplate).query(matchAll()));
   }
 
-  public long getActiveIncidentsCount(Long processInstanceKey) {
+  public long getActiveIncidentsCount(final Long processInstanceKey) {
     return richOpenSearchClient
         .doc()
         .docCount(
@@ -727,7 +730,7 @@ public class OpensearchChecks {
                 .query(and(ACTIVE_INCIDENT_QUERY, term(PROCESS_INSTANCE_KEY, processInstanceKey))));
   }
 
-  public long getIncidentsCount(Long processInstanceKey, IncidentState state) {
+  public long getIncidentsCount(final Long processInstanceKey, final IncidentState state) {
     return richOpenSearchClient
         .doc()
         .docCount(
@@ -738,7 +741,7 @@ public class OpensearchChecks {
                         term(PROCESS_INSTANCE_KEY, processInstanceKey))));
   }
 
-  public long getIncidentsCount(String bpmnProcessId, IncidentState state) {
+  public long getIncidentsCount(final String bpmnProcessId, final IncidentState state) {
     return richOpenSearchClient
         .doc()
         .docCount(
@@ -752,7 +755,7 @@ public class OpensearchChecks {
    * @param processInstanceKey
    * @return
    */
-  public long getIncidentsCount(Long processInstanceKey) {
+  public long getIncidentsCount(final Long processInstanceKey) {
     return richOpenSearchClient
         .doc()
         .docCount(
@@ -787,7 +790,7 @@ public class OpensearchChecks {
       final int incidentsCount = (int) objects[1];
       try {
         return getActiveIncidentsCount(processInstanceKey) == incidentsCount;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -809,7 +812,7 @@ public class OpensearchChecks {
       final int incidentsCount = (int) objects[1];
       try {
         return getIncidentsCount(bpmnProcessId, IncidentState.ACTIVE) == incidentsCount;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -831,7 +834,7 @@ public class OpensearchChecks {
       final int incidentsCount = (int) objects[1];
       try {
         return getIncidentsCount(processInstanceKey) == incidentsCount;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -851,7 +854,7 @@ public class OpensearchChecks {
       final int incidentsCount = (int) objects[0];
       try {
         return getIncidentsCount() == incidentsCount;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -872,7 +875,7 @@ public class OpensearchChecks {
         final List<FlowNodeInstanceEntity> allActivityInstances =
             getAllFlowNodeInstances(processInstanceKey);
         return allActivityInstances.stream().noneMatch(ai -> ai.isIncident());
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -894,7 +897,7 @@ public class OpensearchChecks {
       try {
         return getIncidentsCount(processInstanceKey, IncidentState.RESOLVED)
             == resolvedIncidentsCount;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -915,7 +918,7 @@ public class OpensearchChecks {
         final ProcessInstanceForListViewEntity instance =
             processInstanceReader.getProcessInstanceByKey(processInstanceKey);
         return instance.getState().equals(ProcessInstanceState.CANCELED);
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -935,7 +938,7 @@ public class OpensearchChecks {
       try {
         processInstanceReader.getProcessInstanceByKey(processInstanceKey);
         return true;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -956,7 +959,7 @@ public class OpensearchChecks {
         final ProcessInstanceForListViewEntity instance =
             processInstanceReader.getProcessInstanceByKey(processInstanceKey);
         return instance.getState().equals(ProcessInstanceState.COMPLETED);
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
     };
@@ -1137,9 +1140,25 @@ public class OpensearchChecks {
       try {
         final List<UserTaskEntity> userTasks = userTaskReader.getUserTasks();
         return userTasks.size() == count;
-      } catch (NotFoundException ex) {
+      } catch (final NotFoundException ex) {
         return false;
       }
+    };
+  }
+
+  @Bean(name = "listenerJobIsCreated")
+  public Predicate<Object[]> getListenerJobIsCreatedCheck() {
+    return objects -> {
+      assertThat(objects).hasSize(2);
+      assertThat(objects[0]).isInstanceOf(long.class);
+      assertThat(objects[1]).isInstanceOf(String.class);
+      final long processInstanceId = (long) objects[0];
+      final String flowNodeId = (String) objects[1];
+      final ListenerRequestDto dto = new ListenerRequestDto().setFlowNodeId(flowNodeId);
+      return listenerReader
+              .getListenerExecutions(Long.toString(processInstanceId), dto)
+              .getTotalCount()
+          > 0;
     };
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateZeebeAbstractIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateZeebeAbstractIT.java
@@ -182,6 +182,10 @@ public abstract class OperateZeebeAbstractIT extends OperateAbstractIT {
   protected Predicate<Object[]> processInstancesAreStartedByProcessId;
 
   @Autowired
+  @Qualifier("listenerJobIsCreated")
+  protected Predicate<Object[]> listenerJobIsCreated;
+
+  @Autowired
   @Qualifier("userTasksAreCreated")
   protected Predicate<Object[]> userTasksAreCreated;
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/ProcessInstanceZeebeImportIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/ProcessInstanceZeebeImportIT.java
@@ -38,6 +38,7 @@ import io.camunda.operate.webapp.rest.dto.listview.ListViewRequestDto;
 import io.camunda.operate.webapp.rest.dto.listview.ListViewResponseDto;
 import io.camunda.operate.webapp.rest.dto.listview.ProcessInstanceStateDto;
 import io.camunda.operate.webapp.rest.dto.listview.VariablesQueryDto;
+import io.camunda.operate.zeebe.ImportValueType;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.time.OffsetDateTime;
@@ -102,6 +103,21 @@ public class ProcessInstanceZeebeImportIT extends OperateZeebeAbstractIT {
     assertThat(allFlowNodeInstances).hasSize(2);
     assertStartFlowNodeCompleted(allFlowNodeInstances.get(0));
     assertFlowNodeIsActive(allFlowNodeInstances.get(1), "taskA");
+  }
+
+  @Test
+  public void processInstanceCreatedIfJobRecordProcessedFirst() {
+    final String processId = "Process_Start_Listener";
+    final Long processDefinitionKey = deployProcess("process-start-listener.bpmn");
+
+    // when
+    final Long processInstanceKey =
+        ZeebeTestUtil.startProcessInstance(zeebeClient, processId, null);
+    searchTestRule.processRecordsWithTypeAndWait(
+        ImportValueType.JOB, listenerJobIsCreated, processInstanceKey, processId);
+    searchTestRule.processAllRecordsAndWait(processInstanceIsCreatedCheck, processInstanceKey);
+    final ListViewProcessInstanceDto dto = getSingleProcessInstanceForListView();
+    assertThat(dto.getBpmnProcessId()).isEqualTo(processId);
   }
 
   @Test

--- a/operate/qa/integration-tests/src/test/resources/process-start-listener.bpmn
+++ b/operate/qa/integration-tests/src/test/resources/process-start-listener.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1cl7qw0" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.32.0-nightly.20250116" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="Process_Start_Listener" name="Process Start Listener" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:executionListeners>
+        <zeebe:executionListener eventType="start" type="process_start_listener" />
+      </zeebe:executionListeners>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1qx1uix</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="taskA" name="TaskA">
+      <bpmn:extensionElements />
+      <bpmn:incoming>Flow_1qx1uix</bpmn:incoming>
+      <bpmn:outgoing>Flow_0oy1sg0</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1qx1uix" sourceRef="StartEvent_1" targetRef="taskA" />
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_0oy1sg0</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0oy1sg0" sourceRef="taskA" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_Start_Listener">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ynw1f5_di" bpmnElement="taskA">
+        <dc:Bounds x="260" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_07a7fy8_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="402" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1qx1uix_di" bpmnElement="Flow_1qx1uix">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="260" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0oy1sg0_di" bpmnElement="Flow_0oy1sg0">
+        <di:waypoint x="360" y="120" />
+        <di:waypoint x="402" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Added a check to handlers that update the list-view index from zeebe job records to only do so for jobs that are executed on flow nodes, not on process level.

Backport of https://github.com/camunda/camunda/pull/27294

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates to https://github.com/camunda/camunda/issues/24744
