### PR TITLE
Idempotent message correlation retries

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
@@ -99,7 +99,7 @@ public final class MessageSubscriptionCorrelateProcessor
       final var reason =
           """
           Expected to acknowledge correlating message with key '%d' to subscription with key '%d' \
-          but the subscription is already correlating'"""
+          but the subscription has already been correlated'"""
               .formatted(record.getValue().getMessageKey(), subscription.getKey());
       rejectionWriter.appendRejection(record, RejectionType.INVALID_STATE, reason);
       return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
@@ -74,7 +74,12 @@ public final class MessageSubscriptionCorrelateProcessor
         subscriptionState.get(command.getElementInstanceKey(), command.getMessageNameBuffer());
 
     if (subscription == null) {
-      rejectCommand(record);
+      final var reason =
+          String.format(
+              NO_SUBSCRIPTION_FOUND_MESSAGE,
+              record.getValue().getElementInstanceKey(),
+              BufferUtil.bufferAsString(record.getValue().getMessageNameBuffer()));
+      rejectionWriter.appendRejection(record, RejectionType.NOT_FOUND, reason);
       return;
 
     } else if (subscription.getRecord().getMessageKey() != record.getValue().getMessageKey()) {
@@ -88,7 +93,12 @@ public final class MessageSubscriptionCorrelateProcessor
           record.getValue().getMessageKey(),
           subscription.getKey(),
           subscription.getRecord().getMessageKey());
-      rejectCommand(record);
+      final var reason =
+          String.format(
+              NO_SUBSCRIPTION_FOUND_MESSAGE,
+              record.getValue().getElementInstanceKey(),
+              BufferUtil.bufferAsString(record.getValue().getMessageNameBuffer()));
+      rejectionWriter.appendRejection(record, RejectionType.NOT_FOUND, reason);
       return;
 
     } else if (!subscription.isCorrelating()) {
@@ -101,7 +111,12 @@ public final class MessageSubscriptionCorrelateProcessor
           but the subscription is already correlating'""",
           record.getValue().getMessageKey(),
           subscription.getKey());
-      rejectCommand(record);
+      final var reason =
+          String.format(
+              NO_SUBSCRIPTION_FOUND_MESSAGE,
+              record.getValue().getElementInstanceKey(),
+              BufferUtil.bufferAsString(record.getValue().getMessageNameBuffer()));
+      rejectionWriter.appendRejection(record, RejectionType.NOT_FOUND, reason);
       return;
     }
 
@@ -145,16 +160,5 @@ public final class MessageSubscriptionCorrelateProcessor
           requestData.getRequestId(),
           requestData.getRequestStreamId());
     }
