### PR TITLE
pg-27022-schema-validator-dynamic-field

### DIFF
--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/IndexSchemaValidatorUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/IndexSchemaValidatorUtil.java
@@ -97,20 +97,15 @@ public class IndexSchemaValidatorUtil {
     }
 
     // Validate if the difference is dynamic
-    if (difference.getEntriesDiffering() != null) {
-      for (final PropertyDifference propertyDifference : difference.getEntriesDiffering()) {
-        final Object typeDefinition = propertyDifference.getLeftValue().getTypeDefinition();
-        if (propertyDifference.getLeftValue().getTypeDefinition() instanceof Map) {
-          final Map<String, Object> typeDefMap = (Map<String, Object>) typeDefinition;
-          final Object dynamicValue = typeDefMap.getOrDefault("dynamic", false);
-          if (dynamicValue.equals(true)) {
-            LOGGER.debug(
-                String.format(
-                    "Difference is on dynamic field - continue initialization: %s.",
-                    indexDescriptor.getIndexName()));
-            return;
-          }
-        }
+    if (difference.getEntriesDiffering() != null && difference.getEntriesDiffering().size() > 0) {
+      if (difference.getEntriesDiffering().stream().noneMatch(this::nonDynamicPropertyDifference)) {
+        LOGGER.debug(
+            String.format(
+                "Difference is on dynamic field - continue initialization - left %s, right %s. Actual diff values: %s",
+                difference.getLeftIndexMapping().getIndexName(),
+                difference.getRightIndexMapping().getIndexName(),
+                difference.getEntriesDiffering()));
+        return;
       }
     }
 
@@ -179,14 +174,37 @@ public class IndexSchemaValidatorUtil {
           // all those indices should have the same difference. Compare based only on the
           // differences (exclude the IndexMapping fields in the comparison)
         } else if (!difference.checkEqualityForDifferences(currentDifference)) {
-          throw new TasklistRuntimeException(
-              "Ambiguous schema update. First bring runtime and date indices to one schema. Difference 1: "
-                  + difference
-                  + ". Difference 2: "
-                  + currentDifference);
+          if (currentDifference.getEntriesDiffering().stream()
+              .anyMatch(this::nonDynamicPropertyDifference)) {
+            throw new TasklistRuntimeException(
+                "Ambiguous schema update. First bring runtime and data indices to one schema."
+                    + " Difference 1:"
+                    + difference
+                    + ". Difference 2: "
+                    + currentDifference);
+          } else {
+            LOGGER.debug(
+                String.format(
+                    "Difference is on dynamic field - continue initialization, left: %s, right: %s. Actual diff values: %s",
+                    difference.getLeftIndexMapping().getIndexName(),
+                    difference.getRightIndexMapping().getIndexName(),
+                    difference.getEntriesDiffering()));
+          }
         }
       }
     }
     return difference;
