### PR TITLE
feat: Allow defining `updating` task listener in `bpmn-model` API

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/TaskListenerValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/TaskListenerValidator.java
@@ -27,11 +27,17 @@ import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 public class TaskListenerValidator implements ModelElementValidator<ZeebeTaskListener> {
 
   private static final List<ZeebeTaskListenerEventType> SUPPORTED_VALUES =
-      Arrays.asList(ZeebeTaskListenerEventType.assigning, ZeebeTaskListenerEventType.completing);
+      Arrays.asList(
+          ZeebeTaskListenerEventType.assigning,
+          ZeebeTaskListenerEventType.updating,
+          ZeebeTaskListenerEventType.completing);
 
   @SuppressWarnings("deprecation")
   private static final List<ZeebeTaskListenerEventType> SUPPORTED_DEPRECATED_VALUES =
-      Arrays.asList(ZeebeTaskListenerEventType.assignment, ZeebeTaskListenerEventType.complete);
+      Arrays.asList(
+          ZeebeTaskListenerEventType.assignment,
+          ZeebeTaskListenerEventType.update,
+          ZeebeTaskListenerEventType.complete);
 
   @Override
   public Class<ZeebeTaskListener> getElementType() {

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskListenersValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskListenersValidationTest.java
@@ -99,4 +99,32 @@ public class ZeebeTaskListenersValidationTest {
                     + "and 'assignment', 'complete' deprecated event types are supported.",
                 unsupportedEventType)));
   }
+
+  @DisplayName("task listener with supported `eventType` property")
+  @ParameterizedTest(name = "supported event type: ''{0}''")
+  @EnumSource(
+      value = ZeebeTaskListenerEventType.class,
+      // supported event types
+      names = {
+        "assigning", "completing",
+        // deprecated event types
+        "assignment", "complete"
+      })
+  void testEventTypeSupported(final ZeebeTaskListenerEventType supportedEventType) {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask(
+                "user_task",
+                ut ->
+                    ut.zeebeUserTask()
+                        .zeebeTaskListener(
+                            l -> l.eventType(supportedEventType).type("supported_listener")))
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskListenersValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskListenersValidationTest.java
@@ -70,9 +70,9 @@ public class ZeebeTaskListenersValidationTest {
       mode = EnumSource.Mode.EXCLUDE,
       // supported event types
       names = {
-        "assigning", "completing",
+        "assigning", "updating", "completing",
         // deprecated event types
-        "assignment", "complete"
+        "assignment", "update", "complete"
       })
   void testEventTypeNotSupported(final ZeebeTaskListenerEventType unsupportedEventType) {
     // given
@@ -95,8 +95,8 @@ public class ZeebeTaskListenersValidationTest {
             ZeebeTaskListener.class,
             String.format(
                 "Task listener event type '%s' is not supported. "
-                    + "Currently, only 'assigning', 'completing' event types "
-                    + "and 'assignment', 'complete' deprecated event types are supported.",
+                    + "Currently, only 'assigning', 'updating', 'completing' event types "
+                    + "and 'assignment', 'update', 'complete' deprecated event types are supported.",
                 unsupportedEventType)));
   }
 
@@ -106,9 +106,9 @@ public class ZeebeTaskListenersValidationTest {
       value = ZeebeTaskListenerEventType.class,
       // supported event types
       names = {
-        "assigning", "completing",
+        "assigning", "updating", "completing",
         // deprecated event types
-        "assignment", "complete"
+        "assignment", "update", "complete"
       })
   void testEventTypeSupported(final ZeebeTaskListenerEventType supportedEventType) {
     // given

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskListenersValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskListenersValidationTest.java
@@ -69,7 +69,11 @@ public class ZeebeTaskListenersValidationTest {
       value = ZeebeTaskListenerEventType.class,
       mode = EnumSource.Mode.EXCLUDE,
       // supported event types
-      names = {"assigning", "assignment", "completing", "complete"})
+      names = {
+        "assigning", "completing",
+        // deprecated event types
+        "assignment", "complete"
+      })
   void testEventTypeNotSupported(final ZeebeTaskListenerEventType unsupportedEventType) {
     // given
     final BpmnModelInstance process =


### PR DESCRIPTION
## Description

This PR introduces support for the `updating` event in the BPMN model API, allowing users to define task listeners of type `updating`.  

Additionally, it ensures backward compatibility by supporting the **deprecated** `update` event type, as `ZeebeTaskListenerEventType.update` was released in versions **8.6 and 8.7**.  

### Key changes
- Updated `TaskListenerValidator` to allow the deployment of processes with `updating` and deprecated `update` task listeners.  
- Updated tests to ensure `updating` and `update` event types are correctly recognized.  

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #27511
