### PR TITLE
feat: unassign users from tenants by id not key

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -1550,18 +1550,18 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * <pre>
    * camundaClient
-   *   .newRemoveUserFromTenantCommand(tenantKey)
-   *   .userKey(userKey)
+   *   .newRemoveUserFromTenantCommand(tenantId)
+   *   .username(username)
    *   .send();
    * </pre>
    *
    * <p>This command sends an HTTP DELETE request to remove the specified user from the given
    * tenant.
    *
-   * @param tenantKey the unique identifier of the tenant
+   * @param tenantId the unique identifier of the tenant
    * @return a builder for the remove user from tenant command
    */
-  RemoveUserFromTenantCommandStep1 newRemoveUserFromTenantCommand(long tenantKey);
+  RemoveUserFromTenantCommandStep1 newRemoveUserFromTenantCommand(String tenantId);
 
   /**
    * Command to assign a group to a tenant.

--- a/clients/java/src/main/java/io/camunda/client/api/command/RemoveUserFromTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/RemoveUserFromTenantCommandStep1.java
@@ -22,11 +22,10 @@ public interface RemoveUserFromTenantCommandStep1
     extends FinalCommandStep<RemoveUserFromTenantResponse> {
 
   /**
-   * Sets the user key for the removal of assignment.
+   * Sets the username for the removal of assignment.
    *
-   * @param userKey the key of the user
    * @return the builder for this command. Call {@link #send()} to complete the command and send it
    *     to the broker.
    */
-  RemoveUserFromTenantCommandStep1 userKey(long userKey);
+  RemoveUserFromTenantCommandStep1 username(String username);
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -879,11 +879,6 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public RemoveUserFromTenantCommandStep1 newRemoveUserFromTenantCommand(final long tenantKey) {
-    return new RemoveUserFromTenantCommandImpl(httpClient, tenantKey);
-  }
-
-  @Override
   public AssignGroupToTenantCommandStep1 newAssignGroupToTenantCommand(final long tenantKey) {
     return new AssignGroupToTenantCommandImpl(httpClient, tenantKey);
   }
