### PR TITLE
ci: switch auto backport labeler to 8.7

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -77,11 +77,11 @@ component/build-pipeline:
           - '.github/workflows/**'
           - '.github/actionlint*'
           - 'maven-settings.xml'
-# to Forward-port PRs fixes to the deprecated java client classes in 8.7 (from 8.6)
-backport main: # TODO replace with 'backport stable/8.7' once the stable branch is created https://github.com/camunda/camunda/issues/26820
+# to Forward-port PRs fixes to the deprecated java client classes in 8.8 (from 8.7)
+backport main: # TODO replace with 'backport stable/8.8' once the stable branch is created https://github.com/camunda/camunda/issues/26820
   - all:
       - changed-files:
           - any-glob-to-any-file:
               - 'clients/java/src/main/java/io/camunda/zeebe/**'
               - 'clients/java/src/test/java/io/camunda/zeebe/**'
-      - base-branch: 'stable/8.6'
+      - base-branch: 'stable/8.7'


### PR DESCRIPTION
With the change of scope of 8.7 release, the auto-backporting of Legacy Zeebe client should be done from stable/8.7 to main (then future stable/8.8)

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