+  }
+
+  private boolean nonDynamicPropertyDifference(final PropertyDifference propertyDifference) {
+    final Object typeDefinition = propertyDifference.getLeftValue().getTypeDefinition();
+    if (propertyDifference.getLeftValue().getTypeDefinition() instanceof Map) {
+      final Map<String, Object> typeDefMap = (Map<String, Object>) typeDefinition;
+      final Object dynamicValue = typeDefMap.getOrDefault("dynamic", false);
+      if (dynamicValue.equals("true")) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/IndexSchemaValidatorUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/IndexSchemaValidatorUtil.java
@@ -97,16 +97,17 @@ public class IndexSchemaValidatorUtil {
     }
 
     // Validate if the difference is dynamic
-    if (difference.getEntriesDiffering() != null && difference.getEntriesDiffering().size() > 0) {
-      if (difference.getEntriesDiffering().stream().noneMatch(this::nonDynamicPropertyDifference)) {
-        LOGGER.debug(
-            String.format(
-                "Difference is on dynamic field - continue initialization - left %s, right %s. Actual diff values: %s",
-                difference.getLeftIndexMapping().getIndexName(),
-                difference.getRightIndexMapping().getIndexName(),
-                difference.getEntriesDiffering()));
-        return;
-      }
+    if (difference.getEntriesDiffering() != null
+        && difference.getEntriesDiffering().size() > 0
+        && difference.getEntriesDiffering().stream()
+            .noneMatch(this::nonDynamicPropertyDifference)) {
+      LOGGER.debug(
+          String.format(
+              "Difference is on dynamic field - continue initialization - left %s, right %s. Actual diff values: %s",
+              difference.getLeftIndexMapping().getIndexName(),
+              difference.getRightIndexMapping().getIndexName(),
+              difference.getEntriesDiffering()));
+      return;
     }
 
     LOGGER.debug(
@@ -182,13 +183,6 @@ public class IndexSchemaValidatorUtil {
                     + difference
                     + ". Difference 2: "
                     + currentDifference);
-          } else {
-            LOGGER.debug(
-                String.format(
-                    "Difference is on dynamic field - continue initialization, left: %s, right: %s. Actual diff values: %s",
-                    difference.getLeftIndexMapping().getIndexName(),
-                    difference.getRightIndexMapping().getIndexName(),
-                    difference.getEntriesDiffering()));
           }
         }
       }
@@ -200,8 +194,9 @@ public class IndexSchemaValidatorUtil {
     final Object typeDefinition = propertyDifference.getLeftValue().getTypeDefinition();
     if (propertyDifference.getLeftValue().getTypeDefinition() instanceof Map) {
       final Map<String, Object> typeDefMap = (Map<String, Object>) typeDefinition;
-      final Object dynamicValue = typeDefMap.getOrDefault("dynamic", false);
-      if (dynamicValue.equals("true")) {
+      final boolean isDynamic =
+          Boolean.parseBoolean(typeDefMap.getOrDefault("dynamic", "false").toString());
+      if (isDynamic) {
         return false;
       }
     }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/IndexSchemaValidatorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/IndexSchemaValidatorIT.java
@@ -71,7 +71,7 @@ public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
   public void setUp() throws Exception {
     indexDescriptor = createIndexDescriptor();
     originalSchemaContent = readSchemaContent();
-    assertThat(originalSchemaContent).doesNotContain("\"prop2\"");
+    assertThat(originalSchemaContent).doesNotContain("\"prop3\"");
   }
 
   @AfterEach
@@ -92,10 +92,10 @@ public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
 
     updateSchemaContent(
         originalSchemaContent.replace(
-            "\"properties\": {", "\"properties\": {\n    \"prop2\": { \"type\": \"keyword\" },"));
+            "\"properties\": {", "\"properties\": {\n    \"prop3\": { \"type\": \"keyword\" },"));
 
     final String newSchemaContent = readSchemaContent();
-    assertThat(newSchemaContent).contains("\"prop2\"");
+    assertThat(newSchemaContent).contains("\"prop3\"");
 
     diff = indexSchemaValidator.validateIndexMappings();
     assertThat(diff).isNotEmpty();
@@ -122,6 +122,21 @@ public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
 
     final String newSchemaContent = readSchemaContent();
     assertThat(newSchemaContent).doesNotContain("\"prop0\"");
+
+    diff = indexSchemaValidator.validateIndexMappings();
+    assertThat(diff).isEmpty();
+  }
+
+  @Test
+  public void shouldSkipDifferenceOnDynamicField() throws Exception {
+    replaceIndexDescriptorsInValidator(Collections.singleton(indexDescriptor));
+    schemaManager.createIndex(indexDescriptor);
+
+    var diff = indexSchemaValidator.validateIndexMappings();
+    assertThat(diff).isEmpty();
+
+    /* Create document on the dynamic property to cause it to expand */
+    createDocument("prop2", Map.of("custom-key", "custom-value"));
 
     diff = indexSchemaValidator.validateIndexMappings();
     assertThat(diff).isEmpty();
@@ -163,7 +178,7 @@ public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
         StandardOpenOption.TRUNCATE_EXISTING);
   }
 
