### PR TITLE
refactor: align size of all string columns (ids, names) #24002

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -29,14 +29,14 @@
       <column name="PROCESS_DEFINITION_KEY" type="BIGINT">
         <constraints primaryKey="true"/>
       </column>
-      <column name="PROCESS_DEFINITION_ID" type="VARCHAR(200)" />
-      <column name="NAME" type="VARCHAR(200)" />
+      <column name="PROCESS_DEFINITION_ID" type="VARCHAR(400)" />
+      <column name="NAME" type="VARCHAR(400)" />
       <column name="RESOURCE_NAME" type="VARCHAR(4000)" />
       <column name="BPMN_XML" type="CLOB" />
-      <column name="TENANT_ID" type="VARCHAR(200)" />
+      <column name="TENANT_ID" type="VARCHAR(400)" />
       <column name="VERSION" type="SMALLINT" />
-      <column name="VERSION_TAG" type="VARCHAR(200)" />
-      <column name="FORM_ID" type="VARCHAR(200)" />
+      <column name="VERSION_TAG" type="VARCHAR(400)" />
+      <column name="FORM_ID" type="VARCHAR(400)" />
     </createTable>
 
     <createIndex tableName="${prefix}PROCESS_DEFINITION" indexName="${prefix}IDX_PROCESS_DEFINITION_ID">
@@ -54,11 +54,11 @@
       <column name="STATE" type="VARCHAR(20)" />
       <column name="START_DATE" type="TIMESTAMP WITH TIME ZONE(3)" />
       <column name="END_DATE" type="TIMESTAMP WITH TIME ZONE(3)" />
-      <column name="TENANT_ID" type="VARCHAR(200)" />
+      <column name="TENANT_ID" type="VARCHAR(400)" />
       <column name="PARENT_PROCESS_INSTANCE_KEY" type="BIGINT" />
       <column name="PARENT_ELEMENT_INSTANCE_KEY" type="BIGINT" />
       <column name="NUM_INCIDENTS" type="SMALLINT" />
-      <column name="ELEMENT_ID" type="VARCHAR(255)" />
+      <column name="ELEMENT_ID" type="VARCHAR(400)" />
       <column name="VERSION" type="SMALLINT" />
     </createTable>
 
@@ -74,7 +74,7 @@
         <constraints primaryKey="true"/>
       </column>
       <column name="PROCESS_INSTANCE_KEY" type="BIGINT" />
-      <column name="PROCESS_DEFINITION_ID" type="VARCHAR(255)" />
+      <column name="PROCESS_DEFINITION_ID" type="VARCHAR(400)" />
       <column name="SCOPE_KEY" type="BIGINT" />
       <column name="TYPE" type="VARCHAR(255)"/>
       <column name="VAR_NAME" type="VARCHAR(255)" />
@@ -82,7 +82,7 @@
       <column name="LONG_VALUE" type="BIGINT"/>
       <column name="VAR_VALUE" type="VARCHAR(8192)"/>
       <column name="VAR_FULL_VALUE" type="CLOB"/>
-      <column name="TENANT_ID" type="VARCHAR(255)" />
+      <column name="TENANT_ID" type="VARCHAR(400)" />
       <column name="IS_PREVIEW" type="BOOLEAN"/>
     </createTable>
 
@@ -107,14 +107,14 @@
       </column>
       <column name="FLOW_NODE_ID" type="VARCHAR(400)" />
       <column name="PROCESS_INSTANCE_KEY" type="BIGINT" />
-      <column name="PROCESS_DEFINITION_ID" type="VARCHAR(200)" />
+      <column name="PROCESS_DEFINITION_ID" type="VARCHAR(400)" />
       <column name="PROCESS_DEFINITION_KEY" type="BIGINT" />
       <column name="TYPE" type="VARCHAR(100)" />
       <column name="STATE" type="VARCHAR(20)" />
       <column name="START_DATE" type="TIMESTAMP WITH TIME ZONE(3)" />
       <column name="END_DATE" type="TIMESTAMP WITH TIME ZONE(3)" />
       <column name="TREE_PATH" type="VARCHAR(4000)" />
-      <column name="TENANT_ID" type="VARCHAR(200)" />
+      <column name="TENANT_ID" type="VARCHAR(400)" />
       <column name="INCIDENT_KEY" type="BIGINT" />
       <column name="NUM_SUBPROCESS_INCIDENTS" type="SMALLINT" />
     </createTable>
@@ -130,20 +130,20 @@
       <column name="USER_TASK_KEY" type="BIGINT">
         <constraints primaryKey="true"/>
       </column>
