### PR TITLE
Ensure `withAuthentication()` is called before doing a service call.

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionController.java
@@ -114,7 +114,10 @@ public class ProcessDefinitionController {
         return ResponseEntity.ok()
             .body(
                 SearchQueryResponseMapper.toFormItem(
-                    formServices.getLatestVersionByFormId(processDefinition.formId()).get()));
+                    formServices
+                        .withAuthentication(RequestMapper.getAuthentication())
+                        .getLatestVersionByFormId(processDefinition.formId())
+                        .get()));
       } else {
         return ResponseEntity.noContent().build();
       }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -53,7 +53,11 @@ public class TenantController {
   public ResponseEntity<TenantItem> getTenant(@PathVariable final String tenantId) {
     try {
       return ResponseEntity.ok()
-          .body(SearchQueryResponseMapper.toTenant(tenantServices.getById(tenantId)));
+          .body(
+              SearchQueryResponseMapper.toTenant(
+                  tenantServices
+                      .withAuthentication(RequestMapper.getAuthentication())
+                      .getById(tenantId)));
     } catch (final Exception exception) {
       return RestErrorMapper.mapErrorToResponse(exception);
     }
@@ -155,7 +159,8 @@ public class TenantController {
 
   private ResponseEntity<TenantSearchQueryResponse> search(final TenantQuery query) {
     try {
-      final var result = tenantServices.search(query);
+      final var result =
+          tenantServices.withAuthentication(RequestMapper.getAuthentication()).search(query);
       return ResponseEntity.ok(SearchQueryResponseMapper.toTenantSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupController.java
@@ -110,7 +110,11 @@ public class GroupController {
   public ResponseEntity<Object> getGroup(@PathVariable final long groupKey) {
     try {
       return ResponseEntity.ok()
-          .body(SearchQueryResponseMapper.toGroup(groupServices.getGroup(groupKey)));
+          .body(
+              SearchQueryResponseMapper.toGroup(
+                  groupServices
+                      .withAuthentication(RequestMapper.getAuthentication())
+                      .getGroup(groupKey)));
     } catch (final Exception exception) {
       return RestErrorMapper.mapErrorToResponse(exception);
     }
@@ -125,7 +129,8 @@ public class GroupController {
 
   private ResponseEntity<GroupSearchQueryResponse> search(final GroupQuery query) {
     try {
-      final var result = groupServices.search(query);
+      final var result =
+          groupServices.withAuthentication(RequestMapper.getAuthentication()).search(query);
       return ResponseEntity.ok(SearchQueryResponseMapper.toGroupSearchQueryResponse(result));
     } catch (final Exception e) {
       return RestErrorMapper.mapErrorToResponse(e);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingController.java
@@ -70,7 +70,11 @@ public class MappingController {
   public ResponseEntity<MappingItem> getMapping(@PathVariable final long mappingKey) {
     try {
       return ResponseEntity.ok()
-          .body(SearchQueryResponseMapper.toMapping(mappingServices.getMapping(mappingKey)));
+          .body(
+              SearchQueryResponseMapper.toMapping(
+                  mappingServices
+                      .withAuthentication(RequestMapper.getAuthentication())
+                      .getMapping(mappingKey)));
     } catch (final Exception exception) {
       return RestErrorMapper.mapErrorToResponse(exception);
     }
@@ -85,7 +89,8 @@ public class MappingController {
 
   private ResponseEntity<MappingSearchQueryResponse> search(final MappingQuery query) {
     try {
-      final var result = mappingServices.search(query);
+      final var result =
+          mappingServices.withAuthentication(RequestMapper.getAuthentication()).search(query);
       return ResponseEntity.ok(SearchQueryResponseMapper.toMappingSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -84,7 +84,11 @@ public class RoleController {
   public ResponseEntity<Object> getRole(@PathVariable final long roleKey) {
     try {
       return ResponseEntity.ok()
-          .body(SearchQueryResponseMapper.toRole(roleServices.getRole(roleKey)));
+          .body(
+              SearchQueryResponseMapper.toRole(
+                  roleServices
+                      .withAuthentication(RequestMapper.getAuthentication())
+                      .getRole(roleKey)));
     } catch (final Exception exception) {
       return RestErrorMapper.mapErrorToResponse(exception);
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserRolesController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserRolesController.java
@@ -11,6 +11,7 @@ import io.camunda.search.query.RoleQuery;
 import io.camunda.service.RoleServices;
 import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryResponse;
+import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
@@ -42,7 +43,10 @@ public class UserRolesController {
   private ResponseEntity<RoleSearchQueryResponse> searchRoles(
       final long userKey, final RoleQuery query) {
     try {
-      final var result = roleServices.getMemberRoles(userKey, query);
+      final var result =
+          roleServices
+              .withAuthentication(RequestMapper.getAuthentication())
+              .getMemberRoles(userKey, query);
       return ResponseEntity.ok(SearchQueryResponseMapper.toRoleSearchQueryResponse(result));
     } catch (final Exception e) {
       return RestErrorMapper.mapErrorToResponse(e);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/ControllerAuthorizationArchTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/ControllerAuthorizationArchTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import io.camunda.service.ApiServices;
+import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
+
+@AnalyzeClasses(
+    packages = "io.camunda.zeebe.gateway.rest.controller..",
+    importOptions = ImportOption.DoNotIncludeTests.class)
+public class ControllerAuthorizationArchTest {
+  public static final String WITH_AUTHENTICATION_METHOD_NAME = "withAuthentication";
+
+  @ArchTest()
+  public static final ArchRule CONTROLLERS_CHECK_AUTHORIZATION =
+      fields()
+          .that()
+          .areDeclaredInClassesThat()
+          .areAnnotatedWith(CamundaRestController.class)
+          .and(areAssignableToApiServices())
+          .should(addAuthenticationToServiceCalls());
+
+  /**
+   * Predicate to check if the field is a Service class. We do this by verifying if it (indirectly)
+   * extends {@link ApiServices}.
+   */
+  private static DescribedPredicate<JavaField> areAssignableToApiServices() {
+    return new DescribedPredicate<>("are assignable to ApiServices") {
+      @Override
+      public boolean test(final JavaField javaField) {
+        // Only check this field if it is a Service class (it (indirectly) extends ApiServices).
+        final var serviceClass = javaField.getRawType();
+        return serviceClass.isAssignableTo(ApiServices.class);
+      }
+    };
+  }
+
+  /**
+   * ArchCondition to verify if the first call to the service field is {@link
+   * ApiServices#withAuthentication}. If it isn't we will add a violation, resulting in a failed
+   * test case.
+   */
+  private static ArchCondition<JavaField> addAuthenticationToServiceCalls() {
+    return new ArchCondition<>("add authentication to the service call") {
+      @Override
+      public void check(final JavaField serviceField, final ConditionEvents events) {
+        final var clazz = serviceField.getOwner();
+        // We get all the methods in the class that make any call to the service field. After this
+        // we ensure that the first call made to the service field is the `withAuthentication`
+        // method.
+        clazz.getMethods().stream()
+            .filter(method -> callsService(method, serviceField))
+            .filter(method -> !callsWithAuthenticationFirst(method, serviceField))
+            .forEach(
+                method ->
+                    events.add(
+                        SimpleConditionEvent.violated(
+                            serviceField,
+                            "%s is accessed without first calling withAuthentication in class %s in method %s at: %s"
+                                .formatted(
+                                    serviceField.getName(),
+                                    clazz.getName(),
+                                    method.getName(),
+                                    method.getSourceCodeLocation()))));
+      }
+    };
+  }
+
+  /**
+   * Verifies if the method actually calls the service field we are working with.
+   *
+   * @param method The method to check
+   * @param serviceField The service field that should be called
+   * @return true if the method makes a call to the service field, false otherwise
+   */
+  private static boolean callsService(final JavaMethod method, final JavaField serviceField) {
+    final var callsFromSelf = method.getCallsFromSelf();
+    return callsFromSelf.stream()
+        .anyMatch(c -> c.getTarget().getOwner().equals(serviceField.getRawType()));
+  }
+
+  /**
+   * Verifies if the first call to the service field is the {@link ApiServices#withAuthentication}
+   * method. It does so by getting all the calls this method makes and filtering it to ensure we are
+   * only working with calls to the service field. After this we sort the calls to ensure the {@link
+   * ApiServices#withAuthentication} call becomes the first in the list. Finally, we only have to
+   * ensure the first call in the list is to the {@link ApiServices#withAuthentication} method.
+   *
+   * <p>It is important to note that this method assumes that the service field is only called once,
+   * and chained afterward. If there is multiple separate calls to the service field it will not be
+   * accurate and should be modified! At the time of writing this we did not have such use-cases.
+   *
+   * @param method The method to check
+   * @param serviceField The service field that should call {@link ApiServices#withAuthentication}
+   *     first
+   * @return true if the method calls {@link ApiServices#withAuthentication} first, false otherwise
+   */
+  private static boolean callsWithAuthenticationFirst(
+      final JavaMethod method, final JavaField serviceField) {
+    final var firstServiceCall =
+        method.getCallsFromSelf().stream()
+            .filter(call -> call.getTarget().getOwner().equals(serviceField.getRawType()))
+            .sorted(
+                (call1, call2) -> {
+                  if (call1.getName().equals(WITH_AUTHENTICATION_METHOD_NAME)) {
+                    return -1;
+                  } else if (call2.getName().equals(WITH_AUTHENTICATION_METHOD_NAME)) {
+                    return 1;
+                  } else {
+                    return 0;
+                  }
+                })
+            .toList()
+            .getFirst();
+
+    return firstServiceCall.getName().equals(WITH_AUTHENTICATION_METHOD_NAME);
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/ControllerAuthorizationArchTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/ControllerAuthorizationArchTest.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.gateway;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
 
 import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaAccess;
+import com.tngtech.archunit.core.domain.JavaCall;
 import com.tngtech.archunit.core.domain.JavaField;
 import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.importer.ImportOption;
@@ -21,6 +23,7 @@ import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
 import io.camunda.service.ApiServices;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
+import java.util.Comparator;
 
 @AnalyzeClasses(
     packages = "io.camunda.zeebe.gateway.rest.controller..",
@@ -118,15 +121,17 @@ public class ControllerAuthorizationArchTest {
         method.getCallsFromSelf().stream()
             .filter(call -> call.getTarget().getOwner().equals(serviceField.getRawType()))
             .sorted(
-                (call1, call2) -> {
-                  if (call1.getName().equals(WITH_AUTHENTICATION_METHOD_NAME)) {
-                    return -1;
-                  } else if (call2.getName().equals(WITH_AUTHENTICATION_METHOD_NAME)) {
-                    return 1;
-                  } else {
-                    return 0;
-                  }
-                })
+                Comparator.<JavaCall<?>>comparingInt(JavaAccess::getLineNumber)
+                    .thenComparing(
+                        (call1, call2) -> {
+                          if (call1.getName().equals(WITH_AUTHENTICATION_METHOD_NAME)) {
+                            return -1;
+                          } else if (call2.getName().equals(WITH_AUTHENTICATION_METHOD_NAME)) {
+                            return 1;
+                          } else {
+                            return 0;
+                          }
+                        }))
             .toList()
             .getFirst();
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This ArchUnit test verifies that every call to a Service that is performed by a Controller adds the authentication by
calling withAuthentication first. The test will fail if this is not the case.

This is essential, as not making this call could result in cases where forget to add it, or accidentally remove it (for
example during a merge conflict). As a result the endpoint would not verify a user's authorization anymore. Potentially
causing data-leaks.


It is important to note that this method assumes that the service field is only called once, and chained afterward. If there is multiple separate calls to the service field it will not be accurate and should be modified! Currently, we do not have such use-cases. I tried to make it all-encompassing but the code became too complex and it was not worth it imo.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

N/A
