### PR TITLE
Refactor/24002 move rdbms fixtures

### DIFF
--- a/db/rdbms/pom.xml
+++ b/db/rdbms/pom.xml
@@ -61,6 +61,12 @@
 
     <!-- test -->
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-client-java</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
@@ -89,5 +95,26 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+            <configuration>
+              <includes>
+                <include>**/fixtures/*</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/AuthorizationFixtures.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/AuthorizationFixtures.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.it.rdbms.db.fixtures;
+package io.camunda.db.rdbms.fixtures;
 
 import io.camunda.client.protocol.rest.OwnerTypeEnum;
 import io.camunda.client.protocol.rest.ResourceTypeEnum;

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/CommonFixtures.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/CommonFixtures.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.it.rdbms.db.fixtures;
+package io.camunda.db.rdbms.fixtures;
 
 import java.time.OffsetDateTime;
 import java.util.Random;

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/DecisionDefinitionFixtures.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/DecisionDefinitionFixtures.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.it.rdbms.db.fixtures;
+package io.camunda.db.rdbms.fixtures;
 
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.DecisionDefinitionDbModel;

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/DecisionInstanceFixtures.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/DecisionInstanceFixtures.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.it.rdbms.db.fixtures;
+package io.camunda.db.rdbms.fixtures;
 
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel;

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/DecisionRequirementsFixtures.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/DecisionRequirementsFixtures.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.it.rdbms.db.fixtures;
+package io.camunda.db.rdbms.fixtures;
 
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.DecisionRequirementsDbModel;

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/FlowNodeInstanceFixtures.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/FlowNodeInstanceFixtures.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.it.rdbms.db.fixtures;
+package io.camunda.db.rdbms.fixtures;
 
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel;

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/FormFixtures.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/FormFixtures.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.it.rdbms.db.fixtures;
+package io.camunda.db.rdbms.fixtures;
 
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.write.RdbmsWriter;

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/GroupFixtures.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/GroupFixtures.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.it.rdbms.db.fixtures;
+package io.camunda.db.rdbms.fixtures;
 
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.GroupDbModel;

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/IncidentFixtures.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/IncidentFixtures.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.it.rdbms.db.fixtures;
+package io.camunda.db.rdbms.fixtures;
 
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.IncidentDbModel;

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/MappingFixtures.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/MappingFixtures.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.it.rdbms.db.fixtures;
+package io.camunda.db.rdbms.fixtures;
 
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.write.RdbmsWriter;

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/ProcessDefinitionFixtures.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/ProcessDefinitionFixtures.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.it.rdbms.db.fixtures;
+package io.camunda.db.rdbms.fixtures;
 
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.ProcessDefinitionDbModel;

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/ProcessInstanceFixtures.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/ProcessInstanceFixtures.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.it.rdbms.db.fixtures;
+package io.camunda.db.rdbms.fixtures;
 
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel;

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/RoleFixtures.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/RoleFixtures.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.it.rdbms.db.fixtures;
+package io.camunda.db.rdbms.fixtures;
 
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.RoleDbModel;

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/TenantFixtures.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/TenantFixtures.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.it.rdbms.db.fixtures;
+package io.camunda.db.rdbms.fixtures;
 
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.TenantDbModel;

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/UserFixtures.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/UserFixtures.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.it.rdbms.db.fixtures;
+package io.camunda.db.rdbms.fixtures;
 
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.UserDbModel;

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/UserTaskFixtures.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/UserTaskFixtures.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.it.rdbms.db.fixtures;
+package io.camunda.db.rdbms.fixtures;
 
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.write.RdbmsWriter;

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/VariableFixtures.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/fixtures/VariableFixtures.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.it.rdbms.db.fixtures;
+package io.camunda.db.rdbms.fixtures;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -13,7 +13,6 @@ import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.VariableDbModel;
 import io.camunda.db.rdbms.write.domain.VariableDbModel.VariableDbModelBuilder;
-import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
@@ -100,22 +99,17 @@ public final class VariableFixtures extends CommonFixtures {
     rdbmsWriter.flush();
   }
 
-  public static void prepareRandomVariables(final CamundaRdbmsTestApplication testApplication) {
-    VariableFixtures.createAndSaveRandomVariables(testApplication.getRdbmsService(), b -> b);
+  public static void prepareRandomVariables(final RdbmsService rdbmsService) {
+    VariableFixtures.createAndSaveRandomVariables(rdbmsService, b -> b);
   }
 
   public static VariableDbModel prepareRandomVariablesAndReturnOne(
-      final CamundaRdbmsTestApplication testApplication) {
-    return VariableFixtures.createAndSaveRandomVariables(testApplication.getRdbmsService(), b -> b)
-        .getLast();
+      final RdbmsService rdbmsService) {
+    return VariableFixtures.createAndSaveRandomVariables(rdbmsService, b -> b).getLast();
   }
 
   public static VariableDbModel prepareRandomVariablesAndReturnOne(
-      final CamundaRdbmsTestApplication testApplication,
-      final String variableName,
-      final String valueForOne) {
-    final RdbmsService rdbmsService = testApplication.getRdbmsService();
-
+      final RdbmsService rdbmsService, final String variableName, final String valueForOne) {
     // 20 variables
     createAndSaveRandomVariables(rdbmsService, variableName);
 

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/UserTaskEntityMapperTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/mapper/UserTaskEntityMapperTest.java
@@ -10,12 +10,10 @@ package io.camunda.db.rdbms.read.mapper;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import io.camunda.db.rdbms.fixtures.UserTaskFixtures;
 import io.camunda.db.rdbms.write.domain.UserTaskDbModel;
-import io.camunda.db.rdbms.write.domain.UserTaskDbModel.Builder;
 import io.camunda.search.entities.UserTaskEntity;
-import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.List;
 import java.util.Map;
 import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.Test;
@@ -25,29 +23,7 @@ public class UserTaskEntityMapperTest {
   @Test
   public void testToEntity() {
     // Given
-    final UserTaskDbModel dbModel =
-        new Builder()
-            .userTaskKey(1L)
-            .elementId("flowNodeBpmnId")
-            .processDefinitionId("processDefinitionId")
-            .creationDate(OffsetDateTime.now())
-            .completionDate(OffsetDateTime.now().plusDays(1))
-            .assignee("assignee")
-            .state(UserTaskDbModel.UserTaskState.CREATED)
-            .formKey(1L)
-            .processDefinitionKey(1L)
-            .processInstanceKey(1L)
-            .elementInstanceKey(1L)
-            .tenantId("tenantId")
-            .dueDate(OffsetDateTime.now().plusDays(3))
-            .followUpDate(OffsetDateTime.now().plusDays(2))
-            .candidateGroups(List.of("group1", "group2"))
-            .candidateUsers(List.of("user1", "user2"))
-            .externalFormReference("externalFormReference")
-            .processDefinitionVersion(1)
-            .customHeaders(Map.of("key", "value"))
-            .priority(1)
-            .build();
+    final UserTaskDbModel dbModel = UserTaskFixtures.createRandomized(b -> b);
 
     // When
     final UserTaskEntity entity = UserTaskEntityMapper.toEntity(dbModel);
@@ -74,28 +50,8 @@ public class UserTaskEntityMapperTest {
   public void testToEntityWithNullDates() {
     // Given
     final UserTaskDbModel dbModel =
-        new Builder()
-            .userTaskKey(1L)
-            .elementId("flowNodeBpmnId")
-            .processDefinitionId("processDefinitionId")
-            .creationDate(OffsetDateTime.now())
-            .completionDate(null)
-            .assignee("assignee")
-            .state(UserTaskDbModel.UserTaskState.CREATED)
-            .formKey(1L)
-            .processDefinitionKey(1L)
-            .processInstanceKey(1L)
-            .elementInstanceKey(1L)
-            .tenantId("tenantId")
-            .dueDate(null)
-            .followUpDate(null)
-            .candidateGroups(List.of("group1", "group2"))
-            .candidateUsers(List.of("user1", "user2"))
-            .externalFormReference("externalFormReference")
-            .processDefinitionVersion(1)
-            .customHeaders(Map.of("key", "value"))
-            .priority(1)
-            .build();
+        UserTaskFixtures.createRandomized(
+            b -> b.completionDate(null).dueDate(null).followUpDate(null));
 
     // When
     final UserTaskEntity entity = UserTaskEntityMapper.toEntity(dbModel);

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/UpsertMergerTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/UpsertMergerTest.java
@@ -10,12 +10,11 @@ package io.camunda.db.rdbms.write.queue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import io.camunda.db.rdbms.fixtures.ProcessInstanceFixtures;
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel;
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel.ProcessInstanceDbModelBuilder;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import java.time.OffsetDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.Random;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -36,7 +35,7 @@ class UpsertMergerTest {
             ContextType.PROCESS_INSTANCE, 1L, ProcessInstanceDbModel.class, mergerFunction);
 
     final var insertParameter =
-        createRandomized(
+        ProcessInstanceFixtures.createRandomized(
             b ->
                 b.processInstanceKey(1L)
                     .endDate(NOW.minusDays(1))
@@ -79,26 +78,5 @@ class UpsertMergerTest {
         Arguments.of(new QueueItem(ContextType.PROCESS_INSTANCE, 1L, "statement1", null), false),
         Arguments.of(new QueueItem(ContextType.PROCESS_INSTANCE, 2L, "statement1", null), false),
         Arguments.of(new QueueItem(ContextType.FLOW_NODE, 1L, "statement1", null), false));
-  }
-
-  public static ProcessInstanceDbModel createRandomized(
-      final Function<ProcessInstanceDbModelBuilder, ProcessInstanceDbModelBuilder>
-          builderFunction) {
-    final var random = new Random();
-    final var builder =
-        new ProcessInstanceDbModelBuilder()
-            .processInstanceKey(random.nextLong())
-            .processInstanceKey(random.nextLong())
-            .processDefinitionKey(random.nextLong())
-            .processDefinitionId("process-" + random.nextInt(10000))
-            .startDate(NOW.plus(random.nextInt(), ChronoUnit.MILLIS))
-            .endDate(NOW.plus(random.nextInt(), ChronoUnit.MILLIS))
-            .state(ProcessInstanceState.COMPLETED)
-            .parentProcessInstanceKey(random.nextLong())
-            .parentElementInstanceKey(random.nextLong())
-            .tenantId("tenant-" + random.nextInt(10000))
-            .version(random.nextInt());
-
-    return builderFunction.apply(builder).build();
   }
 }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -825,6 +825,13 @@
 
       <dependency>
         <groupId>io.camunda</groupId>
+        <artifactId>camunda-db-rdbms</artifactId>
+        <version>${project.version}</version>
+        <type>test-jar</type>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
         <artifactId>camunda-db-rdbms-schema</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -251,6 +251,12 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-db-rdbms</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol-test-util</artifactId>
       <scope>test</scope>
     </dependency>

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/PurgerIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/PurgerIT.java
@@ -8,9 +8,9 @@
 package io.camunda.it.rdbms.db;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.ProcessDefinitionFixtures;
+import io.camunda.db.rdbms.fixtures.ProcessInstanceFixtures;
 import io.camunda.db.rdbms.write.RdbmsWriter;
-import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
-import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.query.ProcessDefinitionQuery;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationIT.java
@@ -7,16 +7,16 @@
  */
 package io.camunda.it.rdbms.db.authorization;
 