@@ -909,6 +904,11 @@ public final class CamundaClientImpl implements CamundaClient {
   public UpdateAuthorizationCommandStep1 newUpdateAuthorizationCommand(
       final long authorizationKey) {
     return new UpdateAuthorizationCommandImpl(httpClient, jsonMapper, authorizationKey);
+  }
+
+  @Override
+  public RemoveUserFromTenantCommandStep1 newRemoveUserFromTenantCommand(final String tenantId) {
+    return new RemoveUserFromTenantCommandImpl(httpClient, tenantId);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/client/impl/command/RemoveUserFromTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/RemoveUserFromTenantCommandImpl.java
@@ -27,20 +27,20 @@ import org.apache.hc.client5.http.config.RequestConfig;
 
 public final class RemoveUserFromTenantCommandImpl implements RemoveUserFromTenantCommandStep1 {
 
-  private final long tenantKey;
-  private long userKey;
+  private final String tenantId;
+  private String username;
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
 
-  public RemoveUserFromTenantCommandImpl(final HttpClient httpClient, final long tenantKey) {
+  public RemoveUserFromTenantCommandImpl(final HttpClient httpClient, final String tenantId) {
     this.httpClient = httpClient;
-    this.tenantKey = tenantKey;
+    this.tenantId = tenantId;
     httpRequestConfig = httpClient.newRequestConfig();
   }
 
   @Override
-  public RemoveUserFromTenantCommandStep1 userKey(final long userKey) {
-    this.userKey = userKey;
+  public RemoveUserFromTenantCommandStep1 username(final String username) {
+    this.username = username;
     return this;
   }
 
@@ -54,7 +54,7 @@ public final class RemoveUserFromTenantCommandImpl implements RemoveUserFromTena
   @Override
   public CamundaFuture<RemoveUserFromTenantResponse> send() {
     final HttpCamundaFuture<RemoveUserFromTenantResponse> result = new HttpCamundaFuture<>();
-    final String endpoint = String.format("/tenants/%d/users/%d", tenantKey, userKey);
+    final String endpoint = String.format("/tenants/%s/users/%s", tenantId, username);
     httpClient.delete(endpoint, null, httpRequestConfig.build(), result);
     return result;
   }

--- a/clients/java/src/test/java/io/camunda/client/tenant/RemoveUserFromTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/RemoveUserFromTenantTest.java
@@ -28,19 +28,19 @@ import org.junit.jupiter.api.Test;
 
 public class RemoveUserFromTenantTest extends ClientRestTest {
 
-  private static final long TENANT_KEY = 123L;
-  private static final long USER_KEY = 456L;
+  private static final String TENANT_ID = "tenant-id";
+  private static final String USERNAME = "username";
 
   @Test
   void shouldRemoveUserFromTenant() {
     // when
-    client.newRemoveUserFromTenantCommand(TENANT_KEY).userKey(USER_KEY).send().join();
+    client.newRemoveUserFromTenantCommand(TENANT_ID).username(USERNAME).send().join();
 
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();
     final RequestMethod method = RestGatewayService.getLastRequest().getMethod();
     assertThat(requestPath)
-        .isEqualTo(REST_API_PATH + "/tenants/" + TENANT_KEY + "/users/" + USER_KEY);
+        .isEqualTo(REST_API_PATH + "/tenants/" + TENANT_ID + "/users/" + USERNAME);
     assertThat(method).isEqualTo(RequestMethod.DELETE);
   }
 
@@ -48,12 +48,12 @@ public class RemoveUserFromTenantTest extends ClientRestTest {
   void shouldRaiseExceptionOnNotFoundTenant() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_KEY + "/users/" + USER_KEY,
+        REST_API_PATH + "/tenants/" + TENANT_ID + "/users/" + USERNAME,
         () -> new ProblemDetail().title("Not Found").status(404));
 
     // when / then
     assertThatThrownBy(
-            () -> client.newRemoveUserFromTenantCommand(TENANT_KEY).userKey(USER_KEY).send().join())
+            () -> client.newRemoveUserFromTenantCommand(TENANT_ID).username(USERNAME).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -62,12 +62,12 @@ public class RemoveUserFromTenantTest extends ClientRestTest {
   void shouldRaiseExceptionOnNotFoundUser() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_KEY + "/users/" + USER_KEY,
+        REST_API_PATH + "/tenants/" + TENANT_ID + "/users/" + USERNAME,
         () -> new ProblemDetail().title("Not Found").status(404));
 
     // when / then
     assertThatThrownBy(
-            () -> client.newRemoveUserFromTenantCommand(TENANT_KEY).userKey(USER_KEY).send().join())
+            () -> client.newRemoveUserFromTenantCommand(TENANT_ID).username(USERNAME).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -76,12 +76,12 @@ public class RemoveUserFromTenantTest extends ClientRestTest {
   void shouldHandleServerError() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_KEY + "/users/" + USER_KEY,
+        REST_API_PATH + "/tenants/" + TENANT_ID + "/users/" + USERNAME,
         () -> new ProblemDetail().title("Internal Server Error").status(500));
 
     // when / then
     assertThatThrownBy(
-            () -> client.newRemoveUserFromTenantCommand(TENANT_KEY).userKey(USER_KEY).send().join())
+            () -> client.newRemoveUserFromTenantCommand(TENANT_ID).username(USERNAME).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 500: 'Internal Server Error'");
   }
@@ -90,12 +90,12 @@ public class RemoveUserFromTenantTest extends ClientRestTest {
   void shouldRaiseExceptionOnForbiddenRequest() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_KEY + "/users/" + USER_KEY,
+        REST_API_PATH + "/tenants/" + TENANT_ID + "/users/" + USERNAME,
         () -> new ProblemDetail().title("Forbidden").status(403));
 
     // when / then
     assertThatThrownBy(
-            () -> client.newRemoveUserFromTenantCommand(TENANT_KEY).userKey(USER_KEY).send().join())
+            () -> client.newRemoveUserFromTenantCommand(TENANT_ID).username(USERNAME).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 403: 'Forbidden'");
   }

--- a/clients/java/src/test/java/io/camunda/client/tenant/UnassignGroupFromTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/UnassignGroupFromTenantTest.java
@@ -23,8 +23,11 @@ import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.protocol.rest.ProblemDetail;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+@Disabled(
+    "Disabled while groups are not fully supported yet: https://github.com/camunda/camunda/issues/26961 ")
 public class UnassignGroupFromTenantTest extends ClientRestTest {
 
   private static final long TENANT_KEY = 123L;

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -109,6 +109,14 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
             .setEntity(entityType, entityKey));
   }
 
+  public CompletableFuture<TenantRecord> removeMember(
+      final String tenantId, final EntityType entityType, final String entityId) {
+    return sendBrokerRequest(
+        BrokerTenantEntityRequest.createRemoveRequest()
+            .setTenantId(tenantId)
+            .setEntity(entityType, entityId));
+  }
+
   public Collection<TenantEntity> getTenantsByMemberKey(final long memberKey) {
     return getTenantsByMemberKeys(Set.of(memberKey));
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantProcessors.java
@@ -66,7 +66,7 @@ public class TenantProcessors {
             ValueType.TENANT,
             TenantIntent.DELETE,
             new TenantDeleteProcessor(
-                processingState.getTenantState(),
+                processingState,
                 authCheckBehavior,
                 keyGenerator,
                 writers,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
@@ -124,8 +124,8 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
           tenantKey,
           TenantIntent.ENTITY_REMOVED,
           new TenantRecord()
-              .setTenantKey(tenantKey)
-              .setEntityKey(userKey)
+              .setTenantId(tenantId)
+              .setEntityId(user.getUsername())
               .setEntityType(EntityType.USER));
     }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -494,8 +494,8 @@ public class CommandDistributionIdempotencyTest {
                       .add();
                   ENGINE
                       .tenant()
-                      .removeEntity(tenant.getKey())
-                      .withEntityKey(user.getKey())
+                      .removeEntity(tenant.getValue().getTenantId())
+                      .withEntityId(user.getValue().getUsername())
                       .withEntityType(EntityType.USER)
                       .remove();
                 },

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingTest.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
-import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -128,14 +127,13 @@ public class MappingTest {
   }
 
   @Test
-  public void shouldCleanupMembership() {
+  public void shouldCleanupGroupAndRoleMembership() {
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
     final var mappingRecord =
         engine.mapping().newMapping(claimName).withClaimValue(claimValue).create();
     final var group = engine.group().newGroup("group").create();
     final var role = engine.role().newRole("role").create();
-    final var tenant = engine.tenant().newTenant().withTenantId("tenant").create();
     engine
         .group()
         .addEntity(group.getKey())
@@ -145,12 +143,6 @@ public class MappingTest {
     engine
         .role()
         .addEntity(role.getKey())
-        .withEntityKey(mappingRecord.getKey())
-        .withEntityType(EntityType.MAPPING)
-        .add();
-    engine
-        .tenant()
-        .addEntity(tenant.getKey())
         .withEntityKey(mappingRecord.getKey())
         .withEntityType(EntityType.MAPPING)
         .add();
@@ -168,12 +160,6 @@ public class MappingTest {
     Assertions.assertThat(
             RecordingExporter.roleRecords(RoleIntent.ENTITY_REMOVED)
                 .withRoleKey(role.getKey())
-                .withEntityKey(mappingRecord.getKey())
-                .exists())
-        .isTrue();
-    Assertions.assertThat(
-            RecordingExporter.tenantRecords(TenantIntent.ENTITY_REMOVED)
-                .withTenantKey(tenant.getKey())
                 .withEntityKey(mappingRecord.getKey())
                 .exists())
         .isTrue();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/RemoveEntityTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/RemoveEntityTenantMultiPartitionTest.java
@@ -38,28 +38,26 @@ public class RemoveEntityTenantMultiPartitionTest {
 
   public void setupTenantWithUserAndRemoveEntity() {
     final var username = "foo";
-    final var userKey =
-        engine
-            .user()
-            .newUser(username)
-            .withEmail("foo@bar")
-            .withName("Foo Bar")
-            .withPassword("zabraboof")
-            .create()
-            .getKey();
+    engine
+        .user()
+        .newUser(username)
+        .withEmail("foo@bar")
+        .withName("Foo Bar")
+        .withPassword("zabraboof")
+        .create()
+        .getKey();
     final var tenantId = UUID.randomUUID().toString();
-    final var tenantKey =
-        engine.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
+    engine.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
     engine
         .tenant()
-        .addEntity(tenantKey)
+        .addEntity(tenantId)
         .withEntityId(username)
         .withEntityType(EntityType.USER)
         .add();
     engine
         .tenant()
-        .removeEntity(tenantKey)
-        .withEntityKey(userKey)
+        .removeEntity(tenantId)
+        .withEntityId(username)
         .withEntityType(EntityType.USER)
         .remove();
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/RemoveEntityTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/RemoveEntityTenantTest.java
@@ -27,75 +27,79 @@ public class RemoveEntityTenantTest {
   @Test
   public void shouldRemoveEntityFromTenant() {
     final var tenantId = UUID.randomUUID().toString();
-    final var tenantKey =
-        engine
-            .tenant()
-            .newTenant()
-            .withTenantId(tenantId)
-            .withName("name")
-            .create()
-            .getValue()
-            .getTenantKey();
-    final var username = "foo";
-    final var userKey =
-        engine
-            .user()
-            .newUser(username)
-            .withEmail("foo@bar")
-            .withName("Foo Bar")
-            .withPassword("zabraboof")
-            .create()
-            .getKey();
     engine
         .tenant()
-        .addEntity(tenantKey)
+        .newTenant()
+        .withTenantId(tenantId)
+        .withName("name")
+        .create()
+        .getValue()
+        .getTenantKey();
+    final var username = "foo";
+    engine
+        .user()
+        .newUser(username)
+        .withEmail("foo@bar")
+        .withName("Foo Bar")
+        .withPassword("zabraboof")
+        .create();
+    engine
+        .tenant()
+        .addEntity(tenantId)
         .withEntityId(username)
         .withEntityType(EntityType.USER)
         .add();
     final var removedEntity =
         engine
             .tenant()
-            .removeEntity(tenantKey)
-            .withEntityKey(userKey)
+            .removeEntity(tenantId)
+            .withEntityId(username)
             .withEntityType(EntityType.USER)
             .remove()
             .getValue();
 
     Assertions.assertThat(removedEntity)
         .isNotNull()
-        .hasFieldOrPropertyWithValue("tenantKey", tenantKey)
-        .hasFieldOrPropertyWithValue("entityKey", userKey)
+        .hasFieldOrPropertyWithValue("tenantId", tenantId)
+        .hasFieldOrPropertyWithValue("entityId", username)
         .hasFieldOrPropertyWithValue("entityType", EntityType.USER);
   }
 
   @Test
   public void shouldRejectIfTenantIsNotPresentEntityRemoval() {
-    final var notPresentTenantKey = 1L;
+    final var notPresentTenantId = UUID.randomUUID().toString();
     final var notPresentUpdateRecord =
-        engine.tenant().removeEntity(notPresentTenantKey).expectRejection().remove();
+        engine.tenant().removeEntity(notPresentTenantId).expectRejection().remove();
 
     assertThat(notPresentUpdateRecord)
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
-            "Expected to remove entity from tenant with key '"
-                + notPresentTenantKey
-                + "', but no tenant with this key exists.");
+            "Expected to remove entity from tenant '"
+                + notPresentTenantId
+                + "', but no tenant with this id exists.");
   }
 
   @Test
   public void shouldRejectIfEntityIsNotPresentEntityRemoval() {
     // given
     final var tenantId = UUID.randomUUID().toString();
+    final var username = UUID.randomUUID().toString();
     final var tenantRecord = engine.tenant().newTenant().withTenantId(tenantId).create();
+    engine
+        .user()
+        .newUser(username)
+        .withEmail("foo@bar")
+        .withName("Foo Bar")
+        .withPassword("zabraboof")
+        .create();
 
     // when
     final var createdTenant = tenantRecord.getValue();
-    final var tenantKey = createdTenant.getTenantKey();
     final var notPresentUpdateRecord =
         engine
             .tenant()
-            .removeEntity(tenantKey)
-            .withEntityKey(1L)
+            .removeEntity(tenantId)
+            .withEntityId(username)
             .withEntityType(EntityType.USER)
             .expectRejection()
             .remove();
@@ -107,33 +111,30 @@ public class RemoveEntityTenantTest {
     assertThat(notPresentUpdateRecord)
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
-            "Expected to remove entity with key '%s' from tenant with key '%s', but the entity does not exist."
-                .formatted(1L, tenantKey));
+            "Expected to remove user '%s' from tenant '%s', but the user is not assigned to this tenant."
+                .formatted(username, tenantId));
   }
 
   @Test
   public void shouldRejectIfEntityIsNotAssigned() {
     // given
     final var tenantId = UUID.randomUUID().toString();
-    final var tenantRecord = engine.tenant().newTenant().withTenantId(tenantId).create();
+    engine.tenant().newTenant().withTenantId(tenantId).create();
 
     // when
-    final var createdTenant = tenantRecord.getValue();
-    final var tenantKey = createdTenant.getTenantKey();
-    final var userKey =
-        engine
-            .user()
-            .newUser("foo")
-            .withEmail("foo@bar")
-            .withName("Foo Bar")
-            .withPassword("zabraboof")
-            .create()
-            .getKey();
+    final var username = "foo";
+    engine
+        .user()
+        .newUser(username)
+        .withEmail("foo@bar")
+        .withName("Foo Bar")
+        .withPassword("zabraboof")
+        .create();
     final var notAssignedUpdateRecord =
         engine
             .tenant()
-            .removeEntity(tenantKey)
-            .withEntityKey(userKey)
+            .removeEntity(tenantId)
+            .withEntityId(username)
             .withEntityType(EntityType.USER)
             .expectRejection()
             .remove();
@@ -141,7 +142,7 @@ public class RemoveEntityTenantTest {
     assertThat(notAssignedUpdateRecord)
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
-            "Expected to remove entity with key '%s' from tenant with key '%s', but the entity is not assigned to this tenant."
-                .formatted(userKey, tenantKey));
+            "Expected to remove user '%s' from tenant '%s', but the user is not assigned to this tenant."
+                .formatted(username, tenantId));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessorTest.java
@@ -111,7 +111,7 @@ public class TenantDeleteProcessorTest {
     final var tenantRecords =
         RecordingExporter.tenantRecords()
             .withIntents(TenantIntent.ENTITY_REMOVED, TenantIntent.DELETED)
-            .withTenantKey(tenantKey)
+            .withTenantId(tenantId)
             .asList();
 
     assertThat(deletedTenant).hasTenantKey(tenantKey);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserTest.java
@@ -100,8 +100,8 @@ public class DeleteUserTest {
         .isTrue();
     Assertions.assertThat(
             RecordingExporter.tenantRecords(TenantIntent.ENTITY_REMOVED)
-                .withTenantKey(tenant.getKey())
-                .withEntityKey(userRecord.getKey())
+                .withTenantId(tenantId)
+                .withEntityId(username)
                 .exists())
         .isTrue();
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -143,9 +144,8 @@ public class TenantAppliersTest {
     // when
     final var tenantRecord =
         new TenantRecord()
-            .setTenantKey(tenantKey)
             .setTenantId(tenantId)
-            .setEntityKey(entityKey)
+            .setEntityId(username)
             .setEntityType(EntityType.USER);
     tenantEntityRemovedApplier.applyState(tenantKey, tenantRecord);
 
@@ -156,6 +156,8 @@ public class TenantAppliersTest {
   }
 
   @Test
+  @Disabled(
+      "Disabled while mappings are not supported: https://github.com/camunda/camunda/issues/26981")
   void shouldRemoveEntityFromTenantWithTypeMapping() {
     // given
     final long entityKey = 1L;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/TenantClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/TenantClient.java
@@ -71,14 +71,14 @@ public class TenantClient {
    * uses the internal command writer to submit the remove entity commands.
    *
    * <p>This operation is used when a specific entity (e.g., a user) needs to be disassociated from
-   * a tenant. The entity type and entity key must be provided through the {@link
+   * a tenant. The entity type and entity id must be provided through the {@link
    * TenantRemoveEntityClient}.
    *
-   * @param tenantKey the key of the tenant from which the entity will be removed
+   * @param tenantId the id of the tenant from which the entity will be removed
    * @return a new instance of {@link TenantRemoveEntityClient}
    */
-  public TenantRemoveEntityClient removeEntity(final long tenantKey) {
-    return new TenantRemoveEntityClient(writer, tenantKey);
+  public TenantRemoveEntityClient removeEntity(final String tenantId) {
+    return new TenantRemoveEntityClient(writer, tenantId);
   }
 
   /**
@@ -333,14 +333,14 @@ public class TenantClient {
     private final TenantRecord tenantRecord;
     private Function<Long, Record<TenantRecordValue>> expectation = SUCCESS_SUPPLIER;
 
-    public TenantRemoveEntityClient(final CommandWriter writer, final long tenantKey) {
+    public TenantRemoveEntityClient(final CommandWriter writer, final String tenantId) {
       this.writer = writer;
       tenantRecord = new TenantRecord();
-      tenantRecord.setTenantKey(tenantKey);
+      tenantRecord.setTenantId(tenantId);
     }
 
-    public TenantRemoveEntityClient withEntityKey(final long entityKey) {
-      tenantRecord.setEntityKey(entityKey);
+    public TenantRemoveEntityClient withEntityId(final String entityId) {
+      tenantRecord.setEntityId(entityId);
       return this;
     }
 

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -594,13 +594,13 @@ paths:
       summary: Remove a user from a tenant
       description: Removes a single user from a specified tenant without deleting the user.
       parameters:
-        - name: tenantKey
+        - name: tenantId
           in: path
           required: true
           description: The unique identifier of the tenant.
           schema:
             type: string
-        - name: userKey
+        - name: username
           in: path
           required: true
           description: The unique identifier of the user.

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -550,43 +550,6 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
-
-  /tenants/{tenantId}/users/search:
-    post:
-      tags:
-        - Tenant
-        - User
-      operationId: searchUsersForTenant
-      summary: Query users for tenant
-      description: Retrieves a filtered and sorted list of users for a specified tenant.
-      parameters:
-        - name: tenantId
-          in: path
-          required: true
-          description: The unique identifier of the tenant.
-          schema:
-            type: string
-      requestBody:
-        required: false
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/UserSearchQueryRequest"
-      responses:
-        "200":
-          description: The search result of users for the tenant.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/UserSearchResult"
-            application/vnd.camunda.api.keys.number+json:
-              schema:
-                $ref: "#/components/schemas/UserSearchResult"
-            application/vnd.camunda.api.keys.string+json:
-              schema:
-                $ref: "#/components/schemas/UserSearchResult"
-
-  /tenants/{tenantKey}/users/{userKey}:
     delete:
       tags:
         - Tenant
@@ -626,6 +589,41 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
+
+  /tenants/{tenantId}/users/search:
+    post:
+      tags:
+        - Tenant
+        - User
+      operationId: searchUsersForTenant
+      summary: Query users for tenant
+      description: Retrieves a filtered and sorted list of users for a specified tenant.
+      parameters:
+        - name: tenantId
+          in: path
+          required: true
+          description: The unique identifier of the tenant.
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserSearchQueryRequest"
+      responses:
+        "200":
+          description: The search result of users for the tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserSearchResult"
+            application/vnd.camunda.api.keys.number+json:
+              schema:
+                $ref: "#/components/schemas/UserSearchResult"
+            application/vnd.camunda.api.keys.string+json:
+              schema:
+                $ref: "#/components/schemas/UserSearchResult"
 
   /tenants/{tenantKey}/mapping-rules/{mappingKey}:
     put:

--- a/zeebe/gateway-protocol/vacuum-ignores.yaml
+++ b/zeebe/gateway-protocol/vacuum-ignores.yaml
@@ -1,5 +1,1 @@
 # https://quobix.com/vacuum/ignoring/
-no-ambiguous-paths:
-  - $.paths['/tenants/{tenantKey}/users/{userKey}'] # Temporarily ambiguous until unassign is id-based too
-path-params:
-  - $.paths.['/tenants/{tenantKey}/users/{userKey}'] # Temporarily ambiguous until unassign is id-based too

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -124,6 +124,16 @@ public class TenantController {
                 .addMember(tenantKey, EntityType.GROUP, groupKey));
   }
 
+  @CamundaDeleteMapping(path = "/{tenantId}")
+  public CompletableFuture<ResponseEntity<Object>> deleteTenant(
+      @PathVariable final String tenantId) {
+    return RequestMapper.executeServiceMethodWithNoContentResult(
+        () ->
+            tenantServices
+                .withAuthentication(RequestMapper.getAuthentication())
+                .deleteTenant(tenantId));
+  }
+
   @CamundaDeleteMapping(path = "/{tenantId}/users/{username}")
   public CompletableFuture<ResponseEntity<Object>> removeUserFromTenant(
       @PathVariable final String tenantId, @PathVariable final String username) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -124,24 +124,14 @@ public class TenantController {
                 .addMember(tenantKey, EntityType.GROUP, groupKey));
   }
 
-  @CamundaDeleteMapping(path = "/{tenantId}")
-  public CompletableFuture<ResponseEntity<Object>> deleteTenant(
-      @PathVariable final String tenantId) {
-    return RequestMapper.executeServiceMethodWithNoContentResult(
-        () ->
-            tenantServices
-                .withAuthentication(RequestMapper.getAuthentication())
-                .deleteTenant(tenantId));
-  }
-
-  @CamundaDeleteMapping(path = "/{tenantKey}/users/{userKey}")
+  @CamundaDeleteMapping(path = "/{tenantId}/users/{username}")
   public CompletableFuture<ResponseEntity<Object>> removeUserFromTenant(
-      @PathVariable final long tenantKey, @PathVariable final long userKey) {
+      @PathVariable final String tenantId, @PathVariable final String username) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             tenantServices
                 .withAuthentication(RequestMapper.getAuthentication())
-                .removeMember(tenantKey, EntityType.USER, userKey));
+                .removeMember(tenantId, EntityType.USER, username));
   }
 
   @CamundaDeleteMapping(path = "/{tenantKey}/mapping-rules/{mappingKey}")

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -374,8 +374,8 @@ public class TenantControllerTest extends RestControllerTest {
   }
 
   @ParameterizedTest
-  @MethodSource("provideRemoveMemberTestCases")
-  void testRemoveMemberFromTenant(final EntityType entityType, final String entityPath) {
+  @MethodSource("provideRemoveMemberByKeyTestCases")
+  void testRemoveMemberByKeyFromTenant(final EntityType entityType, final String entityPath) {
     // given
     final var tenantKey = 100L;
     final var entityKey = 42L;
@@ -396,6 +396,29 @@ public class TenantControllerTest extends RestControllerTest {
     verify(tenantServices, times(1)).removeMember(tenantKey, entityType, entityKey);
   }
 
+  @ParameterizedTest
+  @MethodSource("provideRemoveMemberByIdTestCases")
+  void testRemoveMemberByIdFromTenant(final EntityType entityType, final String entityPath) {
+    // given
+    final var tenantId = "some-tenant-id";
+    final var entityId = "entity-id";
+
+    when(tenantServices.removeMember(tenantId, entityType, entityId))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    webClient
+        .delete()
+        .uri("%s/%s/%s/%s".formatted(TENANT_BASE_URL, tenantId, entityPath, entityId))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    // then
+    verify(tenantServices, times(1)).removeMember(tenantId, entityType, entityId);
+  }
+
   private static Stream<Arguments> provideAddMemberByKeyTestCases() {
     return Stream.of(
         Arguments.of(EntityType.MAPPING, "mapping-rules"),
@@ -406,10 +429,13 @@ public class TenantControllerTest extends RestControllerTest {
     return Stream.of(Arguments.of(EntityType.USER, "users"));
   }
 
-  private static Stream<Arguments> provideRemoveMemberTestCases() {
+  private static Stream<Arguments> provideRemoveMemberByKeyTestCases() {
     return Stream.of(
-        Arguments.of(EntityType.USER, "users"),
         Arguments.of(EntityType.MAPPING, "mapping-rules"),
         Arguments.of(EntityType.GROUP, "groups"));
+  }
+
+  private static Stream<Arguments> provideRemoveMemberByIdTestCases() {
+    return Stream.of(Arguments.of(EntityType.USER, "users"));
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RemoveUserFromTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RemoveUserFromTenantTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import java.time.Duration;
+import java.util.UUID;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.Test;
 class RemoveUserFromTenantTest {
 
   private static final String TENANT_ID = "tenant-id";
+  private static final String USERNAME = "username";
 
   @TestZeebe
   private final TestStandaloneBroker zeebe =
@@ -33,116 +35,102 @@ class RemoveUserFromTenantTest {
 
   @AutoClose private CamundaClient client;
 
-  private long tenantKey;
-  private long userKey;
-
   @BeforeEach
   void initClientAndInstances() {
     client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
 
     // Create Tenant
-    tenantKey =
-        client
-            .newCreateTenantCommand()
-            .tenantId(TENANT_ID)
-            .name("Tenant Name")
-            .send()
-            .join()
-            .getTenantKey();
+    client.newCreateTenantCommand().tenantId(TENANT_ID).name("Tenant Name").send().join();
 
     // Create User
-    final var username = "username";
-    userKey =
-        client
-            .newUserCreateCommand()
-            .username(username)
-            .name("name")
-            .email("email@example.com")
-            .password("password")
-            .send()
-            .join()
-            .getUserKey();
+    client
+        .newUserCreateCommand()
+        .username(USERNAME)
+        .name("name")
+        .email("email@example.com")
+        .password("password")
+        .send()
+        .join();
 
     // Assign User to Tenant
-    client.newAssignUserToTenantCommand(TENANT_ID).username(username).send().join();
+    client.newAssignUserToTenantCommand(TENANT_ID).username(USERNAME).send().join();
   }
 
   @Test
   void shouldRemoveUserFromTenant() {
     // When
-    client.newRemoveUserFromTenantCommand(tenantKey).userKey(userKey).send().join();
+    client.newRemoveUserFromTenantCommand(TENANT_ID).username(USERNAME).send().join();
 
     // Then
     ZeebeAssertHelper.assertEntityRemovedFromTenant(
-        tenantKey, userKey, tenant -> assertThat(tenant.getEntityType()).isEqualTo(USER));
+        TENANT_ID, USERNAME, tenant -> assertThat(tenant.getEntityType()).isEqualTo(USER));
   }
 
   @Test
   void shouldRejectUnassignIfTenantDoesNotExist() {
     // Given
-    final long invalidTenantKey = 99999L;
+    final var invalidTenantId = UUID.randomUUID().toString();
 
     // When / Then
     assertThatThrownBy(
             () ->
                 client
-                    .newRemoveUserFromTenantCommand(invalidTenantKey)
-                    .userKey(userKey)
+                    .newRemoveUserFromTenantCommand(invalidTenantId)
+                    .username(USERNAME)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
         .hasMessageContaining(
-            "Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND': Expected to remove entity from tenant with key '%d', but no tenant with this key exists."
-                .formatted(invalidTenantKey));
+            "Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND': Expected to remove entity from tenant '%s', but no tenant with this id exists."
+                .formatted(invalidTenantId));
   }
 
   @Test
   void shouldRejectUnassignIfUserDoesNotExist() {
     // Given
-    final long invalidUserKey = 99999L;
+    final var invalidUsername = UUID.randomUUID().toString();
 
     // When / Then
     assertThatThrownBy(
             () ->
                 client
-                    .newRemoveUserFromTenantCommand(tenantKey)
-                    .userKey(invalidUserKey)
+                    .newRemoveUserFromTenantCommand(TENANT_ID)
+                    .username(invalidUsername)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
         .hasMessageContaining(
-            "Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND': Expected to remove entity with key '%d' from tenant with key '%d', but the entity does not exist."
-                .formatted(invalidUserKey, tenantKey));
+            "Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND': Expected to remove user '%s' from tenant, but no user with this id exists."
+                .formatted(invalidUsername));
   }
 
   @Test
   void shouldRejectUnassignIfUserIsNotAssignedToTenant() {
     // Given
-    final long unassignedUserKey =
-        client
-            .newUserCreateCommand()
-            .username("username2")
-            .name("name2")
-            .email("email2@example.com")
-            .password("password")
-            .send()
-            .join()
-            .getUserKey();
+    final var unassignedUsername = "username2";
+    client
+        .newUserCreateCommand()
+        .username(unassignedUsername)
+        .name("name2")
+        .email("email2@example.com")
+        .password("password")
+        .send()
+        .join();
 
     // When / Then
     assertThatThrownBy(
             () ->
                 client
-                    .newRemoveUserFromTenantCommand(tenantKey)
-                    .userKey(unassignedUserKey)
+                    .newRemoveUserFromTenantCommand(TENANT_ID)
+                    .username(unassignedUsername)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
         .hasMessageContaining(
-            "Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND': Expected to remove entity with key '%d' from tenant with key '%d', but the entity is not assigned to this tenant."
-                .formatted(unassignedUserKey, tenantKey));
+            "Command 'REMOVE_ENTITY' rejected with code 'NOT_FOUND': Expected to remove user '%s' from tenant '%s', but the user is not assigned to this tenant."
+                .formatted(unassignedUsername, TENANT_ID));
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignGroupFromTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignGroupFromTenantTest.java
@@ -19,8 +19,11 @@ import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import java.time.Duration;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+@Disabled(
+    "Disabled while groups are not fully supported yet: https://github.com/camunda/camunda/issues/26961 ")
 @ZeebeIntegration
 class UnassignGroupFromTenantTest {
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
@@ -534,12 +534,12 @@ public final class ZeebeAssertHelper {
   }
 
   public static void assertEntityRemovedFromTenant(
-      final long tenantKey, final long entityKey, final Consumer<TenantRecordValue> consumer) {
+      final String tenantId, final String entityId, final Consumer<TenantRecordValue> consumer) {
     final TenantRecordValue tenantRecordValue =
         RecordingExporter.tenantRecords()
             .withIntent(TenantIntent.ENTITY_REMOVED)
-            .withTenantKey(tenantKey)
-            .withEntityKey(entityKey)
+            .withTenantId(tenantId)
+            .withEntityId(entityId)
             .getFirst()
             .getValue();
 


### PR DESCRIPTION
Unassigning users from tenants now uses the tenant id and username instead of tenant key and user key.

This removes support for unassigning groups and mappings for now because these entities are still key-based for now.

closes #27187