-  }
-
-  private void rejectCommand(final TypedRecord<MessageSubscriptionRecord> record) {
-    final var subscription = record.getValue();
-    final var reason =
-        String.format(
-            NO_SUBSCRIPTION_FOUND_MESSAGE,
-            subscription.getElementInstanceKey(),
-            BufferUtil.bufferAsString(subscription.getMessageNameBuffer()));
-
-    rejectionWriter.appendRejection(record, RejectionType.NOT_FOUND, reason);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
@@ -35,6 +35,14 @@ public final class MessageSubscriptionCorrelateProcessor
   private static final String NO_SUBSCRIPTION_FOUND_MESSAGE =
       "Expected to correlate subscription for element with key '%d' and message name '%s', "
           + "but no such message subscription exists";
+  private static final String SUBSCRIPTION_ALREADY_CORRELATING_AGAIN_MESSAGE =
+      """
+      Expected to acknowledge correlating message with key '%d' to subscription with key '%d' \
+      but the subscription is already correlating to another message with key '%d'""";
+  private static final String SUBSCRIPTION_ALREADY_CORRELATED_MESSAGE =
+      """
+      Expected to acknowledge correlating message with key '%d' to subscription with key '%d' \
+      but the subscription has already been correlated'""";
 
   private final MessageSubscriptionState subscriptionState;
   private final MessageCorrelationState messageCorrelationState;
@@ -82,13 +90,10 @@ public final class MessageSubscriptionCorrelateProcessor
       // command. The message subscription was already marked as correlated for this message, and
       // another message has started correlating. There's no need to update the state.
       final var reason =
-          """
-          Expected to acknowledge correlating message with key '%d' to subscription with key '%d' \
-          but the subscription is already correlating to another message with key '%d'"""
-              .formatted(
-                  record.getValue().getMessageKey(),
-                  subscription.getKey(),
-                  subscription.getRecord().getMessageKey());
+          SUBSCRIPTION_ALREADY_CORRELATING_AGAIN_MESSAGE.formatted(
+              record.getValue().getMessageKey(),
+              subscription.getKey(),
+              subscription.getRecord().getMessageKey());
       rejectionWriter.appendRejection(record, RejectionType.INVALID_STATE, reason);
       return;
 
@@ -97,10 +102,8 @@ public final class MessageSubscriptionCorrelateProcessor
       // command. The message subscription was already marked as correlated. No need to update the
       // state.
       final var reason =
-          """
-          Expected to acknowledge correlating message with key '%d' to subscription with key '%d' \
-          but the subscription has already been correlated'"""
-              .formatted(record.getValue().getMessageKey(), subscription.getKey());
+          SUBSCRIPTION_ALREADY_CORRELATED_MESSAGE.formatted(
+              record.getValue().getMessageKey(), subscription.getKey());
       rejectionWriter.appendRejection(record, RejectionType.INVALID_STATE, reason);
       return;
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
@@ -27,15 +27,10 @@ import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.InstantSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @ExcludeAuthorizationCheck
 public final class MessageSubscriptionCorrelateProcessor
     implements TypedRecordProcessor<MessageSubscriptionRecord> {
-
-  private static final Logger LOG =
-      LoggerFactory.getLogger(MessageSubscriptionCorrelateProcessor.class);
 
   private static final String NO_SUBSCRIPTION_FOUND_MESSAGE =
       "Expected to correlate subscription for element with key '%d' and message name '%s', "
@@ -86,44 +81,29 @@ public final class MessageSubscriptionCorrelateProcessor
       // This concerns the acknowledgement of a retried correlate process message subscription
       // command. The message subscription was already marked as correlated for this message, and
       // another message has started correlating. There's no need to update the state.
-      LOG.warn(
-          """
-          Expected to acknowledge correlating message with key '{}' to subscription with key '{}' \
-          but the subscription is already correlating to another message with key '{}'""",
-          record.getValue().getMessageKey(),
-          subscription.getKey(),
-          subscription.getRecord().getMessageKey());
       final var reason =
-          String.format(
-              NO_SUBSCRIPTION_FOUND_MESSAGE,
-              record.getValue().getElementInstanceKey(),
-              BufferUtil.bufferAsString(record.getValue().getMessageNameBuffer()));
-      rejectionWriter.appendRejection(record, RejectionType.NOT_FOUND, reason);
+          """
+          Expected to acknowledge correlating message with key '%d' to subscription with key '%d' \
+          but the subscription is already correlating to another message with key '%d'"""
+              .formatted(
+                  record.getValue().getMessageKey(),
+                  subscription.getKey(),
+                  subscription.getRecord().getMessageKey());
+      rejectionWriter.appendRejection(record, RejectionType.INVALID_STATE, reason);
       return;
 
     } else if (!subscription.isCorrelating()) {
       // This concerns the acknowledgement of a retried correlate process message subscription
       // command. The message subscription was already marked as correlated. No need to update the
       // state.
-      LOG.debug(
-          """
-          Expected to acknowledge correlating message with key '{}' to subscription with key '{}' \
-          but the subscription is already correlating'""",
-          record.getValue().getMessageKey(),
-          subscription.getKey());
       final var reason =
-          String.format(
-              NO_SUBSCRIPTION_FOUND_MESSAGE,
-              record.getValue().getElementInstanceKey(),
-              BufferUtil.bufferAsString(record.getValue().getMessageNameBuffer()));
-      rejectionWriter.appendRejection(record, RejectionType.NOT_FOUND, reason);
+          """
+          Expected to acknowledge correlating message with key '%d' to subscription with key '%d' \
+          but the subscription is already correlating'"""
+              .formatted(record.getValue().getMessageKey(), subscription.getKey());
+      rejectionWriter.appendRejection(record, RejectionType.INVALID_STATE, reason);
       return;
     }
-
-    LOG.info(
-        "Acknowledged correlating message with key '{}' to subscription with key '{}'",
-        record.getValue().getMessageKey(),
-        subscription.getKey());
 
     final var messageSubscription = subscription.getRecord();
     stateWriter.appendFollowUpEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
@@ -73,6 +73,9 @@ public final class MessageSubscriptionCorrelateProcessor
       return;
     }
 
+    // todo: move the conditions we just added to the applier to here and don't write the event
+    //  under those conditions
+
     final var messageSubscription = subscription.getRecord();
     stateWriter.appendFollowUpEvent(
         subscription.getKey(), MessageSubscriptionIntent.CORRELATED, messageSubscription);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingMessageSubscriptionChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingMessageSubscriptionChecker.java
