### PR TITLE
test: simplified BasicAuthIT setup

### DIFF
--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -216,11 +216,6 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-protocol-impl</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>camunda-search-domain</artifactId>
       <scope>test</scope>
     </dependency>

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
@@ -13,28 +13,15 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.application.commons.CommonsModuleConfiguration;
-import io.camunda.client.protocol.rest.UserRequest;
-import io.camunda.search.entities.AuthorizationEntity;
-import io.camunda.search.entities.TenantEntity;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
-import io.camunda.security.entity.Permission;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.TenantServices;
 import io.camunda.service.UserServices;
-import io.camunda.zeebe.broker.BrokerModuleConfiguration;
-import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
-import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
-import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import org.apache.logging.log4j.util.Base64Util;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,7 +29,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -50,28 +36,24 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 @SpringBootTest(
-    classes = {CommonsModuleConfiguration.class, BrokerModuleConfiguration.class},
-    properties = {"spring.profiles.active=broker,auth-basic"})
+    classes = {CommonsModuleConfiguration.class},
+    properties = {"spring.profiles.active=auth-basic"})
 @WebAppConfiguration
 @AutoConfigureMockMvc
 public class BasicAuthIT {
-
   private static final String USERNAME = "correct_username";
   private static final String PASSWORD = "correct_password";
-  @MockBean UserServices userService;
-  @MockBean AuthorizationServices authorizationServices;
-  @MockBean RoleServices roleServices;
-  @MockBean TenantServices tenantServices;
-  @Autowired private ObjectMapper objectMapper;
-  @Autowired private PasswordEncoder passwordEncoder;
+  @Autowired PasswordEncoder passwordEncoder;
+  @MockBean private UserServices userService;
+  @MockBean private AuthorizationServices authorizationServices;
+  @MockBean private RoleServices roleServices;
+  @MockBean private TenantServices tenantServices;
   @Autowired private MockMvc mockMvc;
-  private String content;
 
   @BeforeEach
   void setUp() throws JsonProcessingException {
+    // return user service when accessed with any authenticated user
     when(userService.withAuthentication(any(Authentication.class))).thenReturn(userService);
-    when(userService.createUser(any()))
-        .thenReturn(CompletableFuture.completedFuture(new UserRecord()));
     when(userService.search(any()))
         .thenReturn(
             new SearchQueryResult<>(
@@ -79,27 +61,11 @@ public class BasicAuthIT {
                 List.of(new UserEntity(1L, USERNAME, "name", "", passwordEncoder.encode(PASSWORD))),
                 null,
                 null));
-    when(tenantServices.getTenantsByMemberKey(anyLong()))
-        .thenReturn(List.of(new TenantEntity(9L, "T1", "Tenant 1", "Tenant 1 description")));
-
-    when(authorizationServices.findAll(any()))
-        .thenReturn(
-            List.of(
-                new AuthorizationEntity(
-                    1L,
-                    AuthorizationOwnerType.USER.name(),
-                    AuthorizationResourceType.APPLICATION.name(),
-                    List.of(new Permission(PermissionType.ACCESS, Set.of("*"))))));
-
+    // mock services involved in authorization resolution to just return no results as we don't test
+    // authorization here but just authentication
+    when(tenantServices.getTenantsByMemberKey(anyLong())).thenReturn(List.of());
+    when(authorizationServices.findAll(any())).thenReturn(List.of());
     when(roleServices.findAll(any())).thenReturn(List.of());
-
-    content =
-        objectMapper.writeValueAsString(
-            new UserRequest()
-                .username("demo-".concat(UUID.randomUUID().toString()))
-                .name("Demo")
-                .password("password")
-                .email("demo@email.com"));
   }
 
   @Test
@@ -114,22 +80,17 @@ public class BasicAuthIT {
   @Test
   void basicAuthWithNoCredentials() throws Exception {
     final MockHttpServletRequestBuilder request =
-        MockMvcRequestBuilders.post("/v2/users")
-            .accept("application/json")
-            .contentType(MediaType.APPLICATION_JSON)
-            .content(content);
+        MockMvcRequestBuilders.get("/v2/authentication/me").accept("application/json");
     mockMvc.perform(request).andExpect(status().isUnauthorized());
   }
 
   @Test
   void basicAuthWithBadCredentials() throws Exception {
     final MockHttpServletRequestBuilder request =
-        MockMvcRequestBuilders.post("/v2/users")
+        MockMvcRequestBuilders.get("/v2/authentication/me")
             .accept("application/json")
-            .contentType(MediaType.APPLICATION_JSON)
             .header(
-                "Authorization", "Basic " + Base64Util.encode(USERNAME + ":" + PASSWORD + "Wrong"))
-            .content(content);
+                "Authorization", "Basic " + Base64Util.encode(USERNAME + ":" + PASSWORD + "Wrong"));
     mockMvc.perform(request).andExpect(status().isUnauthorized()).andReturn();
   }
 }


### PR DESCRIPTION
## Description

No broker setup needed, removed unnecessary content field (all requests it was used for where supposed to be rejected due to missing auth anyway and reduced setup to bare minimum needed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
