### PR TITLE
27144 migrate all prometheus metrics in zeebe workflow engine

### DIFF
--- a/zeebe/engine/pom.xml
+++ b/zeebe/engine/pom.xml
@@ -291,6 +291,11 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <version>1.13.1</version>
+    </dependency>
 
   </dependencies>
 

--- a/zeebe/engine/pom.xml
+++ b/zeebe/engine/pom.xml
@@ -102,11 +102,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
@@ -276,7 +271,6 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
-      <scope>test</scope>
     </dependency>
 
     <dependency>
@@ -290,11 +284,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-core</artifactId>
-      <version>1.13.1</version>
     </dependency>
 
   </dependencies>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/BannedInstanceMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/BannedInstanceMetrics.java
@@ -14,23 +14,23 @@ public final class BannedInstanceMetrics {
   private static final io.micrometer.core.instrument.MeterRegistry METER_REGISTRY =
       Metrics.globalRegistry;
 
-  private final AtomicInteger BANNED_INSTANCES_COUNTER = new AtomicInteger(0);
+  private final AtomicInteger bannedInstancesCounter = new AtomicInteger(0);
 
   public BannedInstanceMetrics(final int partitionId) {
     final String partitionIdLabel = String.valueOf(partitionId);
 
     io.micrometer.core.instrument.Gauge.builder(
-            "zeebe_banned_instances_total", BANNED_INSTANCES_COUNTER, AtomicInteger::get)
+            "zeebe_banned_instances_total", bannedInstancesCounter, AtomicInteger::get)
         .description("Number of banned instances.")
         .tags("partition", partitionIdLabel)
         .register(METER_REGISTRY);
   }
 
   public void countBannedInstance() {
-    BANNED_INSTANCES_COUNTER.incrementAndGet();
+    bannedInstancesCounter.incrementAndGet();
   }
 
   public void setBannedInstanceCounter(final int counter) {
-    BANNED_INSTANCES_COUNTER.set(counter);
+    bannedInstancesCounter.set(counter);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/BannedInstanceMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/BannedInstanceMetrics.java
@@ -7,29 +7,30 @@
  */
 package io.camunda.zeebe.engine.metrics;
 
-import io.prometheus.client.Gauge;
+import io.micrometer.core.instrument.Metrics;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public final class BannedInstanceMetrics {
+  private static final io.micrometer.core.instrument.MeterRegistry METER_REGISTRY =
+      Metrics.globalRegistry;
 
-  private static final Gauge BANNED_INSTANCES_COUNTER =
-      Gauge.build()
-          .namespace("zeebe")
-          .name("banned_instances_total")
-          .help("Number of banned instances")
-          .labelNames("partition")
-          .register();
-
-  private final String partitionIdLabel;
+  private final AtomicInteger BANNED_INSTANCES_COUNTER = new AtomicInteger(0);
 
   public BannedInstanceMetrics(final int partitionId) {
-    partitionIdLabel = String.valueOf(partitionId);
+    final String partitionIdLabel = String.valueOf(partitionId);
+
+    io.micrometer.core.instrument.Gauge.builder(
+            "zeebe_banned_instances_total", BANNED_INSTANCES_COUNTER, AtomicInteger::get)
+        .description("Number of banned instances.")
+        .tags("partition", partitionIdLabel)
+        .register(METER_REGISTRY);
   }
 
   public void countBannedInstance() {
-    BANNED_INSTANCES_COUNTER.labels(partitionIdLabel).inc();
+    BANNED_INSTANCES_COUNTER.incrementAndGet();
   }
 
   public void setBannedInstanceCounter(final int counter) {
-    BANNED_INSTANCES_COUNTER.labels(partitionIdLabel).set(counter);
+    BANNED_INSTANCES_COUNTER.set(counter);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/BufferedMessagesMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/BufferedMessagesMetrics.java
@@ -7,25 +7,26 @@
  */
 package io.camunda.zeebe.engine.metrics;
 
-import io.prometheus.client.Gauge;
+import io.micrometer.core.instrument.Metrics;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class BufferedMessagesMetrics {
+  private static final io.micrometer.core.instrument.MeterRegistry METER_REGISTRY =
+      Metrics.globalRegistry;
 
-  private static final Gauge BUFFERED_MESSAGES_COUNT =
-      Gauge.build()
-          .namespace("zeebe")
-          .name("buffered_messages_count")
-          .help("Current number of buffered messages.")
-          .labelNames("partition")
-          .register();
-
-  private final String partitionIdLabel;
+  private final AtomicInteger BUFFERED_MESSAGES_COUNT = new AtomicInteger(0);
 
   public BufferedMessagesMetrics(final int partitionId) {
-    partitionIdLabel = String.valueOf(partitionId);
+    final String partitionIdLabel = String.valueOf(partitionId);
+
+    io.micrometer.core.instrument.Gauge.builder(
+            "zeebe_buffered_messages_count", BUFFERED_MESSAGES_COUNT, AtomicInteger::get)
+        .description("Current number of buffered messages.")
+        .tags("partition", partitionIdLabel)
+        .register(METER_REGISTRY);
   }
 
   public void setBufferedMessagesCounter(final long counter) {
-    BUFFERED_MESSAGES_COUNT.labels(partitionIdLabel).set((int) counter);
+    BUFFERED_MESSAGES_COUNT.set((int) counter);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/BufferedMessagesMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/BufferedMessagesMetrics.java
@@ -14,19 +14,19 @@ public class BufferedMessagesMetrics {
   private static final io.micrometer.core.instrument.MeterRegistry METER_REGISTRY =
       Metrics.globalRegistry;
 
-  private final AtomicInteger BUFFERED_MESSAGES_COUNT = new AtomicInteger(0);
+  private final AtomicInteger bufferedMessageCount = new AtomicInteger(0);
 
   public BufferedMessagesMetrics(final int partitionId) {
     final String partitionIdLabel = String.valueOf(partitionId);
 
     io.micrometer.core.instrument.Gauge.builder(
-            "zeebe_buffered_messages_count", BUFFERED_MESSAGES_COUNT, AtomicInteger::get)
+            "zeebe_buffered_messages_count", bufferedMessageCount, AtomicInteger::get)
         .description("Current number of buffered messages.")
         .tags("partition", partitionIdLabel)
         .register(METER_REGISTRY);
   }
 
   public void setBufferedMessagesCounter(final long counter) {
-    BUFFERED_MESSAGES_COUNT.set((int) counter);
+    bufferedMessageCount.set((int) counter);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/IncidentMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/IncidentMetrics.java
@@ -7,44 +7,42 @@
  */
 package io.camunda.zeebe.engine.metrics;
 
-import io.prometheus.client.Counter;
-import io.prometheus.client.Gauge;
+import io.micrometer.core.instrument.Metrics;
+import java.util.concurrent.atomic.AtomicLong;
 
 public final class IncidentMetrics {
-
-  private static final Counter INCIDENT_EVENTS =
-      Counter.build()
-          .namespace("zeebe")
-          .name("incident_events_total")
-          .help("Number of incident events")
-          .labelNames("action", "partition")
-          .register();
-
-  private static final Gauge PENDING_INCIDENTS =
-      Gauge.build()
-          .namespace("zeebe")
-          .name("pending_incidents_total")
-          .help("Number of pending incidents")
-          .labelNames("partition")
-          .register();
+  static final io.micrometer.core.instrument.Counter.Builder INCIDENT_EVENTS_BUILDER =
+      io.micrometer.core.instrument.Counter.builder("zeebe_incident_events_total")
+          .description("Number of incident events");
+  private static final io.micrometer.core.instrument.MeterRegistry METER_REGISTRY =
+      Metrics.globalRegistry;
+  private static final AtomicLong PENDING_INCIDENTS = new AtomicLong(0);
 
   private final String partitionIdLabel;
 
   public IncidentMetrics(final int partitionId) {
     partitionIdLabel = String.valueOf(partitionId);
+    io.micrometer.core.instrument.Gauge.builder(
+            "zeebe_pending_incidents_total", PENDING_INCIDENTS, AtomicLong::get)
+        .description("Number of pending incidents")
+        .tags("partition", partitionIdLabel)
+        .register(METER_REGISTRY);
   }
 
   private void incidentEvent(final String action) {
-    INCIDENT_EVENTS.labels(action, partitionIdLabel).inc();
+    INCIDENT_EVENTS_BUILDER
+        .tags("action", action, "partition", partitionIdLabel)
+        .register(METER_REGISTRY)
+        .increment();
   }
 
   public void incidentCreated() {
     incidentEvent("created");
-    PENDING_INCIDENTS.labels(partitionIdLabel).inc();
+    PENDING_INCIDENTS.incrementAndGet();
   }
 
   public void incidentResolved() {
     incidentEvent("resolved");
-    PENDING_INCIDENTS.labels(partitionIdLabel).dec();
+    PENDING_INCIDENTS.decrementAndGet();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Metrics;
 
 public final class ProcessEngineMetrics {
@@ -67,10 +68,11 @@ public final class ProcessEngineMetrics {
             ? CreationMode.CREATION_AT_GIVEN_ELEMENT
             : CreationMode.CREATION_AT_DEFAULT_START_EVENT;
 
-    CREATED_PROCESS_INSTANCES_BUILDER
-        .tags(PARTITION_LABEL, partitionIdLabel, CREATION_MODE_LABEL, creationMode.toString())
-        .register(METER_REGISTRY)
-        .increment();
+    final Counter counter =
+        CREATED_PROCESS_INSTANCES_BUILDER
+            .tags(PARTITION_LABEL, partitionIdLabel, CREATION_MODE_LABEL, creationMode.toString())
+            .register(METER_REGISTRY);
+    counter.increment();
   }
 
   private void elementInstanceEvent(
@@ -80,7 +82,7 @@ public final class ProcessEngineMetrics {
             ACTION_LABEL,
             action,
             TYPE_LABEL,
-            "ROOT_PROCESS_INSTANCE",
+            elementType.name(),
             PARTITION_LABEL,
             partitionIdLabel,
             EVENT_TYPE,
@@ -164,7 +166,7 @@ public final class ProcessEngineMetrics {
             PARTITION_LABEL,
             partitionIdLabel)
         .register(METER_REGISTRY)
-        .increment();
+        .increment(amount);
   }
 
   private String extractEventTypeName(final BpmnEventType eventType) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/JobMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/JobMetricsTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.metrics;
 
-import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -21,9 +20,12 @@ import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import io.micrometer.core.instrument.ImmutableTag;
+import io.micrometer.core.instrument.Tag;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -230,12 +232,14 @@ public class JobMetricsTest {
   }
 
   private static Double jobMetric(final String action, final String type, final JobKind jobKind) {
-    return MetricsTestHelper.readMetricValue(
-        "zeebe_job_events_total",
-        entry("action", action),
-        entry("partition", "1"),
-        entry("type", type),
-        entry("job_kind", jobKind.name()));
+    final List<Tag> tags =
+        List.of(
+            new ImmutableTag("action", action),
+            new ImmutableTag("partition", "0"),
+            new ImmutableTag("type", type),
+            new ImmutableTag("kind", jobKind.name()));
+
+    return MetricsTestHelper.readMetricValue("zeebe_job_events_total", tags);
   }
 
   record JobMetricsTestScenario(JobKind jobKind, BpmnModelInstance process) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/MetricsTestHelper.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/MetricsTestHelper.java
@@ -7,10 +7,8 @@
  */
 package io.camunda.zeebe.engine.metrics;
 
-import io.prometheus.client.CollectorRegistry;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map.Entry;
+// import io.prometheus.client.CollectorRegistry;
+import io.micrometer.core.instrument.Tag;
 
 final class MetricsTestHelper {
 
@@ -20,26 +18,17 @@ final class MetricsTestHelper {
    * <p>This uses the defaultRegistry which is inefficient, so this should only be used in testing.
    *
    * @param name the name of the metric
-   * @param labels names and values for labels. This is useful for filtering the right value within
-   *     the metric.
+   * @param tags names and values for labels or tags. This is useful for filtering the right value
+   *     within the metric.
    * @return the given value or null if it doesn't exist
    */
-  @SafeVarargs
-  static Double readMetricValue(final String name, final Entry<String, String>... labels) {
-    final List<String> labelNames = Arrays.stream(labels).map(Entry::getKey).toList();
-    final List<String> labelValues = Arrays.stream(labels).map(Entry::getValue).toList();
-    return CollectorRegistry.defaultRegistry.getSampleValue(
-        name, labelNames.toArray(new String[] {}), labelValues.toArray(new String[] {}));
-  }
-
   //  @SafeVarargs
-  //  static Double readMetricValue(final String name, final Entry<String, String>... labels) {
-  //    final List<String> labelNames = Arrays.stream(labels).map(Entry::getKey).toList();
-  //    final List<String> labelValues = Arrays.stream(labels).map(Entry::getValue).toList();
-  //    final var metric = Metrics.globalRegistry.get(name);
-  //    final RequiredSearch search = metric.tags(labels);
-  //    search.
-  //    return MeterRegistry.defaultRegistry.getSampleValue(
-  //        name, labelNames.toArray(new String[] {}), labelValues.toArray(new String[] {}));
-  //  }
+  static Double readMetricValue(final String name, final Iterable<Tag> tags) {
+    final var metric = io.micrometer.core.instrument.Metrics.globalRegistry.get(name).tags(tags);
+    if (metric != null) {
+      return metric.counter().count();
+    }
+
+    return null;
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/MetricsTestHelper.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/MetricsTestHelper.java
@@ -31,4 +31,15 @@ final class MetricsTestHelper {
     return CollectorRegistry.defaultRegistry.getSampleValue(
         name, labelNames.toArray(new String[] {}), labelValues.toArray(new String[] {}));
   }
+
+  //  @SafeVarargs
+  //  static Double readMetricValue(final String name, final Entry<String, String>... labels) {
+  //    final List<String> labelNames = Arrays.stream(labels).map(Entry::getKey).toList();
+  //    final List<String> labelValues = Arrays.stream(labels).map(Entry::getValue).toList();
+  //    final var metric = Metrics.globalRegistry.get(name);
+  //    final RequiredSearch search = metric.tags(labels);
+  //    search.
+  //    return MeterRegistry.defaultRegistry.getSampleValue(
+  //        name, labelNames.toArray(new String[] {}), labelValues.toArray(new String[] {}));
+  //  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetricsTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.metrics;
 
-import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
@@ -17,6 +16,9 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import io.micrometer.core.instrument.ImmutableTag;
+import io.micrometer.core.instrument.Tag;
+import java.util.List;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -34,9 +36,10 @@ public class ProcessEngineMetricsTest {
 
   @Before
   public void resetMetrics() {
-    ProcessEngineMetrics.EVALUATED_DMN_ELEMENTS.clear();
-    ProcessEngineMetrics.EXECUTED_INSTANCES.clear();
-    ProcessEngineMetrics.CREATED_PROCESS_INSTANCES.clear();
+
+    //    ProcessEngineMetrics.EVALUATED_DMN_ELEMENTS_BUILDER.clear();
+    //    ProcessEngineMetrics.EXECUTED_INSTANCES_BUILDER.clear();
+    //    ProcessEngineMetrics.CREATED_PROCESS_INSTANCES_BUILDER.clear();
   }
 
   @Test
@@ -195,19 +198,21 @@ public class ProcessEngineMetricsTest {
   }
 
   private Double executedProcessInstanceMetric(final String action) {
-    return MetricsTestHelper.readMetricValue(
-        "zeebe_executed_instances_total",
-        entry("organizationId", "null"),
-        entry("type", "ROOT_PROCESS_INSTANCE"),
-        entry("action", action),
-        entry("partition", "1"));
+    final List<Tag> tags =
+        List.of(
+            new ImmutableTag("organizationId", "null"),
+            new ImmutableTag("type", "ROOT_PROCESS_INSTANCE"),
+            new ImmutableTag("action", action),
+            new ImmutableTag("partition", "1"));
+
+    return MetricsTestHelper.readMetricValue("zeebe_executed_instances_total", tags);
   }
 
   private Double processInstanceCreationsMetric(final String creationMode) {
-    return MetricsTestHelper.readMetricValue(
-        "zeebe_process_instance_creations_total",
-        entry("partition", "1"),
-        entry("creation_mode", creationMode));
+    final List<Tag> tags =
+        List.of(
+            new ImmutableTag("partition", "1"), new ImmutableTag("creation_mode", creationMode));
+    return MetricsTestHelper.readMetricValue("zeebe_process_instance_creations_total", tags);
   }
 
   private Double succeededEvaluatedDmnElementsMetric() {
@@ -219,10 +224,11 @@ public class ProcessEngineMetricsTest {
   }
 
   private Double evaluatedDmnElementsMetric(final String action) {
-    return MetricsTestHelper.readMetricValue(
-        "zeebe_evaluated_dmn_elements_total",
-        entry("organizationId", "null"),
-        entry("action", action),
-        entry("partition", "1"));
+    final List<Tag> tags =
+        List.of(
+            new ImmutableTag("organizationId", "null"),
+            new ImmutableTag("action", action),
+            new ImmutableTag("partition", "1"));
+    return MetricsTestHelper.readMetricValue("zeebe_evaluated_dmn_elements_total", tags);
   }
 }


### PR DESCRIPTION
## Description

Converted the existing Prometheus metrics into Micrometer ones.

## Checklist

TODO BEFORE MERGING
- [ ] Make unit tests pass
- [ ] Duplicate timers metrics without time units to match the Prometheus histogram ones or update the Grafana dashboard

## Related issues

closes #27144
