### PR TITLE
ci: c8run gha setup workflow is separated from testing

### DIFF
--- a/.github/actions/setup-c8run/action.yml
+++ b/.github/actions/setup-c8run/action.yml
@@ -1,0 +1,209 @@
+---
+name: Setup c8run build
+description: Sets up the required stack to build, install, and run c8run
+
+inputs:
+  os:
+    description: The OS to run the action on
+    required: false
+    default: ubuntu-latest
+  vault-address:
+    description: Vault URL to retrieve secrets from
+    required: false
+  vault-role-id:
+    description: Vault Role ID to use
+    required: false
+  vault-secret-id:
+    description: Vault Secret ID to use
+    required: false
+  source-build:
+    description: true if the camunda build should be built from source, false will build from latest camunda release
+    required: false
+    default: false
+  repository:
+    description: The repository to build from
+    required: false
+    default: camunda/camunda
+  github-token:
+    description: The GitHub token to use to clone camunda
+    required: true
+
+outputs:
+  path-to-c8run-build:
+    description: The path to the c8run build
+
+env:
+  NODE_OPTIONS: "--max_old_space_size=4096"
+
+permissions:
+  actions: write
+  attestations: none
+  checks: write
+  contents: read
+  deployments: none
+  id-token: none
+  issues: none
+  discussions: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: write
+
+runs:
+  using: composite
+  steps:
+    - if: ${{ inputs.os == 'ubuntu-latest' }}
+      name: disable and stop mono-xsp4.service
+      shell: bash
+      run: |
+           sudo systemctl stop mono-xsp4.service || true
+           sudo systemctl disable mono-xsp4.service || true
+           sudo killall mono || true
+           sudo killall xsp4 || true
+
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        repository: ${{ inputs.repository }}
+        token: ${{ inputs.github-token }}
+
+    - name: Import Secrets
+      id: secrets
+      uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c # v3.0.0
+      with:
+        url: ${{ inputs.vault-address }}
+        method: approle
+        roleId: ${{ inputs.vault-role-id }}
+        secretId: ${{ inputs.vault-secret-id }}
+        secrets: |
+          secret/data/products/distribution/ci NEXUS_USERNAME;
+          secret/data/products/distribution/ci NEXUS_PASSWORD;
+
+    - name: print architecture
+      run: arch
+      shell: bash
+
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '>=1.23.1'
+        cache: false  # disabling since not working anyways without a cache-dependency-path specified
+
+    - uses: ./.github/actions/setup-build
+      if: ${{ inputs.source-build == 'true' }}
+      with:
+        vault-secret-id: ${{ inputs.vault-secret-id }}
+        vault-address: ${{ inputs.vault-address }}
+        vault-role-id: ${{ inputs.vault-role-id }}
+
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: "20"
+
+    - uses: camunda/infra-global-github-actions/setup-yarn-cache@main
+      if: ${{ inputs.source-build == 'true' }}
+      with:
+        directory: ./tasklist/client
+
+    - name: Install node dependencies
+      if: ${{ inputs.source-build == 'true' }}
+      working-directory: ./tasklist/client
+      shell: bash
+      run: yarn
+
+    - uses: camunda/infra-global-github-actions/setup-yarn-cache@main
+      if: ${{ inputs.source-build == 'true' }}
+      with:
+        directory: ./operate/client
+
+    - uses: camunda/infra-global-github-actions/setup-yarn-cache@main
+      if: ${{ inputs.source-build == 'true' }}
+      with:
+        directory: identity/client
+
+    - name: Install node dependencies
+      if: ${{ inputs.source-build == 'true' }}
+      working-directory: ./operate/client
+      shell: bash
+      run: yarn
+
+    - name: Install node dependencies
+      if: ${{ inputs.source-build == 'true' }}
+      working-directory: ./identity/client
+      shell: bash
+      run: yarn
+
+    - uses: ./.github/actions/build-zeebe
+      if: ${{ inputs.source-build == 'true' }}
+      id: build-zeebe
+      with:
+        maven-extra-args: "-Dskip.fe.build=false"
+
+    - name: Copy zeebe build
+      if: ${{ inputs.source-build == 'true' }}
+      run: cp $distball ./c8run/
+      shell: bash
+      env:
+        distball: ${{ steps.build-zeebe.outputs.distball }}
+
+    - name: Get version number from zeebe archive
+      if: ${{ inputs.source-build == 'true' }}
+      run: echo CAMUNDA_VERSION=$( echo $distball | grep -o 'camunda-zeebe-.*' | sed 's/camunda-zeebe-//' | sed 's/\.tar\.gz//') >> $GITHUB_ENV
+      shell: bash
+      env:
+        distball: ${{ steps.build-zeebe.outputs.distball }}
+
+    - name: Build c8run
+      run: go build
+      shell: bash
+      working-directory: ./c8run
+
+    - name: make a package
+      run: ./c8run package
+      shell: bash
+      working-directory: ./c8run
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        JAVA_ARTIFACTS_USER: ${{ steps.secrets.outputs.NEXUS_USERNAME }}
+        JAVA_ARTIFACTS_PASSWORD: ${{ steps.secrets.outputs.NEXUS_PASSWORD }}
+
+    - name: ls
+      run: ls
+      shell: bash
+      working-directory: ./c8run
+
+    - if: ${{ inputs.os == 'macos-13' }}
+      name: Set env
+      shell: bash
+      run: echo "JAVA_HOME=$(echo $JAVA_HOME_21_X64)" >> $GITHUB_ENV
+
+    - if: ${{ inputs.os == 'ubuntu-latest' }}
+      name: Linux - Run c8run
+      run: ./c8run start
+      shell: bash
+      working-directory: ./c8run
+      env:
+        JAVA_HOME: /usr/lib/jvm/temurin-21-jdk-amd64
+        JAVA_VERSION: 21.0.3
+
+    - if: ${{ startsWith(inputs.os, 'macos') }}
+      name: Mac - Run c8run
+      shell: bash
+      run: ./c8run start
+      working-directory: ./c8run
+      env:
+        JAVA_VERSION: 21.0.3
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: camunda8-run-build-${{ inputs.os }}
+        path: ./c8run/camunda8-run*
+        retention-days: 1
+
+    - name: define c8run filepath
+      id: path-to-build
+      run: echo "path-to-c8run-build=$( ls ./c8run/camunda8-run* )" >> $GITHUB_OUTPUT
+      shell: bash
+

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -14,6 +14,22 @@ on:
       - "c8run/**"
       - ".github/workflows/c8run-build.yaml"
 
