### PR TITLE
[Backport stable/8.6] fix: Store duration values in a normalized format

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityInputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityInputMappingTest.java
@@ -40,7 +40,7 @@ public final class ActivityInputMappingTest {
   private static final String A_DATE_VALUE = "\"2021-02-24\"";
   private static final String A_LOCAL_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20\"";
   private static final String A_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20+01:00\"";
-  private static final String A_DAY_TIME_DURATION_VALUE = "\"PT42H56M33S\"";
+  private static final String A_DAY_TIME_DURATION_VALUE = "\"P1DT18H56M33S\"";
   private static final String A_YEAR_MONTH_DURATION_VALUE = "\"P2Y3M\"";
 
   @Rule

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityOutputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityOutputMappingTest.java
@@ -43,7 +43,7 @@ public final class ActivityOutputMappingTest {
   private static final String A_DATE_VALUE = "\"2021-02-24\"";
   private static final String A_LOCAL_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20\"";
   private static final String A_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20+01:00\"";
-  private static final String A_DAY_TIME_DURATION_VALUE = "\"PT42H56M33S\"";
+  private static final String A_DAY_TIME_DURATION_VALUE = "\"P1DT18H56M33S\"";
   private static final String A_YEAR_MONTH_DURATION_VALUE = "\"P2Y3M\"";
 
   @Rule

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/NoneEndEventOutputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/NoneEndEventOutputMappingTest.java
@@ -41,7 +41,7 @@ public final class NoneEndEventOutputMappingTest {
   private static final String A_DATE_VALUE = "\"2021-02-24\"";
   private static final String A_LOCAL_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20\"";
   private static final String A_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20+01:00\"";
-  private static final String A_DAY_TIME_DURATION_VALUE = "\"PT42H56M33S\"";
+  private static final String A_DAY_TIME_DURATION_VALUE = "\"P1DT18H56M33S\"";
   private static final String A_YEAR_MONTH_DURATION_VALUE = "\"P2Y3M\"";
   private static final String A_STRING = "\"foobar\"";
   private static final String A_SUB_STRING = "\"bar\"";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/SignalEndEventInputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/SignalEndEventInputMappingTest.java
@@ -42,7 +42,7 @@ public final class SignalEndEventInputMappingTest {
   private static final String A_DATE_VALUE = "\"2021-02-24\"";
   private static final String A_LOCAL_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20\"";
   private static final String A_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20+01:00\"";
-  private static final String A_DAY_TIME_DURATION_VALUE = "\"PT42H56M33S\"";
+  private static final String A_DAY_TIME_DURATION_VALUE = "\"P1DT18H56M33S\"";
   private static final String A_YEAR_MONTH_DURATION_VALUE = "\"P2Y3M\"";
 
   private static final String SIGNAL_NAME_1 = "a";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/SignalEndEventOutputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/SignalEndEventOutputMappingTest.java
@@ -43,7 +43,7 @@ public final class SignalEndEventOutputMappingTest {
   private static final String A_DATE_VALUE = "\"2021-02-24\"";
   private static final String A_LOCAL_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20\"";
   private static final String A_DATE_AND_TIME_VALUE = "\"2021-02-24T04:20+01:00\"";
-  private static final String A_DAY_TIME_DURATION_VALUE = "\"PT42H56M33S\"";
+  private static final String A_DAY_TIME_DURATION_VALUE = "\"P1DT18H56M33S\"";
   private static final String A_YEAR_MONTH_DURATION_VALUE = "\"P2Y3M\"";
   private static final String A_STRING = "\"foobar\"";
   private static final String A_SUB_STRING = "\"bar\"";

--- a/zeebe/expression-language/pom.xml
+++ b/zeebe/expression-language/pom.xml
@@ -57,8 +57,20 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/EvaluationContextTest.java
+++ b/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/EvaluationContextTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.el.util.TestFeelEngineClock;
 import java.util.Map;
 import org.agrona.DirectBuffer;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EvaluationContextTest {
 

--- a/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/EvaluationResultTest.java
+++ b/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/EvaluationResultTest.java
@@ -90,6 +90,7 @@ public class EvaluationResultTest {
     assertThat(evaluationResult.getString()).isNull();
     assertThat(evaluationResult.getNumber()).isNull();
     assertThat(evaluationResult.getList()).isNull();
+    assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("\"PT2H\""));
   }
 
   @Test
@@ -103,6 +104,7 @@ public class EvaluationResultTest {
     assertThat(evaluationResult.getString()).isNull();
     assertThat(evaluationResult.getNumber()).isNull();
     assertThat(evaluationResult.getList()).isNull();
+    assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("\"P2M\""));
   }
 
   @Test
@@ -119,6 +121,8 @@ public class EvaluationResultTest {
     assertThat(evaluationResult.getString()).isNull();
     assertThat(evaluationResult.getNumber()).isNull();
     assertThat(evaluationResult.getList()).isNull();
+    assertThat(evaluationResult.toBuffer())
+        .isEqualTo(asMsgPack("\"2020-04-01T10:31:10+02:00[Europe/Berlin]\""));
   }
 
   @Test
@@ -134,6 +138,7 @@ public class EvaluationResultTest {
     assertThat(evaluationResult.getString()).isNull();
     assertThat(evaluationResult.getNumber()).isNull();
     assertThat(evaluationResult.getList()).isNull();
+    assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("\"2020-04-01T10:31:10\""));
   }
 
   @Test
@@ -225,6 +230,34 @@ public class EvaluationResultTest {
     assertThat(evaluationResult.getNumber()).isNull();
     assertThat(evaluationResult.getList()).isNull();
     assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("{'x':\"2020-04-02\"}"));
+  }
+
+  @Test
+  public void shouldReturnNormalizedDuration() {
+    final var evaluationResult = evaluateExpression("=duration(\"P5D\")");
+
+    assertThat(evaluationResult.getType()).isEqualTo(ResultType.DURATION);
+    assertThat(evaluationResult.getDuration()).isEqualTo(Duration.ofDays(5));
+    assertThat(evaluationResult.getPeriod()).isNull();
+    assertThat(evaluationResult.getBoolean()).isNull();
+    assertThat(evaluationResult.getString()).isNull();
+    assertThat(evaluationResult.getNumber()).isNull();
+    assertThat(evaluationResult.getList()).isNull();
+    assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("\"P5D\""));
+  }
+
+  @Test
+  public void shouldReturnNormalizedPeriod() {
+    final var evaluationResult = evaluateExpression("=duration(\"P2Y\")");
+
+    assertThat(evaluationResult.getType()).isEqualTo(ResultType.PERIOD);
+    assertThat(evaluationResult.getDuration()).isNull();
+    assertThat(evaluationResult.getPeriod()).isEqualTo(Period.ofYears(2));
+    assertThat(evaluationResult.getBoolean()).isNull();
+    assertThat(evaluationResult.getString()).isNull();
+    assertThat(evaluationResult.getNumber()).isNull();
+    assertThat(evaluationResult.getList()).isNull();
+    assertThat(evaluationResult.toBuffer()).isEqualTo(asMsgPack("\"P2Y\""));
   }
 
   private EvaluationResult evaluateExpression(final String expression) {

--- a/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/EvaluationResultTest.java
+++ b/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/EvaluationResultTest.java
@@ -17,7 +17,7 @@ import java.time.Period;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class EvaluationResultTest {
 

--- a/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/ExpressionLanguageTest.java
+++ b/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/ExpressionLanguageTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import io.camunda.zeebe.el.impl.StaticExpression;
 import io.camunda.zeebe.el.util.TestFeelEngineClock;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ExpressionLanguageTest {
 

--- a/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/FeelCycleFunctionTest.java
+++ b/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/FeelCycleFunctionTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.el.util.TestFeelEngineClock;
 import io.camunda.zeebe.test.util.MsgPackUtil;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FeelCycleFunctionTest {
 

--- a/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/FeelExpressionTest.java
+++ b/zeebe/expression-language/src/test/java/io/camunda/zeebe/el/FeelExpressionTest.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FeelExpressionTest {
 

--- a/zeebe/feel/src/main/java/io/camunda/zeebe/feel/impl/FeelToMessagePackTransformer.java
+++ b/zeebe/feel/src/main/java/io/camunda/zeebe/feel/impl/FeelToMessagePackTransformer.java
@@ -97,8 +97,8 @@ public class FeelToMessagePackTransformer {
       case final ValDate date -> writeStringValue(date.value().toString());
       case final ValDateTime dateTime -> writeStringValue(dateTime.value().toString());
       case final ValLocalDateTime dateTime -> writeStringValue(dateTime.value().toString());
-      case final ValDayTimeDuration duration -> writeStringValue(duration.value().toString());
-      case final ValYearMonthDuration duration -> writeStringValue(duration.value().toString());
+      case final ValDayTimeDuration duration -> writeStringValue(duration.toString());
+      case final ValYearMonthDuration duration -> writeStringValue(duration.toString());
       default -> {
         writer.writeNil();
         LOGGER.trace(


### PR DESCRIPTION
# Description
Backport of #27161 to `stable/8.6`.

relates to #27098
original author: @saig0