-      <column name="ELEMENT_ID" type="VARCHAR(200)"/>
-      <column name="PROCESS_DEFINITION_ID" type="VARCHAR(200)"/>
+      <column name="ELEMENT_ID" type="VARCHAR(400)"/>
+      <column name="PROCESS_DEFINITION_ID" type="VARCHAR(400)"/>
       <column name="CREATION_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
       <column name="COMPLETION_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
-      <column name="ASSIGNEE" type="VARCHAR(255)"/>
+      <column name="ASSIGNEE" type="VARCHAR(400)"/>
       <column name="STATE" type="VARCHAR(20)"/>
       <column name="FORM_KEY" type="BIGINT"/>
       <column name="PROCESS_DEFINITION_KEY" type="BIGINT"/>
       <column name="PROCESS_INSTANCE_KEY" type="BIGINT"/>
       <column name="ELEMENT_INSTANCE_KEY" type="BIGINT"/>
-      <column name="TENANT_ID" type="VARCHAR(200)"/>
+      <column name="TENANT_ID" type="VARCHAR(400)"/>
       <column name="DUE_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
       <column name="FOLLOW_UP_DATE" type="TIMESTAMP WITH TIME ZONE(3)"/>
-      <column name="EXTERNAL_FORM_REFERENCE" type="VARCHAR(200)"/>
+      <column name="EXTERNAL_FORM_REFERENCE" type="VARCHAR(400)"/>
       <column name="PROCESS_DEFINITION_VERSION" type="SMALLINT"/>
       <column name="CUSTOM_HEADERS" type="CLOB"/>
       <column name="PRIORITY" type="INT"/>
@@ -153,14 +153,14 @@
       <column name="USER_TASK_KEY" type="BIGINT">
         <constraints foreignKeyName="FK_CANDIDATE_USER_USER_TASK"/>
       </column>
-      <column name="CANDIDATE_USER" type="VARCHAR(200)"/>
+      <column name="CANDIDATE_USER" type="VARCHAR(400)"/>
     </createTable>
 
     <createTable tableName="${prefix}CANDIDATE_GROUP">
       <column name="USER_TASK_KEY" type="BIGINT">
         <constraints foreignKeyName="FK_CANDIDATE_GROUP_USER_TASK"/>
       </column>
-      <column name="CANDIDATE_GROUP" type="VARCHAR(200)"/>
+      <column name="CANDIDATE_GROUP" type="VARCHAR(400)"/>
     </createTable>
 
     <createIndex tableName="${prefix}CANDIDATE_USER" indexName="${prefix}IDX_CANDIDATE_USER_USER_TASK_KEY">
@@ -184,7 +184,7 @@
       <column name="FLOW_NODE_INSTANCE_KEY" type="BIGINT" />
       <column name="FLOW_NODE_ID" type="VARCHAR(400)" />
       <column name="PROCESS_INSTANCE_KEY" type="BIGINT" />
-      <column name="PROCESS_DEFINITION_ID" type="VARCHAR(200)" />
+      <column name="PROCESS_DEFINITION_ID" type="VARCHAR(400)" />
       <column name="PROCESS_DEFINITION_KEY" type="BIGINT" />
       <column name="ERROR_MESSAGE" type="VARCHAR(4000)" />
       <column name="ERROR_TYPE" type="VARCHAR(100)" />
@@ -192,7 +192,7 @@
       <column name="CREATION_DATE" type="TIMESTAMP WITH TIME ZONE(3)" />
       <column name="END_DATE" type="TIMESTAMP WITH TIME ZONE(3)" />
       <column name="TREE_PATH" type="VARCHAR(4000)" />
-      <column name="TENANT_ID" type="VARCHAR(200)" />
+      <column name="TENANT_ID" type="VARCHAR(400)" />
       <column name="JOB_KEY" type="BIGINT" />
       <column name="SCOPE_KEY" type="BIGINT" />
     </createTable>
@@ -208,12 +208,12 @@
       <column name="DECISION_DEFINITION_KEY" type="BIGINT">
         <constraints primaryKey="true"/>
       </column>
-      <column name="DECISION_DEFINITION_ID" type="VARCHAR(200)" />
-      <column name="NAME" type="VARCHAR(200)" />
-      <column name="TENANT_ID" type="VARCHAR(255)" />
+      <column name="DECISION_DEFINITION_ID" type="VARCHAR(400)" />
+      <column name="NAME" type="VARCHAR(400)" />
+      <column name="TENANT_ID" type="VARCHAR(400)" />
       <column name="VERSION" type="SMALLINT" />
       <column name="DECISION_REQUIREMENTS_KEY" type="BIGINT" />
