### PR TITLE
test: In AuthorizationCheckBehaviourTest run actions on the same thread as the engine

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Supplier;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -64,7 +65,7 @@ public class AuthorizationCheckBehaviorTest {
     // when
     final var request =
         new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
-    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+    final var authorized = runTaskInActor(() -> authorizationCheckBehavior.isAuthorized(request));
 
     // then
     assertThat(authorized.isRight()).isTrue();
@@ -337,7 +338,7 @@ public class AuthorizationCheckBehaviorTest {
     final var request =
         new AuthorizationRequest(command, resourceType, permissionType, anotherTenantId)
             .addResourceId(resourceId);
-    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+    final var authorized = runTaskInActor(() -> authorizationCheckBehavior.isAuthorized(request));
 
     // then
     assertThat(authorized.isRight()).isFalse();
@@ -352,7 +353,8 @@ public class AuthorizationCheckBehaviorTest {
     final var command = mockCommand(user.getUsername());
 
     // when
-    final var authorizedTenantIds = authorizationCheckBehavior.getAuthorizedTenantIds(command);
+    final var authorizedTenantIds =
+        runTaskInActor(() -> authorizationCheckBehavior.getAuthorizedTenantIds(command));
 
     // then
     assertThat(authorizedTenantIds.getAuthorizedTenantIds())
@@ -376,7 +378,8 @@ public class AuthorizationCheckBehaviorTest {
     final var command = mockCommandWithMapping(claimName, claimValue);
 
     // when
-    final var authorizedTenantIds = authorizationCheckBehavior.getAuthorizedTenantIds(command);
+    final var authorizedTenantIds =
+        runTaskInActor(() -> authorizationCheckBehavior.getAuthorizedTenantIds(command));
 
     // then
     assertThat(authorizedTenantIds.getAuthorizedTenantIds())
@@ -399,7 +402,8 @@ public class AuthorizationCheckBehaviorTest {
     final var command = mockCommand(user.getUsername());
 
     // when
-    final var authorizedTenantIds = authorizationCheckBehavior.getAuthorizedTenantIds(command);
+    final var authorizedTenantIds =
+        runTaskInActor(() -> authorizationCheckBehavior.getAuthorizedTenantIds(command));
 
     // then
     assertThat(authorizedTenantIds.getAuthorizedTenantIds())
@@ -424,7 +428,8 @@ public class AuthorizationCheckBehaviorTest {
     final var command = mockCommandWithMapping(claimName, claimValue);
 
     // when
-    final var authorizedTenantIds = authorizationCheckBehavior.getAuthorizedTenantIds(command);
+    final var authorizedTenantIds =
+        runTaskInActor(() -> authorizationCheckBehavior.getAuthorizedTenantIds(command));
 
     // then
     assertThat(authorizedTenantIds.getAuthorizedTenantIds())
@@ -444,7 +449,11 @@ public class AuthorizationCheckBehaviorTest {
 
     // when
     final var authorizedTenantIds =
-        authorizationCheckBehavior.getAuthorizedTenantIds(command).getAuthorizedTenantIds();
+        runTaskInActor(
+            () ->
+                authorizationCheckBehavior
+                    .getAuthorizedTenantIds(command)
+                    .getAuthorizedTenantIds());
 
     // then
     assertThat(authorizedTenantIds).containsOnly(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
@@ -456,7 +465,8 @@ public class AuthorizationCheckBehaviorTest {
     final var command = mockCommand("not-exists");
 
     // when
-    final var authorizedTenantIds = authorizationCheckBehavior.getAuthorizedTenantIds(command);
+    final var authorizedTenantIds =
+        runTaskInActor(() -> authorizationCheckBehavior.getAuthorizedTenantIds(command));
 
     // then
     assertThat(authorizedTenantIds.getAuthorizedTenantIds())
@@ -483,7 +493,7 @@ public class AuthorizationCheckBehaviorTest {
     // when
     final var request =
         new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
-    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+    final var authorized = runTaskInActor(() -> authorizationCheckBehavior.isAuthorized(request));
 
     // then
     assertThat(authorized.isRight()).isTrue();
@@ -495,7 +505,8 @@ public class AuthorizationCheckBehaviorTest {
     final var command = mockCommandWithAnonymousUser();
 
     // when
-    final var authorizedTenants = authorizationCheckBehavior.getAuthorizedTenantIds(command);
+    final var authorizedTenants =
+        runTaskInActor(() -> authorizationCheckBehavior.getAuthorizedTenantIds(command));
 
     assertThat(authorizedTenants).isEqualTo(AuthorizedTenants.ANONYMOUS);
   }
@@ -516,7 +527,7 @@ public class AuthorizationCheckBehaviorTest {
     // when
     final var request =
         new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
-    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+    final var authorized = runTaskInActor(() -> authorizationCheckBehavior.isAuthorized(request));
 
     // then
     EitherAssert.assertThat(authorized).isRight();
@@ -548,7 +559,7 @@ public class AuthorizationCheckBehaviorTest {
     final var request =
         new AuthorizationRequest(command, resourceType, permissionType, tenantId)
             .addResourceId(resourceId);
-    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+    final var authorized = runTaskInActor(() -> authorizationCheckBehavior.isAuthorized(request));
 
     // then
     EitherAssert.assertThat(authorized).isRight();
@@ -580,7 +591,7 @@ public class AuthorizationCheckBehaviorTest {
     final var request =
         new AuthorizationRequest(command, resourceType, permissionType, "anotherTenantId")
             .addResourceId(resourceId);
-    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+    final var authorized = runTaskInActor(() -> authorizationCheckBehavior.isAuthorized(request));
 
     // then
     EitherAssert.assertThat(authorized).isLeft();
@@ -615,7 +626,7 @@ public class AuthorizationCheckBehaviorTest {
     // when
     final var request =
         new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
-    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+    final var authorized = runTaskInActor(() -> authorizationCheckBehavior.isAuthorized(request));
 
     // then
     EitherAssert.assertThat(authorized).isRight();
@@ -650,7 +661,7 @@ public class AuthorizationCheckBehaviorTest {
     // when
     final var request =
         new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
-    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+    final var authorized = runTaskInActor(() -> authorizationCheckBehavior.isAuthorized(request));
 
     // then
     EitherAssert.assertThat(authorized).isRight();
@@ -668,7 +679,7 @@ public class AuthorizationCheckBehaviorTest {
     final var request =
         new AuthorizationRequest(command, AuthorizationResourceType.RESOURCE, PermissionType.DELETE)
             .addResourceId(UUID.randomUUID().toString());
-    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+    final var authorized = runTaskInActor(() -> authorizationCheckBehavior.isAuthorized(request));
 
     // then
     EitherAssert.assertThat(authorized).isLeft();
@@ -728,14 +739,18 @@ public class AuthorizationCheckBehaviorTest {
 
     // then
     EitherAssert.assertThat(
-            authorizationCheckBehavior.isAuthorized(
-                new AuthorizationRequest(command, resourceType, permissionType)
-                    .addResourceId(firstResourceId)))
+            runTaskInActor(
+                () ->
+                    authorizationCheckBehavior.isAuthorized(
+                        new AuthorizationRequest(command, resourceType, permissionType)
+                            .addResourceId(firstResourceId))))
         .isRight();
     EitherAssert.assertThat(
-            authorizationCheckBehavior.isAuthorized(
-                new AuthorizationRequest(command, resourceType, permissionType)
-                    .addResourceId(secondResourceId)))
+            runTaskInActor(
+                () ->
+                    authorizationCheckBehavior.isAuthorized(
+                        new AuthorizationRequest(command, resourceType, permissionType)
+                            .addResourceId(secondResourceId))))
         .isRight();
   }
 
@@ -779,14 +794,18 @@ public class AuthorizationCheckBehaviorTest {
 
     // then
     EitherAssert.assertThat(
-            authorizationCheckBehavior.isAuthorized(
-                new AuthorizationRequest(command, resourceType, permissionType)
-                    .addResourceId(firstResourceId)))
+            runTaskInActor(
+                () ->
+                    authorizationCheckBehavior.isAuthorized(
+                        new AuthorizationRequest(command, resourceType, permissionType)
+                            .addResourceId(firstResourceId))))
         .isRight();
     EitherAssert.assertThat(
-            authorizationCheckBehavior.isAuthorized(
-                new AuthorizationRequest(command, resourceType, permissionType)
-                    .addResourceId(secondResourceId)))
+            runTaskInActor(
+                () ->
+                    authorizationCheckBehavior.isAuthorized(
+                        new AuthorizationRequest(command, resourceType, permissionType)
+                            .addResourceId(secondResourceId))))
         .isRight();
   }
 
@@ -807,7 +826,8 @@ public class AuthorizationCheckBehaviorTest {
     final var request =
         new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
     final var authorizations =
-        authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request);
+        runTaskInActor(
+            () -> authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request));
 
     // then
     assertThat(authorizations).containsExactlyInAnyOrder(resourceId);
@@ -838,7 +858,8 @@ public class AuthorizationCheckBehaviorTest {
     final var request =
         new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
     final var authorizations =
-        authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request);
+        runTaskInActor(
+            () -> authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request));
 
     // then
     assertThat(authorizations).containsExactlyInAnyOrder(resourceId);
@@ -869,7 +890,8 @@ public class AuthorizationCheckBehaviorTest {
     final var request =
         new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
     final var authorizations =
-        authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request);
+        runTaskInActor(
+            () -> authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request));
 
     // then
     assertThat(authorizations).containsExactlyInAnyOrder(resourceId);
@@ -896,7 +918,9 @@ public class AuthorizationCheckBehaviorTest {
         .add();
 
     // then
-    assertThat(authorizationCheckBehavior.getAuthorizedTenantIds(command).getAuthorizedTenantIds())
+    assertThat(
+            runTaskInActor(() -> authorizationCheckBehavior.getAuthorizedTenantIds(command))
+                .getAuthorizedTenantIds())
         .singleElement()
         .isEqualTo(tenantId);
   }
@@ -911,7 +935,9 @@ public class AuthorizationCheckBehaviorTest {
 
     // when
     // then
-    assertThat(authorizationCheckBehavior.getAuthorizedTenantIds(command).getAuthorizedTenantIds())
+    assertThat(
+            runTaskInActor(() -> authorizationCheckBehavior.getAuthorizedTenantIds(command))
+                .getAuthorizedTenantIds())
         .singleElement()
         .isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   }
@@ -992,5 +1018,9 @@ public class AuthorizationCheckBehaviorTest {
     when(command.getAuthorizations()).thenReturn(Map.of(AUTHORIZED_ANONYMOUS_USER, true));
     when(command.hasRequestMetadata()).thenReturn(true);
     return command;
+  }
+
+  private <A> A runTaskInActor(final Supplier<A> supplier) {
+    return engine.getStreamProcessor(1).call(supplier::get).join();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -52,6 +52,7 @@ import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.stream.api.CommandResponseWriter;
 import io.camunda.zeebe.stream.api.StreamClock;
@@ -521,6 +522,10 @@ public final class EngineRule extends ExternalResource {
 
   public ClockClient clock() {
     return new ClockClient(environmentRule);
+  }
+
+  public ActorScheduler actorScheduler() {
+    return environmentRule.getActorScheduler();
   }
 
   private static final class VersatileBlob implements DbKey, DbValue {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.logstreams.util.TestLogStream;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
 import io.camunda.zeebe.stream.api.CommandResponseWriter;
@@ -57,7 +58,7 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
   private final TemporaryFolder tempFolder;
   private final AutoCloseableRule closeables = new AutoCloseableRule();
   private final ControlledActorClock clock = new ControlledActorClock();
-  private final ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule(clock);
+  private final ActorSchedulerRule actorSchedulerRule;
   private final ZeebeDbFactory zeebeDbFactory;
   private final int startPartitionId;
   private final int partitionCount;
@@ -100,6 +101,7 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
       final TemporaryFolder temporaryFolder) {
     this.startPartitionId = startPartitionId;
     this.partitionCount = partitionCount;
+    actorSchedulerRule = new ActorSchedulerRule(partitionCount, clock);
 
     final SetupRule rule = new SetupRule(startPartitionId, partitionCount);
 
@@ -367,6 +369,10 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
 
   public void maxCommandsInBatch(final int maxCommandsInBatch) {
     this.maxCommandsInBatch = maxCommandsInBatch;
+  }
+
+  public ActorScheduler getActorScheduler() {
+    return actorSchedulerRule.get();
   }
 
   private class SetupRule extends ExternalResource {


### PR DESCRIPTION
## Description
Before this change, authorizationCheckBehaviour interact with mutables classes that are used concurrently by the engine in another thread.

All methods called in authorizationCheckBehaviour are run in the same thread as the StreamProcessor.
Although this may not be the case of the SIGSEV, it can help us identify if it's generated from somewhere else if it's not fixed by this commit.

## Related issues
relates #26068 
