### PR TITLE
ci: switch auto backport labeler to 8.7

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -82,14 +82,6 @@ component/c8-api:
       - any-glob-to-any-file:
           - 'zeebe/gateway-protocol/src/main/proto/rest-api.yaml'
           - 'zeebe/gateway-rest/**'
-# to Forward-port PRs fixes to the deprecated java client classes in 8.7 (from 8.6)
-backport main: # TODO replace with 'backport stable/8.7' once the stable branch is created https://github.com/camunda/camunda/issues/26820
-  - all:
-      - changed-files:
-          - any-glob-to-any-file:
-              - 'clients/java/src/main/java/io/camunda/zeebe/**'
-              - 'clients/java/src/test/java/io/camunda/zeebe/**'
-      - base-branch: 'stable/8.6'
 # hint on changes done to the deprecated java client, and that might need to applied to the supported client
 deprecated-client:
   - all:
@@ -97,4 +89,4 @@ deprecated-client:
           - any-glob-to-any-file:
               - 'clients/java/src/main/java/io/camunda/zeebe/**'
               - 'clients/java/src/test/java/io/camunda/zeebe/**'
-      - base-branch: 'main' # TODO replace with 'backport stable/8.7' in https://github.com/camunda/camunda/issues/26820
+      - base-branch: 'main' # TODO replace with 'backport stable/8.8' in https://github.com/camunda/camunda/issues/26820


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
With the change of scope of 8.7 release, the auto-backporting of Legacy Zeebe client should be done from stable/8.7 to main (then future stable/8.8)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