+permissions:
+  actions: write
+  attestations: none
+  checks: write
+  contents: read
+  deployments: none
+  id-token: none
+  issues: none
+  discussions: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: write
+
 jobs:
   test_c8run:
     strategy:
@@ -24,79 +40,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
     steps:
-
-      - if: ${{ matrix.os == 'ubuntu-latest' }}
-        name: disable and stop mono-xsp4.service
-        run: |
-             sudo systemctl stop mono-xsp4.service || true
-             sudo systemctl disable mono-xsp4.service || true
-             sudo killall mono || true
-             sudo killall xsp4 || true
-
       - uses: actions/checkout@v4
-
-      - name: Import Secrets
-        id: secrets
-        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c # v3.0.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secrets: |
-            secret/data/products/distribution/ci NEXUS_USERNAME;
-            secret/data/products/distribution/ci NEXUS_PASSWORD;
-
-      - name: print architecture
-        run: arch
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '>=1.23.1'
-          cache: false  # disabling since not working anyways without a cache-dependency-path specified
-
-      - name: Build c8run
-        run: go build
-        working-directory: ./c8run
-
-      - name: Unit tests
-        run: go test
-        working-directory: ./c8run
-
-      - name: make a package
-        run: ./c8run package
-        working-directory: ./c8run
-        env:
-          GH_TOKEN: ${{ github.token }}
-          JAVA_ARTIFACTS_USER: ${{ steps.secrets.outputs.NEXUS_USERNAME }}
-          JAVA_ARTIFACTS_PASSWORD: ${{ steps.secrets.outputs.NEXUS_PASSWORD }}
-
-      - name: ls
-        run: ls
-        working-directory: ./c8run
-
-      - if: ${{ matrix.os == 'macos-13' }}
-        name: Set env
-        run: echo "JAVA_HOME=$(echo $JAVA_HOME_21_X64)" >> $GITHUB_ENV
-
-      - if: ${{ matrix.os == 'ubuntu-latest' }}
-        name: Linux - Run c8run
-        run: ./c8run start
-        working-directory: ./c8run
-        env:
-          JAVA_HOME: /usr/lib/jvm/temurin-21-jdk-amd64
-          JAVA_VERSION: 21.0.3
-
-      - if: ${{ startsWith(matrix.os, 'macos') }}
-        name: Mac - Run c8run
-        run: ./c8run start
-        working-directory: ./c8run
-        env:
-          JAVA_VERSION: 21.0.3
 
       - uses: actions/setup-node@v4
         with:
           node-version: 18
+
+      - name: Setup C8Run
+        uses: ./.github/actions/setup-c8run
+        with:
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          os: ${{ matrix.os }}
+          github-token: ${{ github.token }}
 
       - name: Install dependencies
         run: npm ci
@@ -106,9 +63,9 @@ jobs:
         run: npx playwright install --with-deps
         working-directory: ./c8run/e2e_tests
 
-      - name: Wait for camunda process to start
-        run: bash -c 'while ! curl -s -f "http://localhost:9600/actuator/health"; do sleep 5; done'
-        timeout-minutes: 5
+      - name: Unit tests
+        run: go test
+        working-directory: ./c8run
 
       - name: Run Playwright tests
         run: npx playwright test
@@ -125,17 +82,12 @@ jobs:
           retention-days: 30
 
       - uses: actions/upload-artifact@v4
-        with:
-          name: camunda8-run-build-${{ matrix.os }}
-          path: ./c8run/camunda8-run*
-          retention-days: 1
-
-      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: c8run-logs-${{ matrix.os }}
           path: ./c8run/log/*.log
           retention-days: 10
+
 
   test_c8run_windows:
     name: C8Run Test Windows
@@ -214,6 +166,11 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps
         working-directory: .\c8run\e2e_tests
+
+      - name: Wait for camunda process to start
+        run: bash -c 'while ! curl -s -f "http://localhost:9600/actuator/health"; do sleep 5; done'
+        shell: bash
+        timeout-minutes: 5
 
       - name: Run Playwright tests
         run: npx playwright test

--- a/c8run/package.go
+++ b/c8run/package.go
@@ -42,7 +42,11 @@ func downloadAndExtract(filePath, url, extractDir string, authToken string, extr
 }
 
 func downloadGHArtifact(camundaVersion string, camundaFilePath string) error {
-	_, err := exec.LookPath("gh")
+	_, err := os.Stat(camundaFilePath)
+	if !errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	_, err = exec.LookPath("gh")
 	if err != nil {
 		// This is not an error because there is another way to download camunda releases
 		return nil


### PR DESCRIPTION
## Description

This PR introduces a github actions which will simplify the process of retrieving the camunda codebase, building c8run, and running it as one step and additional tests can be ran in subsequent steps.

This PR also introduces a mode for building zeebe from source and using that build in c8run, but this is not the default because it is time consuming and error prone to build zeebe from main. 

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/camunda/issues/27399
