### PR TITLE
Migrate broker step metrics to Micrometer

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
@@ -32,7 +32,7 @@ public final class BrokerStartupProcess {
     concurrencyControl = brokerStartupContext.getConcurrencyControl();
     context = brokerStartupContext;
 
-    final var brokerStepMetrics = new BrokerStepMetrics();
+    final var brokerStepMetrics = new BrokerStepMetrics(context.getMeterRegistry());
 
     final var undecoratedSteps = buildStartupSteps(brokerStartupContext.getBrokerConfiguration());
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStepMetricDecorator.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStepMetricDecorator.java
@@ -13,7 +13,7 @@ import static java.util.Objects.requireNonNull;
 import io.camunda.zeebe.broker.system.monitoring.BrokerStepMetrics;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.startup.StartupStep;
-import io.prometheus.client.Gauge.Timer;
+import io.camunda.zeebe.util.CloseableSilently;
 import java.util.function.Function;
 
 /**
@@ -55,7 +55,7 @@ final class BrokerStepMetricDecorator implements StartupStep<BrokerStartupContex
   private ActorFuture<BrokerStartupContext> callDelegateAndUpdateTimer(
       final BrokerStartupContext brokerStartupContext,
       final Function<BrokerStartupContext, ActorFuture<BrokerStartupContext>> functionToCall,
-      final Timer timer) {
+      final CloseableSilently timer) {
 
     try {
       final var concurrencyControl = brokerStartupContext.getConcurrencyControl();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerStepMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerStepMetrics.java
@@ -30,31 +30,11 @@ public class BrokerStepMetrics {
           .labelNames(STEP_NAME_LABEL)
           .register();
 
-  /**
-   * Meter the time to start for a single step.
-   *
-   * @param stepName the name of the step
-   * @param startupDuration the step start duration in ms
-   */
-  public void observeDurationForStarStep(final String stepName, final long startupDuration) {
-    STARTUP_METRIC.labels(stepName).set(startupDuration);
-  }
-
   public Timer createStartupTimer(final String stepName) {
     return STARTUP_METRIC.labels(stepName).startTimer();
   }
 
   public Timer createCloseTimer(final String stepName) {
     return CLOSE_METRICS.labels(stepName).startTimer();
-  }
-
-  /**
-   * Meter the the time to close for a single step.
-   *
-   * @param stepName the name of the step
-   * @param closeDuration the step close duration in ms
-   */
-  public void observeDurationForCloseStep(final String stepName, final long closeDuration) {
-    CLOSE_METRICS.labels(stepName).set(closeDuration);
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerStepMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerStepMetrics.java
@@ -7,34 +7,48 @@
  */
 package io.camunda.zeebe.broker.system.monitoring;
 
-import io.prometheus.client.Gauge;
-import io.prometheus.client.Gauge.Timer;
+import io.camunda.zeebe.util.CloseableSilently;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.TimeGauge;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class BrokerStepMetrics {
+  private final Map<String, AtomicLong> startup = new HashMap<>();
+  private final Map<String, AtomicLong> close = new HashMap<>();
 
-  public static final String ZEEBE_NAMESPACE = "zeebe";
-  public static final String STEP_NAME_LABEL = "stepName";
-  private static final Gauge STARTUP_METRIC =
-      Gauge.build()
-          .namespace(ZEEBE_NAMESPACE)
-          .name("broker_start_step_latency")
-          .help("Time for each broker start step to complete.")
-          .labelNames(STEP_NAME_LABEL)
-          .register();
+  private final MeterRegistry registry;
 
-  private static final Gauge CLOSE_METRICS =
-      Gauge.build()
-          .namespace(ZEEBE_NAMESPACE)
-          .name("broker_close_step_latency")
-          .help("Time for each broker close step to complete.")
-          .labelNames(STEP_NAME_LABEL)
-          .register();
-
-  public Timer createStartupTimer(final String stepName) {
-    return STARTUP_METRIC.labels(stepName).startTimer();
+  public BrokerStepMetrics(final MeterRegistry registry) {
+    this.registry = Objects.requireNonNull(registry, "must specify a meter registry");
   }
 
-  public Timer createCloseTimer(final String stepName) {
-    return CLOSE_METRICS.labels(stepName).startTimer();
+  public CloseableSilently createStartupTimer(final String stepName) {
+    final var timerTracker =
+        startup.computeIfAbsent(
+            stepName, name -> registerMetric(BrokerStepMetricsDoc.STARTUP, name));
+    return MicrometerUtil.timer(
+        timerTracker::addAndGet, TimeUnit.MILLISECONDS, registry.config().clock());
+  }
+
+  public CloseableSilently createCloseTimer(final String stepName) {
+    final var timerTracker =
+        close.computeIfAbsent(stepName, name -> registerMetric(BrokerStepMetricsDoc.CLOSE, name));
+    return MicrometerUtil.timer(
+        timerTracker::addAndGet, TimeUnit.MILLISECONDS, registry.config().clock());
+  }
+
+  private AtomicLong registerMetric(final BrokerStepMetricsDoc meterDoc, final String stepName) {
+    final var timeTracker = new AtomicLong();
+    TimeGauge.builder(meterDoc.getName(), timeTracker, TimeUnit.MILLISECONDS, AtomicLong::longValue)
+        .description(meterDoc.getDescription())
+        .tag("stepName", stepName)
+        .register(registry);
+
+    return timeTracker;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerStepMetricsDoc.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerStepMetricsDoc.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.monitoring;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.micrometer.core.instrument.Meter;
+
+public enum BrokerStepMetricsDoc implements ExtendedMeterDocumentation {
+  /** The time in milliseconds for each broker start step to complete */
+  STARTUP {
+    @Override
+    public String getName() {
+      return "zeebe.broker.start.step.latency";
+    }
+
+    @Override
+    public Meter.Type getType() {
+      return Meter.Type.GAUGE;
+    }
+
+    @Override
+    public String getBaseUnit() {
+      return "ms";
+    }
+
+    @Override
+    public String getDescription() {
+      return "The time in milliseconds for each broker start step to complete";
+    }
+  },
+
+  /** The time in milliseconds for each broker close step to complete */
+  CLOSE {
+    @Override
+    public String getName() {
+      return "zeebe.broker.close.step.latency";
+    }
+
+    @Override
+    public Meter.Type getType() {
+      return Meter.Type.GAUGE;
+    }
+
+    @Override
+    public String getBaseUnit() {
+      return "ms";
+    }
+
+    @Override
+    public String getDescription() {
+      return "The time in milliseconds for each broker close step to complete";
+    }
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/BrokerStepMetricDecoratorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/BrokerStepMetricDecoratorTest.java
@@ -9,42 +9,42 @@ package io.camunda.zeebe.broker.bootstrap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.broker.system.monitoring.BrokerStepMetrics;
+import io.camunda.zeebe.broker.system.monitoring.BrokerStepMetricsDoc;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.startup.StartupStep;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
-import io.prometheus.client.Gauge.Timer;
+import io.micrometer.core.instrument.MockClock;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 class BrokerStepMetricDecoratorTest {
 
   private static final TestConcurrencyControl CONCURRENCY_CONTROL = new TestConcurrencyControl();
   private static final String DELEGATE_STEP_NAME = "delegate step";
 
+  private final MockClock clock = new MockClock();
+  private final SimpleMeterRegistry registry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, clock);
+  private final BrokerStepMetrics brokerStepMetrics = spy(new BrokerStepMetrics(registry));
+
   private BrokerStartupContext mockBrokerStartupContext;
-  private BrokerStepMetrics mockBrokerStepMetrics;
   private StartupStep<BrokerStartupContext> mockStep;
   private BrokerStepMetricDecorator sut;
   private ActorFuture<BrokerStartupContext> startupFuture;
   private ActorFuture<BrokerStartupContext> shutdownFuture;
-  private Timer mockStartupTimer;
-  private Timer mockCloseTimer;
 
   @BeforeEach
   void setUp() {
-    mockStartupTimer = mock(Timer.class);
-    mockCloseTimer = mock(Timer.class);
-
-    mockBrokerStepMetrics = mock(BrokerStepMetrics.class);
-    when(mockBrokerStepMetrics.createStartupTimer(any())).thenReturn(mockStartupTimer);
-    when(mockBrokerStepMetrics.createCloseTimer(any())).thenReturn(mockCloseTimer);
 
     mockBrokerStartupContext = mock(BrokerStartupContext.class);
     when(mockBrokerStartupContext.getConcurrencyControl()).thenReturn(CONCURRENCY_CONTROL);
@@ -57,7 +57,7 @@ class BrokerStepMetricDecoratorTest {
     when(mockStep.shutdown(mockBrokerStartupContext)).thenReturn(shutdownFuture);
     when(mockStep.getName()).thenReturn(DELEGATE_STEP_NAME);
 
-    sut = new BrokerStepMetricDecorator(mockBrokerStepMetrics, mockStep);
+    sut = new BrokerStepMetricDecorator(brokerStepMetrics, mockStep);
   }
 
   @Test
@@ -80,26 +80,29 @@ class BrokerStepMetricDecoratorTest {
 
   @Test
   void shouldUpdateStartStepDuration() {
-    // when
     sut.startup(mockBrokerStartupContext);
+    clock.addSeconds(1); // fix operation duration to be exactly one second
     startupFuture.complete(mockBrokerStartupContext);
 
     // then
-    verify(mockBrokerStepMetrics).createStartupTimer(eq(DELEGATE_STEP_NAME));
-    verify(mockStartupTimer).close();
-    verifyNoMoreInteractions(mockCloseTimer, mockStartupTimer, mockBrokerStepMetrics);
+    final var gauge = registry.get(BrokerStepMetricsDoc.STARTUP.getName()).timeGauge();
+    verify(brokerStepMetrics, Mockito.times(1)).createStartupTimer(any());
+    verifyNoMoreInteractions(brokerStepMetrics);
+    assertThat(gauge.value(TimeUnit.MILLISECONDS)).isEqualTo(TimeUnit.SECONDS.toMillis(1));
   }
 
   @Test
   void shouldUpdateShutdownStepDuration() {
     // when
     sut.shutdown(mockBrokerStartupContext);
+    clock.addSeconds(1); // fix operation duration to 1 second
     shutdownFuture.complete(mockBrokerStartupContext);
 
     // then
-    verify(mockBrokerStepMetrics).createCloseTimer(eq(DELEGATE_STEP_NAME));
-    verify(mockCloseTimer).close();
-    verifyNoMoreInteractions(mockCloseTimer, mockStartupTimer, mockBrokerStepMetrics);
+    final var gauge = registry.get(BrokerStepMetricsDoc.CLOSE.getName()).timeGauge();
+    verify(brokerStepMetrics, Mockito.times(1)).createCloseTimer(any());
+    verifyNoMoreInteractions(brokerStepMetrics);
+    assertThat(gauge.value(TimeUnit.MILLISECONDS)).isEqualTo(TimeUnit.SECONDS.toMillis(1));
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR migrates the broker step metrics to Micrometer. No names or labels changed.

I added a new utility to track duration of time gauges in `MicrometerUtil` based on the configured clock.

## Related issues

related to #26078 