-  private void createDocument(final String key, final String value) throws Exception {
+  private void createDocument(final String key, final Object value) throws Exception {
     final Map<String, Object> document = Map.of(key, value);
     final boolean created =
         retryElasticsearchClient.createOrUpdateDocument(

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/IndexSchemaValidatorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/IndexSchemaValidatorIT.java
@@ -8,8 +8,10 @@
 package io.camunda.tasklist.es;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.qa.util.TestUtil;
 import io.camunda.tasklist.schema.IndexSchemaValidator;
@@ -71,7 +73,7 @@ public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
   public void setUp() throws Exception {
     indexDescriptor = createIndexDescriptor();
     originalSchemaContent = readSchemaContent();
-    assertThat(originalSchemaContent).doesNotContain("\"prop3\"");
+    assertThat(originalSchemaContent).doesNotContain("\"prop4\"");
   }
 
   @AfterEach
@@ -88,14 +90,14 @@ public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
     var diff = indexSchemaValidator.validateIndexMappings();
     assertThat(diff).isEmpty();
 
-    createDocument("prop0", "test");
+    createDocument(indexDescriptor, "prop0", "test");
 
     updateSchemaContent(
         originalSchemaContent.replace(
-            "\"properties\": {", "\"properties\": {\n    \"prop3\": { \"type\": \"keyword\" },"));
+            "\"properties\":{", "\"properties\": {\"prop4\": {\"type\": \"keyword\" },"));
 
     final String newSchemaContent = readSchemaContent();
-    assertThat(newSchemaContent).contains("\"prop3\"");
+    assertThat(newSchemaContent).contains("\"prop4\"");
 
     diff = indexSchemaValidator.validateIndexMappings();
     assertThat(diff).isNotEmpty();
@@ -110,15 +112,9 @@ public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
     var diff = indexSchemaValidator.validateIndexMappings();
     assertThat(diff).isEmpty();
 
-    createDocument("prop0", "test");
+    createDocument(indexDescriptor, "prop0", "test");
 
-    updateSchemaContent(
-        originalSchemaContent.replace(
-            "    \"properties\": {\n"
-                + "      \"prop0\": {\n"
-                + "        \"type\": \"keyword\"\n"
-                + "      },",
-            "\"properties\": {"));
+    updateSchemaContent(originalSchemaContent.replace("{\"prop0\":{\"type\":\"keyword\"},", "{"));
 
     final String newSchemaContent = readSchemaContent();
     assertThat(newSchemaContent).doesNotContain("\"prop0\"");
@@ -136,10 +132,43 @@ public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
     assertThat(diff).isEmpty();
 
     /* Create document on the dynamic property to cause it to expand */
-    createDocument("prop2", Map.of("custom-key", "custom-value"));
+    createDocument(indexDescriptor, "prop2", Map.of("custom-key", "custom-value"));
 
     diff = indexSchemaValidator.validateIndexMappings();
     assertThat(diff).isEmpty();
+  }
+
+  @Test
+  public void shouldThrowExceptionOnAmbiguousMappings() throws Exception {
+    replaceIndexDescriptorsInValidator(Collections.singleton(indexDescriptor));
+
+    final var datedDescriptor1 = createDatedIndexDescriptor("-2021-01-01");
+    final var datedDescriptor2 = createDatedIndexDescriptor("-2021-01-02");
+    try {
+      schemaManager.createIndex(datedDescriptor1);
+      createDocument(datedDescriptor1, Map.of("prop0", "test"));
+
+      updateSchemaContent(
+          originalSchemaContent.replace(
+              "{\"prop0\":{\"type\":\"keyword\"},", "{\"prop0\":{\"type\":\"integer\"},"));
+      schemaManager.createIndex(datedDescriptor2);
+      createDocument(datedDescriptor2, Map.of("prop0", 123, "prop1", "test"));
+
+      updateSchemaContent(
+          originalSchemaContent.replace(
+              "\"prop1\":{\"type\":\"keyword\"}", "\"prop1\":{\"type\":\"boolean\"}"));
+      schemaManager.createIndex(indexDescriptor);
+      createDocument(indexDescriptor, Map.of("prop0", 123, "prop1", true));
+
+      restoreOriginalSchemaContent();
+
+      assertThatThrownBy(() -> indexSchemaValidator.validateIndexMappings())
+          .isInstanceOf(TasklistRuntimeException.class)
+          .hasMessageContaining("Ambiguous schema update");
+    } finally {
+      retryElasticsearchClient.deleteIndicesFor(datedDescriptor1.getFullQualifiedName());
+      retryElasticsearchClient.deleteIndicesFor(datedDescriptor2.getFullQualifiedName());
+    }
   }
 
   private IndexDescriptor createIndexDescriptor() {
@@ -161,14 +190,44 @@ public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
 
       @Override
       public String getAllVersionsIndexNameRegexPattern() {
-        return getFullIndexName() + "*";
+        return getFullIndexName() + ".*";
+      }
+    };
+  }
+
+  private IndexDescriptor createDatedIndexDescriptor(final String suffix) {
+    return new IndexDescriptor() {
+      @Override
+      public String getIndexName() {
+        return INDEX_NAME + suffix;
+      }
+
+      @Override
+      public String getFullQualifiedName() {
+        return getFullIndexName() + suffix;
+      }
+
+      @Override
+      public String getAlias() {
+        return getFullIndexName() + "-alias";
+      }
+
+      @Override
+      public String getSchemaClasspathFilename() {
+        return ORIGINAL_SCHEMA_PATH;
+      }
+
+      @Override
+      public String getAllVersionsIndexNameRegexPattern() {
+        return getFullIndexName() + ".*";
       }
     };
   }
 
   private String readSchemaContent() throws Exception {
     return new String(
-        Files.readAllBytes(Paths.get(getClass().getResource(ORIGINAL_SCHEMA_PATH).toURI())));
+            Files.readAllBytes(Paths.get(getClass().getResource(ORIGINAL_SCHEMA_PATH).toURI())))
+        .replaceAll("[\\n\\t\\s]+", "");
   }
 
   private void restoreOriginalSchemaContent() throws Exception {
@@ -178,11 +237,19 @@ public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
         StandardOpenOption.TRUNCATE_EXISTING);
   }
 
