### PR TITLE
[Backport stable/8.4] Fix zeebe-io references

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -201,7 +201,7 @@ jobs:
           location: ${{ inputs.cluster-region }}
       - name: Add camunda helm repo
         run: |
-          helm repo add zeebe-benchmark https://zeebe-io.github.io/benchmark-helm
+          helm repo add zeebe-benchmark https://camunda.github.io/zeebe-benchmark-helm
           helm repo update
       - name: Helm install
         run: >

--- a/benchmarks/setup/README.md
+++ b/benchmarks/setup/README.md
@@ -34,7 +34,7 @@ to configure your benchmark.
 ### How to configure a Benchmark
 
 The benchmark configuration is completely done via the `zeebe-values.yaml` file.
-If there is a property missing which you want to change please open an issue in https://github.com/camunda/camunda-cloud-helm
+If there is a property missing which you want to change please open an issue in https://github.com/camunda/zeebe-benchmark-helm
 
 #### Use different Zeebe Snapshot
 

--- a/benchmarks/setup/newBenchmark.sh
+++ b/benchmarks/setup/newBenchmark.sh
@@ -26,5 +26,5 @@ cd $namespace
 sed_inplace "s/default/$namespace/g" Makefile
 
 # get latest updates from zeebe repo
-helm repo add zeebe-benchmark https://zeebe-io.github.io/benchmark-helm # skips if already exists
+helm repo add zeebe-benchmark https://camunda.github.io/zeebe-benchmark-helm # skips if already exists
 helm repo update


### PR DESCRIPTION
## Description

Backport of issue https://github.com/camunda/camunda/pull/26777 to stable/8.4.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