-import static io.camunda.it.rdbms.db.fixtures.AuthorizationFixtures.createAndSaveAuthorization;
-import static io.camunda.it.rdbms.db.fixtures.AuthorizationFixtures.createAndSaveRandomAuthorizations;
+import static io.camunda.db.rdbms.fixtures.AuthorizationFixtures.createAndSaveAuthorization;
+import static io.camunda.db.rdbms.fixtures.AuthorizationFixtures.createAndSaveRandomAuthorizations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.AuthorizationFixtures;
 import io.camunda.db.rdbms.read.service.AuthorizationReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.AuthorizationDbModel;
 import io.camunda.db.rdbms.write.domain.AuthorizationPermissionDbModel;
-import io.camunda.it.rdbms.db.fixtures.AuthorizationFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.AuthorizationEntity;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationSortIT.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.it.rdbms.db.authorization;
 
-import static io.camunda.it.rdbms.db.fixtures.AuthorizationFixtures.createAndSaveRandomAuthorizations;
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
+import static io.camunda.db.rdbms.fixtures.AuthorizationFixtures.createAndSaveRandomAuthorizations;
+import static io.camunda.db.rdbms.fixtures.CommonFixtures.nextKey;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationSpecificFilterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/authorization/AuthorizationSpecificFilterIT.java
@@ -7,15 +7,15 @@
  */
 package io.camunda.it.rdbms.db.authorization;
 
