### PR TITLE
feat: use one ObjectMapper for all classes in the camunda-exporter package

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/SchemaResourceSerializer.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/SchemaResourceSerializer.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.mappers.ExporterObjectMappers;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
@@ -18,7 +19,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 public final class SchemaResourceSerializer {
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectMapper MAPPER = ExporterObjectMappers.getObjectMapper();
 
   private SchemaResourceSerializer() {}
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandler.java
@@ -8,8 +8,9 @@
 package io.camunda.exporter.handlers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import io.camunda.exporter.handlers.UserTaskCompletionVariableHandler.SnapshotTaskVariableBatch;
+import io.camunda.exporter.mappers.ExporterObjectMappers;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.tasklist.template.SnapshotTaskVariableTemplate;
 import io.camunda.webapps.schema.entities.ExporterEntity;
@@ -32,9 +33,9 @@ public class UserTaskCompletionVariableHandler
       LoggerFactory.getLogger(UserTaskCompletionVariableHandler.class);
 
   private static final String ID_PATTERN = "%s-%s";
-  private static final ObjectMapper MAPPER = new ObjectMapper();
   protected final int variableSizeThreshold;
   private final String indexName;
+  private final ObjectWriter objectWriter = ExporterObjectMappers.getObjectMapper().writer();
 
   public UserTaskCompletionVariableHandler(
       final String indexName, final int variableSizeThreshold) {
@@ -132,7 +133,7 @@ public class UserTaskCompletionVariableHandler
 
   private String toJsonString(final Object value) {
     try {
-      return MAPPER.writeValueAsString(value);
+      return objectWriter.writeValueAsString(value);
     } catch (final JsonProcessingException e) {
       LOGGER.error("Failed to parse variable value '{}'", value, e);
       return "";

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskJobBasedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskJobBasedHandler.java
@@ -12,10 +12,11 @@ import static io.camunda.zeebe.protocol.Protocol.USER_TASK_CANDIDATE_GROUPS_HEAD
 import static io.camunda.zeebe.protocol.Protocol.USER_TASK_CANDIDATE_USERS_HEADER_NAME;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
 import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.cache.ExporterEntityCache;
 import io.camunda.exporter.cache.form.CachedFormEntity;
+import io.camunda.exporter.mappers.ExporterObjectMappers;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
@@ -41,7 +42,8 @@ import org.slf4j.LoggerFactory;
 
 public class UserTaskJobBasedHandler implements ExportHandler<TaskEntity, JobRecordValue> {
 
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectReader objectReader =
+      ExporterObjectMappers.getObjectMapper().readerFor(String[].class);
   private static final Logger LOGGER = LoggerFactory.getLogger(UserTaskJobBasedHandler.class);
   private static final Pattern EMBEDDED_FORMS_PATTERN = Pattern.compile("^camunda-forms:bpmn:.*");
   private static final Set<JobIntent> SUPPORTED_INTENTS =
@@ -235,7 +237,7 @@ public class UserTaskJobBasedHandler implements ExportHandler<TaskEntity, JobRec
   private String[] toStringArray(final String value) {
     if (!ExporterUtil.isEmpty(value)) {
       try {
-        return MAPPER.readValue(value, String[].class);
+        return objectReader.readValue(value);
       } catch (final JsonProcessingException e) {
         LOGGER.warn(String.format("Failed to parse value %s: %s", value, e.getMessage()), e);
       }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/mappers/ExporterObjectMappers.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/mappers/ExporterObjectMappers.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.mappers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+public class ExporterObjectMappers {
+  private static final ObjectMapper objectMapper =
+      new ObjectMapper().registerModule(new JavaTimeModule());
+
+  private ExporterObjectMappers() {}
+
+  public static ObjectMapper getObjectMapper() {
+    return objectMapper;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/IncidentNotifier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/IncidentNotifier.java
@@ -8,11 +8,11 @@
 package io.camunda.exporter.notifier;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import io.camunda.exporter.cache.ExporterEntityCache;
 import io.camunda.exporter.cache.process.CachedProcessEntity;
 import io.camunda.exporter.config.ExporterConfiguration.IncidentNotifierConfiguration;
+import io.camunda.exporter.mappers.ExporterObjectMappers;
 import io.camunda.webapps.schema.entities.operate.IncidentEntity;
 import java.io.IOException;
 import java.net.URI;
@@ -50,8 +50,7 @@ public class IncidentNotifier {
   protected static final String FIELD_NAME_PROCESS_NAME = "processName";
   protected static final String FIELD_NAME_PROCESS_VERSION = "processVersion";
   private static final Logger LOGGER = LoggerFactory.getLogger(IncidentNotifier.class);
-  private static final ObjectMapper MAPPER =
-      new ObjectMapper().registerModule(new JavaTimeModule());
+  private static final ObjectWriter objectWriter = ExporterObjectMappers.getObjectMapper().writer();
 
   private final M2mTokenManager m2mTokenManager;
 
@@ -152,6 +151,6 @@ public class IncidentNotifier {
       }
       incidentList.add(incidentFields);
     }
-    return MAPPER.writeValueAsString(Map.of(FIELD_NAME_ALERTS, incidentList));
+    return objectWriter.writeValueAsString(Map.of(FIELD_NAME_ALERTS, incidentList));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/IndexSchemaValidator.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/IndexSchemaValidator.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.schema;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.exceptions.IndexSchemaValidationException;
+import io.camunda.exporter.mappers.ExporterObjectMappers;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import java.util.*;
@@ -48,7 +49,7 @@ import org.slf4j.LoggerFactory;
  */
 public class IndexSchemaValidator {
   private static final Logger LOGGER = LoggerFactory.getLogger(IndexSchemaValidator.class);
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectMapper MAPPER = ExporterObjectMappers.getObjectMapper();
 
   /**
    * Validates existing indices mappings against index/index template mappings defined.

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -26,13 +26,14 @@ import co.elastic.clients.elasticsearch.indices.get_index_template.IndexTemplate
 import co.elastic.clients.elasticsearch.indices.put_index_template.IndexTemplateMapping;
 import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.JsonpDeserializer;
+import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.jackson.JacksonJsonpGenerator;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.SchemaResourceSerializer;
 import io.camunda.exporter.config.ExporterConfiguration.IndexSettings;
 import io.camunda.exporter.exceptions.ElasticsearchExporterException;
 import io.camunda.exporter.exceptions.IndexSchemaValidationException;
+import io.camunda.exporter.mappers.ExporterObjectMappers;
 import io.camunda.exporter.schema.IndexMapping;
 import io.camunda.exporter.schema.IndexMappingProperty;
 import io.camunda.exporter.schema.MappingSource;
@@ -54,8 +55,9 @@ import org.slf4j.LoggerFactory;
 
 public class ElasticsearchEngineClient implements SearchEngineClient {
   private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchEngineClient.class);
-  private static final ObjectMapper MAPPER = new ObjectMapper();
   private final ElasticsearchClient client;
+  private final JsonpMapper jsonpMapper =
+      new JacksonJsonpMapper(ExporterObjectMappers.getObjectMapper());
 
   public ElasticsearchEngineClient(final ElasticsearchClient client) {
     this.client = client;
@@ -308,8 +310,7 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
     try {
       return SchemaResourceSerializer.serialize(
           (JacksonJsonpGenerator::new),
-          (jacksonJsonpGenerator) ->
-              property.serialize(jacksonJsonpGenerator, new JacksonJsonpMapper(MAPPER)));
+          (jacksonJsonpGenerator) -> property.serialize(jacksonJsonpGenerator, jsonpMapper));
     } catch (final IOException e) {
       throw new ElasticsearchExporterException(
           String.format("Failed to serialize property [%s]", property.toString()), e);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/SearchEngineClientUtils.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/SearchEngineClientUtils.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.utils;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.config.ExporterConfiguration.IndexSettings;
+import io.camunda.exporter.mappers.ExporterObjectMappers;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.entities.operate.ImportPositionEntity;
 import java.io.ByteArrayInputStream;
@@ -24,7 +25,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 
 public final class SearchEngineClientUtils {
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectMapper MAPPER = ExporterObjectMappers.getObjectMapper();
 
   private SearchEngineClientUtils() {}
 


### PR DESCRIPTION


## Description
All classes instantiating their own ObjectMapper now use a common instance located in ExporterObjectMappers.

The JavaTimeModule has been registered because it was being used by the classes in the notifier package.

When possible, type specific readers/writers have been used in favour of an ObjectMapper as they are thread-safe and immutable.

## Related issues

closes #24599 
