### PR TITLE
Migrate broker health metrics to Micrometer

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/HealthMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/HealthMetrics.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.monitoring;
 
+import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -14,10 +15,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 public final class HealthMetrics {
   private final AtomicInteger health = new AtomicInteger();
 
-  public HealthMetrics(final MeterRegistry registry) {
+  public HealthMetrics(final MeterRegistry registry, final int partitionId) {
     final var meterDoc = HealthMetricsDoc.HEALTH;
     Gauge.builder(meterDoc.getName(), health, AtomicInteger::intValue)
         .description(meterDoc.getDescription())
+        .tag(PartitionKeyNames.PARTITION.asString(), String.valueOf(partitionId))
         .register(registry);
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/HealthMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/HealthMetrics.java
@@ -7,32 +7,29 @@
  */
 package io.camunda.zeebe.broker.system.monitoring;
 
-import io.prometheus.client.Gauge;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.concurrent.atomic.AtomicInteger;
 
-public class HealthMetrics {
+public final class HealthMetrics {
+  private final AtomicInteger health = new AtomicInteger();
 
-  private static final Gauge HEALTH =
-      Gauge.build()
-          .namespace("zeebe")
-          .name("health")
-          .help("Shows current health of the partition (1 = healthy, 0 = unhealthy, -1 = dead)")
-          .labelNames("partition")
-          .register();
-  private final String partitionIdLabel;
-
-  public HealthMetrics(final int partitionId) {
-    partitionIdLabel = String.valueOf(partitionId);
+  public HealthMetrics(final MeterRegistry registry) {
+    final var meterDoc = HealthMetricsDoc.HEALTH;
+    Gauge.builder(meterDoc.getName(), health, AtomicInteger::intValue)
+        .description(meterDoc.getDescription())
+        .register(registry);
   }
 
   public void setHealthy() {
-    HEALTH.labels(partitionIdLabel).set(1);
+    health.set(1);
   }
 
   public void setUnhealthy() {
-    HEALTH.labels(partitionIdLabel).set(0);
+    health.set(0);
   }
 
   public void setDead() {
-    HEALTH.labels(partitionIdLabel).set(-1);
+    health.set(-1);
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/HealthMetricsDoc.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/HealthMetricsDoc.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.monitoring;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter;
+
+@SuppressWarnings("NullableProblems")
+public enum HealthMetricsDoc implements ExtendedMeterDocumentation {
+  /** Shows current health of the partition (1 = healthy, 0 = unhealthy, -1 = dead) */
+  HEALTH {
+    @Override
+    public String getName() {
+      return "zeebe.health";
+    }
+
+    @Override
+    public Meter.Type getType() {
+      return Meter.Type.GAUGE;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Shows current health of the partition (1 = healthy, 0 = unhealthy, -1 = dead)";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+
+  /**
+   * Shows current health of a specific component. This is useful as the health of a partition in
+   * general is the sum of the health of all its components. If any of them are not healthy, then
+   * the partition is not either.
+   *
+   * <p>Partitions themselves are health components for a broker, so the same logic applies to the
+   * health of a broker.
+   *
+   * <p>Health is defined as:
+   *
+   * <ul>
+   *   <li>Unknown: 0
+   *   <li>Healthy: 1
+   *   <li>Unhealthy: -1
+   *   <li>Dead: -2
+   * </ul>
+   */
+  NODES {
+    @Override
+    public String getName() {
+      return "zeebe.broker.health.nodes";
+    }
+
+    @Override
+    public Meter.Type getType() {
+      return Meter.Type.GAUGE;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Shows current health of a specific component (0 = unknown, 1 = healthy, -1 = unhealthy, -2 = dead)";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return NodesKeyNames.values();
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  };
+
+  /** Allows grouping the component health by ID and their hierarchy. */
+  enum NodesKeyNames implements KeyName {
+    /** The ID of the component node */
+    ID {
+      @Override
+      public String asString() {
+        return "id";
+      }
+    },
+
+    /**
+     * Represents the ownership hierarchy of the component; the component itself is always the last
+     * segment of the path, and is owned by the previous one, which is one by the previous one,
+     * etc., recursively.
+     *
+     * <p>The health of a segment is always the sum of the all of its children. If one segment is
+     * not healthy (unhealthy or dead), and the whole path upwards is marked the same.
+     */
+    PATH {
+      @Override
+      public String asString() {
+        return "path";
+      }
+    }
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -92,7 +92,7 @@ public final class ZeebePartition extends Actor
             Optional.of(transitionContext.brokerHealthCheckService().componentName()),
             LOG));
     zeebePartitionHealth = new ZeebePartitionHealth(transitionContext.getPartitionId(), transition);
-    healthMetrics = new HealthMetrics(transitionContext.getPartitionMeterRegistry());
+    healthMetrics = new HealthMetrics(transitionContext.getBrokerMeterRegistry(), partitionId);
     healthMetrics.setUnhealthy();
     failureListeners = new ArrayList<>();
     roleMetrics = new RoleMetrics(transitionContext.getPartitionId());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -92,7 +92,7 @@ public final class ZeebePartition extends Actor
             Optional.of(transitionContext.brokerHealthCheckService().componentName()),
             LOG));
     zeebePartitionHealth = new ZeebePartitionHealth(transitionContext.getPartitionId(), transition);
-    healthMetrics = new HealthMetrics(transitionContext.getPartitionId());
+    healthMetrics = new HealthMetrics(transitionContext.getPartitionMeterRegistry());
     healthMetrics.setUnhealthy();
     failureListeners = new ArrayList<>();
     roleMetrics = new RoleMetrics(transitionContext.getPartitionId());

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/HealthTreeMetricsTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/HealthTreeMetricsTest.java
@@ -45,7 +45,7 @@ public class HealthTreeMetricsTest {
     metrics.registerRelationship("parent-2", "parent-1");
     // when
     metrics.registerNode(component);
-    final var meter = meterRegistry.get(HealthTreeMetrics.NODES_NAME).gauge();
+    final var meter = meterRegistry.get(HealthMetricsDoc.NODES.getName()).gauge();
 
     // then
     assertThat(meter.getId().getTags())
@@ -67,7 +67,7 @@ public class HealthTreeMetricsTest {
     // given
     final var component = new DummyComponent("test-1");
     metrics.registerNode(component);
-    final var meter = meterRegistry.get(HealthTreeMetrics.NODES_NAME).gauge();
+    final var meter = meterRegistry.get(HealthMetricsDoc.NODES.getName()).gauge();
 
     // when
     component.setReport(HealthReport.fromStatus(status, component));

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
@@ -40,6 +40,7 @@ import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthIssue;
 import io.camunda.zeebe.util.health.HealthReport;
 import io.camunda.zeebe.util.health.HealthStatus;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -85,6 +86,7 @@ public class ZeebePartitionTest {
     when(brokerCheckMock.componentName()).thenReturn("Broker-0");
     when(ctx.brokerHealthCheckService()).thenReturn(brokerCheckMock);
     when(ctx.getComponentTreeListener()).thenReturn(ComponentTreeListener.noop());
+    when(ctx.getBrokerMeterRegistry()).thenReturn(new SimpleMeterRegistry());
 
     partition = new ZeebePartition(ctx, transition, List.of(new NoopStartupStep()));
   }

--- a/zeebe/util/pom.xml
+++ b/zeebe/util/pom.xml
@@ -32,6 +32,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-commons</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.util.micrometer;
 
 import io.camunda.zeebe.util.CloseableSilently;
+import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.Timer.Builder;
@@ -87,6 +88,17 @@ public final class MicrometerUtil {
     @Override
     public void close() {
       setter.accept(unit.convert(clock.monotonicTime() - startNanos, TimeUnit.NANOSECONDS));
+    }
+  }
+
+  @SuppressWarnings("NullableProblems")
+  public enum PartitionKeyNames implements KeyName {
+    /** The ID of the partition associated to the metric */
+    PARTITION {
+      @Override
+      public String asString() {
+        return "partition";
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

This PR migrates the broker health metrics to Micrometer. While none of the names or labels have changed, there is more documentation now for the health component tree metrics.

## Related issues

related to #26078