-import static io.camunda.it.rdbms.db.fixtures.AuthorizationFixtures.createAndSaveAuthorization;
-import static io.camunda.it.rdbms.db.fixtures.AuthorizationFixtures.createAndSaveRandomAuthorizations;
+import static io.camunda.db.rdbms.fixtures.AuthorizationFixtures.createAndSaveAuthorization;
+import static io.camunda.db.rdbms.fixtures.AuthorizationFixtures.createAndSaveRandomAuthorizations;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.AuthorizationFixtures;
 import io.camunda.db.rdbms.read.service.AuthorizationReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
-import io.camunda.it.rdbms.db.fixtures.AuthorizationFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
 import io.camunda.search.filter.AuthorizationFilter;
 import io.camunda.search.page.SearchQueryPage;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionIT.java
@@ -7,14 +7,14 @@
  */
 package io.camunda.it.rdbms.db.decisiondefinition;
 
-import static io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures.createAndSaveDecisionDefinition;
-import static io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures.createAndSaveRandomDecisionDefinitions;
+import static io.camunda.db.rdbms.fixtures.DecisionDefinitionFixtures.createAndSaveDecisionDefinition;
+import static io.camunda.db.rdbms.fixtures.DecisionDefinitionFixtures.createAndSaveRandomDecisionDefinitions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.DecisionDefinitionFixtures;
 import io.camunda.db.rdbms.read.service.DecisionDefinitionReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
-import io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.filter.DecisionDefinitionFilter;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionSortIT.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.it.rdbms.db.decisiondefinition;
 
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
-import static io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures.createAndSaveRandomDecisionDefinitions;
+import static io.camunda.db.rdbms.fixtures.CommonFixtures.nextKey;
+import static io.camunda.db.rdbms.fixtures.DecisionDefinitionFixtures.createAndSaveRandomDecisionDefinitions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionSpecificFilterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionSpecificFilterIT.java
@@ -7,15 +7,15 @@
  */
 package io.camunda.it.rdbms.db.decisiondefinition;
 
-import static io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures.createAndSaveDecisionDefinition;
-import static io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures.createAndSaveRandomDecisionDefinitions;
+import static io.camunda.db.rdbms.fixtures.DecisionDefinitionFixtures.createAndSaveDecisionDefinition;
+import static io.camunda.db.rdbms.fixtures.DecisionDefinitionFixtures.createAndSaveRandomDecisionDefinitions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.DecisionDefinitionFixtures;
 import io.camunda.db.rdbms.read.service.DecisionDefinitionReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
-import io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
 import io.camunda.search.filter.DecisionDefinitionFilter;
 import io.camunda.search.page.SearchQueryPage;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceIT.java
@@ -7,16 +7,16 @@
  */
 package io.camunda.it.rdbms.db.decisioninstance;
 
-import static io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures.createAndSaveDecisionInstance;
-import static io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures.createAndSaveRandomDecisionInstance;
-import static io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures.createAndSaveRandomDecisionInstances;
+import static io.camunda.db.rdbms.fixtures.DecisionInstanceFixtures.createAndSaveDecisionInstance;
+import static io.camunda.db.rdbms.fixtures.DecisionInstanceFixtures.createAndSaveRandomDecisionInstance;
+import static io.camunda.db.rdbms.fixtures.DecisionInstanceFixtures.createAndSaveRandomDecisionInstances;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.DecisionDefinitionFixtures;
+import io.camunda.db.rdbms.fixtures.DecisionInstanceFixtures;
 import io.camunda.db.rdbms.read.service.DecisionInstanceReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
-import io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures;
-import io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.filter.Operation;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSortIT.java
@@ -7,14 +7,14 @@
  */
 package io.camunda.it.rdbms.db.decisioninstance;
 
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
-import static io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures.createAndSaveRandomDecisionInstances;
+import static io.camunda.db.rdbms.fixtures.CommonFixtures.nextKey;
+import static io.camunda.db.rdbms.fixtures.DecisionInstanceFixtures.createAndSaveRandomDecisionInstances;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.DecisionDefinitionFixtures;
 import io.camunda.db.rdbms.read.service.DecisionInstanceReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
-import io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.DecisionInstanceEntity;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSpecificFilterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSpecificFilterIT.java
@@ -7,17 +7,17 @@
  */
 package io.camunda.it.rdbms.db.decisioninstance;
 
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
-import static io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures.createAndSaveDecisionInstance;
-import static io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures.createAndSaveRandomDecisionInstances;
+import static io.camunda.db.rdbms.fixtures.CommonFixtures.nextKey;
+import static io.camunda.db.rdbms.fixtures.DecisionInstanceFixtures.createAndSaveDecisionInstance;
+import static io.camunda.db.rdbms.fixtures.DecisionInstanceFixtures.createAndSaveRandomDecisionInstances;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.DecisionDefinitionFixtures;
+import io.camunda.db.rdbms.fixtures.DecisionInstanceFixtures;
 import io.camunda.db.rdbms.read.service.DecisionInstanceReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
-import io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures;
-import io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceState;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsIT.java
@@ -7,14 +7,14 @@
  */
 package io.camunda.it.rdbms.db.decisionrequirements;
 
-import static io.camunda.it.rdbms.db.fixtures.DecisionRequirementsFixtures.createAndSaveDecisionRequirement;
-import static io.camunda.it.rdbms.db.fixtures.DecisionRequirementsFixtures.createAndSaveRandomDecisionRequirements;
+import static io.camunda.db.rdbms.fixtures.DecisionRequirementsFixtures.createAndSaveDecisionRequirement;
+import static io.camunda.db.rdbms.fixtures.DecisionRequirementsFixtures.createAndSaveRandomDecisionRequirements;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.DecisionRequirementsFixtures;
 import io.camunda.db.rdbms.read.service.DecisionRequirementsReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
