### PR TITLE
ci: publish Optimize 8.7.0-SNAPSHOTs to DockerHub

### DIFF
--- a/.github/optimize/scripts/build-docker-image.sh
+++ b/.github/optimize/scripts/build-docker-image.sh
@@ -12,6 +12,11 @@ if [ "${IS_MAIN}" = "true" ]; then
     tags+=("${DOCKER_IMAGE_DOCKER_HUB}:8-SNAPSHOT")
 fi
 
+# temporarily needed for https://github.com/camunda/product-hub/issues/2618
+if [ "${IS_STABLE_87}" = "true" ]; then
+    tags+=("${DOCKER_IMAGE_DOCKER_HUB}:8.7.0-SNAPSHOT")
+fi
+
 printf -v tag_arguments -- "-t %s " "${tags[@]}"
 docker buildx create --use
 

--- a/.github/workflows/optimize-deploy-artifacts.yml
+++ b/.github/workflows/optimize-deploy-artifacts.yml
@@ -38,6 +38,7 @@ jobs:
           echo "VERSION=${{ steps.pom-info.outputs.project_version }}"
           echo "PUSH_LATEST_TAG=${{ steps.define-values.outputs.is_main_or_stable_branch }}"
           echo "IS_MAIN=${{ steps.define-values.outputs.is_main_branch }}"
+          echo "IS_STABLE_87=${{ github.ref == 'refs/heads/stable/optimize-8.7' }}"
           echo "REVISION=${{ steps.define-values.outputs.git_commit_hash }}"
         } >> "$GITHUB_ENV"
     - name: Login to Harbor registry


### PR DESCRIPTION
## Description

This PR adjusts the Docker SNAPSHOT image deploy job for Optimize to publish to DockerHub with the `8.7.0-SNAPSHOT` tag. This is only needed until 8.7.0 releases.

See similar PRs for other components for context:

* https://github.com/camunda/camunda/pull/27256
* https://github.com/camunda/camunda/pull/27290

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Related to https://github.com/camunda/camunda/issues/27193