-  private void createDocument(final String key, final Object value) throws Exception {
+  private void createDocument(
+      final IndexDescriptor descriptor, final String key, final Object value) throws Exception {
     final Map<String, Object> document = Map.of(key, value);
     final boolean created =
         retryElasticsearchClient.createOrUpdateDocument(
-            indexDescriptor.getFullQualifiedName(), "id", document);
+            descriptor.getFullQualifiedName(), "id", document);
+  }
+
+  private void createDocument(final IndexDescriptor descriptor, final Map<String, Object> value)
+      throws Exception {
+    final boolean created =
+        retryElasticsearchClient.createOrUpdateDocument(
+            descriptor.getFullQualifiedName(), "id", value);
   }
 
   private void updateSchemaContent(final String content) throws Exception {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/IndexSchemaValidatorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/IndexSchemaValidatorIT.java
@@ -61,7 +61,7 @@ public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
   public void setUp() throws Exception {
     indexDescriptor = createIndexDescriptor();
     originalSchemaContent = readSchemaContent();
-    assertThat(originalSchemaContent).doesNotContain("\"prop2\"");
+    assertThat(originalSchemaContent).doesNotContain("\"prop3\"");
   }
 
   @AfterEach
@@ -82,10 +82,10 @@ public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
 
     updateSchemaContent(
         originalSchemaContent.replace(
-            "\"properties\": {", "\"properties\": {\n    \"prop2\": { \"type\": \"keyword\" },"));
+            "\"properties\": {", "\"properties\": {\n    \"prop3\": { \"type\": \"keyword\" },"));
 
     final String newSchemaContent = readSchemaContent();
-    assertThat(newSchemaContent).contains("\"prop2\"");
+    assertThat(newSchemaContent).contains("\"prop3\"");
 
     diff = indexSchemaValidator.validateIndexMappings();
     assertThat(diff).isNotEmpty();
@@ -112,6 +112,21 @@ public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
 
     final String newSchemaContent = readSchemaContent();
     assertThat(newSchemaContent).doesNotContain("\"prop0\"");
+
+    diff = indexSchemaValidator.validateIndexMappings();
+    assertThat(diff).isEmpty();
+  }
+
+  @Test
+  public void shouldSkipDifferenceOnDynamicField() throws Exception {
+    replaceIndexDescriptorsInValidator(Collections.singleton(indexDescriptor));
+    schemaManager.createIndex(indexDescriptor);
+
+    var diff = indexSchemaValidator.validateIndexMappings();
+    assertThat(diff).isEmpty();
+
+    /* Create document on the dynamic property to cause it to expand */
+    createDocument("prop2", Map.of("custom-key", "custom-value"));
 
     diff = indexSchemaValidator.validateIndexMappings();
     assertThat(diff).isEmpty();
@@ -154,7 +169,7 @@ public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
         StandardOpenOption.TRUNCATE_EXISTING);
   }
 