@@ -16,7 +16,13 @@ public final class PendingMessageSubscriptionChecker implements Runnable {
   private final SubscriptionCommandSender commandSender;
   private final PendingMessageSubscriptionState state;
 
+  /**
+   * Specifies the time in ms that no command is sent for a subscription after sending a command for
+   * it. This ensures that we don't overload the broker with duplicate command for the same
+   * subscription.
+   */
   private final long subscriptionTimeout;
+
   private final InstantSource clock;
 
   public PendingMessageSubscriptionChecker(
@@ -48,7 +54,7 @@ public final class PendingMessageSubscriptionChecker implements Runnable {
         record.getCorrelationKeyBuffer(),
         record.getTenantId());
 
-    // TODO (saig0): the state change of the sent time should be reflected by a record (#6364)
+    // Update the sent time for the subscription to avoid it being considered for resending too soon
     final var sentTime = clock.millis();
     state.onSent(record, sentTime);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -159,7 +159,10 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
 
     // return true if it has already been correlated, otherwise false
     final var lastCorrelatedMessageKey = subscription.getRecord().getMessageKey();
-    return lastCorrelatedMessageKey == messageKey;
+    // as correlations are ordered per message, a message is considered to have been correlated
+    // either if it is the last correlated message (keys are equal), or if it was a message prior to
+    // the last correlated one (messageKey is less than lastCorrelatedMessageKey).
+    return messageKey <= lastCorrelatedMessageKey;
   }
 
   private ExecutableFlowElement getCatchEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -160,7 +160,6 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
     // return true if it has already been correlated, otherwise false
     final var lastCorrelatedMessageKey = subscription.getRecord().getMessageKey();
     return lastCorrelatedMessageKey == messageKey;
-    // TODO: ensure the correlations arrive ordered by message key
   }
 
   private ExecutableFlowElement getCatchEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -100,6 +100,10 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
     } else if (subscription.isClosing()) {
       rejectCommand(command, RejectionType.INVALID_STATE, ALREADY_CLOSING_MESSAGE);
 
+    } else if (hasAlreadyBeenCorrelated(record, subscription)) {
+      rejectionWriter.appendRejection(
+          command, RejectionType.INVALID_STATE, "Already correlated this message");
+
     } else {
       final var elementInstance = elementInstanceState.getInstance(elementInstanceKey);
       final var canTriggerElement =
@@ -141,6 +145,18 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
         sendAcknowledgeCommand(record);
       }
     }