-      <column name="DECISION_REQUIREMENTS_ID" type="VARCHAR(255)" />
+      <column name="DECISION_REQUIREMENTS_ID" type="VARCHAR(400)" />
     </createTable>
 
     <createIndex tableName="${prefix}DECISION_DEFINITION" indexName="${prefix}IDX_DECISION_DEFINITION_ID">
@@ -226,9 +226,9 @@
       <column name="DECISION_REQUIREMENTS_KEY" type="BIGINT">
         <constraints primaryKey="true"/>
       </column>
-      <column name="DECISION_REQUIREMENTS_ID" type="VARCHAR(200)" />
-      <column name="NAME" type="VARCHAR(200)" />
-      <column name="TENANT_ID" type="VARCHAR(255)" />
+      <column name="DECISION_REQUIREMENTS_ID" type="VARCHAR(400)" />
+      <column name="NAME" type="VARCHAR(400)" />
+      <column name="TENANT_ID" type="VARCHAR(400)" />
       <column name="VERSION" type="SMALLINT" />
       <column name="RESOURCE_NAME" type="VARCHAR(4000)" />
       <column name="XML" type="CLOB" />
@@ -241,26 +241,26 @@
 
   <changeSet id="create_decision_instance_table" author="cthiel">
     <createTable tableName="${prefix}DECISION_INSTANCE">
-      <column name="DECISION_INSTANCE_ID" type="VARCHAR(255)" >
+      <column name="DECISION_INSTANCE_ID" type="VARCHAR(400)" >
         <constraints primaryKey="true"/>
       </column>
       <column name="DECISION_INSTANCE_KEY" type="BIGINT" />
       <column name="PROCESS_INSTANCE_KEY" type="BIGINT" />
-      <column name="PROCESS_DEFINITION_ID" type="VARCHAR(255)" />
+      <column name="PROCESS_DEFINITION_ID" type="VARCHAR(400)" />
       <column name="PROCESS_DEFINITION_KEY" type="BIGINT" />
-      <column name="DECISION_DEFINITION_ID" type="VARCHAR(255)" />
+      <column name="DECISION_DEFINITION_ID" type="VARCHAR(400)" />
       <column name="DECISION_DEFINITION_KEY" type="BIGINT" />
-      <column name="DECISION_REQUIREMENTS_ID" type="VARCHAR(255)" />
+      <column name="DECISION_REQUIREMENTS_ID" type="VARCHAR(400)" />
       <column name="DECISION_REQUIREMENTS_KEY" type="BIGINT" />
-      <column name="FLOW_NODE_ID" type="VARCHAR(255)" />
+      <column name="FLOW_NODE_ID" type="VARCHAR(400)" />
       <column name="FLOW_NODE_INSTANCE_KEY" type="BIGINT" />
       <column name="ROOT_DECISION_DEFINITION_KEY" type="BIGINT" />
       <column name="EVALUATION_DATE" type="TIMESTAMP WITH TIME ZONE(3)" />
       <column name="TYPE" type="VARCHAR(255)" />
       <column name="STATE" type="VARCHAR(255)" />
       <column name="RESULT" type="VARCHAR(255)" />
-      <column name="EVALUATION_FAILURE" type="VARCHAR(255)" />
-      <column name="TENANT_ID" type="VARCHAR(255)" />
+      <column name="EVALUATION_FAILURE" type="VARCHAR(400)" />
+      <column name="TENANT_ID" type="VARCHAR(400)" />
     </createTable>
 
     <modifySql dbms="mariadb">
@@ -271,13 +271,13 @@
 
   <changeSet id="create_decision_instance_input_table" author="cthiel">
     <createTable tableName="${prefix}DECISION_INSTANCE_INPUT">
-      <column name="DECISION_INSTANCE_ID" type="VARCHAR(255)">
+      <column name="DECISION_INSTANCE_ID" type="VARCHAR(400)">
         <constraints primaryKey="true"/>
       </column>
-      <column name="INPUT_ID" type="VARCHAR(255)">
+      <column name="INPUT_ID" type="VARCHAR(400)">
         <constraints primaryKey="true"/>
       </column>
-      <column name="INPUT_NAME" type="VARCHAR(255)" />
+      <column name="INPUT_NAME" type="VARCHAR(400)" />
       <column name="INPUT_VALUE" type="VARCHAR(4000)" />
     </createTable>
     <!-- No additional index for DECISION_INSTANCE_KEY needed -->
@@ -288,12 +288,12 @@
       <column name="DECISION_INSTANCE_ID" type="VARCHAR(255)">
         <constraints primaryKey="true"/>
       </column>
-      <column name="OUTPUT_ID" type="VARCHAR(255)">
+      <column name="OUTPUT_ID" type="VARCHAR(400)">
         <constraints primaryKey="true"/>
       </column>