-import io.camunda.it.rdbms.db.fixtures.DecisionRequirementsFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.filter.DecisionRequirementsFilter;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsSortIT.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.it.rdbms.db.decisionrequirements;
 
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
-import static io.camunda.it.rdbms.db.fixtures.DecisionRequirementsFixtures.createAndSaveRandomDecisionRequirements;
+import static io.camunda.db.rdbms.fixtures.CommonFixtures.nextStringId;
+import static io.camunda.db.rdbms.fixtures.DecisionRequirementsFixtures.createAndSaveRandomDecisionRequirements;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsSpecificFilterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsSpecificFilterIT.java
@@ -7,15 +7,15 @@
  */
 package io.camunda.it.rdbms.db.decisionrequirements;
 
-import static io.camunda.it.rdbms.db.fixtures.DecisionRequirementsFixtures.createAndSaveDecisionRequirement;
-import static io.camunda.it.rdbms.db.fixtures.DecisionRequirementsFixtures.createAndSaveRandomDecisionRequirements;
+import static io.camunda.db.rdbms.fixtures.DecisionRequirementsFixtures.createAndSaveDecisionRequirement;
+import static io.camunda.db.rdbms.fixtures.DecisionRequirementsFixtures.createAndSaveRandomDecisionRequirements;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.DecisionRequirementsFixtures;
 import io.camunda.db.rdbms.read.service.DecisionRequirementsReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
-import io.camunda.it.rdbms.db.fixtures.DecisionRequirementsFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
 import io.camunda.search.filter.DecisionRequirementsFilter;
 import io.camunda.search.page.SearchQueryPage;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceIT.java
@@ -7,16 +7,16 @@
  */
 package io.camunda.it.rdbms.db.flownodeinstance;
 
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
-import static io.camunda.it.rdbms.db.fixtures.FlowNodeInstanceFixtures.createAndSaveFlowNodeInstance;
-import static io.camunda.it.rdbms.db.fixtures.FlowNodeInstanceFixtures.createAndSaveRandomFlowNodeInstances;
+import static io.camunda.db.rdbms.fixtures.CommonFixtures.nextStringId;
+import static io.camunda.db.rdbms.fixtures.FlowNodeInstanceFixtures.createAndSaveFlowNodeInstance;
+import static io.camunda.db.rdbms.fixtures.FlowNodeInstanceFixtures.createAndSaveRandomFlowNodeInstances;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.ProcessDefinitionFixtures;
 import io.camunda.db.rdbms.read.service.FlowNodeInstanceReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel;
-import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.FlowNodeInstanceEntity;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceSortIT.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.it.rdbms.db.flownodeinstance;
 
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
-import static io.camunda.it.rdbms.db.fixtures.FlowNodeInstanceFixtures.createAndSaveRandomFlowNodeInstances;
+import static io.camunda.db.rdbms.fixtures.CommonFixtures.nextKey;
+import static io.camunda.db.rdbms.fixtures.FlowNodeInstanceFixtures.createAndSaveRandomFlowNodeInstances;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceSpecificFilterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceSpecificFilterIT.java
@@ -7,15 +7,15 @@
  */
 package io.camunda.it.rdbms.db.flownodeinstance;
 
-import static io.camunda.it.rdbms.db.fixtures.FlowNodeInstanceFixtures.createAndSaveFlowNodeInstance;
-import static io.camunda.it.rdbms.db.fixtures.FlowNodeInstanceFixtures.createAndSaveRandomFlowNodeInstances;
+import static io.camunda.db.rdbms.fixtures.FlowNodeInstanceFixtures.createAndSaveFlowNodeInstance;
+import static io.camunda.db.rdbms.fixtures.FlowNodeInstanceFixtures.createAndSaveRandomFlowNodeInstances;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.FlowNodeInstanceFixtures;
 import io.camunda.db.rdbms.read.service.FlowNodeInstanceReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
-import io.camunda.it.rdbms.db.fixtures.FlowNodeInstanceFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/form/FormIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/form/FormIT.java
@@ -7,15 +7,15 @@
  */
 package io.camunda.it.rdbms.db.form;
 
-import static io.camunda.it.rdbms.db.fixtures.FormFixtures.createAndSaveForm;
-import static io.camunda.it.rdbms.db.fixtures.FormFixtures.createAndSaveRandomForms;
+import static io.camunda.db.rdbms.fixtures.FormFixtures.createAndSaveForm;
+import static io.camunda.db.rdbms.fixtures.FormFixtures.createAndSaveRandomForms;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.FormFixtures;
 import io.camunda.db.rdbms.read.service.FormReader;
 import io.camunda.db.rdbms.write.domain.FormDbModel;
 import io.camunda.db.rdbms.write.domain.FormDbModel.FormDbModelBuilder;
-import io.camunda.it.rdbms.db.fixtures.FormFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.FormEntity;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/form/FormSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/form/FormSortIT.java
@@ -7,12 +7,12 @@
  */
 package io.camunda.it.rdbms.db.form;
 
-import static io.camunda.it.rdbms.db.fixtures.FormFixtures.createAndSaveRandomForms;
+import static io.camunda.db.rdbms.fixtures.FormFixtures.createAndSaveRandomForms;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.FormFixtures;
 import io.camunda.db.rdbms.read.service.FormReader;
-import io.camunda.it.rdbms.db.fixtures.FormFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.FormEntity;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupIT.java
@@ -7,15 +7,15 @@
  */
 package io.camunda.it.rdbms.db.group;
 
-import static io.camunda.it.rdbms.db.fixtures.GroupFixtures.createAndSaveGroup;
-import static io.camunda.it.rdbms.db.fixtures.GroupFixtures.createAndSaveRandomGroups;
+import static io.camunda.db.rdbms.fixtures.GroupFixtures.createAndSaveGroup;
+import static io.camunda.db.rdbms.fixtures.GroupFixtures.createAndSaveRandomGroups;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.GroupFixtures;
 import io.camunda.db.rdbms.read.service.GroupReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.GroupDbModel;
-import io.camunda.it.rdbms.db.fixtures.GroupFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.GroupEntity;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupSortIT.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.it.rdbms.db.group;
 
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
-import static io.camunda.it.rdbms.db.fixtures.GroupFixtures.createAndSaveRandomGroups;
+import static io.camunda.db.rdbms.fixtures.CommonFixtures.nextStringId;
+import static io.camunda.db.rdbms.fixtures.GroupFixtures.createAndSaveRandomGroups;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupSpecificFilterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/group/GroupSpecificFilterIT.java
@@ -7,15 +7,15 @@
  */
 package io.camunda.it.rdbms.db.group;
 
