### PR TITLE
Migrate partition role metrics to Micrometer

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -95,7 +95,9 @@ public final class ZeebePartition extends Actor
     healthMetrics = new HealthMetrics(transitionContext.getBrokerMeterRegistry(), partitionId);
     healthMetrics.setUnhealthy();
     failureListeners = new ArrayList<>();
-    roleMetrics = new RoleMetrics(transitionContext.getPartitionId());
+    roleMetrics =
+        new RoleMetrics(
+            transitionContext.getBrokerMeterRegistry(), transitionContext.getPartitionId());
   }
 
   public static String componentName(final int partitionId) {

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
@@ -12,6 +12,7 @@ import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.Timer.Builder;
+import io.micrometer.core.instrument.Timer.Sample;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongConsumer;
@@ -69,6 +70,16 @@ public final class MicrometerUtil {
     return new CloseableTimer(timer, sample);
   }
 
+  /**
+   * Returns a convenience object to measure the duration of a try/catch block targeting a timer
+   * represented by a gauge. If using a normal timer (i.e. histogram), use {@link #timer(Timer,
+   * Sample)}.
+   *
+   * @param setter the gauge state modifier
+   * @param unit the time unit for the time gauge, as declared when it was registered
+   * @param clock the associated registry's clock
+   * @return a closeable which will record the duration of a try/catch block on close
+   */
   public static CloseableSilently timer(
       final LongConsumer setter, final TimeUnit unit, final Clock clock) {
     return new CloseableGaugeTimer(setter, unit, clock, clock.monotonicTime());


### PR DESCRIPTION
## Description

This PR migrates the partition's role metric to Micrometer. No labels or metric names have changed. Depends on #27538.

## Related issues

related to #26078 
