### PR TITLE
fix: fix log message typo

### DIFF
--- a/c8run/package.go
+++ b/c8run/package.go
@@ -74,7 +74,7 @@ func PackageWindows(camundaVersion string, elasticsearchVersion string, connecto
 		return fmt.Errorf("PackageWindows: JAVA_ARTIFACTS_USER or JAVA_ARTIFACTS_PASSWORD env vars are not set")
 	}
 
-	javaArtifactsToken := "Basic " + base64.StdEncoding.EncodeToString([]byte(javaArtifactsUser + ":" + javaArtifactsPassword))
+	javaArtifactsToken := "Basic " + base64.StdEncoding.EncodeToString([]byte(javaArtifactsUser+":"+javaArtifactsPassword))
 
 	Clean(camundaVersion, elasticsearchVersion)
 
@@ -153,7 +153,7 @@ func PackageUnix(camundaVersion string, elasticsearchVersion string, connectorsV
 		return fmt.Errorf("PackageUnix: JAVA_ARTIFACTS_USER or JAVA_ARTIFACTS_PASSWORD env vars are not set")
 	}
 
-	javaArtifactsToken := "Basic " + base64.StdEncoding.EncodeToString([]byte(javaArtifactsUser + ":" + javaArtifactsPassword))
+	javaArtifactsToken := "Basic " + base64.StdEncoding.EncodeToString([]byte(javaArtifactsUser+":"+javaArtifactsPassword))
 
 	Clean(camundaVersion, elasticsearchVersion)
 
@@ -164,7 +164,7 @@ func PackageUnix(camundaVersion string, elasticsearchVersion string, connectorsV
 
 	err = downloadGHArtifact(camundaVersion, camundaFilePath)
 	if err != nil {
-		return fmt.Errorf("PackageWindows: failed to download camunda with gh: %w\n%s", err, debug.Stack())
+		return fmt.Errorf("PackageUnix: failed to download camunda with gh: %w\n%s", err, debug.Stack())
 	}
 
 	err = downloadAndExtract(camundaFilePath, camundaUrl, "camunda-zeebe-"+camundaVersion, authToken, archive.ExtractTarGzArchive)


### PR DESCRIPTION
## Description

`PackageWindows`  -> `PackageUnix`
The whitespace changes are the result of `go fmt`.