-  private void createDocument(final String key, final String value) throws Exception {
+  private void createDocument(final String key, final Object value) throws Exception {
     final Map<String, Object> document = Map.of(key, value);
     final boolean created =
         retryOpenSearchClient.createOrUpdateDocument(

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/IndexSchemaValidatorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/IndexSchemaValidatorIT.java
@@ -8,8 +8,10 @@
 package io.camunda.tasklist.os;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.qa.util.TestUtil;
 import io.camunda.tasklist.schema.IndexSchemaValidator;
@@ -61,7 +63,7 @@ public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
   public void setUp() throws Exception {
     indexDescriptor = createIndexDescriptor();
     originalSchemaContent = readSchemaContent();
-    assertThat(originalSchemaContent).doesNotContain("\"prop3\"");
+    assertThat(originalSchemaContent).doesNotContain("\"prop4\"");
   }
 
   @AfterEach
@@ -78,14 +80,14 @@ public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
     var diff = indexSchemaValidator.validateIndexMappings();
     assertThat(diff).isEmpty();
 
-    createDocument("prop0", "test");
+    createDocument(indexDescriptor, "prop0", "test");
 
     updateSchemaContent(
         originalSchemaContent.replace(
-            "\"properties\": {", "\"properties\": {\n    \"prop3\": { \"type\": \"keyword\" },"));
+            "\"properties\":{", "\"properties\": {\"prop4\": {\"type\": \"keyword\" },"));
 
     final String newSchemaContent = readSchemaContent();
-    assertThat(newSchemaContent).contains("\"prop3\"");
+    assertThat(newSchemaContent).contains("\"prop4\"");
 
     diff = indexSchemaValidator.validateIndexMappings();
     assertThat(diff).isNotEmpty();
@@ -100,15 +102,9 @@ public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
     var diff = indexSchemaValidator.validateIndexMappings();
     assertThat(diff).isEmpty();
 
-    createDocument("prop0", "test");
+    createDocument(indexDescriptor, "prop0", "test");
 
-    updateSchemaContent(
-        originalSchemaContent.replace(
-            "\"properties\": {\n"
-                + "    \"prop0\": {\n"
-                + "      \"type\": \"keyword\"\n"
-                + "    },",
-            "\"properties\": {"));
+    updateSchemaContent(originalSchemaContent.replace("{\"prop0\":{\"type\":\"keyword\"},", "{"));
 
     final String newSchemaContent = readSchemaContent();
     assertThat(newSchemaContent).doesNotContain("\"prop0\"");
@@ -126,10 +122,43 @@ public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
     assertThat(diff).isEmpty();
 
     /* Create document on the dynamic property to cause it to expand */
-    createDocument("prop2", Map.of("custom-key", "custom-value"));
+    createDocument(indexDescriptor, "prop2", Map.of("custom-key", "custom-value"));
 
     diff = indexSchemaValidator.validateIndexMappings();
     assertThat(diff).isEmpty();
+  }
+
+  @Test
+  public void shouldThrowExceptionOnAmbiguousMappings() throws Exception {
+    replaceIndexDescriptorsInValidator(Collections.singleton(indexDescriptor));
+
+    final var datedDescriptor1 = createDatedIndexDescriptor("-2021-01-01");
+    final var datedDescriptor2 = createDatedIndexDescriptor("-2021-01-02");
+    try {
+      schemaManager.createIndex(datedDescriptor1);
+      createDocument(datedDescriptor1, Map.of("prop0", "test"));
+
+      updateSchemaContent(
+          originalSchemaContent.replace(
+              "{\"prop0\":{\"type\":\"keyword\"},", "{\"prop0\":{\"type\":\"integer\"},"));
+      schemaManager.createIndex(datedDescriptor2);
+      createDocument(datedDescriptor2, Map.of("prop0", 123, "prop1", "test"));
+
+      updateSchemaContent(
+          originalSchemaContent.replace(
+              "\"prop1\":{\"type\":\"keyword\"}", "\"prop1\":{\"type\":\"boolean\"}"));
+      schemaManager.createIndex(indexDescriptor);
+      createDocument(indexDescriptor, Map.of("prop0", 123, "prop1", true));
+
+      restoreOriginalSchemaContent();
+
+      assertThatThrownBy(() -> indexSchemaValidator.validateIndexMappings())
+          .isInstanceOf(TasklistRuntimeException.class)
+          .hasMessageContaining("Ambiguous schema update");
+    } finally {
+      retryOpenSearchClient.deleteIndicesFor(datedDescriptor1.getFullQualifiedName());
+      retryOpenSearchClient.deleteIndicesFor(datedDescriptor2.getFullQualifiedName());
+    }
   }
 
   private IndexDescriptor createIndexDescriptor() {
@@ -151,15 +180,45 @@ public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
 
       @Override
       public String getAllVersionsIndexNameRegexPattern() {
-        return getFullIndexName() + "*";
+        return getFullIndexName() + ".*";
+      }
+    };
+  }
+
+  private IndexDescriptor createDatedIndexDescriptor(final String suffix) {
+    return new IndexDescriptor() {
+      @Override
+      public String getIndexName() {
+        return INDEX_NAME + suffix;
+      }
+
+      @Override
+      public String getFullQualifiedName() {
+        return getFullIndexName() + suffix;
+      }
+
+      @Override
+      public String getAlias() {
+        return getFullIndexName() + "-alias";
+      }
+
+      @Override
+      public String getSchemaClasspathFilename() {
+        return ORIGINAL_SCHEMA_PATH_OPENSEARCH;
+      }
+
+      @Override
+      public String getAllVersionsIndexNameRegexPattern() {
+        return getFullIndexName() + ".*";
       }
     };
   }
 
   private String readSchemaContent() throws Exception {
     return new String(
-        Files.readAllBytes(
-            Paths.get(getClass().getResource(ORIGINAL_SCHEMA_PATH_OPENSEARCH).toURI())));
+            Files.readAllBytes(
+                Paths.get(getClass().getResource(ORIGINAL_SCHEMA_PATH_OPENSEARCH).toURI())))
+        .replaceAll("[\\n\\t\\s]+", "");
   }
 
   private void restoreOriginalSchemaContent() throws Exception {
@@ -169,12 +228,19 @@ public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
         StandardOpenOption.TRUNCATE_EXISTING);
   }
 
