### PR TITLE
refactor: introduce a TenantMemberEntity to ES/OS exporters

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantEntity.java
@@ -15,8 +15,6 @@ public class TenantEntity extends AbstractExporterEntity<TenantEntity> {
   private String tenantId;
   private String name;
   private String description;
-  private Long memberKey;
-  private String memberId;
 
   private EntityJoinRelation<String> join;
 
@@ -56,15 +54,6 @@ public class TenantEntity extends AbstractExporterEntity<TenantEntity> {
     return this;
   }
 
-  public Long getMemberKey() {
-    return memberKey;
-  }
-
-  public TenantEntity setMemberKey(final Long memberKey) {
-    this.memberKey = memberKey;
-    return this;
-  }
-
   public EntityJoinRelation<String> getJoin() {
     return join;
   }
@@ -72,14 +61,5 @@ public class TenantEntity extends AbstractExporterEntity<TenantEntity> {
   public TenantEntity setJoin(final EntityJoinRelation<String> join) {
     this.join = join;
     return this;
-  }
-
-  public TenantEntity setMemberId(final String memberId) {
-    this.memberId = memberId;
-    return this;
-  }
-
-  public static String getChildKey(final String tenantId, final String memberId) {
-    return String.format("%s-%s", tenantId, memberId);
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantMemberEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantMemberEntity.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.usermanagement;
+
+import io.camunda.webapps.schema.entities.AbstractExporterEntity;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+
+public class TenantMemberEntity extends AbstractExporterEntity<TenantMemberEntity> {
+
+  private String memberId;
+  private EntityType memberType;
+
+  private EntityJoinRelation<String> join;
+
+  public String getMemberId() {
+    return memberId;
+  }
+
+  public TenantMemberEntity setMemberId(final String memberId) {
+    this.memberId = memberId;
+    return this;
+  }
+
+  public EntityType getMemberType() {
+    return memberType;
+  }
+
+  public TenantMemberEntity setMemberType(final EntityType memberType) {
+    this.memberType = memberType;
+    return this;
+  }
+
+  public EntityJoinRelation<String> getJoin() {
+    return join;
+  }
+
+  public TenantMemberEntity setJoin(final EntityJoinRelation<String> join) {
+    this.join = join;
+    return this;
+  }
+
+  public static String getChildKey(final String tenantId, final String memberId) {
+    return String.format("%s-%s", tenantId, memberId);
+  }
+}

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-tenant.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-tenant.json
@@ -17,8 +17,11 @@
       "description": {
         "type": "text"
       },
-      "memberKey": {
-        "type": "long"
+      "memberId": {
+        "type": "keyword"
+      },
+      "memberType": {
+        "type": "keyword"
       },
       "join": {
         "type": "join",

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-tenant.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-tenant.json
@@ -17,8 +17,11 @@
       "description": {
         "type": "text"
       },
-      "memberKey": {
-        "type": "long"
+      "memberId": {
+        "type": "keyword"
+      },
+      "memberType": {
+        "type": "keyword"
       },
       "join": {
         "type": "join",

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityAddedHandler.java
@@ -10,14 +10,15 @@ package io.camunda.exporter.handlers;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex;
-import io.camunda.webapps.schema.entities.usermanagement.TenantEntity;
+import io.camunda.webapps.schema.entities.usermanagement.TenantMemberEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
 import java.util.List;
 
-public class TenantEntityAddedHandler implements ExportHandler<TenantEntity, TenantRecordValue> {
+public class TenantEntityAddedHandler
+    implements ExportHandler<TenantMemberEntity, TenantRecordValue> {
 
   private final String indexName;
 
@@ -31,8 +32,8 @@ public class TenantEntityAddedHandler implements ExportHandler<TenantEntity, Ten
   }
 
   @Override
-  public Class<TenantEntity> getEntityType() {
-    return TenantEntity.class;
+  public Class<TenantMemberEntity> getEntityType() {
+    return TenantMemberEntity.class;
   }
 
   @Override
@@ -44,24 +45,26 @@ public class TenantEntityAddedHandler implements ExportHandler<TenantEntity, Ten
   public List<String> generateIds(final Record<TenantRecordValue> record) {
     final var tenantRecord = record.getValue();
     return List.of(
-        TenantEntity.getChildKey(tenantRecord.getTenantId(), tenantRecord.getEntityId()));
+        TenantMemberEntity.getChildKey(tenantRecord.getTenantId(), tenantRecord.getEntityId()));
   }
 
   @Override
-  public TenantEntity createNewEntity(final String id) {
-    return new TenantEntity().setId(id);
+  public TenantMemberEntity createNewEntity(final String id) {
+    return new TenantMemberEntity().setId(id);
   }
 
   @Override
-  public void updateEntity(final Record<TenantRecordValue> record, final TenantEntity entity) {
+  public void updateEntity(
+      final Record<TenantRecordValue> record, final TenantMemberEntity entity) {
     final TenantRecordValue value = record.getValue();
     entity
         .setMemberId(value.getEntityId())
+        .setMemberType(value.getEntityType())
         .setJoin(TenantIndex.JOIN_RELATION_FACTORY.createChild(value.getTenantId()));
   }
 
   @Override
-  public void flush(final TenantEntity entity, final BatchRequest batchRequest)
+  public void flush(final TenantMemberEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
     batchRequest.addWithRouting(indexName, entity, entity.getJoin().parent());
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityRemovedHandler.java
@@ -10,14 +10,15 @@ package io.camunda.exporter.handlers;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex;
-import io.camunda.webapps.schema.entities.usermanagement.TenantEntity;
+import io.camunda.webapps.schema.entities.usermanagement.TenantMemberEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
 import java.util.List;
 
-public class TenantEntityRemovedHandler implements ExportHandler<TenantEntity, TenantRecordValue> {
+public class TenantEntityRemovedHandler
+    implements ExportHandler<TenantMemberEntity, TenantRecordValue> {
 
   private final String indexName;
 
@@ -31,8 +32,8 @@ public class TenantEntityRemovedHandler implements ExportHandler<TenantEntity, T
   }
 
   @Override
-  public Class<TenantEntity> getEntityType() {
-    return TenantEntity.class;
+  public Class<TenantMemberEntity> getEntityType() {
+    return TenantMemberEntity.class;
   }
 
   @Override
@@ -45,23 +46,24 @@ public class TenantEntityRemovedHandler implements ExportHandler<TenantEntity, T
   public List<String> generateIds(final Record<TenantRecordValue> record) {
     final var tenantRecord = record.getValue();
     return List.of(
-        TenantEntity.getChildKey(tenantRecord.getTenantId(), tenantRecord.getEntityId()));
+        TenantMemberEntity.getChildKey(tenantRecord.getTenantId(), tenantRecord.getEntityId()));
   }
 
   @Override
-  public TenantEntity createNewEntity(final String id) {
-    return new TenantEntity().setId(id);
+  public TenantMemberEntity createNewEntity(final String id) {
+    return new TenantMemberEntity().setId(id);
   }
 
   @Override
-  public void updateEntity(final Record<TenantRecordValue> record, final TenantEntity entity) {
+  public void updateEntity(
+      final Record<TenantRecordValue> record, final TenantMemberEntity entity) {
     final TenantRecordValue value = record.getValue();
     final var joinRelation = TenantIndex.JOIN_RELATION_FACTORY.createChild(value.getTenantId());
     entity.setMemberId(value.getEntityId()).setJoin(joinRelation);
   }
 
   @Override
-  public void flush(final TenantEntity entity, final BatchRequest batchRequest)
+  public void flush(final TenantMemberEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
     batchRequest.deleteWithRouting(
         indexName, entity.getId(), String.valueOf(entity.getJoin().parent()));

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityAddedHandlerTest.java
@@ -14,6 +14,7 @@ import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex;
 import io.camunda.webapps.schema.entities.usermanagement.TenantEntity;
+import io.camunda.webapps.schema.entities.usermanagement.TenantMemberEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
@@ -59,7 +60,7 @@ public class TenantEntityAddedHandlerTest {
     // then
     final var value = tenantRecord.getValue();
     assertThat(idList)
-        .containsExactly(TenantEntity.getChildKey(value.getTenantId(), value.getEntityId()));
+        .containsExactly(TenantMemberEntity.getChildKey(value.getTenantId(), value.getEntityId()));
   }
 
   @Test
@@ -76,8 +77,8 @@ public class TenantEntityAddedHandlerTest {
   void shouldUpdateTenantEntityOnFlush() throws PersistenceException {
     // given
     final var joinRelation = TenantIndex.JOIN_RELATION_FACTORY.createChild("111");
-    final TenantEntity inputEntity =
-        new TenantEntity().setId("111").setMemberKey(222L).setJoin(joinRelation);
+    final var inputEntity =
+        new TenantMemberEntity().setId("111").setMemberId("member-id-2").setJoin(joinRelation);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityAddedHandlerTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.*;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex;
-import io.camunda.webapps.schema.entities.usermanagement.TenantEntity;
 import io.camunda.webapps.schema.entities.usermanagement.TenantMemberEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -35,7 +34,7 @@ public class TenantEntityAddedHandlerTest {
 
   @Test
   void testGetEntityType() {
-    assertThat(underTest.getEntityType()).isEqualTo(TenantEntity.class);
+    assertThat(underTest.getEntityType()).isEqualTo(TenantMemberEntity.class);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityRemovedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TenantEntityRemovedHandlerTest.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.verify;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex;
-import io.camunda.webapps.schema.entities.usermanagement.TenantEntity;
+import io.camunda.webapps.schema.entities.usermanagement.TenantMemberEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
@@ -36,7 +36,7 @@ public class TenantEntityRemovedHandlerTest {
 
   @Test
   void testGetEntityType() {
-    assertThat(underTest.getEntityType()).isEqualTo(TenantEntity.class);
+    assertThat(underTest.getEntityType()).isEqualTo(TenantMemberEntity.class);
   }
 
   @Test
@@ -61,7 +61,7 @@ public class TenantEntityRemovedHandlerTest {
     // then
     final var value = tenantRecord.getValue();
     assertThat(idList)
-        .containsExactly(TenantEntity.getChildKey(value.getTenantId(), value.getEntityId()));
+        .containsExactly(TenantMemberEntity.getChildKey(value.getTenantId(), value.getEntityId()));
   }
 
   @Test
@@ -78,8 +78,8 @@ public class TenantEntityRemovedHandlerTest {
   void shouldUpdateTenantEntityOnFlush() throws PersistenceException {
     // given
     final var joinRelation = TenantIndex.JOIN_RELATION_FACTORY.createChild("111");
-    final TenantEntity inputEntity =
-        new TenantEntity().setId("111").setMemberKey(222L).setJoin(joinRelation);
+    final var inputEntity =
+        new TenantMemberEntity().setId("111").setMemberId("member-id-1").setJoin(joinRelation);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when


### PR DESCRIPTION
## Description

When sharing the progress of tenant members in the exporters it was suggested that the member docs are not optimal and also are missing a field. This PR achieves two things:

1. Adds in the `memberType` field such that you are able to filter for a specific type of member of a tenant
2. Adds in a `TenantMemberEntity` object that is exported instead of the overall `TenantEntity` object therefore reducing the fields in the child relation docs.

As a before and after, here is the ES indexes:

Before:
```
{
                "_index": "camunda-tenant-8.7.0_",
                "_id": "test-id-demo",
                "_score": 1.0,
                "_routing": "test-id",
                "_source": {
                    "id": "test-id-demo",
                    "key": null,
                    "tenantId": null,
                    "name": null,
                    "description": null,
                    "memberKey": null,
                    "join": {
                        "name": "member",
                        "parent": "test-id"
                    }
                }
            }
```

After: 
```
            {
                "_index": "camunda-tenant-8.8.0_",
                "_id": "test-id-demo",
                "_score": 1.0,
                "_routing": "test-id",
                "_source": {
                    "id": "test-id-demo",
                    "memberId": "demo",
                    "memberType": "USER",
                    "join": {
                        "name": "member",
                        "parent": "test-id"
                    }
                }
            }
```

## Related issues

_no related issue_
