### PR TITLE
feat: Introduce and recognize `UPDATING` job listener event type

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -252,8 +252,10 @@ public final class BpmnJobBehavior {
       final ZeebeTaskListenerEventType eventType) {
     return switch (eventType) {
       case assigning -> JobListenerEventType.ASSIGNING;
+      case updating -> JobListenerEventType.UPDATING;
       case completing -> JobListenerEventType.COMPLETING;
-      default -> throw new IllegalStateException("Unexpected value: " + eventType);
+      default ->
+          throw new IllegalStateException("Unexpected ZeebeTaskListenerEventType: " + eventType);
     };
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCreatedApplier.java
@@ -53,8 +53,9 @@ final class JobCreatedApplier implements TypedEventApplier<JobIntent, JobRecord>
   private ZeebeTaskListenerEventType toTaskListenerEventType(final JobListenerEventType eventType) {
     return switch (eventType) {
       case COMPLETING -> ZeebeTaskListenerEventType.completing;
+      case UPDATING -> ZeebeTaskListenerEventType.updating;
       case ASSIGNING -> ZeebeTaskListenerEventType.assigning;
-      default -> throw new IllegalStateException("Unexpected value: " + eventType);
+      default -> throw new IllegalStateException("Unexpected JobListenerEventType: " + eventType);
     };
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/TaskListenerIndicesRecord.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/TaskListenerIndicesRecord.java
@@ -18,18 +18,22 @@ public final class TaskListenerIndicesRecord extends UnpackedObject implements D
 
   private final IntegerProperty assigningTaskListenerIndexProp =
       new IntegerProperty("assigningTaskListenerIndex", 0);
+  private final IntegerProperty updatingTaskListenerIndexProp =
+      new IntegerProperty("updatingTaskListenerIndex", 0);
   private final IntegerProperty completingTaskListenerIndexProp =
       new IntegerProperty("completingTaskListenerIndex", 0);
 
   TaskListenerIndicesRecord() {
-    super(2);
+    super(3);
     declareProperty(assigningTaskListenerIndexProp)
+        .declareProperty(updatingTaskListenerIndexProp)
         .declareProperty(completingTaskListenerIndexProp);
   }
 
   public Integer getTaskListenerIndex(final ZeebeTaskListenerEventType eventType) {
     return switch (eventType) {
       case assigning -> assigningTaskListenerIndexProp.getValue();
+      case updating -> updatingTaskListenerIndexProp.getValue();
       case completing -> completingTaskListenerIndexProp.getValue();
       default ->
           throw new IllegalArgumentException("Unsupported ZeebeTaskListenerEventType " + eventType);
@@ -39,6 +43,7 @@ public final class TaskListenerIndicesRecord extends UnpackedObject implements D
   public void incrementTaskListenerIndex(final ZeebeTaskListenerEventType eventType) {
     switch (eventType) {
       case assigning -> assigningTaskListenerIndexProp.increment();
+      case updating -> updatingTaskListenerIndexProp.increment();
       case completing -> completingTaskListenerIndexProp.increment();
       default ->
           throw new IllegalArgumentException("Unsupported ZeebeTaskListenerEventType " + eventType);
@@ -48,6 +53,7 @@ public final class TaskListenerIndicesRecord extends UnpackedObject implements D
   public void resetTaskListenerIndex(final ZeebeTaskListenerEventType eventType) {
     switch (eventType) {
       case assigning -> assigningTaskListenerIndexProp.reset();
+      case updating -> updatingTaskListenerIndexProp.reset();
       case completing -> completingTaskListenerIndexProp.reset();
       default ->
           throw new IllegalArgumentException("Unsupported ZeebeTaskListenerEventType " + eventType);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/TaskListenerIndicesRecord.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/TaskListenerIndicesRecord.java
@@ -16,20 +16,21 @@ import org.agrona.concurrent.UnsafeBuffer;
 
 public final class TaskListenerIndicesRecord extends UnpackedObject implements DbValue {
 
-  private final IntegerProperty assignmentTaskListenerIndexProp =
-      new IntegerProperty("assignmentTaskListenerIndex", 0);
-  private final IntegerProperty completeTaskListenerIndexProp =
-      new IntegerProperty("completeTaskListenerIndex", 0);
+  private final IntegerProperty assigningTaskListenerIndexProp =
+      new IntegerProperty("assigningTaskListenerIndex", 0);
+  private final IntegerProperty completingTaskListenerIndexProp =
+      new IntegerProperty("completingTaskListenerIndex", 0);
 
   TaskListenerIndicesRecord() {
     super(2);
-    declareProperty(assignmentTaskListenerIndexProp).declareProperty(completeTaskListenerIndexProp);
+    declareProperty(assigningTaskListenerIndexProp)
+        .declareProperty(completingTaskListenerIndexProp);
   }
 
   public Integer getTaskListenerIndex(final ZeebeTaskListenerEventType eventType) {
     return switch (eventType) {
-      case assigning -> assignmentTaskListenerIndexProp.getValue();
-      case completing -> completeTaskListenerIndexProp.getValue();
+      case assigning -> assigningTaskListenerIndexProp.getValue();
+      case completing -> completingTaskListenerIndexProp.getValue();
       default ->
           throw new IllegalArgumentException("Unsupported ZeebeTaskListenerEventType " + eventType);
     };
@@ -37,8 +38,8 @@ public final class TaskListenerIndicesRecord extends UnpackedObject implements D
 
   public void incrementTaskListenerIndex(final ZeebeTaskListenerEventType eventType) {
     switch (eventType) {
-      case assigning -> assignmentTaskListenerIndexProp.increment();
-      case completing -> completeTaskListenerIndexProp.increment();
+      case assigning -> assigningTaskListenerIndexProp.increment();
+      case completing -> completingTaskListenerIndexProp.increment();
       default ->
           throw new IllegalArgumentException("Unsupported ZeebeTaskListenerEventType " + eventType);
     }
@@ -46,8 +47,8 @@ public final class TaskListenerIndicesRecord extends UnpackedObject implements D
 
   public void resetTaskListenerIndex(final ZeebeTaskListenerEventType eventType) {
     switch (eventType) {
-      case assigning -> assignmentTaskListenerIndexProp.reset();
-      case completing -> completeTaskListenerIndexProp.reset();
+      case assigning -> assigningTaskListenerIndexProp.reset();
+      case completing -> completingTaskListenerIndexProp.reset();
       default ->
           throw new IllegalArgumentException("Unsupported ZeebeTaskListenerEventType " + eventType);
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobListenerEventType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobListenerEventType.java
@@ -48,4 +48,13 @@ public enum JobListenerEventType {
    * logic before the task is assigned, to correct user task data, and to deny the assignment.
    */
   ASSIGNING,
+
+  /**
+   * Represents the `updating` event for a task listener. This event type is used to indicate that
+   * the listener should be triggered when a user task is updating. Updates may include changes to
+   * attributes such as `candidateGroupsList`, `candidateUsersList`, `dueDate`, `followUpDate`, and
+   * `priority`. It allows executing custom logic before the task is updated, to correct user task
+   * data, and to deny the update.
+   */
+  UPDATING
 }


### PR DESCRIPTION
## Description
This PR introduces the `UPDATING` event type to the `JobListenerEventType` enum and ensures it is correctly recognized and processed in the Zeebe engine.  

### Key changes:
- Added `UPDATING` event type to `JobListenerEventType` to support user task listeners triggered during task updates.
- Updated `BpmnJobBehavior` and `JobCreatedApplier` to recognize and process `UPDATING` job listener events.  
- Refactored task listener index properties in `TaskListenerIndicesRecord` to align with the gerund-based event naming convention (`assigning`, `completing`), introduced in the scope of https://github.com/camunda/camunda/pull/25845.  
- Introduced `updatingTaskListenerIndexProp` in `TaskListenerIndicesRecord` to track `UPDATING` task listener indices. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #27516