-  private void createDocument(final String key, final Object value) throws Exception {
+  private void createDocument(
+      final IndexDescriptor descriptor, final String key, final Object value) throws Exception {
     final Map<String, Object> document = Map.of(key, value);
     final boolean created =
         retryOpenSearchClient.createOrUpdateDocument(
-            indexDescriptor.getFullQualifiedName(), "id", document);
-    System.out.println("Created: " + created);
+            descriptor.getFullQualifiedName(), "id", document);
+  }
+
+  private void createDocument(final IndexDescriptor descriptor, final Map<String, Object> value)
+      throws Exception {
+    final boolean created =
+        retryOpenSearchClient.createOrUpdateDocument(
+            descriptor.getFullQualifiedName(), "id", value);
   }
 
   private void updateSchemaContent(final String content) throws Exception {

--- a/tasklist/qa/integration-tests/src/test/resources/tasklist-test-elasticsearch-schema-validator.json
+++ b/tasklist/qa/integration-tests/src/test/resources/tasklist-test-elasticsearch-schema-validator.json
@@ -7,6 +7,10 @@
       },
       "prop1": {
         "type": "keyword"
+      },
+      "prop2": {
+        "dynamic": "true",
+        "type": "object"
       }
     }
   }

--- a/tasklist/qa/integration-tests/src/test/resources/tasklist-test-opensearch-schema-validator.json
+++ b/tasklist/qa/integration-tests/src/test/resources/tasklist-test-opensearch-schema-validator.json
@@ -6,6 +6,10 @@
     },
     "prop1": {
       "type": "keyword"
+    },
+    "prop2": {
+      "dynamic": "true",
+      "type": "object"
     }
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- Do not throw validation exception if difference is present on dynamic fields when comparing schemas
- Test case for ambiguous mappings between runtime and dated indices

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #27022