-import static io.camunda.it.rdbms.db.fixtures.GroupFixtures.createAndSaveGroup;
-import static io.camunda.it.rdbms.db.fixtures.GroupFixtures.createAndSaveRandomGroups;
+import static io.camunda.db.rdbms.fixtures.GroupFixtures.createAndSaveGroup;
+import static io.camunda.db.rdbms.fixtures.GroupFixtures.createAndSaveRandomGroups;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.GroupFixtures;
 import io.camunda.db.rdbms.read.service.GroupReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
-import io.camunda.it.rdbms.db.fixtures.GroupFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
 import io.camunda.search.filter.GroupFilter;
 import io.camunda.search.page.SearchQueryPage;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentIT.java
@@ -7,16 +7,16 @@
  */
 package io.camunda.it.rdbms.db.incident;
 
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
-import static io.camunda.it.rdbms.db.fixtures.IncidentFixtures.createAndSaveIncident;
-import static io.camunda.it.rdbms.db.fixtures.IncidentFixtures.createAndSaveRandomIncidents;
+import static io.camunda.db.rdbms.fixtures.CommonFixtures.nextKey;
+import static io.camunda.db.rdbms.fixtures.IncidentFixtures.createAndSaveIncident;
+import static io.camunda.db.rdbms.fixtures.IncidentFixtures.createAndSaveRandomIncidents;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.IncidentFixtures;
 import io.camunda.db.rdbms.read.service.IncidentReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.IncidentDbModel;
-import io.camunda.it.rdbms.db.fixtures.IncidentFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.IncidentEntity;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentSortIT.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.it.rdbms.db.incident;
 
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
-import static io.camunda.it.rdbms.db.fixtures.IncidentFixtures.createAndSaveRandomIncidents;
+import static io.camunda.db.rdbms.fixtures.CommonFixtures.nextKey;
+import static io.camunda.db.rdbms.fixtures.IncidentFixtures.createAndSaveRandomIncidents;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentSpecificFilterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentSpecificFilterIT.java
@@ -7,17 +7,17 @@
  */
 package io.camunda.it.rdbms.db.incident;
 
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.NOW;
-import static io.camunda.it.rdbms.db.fixtures.IncidentFixtures.createAndSaveIncident;
-import static io.camunda.it.rdbms.db.fixtures.IncidentFixtures.createAndSaveRandomIncidents;
+import static io.camunda.db.rdbms.fixtures.CommonFixtures.NOW;
+import static io.camunda.db.rdbms.fixtures.IncidentFixtures.createAndSaveIncident;
+import static io.camunda.db.rdbms.fixtures.IncidentFixtures.createAndSaveRandomIncidents;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.CommonFixtures;
+import io.camunda.db.rdbms.fixtures.IncidentFixtures;
 import io.camunda.db.rdbms.read.service.IncidentReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
-import io.camunda.it.rdbms.db.fixtures.CommonFixtures;
-import io.camunda.it.rdbms.db.fixtures.IncidentFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
 import io.camunda.search.entities.IncidentEntity.ErrorType;
 import io.camunda.search.entities.IncidentEntity.IncidentState;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/mapping/MappingIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/mapping/MappingIT.java
@@ -7,15 +7,15 @@
  */
 package io.camunda.it.rdbms.db.mapping;
 
-import static io.camunda.it.rdbms.db.fixtures.MappingFixtures.createAndSaveMapping;
-import static io.camunda.it.rdbms.db.fixtures.MappingFixtures.createAndSaveRandomMappings;
+import static io.camunda.db.rdbms.fixtures.MappingFixtures.createAndSaveMapping;
+import static io.camunda.db.rdbms.fixtures.MappingFixtures.createAndSaveRandomMappings;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.MappingFixtures;
 import io.camunda.db.rdbms.read.service.MappingReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.MappingDbModel;
-import io.camunda.it.rdbms.db.fixtures.MappingFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.filter.MappingFilter;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/mapping/MappingSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/mapping/MappingSortIT.java
@@ -7,11 +7,11 @@
  */
 package io.camunda.it.rdbms.db.mapping;
 
-import static io.camunda.it.rdbms.db.fixtures.MappingFixtures.createAndSaveRandomMappings;
+import static io.camunda.db.rdbms.fixtures.MappingFixtures.createAndSaveRandomMappings;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
-import io.camunda.it.rdbms.db.fixtures.MappingFixtures;
+import io.camunda.db.rdbms.fixtures.MappingFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.MappingEntity;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionIT.java
@@ -7,14 +7,14 @@
  */
 package io.camunda.it.rdbms.db.processdefinition;
 
-import static io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures.createAndSaveProcessDefinition;
-import static io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures.createAndSaveRandomProcessDefinitions;
+import static io.camunda.db.rdbms.fixtures.ProcessDefinitionFixtures.createAndSaveProcessDefinition;
+import static io.camunda.db.rdbms.fixtures.ProcessDefinitionFixtures.createAndSaveRandomProcessDefinitions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.ProcessDefinitionFixtures;
 import io.camunda.db.rdbms.read.service.ProcessDefinitionReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
-import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.filter.ProcessDefinitionFilter;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionSortIT.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.it.rdbms.db.processdefinition;
 
-import static io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures.createAndSaveRandomProcessDefinitions;
-import static io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures.nextStringId;
+import static io.camunda.db.rdbms.fixtures.ProcessDefinitionFixtures.createAndSaveRandomProcessDefinitions;
+import static io.camunda.db.rdbms.fixtures.ProcessDefinitionFixtures.nextStringId;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionSpecificFilterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionSpecificFilterIT.java
@@ -7,15 +7,15 @@
  */
 package io.camunda.it.rdbms.db.processdefinition;
 
-import static io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures.createAndSaveProcessDefinition;
-import static io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures.createAndSaveRandomProcessDefinitions;
+import static io.camunda.db.rdbms.fixtures.ProcessDefinitionFixtures.createAndSaveProcessDefinition;
+import static io.camunda.db.rdbms.fixtures.ProcessDefinitionFixtures.createAndSaveRandomProcessDefinitions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.ProcessDefinitionFixtures;
 import io.camunda.db.rdbms.read.service.ProcessDefinitionReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
-import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
 import io.camunda.search.filter.ProcessDefinitionFilter;
 import io.camunda.search.page.SearchQueryPage;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceIT.java
@@ -7,16 +7,16 @@
  */
 package io.camunda.it.rdbms.db.processinstance;
 