-      <column name="OUTPUT_NAME" type="VARCHAR(255)" />
+      <column name="OUTPUT_NAME" type="VARCHAR(400)" />
       <column name="OUTPUT_VALUE" type="VARCHAR(4000)" />
-      <column name="RULE_ID" type="VARCHAR(255)" />
+      <column name="RULE_ID" type="VARCHAR(400)" />
       <column name="RULE_INDEX" type="SMALLINT" />
     </createTable>
     <!-- No additional index for DECISION_INSTANCE_KEY needed -->
@@ -301,13 +301,13 @@
 
   <changeSet id="create_user_table" author="cthiel">
     <createTable tableName="${prefix}USERS">
-      <column name="USERNAME" type="VARCHAR(255)">
+      <column name="USERNAME" type="VARCHAR(400)">
         <constraints primaryKey="true"/>
       </column>
       <column name="USER_KEY" type="BIGINT"/>
-      <column name="NAME" type="VARCHAR(255)" />
-      <column name="EMAIL" type="VARCHAR(255)" />
-      <column name="PASSWORD" type="VARCHAR(255)" />
+      <column name="NAME" type="VARCHAR(400)" />
+      <column name="EMAIL" type="VARCHAR(400)" />
+      <column name="PASSWORD" type="VARCHAR(400)" />
     </createTable>
   </changeSet>
 
@@ -316,8 +316,8 @@
       <column name="FORM_KEY" type="BIGINT">
         <constraints primaryKey="true"/>
       </column>
-      <column name="FORM_ID" type="VARCHAR(200)"/>
-      <column name="TENANT_ID" type="VARCHAR(200)"/>
+      <column name="FORM_ID" type="VARCHAR(400)"/>
+      <column name="TENANT_ID" type="VARCHAR(400)"/>
       <column name="SCHEMA" type="CLOB"/>
       <column name="VERSION" type="BIGINT"/>
       <column name="IS_DELETED" type="BOOLEAN"/>
@@ -336,8 +336,8 @@
       <column name="MAPPING_KEY" type="BIGINT">
         <constraints primaryKey="true"/>
       </column>
-      <column name="CLAIM_NAME" type="VARCHAR(255)"/>
-      <column name="CLAIM_VALUE" type="VARCHAR(255)"/>
+      <column name="CLAIM_NAME" type="VARCHAR(400)"/>
+      <column name="CLAIM_VALUE" type="VARCHAR(400)"/>
       <column name="NAME" type="VARCHAR(255)"/>
     </createTable>
   </changeSet>
@@ -348,17 +348,17 @@
         <constraints primaryKey="true"/>
       </column>
       <column name="TENANT_KEY" type="BIGINT"/>
-      <column name="NAME" type="VARCHAR(255)" />
-      <column name="DESCRIPTION" type="VARCHAR(255)" />
+      <column name="NAME" type="VARCHAR(400)" />
+      <column name="DESCRIPTION" type="VARCHAR(400)" />
     </createTable>
   </changeSet>
 
   <changeSet id="tenant_members_table" author="cthiel">
     <createTable tableName="${prefix}TENANT_MEMBER">
-      <column name="TENANT_ID" type="VARCHAR(255)">
+      <column name="TENANT_ID" type="VARCHAR(400)">
         <constraints primaryKey="true"/>
       </column>
-      <column name="ENTITY_ID" type="VARCHAR(255)" >
+      <column name="ENTITY_ID" type="VARCHAR(400)" >
         <constraints primaryKey="true"/>
       </column>
       <column name="ENTITY_TYPE" type="VARCHAR(255)" />
@@ -371,7 +371,7 @@
       <column name="ROLE_KEY" type="BIGINT" >
         <constraints primaryKey="true"/>
       </column>
-      <column name="NAME" type="VARCHAR(255)" />
+      <column name="NAME" type="VARCHAR(400)" />
     </createTable>
   </changeSet>
 
@@ -415,7 +415,7 @@
       <column name="OWNER_TYPE" type="VARCHAR(255)" />
       <column name="RESOURCE_TYPE" type="VARCHAR(255)" />
       <column name="PERMISSION_TYPE" type="VARCHAR(255)" />
-      <column name="RESOURCE_ID" type="VARCHAR(255)" />
+      <column name="RESOURCE_ID" type="VARCHAR(400)" />
     </createTable>
 
     <createIndex tableName="${prefix}AUTHORIZATIONS" indexName="${prefix}IDX_AUTHORIZATIONS">


### PR DESCRIPTION
## Description

Aligns all columns like *_id, *_name to 400 characters. Also updated limitations in camunda-docs ([rdbms branch](https://github.com/camunda/camunda-docs/pull/4877))

relates to #24002
