### PR TITLE
fix: fix "Camunda Performance" dashboard performance

### DIFF
--- a/monitor/grafana/camunda-performance.json
+++ b/monitor/grafana/camunda-performance.json
@@ -3291,7 +3291,7 @@
       "type": "row"
     }
   ],
-  "refresh": "30s",
+  "refresh": "",
   "schemaVersion": 38,
   "style": "dark",
   "tags": [],
@@ -3325,7 +3325,7 @@
         },
         "definition": "label_values(operate_events_processed_total, namespace)",
         "hide": 0,
-        "includeAll": true,
+        "includeAll": false,
         "multi": false,
         "name": "namespace",
         "options": [],
@@ -3400,8 +3400,6 @@
   },
   "timepicker": {
     "refresh_intervals": [
-      "5s",
-      "10s",
       "30s",
       "1m",
       "5m",
@@ -3426,6 +3424,6 @@
   "timezone": "",
   "title": "Camunda Performance",
   "uid": "camunda-benchmarks",
-  "version": 14,
+  "version": 15,
   "weekStart": ""
 }


### PR DESCRIPTION
## Description

The dashboard can be very expensive to run:

1. It defaults to all the Kubernetes namespaces, including non-Camunda ones. This pulls in a lot of metrics from Prometheus by default, even metrics completely unrelated to Camunda services. Some visualization are extremely expensive to display on large Kubernetes clusters if no namespace has been specifically selected.
2. It refreshed by default every 30 seconds. Combined with 1., this makes the dashboard even more expensive to display or interact with.
3. It removes extremely low refresh intervals. They are lower than most default Prometheus scrape interval and are not useful.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
