### PR TITLE
Migrate all Prometheus metrics in zeebe-scheduler

### DIFF
--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -33,10 +33,6 @@ management.endpoint.health.enabled=true
 management.endpoint.health.show-details=always
 management.health.defaults.enabled=false
 # Metrics related configurations
-management.simple.metrics.export.enabled=true
-management.endpoint.metrics.enabled=true
-
-
 management.endpoint.prometheus.enabled=true
 management.prometheus.metrics.export.enabled=true
 # Allow runtime configuration of log levels
@@ -69,7 +65,6 @@ camunda.security.initialization.users[0].email=demo@demo.com
 spring.servlet.multipart.max-file-size=4MB
 spring.servlet.multipart.max-request-size=4MB
 
-<<<<<<< Updated upstream
 #
 # RDBMS extension default properties
 #
@@ -82,7 +77,3 @@ spring.datasource.url=${camunda.database.url:}
 spring.datasource.username=${camunda.database.username:}
 spring.datasource.password=${camunda.database.password:}
 mybatis.mapper-locations: classpath:mapper/**/*-mapper.xml
-=======
-# disable global Liquibase setup to only opt-in to module-specific liquibase schemas
-spring.liquibase.enabled=false
->>>>>>> Stashed changes

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -33,6 +33,10 @@ management.endpoint.health.enabled=true
 management.endpoint.health.show-details=always
 management.health.defaults.enabled=false
 # Metrics related configurations
+management.simple.metrics.export.enabled=true
+management.endpoint.metrics.enabled=true
+
+
 management.endpoint.prometheus.enabled=true
 management.prometheus.metrics.export.enabled=true
 # Allow runtime configuration of log levels
@@ -65,6 +69,7 @@ camunda.security.initialization.users[0].email=demo@demo.com
 spring.servlet.multipart.max-file-size=4MB
 spring.servlet.multipart.max-request-size=4MB
 
+<<<<<<< Updated upstream
 #
 # RDBMS extension default properties
 #
@@ -77,3 +82,7 @@ spring.datasource.url=${camunda.database.url:}
 spring.datasource.username=${camunda.database.username:}
 spring.datasource.password=${camunda.database.password:}
 mybatis.mapper-locations: classpath:mapper/**/*-mapper.xml
+=======
+# disable global Liquibase setup to only opt-in to module-specific liquibase schemas
+spring.liquibase.enabled=false
+>>>>>>> Stashed changes

--- a/zeebe/scheduler/pom.xml
+++ b/zeebe/scheduler/pom.xml
@@ -81,7 +81,6 @@
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
-      <version>1.13.8</version>
     </dependency>
 
   </dependencies>

--- a/zeebe/scheduler/pom.xml
+++ b/zeebe/scheduler/pom.xml
@@ -78,6 +78,11 @@
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <version>1.13.8</version>
+    </dependency>
 
   </dependencies>
   <build>

--- a/zeebe/scheduler/pom.xml
+++ b/zeebe/scheduler/pom.xml
@@ -31,10 +31,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
       <scope>provided</scope>

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorMetrics.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorMetrics.java
@@ -13,6 +13,9 @@ import io.prometheus.client.Histogram;
 
 final class ActorMetrics {
 
+  private static final io.micrometer.core.instrument.MeterRegistry meterRegistry =
+      io.micrometer.core.instrument.Metrics.globalRegistry;
+
   private static final Histogram EXECUTION_LATENCY =
       Histogram.build()
           // goes up to ~26 seconds while being more fine-grained in the <5ms range.
@@ -40,6 +43,11 @@ final class ActorMetrics {
           .labelNames("actorName")
           .register();
 
+  private static final io.micrometer.core.instrument.Counter MICRO_EXECUTION_COUNT =
+      io.micrometer.core.instrument.Counter.builder("zeebe_actor_task_execution_count_micro")
+          .description("Number of times a certain actor task was executed successfully")
+          .register(meterRegistry);
+
   private static final Gauge JOB_QUEUE_LENGTH =
       Gauge.build()
           .namespace("zeebe")
@@ -63,6 +71,9 @@ final class ActorMetrics {
   void countExecution(final String name) {
     if (enabled) {
       EXECUTION_COUNT.labels(name).inc();
+      meterRegistry
+          .counter("zeebe_actor_task_execution_count_micro", "actorName", name)
+          .increment();
     }
   }
 

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThread.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThread.java
@@ -104,9 +104,12 @@ public class ActorThread extends Thread implements Consumer<Runnable> {
 
     if (currentTask != null) {
       final var actorName = currentTask.actor.getName();
-      try (final var timer = actorMetrics.startExecutionTimer(actorName)) {
-        executeCurrentTask();
+      final var timerSample = actorMetrics.startExecutionTimer();
+      executeCurrentTask();
+      if (timerSample != null) {
+        actorMetrics.stopExecutionTimer(timerSample, actorName);
       }
+
       if (actorMetrics.isEnabled()) {
         actorMetrics.updateJobQueueLength(actorName, currentTask.estimateQueueLength());
         actorMetrics.countExecution(actorName);


### PR DESCRIPTION
## Description

Converted the existing Prometheus metrics into Micrometer ones.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
TODO BEFORE MERGING
- [ ] Duplicate timers metrics without time units to match the Prometheus histogram ones or update the Grafana dashboard

## Related issues

closes #27150