-import static io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures.createAndSaveProcessInstance;
-import static io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures.createAndSaveRandomProcessInstances;
+import static io.camunda.db.rdbms.fixtures.ProcessInstanceFixtures.createAndSaveProcessInstance;
+import static io.camunda.db.rdbms.fixtures.ProcessInstanceFixtures.createAndSaveRandomProcessInstances;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.ProcessDefinitionFixtures;
+import io.camunda.db.rdbms.fixtures.ProcessInstanceFixtures;
 import io.camunda.db.rdbms.read.service.ProcessInstanceReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel;
-import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
-import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSortIT.java
@@ -7,15 +7,15 @@
  */
 package io.camunda.it.rdbms.db.processinstance;
 
-import static io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures.createAndSaveProcessDefinition;
-import static io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures.createAndSaveProcessInstances;
+import static io.camunda.db.rdbms.fixtures.ProcessDefinitionFixtures.createAndSaveProcessDefinition;
+import static io.camunda.db.rdbms.fixtures.ProcessInstanceFixtures.createAndSaveProcessInstances;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.ProcessDefinitionFixtures;
+import io.camunda.db.rdbms.fixtures.ProcessInstanceFixtures;
 import io.camunda.db.rdbms.read.service.ProcessInstanceReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
-import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
-import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.ProcessInstanceEntity;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSpecificFilterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSpecificFilterIT.java
@@ -7,17 +7,17 @@
  */
 package io.camunda.it.rdbms.db.processinstance;
 
-import static io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures.createAndSaveProcessDefinition;
-import static io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures.createAndSaveProcessInstance;
-import static io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures.createAndSaveRandomProcessInstances;
+import static io.camunda.db.rdbms.fixtures.ProcessDefinitionFixtures.createAndSaveProcessDefinition;
+import static io.camunda.db.rdbms.fixtures.ProcessInstanceFixtures.createAndSaveProcessInstance;
+import static io.camunda.db.rdbms.fixtures.ProcessInstanceFixtures.createAndSaveRandomProcessInstances;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.ProcessDefinitionFixtures;
+import io.camunda.db.rdbms.fixtures.ProcessInstanceFixtures;
 import io.camunda.db.rdbms.read.service.ProcessInstanceReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
-import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
-import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.search.filter.ProcessInstanceFilter;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleIT.java
@@ -7,15 +7,15 @@
  */
 package io.camunda.it.rdbms.db.role;
 
-import static io.camunda.it.rdbms.db.fixtures.RoleFixtures.createAndSaveRandomRoles;
-import static io.camunda.it.rdbms.db.fixtures.RoleFixtures.createAndSaveRole;
+import static io.camunda.db.rdbms.fixtures.RoleFixtures.createAndSaveRandomRoles;
+import static io.camunda.db.rdbms.fixtures.RoleFixtures.createAndSaveRole;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.RoleFixtures;
 import io.camunda.db.rdbms.read.service.RoleReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.RoleDbModel;
-import io.camunda.it.rdbms.db.fixtures.RoleFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.RoleEntity;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSortIT.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.it.rdbms.db.role;
 
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
-import static io.camunda.it.rdbms.db.fixtures.RoleFixtures.createAndSaveRandomRoles;
+import static io.camunda.db.rdbms.fixtures.CommonFixtures.nextStringId;
+import static io.camunda.db.rdbms.fixtures.RoleFixtures.createAndSaveRandomRoles;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/role/RoleSpecificFilterIT.java
@@ -7,15 +7,15 @@
  */
 package io.camunda.it.rdbms.db.role;
 
-import static io.camunda.it.rdbms.db.fixtures.RoleFixtures.createAndSaveRandomRoles;
-import static io.camunda.it.rdbms.db.fixtures.RoleFixtures.createAndSaveRole;
+import static io.camunda.db.rdbms.fixtures.RoleFixtures.createAndSaveRandomRoles;
+import static io.camunda.db.rdbms.fixtures.RoleFixtures.createAndSaveRole;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.RoleFixtures;
 import io.camunda.db.rdbms.read.service.RoleReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
-import io.camunda.it.rdbms.db.fixtures.RoleFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
 import io.camunda.search.filter.RoleFilter;
 import io.camunda.search.page.SearchQueryPage;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantIT.java
@@ -7,16 +7,16 @@
  */
 package io.camunda.it.rdbms.db.tenant;
 
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
-import static io.camunda.it.rdbms.db.fixtures.TenantFixtures.createAndSaveRandomTenants;
-import static io.camunda.it.rdbms.db.fixtures.TenantFixtures.createAndSaveTenant;
+import static io.camunda.db.rdbms.fixtures.CommonFixtures.nextStringId;
+import static io.camunda.db.rdbms.fixtures.TenantFixtures.createAndSaveRandomTenants;
+import static io.camunda.db.rdbms.fixtures.TenantFixtures.createAndSaveTenant;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.TenantFixtures;
 import io.camunda.db.rdbms.read.service.TenantReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.TenantDbModel;
-import io.camunda.it.rdbms.db.fixtures.TenantFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.TenantEntity;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantSortIT.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.it.rdbms.db.tenant;
 
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
-import static io.camunda.it.rdbms.db.fixtures.TenantFixtures.createAndSaveRandomTenants;
+import static io.camunda.db.rdbms.fixtures.CommonFixtures.nextKey;
+import static io.camunda.db.rdbms.fixtures.CommonFixtures.nextStringId;
+import static io.camunda.db.rdbms.fixtures.TenantFixtures.createAndSaveRandomTenants;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantSpecificFilterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantSpecificFilterIT.java
@@ -7,15 +7,15 @@
  */
 package io.camunda.it.rdbms.db.tenant;
 
-import static io.camunda.it.rdbms.db.fixtures.TenantFixtures.createAndSaveRandomTenants;
-import static io.camunda.it.rdbms.db.fixtures.TenantFixtures.createAndSaveTenant;
+import static io.camunda.db.rdbms.fixtures.TenantFixtures.createAndSaveRandomTenants;
+import static io.camunda.db.rdbms.fixtures.TenantFixtures.createAndSaveTenant;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.TenantFixtures;
 import io.camunda.db.rdbms.read.service.TenantReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
