### PR TITLE
feat: use one ObjectMapper for all classes in the camunda-exporter package

### DIFF
--- a/dist/src/main/java/io/camunda/application/StandaloneSchemaManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneSchemaManager.java
@@ -96,10 +96,15 @@ public class StandaloneSchemaManager {
     final IndexDescriptors indexDescriptors =
         new IndexDescriptors(connectConfiguration.getIndexPrefix(), IS_ELASTICSEARCH);
 
-    final SearchEngineClient client = ClientAdapter.of(exporterConfig).getSearchEngineClient();
+    final ClientAdapter clientAdapter = ClientAdapter.of(exporterConfig);
+    final SearchEngineClient client = clientAdapter.getSearchEngineClient();
     final SchemaManager schemaManager =
         new SchemaManager(
-            client, indexDescriptors.indices(), indexDescriptors.templates(), exporterConfig);
+            client,
+            indexDescriptors.indices(),
+            indexDescriptors.templates(),
+            exporterConfig,
+            clientAdapter.objectMapper());
 
     schemaManager.startup();
 

--- a/migration/process-migration/pom.xml
+++ b/migration/process-migration/pom.xml
@@ -63,6 +63,11 @@
       <artifactId>jackson-annotations</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.github.resilience4j</groupId>
       <artifactId>resilience4j-retry</artifactId>
     </dependency>

--- a/migration/process-migration/src/test/java/io/camunda/migration/process/it/AdapterTest.java
+++ b/migration/process-migration/src/test/java/io/camunda/migration/process/it/AdapterTest.java
@@ -20,6 +20,7 @@ import co.elastic.clients.elasticsearch.core.IndexRequest;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.config.ExporterConfiguration.IndexSettings;
 import io.camunda.exporter.schema.elasticsearch.ElasticsearchEngineClient;
 import io.camunda.exporter.schema.opensearch.OpensearchEngineClient;
