### PR TITLE
Migrate exporter director metrics to Micrometer

### DIFF
--- a/monitor/grafana/camunda-performance.json
+++ b/monitor/grafana/camunda-performance.json
@@ -1579,7 +1579,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.5, sum(rate(zeebe_exporting_latency_bucket{namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.5, sum(rate(zeebe_exporting_latency_bucket{namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval]) or rate(zeebe_exporting_latency_seconds_bucket{namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "p50 (avg)",
@@ -1592,7 +1592,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum(rate(zeebe_exporting_latency_bucket{namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(zeebe_exporting_latency_bucket{namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval]) or rate(zeebe_exporting_latency_seconds_bucket{namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
               "hide": false,
               "instant": false,
               "legendFormat": "p99",
@@ -1605,7 +1605,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.90, sum(rate(zeebe_exporting_latency_bucket{namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.90, sum(rate(zeebe_exporting_latency_bucket{namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval]) or rate(zeebe_exporting_latency_seconds_bucket{namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
               "hide": false,
               "instant": false,
               "legendFormat": "p90",
@@ -1970,7 +1970,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.50, sum(rate(zeebe_exporter_exporting_duration_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.50, sum(rate(zeebe_exporter_exporting_duration_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval]) or rate(zeebe_exporter_exporting_duration_seconds_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (le))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "p50",
@@ -1983,7 +1983,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum(rate(zeebe_exporter_exporting_duration_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(zeebe_exporter_exporting_duration_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval]) or rate(zeebe_exporter_exporting_duration_seconds_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (le))",
               "hide": false,
               "instant": false,
               "legendFormat": "p99",
@@ -1996,7 +1996,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.90, sum(rate(zeebe_exporter_exporting_duration_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.90, sum(rate(zeebe_exporter_exporting_duration_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval]) or rate(zeebe_exporter_exporting_duration_seconds_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (le))",
               "hide": false,
               "instant": false,
               "legendFormat": "p90",

--- a/zeebe/broker/pom.xml
+++ b/zeebe/broker/pom.xml
@@ -186,6 +186,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-commons</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -112,7 +112,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
                         meterRegistry,
                         clock))
             .collect(Collectors.toCollection(ArrayList::new));
-    metrics = new ExporterMetrics(partitionId);
+    metrics = new ExporterMetrics(meterRegistry);
     metrics.initializeExporterState(exporterPhase);
     recordExporter = new RecordExporter(metrics, containers, partitionId, clock);
     exportingRetryStrategy = new BackOffRetryStrategy(actor, Duration.ofSeconds(10));

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetrics.java
@@ -33,8 +33,8 @@ public final class ExporterMetrics {
   private final Map<String, AtomicLong> lastUpdatedExportedPositions = new HashMap<>();
   private final AtomicInteger exporterState = new AtomicInteger();
   private final Map<ValueType, Timer> exportingLatency = new HashMap<>();
-  private final Table<Timer, String, ValueType> exporterExportingDuration = Table.simple();
-  private final Table<Counter, ExporterActionKeyNames, ValueType> exporterEvents =
+  private final Table<String, ValueType, Timer> exporterExportingDuration = Table.simple();
+  private final Table<ExporterActionKeyNames, ValueType, Counter> exporterEvents =
       Table.ofEnum(ExporterActionKeyNames.class, ValueType.class, Counter[]::new);
 
   private final MeterRegistry meterRegistry;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetrics.java
@@ -7,120 +7,99 @@
  */
 package io.camunda.zeebe.broker.exporter.stream;
 
+import io.camunda.zeebe.broker.exporter.stream.ExporterMetricsDoc.ExporterActionKeyNames;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.prometheus.client.Counter;
-import io.prometheus.client.Gauge;
-import io.prometheus.client.Histogram;
+import io.camunda.zeebe.util.CloseableSilently;
+import io.camunda.zeebe.util.collection.Table;
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 public final class ExporterMetrics {
-
-  private static final String LABEL_NAME_PARTITION = "partition";
   private static final String LABEL_NAME_EXPORTER = "exporter";
   private static final String LABEL_NAME_ACTION = "action";
   private static final String LABEL_NAME_VALUE_TYPE = "valueType";
-  private static final String NAMESPACE_ZEEBE = "zeebe";
 
-  private static final Histogram EXPORTING_LATENCY =
-      Histogram.build()
-          .namespace(NAMESPACE_ZEEBE)
-          .name("exporting_latency")
-          .help("Time between a record is written until it is picked up for exporting (in seconds)")
-          .labelNames(LABEL_NAME_PARTITION, LABEL_NAME_VALUE_TYPE)
-          .register();
+  private final Map<String, AtomicLong> lastExportedPositions = new HashMap<>();
+  private final Map<String, AtomicLong> lastUpdatedExportedPositions = new HashMap<>();
+  private final AtomicInteger exporterState = new AtomicInteger();
+  private final Map<ValueType, Timer> exportingLatency = new HashMap<>();
+  private final Table<Timer, String, ValueType> exporterExportingDuration = Table.simple();
+  private final Table<Counter, ExporterActionKeyNames, ValueType> exporterEvents =
+      Table.ofEnum(ExporterActionKeyNames.class, ValueType.class, Counter[]::new);
 
-  private static final Histogram EXPORTER_EXPORTING_DURATION =
-      Histogram.build()
-          .namespace(NAMESPACE_ZEEBE)
-          .name("exporter_exporting_duration")
-          .help("The time an exporter needs to export certain record (duration in seconds)")
-          .labelNames(LABEL_NAME_PARTITION, LABEL_NAME_EXPORTER, LABEL_NAME_VALUE_TYPE)
-          .register();
+  private final MeterRegistry meterRegistry;
 
-  private static final Counter EXPORTER_EVENTS =
-      Counter.build()
-          .namespace(NAMESPACE_ZEEBE)
-          .name("exporter_events_total")
-          .help("Number of events processed by exporter")
-          .labelNames(LABEL_NAME_ACTION, LABEL_NAME_PARTITION, LABEL_NAME_VALUE_TYPE)
-          .register();
-
-  private static final Gauge LAST_EXPORTED_POSITION =
-      Gauge.build()
-          .namespace(NAMESPACE_ZEEBE)
-          .name("exporter_last_exported_position")
-          .help("The last exported position by exporter and partition.")
-          .labelNames(LABEL_NAME_EXPORTER, LABEL_NAME_PARTITION)
-          .register();
-
-  private static final Gauge LAST_UPDATED_EXPORTED_POSITION =
-      Gauge.build()
-          .namespace(NAMESPACE_ZEEBE)
-          .name("exporter_last_updated_exported_position")
-          .help("The last exported position which was also updated/committed by the exporter.")
-          .labelNames(LABEL_NAME_EXPORTER, LABEL_NAME_PARTITION)
-          .register();
-
-  private static final Gauge EXPORTER_PHASE =
-      Gauge.build()
-          .namespace(NAMESPACE_ZEEBE)
-          .name("exporter_state")
-          .help(
-              "Describes the phase of the exporter, namely if it is exporting, paused or soft paused.")
-          .labelNames(LABEL_NAME_PARTITION)
-          .register();
-  private final String partitionIdLabel;
-
-  private final Gauge.Child exporterPhase;
-
-  public ExporterMetrics(final int partitionId) {
-    partitionIdLabel = String.valueOf(partitionId);
-    exporterPhase = EXPORTER_PHASE.labels(partitionIdLabel);
-  }
-
-  private void event(final String action, final ValueType valueType) {
-    EXPORTER_EVENTS.labels(action, partitionIdLabel, valueType.name()).inc();
+  public ExporterMetrics(final MeterRegistry meterRegistry) {
+    this.meterRegistry = Objects.requireNonNull(meterRegistry, "must specify a meter registry");
   }
 
   public void setExporterActive() {
-    exporterPhase.set(0);
+    exporterState.set(0);
   }
 
   public void setExporterPaused() {
-    exporterPhase.set(1);
+    exporterState.set(1);
   }
 
   public void setExporterSoftPaused() {
-    exporterPhase.set(2);
+    exporterState.set(2);
   }
 
   public void eventExported(final ValueType valueType) {
-    event("exported", valueType);
+    event(ExporterActionKeyNames.EXPORTED, valueType);
   }
 
   public void eventSkipped(final ValueType valueType) {
-    event("skipped", valueType);
+    event(ExporterActionKeyNames.SKIPPED, valueType);
   }
 
   public void setLastUpdatedExportedPosition(final String exporter, final long position) {
-    LAST_UPDATED_EXPORTED_POSITION.labels(exporter, partitionIdLabel).set(position);
+    lastUpdatedExportedPositions
+        .computeIfAbsent(
+            exporter,
+            id ->
+                registerPerExporterGauge(
+                    ExporterMetricsDoc.LAST_UPDATED_EXPORTED_POSITION, id, position))
+        .set(position);
   }
 
   public void setLastExportedPosition(final String exporter, final long position) {
-    LAST_EXPORTED_POSITION.labels(exporter, partitionIdLabel).set(position);
+    lastExportedPositions
+        .computeIfAbsent(
+            exporter,
+            id -> registerPerExporterGauge(ExporterMetricsDoc.LAST_EXPORTED_POSITION, id, position))
+        .set(position);
   }
 
   public void exportingLatency(
       final ValueType valueType, final long written, final long exporting) {
-    EXPORTING_LATENCY
-        .labels(partitionIdLabel, valueType.name())
-        .observe((exporting - written) / 1000f);
+    exportingLatency
+        .computeIfAbsent(valueType, this::registerExportingLatency)
+        .record(exporting - written, TimeUnit.MILLISECONDS);
   }
 
-  public Histogram.Timer startExporterExportingTimer(
+  public CloseableSilently startExporterExportingTimer(
       final ValueType valueType, final String exporter) {
-    return EXPORTER_EXPORTING_DURATION
-        .labels(partitionIdLabel, exporter, valueType.name())
-        .startTimer();
+    final var timer =
+        exporterExportingDuration.computeIfAbsent(
+            exporter, valueType, this::registerExportingDuration);
+    return MicrometerUtil.timer(timer, Timer.start(meterRegistry));
+  }
+
+  private void event(final ExporterActionKeyNames action, final ValueType valueType) {
+    exporterEvents
+        .computeIfAbsent(action, valueType, this::registerExporterEventCounter)
+        .increment();
   }
 
   public void initializeExporterState(final ExporterPhase state) {
@@ -135,5 +114,51 @@ public final class ExporterMetrics {
         setExporterActive();
         break;
     }
+
+    final ExtendedMeterDocumentation meterDoc = ExporterMetricsDoc.EXPORTER_STATE;
+    Gauge.builder(meterDoc.getName(), exporterState, Number::intValue)
+        .description(meterDoc.getDescription())
+        .register(meterRegistry);
+  }
+
+  private Counter registerExporterEventCounter(
+      final ExporterActionKeyNames action, final ValueType valueType) {
+    final var meterDoc = ExporterMetricsDoc.EXPORTER_EVENTS;
+    return Counter.builder(meterDoc.getName())
+        .description(meterDoc.getDescription())
+        .tag(LABEL_NAME_ACTION, action.name())
+        .tag(LABEL_NAME_VALUE_TYPE, valueType.name())
+        .register(meterRegistry);
+  }
+
+  private AtomicLong registerPerExporterGauge(
+      final ExtendedMeterDocumentation meterDoc,
+      final String exporterId,
+      final long initialPosition) {
+    final var position = new AtomicLong(initialPosition);
+    Gauge.builder(meterDoc.getName(), position, Number::longValue)
+        .tag(LABEL_NAME_EXPORTER, exporterId)
+        .description(meterDoc.getDescription())
+        .register(meterRegistry);
+    return position;
+  }
+
+  private Timer registerExportingDuration(final String exporterId, final ValueType valueType) {
+    final var meterDoc = ExporterMetricsDoc.EXPORTING_DURATION;
+    return Timer.builder(meterDoc.getName())
+        .description(meterDoc.getDescription())
+        .serviceLevelObjectives(meterDoc.getServiceLevelObjectives())
+        .tag(LABEL_NAME_VALUE_TYPE, valueType.name())
+        .tag(LABEL_NAME_EXPORTER, exporterId)
+        .register(meterRegistry);
+  }
+
+  private Timer registerExportingLatency(final ValueType valueType) {
+    final var meterDoc = ExporterMetricsDoc.EXPORTING_LATENCY;
+    return Timer.builder(meterDoc.getName())
+        .description(meterDoc.getDescription())
+        .serviceLevelObjectives(meterDoc.getServiceLevelObjectives())
+        .tag(LABEL_NAME_VALUE_TYPE, valueType.name())
+        .register(meterRegistry);
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetricsDoc.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetricsDoc.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.exporter.stream;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Meter.Type;
+
+/**
+ * Documents the various generic exporter related metrics as used by the {@link ExporterDirector}.
+ */
+@SuppressWarnings("NullableProblems")
+public enum ExporterMetricsDoc implements ExtendedMeterDocumentation {
+  /** The last exported position by exporter and partition */
+  LAST_EXPORTED_POSITION {
+    @Override
+    public String getName() {
+      return "zeebe.exporter.last.exported.position";
+    }
+
+    @Override
+    public Meter.Type getType() {
+      return Meter.Type.GAUGE;
+    }
+
+    @Override
+    public String getDescription() {
+      return "The last exported position by exporter and partition";
+    }
+  },
+
+  /** The last exported position which was also updated/committed by the exporter */
+  LAST_UPDATED_EXPORTED_POSITION {
+    @Override
+    public String getName() {
+      return "zeebe.exporter.last.updated.exported.position";
+    }
+
+    @Override
+    public Meter.Type getType() {
+      return Meter.Type.GAUGE;
+    }
+
+    @Override
+    public String getDescription() {
+      return "The last exported position which was also updated/committed by the exporter";
+    }
+  },
+
+  /**
+   * Describes the phase of the exporter, namely if it is exporting, paused or soft paused; valid
+   * values are those found in {@link ExporterPhase}
+   */
+  EXPORTER_STATE {
+    @Override
+    public String getName() {
+      return "zeebe.exporter.state";
+    }
+
+    @Override
+    public Meter.Type getType() {
+      return Meter.Type.GAUGE;
+    }
+
+    @Override
+    public String getDescription() {
+      return """
+        Describes the phase of the exporter, namely if it is exporting (0), paused (1), soft \
+        paused (2), or closed (3)""";
+    }
+  },
+
+  /** Time between a record is written until it is picked up for exporting (in seconds). */
+  EXPORTING_LATENCY {
+    @Override
+    public String getName() {
+      return "zeebe.exporting.latency";
+    }
+
+    @Override
+    public Meter.Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Time between a record is written until it is picked up for exporting (in seconds)";
+    }
+  },
+
+  /** The time an exporter needs to export certain record (duration in seconds) */
+  EXPORTING_DURATION {
+    @Override
+    public String getName() {
+      return "zeebe.exporter.exporting.duration";
+    }
+
+    @Override
+    public Meter.Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "The time an exporter needs to export certain record (duration in seconds)";
+    }
+  },
+
+  /** Number of events processed by exporter by action (see {@link ExporterActionKeyNames} */
+  EXPORTER_EVENTS {
+    @Override
+    public String getName() {
+      return "zeebe.exporter.events.total";
+    }
+
+    @Override
+    public Meter.Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Number of events processed by exporter";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return ExporterActionKeyNames.values();
+    }
+  };
+
+  @SuppressWarnings("NullableProblems")
+  enum ExporterActionKeyNames implements KeyName {
+    SKIPPED {
+      @Override
+      public String asString() {
+        return "skipped";
+      }
+    },
+
+    EXPORTED {
+      @Override
+      public String asString() {
+        return "exported";
+      }
+    };
+
+    @Override
+    public boolean isRequired() {
+      return true;
+    }
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerRuntime.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerRuntime.java
@@ -51,7 +51,7 @@ public final class ExporterContainerRuntime implements CloseableSilently {
     scheduler.submitActor(actor).join();
 
     state = new ExportersState(zeebeDb, zeebeDb.createContext());
-    metrics = new ExporterMetrics(1);
+    metrics = new ExporterMetrics(new SimpleMeterRegistry());
     metrics.initializeExporterState(ExporterPhase.EXPORTING);
     meterRegistry = new SimpleMeterRegistry();
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -56,8 +56,6 @@ import org.mockito.verification.VerificationWithTimeout;
 
 public final class ExporterDirectorTest {
 
-  private static final int PARTITION_ID = 1;
-
   private static final String EXPORTER_ID_1 = "exporter-1";
   private static final String EXPORTER_ID_2 = "exporter-2";
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDisableTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDisableTest.java
@@ -97,7 +97,7 @@ public class ExporterDisableTest {
 
     // when - then
     assertThat(rule.getDirector().disableExporter(EXPORTER_ID_1))
-        .succeedsWithin(Duration.ofMillis(100));
+        .succeedsWithin(Duration.ofSeconds(5));
   }
 
   @Test
@@ -107,7 +107,7 @@ public class ExporterDisableTest {
 
     // when - then
     assertThat(rule.getDirector().disableExporter("non-existing-exporter"))
-        .succeedsWithin(Duration.ofMillis(100));
+        .succeedsWithin(Duration.ofSeconds(5));
   }
 
   @Test
@@ -120,6 +120,6 @@ public class ExporterDisableTest {
 
     // then
     assertThat(rule.getDirector().disableExporter(EXPORTER_ID_1))
-        .succeedsWithin(Duration.ofMillis(100));
+        .succeedsWithin(Duration.ofSeconds(5));
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRule.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.stream.api.EventFilter;
 import io.camunda.zeebe.stream.api.StreamClock;
 import io.camunda.zeebe.stream.impl.SkipPositionsFilter;
 import io.camunda.zeebe.test.util.AutoCloseableRule;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.List;
 import java.util.Set;
@@ -128,6 +129,7 @@ public final class ExporterRule implements TestRule {
             .distributionInterval(distributionInterval)
             .partitionMessagingService(partitionMessagingService)
             .descriptors(descriptorsWithInitializationInfo)
+            .meterRegistry(new SimpleMeterRegistry())
             .positionsToSkipFilter(positionsToSkipFilter);
 
     director = new ExporterDirector(context, phase);

--- a/zeebe/util/pom.xml
+++ b/zeebe/util/pom.xml
@@ -27,6 +27,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/collection/EnumTable.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/collection/EnumTable.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util.collection;
+
+import java.util.function.BiFunction;
+import java.util.function.IntFunction;
+
+/**
+ * A table implementation optimized for {@link Enum} keys. See {@link MapTable} for more on tables.
+ *
+ * <p>Enums allow us to define a finite keyspace, so we can efficiently use a single array to
+ * represent all possible value combinations. The cardinality of the {@link RowT} enum represents
+ * how many rows are in the table, and the cardinality of the {@link ColT} enum represents how many
+ * columns.
+ *
+ * <p>The table indexes all possible combination of the {@link RowT} and {@link ColT} enums in a
+ * single array whose size is equal to the cardinality of T times the cardinality of U. So given two
+ * enums, one with 3 elements, and the other with 4, the array size would be 12.
+ *
+ * <p>The values in the table are stored in rows, where every element on a row is stored
+ * contiguously. So the first row starts at index 0, and the second row starts at the index equal to
+ * the cardinality of the second enum.
+ *
+ * <p>Let's use an example. Assume we have the following enums:
+ *
+ * <pre>{@code
+ * enum T {
+ *   FOO, BAR
+ * }
+ * enum U {
+ *   A, B, C
+ * }
+ * }</pre>
+ *
+ * In this case, we will have an array of size 6, with 2 rows, and 3 columns, meaning each row
+ * contains 3 elements. If we map our table visually as a matrix (with dummy values), it looks like:
+ *
+ * <pre>
+ *     | A | B | C
+ * FOO | 1 | 2 | 3
+ * BAR | 4 | 5 | 6
+ * </pre>
+ *
+ * Let FOO_A denote the value at row FOO and column A (i.e. 1). If we map this as an array, we have:
+ *
+ * <pre>
+ * [ FOO_A, FOO_B, FOO_C, BAR_A, BAR_B, BAR_C ]
+ * </pre>
+ */
+final class EnumTable<T, RowT extends Enum<RowT>, ColT extends Enum<ColT>>
+    implements Table<T, RowT, ColT> {
+  private final T[] items;
+  private final int columnCount;
+
+  EnumTable(
+      final Class<RowT> rowClass,
+      final Class<ColT> columnClass,
+      final IntFunction<T[]> arraySupplier) {
+    final int rowCount = rowClass.getEnumConstants().length;
+    columnCount = columnClass.getEnumConstants().length;
+    items = arraySupplier.apply(rowCount * columnCount);
+  }
+
+  @Override
+  public T get(final RowT rowKey, final ColT columnKey) {
+    final var index = mapToIndex(rowKey, columnKey);
+    return items[index];
+  }
+
+  @Override
+  public void put(final RowT rowKey, final ColT columnKey, final T value) {
+    final var index = mapToIndex(rowKey, columnKey);
+    items[index] = value;
+  }
+
+  @Override
+  public T computeIfAbsent(
+      final RowT rowKey, final ColT columnKey, final BiFunction<RowT, ColT, T> computer) {
+    final var index = mapToIndex(rowKey, columnKey);
+    final var value = items[index];
+    if (value != null) {
+      return value;
+    }
+
+    final var updated = computer.apply(rowKey, columnKey);
+    items[index] = updated;
+    return updated;
+  }
+
+  private int mapToIndex(final RowT firstPart, final ColT secondPart) {
+    return firstPart.ordinal() * columnCount + secondPart.ordinal();
+  }
+}

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/collection/EnumTable.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/collection/EnumTable.java
@@ -22,9 +22,9 @@ import java.util.function.IntFunction;
  * single array whose size is equal to the cardinality of T times the cardinality of U. So given two
  * enums, one with 3 elements, and the other with 4, the array size would be 12.
  *
- * <p>The values in the table are stored in rows, where every element on a row is stored
- * contiguously. So the first row starts at index 0, and the second row starts at the index equal to
- * the cardinality of the second enum.
+ * <p>The values in the table are stored in row-major order; that is, in rows where every element on
+ * a row is stored contiguously. So the first row starts at index 0, and the second row starts at
+ * the index equal to the cardinality of the second enum.
  *
  * <p>Let's use an example. Assume we have the following enums:
  *
@@ -52,8 +52,8 @@ import java.util.function.IntFunction;
  * [ FOO_A, FOO_B, FOO_C, BAR_A, BAR_B, BAR_C ]
  * </pre>
  */
-final class EnumTable<T, RowT extends Enum<RowT>, ColT extends Enum<ColT>>
-    implements Table<T, RowT, ColT> {
+final class EnumTable<RowT extends Enum<RowT>, ColT extends Enum<ColT>, T>
+    implements Table<RowT, ColT, T> {
   private final T[] items;
   private final int columnCount;
 

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/collection/MapTable.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/collection/MapTable.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util.collection;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+/** A very simple implementation using a map-of-map approach. */
+final class MapTable<T, RowT, ColT> implements Table<T, RowT, ColT> {
+  private final Map<RowT, Map<ColT, T>> table = new HashMap<>();
+
+  @Override
+  public T get(final RowT rowKey, final ColT columnKey) {
+    final var row = table.get(rowKey);
+    if (row == null) {
+      return null;
+    }
+
+    return row.get(columnKey);
+  }
+
+  @Override
+  public void put(final RowT rowKey, final ColT columnKey, final T value) {
+    table.computeIfAbsent(rowKey, ignored -> new HashMap<>()).put(columnKey, value);
+  }
+
+  @Override
+  public T computeIfAbsent(
+      final RowT rowKey, final ColT columnKey, final BiFunction<RowT, ColT, T> computer) {
+    return table
+        .computeIfAbsent(rowKey, ignored -> new HashMap<>())
+        .computeIfAbsent(columnKey, ignored -> computer.apply(rowKey, columnKey));
+  }
+}

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/collection/MapTable.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/collection/MapTable.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import java.util.function.BiFunction;
 
 /** A very simple implementation using a map-of-map approach. */
-final class MapTable<T, RowT, ColT> implements Table<T, RowT, ColT> {
+final class MapTable<RowT, ColT, T> implements Table<RowT, ColT, T> {
   private final Map<RowT, Map<ColT, T>> table = new HashMap<>();
 
   @Override

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/collection/Table.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/collection/Table.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util.collection;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.IntFunction;
+
+/**
+ * A table is a data structure which maps rows and columns to a single value. Think of it like your
+ * usual {@link Map}, except your key is made of two parts.
+ *
+ * <p>If we map our table visually as a matrix (with dummy values), it looks like:
+ *
+ * <pre>
+ *     | A | B | C
+ * FOO | 1 | 2 | 3
+ * BAR | 4 | 5 | 6
+ * </pre>
+ *
+ * NOTE: there exists an equivalent concept in Guava. As we only need very, very limited
+ * capabilities at the moment, it's fine to have our own. If this grows quite a bit, we can evaluate
+ * using Guava's directly.
+ *
+ * <p>If your row and column types are enums, use {@link EnumTable}.
+ *
+ * @param <T> the type for the actual values stored
+ * @param <RowT> the type of the row keys
+ * @param <ColT> the type of the column keys
+ */
+public interface Table<T, RowT, ColT> {
+
+  /**
+   * Returns the value indexed by the two given key parts. If none found, returns null.
+   *
+   * @param rowKey the key of the row to look into
+   * @param columnKey which column in the row to return
+   * @return the value indexed at the row/column, or null if none
+   */
+  T get(RowT rowKey, ColT columnKey);
+
+  /**
+   * Sets the given value at the column {@code columnKey} in row {@code rowKey}.
+   *
+   * @param rowKey the key to select the row with
+   * @param columnKey the key to select the column in the row with
+   * @param value the value to store
+   */
+  void put(RowT rowKey, ColT columnKey, T value);
+
+  /**
+   * Returns the current value at the given column in the given row. If there is none, sets it to
+   * whatever the given supplier returns, and returns that immediately.
+   *
+   * @param rowKey the key of the row to look into
+   * @param columnKey which column in the row to return
+   * @param computer a function which should compute the value for this row/column pair
+   * @return the value indexed at the row/column, or null if none
+   */
+  T computeIfAbsent(RowT rowKey, ColT columnKey, BiFunction<RowT, ColT, T> computer);
+
+  /**
+   * Returns a basic implementation of a table. If using enums for row and column keys, use {@link
+   * #ofEnum(Class, Class, IntFunction)} instead.
+   */
+  static <T, RowT, ColT> Table<T, RowT, ColT> simple() {
+    return new MapTable<>();
+  }
+
+  /** Returns an optimized table for enum keys (both rows and columns). */
+  static <T, RowT extends Enum<RowT>, ColT extends Enum<ColT>> Table<T, RowT, ColT> ofEnum(
+      final Class<RowT> rowClass,
+      final Class<ColT> columnClass,
+      final IntFunction<T[]> arraySupplier) {
+    return new EnumTable<>(rowClass, columnClass, arraySupplier);
+  }
+}

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/collection/Table.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/collection/Table.java
@@ -33,7 +33,7 @@ import java.util.function.IntFunction;
  * @param <RowT> the type of the row keys
  * @param <ColT> the type of the column keys
  */
-public interface Table<T, RowT, ColT> {
+public interface Table<RowT, ColT, T> {
 
   /**
    * Returns the value indexed by the two given key parts. If none found, returns null.
@@ -68,12 +68,12 @@ public interface Table<T, RowT, ColT> {
    * Returns a basic implementation of a table. If using enums for row and column keys, use {@link
    * #ofEnum(Class, Class, IntFunction)} instead.
    */
-  static <T, RowT, ColT> Table<T, RowT, ColT> simple() {
+  static <RowT, ColT, T> Table<RowT, ColT, T> simple() {
     return new MapTable<>();
   }
 
   /** Returns an optimized table for enum keys (both rows and columns). */
-  static <T, RowT extends Enum<RowT>, ColT extends Enum<ColT>> Table<T, RowT, ColT> ofEnum(
+  static <RowT extends Enum<RowT>, ColT extends Enum<ColT>, T> Table<RowT, ColT, T> ofEnum(
       final Class<RowT> rowClass,
       final Class<ColT> columnClass,
       final IntFunction<T[]> arraySupplier) {

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/ExtendedMeterDocumentation.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/ExtendedMeterDocumentation.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util.micrometer;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.docs.MeterDocumentation;
+import java.time.Duration;
+
+/**
+ * Extends the base {@link MeterDocumentation} API to allow for more static description, e.g.
+ * help/description associated with a given metric.
+ */
+public interface ExtendedMeterDocumentation extends MeterDocumentation {
+
+  /** Returns the description (also known as {@code help} in some systems) for the given meter. */
+  String getDescription();
+
+  /**
+   * Returns the buckets to be used if the meter type is a {@link Meter.Type#TIMER} or {@link
+   * Meter.Type#DISTRIBUTION_SUMMARY}.
+   */
+  default Duration[] getServiceLevelObjectives() {
+    return MicrometerUtil.defaultPrometheusBuckets();
+  }
+}

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.util.micrometer;
 
+import io.camunda.zeebe.util.CloseableSilently;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.Timer.Builder;
 import java.time.Duration;
 
@@ -53,5 +55,20 @@ public final class MicrometerUtil {
    */
   public static Duration[] defaultPrometheusBuckets() {
     return DEFAULT_PROMETHEUS_BUCKETS;
+  }
+
+  /**
+   * Returns a convenience object to measure the duration of try/catch block using a Micrometer
+   * timer.
+   */
+  public static CloseableSilently timer(final Timer timer, final Timer.Sample sample) {
+    return new CloseableTimer(timer, sample);
+  }
+
+  private record CloseableTimer(Timer timer, Timer.Sample sample) implements CloseableSilently {
+    @Override
+    public void close() {
+      sample.stop(timer);
+    }
   }
 }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util.micrometer;
+
+import io.micrometer.core.instrument.Timer.Builder;
+import java.time.Duration;
+
+/** Collection of disparate convenience methods for Micrometer. */
+public final class MicrometerUtil {
+  private static final Duration[] DEFAULT_PROMETHEUS_BUCKETS = {
+    Duration.ofMillis(5),
+    Duration.ofMillis(10),
+    Duration.ofMillis(25),
+    Duration.ofMillis(50),
+    Duration.ofMillis(100),
+    Duration.ofMillis(75),
+    Duration.ofMillis(100),
+    Duration.ofMillis(250),
+    Duration.ofMillis(500),
+    Duration.ofMillis(750),
+    Duration.ofSeconds(1),
+    Duration.ofMillis(2500),
+    Duration.ofSeconds(5),
+    Duration.ofMillis(7500),
+    Duration.ofSeconds(10)
+  };
+
+  private MicrometerUtil() {}
+
+  /**
+   * Returns the set of buckets that Prometheus would normally use as default for their histograms.
+   * This is mostly used while we transition from Prometheus to Micrometer.
+   *
+   * <p>By default, Prometheus defines 14 buckets, which means an approximate memory usage of ~360
+   * bytes per histogram.
+   *
+   * <p>Micrometer, when using {@link Builder#publishPercentileHistogram()} will define 66 buckets,
+   * which means an approximate memory usage of ~1.5kb.
+   *
+   * <p>This seems like little, but as it goes for all histograms, it can make some difference
+   * ultimately. Of course, if we do see a use for more buckets, we should do it, and stop using
+   * this method.
+   *
+   * <p>NOTE: memory usage approximation taken from <a
+   * href="https://docs.micrometer.io/micrometer/reference/concepts/timers.html#_memory_footprint_estimation">here</a>.
+   *
+   * @return the default buckets as defined by the Prometheus client library
+   */
+  public static Duration[] defaultPrometheusBuckets() {
+    return DEFAULT_PROMETHEUS_BUCKETS;
+  }
+}

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/collection/TableTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/collection/TableTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util.collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+final class TableTest {
+  @ParameterizedTest
+  @MethodSource("provideImplementations")
+  void shouldReturnNullOnMissingColumn(final Table<Integer, Row, Column> table) {
+    // given
+    table.put(Row.A, Column.D, 1);
+
+    // when
+    final var value = table.get(Row.A, Column.E);
+
+    // then
+    assertThat(value).isNull();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideImplementations")
+  void shouldReturnNullOnMissingRow(final Table<Integer, Row, Column> table) {
+    // given
+    table.put(Row.A, Column.D, 1);
+
+    // when
+    final var value = table.get(Row.B, Column.E);
+
+    // then
+    assertThat(value).isNull();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideImplementations")
+  void shouldReturnLatestValue(final Table<Integer, Row, Column> table) {
+    // given
+    table.put(Row.A, Column.D, 1);
+    table.put(Row.A, Column.D, 2);
+
+    // when
+    final var value = table.get(Row.A, Column.D);
+
+    // then
+    assertThat(value).isEqualTo(2);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideImplementations")
+  void shouldNotModifyOtherValues(final Table<Integer, Row, Column> table) {
+    // given
+    table.put(Row.A, Column.D, 1);
+    table.put(Row.A, Column.E, 2);
+    table.put(Row.B, Column.D, 3);
+
+    // when
+    table.put(Row.A, Column.D, 2);
+
+    // then
+    assertThat(table.get(Row.A, Column.D)).isEqualTo(2);
+    assertThat(table.get(Row.A, Column.E)).isEqualTo(2);
+    assertThat(table.get(Row.B, Column.D)).isEqualTo(3);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideImplementations")
+  void shouldComputeOnlyIfAbsent(final Table<Integer, Row, Column> table) {
+    // given
+    table.put(Row.A, Column.D, 1);
+
+    // when
+    final var value = table.computeIfAbsent(Row.A, Column.D, (r, c) -> 2);
+
+    // then
+    assertThat(value).isOne();
+    assertThat(table.get(Row.A, Column.D)).isOne();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideImplementations")
+  void shouldComputeIfAbsent(final Table<Integer, Row, Column> table) {
+    // given
+    table.put(Row.A, Column.D, 1);
+
+    // when
+    final var value = table.computeIfAbsent(Row.A, Column.E, (r, c) -> 2);
+
+    // then
+    assertThat(value).isEqualTo(2);
+    assertThat(table.get(Row.A, Column.E)).isEqualTo(2);
+  }
+
+  private static Stream<Named<Table<Integer, Row, Column>>> provideImplementations() {
+    return Stream.of(
+        Named.named("EnumTable", Table.ofEnum(Row.class, Column.class, Integer[]::new)),
+        Named.named("MapTable", Table.simple()));
+  }
+
+  private enum Row {
+    A,
+    B,
+    C
+  }
+
+  private enum Column {
+    D,
+    E,
+    F
+  }
+}

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/collection/TableTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/collection/TableTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 final class TableTest {
   @ParameterizedTest
   @MethodSource("provideImplementations")
-  void shouldReturnNullOnMissingColumn(final Table<Integer, Row, Column> table) {
+  void shouldReturnNullOnMissingColumn(final Table<Row, Column, Integer> table) {
     // given
     table.put(Row.A, Column.D, 1);
 
@@ -30,7 +30,7 @@ final class TableTest {
 
   @ParameterizedTest
   @MethodSource("provideImplementations")
-  void shouldReturnNullOnMissingRow(final Table<Integer, Row, Column> table) {
+  void shouldReturnNullOnMissingRow(final Table<Row, Column, Integer> table) {
     // given
     table.put(Row.A, Column.D, 1);
 
@@ -43,7 +43,7 @@ final class TableTest {
 
   @ParameterizedTest
   @MethodSource("provideImplementations")
-  void shouldReturnLatestValue(final Table<Integer, Row, Column> table) {
+  void shouldReturnLatestValue(final Table<Row, Column, Integer> table) {
     // given
     table.put(Row.A, Column.D, 1);
     table.put(Row.A, Column.D, 2);
@@ -57,7 +57,7 @@ final class TableTest {
 
   @ParameterizedTest
   @MethodSource("provideImplementations")
-  void shouldNotModifyOtherValues(final Table<Integer, Row, Column> table) {
+  void shouldNotModifyOtherValues(final Table<Row, Column, Integer> table) {
     // given
     table.put(Row.A, Column.D, 1);
     table.put(Row.A, Column.E, 2);
@@ -74,7 +74,7 @@ final class TableTest {
 
   @ParameterizedTest
   @MethodSource("provideImplementations")
-  void shouldComputeOnlyIfAbsent(final Table<Integer, Row, Column> table) {
+  void shouldComputeOnlyIfAbsent(final Table<Row, Column, Integer> table) {
     // given
     table.put(Row.A, Column.D, 1);
 
@@ -88,7 +88,7 @@ final class TableTest {
 
   @ParameterizedTest
   @MethodSource("provideImplementations")
-  void shouldComputeIfAbsent(final Table<Integer, Row, Column> table) {
+  void shouldComputeIfAbsent(final Table<Row, Column, Integer> table) {
     // given
     table.put(Row.A, Column.D, 1);
 
@@ -100,7 +100,7 @@ final class TableTest {
     assertThat(table.get(Row.A, Column.E)).isEqualTo(2);
   }
 
-  private static Stream<Named<Table<Integer, Row, Column>>> provideImplementations() {
+  private static Stream<Named<Table<Row, Column, Integer>>> provideImplementations() {
     return Stream.of(
         Named.named("EnumTable", Table.ofEnum(Row.class, Column.class, Integer[]::new)),
         Named.named("MapTable", Table.simple()));


### PR DESCRIPTION
## Description

This PR migrates the exporter director metrics from Prometheus simple client to Micrometer. The main changes is that the histograms now have `_seconds_bucket` as suffix, instead of just `_bucket`. There are also no `_created` metrics for all, but we were not using them either in the past. Everything else is kept the same, including the histogram buckets.

> [!Note]
> Micrometer suggests using more buckets to properly quantify percentiles, but it does mean an increase from ~350 bytes per histogram to ~1.5KB per histogram, so we should do it only if we think it's a good idea. It likely is, but I have no time to evaluate this right now.

With Micrometer, we now have to track metrics as instance level state. While their recommended usage is to recreate the builder or the `Meter.Id` every time you access a metric, this creates unnecessary garbage and possible allocations. To avoid this, you can simply keep track of the meters - or in the case of gauges, of the object tracking the state.

Since every combination of meter name + tag creates a new metric, the state has to be kept based on that. This can include multiple tags, though typically we don't use much more than two (if we ignore the common tags).

To help, I introduced a very simple collection, `Table`. This isn't a new concept - for example, Guava has a much more extensive implementation of this. I opted against using Guava's for now, mostly because we need so little from it. As usual, if we do need more functionality in the future, we should consider switching to a well established implementation. **This makes the PR bigger, but should help keep things simple in future PRs.**

> [!Note]
> A table is basically a map, where values are indexed by two keys, row and column. Think of it like a matrix.

I also decided to start using the Micrometer documentation format, in the hopes that we can in the future use their documentation generator (see [here](https://docs.micrometer.io/micrometer-docs-generator/reference/index.html))

Finally, the dashboard using the histograms with new names has been updated, now showing the union of both series (since the usage of one or the other is mutually exclusive).

## Related issues

related to #26078 
