### PR TITLE
fix: use linting in c8run

### DIFF
--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -31,6 +31,22 @@ permissions:
   statuses: write
 
 jobs:
+  linting:
+    name: C8Run linting
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.23.1'
+          cache: false  # disabling since not working anyways without a cache-dependency-path specified
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@ec5d18412c0aeab7936cb16880d708ba2a64e1ae # v6.2.0
+        with:
+          working-directory: ./c8run
+
   test_c8run:
     strategy:
       matrix:

--- a/c8run/internal/archive/archive.go
+++ b/c8run/internal/archive/archive.go
@@ -33,7 +33,7 @@ func DownloadFile(filepath string, url string, authToken string) error {
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return fmt.Errorf("DownloadFile: failed to create request for url: %s\n%w\n%s", url)
+		return fmt.Errorf("DownloadFile: failed to create request for url: %s\n%w\n%s", url, err, debug.Stack())
 	}
 
 	if strings.HasPrefix(authToken, "Basic ") {
@@ -114,7 +114,10 @@ func ExtractTarGzArchive(filename string, xpath string) error {
 
 	_, err = os.Stat(absPath)
 	if errors.Is(err, os.ErrNotExist) {
-		os.Mkdir(absPath, ReadWriteMode)
+		err = os.Mkdir(absPath, ReadWriteMode)
+                if err != nil {
+		        return fmt.Errorf("ExtractTarGzArchive: failed to make directory %s\n%w\n%s", absPath, err, debug.Stack())
+                }
 	}
 
 	tr := tar.NewReader(gz)

--- a/c8run/package.go
+++ b/c8run/package.go
@@ -107,7 +107,10 @@ func PackageWindows(camundaVersion string, elasticsearchVersion string, connecto
 		return fmt.Errorf("PackageWindows: failed to fetch compose release %w\n%s", err, debug.Stack())
 	}
 
-	os.Chdir("..")
+	err = os.Chdir("..")
+	if err != nil {
+		return fmt.Errorf("PackageWindows: failed to chdir %w", err)
+	}
 	filesToArchive := []string{
 		filepath.Join("c8run", "README.md"),
 		filepath.Join("c8run", "connectors-application.properties"),
@@ -126,7 +129,10 @@ func PackageWindows(camundaVersion string, elasticsearchVersion string, connecto
 	if err != nil {
 		return fmt.Errorf("PackageWindows: failed to create c8run package %w\n%s", err, debug.Stack())
 	}
-	os.Chdir("c8run")
+	err = os.Chdir("c8run")
+	if err != nil {
+		return fmt.Errorf("PackageWindows: failed to chdir %w", err)
+	}
 	return nil
 }
 
@@ -186,7 +192,10 @@ func PackageUnix(camundaVersion string, elasticsearchVersion string, connectorsV
 		return fmt.Errorf("PackageUnix: failed to fetch compose release %w\n%s", err, debug.Stack())
 	}
 
-	os.Chdir("..")
+	err = os.Chdir("..")
+	if err != nil {
+		return fmt.Errorf("PackageUnix: failed to chdir %w", err)
+	}
 	filesToArchive := []string{
 		filepath.Join("c8run", "README.md"),
 		filepath.Join("c8run", "connectors-application.properties"),
@@ -211,6 +220,9 @@ func PackageUnix(camundaVersion string, elasticsearchVersion string, connectorsV
 	if err != nil {
 		return fmt.Errorf("PackageUnix: failed to fill camunda archive %w\n%s", err, debug.Stack())
 	}
-	os.Chdir("c8run")
+	err = os.Chdir("c8run")
+	if err != nil {
+		return fmt.Errorf("PackageUnix: failed to chdir %w", err)
+	}
 	return nil
 }


### PR DESCRIPTION
## Description

c8run is a golang project, and this PR introduces some linting. I'm hoping it can help prevent me from forgetting to run `go fmt`, but it may get annoying with other issues, so I want to test it in this PR first, and maybe reduce which linting rules make it error.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
