### PR TITLE
To improve IT foundation: Add ES exporter to test set up

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/CamundaMultiDBExtension.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/CamundaMultiDBExtension.java
@@ -104,7 +104,7 @@ public class CamundaMultiDBExtension
   public static final String DEFAULT_OS_ADMIN_USER = "admin";
   public static final String DEFAULT_OS_ADMIN_PW = "yourStrongPassword123!";
   public static final Duration TIMEOUT_DATABASE_EXPORTER_READINESS = Duration.ofMinutes(1);
-  private static final ObjectMapper objectMapper = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private static final Logger LOGGER = LoggerFactory.getLogger(CamundaMultiDBExtension.class);
 
   private final DatabaseType databaseType;
@@ -202,7 +202,7 @@ public class CamundaMultiDBExtension
       assertThat(statusCode).isBetween(200, 299);
 
       // Get how many indices with given prefix we have
-      final JsonNode jsonNode = objectMapper.readTree(response.body());
+      final JsonNode jsonNode = OBJECT_MAPPER.readTree(response.body());
       final int count = jsonNode.size();
       /*
        * ES exporter indices are only created, on first exporting, so we expect at least the

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfigurator.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfigurator.java
@@ -13,6 +13,7 @@ import io.camunda.operate.property.OperateProperties;
 import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.tasklist.property.TasklistOpenSearchProperties;
 import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.zeebe.exporter.ElasticsearchExporter;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
 import java.util.Map;
 import java.util.UUID;
@@ -43,9 +44,11 @@ public class MultiDbConfigurator {
     operateProperties.getElasticsearch().setUrl(elasticsearchUrl);
     operateProperties.getElasticsearch().setIndexPrefix(indexPrefix);
     operateProperties.getZeebeElasticsearch().setUrl(elasticsearchUrl);
+    operateProperties.getZeebeElasticsearch().setPrefix(indexPrefix);
     tasklistProperties.getElasticsearch().setUrl(elasticsearchUrl);
     tasklistProperties.getElasticsearch().setIndexPrefix(indexPrefix);
     tasklistProperties.getZeebeElasticsearch().setUrl(elasticsearchUrl);
+    tasklistProperties.getZeebeElasticsearch().setPrefix(indexPrefix);
     testApplication.withExporter(
         "CamundaExporter",
         cfg -> {
@@ -65,6 +68,14 @@ public class MultiDbConfigurator {
                   "bulk",
                   Map.of("size", 1)));
         });
+
+    testApplication.withExporter(
+        "ElasticsearchExporter",
+        cfg -> {
+          cfg.setClassName(ElasticsearchExporter.class.getName());
+          cfg.setArgs(Map.of("url", elasticsearchUrl, "index", Map.of("prefix", indexPrefix)));
+        });
+
     testApplication.withProperty(
         "camunda.database.type",
         io.camunda.search.connect.configuration.DatabaseType.ELASTICSEARCH);

--- a/qa/integration-tests/src/test/resources/log4j2-test.xml
+++ b/qa/integration-tests/src/test/resources/log4j2-test.xml
@@ -17,6 +17,7 @@
 
   <Loggers>
     <Logger name="io.camunda.zeebe" level="debug"/>
+    <Logger name="io.camunda.it" level="debug"/>
     <Logger name="io.atomix" level="debug"/>
     <Logger name="io.zeebe.containers.ZeebeTopologyWaitStrategy" level="trace"/>
 


### PR DESCRIPTION
## Description

While migrating more tests I found an interesting [race condition.](https://camunda.slack.com/archives/C07PNCGJHAA/p1737637610301689)

Our IT infrastructure is just configuring and setting up Camunda Exporter and the single application. In most cases, this works fine, but now I ran into some issues that data is not available sometimes.
I investigated this further, and found out the following.

* When Camunda Exporter starts it checks whether importers are done
  * If they are done or the positions index doesn't exist, it continues with exporting
  * If they are not done, it loops until they are marked as done
* Depending on the bootstrap order this can cause issues. For example
  * Exporter first; then Importer is fine.
  * But if the importer starts first, it will initialize the position index and mark it as non-completed
    * The exporter will loop and wait
    * The importer cant mark it as complete as the ES exporter is missing 💥
* This means we have sometimes cases where not data is published and causing test failures with no data -> flakes.


## Proposal

This PR enables the ES Exporter (which would be also a step closer to production), as we have to run them anyway for Optimize, and as we have seen for the Exporter to come up.

I would suggest we set up the ES exporter as well in our IT, to make sure this setup always works.

I added additionally a new wait strategy to make sure that the Schema is at least created, so to avoid starting too early. 

This was implemented only for ES, for now. It will be added for OS (or RDBMS) later as well.
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
