### PR TITLE
fix: set the working directory to the identity/client folder for yarn to execute on the right version

### DIFF
--- a/identity/pom.xml
+++ b/identity/pom.xml
@@ -105,6 +105,15 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+          <groupId>com.github.eirslett</groupId>
+          <artifactId>frontend-maven-plugin</artifactId>
+
+          <!-- optional -->
+          <configuration>
+              <workingDirectory>client</workingDirectory>
+          </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
## Description

When testing my other PR, I came across this issue in the build process for the identity frontend where `yarn version 8.8.0-SNAPSHOT` failed to execute because `yarn` evaluated to version 1.22.22 instead of `4.3.1`. The reason for this is that the maven plugin for the yarn executor is not changing the working directory inside the client folder so yarn is not processing the specified packageManager version.

This change adds the configuration documented here:
https://github.com/eirslett/frontend-maven-plugin?tab=readme-ov-file#working-directory

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
