### PR TITLE
Remove OWNER_TYPE_BY_OWNER_KEY column family and related methods

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationAddPermissionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationAddPermissionProcessor.java
@@ -48,7 +48,6 @@ public final class AuthorizationAddPermissionProcessor
   public void processNewCommand(final TypedRecord<AuthorizationRecord> command) {
     permissionsBehavior
         .isAuthorized(command)
-        .flatMap(permissionsBehavior::ownerExists)
         .flatMap(permissionsBehavior::hasValidPermissionTypes)
         .flatMap(permissionsBehavior::permissionAlreadyExists)
         .ifRightOrLeft(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationRemovePermissionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationRemovePermissionProcessor.java
@@ -48,7 +48,6 @@ public final class AuthorizationRemovePermissionProcessor
   public void processNewCommand(final TypedRecord<AuthorizationRecord> command) {
     permissionsBehavior
         .isAuthorized(command)
-        .flatMap(permissionsBehavior::ownerExists)
         .flatMap(permissionsBehavior::permissionDoesNotExist)
         .ifRightOrLeft(
             authorizationRecord -> writeEventAndDistribute(command, authorizationRecord),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -54,24 +54,6 @@ public class PermissionsBehavior {
     return authCheckBehavior.isAuthorized(authorizationRequest).map(unused -> command.getValue());
   }
 
-  public Either<Rejection, AuthorizationRecord> ownerExists(
-      final AuthorizationRecord authorizationRecord) {
-    final var ownerKey = authorizationRecord.getOwnerKey();
-
-    return authorizationState
-        .getOwnerType(ownerKey)
-        .map(
-            ownerType -> {
-              authorizationRecord.setOwnerType(ownerType);
-              return Either.<Rejection, AuthorizationRecord>right(authorizationRecord);
-            })
-        .orElseGet(
-            () ->
-                Either.left(
-                    new Rejection(
-                        RejectionType.NOT_FOUND, OWNER_NOT_FOUND_MESSAGE.formatted(ownerKey))));
-  }
-
   public Either<Rejection, AuthorizationRecord> permissionAlreadyExists(
       final AuthorizationRecord record) {
     for (final PermissionValue permission : record.getPermissions()) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -270,8 +270,8 @@ public final class EventAppliers implements EventApplier {
   }
 
   private void registerUserAppliers(final MutableProcessingState state) {
-    register(UserIntent.CREATED, new UserCreatedApplier(state));
-    register(UserIntent.UPDATED, new UserUpdatedApplier(state));
+    register(UserIntent.CREATED, new UserCreatedApplier(state.getUserState()));
+    register(UserIntent.UPDATED, new UserUpdatedApplier(state.getUserState()));
     register(UserIntent.DELETED, new UserDeletedApplier(state));
   }
 
@@ -508,9 +508,7 @@ public final class EventAppliers implements EventApplier {
   }
 
   private void registerRoleAppliers(final MutableProcessingState state) {
-    register(
-        RoleIntent.CREATED,
-        new RoleCreatedApplier(state.getRoleState(), state.getAuthorizationState()));
+    register(RoleIntent.CREATED, new RoleCreatedApplier(state.getRoleState()));
     register(RoleIntent.UPDATED, new RoleUpdatedApplier(state.getRoleState()));
     register(RoleIntent.ENTITY_ADDED, new RoleEntityAddedApplier(state));
     register(RoleIntent.ENTITY_REMOVED, new RoleEntityRemovedApplier(state));
@@ -520,9 +518,7 @@ public final class EventAppliers implements EventApplier {
   }
 
   private void registerGroupAppliers(final MutableProcessingState state) {
-    register(
-        GroupIntent.CREATED,
-        new GroupCreatedApplier(state.getGroupState(), state.getAuthorizationState()));
+    register(GroupIntent.CREATED, new GroupCreatedApplier(state.getGroupState()));
     register(GroupIntent.UPDATED, new GroupUpdatedApplier(state.getGroupState()));
     register(GroupIntent.ENTITY_ADDED, new GroupEntityAddedApplier(state));
     register(GroupIntent.ENTITY_REMOVED, new GroupEntityRemovedApplier(state));
@@ -538,9 +534,7 @@ public final class EventAppliers implements EventApplier {
   }
 
   private void registerTenantAppliers(final MutableProcessingState state) {
-    register(
-        TenantIntent.CREATED,
-        new TenantCreatedApplier(state.getTenantState(), state.getAuthorizationState()));
+    register(TenantIntent.CREATED, new TenantCreatedApplier(state.getTenantState()));
     register(TenantIntent.UPDATED, new TenantUpdatedApplier(state.getTenantState()));
     register(TenantIntent.ENTITY_ADDED, new TenantEntityAddedApplier(state));
     register(TenantIntent.ENTITY_REMOVED, new TenantEntityRemovedApplier(state));
@@ -550,9 +544,7 @@ public final class EventAppliers implements EventApplier {
   }
 
   private void registerMappingAppliers(final MutableProcessingState state) {
-    register(
-        MappingIntent.CREATED,
-        new MappingCreatedApplier(state.getMappingState(), state.getAuthorizationState()));
+    register(MappingIntent.CREATED, new MappingCreatedApplier(state.getMappingState()));
     register(MappingIntent.DELETED, new MappingDeletedApplier(state));
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupCreatedApplier.java
@@ -8,26 +8,20 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
-import io.camunda.zeebe.engine.state.mutable.MutableAuthorizationState;
 import io.camunda.zeebe.engine.state.mutable.MutableGroupState;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
-import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 
 public class GroupCreatedApplier implements TypedEventApplier<GroupIntent, GroupRecord> {
 
   private final MutableGroupState groupState;
-  private final MutableAuthorizationState authorizationState;
 
-  public GroupCreatedApplier(
-      final MutableGroupState groupState, final MutableAuthorizationState authorizationState) {
+  public GroupCreatedApplier(final MutableGroupState groupState) {
     this.groupState = groupState;
-    this.authorizationState = authorizationState;
   }
 
   @Override
   public void applyState(final long key, final GroupRecord value) {
     groupState.create(key, value);
-    authorizationState.insertOwnerTypeByKey(key, AuthorizationOwnerType.GROUP);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupDeletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupDeletedApplier.java
@@ -36,7 +36,6 @@ public class GroupDeletedApplier implements TypedEventApplier<GroupIntent, Group
     // delete group from authorization state
     authorizationState.deleteAuthorizationsByOwnerTypeAndIdPrefix(
         AuthorizationOwnerType.GROUP, groupId);
-    authorizationState.deleteOwnerTypeByKey(groupKey);
 
     // delete group from group state
     groupState.delete(groupKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MappingCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MappingCreatedApplier.java
@@ -8,26 +8,20 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
-import io.camunda.zeebe.engine.state.mutable.MutableAuthorizationState;
 import io.camunda.zeebe.engine.state.mutable.MutableMappingState;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.record.intent.MappingIntent;
-import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 
 public class MappingCreatedApplier implements TypedEventApplier<MappingIntent, MappingRecord> {
 
   private final MutableMappingState mappingState;
-  private final MutableAuthorizationState authorizationState;
 
-  public MappingCreatedApplier(
-      final MutableMappingState mappingState, final MutableAuthorizationState authorizationState) {
+  public MappingCreatedApplier(final MutableMappingState mappingState) {
     this.mappingState = mappingState;
-    this.authorizationState = authorizationState;
   }
 
   @Override
   public void applyState(final long key, final MappingRecord value) {
     mappingState.create(value);
-    authorizationState.insertOwnerTypeByKey(value.getMappingKey(), AuthorizationOwnerType.MAPPING);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MappingDeletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MappingDeletedApplier.java
@@ -39,7 +39,6 @@ public class MappingDeletedApplier implements TypedEventApplier<MappingIntent, M
               value.getMappingKey()));
     }
     // remove mapping from authorization state
-    authorizationState.deleteOwnerTypeByKey(mappingKey);
     authorizationState.deleteAuthorizationsByOwnerTypeAndIdPrefix(
         AuthorizationOwnerType.MAPPING, mappingId);
     mappingState.delete(mappingKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleCreatedApplier.java
@@ -8,26 +8,20 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
-import io.camunda.zeebe.engine.state.mutable.MutableAuthorizationState;
 import io.camunda.zeebe.engine.state.mutable.MutableRoleState;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
-import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 
 public class RoleCreatedApplier implements TypedEventApplier<RoleIntent, RoleRecord> {
 
   private final MutableRoleState roleState;
-  private final MutableAuthorizationState authorizationState;
 
-  public RoleCreatedApplier(
-      final MutableRoleState roleState, final MutableAuthorizationState authorizationState) {
+  public RoleCreatedApplier(final MutableRoleState roleState) {
     this.roleState = roleState;
-    this.authorizationState = authorizationState;
   }
 
   @Override
   public void applyState(final long key, final RoleRecord value) {
     roleState.create(value);
-    authorizationState.insertOwnerTypeByKey(value.getRoleKey(), AuthorizationOwnerType.ROLE);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleDeletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleDeletedApplier.java
@@ -27,14 +27,12 @@ public class RoleDeletedApplier implements TypedEventApplier<RoleIntent, RoleRec
 
   @Override
   public void applyState(final long key, final RoleRecord value) {
-    final var roleKey = value.getRoleKey();
-    // TODO: refactor when Mapping Rules use String-based IDs
-    final var roleId = String.valueOf(roleKey);
-
     // delete role from authorization state
+    // TODO: refactor when Mapping Rules use String-based IDs
+    final var roleId = String.valueOf(value.getRoleKey());
     authorizationState.deleteAuthorizationsByOwnerTypeAndIdPrefix(
         AuthorizationOwnerType.ROLE, roleId);
-    authorizationState.deleteOwnerTypeByKey(roleKey);
+
     roleState.delete(value);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantCreatedApplier.java
@@ -8,26 +8,20 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
-import io.camunda.zeebe.engine.state.mutable.MutableAuthorizationState;
 import io.camunda.zeebe.engine.state.mutable.MutableTenantState;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
-import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 
 public class TenantCreatedApplier implements TypedEventApplier<TenantIntent, TenantRecord> {
 
   private final MutableTenantState tenantState;
-  private final MutableAuthorizationState authorizationState;
 
-  public TenantCreatedApplier(
-      final MutableTenantState tenantState, final MutableAuthorizationState authorizationState) {
+  public TenantCreatedApplier(final MutableTenantState tenantState) {
     this.tenantState = tenantState;
-    this.authorizationState = authorizationState;
   }
 
   @Override
   public void applyState(final long key, final TenantRecord value) {
     tenantState.createTenant(value);
-    authorizationState.insertOwnerTypeByKey(value.getTenantKey(), AuthorizationOwnerType.TENANT);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantDeletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantDeletedApplier.java
@@ -26,15 +26,10 @@ public class TenantDeletedApplier implements TypedEventApplier<TenantIntent, Ten
 
   @Override
   public void applyState(final long key, final TenantRecord tenantRecord) {
-    final var tenantKey = tenantRecord.getTenantKey();
     final var tenantId = tenantRecord.getTenantId();
-    deleteTenantAuthorizations(tenantKey, tenantId);
-    tenantState.delete(tenantRecord);
-  }
-
-  private void deleteTenantAuthorizations(final long tenantKey, final String tenantId) {
     authorizationState.deleteAuthorizationsByOwnerTypeAndIdPrefix(
         AuthorizationOwnerType.TENANT, tenantId);
-    authorizationState.deleteOwnerTypeByKey(tenantKey);
+
+    tenantState.delete(tenantRecord);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserCreatedApplier.java
@@ -8,26 +8,20 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
-import io.camunda.zeebe.engine.state.mutable.MutableAuthorizationState;
-import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableUserState;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
-import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 
 public class UserCreatedApplier implements TypedEventApplier<UserIntent, UserRecord> {
 
   private final MutableUserState userState;
-  private final MutableAuthorizationState authorizationState;
 
-  public UserCreatedApplier(final MutableProcessingState processingState) {
-    userState = processingState.getUserState();
-    authorizationState = processingState.getAuthorizationState();
+  public UserCreatedApplier(final MutableUserState userState) {
+    this.userState = userState;
   }
 
   @Override
   public void applyState(final long key, final UserRecord value) {
     userState.create(value);
-    authorizationState.insertOwnerTypeByKey(value.getUserKey(), AuthorizationOwnerType.USER);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserDeletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserDeletedApplier.java
@@ -29,7 +29,6 @@ public class UserDeletedApplier implements TypedEventApplier<UserIntent, UserRec
     final var username = value.getUsername();
     authorizationState.deleteAuthorizationsByOwnerTypeAndIdPrefix(
         AuthorizationOwnerType.USER, username);
-    authorizationState.deleteOwnerTypeByKey(value.getUserKey());
     userState.delete(username);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserUpdatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserUpdatedApplier.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
-import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableUserState;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
@@ -17,8 +16,8 @@ public class UserUpdatedApplier implements TypedEventApplier<UserIntent, UserRec
 
   private final MutableUserState userState;
 
-  public UserUpdatedApplier(final MutableProcessingState processingState) {
-    userState = processingState.getUserState();
+  public UserUpdatedApplier(final MutableUserState userState) {
+    this.userState = userState;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AuthorizationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AuthorizationState.java
@@ -22,6 +22,4 @@ public interface AuthorizationState {
       final String ownerId,
       AuthorizationResourceType resourceType,
       final PermissionType permissionType);
-
-  Optional<AuthorizationOwnerType> getOwnerType(final long ownerKey);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableAuthorizationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableAuthorizationState.java
@@ -62,14 +62,6 @@ public interface MutableAuthorizationState extends AuthorizationState {
       Set<String> resourceIds);
 
   /**
-   * Stores the owner type for a new owner in the state.
-   *
-   * @param ownerKey the key of the owner
-   * @param ownerType the type of the owner
-   */
-  void insertOwnerTypeByKey(final long ownerKey, final AuthorizationOwnerType ownerType);
-
-  /**
    * Removes all permissions for the provided ownerKey.
    *
    * @param ownerType the type of the owner of the authorizations
@@ -77,11 +69,4 @@ public interface MutableAuthorizationState extends AuthorizationState {
    */
   void deleteAuthorizationsByOwnerTypeAndIdPrefix(
       final AuthorizationOwnerType ownerType, final String ownerId);
-
-  /**
-   * Removes the owner type for the provided ownerKey.
-   *
-   * @param ownerKey the key of the owner
-   */
-  void deleteOwnerTypeByKey(final long ownerKey);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationTest.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
 import org.junit.rules.TestWatcher;
 
 public class AddPermissionAuthorizationTest {
@@ -73,6 +74,8 @@ public class AddPermissionAuthorizationTest {
             tuple(PermissionType.DELETE_PROCESS, Set.of("bar")));
   }
 
+  // TODO: we should decide if we refactor or remove this test with the GitHub issue specified below
+  @Disabled("https://github.com/camunda/camunda/issues/27344")
   @Test
   public void shouldRejectIfNoOwnerExists() {
     // given no user

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationTest.java
@@ -25,7 +25,6 @@ import java.util.Set;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.jupiter.api.Disabled;
 import org.junit.rules.TestWatcher;
 
 public class AddPermissionAuthorizationTest {
@@ -75,7 +74,7 @@ public class AddPermissionAuthorizationTest {
   }
 
   // TODO: we should decide if we refactor or remove this test with the GitHub issue specified below
-  @Disabled("https://github.com/camunda/camunda/issues/27344")
+  @Ignore("https://github.com/camunda/camunda/issues/27344")
   @Test
   public void shouldRejectIfNoOwnerExists() {
     // given no user

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -743,13 +743,14 @@ public class AuthorizationCheckBehaviorTest {
     final var resourceId = UUID.randomUUID().toString();
     engine
         .authorization()
-        .permission()
+        .newAuthorization()
         .withOwnerKey(roleKey)
         .withOwnerId(String.valueOf(roleKey))
-        .withOwnerType(AuthorizationOwnerType.GROUP)
+        .withOwnerType(AuthorizationOwnerType.ROLE)
         .withResourceType(resourceType)
-        .withPermission(permissionType, resourceId)
-        .add();
+        .withResourceId(resourceId)
+        .withPermissions(permissionType)
+        .create();
     final var command = mockCommandWithMapping(claimName, claimValue);
 
     // when

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RemovePermissionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RemovePermissionAuthorizationTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.Set;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
 import org.junit.rules.TestWatcher;
 
 public class RemovePermissionAuthorizationTest {
@@ -84,6 +85,8 @@ public class RemovePermissionAuthorizationTest {
             tuple(PermissionType.DELETE_PROCESS, Set.of("bar")));
   }
 
+  // TODO: we should decide if we refactor or remove this test with the GitHub issue specified below
+  @Disabled("https://github.com/camunda/camunda/issues/27344")
   @Test
   public void shouldRejectIfNoOwnerExists() {
     // given no user

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RemovePermissionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RemovePermissionAuthorizationTest.java
@@ -21,9 +21,9 @@ import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.Set;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.jupiter.api.Disabled;
 import org.junit.rules.TestWatcher;
 
 public class RemovePermissionAuthorizationTest {
@@ -86,7 +86,7 @@ public class RemovePermissionAuthorizationTest {
   }
 
   // TODO: we should decide if we refactor or remove this test with the GitHub issue specified below
-  @Disabled("https://github.com/camunda/camunda/issues/27344")
+  @Ignore("https://github.com/camunda/camunda/issues/27344")
   @Test
   public void shouldRejectIfNoOwnerExists() {
     // given no user

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/GroupAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/GroupAppliersTest.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.engine.state.mutable.MutableAuthorizationState;
 import io.camunda.zeebe.engine.state.mutable.MutableGroupState;
 import io.camunda.zeebe.engine.state.mutable.MutableMappingState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -31,7 +30,6 @@ public class GroupAppliersTest {
   private MutableProcessingState processingState;
 
   private MutableGroupState groupState;
-  private MutableAuthorizationState authorizationState;
   private MutableUserState userState;
   private MutableMappingState mappingState;
 
@@ -44,11 +42,10 @@ public class GroupAppliersTest {
   @BeforeEach
   public void setup() {
     groupState = processingState.getGroupState();
-    authorizationState = processingState.getAuthorizationState();
     userState = processingState.getUserState();
     mappingState = processingState.getMappingState();
 
-    groupCreatedApplier = new GroupCreatedApplier(groupState, authorizationState);
+    groupCreatedApplier = new GroupCreatedApplier(groupState);
     groupUpdatedApplier = new GroupUpdatedApplier(groupState);
     groupEntityAddedApplier = new GroupEntityAddedApplier(processingState);
     groupEntityRemovedApplier = new GroupEntityRemovedApplier(processingState);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
@@ -98,8 +98,6 @@ public class MappingAppliersTest {
             .setEntityType(EntityType.MAPPING);
     groupState.create(groupKey, group);
     groupState.addEntity(groupKey, group);
-    // create owner
-    authorizationState.insertOwnerTypeByKey(mappingKey, AuthorizationOwnerType.MAPPING);
     // create authorization
     authorizationState.createOrAddPermission(
         AuthorizationOwnerType.MAPPING,
@@ -113,7 +111,6 @@ public class MappingAppliersTest {
 
     // then
     assertThat(mappingState.get(mappingKey)).isEmpty();
-    assertThat(authorizationState.getOwnerType(mappingKey)).isEmpty();
     assertThat(
             authorizationState.getResourceIdentifiers(
                 AuthorizationOwnerType.MAPPING,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/RoleAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/RoleAppliersTest.java
@@ -111,7 +111,6 @@ public class RoleAppliersTest {
     final String roleName = "foo";
     final var roleRecord = new RoleRecord().setRoleKey(roleKey).setName(roleName);
     roleState.create(roleRecord);
-    authorizationState.insertOwnerTypeByKey(roleKey, AuthorizationOwnerType.ROLE);
     authorizationState.createOrAddPermission(
         AuthorizationOwnerType.ROLE,
         roleName,
@@ -124,8 +123,6 @@ public class RoleAppliersTest {
 
     // then
     assertThat(roleState.getRole(roleKey)).isEmpty();
-    final var ownerType = authorizationState.getOwnerType(roleKey);
-    assertThat(ownerType).isEmpty();
     final var resourceIdentifiers =
         authorizationState.getResourceIdentifiers(
             AuthorizationOwnerType.ROLE,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
@@ -114,8 +114,6 @@ public class TenantAppliersTest {
 
     // then
     assertThat(tenantState.getTenantByKey(tenantKey)).isEmpty();
-    final var ownerType = authorizationState.getOwnerType(tenantKey);
-    assertThat(ownerType).isEmpty();
     final var resourceIdentifiers =
         authorizationState.getResourceIdentifiers(
             AuthorizationOwnerType.TENANT,
@@ -193,7 +191,7 @@ public class TenantAppliersTest {
             .setTenantKey(tenantKey)
             .setTenantId(tenantId)
             .setName("Tenant-" + tenantId);
-    new TenantCreatedApplier(tenantState, authorizationState).applyState(tenantKey, tenantRecord);
+    new TenantCreatedApplier(tenantState).applyState(tenantKey, tenantRecord);
     return tenantRecord;
   }
 
@@ -205,7 +203,7 @@ public class TenantAppliersTest {
             .setName("User-" + username)
             .setEmail(username + "@test.com")
             .setPassword("password");
-    new UserCreatedApplier(processingState).applyState(userKey, userRecord);
+    new UserCreatedApplier(userState).applyState(userKey, userRecord);
   }
 
   private void associateUserWithTenant(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserDeletedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserDeletedApplierTest.java
@@ -52,8 +52,6 @@ public class UserDeletedApplierTest {
             .setPassword("password");
     userState.create(userRecord);
 
-    authorizationState.insertOwnerTypeByKey(userRecord.getUserKey(), AuthorizationOwnerType.USER);
-
     authorizationState.createOrAddPermission(
         AuthorizationOwnerType.USER,
         userRecord.getUsername(),
@@ -67,11 +65,6 @@ public class UserDeletedApplierTest {
         DECISION_DEFINITION,
         DELETE,
         Set.of("definition1"));
-
-    final var ownerType = authorizationState.getOwnerType(userRecord.getUserKey());
-
-    assertThat(ownerType).isPresent();
-    assertThat(ownerType.get()).isEqualTo(AuthorizationOwnerType.USER);
 
     assertThat(
             authorizationState.getResourceIdentifiers(
@@ -89,7 +82,6 @@ public class UserDeletedApplierTest {
     userDeletedApplier.applyState(userRecord.getUserKey(), userRecord);
 
     // then
-    assertThat(authorizationState.getOwnerType(userRecord.getUserKey())).isEmpty();
     assertThat(
             authorizationState.getResourceIdentifiers(
                 AuthorizationOwnerType.USER, userRecord.getUsername(), PROCESS_DEFINITION, CREATE))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
@@ -8,9 +8,7 @@
 package io.camunda.zeebe.engine.state.authorization;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.zeebe.db.ZeebeDbInconsistentException;
 import io.camunda.zeebe.engine.state.mutable.MutableAuthorizationState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
@@ -199,51 +197,6 @@ public class AuthorizationStateTest {
 
     // then
     assertThat(resourceIds1).isNotEqualTo(resourceIds2);
-  }
-
-  @Test
-  void shouldInsertOwnerTypeByKey() {
-    // given
-    final var ownerKey = 1L;
-    final var ownerType = AuthorizationOwnerType.USER;
-
-    // when
-    authorizationState.insertOwnerTypeByKey(ownerKey, ownerType);
-
-    // then
-    final var persistedOwnerType = authorizationState.getOwnerType(ownerKey);
-    assertThat(persistedOwnerType).contains(ownerType);
-  }
-
-  @Test
-  void shouldNotInsertOwnerTypeByKeyTwice() {
-    // given
-    final var ownerKey = 1L;
-    final var ownerType = AuthorizationOwnerType.USER;
-
-    // when
-    authorizationState.insertOwnerTypeByKey(ownerKey, ownerType);
-
-    // then
-    assertThatThrownBy(() -> authorizationState.insertOwnerTypeByKey(ownerKey, ownerType))
-        .isInstanceOf(ZeebeDbInconsistentException.class)
-        .hasMessageContaining(
-            "Key DbLong{1} in ColumnFamily OWNER_TYPE_BY_OWNER_KEY already exists");
-  }
-
-  @Test
-  void shouldRemoveOwnerTypeByKey() {
-    // given
-    final var ownerKey = 1L;
-    final var ownerType = AuthorizationOwnerType.USER;
-    authorizationState.insertOwnerTypeByKey(ownerKey, ownerType);
-
-    // when
-    authorizationState.deleteOwnerTypeByKey(ownerKey);
-
-    // then
-    final var persistedOwnerType = authorizationState.getOwnerType(ownerKey);
-    assertThat(persistedOwnerType).isEmpty();
   }
 
   @Test

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -192,6 +192,7 @@ public enum ZbColumnFamilies implements EnumValue {
 
   @Deprecated
   AUTHORIZATION_KEY_BY_RESOURCE_ID(94),
+  @Deprecated
   OWNER_TYPE_BY_OWNER_KEY(95),
 
   ROUTING(96),

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AddPermissionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AddPermissionsTest.java
@@ -16,7 +16,6 @@ import io.camunda.client.protocol.rest.PermissionTypeEnum;
 import io.camunda.client.protocol.rest.ResourceTypeEnum;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
-import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -25,6 +24,7 @@ import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @ZeebeIntegration
@@ -65,12 +65,15 @@ public class AddPermissionsTest {
             .getLast()
             .getValue();
     assertThat(recordValue.getResourceType()).isEqualTo(AuthorizationResourceType.RESOURCE);
-    assertThat(recordValue.getOwnerType()).isEqualTo(AuthorizationOwnerType.USER);
+    // TODO: re-enable or remove whole test with https://github.com/camunda/camunda/issues/27344
+    // assertThat(recordValue.getOwnerType()).isEqualTo(AuthorizationOwnerType.USER);
     final var permission = recordValue.getPermissions().getFirst();
     assertThat(permission.getPermissionType()).isEqualTo(PermissionType.CREATE);
     assertThat(permission.getResourceIds()).containsExactly("resourceId");
   }
 
+  // TODO: we should decide if we refactor or remove this test with the GitHub issue specified below
+  @Disabled("https://github.com/camunda/camunda/issues/27344")
   @Test
   void shouldRejectWhenOwnerNotFound() {
     // given

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RemovePermissionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RemovePermissionsTest.java
@@ -17,7 +17,6 @@ import io.camunda.client.protocol.rest.PermissionTypeEnum;
 import io.camunda.client.protocol.rest.ResourceTypeEnum;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
-import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -26,6 +25,7 @@ import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @ZeebeIntegration
@@ -70,12 +70,15 @@ public class RemovePermissionsTest {
             .getFirst()
             .getValue();
     assertThat(recordValue.getResourceType()).isEqualTo(AuthorizationResourceType.RESOURCE);
-    assertThat(recordValue.getOwnerType()).isEqualTo(AuthorizationOwnerType.USER);
+    // TODO: re-enable or remove whole test with https://github.com/camunda/camunda/issues/27344
+    // assertThat(recordValue.getOwnerType()).isEqualTo(AuthorizationOwnerType.USER);
     final var permission = recordValue.getPermissions().getFirst();
     assertThat(permission.getPermissionType()).isEqualTo(PermissionType.CREATE);
     assertThat(permission.getResourceIds()).containsExactly(resourceId);
   }
 
+  // TODO: we should decide if we refactor or remove this test with the GitHub issue specified below
+  @Disabled("https://github.com/camunda/camunda/issues/27344")
   @Test
   void shouldRejectWhenOwnerNotFound() {
     // given


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Remove the `DbAuthorizatonState#OWNER_TYPE_BY_OWNER_KEY` column family and it's related methods (insert, get, remove).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #27051
