### PR TITLE
fix: ensure all random strings are distinct

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/CommonFixtures.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/CommonFixtures.java
@@ -8,9 +8,11 @@
 package io.camunda.it.rdbms.db.fixtures;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.IntStream;
 
 public class CommonFixtures {
 
@@ -32,6 +34,20 @@ public class CommonFixtures {
       sb.append(UUID.randomUUID().toString().replace("-", ""));
     }
     return sb.substring(0, length);
+  }
+
+  public static String generateRandomString(final int length, final String prefix) {
+    return "%s-%s".formatted(generateRandomString(length), prefix);
+  }
+
+  public static String generateRandomString(final String prefix) {
+    return "%s-%s".formatted(generateRandomString(10), prefix);
+  }
+
+  public static List<String> generateRandomStrings(final String prefix, final int n) {
+    return IntStream.range(0, n)
+        .mapToObj(i -> generateRandomString("%s%02d".formatted(prefix, i)))
+        .toList();
   }
 
   /** Random String which contains random text values, as well es Doubles or Longs */

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/UserTaskFixtures.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/UserTaskFixtures.java
@@ -28,8 +28,8 @@ public final class UserTaskFixtures extends CommonFixtures {
     final var builder =
         new Builder()
             .userTaskKey(nextKey())
-            .elementId("flowNodeBpmnId-" + RANDOM.nextInt(1000))
-            .processDefinitionId("processDefinitionId-" + RANDOM.nextInt(1000))
+            .elementId(generateRandomString("flowNodeBpmnId"))
+            .processDefinitionId(generateRandomString("processDefinitionId"))
             .processInstanceKey(nextKey())
             .creationDate(NOW)
             .completionDate(NOW.plusDays(1))
@@ -39,13 +39,12 @@ public final class UserTaskFixtures extends CommonFixtures {
             .processDefinitionKey(nextKey())
             .processInstanceKey(nextKey())
             .elementInstanceKey(nextKey())
-            .tenantId("tenant-" + RANDOM.nextInt(1000))
+            .tenantId(generateRandomString("tenant"))
             .dueDate(NOW.plusDays(3))
             .followUpDate(NOW.plusDays(2))
-            .candidateGroups(
-                List.of("group" + RANDOM.nextInt(1000), "group" + RANDOM.nextInt(1000)))
-            .candidateUsers(List.of("user" + RANDOM.nextInt(1000), "user" + RANDOM.nextInt(1000)))
-            .externalFormReference("externalFormReference-" + RANDOM.nextInt(1000))
+            .candidateGroups(generateRandomStrings("group", 2))
+            .candidateUsers(generateRandomStrings("user", 2))
+            .externalFormReference(generateRandomString("externalFormReference"))
             .processDefinitionVersion(RANDOM.nextInt(100))
             .customHeaders(Map.of("key", "value"))
             .priority(RANDOM.nextInt(100));


### PR DESCRIPTION
Tests expect that users and groups have distinct names.

This caused a test failure here: https://github.com/camunda/camunda/actions/runs/13073950614/job/36481457686?pr=27485#step:7:726

