### PR TITLE
feat: add option to override detected database vendor id #27317

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -33,7 +33,6 @@ import javax.sql.DataSource;
 import liquibase.integration.spring.MultiTenantSpringLiquibase;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.ibatis.mapping.DatabaseIdProvider;
-import org.apache.ibatis.mapping.VendorDatabaseIdProvider;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.OffsetDateTimeTypeHandler;
@@ -77,23 +76,14 @@ public class MyBatisConfiguration {
   }
 
   @Bean
-  public VendorDatabaseIdProvider vendorDatabaseIdProvider() {
-    final var vendorProperties = new Properties();
-    vendorProperties.put("H2", "h2");
-    vendorProperties.put("PostgreSQL", "postgresql");
-    vendorProperties.put("Oracle", "oracle");
-    vendorProperties.put("MariaDB", "mariadb");
-    vendorProperties.put("MySQL", "mariadb");
-    vendorProperties.put("SQL Server", "sqlserver");
-    final var databaseIdProvider = new VendorDatabaseIdProvider();
-    databaseIdProvider.setProperties(vendorProperties);
-
-    return databaseIdProvider;
+  public RdbmsDatabaseIdProvider databaseIdProvider(
+      @Value("${camunda.database.database-vendor-id:}") final String vendorId) {
+    return new RdbmsDatabaseIdProvider(vendorId);
   }
 
   @Bean
   public VendorDatabaseProperties databaseProperties(
-      final DataSource dataSource, final VendorDatabaseIdProvider databaseIdProvider)
+      final DataSource dataSource, final RdbmsDatabaseIdProvider databaseIdProvider)
       throws IOException {
     final var databaseId = databaseIdProvider.getDatabaseId(dataSource);
     LOGGER.info("Detected databaseId: {}", databaseId);

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsDatabaseIdProvider.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsDatabaseIdProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.rdbms;
+
+import java.util.Properties;
+import javax.sql.DataSource;
+import org.apache.ibatis.mapping.VendorDatabaseIdProvider;
+
+public class RdbmsDatabaseIdProvider extends VendorDatabaseIdProvider {
+
+  private static final Properties VENDOR_PROPERTIES = new Properties();
+
+  static {
+    VENDOR_PROPERTIES.put("H2", "h2");
+    VENDOR_PROPERTIES.put("PostgreSQL", "postgresql");
+    VENDOR_PROPERTIES.put("Oracle", "oracle");
+    VENDOR_PROPERTIES.put("MariaDB", "mariadb");
+    VENDOR_PROPERTIES.put("MySQL", "mariadb");
+  }
+
+  private final String databaseIdOverride;
+
+  public RdbmsDatabaseIdProvider(final String databaseIdOverride) {
+    this.databaseIdOverride = databaseIdOverride;
+    setProperties(VENDOR_PROPERTIES);
+  }
+
+  @Override
+  public String getDatabaseId(final DataSource dataSource) {
+    if (databaseIdOverride != null && !databaseIdOverride.isBlank()) {
+      if (VENDOR_PROPERTIES.containsValue(databaseIdOverride)) {
+        return databaseIdOverride;
+      } else {
+        throw new IllegalArgumentException(
+            "Invalid databaseIdOverride '"
+                + databaseIdOverride
+                + "', must be one of "
+                + VENDOR_PROPERTIES.values());
+      }
+    }
+
+    final var vendorId = super.getDatabaseId(dataSource);
+    if (vendorId == null) {
+      throw new IllegalArgumentException("Unable to detect database vendor");
+    }
+
+    return vendorId;
+  }
+}

--- a/dist/src/test/java/io/camunda/application/commons/rdbms/RdbmsDatabaseIdProviderTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/rdbms/RdbmsDatabaseIdProviderTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.rdbms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class RdbmsDatabaseIdProviderTest {
+
+  @Test
+  void shouldReturnOverrideWhenSet() {
+    final var dataSource = mock(DataSource.class);
+    final var databaseIdProvider = new RdbmsDatabaseIdProvider("h2");
+
+    assertThat(databaseIdProvider.getDatabaseId(dataSource)).isEqualTo("h2");
+  }
+
+  @Test
+  void shouldReturnOriginalWhenOverrideIsNotSet() throws SQLException {
+    final var dataSource = mock(DataSource.class, Mockito.RETURNS_DEEP_STUBS);
+    when(dataSource.getConnection().getMetaData().getDatabaseProductName()).thenReturn("H2");
+
+    final var databaseIdProvider = new RdbmsDatabaseIdProvider(null);
+
+    assertThat(databaseIdProvider.getDatabaseId(dataSource)).isEqualTo("h2");
+  }
+
+  @Test
+  void shouldFailIfInvalidOverride() {
+    final var dataSource = mock(DataSource.class, Mockito.RETURNS_DEEP_STUBS);
+    final var databaseIdProvider = new RdbmsDatabaseIdProvider("foo");
+
+    assertThatThrownBy(() -> databaseIdProvider.getDatabaseId(dataSource))
+        .hasMessageStartingWith("Invalid databaseIdOverride 'foo'");
+  }
+
+  @Test
+  void shouldFailIfVendorCouldNotBeDetected() throws SQLException {
+    final var dataSource = mock(DataSource.class, Mockito.RETURNS_DEEP_STUBS);
+    when(dataSource.getConnection().getMetaData().getDatabaseProductName()).thenReturn("Foo");
+
+    final var databaseIdProvider = new RdbmsDatabaseIdProvider(null);
+
+    assertThatThrownBy(() -> databaseIdProvider.getDatabaseId(dataSource))
+        .hasMessage("Unable to detect database vendor");
+  }
+}


### PR DESCRIPTION
## Description

The RDBMS module uses some database autodetection for special database handling (e.g. SQL syntax). In case this auto-detection fails or is incorrect, this PR adds the an optional property, to override this setting:

```yaml
camunda:
  database:
    database-vendor-id: someVendor
```

## Related issues

closes #27317 
