### PR TITLE
Migrate bounded command cache metrics to Micrometer

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -142,7 +142,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
         List.of(engine, context.getCheckpointProcessor());
     final var scheduledCommandCache =
         BoundedScheduledCommandCache.ofIntent(
-            new BoundedCommandCacheMetrics(context.getPartitionId()),
+            new BoundedCommandCacheMetrics(context.getPartitionMeterRegistry()),
             TimerIntent.TRIGGER,
             JobIntent.TIME_OUT,
             JobIntent.RECUR_AFTER_BACKOFF,


### PR DESCRIPTION
## Description

Migrates the bounded command cache metrics to Micrometer. The partition ID label is provided by the partition specific meter registry, so there's only the intent label on the metric itself.

The name or labels didn't change, so no dashboard updates required.

## Related issues

related to #26078