-import io.camunda.it.rdbms.db.fixtures.TenantFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
 import io.camunda.search.filter.TenantFilter;
 import io.camunda.search.page.SearchQueryPage;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/user/UserIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/user/UserIT.java
@@ -7,15 +7,15 @@
  */
 package io.camunda.it.rdbms.db.user;
 
-import static io.camunda.it.rdbms.db.fixtures.UserFixtures.createAndSaveRandomUsers;
-import static io.camunda.it.rdbms.db.fixtures.UserFixtures.createAndSaveUser;
+import static io.camunda.db.rdbms.fixtures.UserFixtures.createAndSaveRandomUsers;
+import static io.camunda.db.rdbms.fixtures.UserFixtures.createAndSaveUser;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.UserFixtures;
 import io.camunda.db.rdbms.read.service.UserReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.UserDbModel;
-import io.camunda.it.rdbms.db.fixtures.UserFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.UserEntity;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/user/UserSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/user/UserSortIT.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.it.rdbms.db.user;
 
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
-import static io.camunda.it.rdbms.db.fixtures.UserFixtures.createAndSaveRandomUsers;
+import static io.camunda.db.rdbms.fixtures.CommonFixtures.nextStringId;
+import static io.camunda.db.rdbms.fixtures.UserFixtures.createAndSaveRandomUsers;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/user/UserSpecificFilterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/user/UserSpecificFilterIT.java
@@ -7,15 +7,15 @@
  */
 package io.camunda.it.rdbms.db.user;
 
-import static io.camunda.it.rdbms.db.fixtures.UserFixtures.createAndSaveRandomUsers;
-import static io.camunda.it.rdbms.db.fixtures.UserFixtures.createAndSaveUser;
+import static io.camunda.db.rdbms.fixtures.UserFixtures.createAndSaveRandomUsers;
+import static io.camunda.db.rdbms.fixtures.UserFixtures.createAndSaveUser;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.UserFixtures;
 import io.camunda.db.rdbms.read.service.UserReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
-import io.camunda.it.rdbms.db.fixtures.UserFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
 import io.camunda.search.filter.UserFilter;
 import io.camunda.search.page.SearchQueryPage;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskIT.java
@@ -7,20 +7,20 @@
  */
 package io.camunda.it.rdbms.db.usertask;
 
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.NOW;
-import static io.camunda.it.rdbms.db.fixtures.UserTaskFixtures.createAndSaveRandomUserTasks;
-import static io.camunda.it.rdbms.db.fixtures.UserTaskFixtures.createAndSaveUserTask;
+import static io.camunda.db.rdbms.fixtures.CommonFixtures.NOW;
+import static io.camunda.db.rdbms.fixtures.UserTaskFixtures.createAndSaveRandomUserTasks;
+import static io.camunda.db.rdbms.fixtures.UserTaskFixtures.createAndSaveUserTask;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.UserTaskFixtures;
+import io.camunda.db.rdbms.fixtures.VariableFixtures;
 import io.camunda.db.rdbms.read.domain.UserTaskDbQuery;
 import io.camunda.db.rdbms.read.service.UserTaskReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.UserTaskDbModel;
 import io.camunda.db.rdbms.write.domain.UserTaskDbModel.UserTaskState;
 import io.camunda.db.rdbms.write.domain.VariableDbModel;
-import io.camunda.it.rdbms.db.fixtures.UserTaskFixtures;
-import io.camunda.it.rdbms.db.fixtures.VariableFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.UserTaskEntity;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskSortIT.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.it.rdbms.db.usertask;
 
-import static io.camunda.it.rdbms.db.fixtures.UserTaskFixtures.createAndSaveRandomUserTasks;
-import static io.camunda.it.rdbms.db.fixtures.UserTaskFixtures.nextStringId;
+import static io.camunda.db.rdbms.fixtures.UserTaskFixtures.createAndSaveRandomUserTasks;
+import static io.camunda.db.rdbms.fixtures.UserTaskFixtures.nextStringId;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableIT.java
@@ -7,17 +7,17 @@
  */
 package io.camunda.it.rdbms.db.variables;
 
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.generateRandomString;
-import static io.camunda.it.rdbms.db.fixtures.VariableFixtures.createAndSaveVariable;
-import static io.camunda.it.rdbms.db.fixtures.VariableFixtures.prepareRandomVariablesAndReturnOne;
+import static io.camunda.db.rdbms.fixtures.CommonFixtures.generateRandomString;
+import static io.camunda.db.rdbms.fixtures.VariableFixtures.createAndSaveVariable;
+import static io.camunda.db.rdbms.fixtures.VariableFixtures.prepareRandomVariablesAndReturnOne;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.VariableFixtures;
 import io.camunda.db.rdbms.read.service.VariableReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.VariableDbModel;
 import io.camunda.db.rdbms.write.domain.VariableDbModel.VariableDbModelBuilder;
