### PR TITLE
Migrate all tests in client package to new IT/E2E foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,8 +286,8 @@ jobs:
       #
       - name: Run integration test with externalized ES
         run: >
-          ./mvnw -B -T 2 --no-snapshot-updates
-          -D forkCount=7
+          ./mvnw -B -T 1 --no-snapshot-updates
+          -D forkCount=1
           -D maven.javadoc.skip=true
           -D skipUTs -D skipChecks
           -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/CreateDocumentBatchTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/CreateDocumentBatchTest.java
@@ -12,32 +12,21 @@ import static org.assertj.core.api.Assertions.within;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.qa.util.cluster.TestStandaloneCamunda;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.it.utils.MultiDbTest;
 import java.io.ByteArrayInputStream;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import org.junit.jupiter.api.Test;
 
-@ZeebeIntegration
+@MultiDbTest
 public class CreateDocumentBatchTest {
 
   private static CamundaClient camundaClient;
 
-  @TestZeebe(initMethod = "initTestStandaloneCamunda")
-  private static TestStandaloneCamunda testStandaloneCamunda;
-
-  @SuppressWarnings("unused")
-  static void initTestStandaloneCamunda() {
-    testStandaloneCamunda = new TestStandaloneCamunda();
-  }
-
   @Test
   public void shouldCreateDocumentsFromInputStreams() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     final var documentContent1 = new ByteArrayInputStream("test one".getBytes());
     final var documentContent2 = new ByteArrayInputStream("test two".getBytes());
 
@@ -65,7 +54,6 @@ public class CreateDocumentBatchTest {
   @Test
   public void shouldCreateDocumentsFromDifferentSources() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     final var documentContent1 = new ByteArrayInputStream("test one".getBytes());
     final var documentContent2 = "test two".getBytes();
 
@@ -93,7 +81,6 @@ public class CreateDocumentBatchTest {
   @Test
   public void shouldCreateDocumentsWithBasicMetadata() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     final var documentContent1 = new ByteArrayInputStream("test one".getBytes());
     final var documentContent2 = new ByteArrayInputStream("test two".getBytes());
 
@@ -143,7 +130,6 @@ public class CreateDocumentBatchTest {
   @Test
   public void shouldCreateDocumentsWithCustomMetadata() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     final var documentContent1 = new ByteArrayInputStream("test one".getBytes());
     final var documentContent2 = new ByteArrayInputStream("test two".getBytes());
 
@@ -193,7 +179,6 @@ public class CreateDocumentBatchTest {
   @Test
   public void shouldThrowIfContentIsMissing() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
 
     // when
     final var command = camundaClient.newCreateDocumentBatchCommand().addDocument().done();
@@ -206,7 +191,6 @@ public class CreateDocumentBatchTest {
   @Test
   public void shouldCalculateSize() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     final var documentContent1 = new ByteArrayInputStream("test one".getBytes());
     final var documentContent2 = new ByteArrayInputStream("test two".getBytes());
 
@@ -240,7 +224,6 @@ public class CreateDocumentBatchTest {
   @Test
   public void shouldUseProvidedStoreId() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     final var documentContent = new ByteArrayInputStream("test one".getBytes());
     final var storeId = "in-memory";
 
@@ -266,7 +249,6 @@ public class CreateDocumentBatchTest {
   @Test
   public void shouldReturnBadRequestForNonExistingStoreId() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     final var documentContent = new ByteArrayInputStream("test one".getBytes());
 
     // when
@@ -288,7 +270,6 @@ public class CreateDocumentBatchTest {
   @Test
   public void shouldUseProvidedProcessDefinitionIdAndProcessInstanceKey() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     final var documentContent1 = new ByteArrayInputStream("test one".getBytes());
     final var documentContent2 = new ByteArrayInputStream("test two".getBytes());
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/CreateDocumentLinkTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/CreateDocumentLinkTest.java
@@ -13,13 +13,11 @@ import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.DocumentReferenceResponse;
-import io.camunda.qa.util.cluster.TestStandaloneCamunda;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.it.utils.MultiDbTest;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-@ZeebeIntegration
+@MultiDbTest
 public class CreateDocumentLinkTest {
 
   private static final String DOCUMENT_CONTENT = "test";
@@ -27,17 +25,8 @@ public class CreateDocumentLinkTest {
   private static CamundaClient camundaClient;
   private static DocumentReferenceResponse documentReference;
 
-  @TestZeebe(initMethod = "initTestStandaloneCamunda")
-  private static TestStandaloneCamunda testStandaloneCamunda;
-
-  @SuppressWarnings("unused")
-  static void initTestStandaloneCamunda() {
-    testStandaloneCamunda = new TestStandaloneCamunda();
-  }
-
   @BeforeAll
   public static void beforeAll() {
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     documentReference =
         camundaClient.newCreateDocumentCommand().content(DOCUMENT_CONTENT).send().join();
   }
@@ -46,7 +35,6 @@ public class CreateDocumentLinkTest {
   public void shouldReturnBadRequestWhenDocumentStoreDoesNotExist() {
     // given
     final var storeId = "invalid-document-store-id";
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
 
     // when
     final var exception =
@@ -71,7 +59,6 @@ public class CreateDocumentLinkTest {
     // given
     final var storeId = "in-memory";
     final var documentId = documentReference.getDocumentId();
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
 
     // when
     final var exception =

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/CreateDocumentTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/CreateDocumentTest.java
@@ -13,9 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
-import io.camunda.qa.util.cluster.TestStandaloneCamunda;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.it.utils.MultiDbTest;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.time.Duration;
@@ -24,23 +22,14 @@ import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-@ZeebeIntegration
+@MultiDbTest
 public class CreateDocumentTest {
 
   private static CamundaClient camundaClient;
 
-  @TestZeebe(initMethod = "initTestStandaloneCamunda")
-  private static TestStandaloneCamunda testStandaloneCamunda;
-
-  @SuppressWarnings("unused")
-  static void initTestStandaloneCamunda() {
-    testStandaloneCamunda = new TestStandaloneCamunda();
-  }
-
   @Test
   public void shouldCreateDocumentFromInputStream() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     final var documentContent = new ByteArrayInputStream("test".getBytes());
 
     // when
@@ -54,7 +43,6 @@ public class CreateDocumentTest {
   @Test
   public void shouldCreateDocumentFromByteArray() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     final var documentContent = "test".getBytes();
 
     // when
@@ -68,7 +56,6 @@ public class CreateDocumentTest {
   @Test
   public void shouldThrowIfContentIsNull() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
 
     // when
     final var exception =
@@ -85,7 +72,7 @@ public class CreateDocumentTest {
   @Test
   public void shouldUseTheProvidedDocumentId() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
+
     final var documentContent = "test";
     final var documentId = "test";
 
@@ -121,7 +108,6 @@ public class CreateDocumentTest {
   @Test
   public void shouldUseTheProvidedStoreId() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     final var documentContent = "test";
     final var storeId = "in-memory";
 
@@ -142,7 +128,6 @@ public class CreateDocumentTest {
   @Test
   public void shouldReturnBadRequestForNonExistingStoreId() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     final var documentContent = "test";
     final var storeId = "non-existing";
 
@@ -162,7 +147,6 @@ public class CreateDocumentTest {
   @Test
   public void shouldIncludeFileName() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     final var documentContent = "test";
     final var fileName = "test.txt";
 
@@ -182,7 +166,6 @@ public class CreateDocumentTest {
   @Test
   public void shouldIncludeTimeToLive() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     final var documentContent = "test";
     final var timeToLive = Duration.ofMinutes(1);
 
@@ -203,7 +186,6 @@ public class CreateDocumentTest {
   @Test
   public void shouldIncludeContentType() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     final var documentContent = "test";
     final var contentType = "text/plain";
 
@@ -224,7 +206,6 @@ public class CreateDocumentTest {
   @Test
   public void shouldCalculateSize() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     final var documentContent = "test";
 
     // when
@@ -239,7 +220,6 @@ public class CreateDocumentTest {
   @Test
   public void shouldAddCustomMetadata() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     final var documentContent = "test";
     final String key = "key1";
     final String value = "value1";
@@ -266,7 +246,6 @@ public class CreateDocumentTest {
   @Test
   public void shouldAddProcessDefinitionId() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     final var documentContent = "test";
     final String processDefinitionId = "test";
 
@@ -288,7 +267,6 @@ public class CreateDocumentTest {
   @Test
   public void shouldAddProcessInstanceKey() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     final var documentContent = "test";
     final long processInstanceKey = 1;
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/DecisionInstanceQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/DecisionInstanceQueryTest.java
@@ -17,7 +17,7 @@ import io.camunda.client.api.response.EvaluateDecisionResponse;
 import io.camunda.client.api.search.response.DecisionDefinitionType;
 import io.camunda.client.api.search.response.DecisionInstance;
 import io.camunda.client.api.search.response.DecisionInstanceState;
-import io.camunda.it.utils.BrokerITInvocationProvider;
+import io.camunda.it.utils.MultiDbTest;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
@@ -25,55 +25,45 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.TestInstance.Lifecycle;
-import org.junit.jupiter.api.TestTemplate;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
-@TestInstance(Lifecycle.PER_CLASS)
+@MultiDbTest
 class DecisionInstanceQueryTest {
-
-  // TODO Bugs in RDBMS
-  @RegisterExtension
-  static final BrokerITInvocationProvider PROVIDER =
-      new BrokerITInvocationProvider().withoutRdbmsExporter();
 
   private static final String DECISION_DEFINITION_ID_1 = "decision_1";
   private static final String DECISION_DEFINITION_ID_2 = "invoiceAssignApprover";
+  private static CamundaClient camundaClient;
   // evaluated decisions mapped by decision definition id
-  private final Map<String, EvaluateDecisionResponse> evaluatedDecisions = new HashMap<>();
+  private static final Map<String, EvaluateDecisionResponse> EVALUATED_DECISIONS = new HashMap<>();
   private boolean initialized;
 
-  @BeforeEach
-  void setUp(final CamundaClient camundaClient) {
-    if (!initialized) {
+  @BeforeAll
+  static void setUp() {
 
-      List.of("decision_model.dmn", "invoiceBusinessDecisions_v_1.dmn")
-          .forEach(
-              dmn ->
-                  deployResource(camundaClient, String.format("decisions/%s", dmn)).getDecisions());
-      evaluatedDecisions.put(
-          DECISION_DEFINITION_ID_1,
-          evaluateDecision(
-              camundaClient, DECISION_DEFINITION_ID_1, "{\"age\": 20, \"income\": 20000}"));
-      evaluatedDecisions.put(
-          DECISION_DEFINITION_ID_2,
-          evaluateDecision(
-              camundaClient,
-              DECISION_DEFINITION_ID_2,
-              "{\"amount\": 100, \"invoiceCategory\": \"Misc\"}"));
-      waitForDecisionsToBeEvaluated(
-          camundaClient,
-          evaluatedDecisions.values().stream()
-              .mapToInt(v -> v.getEvaluatedDecisions().size())
-              .sum());
-      initialized = true;
-    }
+    List.of("decision_model.dmn", "invoiceBusinessDecisions_v_1.dmn")
+        .forEach(
+            dmn ->
+                deployResource(camundaClient, String.format("decisions/%s", dmn)).getDecisions());
+    EVALUATED_DECISIONS.put(
+        DECISION_DEFINITION_ID_1,
+        evaluateDecision(
+            camundaClient, DECISION_DEFINITION_ID_1, "{\"age\": 20, \"income\": 20000}"));
+    EVALUATED_DECISIONS.put(
+        DECISION_DEFINITION_ID_2,
+        evaluateDecision(
+            camundaClient,
+            DECISION_DEFINITION_ID_2,
+            "{\"amount\": 100, \"invoiceCategory\": \"Misc\"}"));
+    waitForDecisionsToBeEvaluated(
+        camundaClient,
+        EVALUATED_DECISIONS.values().stream()
+            .mapToInt(v -> v.getEvaluatedDecisions().size())
+            .sum());
   }
 
-  @TestTemplate
-  public void shouldRetrieveAllDecisionInstances(final CamundaClient camundaClient) {
+  @Test
+  public void shouldRetrieveAllDecisionInstances() {
     // when
     final var result =
         camundaClient
@@ -90,13 +80,13 @@ class DecisionInstanceQueryTest {
                 .map(DecisionInstance::getDecisionInstanceKey)
                 .collect(Collectors.toSet()))
         .containsExactlyElementsOf(
-            evaluatedDecisions.values().stream()
+            EVALUATED_DECISIONS.values().stream()
                 .map(EvaluateDecisionResponse::getDecisionInstanceKey)
                 .collect(Collectors.toSet()));
   }
 
-  @TestTemplate
-  void shouldSearchByFromWithLimit(final CamundaClient camundaClient) {
+  @Test
+  void shouldSearchByFromWithLimit() {
     // when
     final var resultAll = camundaClient.newDecisionInstanceQuery().send().join();
 
@@ -114,12 +104,12 @@ class DecisionInstanceQueryTest {
         .isEqualTo(thirdKey);
   }
 
-  @TestTemplate
+  @Test
   public void shouldRetrieveDecisionInstanceByDecisionDefinitionKey(
       final CamundaClient camundaClient) {
     // when
     final long decisionDefinitionKey =
-        evaluatedDecisions.get(DECISION_DEFINITION_ID_1).getDecisionKey();
+        EVALUATED_DECISIONS.get(DECISION_DEFINITION_ID_1).getDecisionKey();
     final var result =
         camundaClient
             .newDecisionInstanceQuery()
@@ -132,15 +122,15 @@ class DecisionInstanceQueryTest {
     assertThat(result.items().getFirst().getDecisionDefinitionKey())
         .isEqualTo(decisionDefinitionKey);
     assertThat(result.items().getFirst().getDecisionInstanceKey())
-        .isEqualTo(evaluatedDecisions.get(DECISION_DEFINITION_ID_1).getDecisionInstanceKey());
+        .isEqualTo(EVALUATED_DECISIONS.get(DECISION_DEFINITION_ID_1).getDecisionInstanceKey());
   }
 
-  @TestTemplate
+  @Test
   public void shouldRetrieveDecisionInstanceByDecisionKeyFilterIn(
       final CamundaClient camundaClient) {
     // when
     final long decisionDefinitionKey =
-        evaluatedDecisions.get(DECISION_DEFINITION_ID_1).getDecisionKey();
+        EVALUATED_DECISIONS.get(DECISION_DEFINITION_ID_1).getDecisionKey();
     final var result =
         camundaClient
             .newDecisionInstanceQuery()
@@ -153,15 +143,15 @@ class DecisionInstanceQueryTest {
     assertThat(result.items().getFirst().getDecisionDefinitionKey())
         .isEqualTo(decisionDefinitionKey);
     assertThat(result.items().getFirst().getDecisionInstanceKey())
-        .isEqualTo(evaluatedDecisions.get(DECISION_DEFINITION_ID_1).getDecisionInstanceKey());
+        .isEqualTo(EVALUATED_DECISIONS.get(DECISION_DEFINITION_ID_1).getDecisionInstanceKey());
   }
 
-  @TestTemplate
+  @Test
   public void shouldRetrieveDecisionInstanceByDecisionInstanceKey(
       final CamundaClient camundaClient) {
     // when
     final long decisionInstanceKey =
-        evaluatedDecisions.get(DECISION_DEFINITION_ID_2).getDecisionInstanceKey();
+        EVALUATED_DECISIONS.get(DECISION_DEFINITION_ID_2).getDecisionInstanceKey();
     final var result =
         camundaClient
             .newDecisionInstanceQuery()
@@ -175,8 +165,8 @@ class DecisionInstanceQueryTest {
     assertThat(result.items().getLast().getDecisionInstanceKey()).isEqualTo(decisionInstanceKey);
   }
 
-  @TestTemplate
-  public void shouldRetrieveDecisionInstanceByStateAndType(final CamundaClient camundaClient) {
+  @Test
+  public void shouldRetrieveDecisionInstanceByStateAndType() {
     // when
     final DecisionInstanceState state = DecisionInstanceState.EVALUATED;
     final DecisionDefinitionType type = DecisionDefinitionType.DECISION_TABLE;
@@ -191,8 +181,8 @@ class DecisionInstanceQueryTest {
     assertThat(result.items().size()).isEqualTo(3);
   }
 
-  @TestTemplate
-  public void shouldRetrieveDecisionInstanceByEvaluationDate(final CamundaClient camundaClient) {
+  @Test
+  public void shouldRetrieveDecisionInstanceByEvaluationDate() {
     // given
     final var allResult =
         camundaClient.newDecisionInstanceQuery().page(p -> p.limit(1)).send().join();
@@ -212,7 +202,7 @@ class DecisionInstanceQueryTest {
         .isEqualTo(di.getDecisionInstanceKey());
   }
 
-  @TestTemplate
+  @Test
   public void shouldRetrieveDecisionInstanceByEvaluationDateFilterGt(
       final CamundaClient camundaClient) {
     // given
@@ -244,7 +234,7 @@ class DecisionInstanceQueryTest {
         .noneMatch(key -> di.getDecisionInstanceKey() == key);
   }
 
-  @TestTemplate
+  @Test
   public void shouldRetrieveDecisionInstanceByEvaluationDateFilterGte(
       final CamundaClient camundaClient) {
     // given
@@ -276,13 +266,13 @@ class DecisionInstanceQueryTest {
         .anyMatch(key -> di.getDecisionInstanceKey() == key);
   }
 
-  @TestTemplate
+  @Test
   public void shouldRetrieveDecisionInstanceByDmnDecisionIdAndDecisionVersion(
       final CamundaClient camundaClient) {
     // when
-    final String dmnDecisionId = evaluatedDecisions.get(DECISION_DEFINITION_ID_1).getDecisionId();
+    final String dmnDecisionId = EVALUATED_DECISIONS.get(DECISION_DEFINITION_ID_1).getDecisionId();
     final int decisionVersion =
-        evaluatedDecisions.get(DECISION_DEFINITION_ID_1).getDecisionVersion();
+        EVALUATED_DECISIONS.get(DECISION_DEFINITION_ID_1).getDecisionVersion();
     final var result =
         camundaClient
             .newDecisionInstanceQuery()
@@ -296,14 +286,14 @@ class DecisionInstanceQueryTest {
     // then
     assertThat(result.items().size()).isEqualTo(1);
     assertThat(result.items().get(0).getDecisionInstanceKey())
-        .isEqualTo(evaluatedDecisions.get(DECISION_DEFINITION_ID_1).getDecisionInstanceKey());
+        .isEqualTo(EVALUATED_DECISIONS.get(DECISION_DEFINITION_ID_1).getDecisionInstanceKey());
   }
 
-  @TestTemplate
-  void shouldGetDecisionInstance(final CamundaClient camundaClient) {
+  @Test
+  void shouldGetDecisionInstance() {
     // when
     final long decisionInstanceKey =
-        evaluatedDecisions.get(DECISION_DEFINITION_ID_2).getDecisionInstanceKey();
+        EVALUATED_DECISIONS.get(DECISION_DEFINITION_ID_2).getDecisionInstanceKey();
     final var decisionInstanceId = "%d-%d".formatted(decisionInstanceKey, 1);
     final var result =
         camundaClient.newDecisionInstanceGetRequest(decisionInstanceId).send().join();
@@ -313,8 +303,8 @@ class DecisionInstanceQueryTest {
     assertThat(result.getDecisionInstanceKey()).isEqualTo(decisionInstanceKey);
   }
 
-  @TestTemplate
-  void shouldReturn404ForNotFoundDecisionInstance(final CamundaClient camundaClient) {
+  @Test
+  void shouldReturn404ForNotFoundDecisionInstance() {
     // when
     final var decisionInstanceId = "not-existing";
     final var problemException =
@@ -327,7 +317,7 @@ class DecisionInstanceQueryTest {
         .isEqualTo("Decision instance with key %s not found".formatted(decisionInstanceId));
   }
 
-  private DeploymentEvent deployResource(
+  private static DeploymentEvent deployResource(
       final CamundaClient camundaClient, final String resourceName) {
     return camundaClient
         .newDeployResourceCommand()
@@ -336,7 +326,7 @@ class DecisionInstanceQueryTest {
         .join();
   }
 
-  private EvaluateDecisionResponse evaluateDecision(
+  private static EvaluateDecisionResponse evaluateDecision(
       final CamundaClient camundaClient,
       final String decisionDefinitionId,
       final String variables) {
@@ -348,7 +338,7 @@ class DecisionInstanceQueryTest {
         .join();
   }
 
-  private void waitForDecisionsToBeEvaluated(
+  private static void waitForDecisionsToBeEvaluated(
       final CamundaClient camundaClient, final int expectedCount) {
     Awaitility.await("should deploy decision definitions and import in Operate")
         .atMost(Duration.ofSeconds(15))

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/DecisionQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/DecisionQueryTest.java
@@ -17,9 +17,7 @@ import io.camunda.client.api.response.DecisionRequirements;
 import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.client.api.search.response.DecisionDefinition;
 import io.camunda.client.impl.search.response.DecisionDefinitionImpl;
-import io.camunda.qa.util.cluster.TestStandaloneCamunda;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.it.utils.MultiDbTest;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -37,24 +35,15 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-@ZeebeIntegration
+@MultiDbTest
 class DecisionQueryTest {
   private static final List<Decision> DEPLOYED_DECISIONS = new ArrayList<>();
   private static final List<DecisionRequirements> DEPLOYED_DECISION_REQUIREMENTS =
       new ArrayList<>();
   private static CamundaClient camundaClient;
 
-  @TestZeebe(initMethod = "initTestStandaloneCamunda")
-  private static TestStandaloneCamunda testStandaloneCamunda;
-
-  @SuppressWarnings("unused")
-  static void initTestStandaloneCamunda() {
-    testStandaloneCamunda = new TestStandaloneCamunda();
-  }
-
   @BeforeAll
   static void beforeAll() {
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     Stream.of(
             "decisions/decision_model.dmn",
             "decisions/decision_model_1.dmn",

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/DeleteDocumentTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/DeleteDocumentTest.java
@@ -13,32 +13,21 @@ import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.DocumentReferenceResponse;
-import io.camunda.qa.util.cluster.TestStandaloneCamunda;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.it.utils.MultiDbTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-@ZeebeIntegration
+@MultiDbTest
 public class DeleteDocumentTest {
 
   private static final String DOCUMENT_CONTENT = "test";
 
   private static CamundaClient camundaClient;
 
-  @TestZeebe(initMethod = "initTestStandaloneCamunda")
-  private static TestStandaloneCamunda testStandaloneCamunda;
-
   private DocumentReferenceResponse documentReference;
-
-  @SuppressWarnings("unused")
-  static void initTestStandaloneCamunda() {
-    testStandaloneCamunda = new TestStandaloneCamunda();
-  }
 
   @BeforeEach
   public void beforeEach() {
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     documentReference =
         camundaClient.newCreateDocumentCommand().content(DOCUMENT_CONTENT).send().join();
   }
@@ -47,7 +36,6 @@ public class DeleteDocumentTest {
   public void shouldWorkWithDocumentId() {
     // given
     final var documentId = documentReference.getDocumentId();
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
 
     // when
     camundaClient.newDeleteDocumentCommand(documentId).send().join();
@@ -61,7 +49,6 @@ public class DeleteDocumentTest {
     // given
     final var documentId = documentReference.getDocumentId();
     final var storeId = documentReference.getStoreId();
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
 
     // when
     camundaClient.newDeleteDocumentCommand(documentId).storeId(storeId).send().join();
@@ -73,7 +60,6 @@ public class DeleteDocumentTest {
   @Test
   public void shouldWorkWithDocumentReference() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
 
     // when
     camundaClient.newDeleteDocumentCommand(documentReference).send().join();
@@ -86,7 +72,6 @@ public class DeleteDocumentTest {
   public void shouldReturnNotFoundIfDocumentDoesNotExist() {
     // given
     final var documentId = "non-existing-document";
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
 
     // when
     final var exception =
@@ -105,7 +90,6 @@ public class DeleteDocumentTest {
   @Test
   public void shouldReturnBadRequestForNonExistingStoreId() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     final var documentContent = "test";
     final var storeId = "non-existing";
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/GetDocumentContentTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/GetDocumentContentTest.java
@@ -13,14 +13,12 @@ import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.DocumentReferenceResponse;
-import io.camunda.qa.util.cluster.TestStandaloneCamunda;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.it.utils.MultiDbTest;
 import java.io.InputStream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-@ZeebeIntegration
+@MultiDbTest
 public class GetDocumentContentTest {
 
   private static final String DOCUMENT_CONTENT = "test";
@@ -28,17 +26,8 @@ public class GetDocumentContentTest {
   private static CamundaClient camundaClient;
   private static DocumentReferenceResponse documentReference;
 
-  @TestZeebe(initMethod = "initTestStandaloneCamunda")
-  private static TestStandaloneCamunda testStandaloneCamunda;
-
-  @SuppressWarnings("unused")
-  static void initTestStandaloneCamunda() {
-    testStandaloneCamunda = new TestStandaloneCamunda();
-  }
-
   @BeforeAll
   public static void beforeAll() {
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     documentReference =
         camundaClient.newCreateDocumentCommand().content(DOCUMENT_CONTENT).send().join();
   }
@@ -46,7 +35,6 @@ public class GetDocumentContentTest {
   @Test
   public void shouldWorkWithDocumentReference() {
     // given
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
 
     // when
     try (final InputStream is =
@@ -64,7 +52,6 @@ public class GetDocumentContentTest {
   public void shouldReturnNotFoundIfDocumentDoesNotExist() {
     // given
     final var documentId = "non-existing-document";
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
 
     // when
     final var command = camundaClient.newDocumentContentGetRequest(documentId).send();
@@ -83,7 +70,6 @@ public class GetDocumentContentTest {
     // given
     final var documentId = documentReference.getDocumentId();
     final var storeId = "non-existing-store";
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
 
     // when
     final var command =

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentQueryTest.java
@@ -19,9 +19,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.Process;
 import io.camunda.client.api.search.response.Incident;
-import io.camunda.qa.util.cluster.TestStandaloneCamunda;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.it.utils.MultiDbTest;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -31,26 +29,17 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-@ZeebeIntegration
+@MultiDbTest
 class IncidentQueryTest {
 
   private static final List<Process> DEPLOYED_PROCESSES = new ArrayList<>();
 
   private static CamundaClient camundaClient;
 
-  @TestZeebe(initMethod = "initTestStandaloneCamunda")
-  private static TestStandaloneCamunda testStandaloneCamunda;
-
   private static Incident incident;
-
-  @SuppressWarnings("unused")
-  static void initTestStandaloneCamunda() {
-    testStandaloneCamunda = new TestStandaloneCamunda();
-  }
 
   @BeforeAll
   static void beforeAll() {
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
 
     final var processes =
         List.of("service_tasks_v1.bpmn", "service_tasks_v2.bpmn", "incident_process_v1.bpmn");

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessDefinitionQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessDefinitionQueryTest.java
@@ -15,9 +15,7 @@ import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.client.api.response.Process;
 import io.camunda.client.api.search.response.ProcessDefinition;
-import io.camunda.qa.util.cluster.TestStandaloneCamunda;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.it.utils.MultiDbTest;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -30,7 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@ZeebeIntegration
+@MultiDbTest
 public class ProcessDefinitionQueryTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ProcessDefinitionQueryTest.class);
@@ -38,17 +36,8 @@ public class ProcessDefinitionQueryTest {
 
   private static CamundaClient camundaClient;
 
-  @TestZeebe(initMethod = "initTestStandaloneCamunda")
-  private static TestStandaloneCamunda testStandaloneCamunda;
-
-  static void initTestStandaloneCamunda() {
-    testStandaloneCamunda = new TestStandaloneCamunda().withCamundaExporter();
-  }
-
   @BeforeAll
   public static void beforeAll() throws InterruptedException {
-
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
 
     // Deploy form
     deployResource(String.format("form/%s", "form.form"));

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
@@ -18,10 +18,8 @@ import io.camunda.client.api.search.response.UserTask;
 import io.camunda.client.api.search.response.UserTaskState;
 import io.camunda.client.protocol.rest.StringFilterProperty;
 import io.camunda.client.protocol.rest.UserTaskVariableFilterRequest;
-import io.camunda.qa.util.cluster.TestStandaloneCamunda;
+import io.camunda.it.utils.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import java.io.InputStream;
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -36,23 +34,14 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-@ZeebeIntegration
+@MultiDbTest
 class UserTaskQueryTest {
   private static Long userTaskKeyTaskAssigned;
 
-  @TestZeebe(initMethod = "initTestStandaloneCamunda")
-  private static TestStandaloneCamunda testStandaloneCamunda;
-
   private static CamundaClient camundaClient;
-
-  @SuppressWarnings("unused")
-  static void initTestStandaloneCamunda() {
-    testStandaloneCamunda = new TestStandaloneCamunda();
-  }
 
   @BeforeAll
   static void beforeAll() {
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
 
     deployProcess("process", "simple.bpmn", "test", "", "");
     deployProcess("process-2", "simple-2.bpmn", "test-2", "group", "user");

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/VariableQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/VariableQueryTest.java
@@ -13,10 +13,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.search.response.Variable;
-import io.camunda.qa.util.cluster.TestStandaloneCamunda;
+import io.camunda.it.utils.MultiDbTest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.Comparator;
@@ -27,23 +25,15 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-@ZeebeIntegration
+@MultiDbTest
 class VariableQueryTest {
-  @TestZeebe(initMethod = "initTestStandaloneCamunda")
-  private static TestStandaloneCamunda testStandaloneCamunda;
 
   private static CamundaClient camundaClient;
 
   private static Variable variable;
 
-  @SuppressWarnings("unused")
-  static void initTestStandaloneCamunda() {
-    testStandaloneCamunda = new TestStandaloneCamunda();
-  }
-
   @BeforeAll
   static void beforeAll() {
-    camundaClient = testStandaloneCamunda.newClientBuilder().build();
     delpoyProcessFromResourcePath("/process/bpm_variable_test.bpmn", "bpm_variable_test.bpmn");
 
     startProcessInstance("bpmProcessVariable");


### PR DESCRIPTION
## Description

Migrates all tests that are in `package io.camunda.it.client;` to the new IT foundation. that means to the usage of the `@MultiDbTest` annotation.


### Details

Tests are not separate, and executed as part of `[IT] Elasticsearch`. Later, we will add support for Opensearch as well, which will be added as separate CI JOB.

#### Performance

Due to setting up database once, and application we were able to reducing the execution by a factor 10 for each individual test. **Most test were running before around 100s (due to set up code) and now running within 10s.**

Examples from Main branch:

![main-client2](https://github.com/user-attachments/assets/f112e9d2-8fa7-406e-94d6-756b4a28cda7)
![main-client](https://github.com/user-attachments/assets/e315d635-11b5-40c0-8695-283586233bf6)


Examples from branch:

![migrate-client](https://github.com/user-attachments/assets/fe43a8aa-1308-4a05-bf2b-016473780ec2)

![migrate-client2](https://github.com/user-attachments/assets/95148172-6bab-4078-88e5-8bf897216cb0)

<!--
![2025-01-23_12-01_1](https://github.com/user-attachments/assets/041a6f69-67ef-44ff-98a8-7d6409ce2fa3)
![2025-01-23_12-01](https://github.com/user-attachments/assets/8011301d-771a-4956-809f-34f4b8f2ced1)
-->



<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to https://github.com/camunda/camunda/issues/26896