+  }
+
+  private boolean hasAlreadyBeenCorrelated(
+      final ProcessMessageSubscriptionRecord record,
+      final ProcessMessageSubscription subscription) {
+    // we only want to correlate a subscription once per message (by key)
+    final var messageKey = record.getMessageKey();
+
+    // return true if it has already been correlated, otherwise false
+    final var lastCorrelatedMessageKey = subscription.getRecord().getMessageKey();
+    return lastCorrelatedMessageKey == messageKey;
+    // TODO: ensure the correlations arrive ordered by message key
   }
 
   private ExecutableFlowElement getCatchEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -103,6 +103,10 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
     } else if (hasAlreadyBeenCorrelated(record, subscription)) {
       rejectionWriter.appendRejection(
           command, RejectionType.INVALID_STATE, "Already correlated this message");
+      // while we don't accept the command on this partition, we still need to acknowledge it to
+      // attempt recovering from a previous acknowledgment that didn't make it to the other
+      // partition.
+      sendAcknowledgeCommand(record);
 
     } else {
       final var elementInstance = elementInstanceState.getInstance(elementInstanceKey);
@@ -187,6 +191,7 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
 
   private void sendAcknowledgeCommand(final ProcessMessageSubscriptionRecord subscription) {
     subscriptionCommandSender.correlateMessageSubscription(
+        subscription.getMessageKey(),
         subscription.getSubscriptionPartitionId(),
         subscription.getProcessInstanceKey(),
         subscription.getElementInstanceKey(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
@@ -198,6 +198,7 @@ public class SubscriptionCommandSender {
   }
 
   public boolean correlateMessageSubscription(
+      final long messageKey,
       final int subscriptionPartitionId,
       final long processInstanceKey,
       final long elementInstanceKey,
@@ -212,7 +213,7 @@ public class SubscriptionCommandSender {
             .setProcessInstanceKey(processInstanceKey)
             .setElementInstanceKey(elementInstanceKey)
             .setBpmnProcessId(bpmnProcessId)
-            .setMessageKey(-1)
+            .setMessageKey(messageKey)
             .setMessageName(messageName)
             .setTenantId(tenantId));
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageSubscriptionCorrelatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageSubscriptionCorrelatedApplier.java
@@ -11,9 +11,14 @@ import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class MessageSubscriptionCorrelatedApplier
     implements TypedEventApplier<MessageSubscriptionIntent, MessageSubscriptionRecord> {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(MessageSubscriptionCorrelatedApplier.class);
 
   private final MutableMessageSubscriptionState messageSubscriptionState;
 
@@ -28,6 +33,37 @@ public final class MessageSubscriptionCorrelatedApplier
     // - workaround: load the subscription from the state instead of using the record directly
     final var subscription =
         messageSubscriptionState.get(value.getElementInstanceKey(), value.getMessageNameBuffer());
+
+    if (subscription.getRecord().getMessageKey() != value.getMessageKey()) {
+      // This concerns the acknowledgement of a retried correlate process message subscription
+      // command. The message subscription was already marked as correlated for this message, and
+      // another message has started correlating. There's no need to update the state.
+      LOG.warn(
+          """
+          Expected to acknowledge correlating message with key '{}' to subscription with key '{}' \
+          but the subscription is already correlating to another message with key '{}'""",
+          value.getMessageKey(),
+          key,
+          subscription.getRecord().getMessageKey());
+      return;
+
+    } else if (!subscription.isCorrelating()) {
+      // This concerns the acknowledgement of a retried correlate process message subscription
+      // command. The message subscription was already marked as correlated. No need to update the
+      // state.
+      LOG.debug(
+          """
+          Expected to acknowledge correlating message with key '{}' to subscription with key '{}' \
+          but the subscription is already correlating'""",
+          value.getMessageKey(),
+          key);
+      return;
+    }
+
+    LOG.info(
+        "Acknowledged correlating message with key '{}' to subscription with key '{}'",
+        value.getMessageKey(),
+        key);
 
     if (value.isInterrupting()) {
       messageSubscriptionState.remove(subscription);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
@@ -269,18 +269,17 @@ public final class DbMessageSubscriptionState
   @Override
   public void visitPending(final long deadline, final MessageSubscriptionVisitor visitor) {
     for (final var pendingSubscription : transientState.entriesBefore(deadline)) {
-      final var subscription =
-          get(
-              pendingSubscription.elementInstanceKey(),
-              BufferUtil.wrapString(pendingSubscription.messageName()));
+      final var elementInstanceKey = pendingSubscription.elementInstanceKey();
+      final var messageName = pendingSubscription.messageName();
+      final var subscription = get(elementInstanceKey, BufferUtil.wrapString(messageName));
 
       if (subscription == null) {
         // This case can occur while a scheduled job is running asynchronously
         // and the stream processor removes one of the returned subscriptions from the state.
         LOG.warn(
             "Expected to find a subscription with key {} and message name {}, but none found. The state is inconsistent.",
-            pendingSubscription.elementInstanceKey(),
-            pendingSubscription.messageName());
+            elementInstanceKey,
+            messageName);
       } else {
         visitor.visit(subscription);
       }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
@@ -276,7 +276,7 @@ public final class DbMessageSubscriptionState
       if (subscription == null) {
         // This case can occur while a scheduled job is running asynchronously
         // and the stream processor removes one of the returned subscriptions from the state.
-        LOG.warn(
+        LOG.debug(
             "Expected to find a subscription with key {} and message name {}, but none found. The state is inconsistent.",
             elementInstanceKey,
             messageName);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationMultiplePartitionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationMultiplePartitionsTest.java
@@ -17,12 +17,17 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.client.ProcessInstanceClient.ProcessInstanceCreationClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AbstractEndEventBuilder;
+import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
 import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.collection.Maps;
 import io.camunda.zeebe.test.util.record.ProcessInstances;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -279,6 +284,87 @@ public final class MessageCorrelationMultiplePartitionsTest {
             ProcessInstances.getCurrentVariables(processInstanceKey3).get("p"));
 
     assertThat(correlatedValues).contains("\"p1\"", "\"p2\"", "\"p3\"");
+  }
+
+  @Test
+  public void shouldCorrelateMessagesIdempotent() {
+    final var processId = Strings.newRandomValidBpmnId();
+    final var messageName = "event_message";
+    final var correlationKey = CORRELATION_KEYS.get(START_PARTITION_ID);
+    final var eventSubProcessStartId = "eventSubProcessStart";
+
+    // given
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .eventSubProcess(
+                    "subprocess",
+                    s ->
+                        s.startEvent(eventSubProcessStartId)
+                            .interrupting(false)
+                            .message(
+                                m ->
+                                    m.name(messageName)
+                                        .zeebeCorrelationKeyExpression("correlationKey"))
+                            .userTask()
+                            .endEvent())
+                .startEvent()
+                .userTask("wait", AbstractUserTaskBuilder::zeebeUserTask)
+                .endEvent("terminate_instance", AbstractEndEventBuilder::terminate)
+                .done())
+        .deploy();
+    final var processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariable("correlationKey", correlationKey)
+            .createOnPartition(2);
+
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+    engine.pauseProcessing(2);
+
+    // when
+    for (int i = 0; i < 10; i++) {
+      engine
+          .message()
+          .withName(messageName)
+          .withCorrelationKey(correlationKey)
+          .withTimeToLive(Duration.ofMinutes(30))
+          .onPartition(1)
+          .publish();
+    }
+
+    // increase the time to retry the inter-partition correlation several times
+    engine.increaseTime(MessageObserver.SUBSCRIPTION_CHECK_INTERVAL);
+    engine.increaseTime(MessageObserver.SUBSCRIPTION_CHECK_INTERVAL);
+    engine.increaseTime(MessageObserver.SUBSCRIPTION_CHECK_INTERVAL);
+    engine.resumeProcessing(2);
+
+    // await for all 10 messages to be correlated
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId(eventSubProcessStartId)
+                .limit(10)
+                .toList())
+        .hasSize(10);
+
+    // complete the task to complete the process instance, for easy record stream limiting
+    engine.userTask().ofInstance(processInstanceKey).complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted()
+                .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withElementId(eventSubProcessStartId)
+                .count())
+        .describedAs("Expected to correlate 10 messages exactly")
+        .isEqualTo(10);
   }
 
   private int getPartitionId(final String correlationKey) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationMultiplePartitionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationMultiplePartitionsTest.java
@@ -319,7 +319,8 @@ public final class MessageCorrelationMultiplePartitionsTest {
             .processInstance()
             .ofBpmnProcessId(processId)
             .withVariable("correlationKey", correlationKey)
-            .createOnPartition(2);
+            .onPartition(2)
+            .create();
 
     RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
         .withProcessInstanceKey(processInstanceKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -306,7 +306,14 @@ public final class MessageStreamProcessorTest {
     // when
     rule.writeCommand(MessageSubscriptionIntent.CREATE, subscription);
     rule.writeCommand(MessageIntent.PUBLISH, message);
-    rule.writeCommand(MessageSubscriptionIntent.CORRELATE, subscription);
+
+    final var firstMessage =
+        awaitAndGet(
+            () ->
+                rule.events().onlyMessageRecords().withIntent(MessageIntent.PUBLISHED).findFirst());
+
+    rule.writeCommand(
+        MessageSubscriptionIntent.CORRELATE, subscription.setMessageKey(firstMessage.getKey()));
     rule.writeCommand(MessageIntent.PUBLISH, message);
 
     // then
@@ -314,8 +321,6 @@ public final class MessageStreamProcessorTest {
         () ->
             rule.events().onlyMessageRecords().withIntent(MessageIntent.PUBLISHED).limit(2).count()
                 == 2);
-    final long firstMessageKey =
-        rule.events().onlyMessageRecords().withIntent(MessageIntent.PUBLISHED).getFirst().getKey();
     final long lastMessageKey =
         rule.events()
             .onlyMessageRecords()
@@ -330,7 +335,7 @@ public final class MessageStreamProcessorTest {
             eq(subscription.getElementInstanceKey()),
             eq(subscription.getBpmnProcessIdBuffer()),
             any(),
-            eq(firstMessageKey),
+            eq(firstMessage.getKey()),
             any(),
             any(),
             eq(DEFAULT_TENANT));
@@ -365,7 +370,12 @@ public final class MessageStreamProcessorTest {
                 .withIntent(MessageSubscriptionIntent.CREATED)
                 .exists());
 
-    rule.writeCommand(MessageSubscriptionIntent.CORRELATE, subscription);
+    final var firstMessageRecord =
+        rule.events().onlyMessageRecords().withIntent(MessageIntent.PUBLISHED).getFirst();
+
+    rule.writeCommand(
+        MessageSubscriptionIntent.CORRELATE,
+        subscription.setMessageKey(firstMessageRecord.getKey()));
     rule.writeCommand(MessageIntent.PUBLISH, second);
 
     // then
@@ -390,7 +400,13 @@ public final class MessageStreamProcessorTest {
                 .onlyMessageSubscriptionRecords()
                 .withIntent(MessageSubscriptionIntent.CREATED)
                 .exists());
-    rule.writeCommand(MessageSubscriptionIntent.CORRELATE, subscription);
+
+    final var firstMessage =
+        awaitAndGet(
+            () ->
+                rule.events().onlyMessageRecords().withIntent(MessageIntent.PUBLISHED).findFirst());
+    rule.writeCommand(
+        MessageSubscriptionIntent.CORRELATE, subscription.setMessageKey(firstMessage.getKey()));
 
     // then
     assertAllMessagesReceived(subscription);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.engine.util.StreamProcessorRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
@@ -46,6 +47,8 @@ import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.FeatureFlags;
 import java.time.Duration;
 import java.time.InstantSource;
+import java.util.Optional;
+import java.util.function.Supplier;
 import org.agrona.DirectBuffer;
 import org.awaitility.Awaitility;
 import org.junit.Before;
@@ -116,7 +119,9 @@ public final class MessageStreamProcessorTest {
     rule.writeCommand(MessageSubscriptionIntent.CREATE, subscription);
 
     // then
-    final Record<MessageSubscriptionRecord> rejection = awaitAndGetFirstSubscriptionRejection();
+    final Record<MessageSubscriptionRecord> rejection =
+        awaitAndGet(
+            () -> rule.events().onlyMessageSubscriptionRecords().onlyRejections().findFirst());
 
     assertThat(rejection.getIntent()).isEqualTo(MessageSubscriptionIntent.CREATE);
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
@@ -219,7 +224,9 @@ public final class MessageStreamProcessorTest {
     rule.writeCommand(MessageSubscriptionIntent.CORRELATE, subscription);
 
     // then
-    final Record<MessageSubscriptionRecord> rejection = awaitAndGetFirstSubscriptionRejection();
+    final Record<MessageSubscriptionRecord> rejection =
+        awaitAndGet(
+            () -> rule.events().onlyMessageSubscriptionRecords().onlyRejections().findFirst());
 
     assertThat(rejection.getIntent()).isEqualTo(MessageSubscriptionIntent.CORRELATE);
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
@@ -243,7 +250,9 @@ public final class MessageStreamProcessorTest {
     rule.writeCommand(MessageSubscriptionIntent.DELETE, subscription);
 
     // then
-    final Record<MessageSubscriptionRecord> rejection = awaitAndGetFirstSubscriptionRejection();
+    final Record<MessageSubscriptionRecord> rejection =
+        awaitAndGet(
+            () -> rule.events().onlyMessageSubscriptionRecords().onlyRejections().findFirst());
 
     assertThat(rejection.getIntent()).isEqualTo(MessageSubscriptionIntent.DELETE);
     assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
@@ -503,15 +512,9 @@ public final class MessageStreamProcessorTest {
     return message;
   }
 
-  private Record<MessageSubscriptionRecord> awaitAndGetFirstSubscriptionRejection() {
-    waitUntil(
-        () ->
-            rule.events()
-                .onlyMessageSubscriptionRecords()
-                .onlyRejections()
-                .findFirst()
-                .isPresent());
-
-    return rule.events().onlyMessageSubscriptionRecords().onlyRejections().findFirst().get();
+  private <T extends RecordValue> Record<T> awaitAndGet(
+      final Supplier<Optional<Record<T>>> supplier) {
+    waitUntil(() -> supplier.get().isPresent());
+    return supplier.get().get();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
@@ -361,6 +361,7 @@ public class SubscriptionCommandSenderTest {
 
     // when
     subscriptionCommandSender.correlateMessageSubscription(
+        -1,
         DIFFERENT_PARTITION,
         DIFFERENT_RECEIVER_PARTITION_KEY,
         DEFAULT_ELEMENT_INSTANCE_KEY,
@@ -379,6 +380,7 @@ public class SubscriptionCommandSenderTest {
 
     // when
     subscriptionCommandSender.correlateMessageSubscription(
+        -1,
         SAME_PARTITION,
         DIFFERENT_RECEIVER_PARTITION_KEY,
         DEFAULT_ELEMENT_INSTANCE_KEY,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorCo
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFactory;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.TestStreams.FluentLogWriter;
 import io.camunda.zeebe.engine.util.client.CommandWriter;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.WriteContext;
@@ -34,6 +35,7 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
 
 public class StreamProcessingComposite implements CommandWriter {
 
@@ -344,6 +346,14 @@ public class StreamProcessingComposite implements CommandWriter {
             .intent(intent)
             .authorizationsWithUsername(username, TenantOwned.DEFAULT_TENANT_IDENTIFIER)
             .event(value);
+    return writeActor.submit(writer::write).join();
+  }
+
+  @Override
+  public long writeCommandOnPartition(
+      final int partitionId, final UnaryOperator<FluentLogWriter> builder) {
+    final var writer =
+        builder.apply(streams.newRecord(getLogName(partitionId)).recordType(RecordType.COMMAND));
     return writeActor.submit(writer::write).join();
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorFa
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.StreamProcessingComposite.StreamProcessorTestFactory;
+import io.camunda.zeebe.engine.util.TestStreams.FluentLogWriter;
 import io.camunda.zeebe.engine.util.client.CommandWriter;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.util.ListLogStorage;
@@ -40,6 +41,7 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
@@ -309,6 +311,12 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
       final String username) {
     return streamProcessingComposite.writeCommand(
         requestStreamId, requestId, intent, value, username);
+  }
+
+  @Override
+  public long writeCommandOnPartition(
+      final int partitionId, final UnaryOperator<FluentLogWriter> builder) {
+    return streamProcessingComposite.writeCommandOnPartition(partitionId, builder);
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/CommandWriter.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/CommandWriter.java
@@ -7,9 +7,11 @@
  */
 package io.camunda.zeebe.engine.util.client;
 
+import io.camunda.zeebe.engine.util.TestStreams.FluentLogWriter;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import java.util.function.UnaryOperator;
 
 public interface CommandWriter {
 
@@ -71,6 +73,8 @@ public interface CommandWriter {
       final Intent intent,
       final UnifiedRecordValue value,
       final String username);
+
+  long writeCommandOnPartition(int partitionId, final UnaryOperator<FluentLogWriter> builder);
 
   long writeCommandOnPartition(
       final int partitionId, final Intent intent, final UnifiedRecordValue recordValue);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -146,6 +146,15 @@ public final class ProcessInstanceClient {
       return create(AuthorizationUtil.getAuthInfo(username));
     }
 
+    public long createOnPartition(final int partitionId) {
+      final long position =
+          writer.writeCommandOnPartition(
+              partitionId, ProcessInstanceCreationIntent.CREATE, processInstanceCreationRecord);
+
+      final var resultingRecord = expectation.apply(position);
+      return resultingRecord.getValue().getProcessInstanceKey();
+    }
+
     public ProcessInstanceCreationClient expectRejection() {
       expectation = REJECTION_EXPECTATION;
       return this;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ProcessInstanceClient.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.util.client;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
+import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.util.AuthorizationUtil;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
@@ -39,6 +40,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 import java.util.function.Function;
 import org.agrona.DirectBuffer;
@@ -77,9 +79,11 @@ public final class ProcessInstanceClient {
                     .withIntent(ProcessInstanceCreationIntent.CREATE)
                     .withSourceRecordPosition(position)
                     .getFirst();
+    private static final int DEFAULT_PARTITION = 1;
 
     private final CommandWriter writer;
     private final ProcessInstanceCreationRecord processInstanceCreationRecord;
+    private int partition = DEFAULT_PARTITION;
 
     private Function<Long, Record<ProcessInstanceCreationRecordValue>> expectation =
         SUCCESS_EXPECTATION;
@@ -88,6 +92,11 @@ public final class ProcessInstanceClient {
       this.writer = writer;
       processInstanceCreationRecord = new ProcessInstanceCreationRecord();
       processInstanceCreationRecord.setBpmnProcessId(bpmnProcessId);
+    }
+
+    public ProcessInstanceCreationClient onPartition(final int partition) {
+      this.partition = partition;
+      return this;
     }
 
     public ProcessInstanceCreationClient withVersion(final int version) {
@@ -126,17 +135,20 @@ public final class ProcessInstanceClient {
     }
 
     public long create() {
-      final long position =
-          writer.writeCommand(ProcessInstanceCreationIntent.CREATE, processInstanceCreationRecord);
-
-      final var resultingRecord = expectation.apply(position);
-      return resultingRecord.getValue().getProcessInstanceKey();
+      return create(
+          AuthorizationUtil.getAuthInfoWithClaim(Authorization.AUTHORIZED_ANONYMOUS_USER, true));
     }
 
     public long create(final AuthInfo authorizations) {
       final long position =
-          writer.writeCommand(
-              ProcessInstanceCreationIntent.CREATE, processInstanceCreationRecord, authorizations);
+          writer.writeCommandOnPartition(
+              partition,
+              r ->
+                  r.intent(ProcessInstanceCreationIntent.CREATE)
+                      .event(processInstanceCreationRecord)
+                      .authorizations(authorizations)
+                      .requestId(new Random().nextLong())
+                      .requestStreamId(new Random().nextInt()));
 
       final var resultingRecord = expectation.apply(position);
       return resultingRecord.getValue().getProcessInstanceKey();
@@ -144,15 +156,6 @@ public final class ProcessInstanceClient {
 
     public long create(final String username) {
       return create(AuthorizationUtil.getAuthInfo(username));
-    }
-
-    public long createOnPartition(final int partitionId) {
-      final long position =
-          writer.writeCommandOnPartition(
-              partitionId, ProcessInstanceCreationIntent.CREATE, processInstanceCreationRecord);
-
-      final var resultingRecord = expectation.apply(position);
-      return resultingRecord.getValue().getProcessInstanceKey();
     }
 
     public ProcessInstanceCreationClient expectRejection() {

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -555,6 +555,9 @@ public class CompactRecordLogger {
         .append("@[")
         .append(shortenKey(value.getElementInstanceKey()))
         .append("]")
+        .append(" msg[")
+        .append(shortenKey(value.getMessageKey()))
+        .append("]")
         .append(
             summarizeProcessInformation(value.getBpmnProcessId(), value.getProcessInstanceKey()))
         .append(summarizeVariables(value.getVariables()));


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This pull request resolves a bug related to message correlation retries by ensuring that message correlation commands are processed idempotently.

### Problem context
A message correlation is split across two partitions: the message partition (where the message is expected) and the process instance partition (where the process instance exists that awaits a message). When a message is published to the message partition, and that partition is aware of a process instance awaiting the message (represented by a message subscription on the message partition), it attempts to correlate the message by sending a `CORRELATE` command to the process instance partition. This command must be processed and then acknowledged by sending a `CORRELATE` command back to the message partition. The communication between these partition is unreliable, and so either of these commands may fail to arrive at the other partition. Therefore, a retry mechanism exists in the message subscription partition to re-send this `CORRELATE` command to the process instance partition. The checker runs every 30s and only retries commands that haven't been communicated about at least 10s.

If the acknowledgement would be lost, or the partition is down for some time, then multiple `CORRELATE` commands for the same message may exist on the process instance partition due to the retry. Each of these commands would trigger a non-interrupting message catch event an additional time.

```mermaid
sequenceDiagram
    participant MP as Message Partition
    participant PIP as Process Instance Partition

    MP->>PIP: CORRELATE (Message 1)
    Note right of MP: Initial correlation attempt

    PIP->>PIP: Trigger non-interrupting message catch event
    PIP-->>MP: ACK (CORRELATE)
    Note left of PIP: ACK lost due to network issues

    MP->>PIP: CORRELATE (Message 1) [Retry]
    Note right of MP: Retry due to missing ACK
    
    PIP->>PIP: Trigger non-interrupting message catch event again
    Note right of PIP: Multiple correlations trigger the event multiple times
```

### Solving the problem

This pull request solves the problem by deduplicating the `CORRELATE` commands on the process instance partition. It can do this because only one message will be correlating to the message subscription at a time. This means that ordering is guaranteed already, and we can simply reject a secondary `CORRELATE` command for the same message (by its message key). Note that the last correlated message key is stored in the process message subscription.

```mermaid
sequenceDiagram
    participant MP as Message Partition
    participant PIP as Process Instance Partition

    MP->>PIP: CORRELATE (Message 1)
    Note right of MP: Initial correlation attempt

    PIP->>PIP: Trigger non-interrupting message catch event
    PIP-->>MP: ACK (CORRELATE)
    Note left of PIP: ACK lost due to network issues

    MP->>PIP: CORRELATE (Message 1) [Retry]
    Note right of MP: Retry due to missing ACK
    
    PIP->>PIP: Reject duplicate CORRELATE (Message 1)
    Note right of PIP: Subscription knows message 1 correlated last
```

This change required an additional change: Reject retried acknowledgements. We must acknowledge again, because the acknowledgement can be lost. If we would not do this, then we may accidentally change things about our message subscription that are no longer valid because it may have already moved on. We have to reject it:
- if the message key of the acknowledgement doesn't match the message key currently on the message subscription, because this means that we're already correlating a different message
- or if the message subscription is already not correlating anymore. This simply means that we've processed the previous acknowledgement and there were no messages that correlated to it afterward.

```mermaid
sequenceDiagram
    participant MP as Message Partition
    participant PIP as Process Instance Partition

    MP->>PIP: CORRELATE (Message 1)
    MP->>PIP: CORRELATE (Message 1) [Retry]

    PIP->>PIP: Trigger non-interrupting message catch event
    PIP-->>MP: ACK (Message 1)

    MP->>MP: Accept ACK (Message 1)

    PIP->>PIP: Reject duplicate CORRELATE (Message 1)
    PIP-->>MP: ACK (Message 1)

    MP->>MP: Reject ACK (Message 1)
    Note right of MP: Subscription already accepted this ack
```

### Additional changes

- As part of resolving this bug, a test case is added for the bug specifically. To ensure that the test case worked, some special test infrastructure required changes. For the test, see 222c0de. For the infrastructure changes, see 9ab9c37, d5413e1, 8fdbfc5.
- The bugfix itself also requires some test changes. Correlate commands must now reference a message key, otherwise they can be rejected. This was not always the case in existing tests. See 303fbcd and e4d55c4.
- A warning log was lowered to debug level, as it is not anything actionable for a user. See 5c76a8e.
- The compact record logger didn't print the message key for message subscription. See 2dc4545.
- I've added some documentation where useful.

### Backporting

This problems seems to be very old, and will require backporting to all supported versions. I'll be backporting this to 8.7, 8.6, 8.5, 8.4, and 8.3.

Given that some of the test infrastructure changes are specific to authorizations in zeebe (a so far unreleased feature), I expect some conflicts. I'll let backport-action take care of creating the pull requests for me, and will record the conflict resolutions locally for easy re-applying.

## Related issues

closes #26926