-import io.camunda.it.rdbms.db.fixtures.VariableFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.VariableEntity;
@@ -35,7 +35,8 @@ public class VariableIT {
 
   @TestTemplate
   public void shouldSaveAndFindVariableByKey(final CamundaRdbmsTestApplication testApplication) {
-    final VariableDbModel randomizedVariable = prepareRandomVariablesAndReturnOne(testApplication);
+    final VariableDbModel randomizedVariable =
+        prepareRandomVariablesAndReturnOne(testApplication.getRdbmsService());
 
     final var instance =
         testApplication
@@ -52,7 +53,8 @@ public class VariableIT {
   @TestTemplate
   public void shouldUpdateAndFindVariableByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final VariableDbModel randomizedVariable = prepareRandomVariablesAndReturnOne(testApplication);
+    final VariableDbModel randomizedVariable =
+        prepareRandomVariablesAndReturnOne(testApplication.getRdbmsService());
 
     final var newValue = "new value";
     final VariableDbModel updatedVariable =

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableSortIT.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.it.rdbms.db.variables;
 
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
-import static io.camunda.it.rdbms.db.fixtures.VariableFixtures.createAndSaveRandomVariables;
+import static io.camunda.db.rdbms.fixtures.CommonFixtures.nextKey;
+import static io.camunda.db.rdbms.fixtures.CommonFixtures.nextStringId;
+import static io.camunda.db.rdbms.fixtures.VariableFixtures.createAndSaveRandomVariables;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableValueFilterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableValueFilterIT.java
@@ -7,16 +7,16 @@
  */
 package io.camunda.it.rdbms.db.variables;
 
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.generateRandomString;
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
-import static io.camunda.it.rdbms.db.fixtures.VariableFixtures.createAndSaveVariable;
-import static io.camunda.it.rdbms.db.fixtures.VariableFixtures.prepareRandomVariables;
-import static io.camunda.it.rdbms.db.fixtures.VariableFixtures.prepareRandomVariablesAndReturnOne;
+import static io.camunda.db.rdbms.fixtures.CommonFixtures.generateRandomString;
+import static io.camunda.db.rdbms.fixtures.CommonFixtures.nextStringId;
+import static io.camunda.db.rdbms.fixtures.VariableFixtures.createAndSaveVariable;
+import static io.camunda.db.rdbms.fixtures.VariableFixtures.prepareRandomVariables;
+import static io.camunda.db.rdbms.fixtures.VariableFixtures.prepareRandomVariablesAndReturnOne;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.fixtures.VariableFixtures;
 import io.camunda.db.rdbms.write.domain.VariableDbModel;
-import io.camunda.it.rdbms.db.fixtures.VariableFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.filter.Operation;
@@ -39,7 +39,7 @@ public class VariableValueFilterIT {
   public void shouldFindVariableWithNameFilter(final CamundaRdbmsTestApplication testApplication) {
     // given 20 random variables
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    prepareRandomVariables(testApplication);
+    prepareRandomVariables(rdbmsService);
 
     // and one variable with a specific name
     final String varName = "var-name-" + nextStringId();
@@ -57,7 +57,7 @@ public class VariableValueFilterIT {
       final CamundaRdbmsTestApplication testApplication) {
     // given 21 variables
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final var randomizedVariable = prepareRandomVariablesAndReturnOne(testApplication);
+    final var randomizedVariable = prepareRandomVariablesAndReturnOne(rdbmsService);
 
     // and an eq value filter
     final Operation<String> operation = Operation.eq(randomizedVariable.value());
@@ -73,8 +73,7 @@ public class VariableValueFilterIT {
     // given 21 variables
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final String varName = "var-name-" + nextStringId();
-    final var randomizedVariable =
-        prepareRandomVariablesAndReturnOne(testApplication, varName, "42");
+    final var randomizedVariable = prepareRandomVariablesAndReturnOne(rdbmsService, varName, "42");
 
     // and an eq value filter
     final Operation<String> operation = Operation.eq("42");
@@ -91,7 +90,7 @@ public class VariableValueFilterIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final String varName = "var-name-" + nextStringId();
     final var randomizedVariable =
-        prepareRandomVariablesAndReturnOne(testApplication, varName, "true");
+        prepareRandomVariablesAndReturnOne(rdbmsService, varName, "true");
 
     // and an eq value filter
     final Operation<String> operation = Operation.eq("true");
@@ -106,7 +105,7 @@ public class VariableValueFilterIT {
       final CamundaRdbmsTestApplication testApplication) {
     // given 20 random variables
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    prepareRandomVariables(testApplication);
+    prepareRandomVariables(rdbmsService);
 
     // and one variable with a specific name
     final String varName = "var-name-" + nextStringId();
@@ -128,7 +127,7 @@ public class VariableValueFilterIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final String varName = "var-name-" + nextStringId();
     final var randomizedVariable =
-        prepareRandomVariablesAndReturnOne(testApplication, varName, "42000");
+        prepareRandomVariablesAndReturnOne(rdbmsService, varName, "42000");
 
     // and a gt value filter
     final Operation<String> operation = Operation.gt("40000");
@@ -144,7 +143,7 @@ public class VariableValueFilterIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final String varName = "var-name-" + nextStringId();
     final var randomizedVariable =
-        prepareRandomVariablesAndReturnOne(testApplication, varName, "42000");
+        prepareRandomVariablesAndReturnOne(rdbmsService, varName, "42000");
 
     // and a gte value filter
     final Operation<String> operation = Operation.gte("42000");
@@ -160,7 +159,7 @@ public class VariableValueFilterIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final String varName = "var-name-" + nextStringId();
     final var randomizedVariable =
-        prepareRandomVariablesAndReturnOne(testApplication, varName, "-42000");
+        prepareRandomVariablesAndReturnOne(rdbmsService, varName, "-42000");
 
     // and a lt value filter
     final Operation<String> operation = Operation.lt("-40000");
@@ -176,7 +175,7 @@ public class VariableValueFilterIT {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final String varName = "var-name-" + nextStringId();
     final var randomizedVariable =
-        prepareRandomVariablesAndReturnOne(testApplication, varName, "-42000");
+        prepareRandomVariablesAndReturnOne(rdbmsService, varName, "-42000");
 
     // and a lte value filter
     final Operation<String> operation = Operation.lte("-42000");
@@ -190,7 +189,7 @@ public class VariableValueFilterIT {
       final CamundaRdbmsTestApplication testApplication) {
     // given 21 variables
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final var randomizedVariable = prepareRandomVariablesAndReturnOne(testApplication);
+    final var randomizedVariable = prepareRandomVariablesAndReturnOne(rdbmsService);
 
     // and two name filters
     final VariableValueFilter variableValueFilter =
@@ -226,7 +225,7 @@ public class VariableValueFilterIT {
       final CamundaRdbmsTestApplication testApplication) {
     // given 21 variables
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    prepareRandomVariablesAndReturnOne(testApplication);
+    prepareRandomVariablesAndReturnOne(rdbmsService);
     final VariableDbModel randomizedVariable =
         VariableFixtures.createRandomized(b -> b.name("unique-name" + generateRandomString(10)));
     createAndSaveVariable(rdbmsService, randomizedVariable);

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.it.rdbms.exporter;
 
-import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
+import static io.camunda.db.rdbms.fixtures.CommonFixtures.nextKey;
 import static io.camunda.it.rdbms.exporter.RecordFixtures.getAuthorizationRecord;
 import static io.camunda.it.rdbms.exporter.RecordFixtures.getDecisionDefinitionCreatedRecord;
 import static io.camunda.it.rdbms.exporter.RecordFixtures.getDecisionRequirementsCreatedRecord;


### PR DESCRIPTION
## Description

This changed moved all Rdbms fixture classes from the qa module to the db/rdbms module. Developers now can use them in other modules too.

To solve circular maven dependencies, I used a small trick: I packaged an archive of type `test-jar` which has to be imported separately.

relates to #24002 