@@ -75,6 +76,9 @@ public abstract class AdapterTest {
   private static final OpensearchContainer<?> OS_CONTAINER =
       TestSearchContainers.createDefaultOpensearchContainer();
 
+  private static ObjectMapper esObjectMapper;
+  private static ObjectMapper osObjectMapper;
+
   protected boolean isElasticsearch = true;
 
   @BeforeAll
@@ -87,15 +91,19 @@ public abstract class AdapterTest {
     ES_CONFIGURATION.setUrl("http://localhost:" + ES_CONTAINER.getMappedPort(9200));
     OS_CONFIGURATION.setType("opensearch");
     OS_CONFIGURATION.setUrl("http://localhost:" + OS_CONTAINER.getMappedPort(9200));
-    esClient = new ElasticsearchConnector(ES_CONFIGURATION).createClient();
-    osClient = new OpensearchConnector(OS_CONFIGURATION).createClient();
+    final var esConnector = new ElasticsearchConnector(ES_CONFIGURATION);
+    esObjectMapper = esConnector.objectMapper();
+    esClient = esConnector.createClient();
+    final var osConnector = new OpensearchConnector(OS_CONFIGURATION);
+    osObjectMapper = osConnector.objectMapper();
+    osClient = osConnector.createClient();
     esMigrator = new MigrationRunner(properties, ES_CONFIGURATION, meterRegistry);
     osMigrator = new MigrationRunner(properties, OS_CONFIGURATION, meterRegistry);
     createIndices();
   }
 
   private static void createIndices() {
-    final OpensearchEngineClient osEngine = new OpensearchEngineClient(osClient);
+    final OpensearchEngineClient osEngine = new OpensearchEngineClient(osClient, osObjectMapper);
     processIndex = new ProcessIndex(ES_CONFIGURATION.getIndexPrefix(), false);
     migrationRepositoryIndex =
         new MigrationRepositoryIndex(ES_CONFIGURATION.getIndexPrefix(), false);
@@ -104,7 +112,8 @@ public abstract class AdapterTest {
     osEngine.createIndex(migrationRepositoryIndex, new IndexSettings());
     osEngine.createIndex(importPositionIndex, new IndexSettings());
 
-    final ElasticsearchEngineClient esEngine = new ElasticsearchEngineClient(esClient);
+    final ElasticsearchEngineClient esEngine =
+        new ElasticsearchEngineClient(esClient, esObjectMapper);
     processIndex = new ProcessIndex(ES_CONFIGURATION.getIndexPrefix(), true);
     migrationRepositoryIndex =
         new MigrationRepositoryIndex(ES_CONFIGURATION.getIndexPrefix(), true);

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/util/camunda/exporter/SchemaWithExporter.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/util/camunda/exporter/SchemaWithExporter.java
@@ -35,14 +35,16 @@ public class SchemaWithExporter {
         config,
         clientAdapter.getExporterEntityCacheProvider(),
         new SimpleMeterRegistry(),
-        new ExporterMetadata());
+        new ExporterMetadata(clientAdapter.objectMapper()),
+        clientAdapter.objectMapper());
 
     schemaManager =
         new SchemaManager(
             clientAdapter.getSearchEngineClient(),
             provider.getIndexDescriptors(),
             provider.getIndexTemplateDescriptors(),
-            config);
+            config,
+            clientAdapter.objectMapper());
   }
 
   public void createSchema() {

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/es/ElasticsearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/es/ElasticsearchConnector.java
@@ -86,6 +86,10 @@ public final class ElasticsearchConnector {
     return new ElasticsearchAsyncClient(transport);
   }
 
+  public ObjectMapper objectMapper() {
+    return objectMapper;
+  }
+
   private RestClient createRestClient(final ConnectConfiguration configuration) {
     final var httpHost = getHttpHost(configuration);
     final var restClientBuilder = RestClient.builder(httpHost);

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
@@ -89,6 +89,10 @@ public final class OpensearchConnector {
     return new OpenSearchAsyncClient(transport);
   }
 
+  public ObjectMapper objectMapper() {
+    return objectMapper;
+  }
+
   private OpenSearchTransport createTransport(final ConnectConfiguration configuration) {
     if (shouldCreateAWSBasedTransport()) {
       return createAWSBasedTransport(configuration);

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -138,6 +138,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterMetadata.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterMetadata.java
@@ -7,11 +7,14 @@
  */
 package io.camunda.exporter;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -26,14 +29,13 @@ import org.slf4j.LoggerFactory;
 @JsonInclude(Include.NON_DEFAULT)
 public final class ExporterMetadata {
   private static final Logger LOGGER = LoggerFactory.getLogger(ExporterMetadata.class);
-  private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final AtomicLongFieldUpdater<ExporterMetadata> INCIDENT_POSITION_SETTER =
       AtomicLongFieldUpdater.newUpdater(ExporterMetadata.class, "lastIncidentUpdatePosition");
-
   private static final int UNSET_POSITION = -1;
 
+  @JsonIgnore private final ObjectWriter objectWriter;
+  @JsonIgnore private final ObjectReader objectReader;
   private volatile long lastIncidentUpdatePosition = UNSET_POSITION;
-
   private Map<TaskImplementation, Long> firstUserTaskKeys =
       new HashMap<>() {
         {
@@ -41,6 +43,12 @@ public final class ExporterMetadata {
           put(TaskImplementation.JOB_WORKER, (long) UNSET_POSITION);
         }
       };
+
+  public ExporterMetadata(final ObjectMapper objectMapper) {
+    // Specialized reader/writer for this class for efficiency
+    objectWriter = objectMapper.writerFor(ExporterMetadata.class);
+    objectReader = objectMapper.readerForUpdating(this);
+  }
 
   public long getLastIncidentUpdatePosition() {
     return lastIncidentUpdatePosition;
@@ -72,7 +80,7 @@ public final class ExporterMetadata {
 
   public void deserialize(final byte[] bytes) {
     try {
-      MAPPER.readerForUpdating(this).readValue(bytes);
+      objectReader.readValue(bytes);
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
     }
@@ -81,7 +89,7 @@ public final class ExporterMetadata {
   // TODO: cache serialized version and only re-serialize if values have changed
   public byte[] serialize() {
     try {
-      return MAPPER.writeValueAsBytes(this);
+      return objectWriter.writeValueAsBytes(this);
     } catch (final JsonProcessingException e) {
       throw new UncheckedIOException(e);
     }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.errorhandling.Error;
@@ -24,7 +25,8 @@ public interface ExporterResourceProvider {
       final ExporterConfiguration configuration,
       final ExporterEntityCacheProvider entityCacheProvider,
       final MeterRegistry meterRegistry,
-      final ExporterMetadata exporterMetadata);
+      final ExporterMetadata exporterMetadata,
+      final ObjectMapper objectMapper);
 
   void close();
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/SchemaResourceSerializer.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/SchemaResourceSerializer.java
@@ -18,11 +18,14 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 public final class SchemaResourceSerializer {
-  private static final ObjectMapper MAPPER = new ObjectMapper();
 
-  private SchemaResourceSerializer() {}
+  private final ObjectMapper objectMapper;
 
-  public static Map<String, Object> serialize(
+  public SchemaResourceSerializer(final ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  public Map<String, Object> serialize(
       final Function<JsonGenerator, jakarta.json.stream.JsonGenerator> jacksonGenerator,
       final Consumer<jakarta.json.stream.JsonGenerator> serialize)
       throws IOException {
@@ -33,7 +36,7 @@ public final class SchemaResourceSerializer {
       serialize.accept(jacksonJsonpGenerator);
       jacksonJsonpGenerator.flush();
 
-      return MAPPER.readValue(out.toString(), new TypeReference<>() {});
+      return objectMapper.readValue(out.toString(), new TypeReference<>() {});
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ClientAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ClientAdapter.java
@@ -7,21 +7,26 @@
  */
 package io.camunda.exporter.adapters;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
-import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.schema.SearchEngineClient;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.search.connect.configuration.DatabaseType;
 import java.io.IOException;
 
 public interface ClientAdapter {
 
   static ClientAdapter of(final ExporterConfiguration configuration) {
-    return switch (ConnectionTypes.from(configuration.getConnect().getType())) {
-      case ELASTICSEARCH -> new ElasticsearchAdapter(configuration);
-      case OPENSEARCH -> new OpensearchAdapter(configuration);
+    final var databaseType = configuration.getConnect().getTypeEnum();
+    return switch (databaseType) {
+      case DatabaseType.ELASTICSEARCH -> new ElasticsearchAdapter(configuration.getConnect());
+      case DatabaseType.OPENSEARCH -> new OpensearchAdapter(configuration.getConnect());
+      default -> throw new IllegalArgumentException("Unsupported databaseType: " + databaseType);
     };
   }
+
+  ObjectMapper objectMapper();
 
   SearchEngineClient getSearchEngineClient();
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ElasticsearchAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ElasticsearchAdapter.java
@@ -9,18 +9,19 @@ package io.camunda.exporter.adapters;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
 import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.cache.form.ElasticSearchFormCacheLoader;
 import io.camunda.exporter.cache.process.CachedProcessEntity;
 import io.camunda.exporter.cache.process.ElasticSearchProcessCacheLoader;
-import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.schema.SearchEngineClient;
 import io.camunda.exporter.schema.elasticsearch.ElasticsearchEngineClient;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.store.ElasticsearchBatchRequest;
 import io.camunda.exporter.utils.ElasticsearchScriptBuilder;
+import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.es.ElasticsearchConnector;
 import java.io.IOException;
 
@@ -28,12 +29,19 @@ class ElasticsearchAdapter implements ClientAdapter {
   private final ElasticsearchClient client;
   private final ElasticsearchEngineClient searchEngineClient;
   private final ElasticsearchExporterEntityCacheProvider entityCacheLoader;
+  private final ObjectMapper objectMapper;
 
-  ElasticsearchAdapter(final ExporterConfiguration configuration) {
-    final var connector = new ElasticsearchConnector(configuration.getConnect());
+  ElasticsearchAdapter(final ConnectConfiguration configuration) {
+    final var connector = new ElasticsearchConnector(configuration);
     client = connector.createClient();
-    searchEngineClient = new ElasticsearchEngineClient(client);
+    objectMapper = connector.objectMapper();
+    searchEngineClient = new ElasticsearchEngineClient(client, objectMapper);
     entityCacheLoader = new ElasticsearchExporterEntityCacheProvider(client);
+  }
+
+  @Override
+  public ObjectMapper objectMapper() {
+    return objectMapper;
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/OpensearchAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/OpensearchAdapter.java
@@ -7,18 +7,19 @@
  */
 package io.camunda.exporter.adapters;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
 import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.cache.form.OpenSearchFormCacheLoader;
 import io.camunda.exporter.cache.process.CachedProcessEntity;
 import io.camunda.exporter.cache.process.OpenSearchProcessCacheLoader;
-import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.schema.SearchEngineClient;
 import io.camunda.exporter.schema.opensearch.OpensearchEngineClient;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.store.OpensearchBatchRequest;
 import io.camunda.exporter.utils.OpensearchScriptBuilder;
+import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.os.OpensearchConnector;
 import java.io.IOException;
 import org.opensearch.client.opensearch.OpenSearchClient;
@@ -28,12 +29,19 @@ class OpensearchAdapter implements ClientAdapter {
   private final OpenSearchClient client;
   private final OpensearchEngineClient searchEngineClient;
   private final OpensearchExporterEntityCacheProvider entityCacheLoader;
+  private final ObjectMapper objectMapper;
 
-  OpensearchAdapter(final ExporterConfiguration configuration) {
-    final var connector = new OpensearchConnector(configuration.getConnect());
+  OpensearchAdapter(final ConnectConfiguration configuration) {
+    final var connector = new OpensearchConnector(configuration);
     client = connector.createClient();
-    searchEngineClient = new OpensearchEngineClient(client);
+    objectMapper = connector.objectMapper();
+    searchEngineClient = new OpensearchEngineClient(client, objectMapper);
     entityCacheLoader = new OpensearchExporterEntityCacheProvider(client);
+  }
+
+  @Override
+  public ObjectMapper objectMapper() {
+    return objectMapper;
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandler.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.handlers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import io.camunda.exporter.handlers.UserTaskCompletionVariableHandler.SnapshotTaskVariableBatch;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.tasklist.template.SnapshotTaskVariableTemplate;
@@ -32,14 +33,15 @@ public class UserTaskCompletionVariableHandler
       LoggerFactory.getLogger(UserTaskCompletionVariableHandler.class);
 
   private static final String ID_PATTERN = "%s-%s";
-  private static final ObjectMapper MAPPER = new ObjectMapper();
   protected final int variableSizeThreshold;
   private final String indexName;
+  private final ObjectWriter objectWriter;
 
   public UserTaskCompletionVariableHandler(
-      final String indexName, final int variableSizeThreshold) {
+      final String indexName, final int variableSizeThreshold, final ObjectMapper objectMapper) {
     this.indexName = indexName;
     this.variableSizeThreshold = variableSizeThreshold;
+    objectWriter = objectMapper.writerWithDefaultPrettyPrinter();
   }
 
   @Override
@@ -132,7 +134,7 @@ public class UserTaskCompletionVariableHandler
 
   private String toJsonString(final Object value) {
     try {
-      return MAPPER.writeValueAsString(value);
+      return objectWriter.writeValueAsString(value);
     } catch (final JsonProcessingException e) {
       LOGGER.error("Failed to parse variable value '{}'", value, e);
       return "";

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/IncidentNotifier.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/notifier/IncidentNotifier.java
@@ -9,7 +9,7 @@ package io.camunda.exporter.notifier;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import io.camunda.exporter.cache.ExporterEntityCache;
 import io.camunda.exporter.cache.process.CachedProcessEntity;
 import io.camunda.exporter.config.ExporterConfiguration.IncidentNotifierConfiguration;
@@ -50,8 +50,6 @@ public class IncidentNotifier {
   protected static final String FIELD_NAME_PROCESS_NAME = "processName";
   protected static final String FIELD_NAME_PROCESS_VERSION = "processVersion";
   private static final Logger LOGGER = LoggerFactory.getLogger(IncidentNotifier.class);
-  private static final ObjectMapper MAPPER =
-      new ObjectMapper().registerModule(new JavaTimeModule());
 
   private final M2mTokenManager m2mTokenManager;
 
@@ -59,18 +57,21 @@ public class IncidentNotifier {
   private final IncidentNotifierConfiguration configuration;
   private final HttpClient httpClient;
   private final Executor executor;
+  private final ObjectWriter objectWriter;
 
   public IncidentNotifier(
       final M2mTokenManager m2mTokenManager,
       final ExporterEntityCache<Long, CachedProcessEntity> processCache,
       final IncidentNotifierConfiguration configuration,
       final HttpClient httpClient,
-      final Executor executor) {
+      final Executor executor,
+      final ObjectMapper objectMapper) {
     this.m2mTokenManager = m2mTokenManager;
     this.processCache = processCache;
     this.configuration = configuration;
     this.httpClient = httpClient;
     this.executor = executor;
+    objectWriter = objectMapper.writer();
   }
 
   public void notifyAsync(final List<IncidentEntity> incidents) {
@@ -152,6 +153,6 @@ public class IncidentNotifier {
       }
       incidentList.add(incidentFields);
     }
-    return MAPPER.writeValueAsString(Map.of(FIELD_NAME_ALERTS, incidentList));
+    return objectWriter.writeValueAsString(Map.of(FIELD_NAME_ALERTS, incidentList));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/IndexSchemaValidator.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/IndexSchemaValidator.java
@@ -48,7 +48,12 @@ import org.slf4j.LoggerFactory;
  */
 public class IndexSchemaValidator {
   private static final Logger LOGGER = LoggerFactory.getLogger(IndexSchemaValidator.class);
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private final ObjectMapper objectMapper;
+
+  public IndexSchemaValidator(final ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
 
   /**
    * Validates existing indices mappings against index/index template mappings defined.
@@ -112,7 +117,7 @@ public class IndexSchemaValidator {
 
   private IndexMappingDifference getIndexMappingDifference(
       final IndexDescriptor indexDescriptor, final Map<String, IndexMapping> indexMappingsGroup) {
-    final IndexMapping indexMappingMustBe = IndexMapping.from(indexDescriptor, MAPPER);
+    final IndexMapping indexMappingMustBe = IndexMapping.from(indexDescriptor, objectMapper);
 
     final var differences =
         indexMappingsGroup.values().stream()

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SchemaManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SchemaManager.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.schema;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.IndexSettings;
 import io.camunda.exporter.config.ExporterConfiguration.RetentionConfiguration;
@@ -24,16 +25,19 @@ public class SchemaManager {
   private final Collection<IndexDescriptor> indexDescriptors;
   private final Collection<IndexTemplateDescriptor> indexTemplateDescriptors;
   private final ExporterConfiguration config;
+  private final ObjectMapper objectMapper;
 
   public SchemaManager(
       final SearchEngineClient searchEngineClient,
       final Collection<IndexDescriptor> indexDescriptors,
       final Collection<IndexTemplateDescriptor> indexTemplateDescriptors,
-      final ExporterConfiguration config) {
+      final ExporterConfiguration config,
+      final ObjectMapper objectMapper) {
     this.searchEngineClient = searchEngineClient;
     this.indexDescriptors = indexDescriptors;
     this.indexTemplateDescriptors = indexTemplateDescriptors;
     this.config = config;
+    this.objectMapper = objectMapper;
   }
 
   public void startup() {
@@ -43,10 +47,9 @@ public class SchemaManager {
       return;
     }
     LOG.info("Schema creation is enabled. Start Schema management.");
-    final var schemaValidator = new IndexSchemaValidator();
-    final var newIndexProperties = validateIndices(schemaValidator, searchEngineClient);
-    final var newIndexTemplateProperties =
-        validateIndexTemplates(schemaValidator, searchEngineClient);
+    final var schemaValidator = new IndexSchemaValidator(objectMapper);
+    final var newIndexProperties = validateIndices(schemaValidator);
+    final var newIndexTemplateProperties = validateIndexTemplates(schemaValidator);
     //  used to create any indices/templates which don't exist
     initialiseResources();
 
@@ -171,7 +174,7 @@ public class SchemaManager {
   }
 
   private Map<IndexDescriptor, Collection<IndexMappingProperty>> validateIndices(
-      final IndexSchemaValidator schemaValidator, final SearchEngineClient searchEngineClient) {
+      final IndexSchemaValidator schemaValidator) {
     if (indexDescriptors.isEmpty()) {
       LOG.info("No validation of indices, as there are no descriptors");
       return Map.of();
@@ -186,7 +189,7 @@ public class SchemaManager {
   }
 
   private Map<IndexDescriptor, Collection<IndexMappingProperty>> validateIndexTemplates(
-      final IndexSchemaValidator schemaValidator, final SearchEngineClient searchEngineClient) {
+      final IndexSchemaValidator schemaValidator) {
     if (indexTemplateDescriptors.isEmpty()) {
       LOG.info("No validation of index templates, as there are no descriptors");
       return Map.of();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -7,10 +7,6 @@
  */
 package io.camunda.exporter.schema.elasticsearch;
 
-import static io.camunda.exporter.utils.SearchEngineClientUtils.appendToFileSchemaSettings;
-import static io.camunda.exporter.utils.SearchEngineClientUtils.listIndices;
-import static io.camunda.exporter.utils.SearchEngineClientUtils.mapToSettings;
-
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.mapping.Property;
@@ -27,7 +23,6 @@ import co.elastic.clients.elasticsearch.indices.put_index_template.IndexTemplate
 import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.jackson.JacksonJsonpGenerator;
-import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.SchemaResourceSerializer;
 import io.camunda.exporter.config.ExporterConfiguration.IndexSettings;
@@ -37,6 +32,7 @@ import io.camunda.exporter.schema.IndexMapping;
 import io.camunda.exporter.schema.IndexMappingProperty;
 import io.camunda.exporter.schema.MappingSource;
 import io.camunda.exporter.schema.SearchEngineClient;
+import io.camunda.exporter.utils.SearchEngineClientUtils;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.index.ImportPositionIndex;
@@ -54,11 +50,17 @@ import org.slf4j.LoggerFactory;
 
 public class ElasticsearchEngineClient implements SearchEngineClient {
   private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchEngineClient.class);
-  private static final ObjectMapper MAPPER = new ObjectMapper();
   private final ElasticsearchClient client;
+  private final SearchEngineClientUtils utils;
+  private final ObjectMapper mapper;
+  private final SchemaResourceSerializer schemaSerializer;
 
-  public ElasticsearchEngineClient(final ElasticsearchClient client) {
+  public ElasticsearchEngineClient(
+      final ElasticsearchClient client, final ObjectMapper objectMapper) {
     this.client = client;
+    utils = new SearchEngineClientUtils(objectMapper);
+    mapper = objectMapper;
+    schemaSerializer = new SchemaResourceSerializer(mapper);
   }
 
   @Override
@@ -178,7 +180,8 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
     } catch (final IOException | ElasticsearchException e) {
       final var errMsg =
           String.format(
-              "settings PUT failed for the following indices [%s]", listIndices(indexDescriptors));
+              "settings PUT failed for the following indices [%s]",
+              utils.listIndices(indexDescriptors));
       LOG.error(errMsg, e);
       throw new ElasticsearchExporterException(errMsg, e);
     }
@@ -238,13 +241,13 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
   private PutIndicesSettingsRequest putIndexSettingsRequest(
       final List<IndexDescriptor> indexDescriptors, final Map<String, String> toAppendSettings) {
     final co.elastic.clients.elasticsearch.indices.IndexSettings settings =
-        mapToSettings(
+        utils.mapToSettings(
             toAppendSettings,
             (inp) ->
                 deserializeJson(
                     co.elastic.clients.elasticsearch.indices.IndexSettings._DESERIALIZER, inp));
     return new PutIndicesSettingsRequest.Builder()
-        .index(listIndices(indexDescriptors))
+        .index(utils.listIndices(indexDescriptors))
         .settings(settings)
         .build();
   }
@@ -306,10 +309,10 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
 
   private Map<String, Object> propertyToMap(final Property property) {
     try {
-      return SchemaResourceSerializer.serialize(
+      return schemaSerializer.serialize(
           (JacksonJsonpGenerator::new),
           (jacksonJsonpGenerator) ->
-              property.serialize(jacksonJsonpGenerator, new JacksonJsonpMapper(MAPPER)));
+              property.serialize(jacksonJsonpGenerator, client._transport().jsonpMapper()));
     } catch (final IOException e) {
       throw new ElasticsearchExporterException(
           String.format("Failed to serialize property [%s]", property.toString()), e);
@@ -331,7 +334,7 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
 
     final var elsProperties =
         newProperties.stream()
-            .map(IndexMappingProperty::toElasticsearchProperty)
+            .map(p -> p.toElasticsearchProperty(client._jsonpMapper(), mapper))
             .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
 
     return new PutMappingRequest.Builder()
@@ -361,7 +364,7 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
       final var templateFields =
           deserializeJson(
               IndexTemplateMapping._DESERIALIZER,
-              appendToFileSchemaSettings(templateFile, settings));
+              utils.appendToFileSchemaSettings(templateFile, settings));
 
       return new PutIndexTemplateRequest.Builder()
           .name(indexTemplateDescriptor.getTemplateName())
@@ -391,7 +394,7 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
       final var templateFields =
           deserializeJson(
               IndexTemplateMapping._DESERIALIZER,
-              appendToFileSchemaSettings(templateFile, settings));
+              utils.appendToFileSchemaSettings(templateFile, settings));
 
       return new CreateIndexRequest.Builder()
           .index(indexDescriptor.getFullQualifiedName())

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/opensearch/OpensearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/opensearch/OpensearchEngineClient.java
@@ -7,11 +7,9 @@
  */
 package io.camunda.exporter.schema.opensearch;
 
-import static io.camunda.exporter.utils.SearchEngineClientUtils.appendToFileSchemaSettings;
-import static io.camunda.exporter.utils.SearchEngineClientUtils.listIndices;
-import static io.camunda.exporter.utils.SearchEngineClientUtils.mapToSettings;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.camunda.exporter.SchemaResourceSerializer;
 import io.camunda.exporter.config.ExporterConfiguration.IndexSettings;
@@ -21,6 +19,7 @@ import io.camunda.exporter.schema.IndexMapping;
 import io.camunda.exporter.schema.IndexMappingProperty;
 import io.camunda.exporter.schema.MappingSource;
 import io.camunda.exporter.schema.SearchEngineClient;
+import io.camunda.exporter.utils.SearchEngineClientUtils;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.index.ImportPositionIndex;
@@ -35,7 +34,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.json.jackson.JacksonJsonpGenerator;
-import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.OpenSearchException;
@@ -56,13 +54,22 @@ import org.slf4j.LoggerFactory;
 
 public class OpensearchEngineClient implements SearchEngineClient {
   private static final Logger LOG = LoggerFactory.getLogger(OpensearchEngineClient.class);
-  private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final String OPERATE_DELETE_ARCHIVED_POLICY =
       "/schema/opensearch/create/policy/operate_delete_archived_indices.json";
+  private final ObjectReader objectReader;
+  private final ObjectWriter objectWriter;
   private final OpenSearchClient client;
+  private final SearchEngineClientUtils utils;
+  private final ObjectMapper objectMappper;
+  private final SchemaResourceSerializer schemaResourceSerializer;
 
-  public OpensearchEngineClient(final OpenSearchClient client) {
+  public OpensearchEngineClient(final OpenSearchClient client, final ObjectMapper objectMapper) {
     this.client = client;
+    objectMappper = objectMapper;
+    objectReader = objectMapper.reader();
+    objectWriter = objectMapper.writer();
+    utils = new SearchEngineClientUtils(objectMapper);
+    schemaResourceSerializer = new SchemaResourceSerializer(objectMapper);
   }
 
   @Override
@@ -182,7 +189,8 @@ public class OpensearchEngineClient implements SearchEngineClient {
     } catch (final IOException | OpenSearchException e) {
       final var errMsg =
           String.format(
-              "settings PUT failed for the following indices [%s]", listIndices(indexDescriptors));
+              "settings PUT failed for the following indices [%s]",
+              utils.listIndices(indexDescriptors));
       LOG.error(errMsg, e);
       throw new OpensearchExporterException(errMsg, e);
     }
@@ -252,7 +260,7 @@ public class OpensearchEngineClient implements SearchEngineClient {
   public Request createIndexStateManagementPolicy(
       final String policyName, final String deletionMinAge) {
     try (final var policyJson = getClass().getResourceAsStream(OPERATE_DELETE_ARCHIVED_POLICY)) {
-      final var jsonMap = MAPPER.readTree(policyJson);
+      final var jsonMap = objectReader.readTree(policyJson);
       final var conditions =
           (ObjectNode)
               jsonMap
@@ -264,7 +272,7 @@ public class OpensearchEngineClient implements SearchEngineClient {
                   .path("conditions");
       conditions.put("min_index_age", deletionMinAge);
 
-      final var policy = MAPPER.writeValueAsBytes(jsonMap);
+      final var policy = objectWriter.writeValueAsBytes(jsonMap);
 
       return Requests.builder()
           .method("PUT")
@@ -282,13 +290,13 @@ public class OpensearchEngineClient implements SearchEngineClient {
       final List<IndexDescriptor> indexDescriptors, final Map<String, String> toAppendSettings) {
 
     final org.opensearch.client.opensearch.indices.IndexSettings settings =
-        mapToSettings(
+        utils.mapToSettings(
             toAppendSettings,
             (inp) ->
                 deserializeJson(
                     org.opensearch.client.opensearch.indices.IndexSettings._DESERIALIZER, inp));
     return new PutIndicesSettingsRequest.Builder()
-        .index(listIndices(indexDescriptors))
+        .index(utils.listIndices(indexDescriptors))
         .settings(settings)
         .build();
   }
@@ -316,10 +324,10 @@ public class OpensearchEngineClient implements SearchEngineClient {
 
   private Map<String, Object> propertyToMap(final Property property) {
     try {
-      return SchemaResourceSerializer.serialize(
+      return schemaResourceSerializer.serialize(
           (JacksonJsonpGenerator::new),
           (jacksonJsonpGenerator) ->
-              property.serialize(jacksonJsonpGenerator, new JacksonJsonpMapper(MAPPER)));
+              property.serialize(jacksonJsonpGenerator, client._transport().jsonpMapper()));
     } catch (final IOException e) {
       throw new OpensearchExporterException(
           String.format("Failed to serialize property [%s]", property.toString()), e);
@@ -357,7 +365,7 @@ public class OpensearchEngineClient implements SearchEngineClient {
 
     final var opensearchProperties =
         newProperties.stream()
-            .map(IndexMappingProperty::toOpensearchProperty)
+            .map(p -> p.toOpensearchProperty(client._transport().jsonpMapper(), objectMappper))
             .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
 
     return new PutMappingRequest.Builder()
@@ -375,7 +383,7 @@ public class OpensearchEngineClient implements SearchEngineClient {
       final var templateFields =
           deserializeJson(
               IndexTemplateMapping._DESERIALIZER,
-              appendToFileSchemaSettings(templateFile, settings));
+              utils.appendToFileSchemaSettings(templateFile, settings));
 
       return new PutIndexTemplateRequest.Builder()
           .name(indexTemplateDescriptor.getTemplateName())
@@ -405,7 +413,7 @@ public class OpensearchEngineClient implements SearchEngineClient {
       final var templateFields =
           deserializeJson(
               IndexTemplateMapping._DESERIALIZER,
-              appendToFileSchemaSettings(templateFile, settings));
+              utils.appendToFileSchemaSettings(templateFile, settings));
 
       return new CreateIndexRequest.Builder()
           .index(indexDescriptor.getFullQualifiedName())

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -38,6 +38,7 @@ import io.camunda.exporter.schema.SchemaTestUtil;
 import io.camunda.exporter.utils.CamundaExporterITTemplateExtension;
 import io.camunda.exporter.utils.SearchClientAdapter;
 import io.camunda.exporter.utils.SearchDBExtension;
+import io.camunda.exporter.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.index.ImportPositionIndex;
@@ -409,7 +410,8 @@ final class CamundaExporterIT {
         config,
         mock(ExporterEntityCacheProvider.class),
         new SimpleMeterRegistry(),
-        new ExporterMetadata());
+        new ExporterMetadata(TestObjectMapper.objectMapper()),
+        TestObjectMapper.objectMapper());
     final var expectedHandlers =
         resourceProvider.getExportHandlers().stream()
             .filter(exportHandler -> exportHandler.getHandledValueType() == valueType)
@@ -471,7 +473,8 @@ final class CamundaExporterIT {
         config,
         mock(ExporterEntityCacheProvider.class),
         new SimpleMeterRegistry(),
-        new ExporterMetadata());
+        new ExporterMetadata(TestObjectMapper.objectMapper()),
+        TestObjectMapper.objectMapper());
 
     final CamundaExporter camundaExporter = new CamundaExporter();
     final ExporterTestContext exporterTestContext =
@@ -503,7 +506,8 @@ final class CamundaExporterIT {
         config,
         mock(ExporterEntityCacheProvider.class),
         new SimpleMeterRegistry(),
-        new ExporterMetadata());
+        new ExporterMetadata(TestObjectMapper.objectMapper()),
+        TestObjectMapper.objectMapper());
 
     final CamundaExporter camundaExporter = new CamundaExporter();
     final ExporterTestContext exporterTestContext =
@@ -571,7 +575,8 @@ final class CamundaExporterIT {
         config,
         mock(ExporterEntityCacheProvider.class),
         new SimpleMeterRegistry(),
-        new ExporterMetadata());
+        new ExporterMetadata(TestObjectMapper.objectMapper()),
+        TestObjectMapper.objectMapper());
 
     return defaultExporterResourceProvider.getExportHandlers().stream()
         .map(handler -> (ExportHandler<T, R>) handler)
@@ -649,7 +654,8 @@ final class CamundaExporterIT {
         config,
         mock(ExporterEntityCacheProvider.class),
         new SimpleMeterRegistry(),
-        new ExporterMetadata());
+        new ExporterMetadata(TestObjectMapper.objectMapper()),
+        TestObjectMapper.objectMapper());
 
     when(provider.getIndexDescriptors()).thenReturn(indexDescriptors);
     when(provider.getIndexTemplateDescriptors()).thenReturn(templateDescriptors);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
 import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.ComponentNames;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
@@ -33,7 +34,8 @@ public class DefaultExporterResourceProviderTest {
         config,
         mock(ExporterEntityCacheProvider.class),
         new SimpleMeterRegistry(),
-        new ExporterMetadata());
+        new ExporterMetadata(TestObjectMapper.objectMapper()),
+        TestObjectMapper.objectMapper());
 
     provider
         .getIndexDescriptors()

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/ExporterMetadataTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/ExporterMetadataTest.java
@@ -9,14 +9,15 @@ package io.camunda.exporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.exporter.utils.TestObjectMapper;
 import org.junit.jupiter.api.Test;
 
 final class ExporterMetadataTest {
   @Test
   void shouldSerializeToJson() {
     // given
-    final var source = new ExporterMetadata();
-    final var destination = new ExporterMetadata();
+    final var source = new ExporterMetadata(TestObjectMapper.objectMapper());
+    final var destination = new ExporterMetadata(TestObjectMapper.objectMapper());
     source.setLastIncidentUpdatePosition(3);
     destination.setLastIncidentUpdatePosition(-1);
 
@@ -31,7 +32,7 @@ final class ExporterMetadataTest {
   @Test
   void shouldNotUpdateIncidentPositionWithALowerValue() {
     // given
-    final var metadata = new ExporterMetadata();
+    final var metadata = new ExporterMetadata(TestObjectMapper.objectMapper());
     metadata.setLastIncidentUpdatePosition(3);
 
     // when

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.handlers.UserTaskCompletionVariableHandler.SnapshotTaskVariableBatch;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.exporter.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.tasklist.template.SnapshotTaskVariableTemplate;
 import io.camunda.webapps.schema.entities.tasklist.SnapshotTaskVariableEntity;
 import io.camunda.zeebe.protocol.record.Record;
@@ -34,7 +35,7 @@ public class UserTaskCompletionVariableHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
   private final String indexName = "test-tasklist-task";
   private final UserTaskCompletionVariableHandler underTest =
-      new UserTaskCompletionVariableHandler(indexName, 100);
+      new UserTaskCompletionVariableHandler(indexName, 100, TestObjectMapper.objectMapper());
 
   @Test
   void testGetHandledValueType() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
@@ -17,6 +17,7 @@ import io.camunda.exporter.cache.TestFormCache;
 import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
+import io.camunda.exporter.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
 import io.camunda.webapps.schema.entities.tasklist.TaskEntity;
 import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
@@ -53,7 +54,8 @@ public class UserTaskHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
   private final String indexName = "test-tasklist-task";
   private final TestFormCache formCache = new TestFormCache();
-  private final ExporterMetadata exporterMetadata = new ExporterMetadata();
+  private final ExporterMetadata exporterMetadata =
+      new ExporterMetadata(TestObjectMapper.objectMapper());
   private final UserTaskHandler underTest =
       new UserTaskHandler(indexName, formCache, exporterMetadata);
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
@@ -17,6 +17,7 @@ import io.camunda.exporter.cache.TestFormCache;
 import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
+import io.camunda.exporter.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
 import io.camunda.webapps.schema.entities.tasklist.TaskEntity;
 import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
@@ -53,9 +54,11 @@ public class UserTaskJobBasedHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
   private final String indexName = "test-tasklist-task";
   private final TestFormCache formCache = new TestFormCache();
-  private final ExporterMetadata exporterMetadata = new ExporterMetadata();
+  private final ExporterMetadata exporterMetadata =
+      new ExporterMetadata(TestObjectMapper.objectMapper());
   private final UserTaskJobBasedHandler underTest =
-      new UserTaskJobBasedHandler(indexName, formCache, exporterMetadata);
+      new UserTaskJobBasedHandler(
+          indexName, formCache, exporterMetadata, TestObjectMapper.objectMapper());
 
   @BeforeEach
   void resetMetadata() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/notifier/IncidentNotifierTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/notifier/IncidentNotifierTest.java
@@ -40,6 +40,7 @@ import com.jayway.jsonpath.JsonPath;
 import io.camunda.exporter.cache.ExporterEntityCache;
 import io.camunda.exporter.cache.process.CachedProcessEntity;
 import io.camunda.exporter.config.ExporterConfiguration.IncidentNotifierConfiguration;
+import io.camunda.exporter.utils.TestObjectMapper;
 import io.camunda.webapps.schema.entities.operate.ErrorType;
 import io.camunda.webapps.schema.entities.operate.IncidentEntity;
 import io.camunda.webapps.schema.entities.operate.IncidentState;
@@ -90,7 +91,13 @@ class IncidentNotifierTest {
     final IncidentNotifierConfiguration configuration = new IncidentNotifierConfiguration();
     configuration.setWebhook(ALERT_WEBHOOKURL_URL);
     incidentNotifier =
-        new IncidentNotifier(m2mTokenManager, processCache, configuration, httpClient, null);
+        new IncidentNotifier(
+            m2mTokenManager,
+            processCache,
+            configuration,
+            httpClient,
+            null,
+            TestObjectMapper.objectMapper());
     when(processCache.get(any()))
         .thenReturn(Optional.of(new CachedProcessEntity(processName, processVersion, null)));
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/notifier/M2mTokenManagerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/notifier/M2mTokenManagerTest.java
@@ -28,10 +28,10 @@ import static org.mockito.Mockito.withSettings;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
 import io.camunda.exporter.config.ExporterConfiguration.IncidentNotifierConfiguration;
+import io.camunda.exporter.utils.TestObjectMapper;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.http.HttpClient;
@@ -57,8 +57,7 @@ class M2mTokenManagerTest {
   protected static final String M2M_CLIENT_ID = "clientId";
   protected static final String M2M_CLIENT_SECRET = "clientSecret";
   protected static final String M2M_AUDIENCE = "audience";
-  private static final ObjectMapper MAPPER =
-      new ObjectMapper().registerModule(new JavaTimeModule());
+  private static final ObjectMapper MAPPER = TestObjectMapper.objectMapper();
   private final String mockJwtToken =
       JWT.create()
           .withExpiresAt(new Date(Instant.now().plus(10, ChronoUnit.MINUTES).toEpochMilli()))
@@ -74,7 +73,8 @@ class M2mTokenManagerTest {
     configuration.setM2mClientSecret(M2M_CLIENT_SECRET);
     configuration.setM2mAudience(M2M_AUDIENCE);
 
-    m2mTokenManager = new M2mTokenManager(configuration, httpClient);
+    m2mTokenManager =
+        new M2mTokenManager(configuration, httpClient, TestObjectMapper.objectMapper());
   }
 
   @AfterEach

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchEngineClientIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchEngineClientIT.java
@@ -52,9 +52,10 @@ public class ElasticsearchEngineClientIT {
     // Create the low-level client
     final var config = new ExporterConfiguration();
     config.getConnect().setUrl(CONTAINER.getHttpHostAddress());
-    elsClient = new ElasticsearchConnector(config.getConnect()).createClient();
+    final var esConnector = new ElasticsearchConnector(config.getConnect());
+    elsClient = esConnector.createClient();
 
-    elsEngineClient = new ElasticsearchEngineClient(elsClient);
+    elsEngineClient = new ElasticsearchEngineClient(elsClient, esConnector.objectMapper());
   }
 
   @BeforeEach

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/IndexMappingTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/IndexMappingTest.java
@@ -9,7 +9,7 @@ package io.camunda.exporter.schema;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.utils.TestObjectMapper;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +22,7 @@ public class IndexMappingTest {
         SchemaTestUtil.mockIndex("index_name", "alias", "index_name", "/mappings.json");
 
     // when
-    final var indexMapping = IndexMapping.from(index, new ObjectMapper());
+    final var indexMapping = IndexMapping.from(index, TestObjectMapper.objectMapper());
 
     // then
     assertThat(indexMapping.dynamic()).isEqualTo("strict");

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/IndexSchemaValidatorTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/IndexSchemaValidatorTest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.exceptions.IndexSchemaValidationException;
+import io.camunda.exporter.utils.TestObjectMapper;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
@@ -23,9 +24,10 @@ import org.junit.jupiter.api.Test;
 
 public class IndexSchemaValidatorTest {
 
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectMapper MAPPER = TestObjectMapper.objectMapper();
 
-  private static final IndexSchemaValidator VALIDATOR = new IndexSchemaValidator();
+  private static final IndexSchemaValidator VALIDATOR =
+      new IndexSchemaValidator(TestObjectMapper.objectMapper());
 
   @Test
   void shouldDetectIndexWithAddedProperty() throws IOException {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/SchemaTestUtil.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/SchemaTestUtil.java
@@ -12,24 +12,16 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
-import co.elastic.clients.json.JsonpMapper;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.utils.TestObjectMapper;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 
 public final class SchemaTestUtil {
-
-  private static final ObjectMapper MAPPER = new ObjectMapper();
-  private static final JsonpMapper ELS_JSON_MAPPER =
-      new co.elastic.clients.json.jackson.JacksonJsonpMapper(MAPPER);
-  private static final org.opensearch.client.json.JsonpMapper OPENSEARCH_JSON_MAPPER =
-      new JacksonJsonpMapper(MAPPER);
 
   private SchemaTestUtil() {}
 
@@ -97,8 +89,9 @@ public final class SchemaTestUtil {
       throws IOException {
     try (final var expectedMappings = SchemaTestUtil.class.getResourceAsStream(fileName)) {
       final var jsonMap =
-          MAPPER.readValue(
-              expectedMappings, new TypeReference<Map<String, Map<String, Object>>>() {});
+          TestObjectMapper.objectMapper()
+              .readValue(
+                  expectedMappings, new TypeReference<Map<String, Map<String, Object>>>() {});
       return (Map<String, Map<String, Object>>) jsonMap.get("mappings").get("properties");
     }
   }
@@ -106,7 +99,8 @@ public final class SchemaTestUtil {
   public static boolean mappingsMatch(final JsonNode mappings, final String fileName)
       throws IOException {
     try (final var expectedMappingsJson = SchemaTestUtil.class.getResourceAsStream(fileName)) {
-      final var expectedMappingsTree = new ObjectMapper().readTree(expectedMappingsJson);
+      final var expectedMappingsTree =
+          TestObjectMapper.objectMapper().readTree(expectedMappingsJson);
       return mappings.equals(expectedMappingsTree.get("mappings"));
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryIT.java
@@ -14,6 +14,7 @@ import io.camunda.exporter.config.ExporterConfiguration.ArchiverConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.RetentionConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.schema.opensearch.OpensearchEngineClient;
+import io.camunda.exporter.utils.TestObjectMapper;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate;
@@ -68,7 +69,7 @@ final class OpenSearchArchiverRepositoryIT {
   private static final OpensearchContainer<?> OPENSEARCH =
       TestSearchContainers.createDefaultOpensearchContainer();
 
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectMapper MAPPER = TestObjectMapper.objectMapper();
   @AutoClose private final RestClientTransport transport = createRestClient();
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
   private final ArchiverConfiguration config = new ArchiverConfiguration();
@@ -369,7 +370,7 @@ final class OpenSearchArchiverRepositoryIT {
   }
 
   private void createLifeCyclePolicy() {
-    final var engineClient = new OpensearchEngineClient(testClient);
+    final var engineClient = new OpensearchEngineClient(testClient, MAPPER);
     try {
       engineClient.putIndexLifeCyclePolicy(retention.getPolicyName(), retention.getMinimumAge());
     } catch (final Exception e) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -17,6 +17,7 @@ import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentDocum
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.NoopIncidentUpdateRepository;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.PendingIncidentUpdateBatch;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.ProcessInstanceDocument;
+import io.camunda.exporter.utils.TestObjectMapper;
 import io.camunda.webapps.operate.TreePath;
 import io.camunda.webapps.schema.descriptors.operate.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.IncidentTemplate;
@@ -41,7 +42,7 @@ import org.slf4j.LoggerFactory;
 
 final class IncidentUpdateTaskTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(IncidentUpdateTaskTest.class);
-  private final ExporterMetadata metadata = new ExporterMetadata();
+  private final ExporterMetadata metadata = new ExporterMetadata(TestObjectMapper.objectMapper());
   private final TestRepository repository = Mockito.spy(new TestRepository());
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterITInvocationProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterITInvocationProvider.java
@@ -85,12 +85,14 @@ public class CamundaExporterITInvocationProvider
     osContainer.start();
 
     final var osConfig = getConfigWithConnectionDetails(OPENSEARCH);
-    osClient = new OpensearchConnector(osConfig.getConnect()).createClient();
-    osClientAdapter = new SearchClientAdapter(osClient);
+    final var osConnector = new OpensearchConnector(osConfig.getConnect());
+    osClient = osConnector.createClient();
+    osClientAdapter = new SearchClientAdapter(osClient, osConnector.objectMapper());
 
     final var elsConfig = getConfigWithConnectionDetails(ELASTICSEARCH);
-    elsClient = new ElasticsearchConnector(elsConfig.getConnect()).createClient();
-    elsClientAdapter = new SearchClientAdapter(elsClient);
+    final var esConnector = new ElasticsearchConnector(elsConfig.getConnect());
+    elsClient = esConnector.createClient();
+    elsClientAdapter = new SearchClientAdapter(elsClient, esConnector.objectMapper());
 
     closeables.add(elsContainer);
     closeables.add(osContainer);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterITTemplateExtension.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterITTemplateExtension.java
@@ -136,8 +136,8 @@ public class CamundaExporterITTemplateExtension
   public void beforeAll(final ExtensionContext context) throws Exception {
     if (Optional.ofNullable(System.getProperty(IT_OPENSEARCH_AWS_INSTANCE_URL_PROPERTY))
         .isEmpty()) {
-      elsClientAdapter = new SearchClientAdapter(extension.esClient());
+      elsClientAdapter = new SearchClientAdapter(extension.esClient(), extension.objectMapper());
     }
-    osClientAdapter = new SearchClientAdapter(extension.osClient());
+    osClientAdapter = new SearchClientAdapter(extension.osClient(), extension.objectMapper());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/SearchDBExtension.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/SearchDBExtension.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.utils;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.webapps.schema.descriptors.operate.index.ProcessIndex;
 import io.camunda.webapps.schema.descriptors.tasklist.index.FormIndex;
 import java.util.Optional;
@@ -45,6 +46,8 @@ public abstract class SearchDBExtension
       return new AWSSearchDBExtension(openSearchAwsInstanceUrl);
     }
   }
+
+  public abstract ObjectMapper objectMapper();
 
   public abstract ElasticsearchClient esClient();
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/TestObjectMapper.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/TestObjectMapper.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+public class TestObjectMapper {
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper().registerModule(new JavaTimeModule());
+
+  public static ObjectMapper objectMapper() {
+    return OBJECT_MAPPER;
+  }
+}


### PR DESCRIPTION
## Description
All classes instantiating their own ObjectMapper now use a common instance created using `io.camunda.search.connect.jackson.JacksonConfiguration` (from the common `search` module)
This instance is injected at runtime in all exporter classes and it's shared with ES/OS clients.

The `ObjectMapper` is available as a method in `ClientAdapter`. 

When possible, type specific readers/writers have been used in favour of an ObjectMapper as they are thread-safe and immutable.

As a result, there is `new ObjectMapper()` call in production code, and a `TestObjectMapper` is created which contains a static shared instance for when there is no ES/OS connection.

## Related issues

closes #24599
