### PR TITLE
fix: adapt c8run to auth config changes

### DIFF
--- a/c8run/main.go
+++ b/c8run/main.go
@@ -134,7 +134,9 @@ func adjustJavaOpts(javaOpts string, settings C8RunSettings) string {
 	if settings.password != "" {
 		javaOpts = javaOpts + " -Dcamunda.security.initialization.users[0].password=" + settings.password
 	}
-	javaOpts = javaOpts + " -Dspring.profiles.active=operate,tasklist,broker,identity,auth-basic"
+	javaOpts += " -Dspring.profiles.active=operate,tasklist,broker,identity,consolidated-auth"
+	javaOpts += " -Dcamunda.security.authentication.method=basic"
+	javaOpts += " -Dcamunda.security.authentication.basic.allow-unauthenticated-api-access=true"
 	os.Setenv("CAMUNDA_OPERATE_ZEEBE_RESTADDRESS", protocol+"://localhost:"+strconv.Itoa(settings.port))
 	fmt.Println("Java opts: " + javaOpts)
 	return javaOpts

--- a/c8run/main_test.go
+++ b/c8run/main_test.go
@@ -22,7 +22,10 @@ func TestCamundaCmdWithKeystoreSettings(t *testing.T) {
 		keystore:         "/tmp/camundatest/certs/secret.jks",
 		keystorePassword: "changeme",
 	}
-	expectedJavaOpts := "JAVA_OPTS= -Dserver.ssl.keystore=file:" + settings.keystore + " -Dserver.ssl.enabled=true" + " -Dserver.ssl.key-password=" + settings.keystorePassword + " -Dspring.profiles.active=operate,tasklist,broker,identity,auth-basic"
+	expectedJavaOpts := "JAVA_OPTS= -Dserver.ssl.keystore=file:" + settings.keystore + " -Dserver.ssl.enabled=true" + " -Dserver.ssl.key-password=" + settings.keystorePassword
+	expectedJavaOpts += " -Dspring.profiles.active=operate,tasklist,broker,identity,consolidated-auth"
+	expectedJavaOpts += " -Dcamunda.security.authentication.method=basic"
+	expectedJavaOpts += " -Dcamunda.security.authentication.basic.allow-unauthenticated-api-access=true"
 
 	javaOpts := adjustJavaOpts("", settings)
 	c8runPlatform := getC8RunPlatform()


### PR DESCRIPTION
## Description

This PR adapts c8run to work with the basic auth config introduced in https://github.com/camunda/camunda/pull/26960.

It can't be included in the PR directly because `c8run package` pulls the latest release from GitHub instead of using the snapshot from the branch. 

See [this slack thread](https://camunda.slack.com/archives/C074T8BTTM2/p1737644000219619) for context.

closes #28187

