### PR TITLE
revert: OpenAPI key parameters as string

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -103,7 +103,8 @@ paths:
           required: true
           description: The key of the job to fail.
           schema:
-            type: string
+            type: integer
+            format: int64
       requestBody:
         required: false
         content:
@@ -155,7 +156,8 @@ paths:
           required: true
           description: The key of the job.
           schema:
-            type: string
+            type: integer
+            format: int64
       requestBody:
         required: true
         content:
@@ -207,7 +209,8 @@ paths:
           required: true
           description: The key of the job to complete.
           schema:
-            type: string
+            type: integer
+            format: int64
       requestBody:
         required: false
         content:
@@ -258,7 +261,8 @@ paths:
           required: true
           description: The key of the job to update.
           schema:
-            type: string
+            type: integer
+            format: int64
       requestBody:
         required: true
         content:
@@ -311,7 +315,8 @@ paths:
           required: true
           description: Key of the incident to resolve.
           schema:
-            type: string
+            type: integer
+            format: int64
       responses:
         "204":
           description: The incident is marked as resolved.
@@ -346,7 +351,8 @@ paths:
           required: true
           description: The key of the user task to complete.
           schema:
-            type: string
+            type: integer
+            format: int64
       requestBody:
         required: false
         content:
@@ -398,7 +404,8 @@ paths:
           required: true
           description: The key of the user task to assign.
           schema:
-            type: string
+            type: integer
+            format: int64
       requestBody:
         required: true
         content:
@@ -449,7 +456,8 @@ paths:
           required: true
           description: The key of the user task to update.
           schema:
-            type: string
+            type: integer
+            format: int64
       requestBody:
         required: false
         content:
@@ -500,7 +508,8 @@ paths:
           required: true
           description: The key of the user task.
           schema:
-            type: string
+            type: integer
+            format: int64
       responses:
         "204":
           description: The user task was unassigned successfully.
@@ -770,7 +779,8 @@ paths:
           required: true
           description: The key of the process instance to cancel.
           schema:
-            type: string
+            type: integer
+            format: int64
       requestBody:
         required: false
         content:
@@ -817,7 +827,8 @@ paths:
           required: true
           description: The key of the process instance that should be migrated.
           schema:
-            type: string
+            type: integer
+            format: int64
       requestBody:
         required: true
         content:
@@ -869,7 +880,8 @@ paths:
           required: true
           description: The key of the process instance that should be modified.
           schema:
-            type: string
+            type: integer
+            format: int64
       requestBody:
         required: true
         content:
@@ -1031,7 +1043,8 @@ paths:
           required: true
           description: The assigned key of the decision definition, which acts as a unique identifier for this decision.
           schema:
-            type: string
+            type: integer
+            format: int64
       responses:
         "200":
           description: >
@@ -1662,7 +1675,8 @@ paths:
           required: true
           description: The assigned key of the incident, which acts as a unique identifier for this incident.
           schema:
-            type: string
+            type: integer
+            format: int64
       responses:
         "200":
           description: >
@@ -1765,7 +1779,8 @@ paths:
             This can be the key of a process definition, the key of a decision requirements
             definition or the key of a form definition
           schema:
-            type: string
+            type: integer
+            format: int64
       requestBody:
         required: false
         content:
@@ -1812,7 +1827,8 @@ paths:
             This can be the process instance key (as obtained during instance creation), or a given
             element, such as a service task (see the `elementInstanceKey` on the job message).
           schema:
-            type: string
+            type: integer
+            format: int64
       requestBody:
         required: true
         content:


### PR DESCRIPTION
## Description

- OpenAPI key parameters remain int64 for 8.6

## Related issues

related to https://github.com/camunda/camunda/issues/26761
