### PR TITLE
feat: Trigger `updating` task listeners on direct task updates

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -150,7 +150,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
         .validateCommand(command)
         .ifRightOrLeft(
             persistedRecord ->
-                handleCommandProcessing(commandProcessor, command, persistedRecord, intent),
+                handleCommandProcessing(commandProcessor, command, persistedRecord.copy(), intent),
             rejection -> handleCommandRejection(command, rejection));
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -423,8 +423,10 @@ public final class EventAppliers implements EventApplier {
     register(UserTaskIntent.ASSIGNED, 1, new UserTaskAssignedV1Applier(state));
     register(UserTaskIntent.ASSIGNED, 2, new UserTaskAssignedV2Applier(state));
     register(UserTaskIntent.CLAIMING, new UserTaskClaimingApplier(state));
-    register(UserTaskIntent.UPDATING, new UserTaskUpdatingApplier(state));
-    register(UserTaskIntent.UPDATED, new UserTaskUpdatedApplier(state));
+    register(UserTaskIntent.UPDATING, 1, new UserTaskUpdatingV1Applier(state));
+    register(UserTaskIntent.UPDATING, 2, new UserTaskUpdatingV2Applier(state));
+    register(UserTaskIntent.UPDATED, 1, new UserTaskUpdatedV1Applier(state));
+    register(UserTaskIntent.UPDATED, 2, new UserTaskUpdatedV2Applier(state));
     register(UserTaskIntent.MIGRATED, new UserTaskMigratedApplier(state));
     register(UserTaskIntent.CORRECTED, new UserTaskCorrectedApplier(state));
     register(UserTaskIntent.COMPLETION_DENIED, new UserTaskCompletionDeniedApplier(state));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskUpdatedV1Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskUpdatedV1Applier.java
@@ -14,12 +14,12 @@ import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 
-public final class UserTaskUpdatedApplier
+public final class UserTaskUpdatedV1Applier
     implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
 
   private final MutableUserTaskState userTaskState;
 
-  public UserTaskUpdatedApplier(final MutableProcessingState processingState) {
+  public UserTaskUpdatedV1Applier(final MutableProcessingState processingState) {
     userTaskState = processingState.getUserTaskState();
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskUpdatedV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskUpdatedV2Applier.java
@@ -14,17 +14,20 @@ import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 
-public final class UserTaskUpdatingApplier
+public final class UserTaskUpdatedV2Applier
     implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
 
   private final MutableUserTaskState userTaskState;
 
-  public UserTaskUpdatingApplier(final MutableProcessingState processingState) {
+  public UserTaskUpdatedV2Applier(final MutableProcessingState processingState) {
     userTaskState = processingState.getUserTaskState();
   }
 
   @Override
   public void applyState(final long key, final UserTaskRecord value) {
-    userTaskState.updateUserTaskLifecycleState(key, LifecycleState.UPDATING);
+    final UserTaskRecord userTask = userTaskState.getUserTask(key);
+    userTask.wrapChangedAttributes(value, false);
+    userTaskState.update(userTask);
+    userTaskState.updateUserTaskLifecycleState(key, LifecycleState.CREATED);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskUpdatingV1Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskUpdatingV1Applier.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+
+public final class UserTaskUpdatingV1Applier
+    implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
+
+  private final MutableUserTaskState userTaskState;
+
+  public UserTaskUpdatingV1Applier(final MutableProcessingState processingState) {
+    userTaskState = processingState.getUserTaskState();
+  }
+
+  @Override
+  public void applyState(final long key, final UserTaskRecord value) {
+    userTaskState.updateUserTaskLifecycleState(key, LifecycleState.UPDATING);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskUpdatingV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskUpdatingV2Applier.java
@@ -26,5 +26,6 @@ public final class UserTaskUpdatingV2Applier
   @Override
   public void applyState(final long key, final UserTaskRecord value) {
     userTaskState.updateUserTaskLifecycleState(key, LifecycleState.UPDATING);
+    userTaskState.storeIntermediateState(value, LifecycleState.UPDATING);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskUpdatingV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskUpdatingV2Applier.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+
+public final class UserTaskUpdatingV2Applier
+    implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
+
+  private final MutableUserTaskState userTaskState;
+
+  public UserTaskUpdatingV2Applier(final MutableProcessingState processingState) {
+    userTaskState = processingState.getUserTaskState();
+  }
+
+  @Override
+  public void applyState(final long key, final UserTaskRecord value) {
+    userTaskState.updateUserTaskLifecycleState(key, LifecycleState.UPDATING);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -565,13 +565,67 @@ public class TaskListenerTest {
   }
 
   @Test
-  public void shouldRetryTaskListenerWhenListenerJobFailed() {
+  public void shouldRetryAssigningListenerWhenListenerJobFailedOnTaskAssignAfterCreation() {
+    verifyListenerIsRetriedWhenListenerJobFailed(
+        ZeebeTaskListenerEventType.assigning,
+        userTask -> userTask.zeebeAssignee("gandalf"),
+        userTaskClient -> {},
+        UserTaskIntent.ASSIGNED);
+  }
+
+  @Test
+  public void shouldRetryAssigningListenerWhenListenerJobFailedOnTaskAssign() {
+    verifyListenerIsRetriedWhenListenerJobFailed(
+        ZeebeTaskListenerEventType.assigning,
+        UnaryOperator.identity(),
+        userTaskClient -> userTaskClient.withAssignee("bilbo").assign(),
+        UserTaskIntent.ASSIGNED);
+  }
+
+  @Test
+  public void shouldRetryAssigningListenerWhenListenerJobFailedOnTaskClaim() {
+    verifyListenerIsRetriedWhenListenerJobFailed(
+        ZeebeTaskListenerEventType.assigning,
+        UnaryOperator.identity(),
+        userTaskClient -> userTaskClient.withAssignee("bilbo").claim(),
+        UserTaskIntent.ASSIGNED);
+  }
+
+  @Test
+  public void shouldRetryUpdatingListenerWhenListenerJobFailedOnTaskUpdate() {
+    verifyListenerIsRetriedWhenListenerJobFailed(
+        ZeebeTaskListenerEventType.updating,
+        UnaryOperator.identity(),
+        userTaskClient -> userTaskClient.update(new UserTaskRecord()),
+        UserTaskIntent.UPDATED);
+  }
+
+  @Test
+  public void shouldRetryCompletingListenerWhenListenerJobFailedOnTaskComplete() {
+    verifyListenerIsRetriedWhenListenerJobFailed(
+        ZeebeTaskListenerEventType.completing,
+        UnaryOperator.identity(),
+        UserTaskClient::complete,
+        UserTaskIntent.COMPLETED);
+  }
+
+  private void verifyListenerIsRetriedWhenListenerJobFailed(
+      final ZeebeTaskListenerEventType eventType,
+      final UnaryOperator<UserTaskBuilder> userTaskBuilder,
+      final Consumer<UserTaskClient> userTaskAction,
+      final UserTaskIntent terminalActionIntent) {
     // given
     final long processInstanceKey =
         createProcessInstance(
-            createProcessWithCompletingTaskListeners(listenerType, listenerType + "_2"));
+            createProcessWithZeebeUserTask(
+                t ->
+                    userTaskBuilder
+                        .apply(t)
+                        .zeebeTaskListener(l -> l.eventType(eventType).type(listenerType))
+                        .zeebeTaskListener(l -> l.eventType(eventType).type(listenerType + "_2"))));
 
-    ENGINE.userTask().ofInstance(processInstanceKey).complete();
+    // when: performing the user task action
+    userTaskAction.accept(ENGINE.userTask().ofInstance(processInstanceKey));
 
     // when: fail listener job with retries
     ENGINE.job().ofInstance(processInstanceKey).withType(listenerType).withRetries(1).fail();
@@ -579,10 +633,9 @@ public class TaskListenerTest {
     completeJobs(processInstanceKey, listenerType, listenerType + "_2");
 
     // then: assert the listener job was completed after the failure
-    assertThat(records().betweenProcessInstance(processInstanceKey))
+    assertThat(records().limit(r -> r.getIntent() == terminalActionIntent))
         .extracting(Record::getValueType, Record::getIntent)
         .containsSubsequence(
-            tuple(ValueType.USER_TASK, UserTaskIntent.COMPLETING),
             tuple(ValueType.JOB, JobIntent.CREATED),
             tuple(ValueType.JOB, JobIntent.FAILED),
             tuple(ValueType.JOB, JobIntent.COMPLETE),
@@ -592,9 +645,7 @@ public class TaskListenerTest {
             tuple(ValueType.JOB, JobIntent.COMPLETE),
             tuple(ValueType.JOB, JobIntent.COMPLETED),
             tuple(ValueType.USER_TASK, UserTaskIntent.COMPLETE_TASK_LISTENER),
-            tuple(ValueType.USER_TASK, UserTaskIntent.COMPLETED));
-
-    assertThatProcessInstanceCompleted(processInstanceKey);
+            tuple(ValueType.USER_TASK, terminalActionIntent));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -649,17 +649,79 @@ public class TaskListenerTest {
   }
 
   @Test
-  public void shouldCreateIncidentOnCompletingListenerJobNoRetriesAndContinueAfterResolution() {
+  public void
+      shouldCreateJobNoRetriesIncidentForAssigningListenerAndContinueAfterResolutionOnTaskAssignAfterCreation() {
+    verifyIncidentCreationOnListenerJobWithoutRetriesAndResolution(
+        ZeebeTaskListenerEventType.assigning,
+        userTask -> userTask.zeebeAssignee("gandalf"),
+        userTaskClient -> {},
+        UserTaskIntent.ASSIGNED);
+  }
+
+  @Test
+  public void
+      shouldCreateJobNoRetriesIncidentForAssigningListenerAndContinueAfterResolutionOnTaskAssign() {
+    verifyIncidentCreationOnListenerJobWithoutRetriesAndResolution(
+        ZeebeTaskListenerEventType.assigning,
+        UnaryOperator.identity(),
+        userTaskClient -> userTaskClient.withAssignee("bilbo").assign(),
+        UserTaskIntent.ASSIGNED);
+  }
+
+  @Test
+  public void
+      shouldCreateJobNoRetriesIncidentForAssigningListenerAndContinueAfterResolutionOnTaskClaim() {
+    verifyIncidentCreationOnListenerJobWithoutRetriesAndResolution(
+        ZeebeTaskListenerEventType.assigning,
+        UnaryOperator.identity(),
+        userTaskClient -> userTaskClient.withAssignee("bilbo").claim(),
+        UserTaskIntent.ASSIGNED);
+  }
+
+  @Test
+  public void
+      shouldCreateJobNoRetriesIncidentForUpdatingListenerAndContinueAfterResolutionOnTaskUpdate() {
+    verifyIncidentCreationOnListenerJobWithoutRetriesAndResolution(
+        ZeebeTaskListenerEventType.updating,
+        UnaryOperator.identity(),
+        userTaskClient -> userTaskClient.update(new UserTaskRecord()),
+        UserTaskIntent.UPDATED);
+  }
+
+  @Test
+  public void
+      shouldCreateJobNoRetriesIncidentForCompletingListenerAndContinueAfterResolutionOnTaskComplete() {
+    verifyIncidentCreationOnListenerJobWithoutRetriesAndResolution(
+        ZeebeTaskListenerEventType.completing,
+        UnaryOperator.identity(),
+        UserTaskClient::complete,
+        UserTaskIntent.COMPLETED);
+  }
+
+  private void verifyIncidentCreationOnListenerJobWithoutRetriesAndResolution(
+      final ZeebeTaskListenerEventType eventType,
+      final UnaryOperator<UserTaskBuilder> userTaskBuilder,
+      final Consumer<UserTaskClient> userTaskAction,
+      final UserTaskIntent terminalActionIntent) {
+
     // given
     final long processInstanceKey =
         createProcessInstance(
-            createProcessWithCompletingTaskListeners(
-                listenerType, listenerType + "_2", listenerType + "_3"));
+            createProcessWithZeebeUserTask(
+                t ->
+                    userTaskBuilder
+                        .apply(t)
+                        .zeebeTaskListener(l -> l.eventType(eventType).type(listenerType))
+                        .zeebeTaskListener(l -> l.eventType(eventType).type(listenerType + "_2"))
+                        .zeebeTaskListener(l -> l.eventType(eventType).type(listenerType + "_3"))));
 
-    ENGINE.userTask().ofInstance(processInstanceKey).complete();
+    // when: performing the user task action
+    userTaskAction.accept(ENGINE.userTask().ofInstance(processInstanceKey));
+
+    // complete first listener job
     completeJobs(processInstanceKey, listenerType);
 
-    // when: fail 2nd listener job with no retries
+    // fail the second listener job with no retries
     final var failedJob =
         ENGINE
             .job()
@@ -668,7 +730,7 @@ public class TaskListenerTest {
             .withRetries(0)
             .fail();
 
-    // then: incident created
+    // then: incident should be created
     final var incident =
         RecordingExporter.incidentRecords(IncidentIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
@@ -688,22 +750,21 @@ public class TaskListenerTest {
         .updateRetries();
     ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
 
-    // complete failed and remaining listener job
+    // complete failed and remaining listener jobs
     completeJobs(processInstanceKey, listenerType + "_2", listenerType + "_3");
 
     // then
-    assertThat(records().betweenProcessInstance(processInstanceKey))
+    assertThat(records().limit(r -> r.getIntent() == terminalActionIntent))
         .extracting(Record::getValueType, Record::getIntent)
-        .describedAs(
-            "Expected the listener jobs to complete after incident resolution, leading to the user task being completed")
+        .describedAs("Expected listener jobs to complete after incident resolution")
         .containsSubsequence(
-            tuple(ValueType.USER_TASK, UserTaskIntent.COMPLETING),
             tuple(ValueType.JOB, JobIntent.CREATED),
             tuple(ValueType.JOB, JobIntent.COMPLETE),
             tuple(ValueType.JOB, JobIntent.COMPLETED),
             tuple(ValueType.USER_TASK, UserTaskIntent.COMPLETE_TASK_LISTENER),
             tuple(ValueType.JOB, JobIntent.CREATED),
             tuple(ValueType.JOB, JobIntent.FAILED),
+            // the incident was created & resolved
             tuple(ValueType.INCIDENT, IncidentIntent.CREATED),
             tuple(ValueType.JOB, JobIntent.RETRIES_UPDATED),
             tuple(ValueType.INCIDENT, IncidentIntent.RESOLVED),
@@ -716,64 +777,7 @@ public class TaskListenerTest {
             tuple(ValueType.JOB, JobIntent.COMPLETE),
             tuple(ValueType.JOB, JobIntent.COMPLETED),
             tuple(ValueType.USER_TASK, UserTaskIntent.COMPLETE_TASK_LISTENER),
-            tuple(ValueType.USER_TASK, UserTaskIntent.COMPLETED));
-
-    assertThatProcessInstanceCompleted(processInstanceKey);
-  }
-
-  @Test
-  public void shouldCreateIncidentOnAssigningListenerJobNoRetriesAndContinueAfterResolution() {
-    // given
-    final long processInstanceKey =
-        createProcessInstance(
-            createUserTaskWithTaskListeners(ZeebeTaskListenerEventType.assigning, listenerType));
-
-    ENGINE.userTask().ofInstance(processInstanceKey).withAssignee("chewey").assign();
-
-    // when: fail assigning listener job with no retries
-    final var failedJob =
-        ENGINE.job().ofInstance(processInstanceKey).withType(listenerType).withRetries(0).fail();
-
-    // then
-    final var incident =
-        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .getFirst();
-    Assertions.assertThat(incident.getValue())
-        .hasProcessInstanceKey(processInstanceKey)
-        .hasErrorType(ErrorType.TASK_LISTENER_NO_RETRIES)
-        .hasJobKey(failedJob.getKey())
-        .hasErrorMessage("No more retries left.");
-
-    // when: update retries and resolve incident
-    ENGINE
-        .job()
-        .ofInstance(processInstanceKey)
-        .withType(listenerType)
-        .withRetries(1)
-        .updateRetries();
-    ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
-
-    // complete assigning listener job
-    completeJobs(processInstanceKey, listenerType);
-
-    // then
-    assertThat(records().limit(r -> r.getIntent() == UserTaskIntent.ASSIGNED))
-        .extracting(Record::getValueType, Record::getIntent)
-        .describedAs(
-            "Expected the listener job to complete after incident resolution, leading to the user task being assigned")
-        .containsSubsequence(
-            tuple(ValueType.USER_TASK, UserTaskIntent.ASSIGNING),
-            tuple(ValueType.JOB, JobIntent.CREATED),
-            tuple(ValueType.JOB, JobIntent.FAILED),
-            tuple(ValueType.INCIDENT, IncidentIntent.CREATED),
-            tuple(ValueType.JOB, JobIntent.RETRIES_UPDATED),
-            tuple(ValueType.INCIDENT, IncidentIntent.RESOLVED),
-            // the failed listener job was retried
-            tuple(ValueType.JOB, JobIntent.COMPLETE),
-            tuple(ValueType.JOB, JobIntent.COMPLETED),
-            tuple(ValueType.USER_TASK, UserTaskIntent.COMPLETE_TASK_LISTENER),
-            tuple(ValueType.USER_TASK, UserTaskIntent.ASSIGNED));
+            tuple(ValueType.USER_TASK, terminalActionIntent));
   }
 
   @Test


### PR DESCRIPTION
## Description
This PR implements support for triggering `updating` task listeners when a user task is updated.
It ensures that listeners execute custom logic before the task update is finalized.

> [!NOTE]  
> The support for job result features (`deny` and `corrections`) by `updating` listeners is out of scope for this PR and will be addressed in a separate issue (https://github.com/camunda/camunda/issues/27558).

### Covered items
- Trigger `updating` task listeners on direct user task updates.
- Ensure correct job creation and execution for `updating` task listener jobs.
- Persiste intermediate user task state during the `UPDATING` event processing to support listener execution.
- Clear operational data during the `UPDATED` event processing.
- Properly finalize `UPDATED` user task events after all listeners are processed, cover the case when request metadata is missing.
- Enhance test coverage with integration and unit tests for update commands with listeners.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #27519 
