### PR TITLE
Migrate ProcessingMetrics from stream platform to Micrometer

### DIFF
--- a/monitor/grafana/camunda-performance.json
+++ b/monitor/grafana/camunda-performance.json
@@ -1075,7 +1075,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_stream_processor_latency_sum{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) / sum(rate(zeebe_stream_processor_latency_count{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_stream_processor_latency_sum{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval]) or rate(zeebe_stream_processor_latency_seconds_sum{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) / sum(rate(zeebe_stream_processor_latency_count{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval]) or rate(zeebe_stream_processor_latency_seconds_count{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval]))",
               "hide": false,
               "instant": false,
               "legendFormat": "Processing latency",
@@ -1167,7 +1167,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_stream_processor_latency_sum{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) / sum(rate(zeebe_stream_processor_latency_count{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_stream_processor_latency_sum{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval]) or rate(zeebe_stream_processor_latency_seconds_sum{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) / sum(rate(zeebe_stream_processor_latency_count{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval]) or rate(zeebe_stream_processor_latency_seconds_count{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval]))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -1439,7 +1439,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.5, sum(rate(zeebe_stream_processor_latency_bucket{namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.5, sum(rate(zeebe_stream_processor_latency_bucket{namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval]) or rate(zeebe_stream_processor_latency_seconds_bucket{namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -1453,7 +1453,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum(rate(zeebe_stream_processor_latency_bucket{namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(zeebe_stream_processor_latency_bucket{namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval]) or rate(zeebe_stream_processor_latency_seconds_bucket{namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
               "hide": false,
               "instant": false,
               "legendFormat": "p99",
@@ -1466,7 +1466,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.90, sum(rate(zeebe_stream_processor_latency_bucket{namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.90, sum(rate(zeebe_stream_processor_latency_bucket{namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval]) or rate(zeebe_stream_processor_latency_seconds_bucket{namespace=~\"$namespace\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
               "hide": false,
               "instant": false,
               "legendFormat": "p90",
@@ -1831,7 +1831,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.50, sum(rate(zeebe_stream_processor_processing_duration_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.50, sum(rate(zeebe_stream_processor_processing_duration_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval]) or rate(zeebe_stream_processor_processing_duration_seconds_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (le))",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "p50",
@@ -1844,7 +1844,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum(rate(zeebe_stream_processor_processing_duration_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.99, sum(rate(zeebe_stream_processor_processing_duration_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval]) or rate(zeebe_stream_processor_processing_duration_seconds_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (le))",
               "hide": false,
               "instant": false,
               "legendFormat": "p99",
@@ -1857,7 +1857,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.90, sum(rate(zeebe_stream_processor_processing_duration_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.90, sum(rate(zeebe_stream_processor_processing_duration_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval]) or rate(zeebe_stream_processor_processing_duration_seconds_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (le))",
               "hide": false,
               "instant": false,
               "legendFormat": "p90",

--- a/monitor/grafana/dashboards/operate.json
+++ b/monitor/grafana/dashboards/operate.json
@@ -530,7 +530,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(rate(zeebe_stream_processor_latency_sum{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) / sum(rate(zeebe_stream_processor_latency_count{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(rate(zeebe_stream_processor_latency_sum{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval]) or rate(zeebe_stream_processor_latency_seconds_sum{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) / sum(rate(zeebe_stream_processor_latency_count{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval]) or rate(zeebe_stream_processor_latency_seconds_count{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval]))",
               "hide": false,
               "instant": false,
               "legendFormat": "Processing latency",

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -9113,7 +9113,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(increase(zeebe_replay_event_batch_replay_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_replay_event_batch_replay_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or increase(zeebe_replay_event_batch_replay_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -8815,7 +8815,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_stream_processor_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_stream_processor_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or increase(zeebe_stream_processor_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -8914,7 +8914,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.50, sum(increase(zeebe_stream_processor_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le, valueType, intent))",
+              "expr": "histogram_quantile(0.50, sum(increase(zeebe_stream_processor_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or rate(zeebe_stream_processor_processing_duration_seconds_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (le, valueType, intent))",
               "format": "time_series",
               "interval": "30s",
               "intervalFactor": 1,
@@ -8927,7 +8927,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.90, sum(increase(zeebe_stream_processor_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le, valueType, intent))",
+              "expr": "histogram_quantile(0.90, sum(increase(zeebe_stream_processor_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or rate(zeebe_stream_processor_processing_duration_seconds_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (le, valueType, intent))",
               "format": "time_series",
               "hide": false,
               "interval": "30s",
@@ -8942,7 +8942,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.99, sum(increase(zeebe_stream_processor_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le, valueType, intent))",
+              "expr": "histogram_quantile(0.99, sum(increase(zeebe_stream_processor_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or rate(zeebe_stream_processor_processing_duration_seconds_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (le, valueType, intent))",
               "format": "time_series",
               "hide": false,
               "interval": "30s",
@@ -9029,7 +9029,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_stream_processor_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_stream_processor_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or rate(zeebe_stream_processor_processing_duration_seconds_bucket{namespace=~\"$namespace\",partition=~\"$partition\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,

--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -9195,7 +9195,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_stream_processor_batch_processing_post_commit_tasks_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_stream_processor_batch_processing_post_commit_tasks_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval]) or increase(zeebe_stream_processor_batch_processing_post_commit_tasks_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "legendFormat": "{{le}}",
@@ -9277,7 +9277,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_stream_processor_batch_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_stream_processor_batch_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval]) or increase(zeebe_stream_processor_batch_processing_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "legendFormat": "{{le}}",

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetrics.java
@@ -147,7 +147,7 @@ public final class ExporterMetrics {
     final var meterDoc = ExporterMetricsDoc.EXPORTING_DURATION;
     return Timer.builder(meterDoc.getName())
         .description(meterDoc.getDescription())
-        .serviceLevelObjectives(meterDoc.getServiceLevelObjectives())
+        .serviceLevelObjectives(meterDoc.getTimerSLOs())
         .tag(LABEL_NAME_VALUE_TYPE, valueType.name())
         .tag(LABEL_NAME_EXPORTER, exporterId)
         .register(meterRegistry);
@@ -157,7 +157,7 @@ public final class ExporterMetrics {
     final var meterDoc = ExporterMetricsDoc.EXPORTING_LATENCY;
     return Timer.builder(meterDoc.getName())
         .description(meterDoc.getDescription())
-        .serviceLevelObjectives(meterDoc.getServiceLevelObjectives())
+        .serviceLevelObjectives(meterDoc.getTimerSLOs())
         .tag(LABEL_NAME_VALUE_TYPE, valueType.name())
         .register(meterRegistry);
   }

--- a/zeebe/stream-platform/pom.xml
+++ b/zeebe/stream-platform/pom.xml
@@ -80,11 +80,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
     </dependency>

--- a/zeebe/stream-platform/pom.xml
+++ b/zeebe/stream-platform/pom.xml
@@ -90,6 +90,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-commons</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -195,7 +195,7 @@ public final class ProcessingStateMachine {
     metrics.initializeProcessorPhase(context.getStreamProcessorPhase());
     streamProcessorListener = context.getStreamProcessorListener();
 
-    processingMetrics = new ProcessingMetrics(Integer.toString(partitionId));
+    processingMetrics = new ProcessingMetrics(context.getMeterRegistry());
 
     processingFilter =
         new MetadataEventFilter(

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -39,14 +39,13 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache;
 import io.camunda.zeebe.stream.api.state.MutableLastProcessedPositionState;
 import io.camunda.zeebe.stream.impl.metrics.ProcessingMetrics;
-import io.camunda.zeebe.stream.impl.metrics.StreamProcessorMetrics;
 import io.camunda.zeebe.stream.impl.records.RecordValues;
 import io.camunda.zeebe.stream.impl.records.TypedRecordImpl;
 import io.camunda.zeebe.stream.impl.records.UnwrittenRecord;
+import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.exception.RecoverableException;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
-import io.prometheus.client.Histogram;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -139,7 +138,6 @@ public final class ProcessingStateMachine {
   private final BooleanSupplier abortCondition;
   private final RecordValues recordValues;
   private final TypedRecordImpl typedCommand;
-  private final StreamProcessorMetrics metrics;
   private final StreamProcessorListener streamProcessorListener;
   // current iteration
   private LoggedEvent currentRecord;
@@ -149,7 +147,7 @@ public final class ProcessingStateMachine {
   private long lastWrittenPosition = StreamProcessor.UNSET_POSITION;
   private int onErrorRetries;
   // Used for processing duration metrics
-  private Histogram.Timer processingTimer;
+  private CloseableSilently processingTimer;
   private boolean reachedEnd = true;
   private final StreamProcessorContext context;
   private final List<RecordProcessor> recordProcessors;
@@ -191,12 +189,8 @@ public final class ProcessingStateMachine {
     final int partitionId = context.getLogStream().getPartitionId();
     typedCommand = new TypedRecordImpl(partitionId);
 
-    metrics = new StreamProcessorMetrics(partitionId);
-    metrics.initializeProcessorPhase(context.getStreamProcessorPhase());
     streamProcessorListener = context.getStreamProcessorListener();
-
     processingMetrics = new ProcessingMetrics(context.getMeterRegistry());
-
     processingFilter =
         new MetadataEventFilter(
                 recordMetadata -> recordMetadata.getRecordType() == RecordType.COMMAND)
@@ -209,7 +203,7 @@ public final class ProcessingStateMachine {
     notifySkippedListener(currentRecord);
     markProcessingCompleted();
     actor.submit(this::tryToReadNextRecord);
-    metrics.eventSkipped();
+    processingMetrics.eventSkipped();
   }
 
   void markProcessingCompleted() {
@@ -273,9 +267,10 @@ public final class ProcessingStateMachine {
       // Here we need to get the current time, since we want to calculate
       // how long it took between writing to the dispatcher and processing.
       // In all other cases we should prefer to use the Prometheus Timer API.
-      metrics.processingLatency(loggedEvent.getTimestamp(), clock.millis());
+      processingMetrics.processingLatency(loggedEvent.getTimestamp(), clock.millis());
       processingTimer =
-          metrics.startProcessingDurationTimer(metadata.getValueType(), metadata.getIntent());
+          processingMetrics.startProcessingDurationTimer(
+              metadata.getValueType(), metadata.getIntent());
 
       final var value = recordValues.readRecordValue(loggedEvent, metadata.getValueType());
       typedCommand.wrap(loggedEvent, metadata, value);
@@ -388,7 +383,7 @@ public final class ProcessingStateMachine {
 
       lastProcessingResultSize = currentProcessingResult.getRecordBatch().entries().size();
       processedCommandsCount++;
-      metrics.commandsProcessed();
+      processingMetrics.commandsProcessed();
     }
   }
 
@@ -592,7 +587,7 @@ public final class ProcessingStateMachine {
     if (currentProcessingResult.isEmpty()) {
       // we skipped the processing entirely; we have no results
       notifySkippedListener(currentRecord);
-      metrics.eventSkipped();
+      processingMetrics.eventSkipped();
       writeFuture = CompletableActorFuture.completed(true);
     } else if (pendingWrites.isEmpty()) {
       // we might have nothing to write but likely something to send as response
@@ -635,7 +630,7 @@ public final class ProcessingStateMachine {
             // incremented by 1 for one record (even in a batch), so we can count the amount
             // of written records via the lastWritten and now written position.
             final var amount = writtenPosition - lastWrittenPosition;
-            metrics.recordsWritten(amount);
+            processingMetrics.recordsWritten(amount);
             updateState();
           }
         });
@@ -647,7 +642,7 @@ public final class ProcessingStateMachine {
             () -> {
               zeebeDbTransaction.commit();
               lastSuccessfulProcessedRecordPosition = currentRecord.getPosition();
-              metrics.setLastProcessedPosition(lastSuccessfulProcessedRecordPosition);
+              processingMetrics.setLastProcessedPosition(lastSuccessfulProcessedRecordPosition);
               lastWrittenPosition = writtenPosition;
               return true;
             },

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
@@ -106,7 +106,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
     streamProcessorMode = context.getProcessorMode();
     logStream = context.getLogStream();
     logStreamBatchReader = new LogStreamBatchReaderImpl(context.getLogStreamReader());
-    replayMetrics = new ReplayMetrics(logStream.getPartitionId());
+    replayMetrics = new ReplayMetrics(context.getMeterRegistry());
   }
 
   /**

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -114,7 +114,6 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   private ProcessingScheduleServiceImpl processorActorService;
   private ProcessingScheduleServiceImpl asyncScheduleService;
   private AsyncProcessingScheduleServiceActor asyncActor;
-  private ScheduledTaskMetrics scheduledTaskMetrics;
 
   protected StreamProcessor(final StreamProcessorBuilder processorBuilder) {
     actorSchedulingService = processorBuilder.getActorSchedulingService();
@@ -131,7 +130,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     logStream = streamProcessorContext.getLogStream();
     partitionId = logStream.getPartitionId();
     actorName = buildActorName("StreamProcessor", partitionId);
-    metrics = new StreamProcessorMetrics(partitionId);
+    metrics = new StreamProcessorMetrics(streamProcessorContext.getMeterRegistry());
     metrics.initializeProcessorPhase(streamProcessorContext.getStreamProcessorPhase());
     recordProcessors.addAll(processorBuilder.getRecordProcessors());
   }
@@ -162,11 +161,12 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   @Override
   protected void onActorStarted() {
     try {
-      LOG.debug("Recovering state of partition {} from snapshot", partitionId);
       final var startRecoveryTimer = metrics.startRecoveryTimer();
+      LOG.debug("Recovering state of partition {} from snapshot", partitionId);
       final long snapshotPosition = recoverFromSnapshot();
 
-      scheduledTaskMetrics = ScheduledTaskMetrics.of(streamProcessorContext.getMeterRegistry());
+      final var scheduledTaskMetrics =
+          ScheduledTaskMetrics.of(streamProcessorContext.getMeterRegistry());
       processorActorService =
           new ProcessingScheduleServiceImpl(
               streamProcessorContext::getStreamProcessorPhase,

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/ProcessingMetrics.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/ProcessingMetrics.java
@@ -7,47 +7,66 @@
  */
 package io.camunda.zeebe.stream.impl.metrics;
 
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.impl.ProcessingStateMachine.ErrorHandlingPhase;
 import io.camunda.zeebe.stream.impl.metrics.StreamMetricsDoc.ErrorHandlingPhaseKeys;
+import io.camunda.zeebe.stream.impl.metrics.StreamMetricsDoc.ProcessingDurationKeys;
+import io.camunda.zeebe.stream.impl.metrics.StreamMetricsDoc.StreamProcessorActionKeys;
 import io.camunda.zeebe.util.CloseableSilently;
+import io.camunda.zeebe.util.collection.Table;
 import io.camunda.zeebe.util.micrometer.EnumMeter;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
-import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class ProcessingMetrics {
+  private static final String ACTION_WRITTEN = "written";
+  private static final String ACTION_SKIPPED = "skipped";
+  private static final String ACTION_PROCESSED = "processed";
 
-  private final Clock clock;
+  private final AtomicLong lastProcessedPosition = new AtomicLong();
+  private final Table<ValueType, Intent, Timer> processingDuration = Table.simple();
+  private final Map<String, Counter> streamProcessorEvents = new HashMap<>();
+
+  private final MeterRegistry registry;
   private final Timer batchProcessingDuration;
   private final Timer batchProcessingPostCommitTasks;
   private final DistributionSummary batchProcessingCommands;
   private final Counter batchProcessingRetries;
   private final EnumMeter<ErrorHandlingPhase> errorHandlingPhase;
+  private final Timer processingLatency;
 
   public ProcessingMetrics(final MeterRegistry registry) {
-    clock = registry.config().clock();
+    this.registry = registry;
 
-    batchProcessingDuration = registerTimer(StreamMetricsDoc.BATCH_PROCESSING_DURATION, registry);
+    registerLastProcessedPosition();
+    batchProcessingDuration = registerTimer(StreamMetricsDoc.BATCH_PROCESSING_DURATION);
     batchProcessingPostCommitTasks =
-        registerTimer(StreamMetricsDoc.BATCH_PROCESSING_POST_COMMIT_TASKS, registry);
-    batchProcessingCommands = registerBatchProcessingCommands(registry);
-    batchProcessingRetries = registerBatchProcessingRetries(registry);
+        registerTimer(StreamMetricsDoc.BATCH_PROCESSING_POST_COMMIT_TASKS);
+    batchProcessingCommands = registerBatchProcessingCommands();
+    batchProcessingRetries = registerBatchProcessingRetries();
     errorHandlingPhase =
         EnumMeter.register(
             ErrorHandlingPhase.class,
             StreamMetricsDoc.ERROR_HANDLING_PHASE,
             ErrorHandlingPhaseKeys.ERROR_HANDLING_PHASE,
             registry);
+    processingLatency = registerProcessingLatency();
 
     // initialize as no error to start with
     errorHandlingPhase.state(ErrorHandlingPhase.NO_ERROR);
   }
 
   public CloseableSilently startBatchProcessingDurationTimer() {
-    return MicrometerUtil.timer(batchProcessingDuration, Timer.start(clock));
+    return MicrometerUtil.timer(batchProcessingDuration, Timer.start(registry.config().clock()));
   }
 
   public void observeCommandCount(final int commandCount) {
@@ -59,14 +78,53 @@ public class ProcessingMetrics {
   }
 
   public CloseableSilently startBatchProcessingPostCommitTasksTimer() {
-    return MicrometerUtil.timer(batchProcessingPostCommitTasks, Timer.start(clock));
+    return MicrometerUtil.timer(
+        batchProcessingPostCommitTasks, Timer.start(registry.config().clock()));
   }
 
   public void errorHandlingPhase(final ErrorHandlingPhase phase) {
     errorHandlingPhase.state(phase);
   }
 
-  private DistributionSummary registerBatchProcessingCommands(final MeterRegistry registry) {
+  public void processingLatency(final long written, final long processed) {
+    processingLatency.record(processed - written, TimeUnit.MILLISECONDS);
+  }
+
+  public CloseableSilently startProcessingDurationTimer(
+      final ValueType valueType, final Intent intent) {
+    final var timer =
+        processingDuration.computeIfAbsent(
+            valueType, intent, this::registerProcessingDurationTimer);
+    return MicrometerUtil.timer(timer, Timer.start(registry.config().clock()));
+  }
+
+  /** We only process commands. */
+  public void commandsProcessed() {
+    event(ACTION_PROCESSED);
+  }
+
+  /**
+   * We write various type of records. The positions are always increasing and incremented by 1 for
+   * one record.
+   */
+  public void recordsWritten(final long amount) {
+    if (amount < 1) {
+      return;
+    }
+
+    countStreamProcessorEvent(ACTION_WRITTEN, amount);
+  }
+
+  /** We skip events on processing. */
+  public void eventSkipped() {
+    event(ACTION_SKIPPED);
+  }
+
+  public void setLastProcessedPosition(final long position) {
+    lastProcessedPosition.set(position);
+  }
+
+  private DistributionSummary registerBatchProcessingCommands() {
     final DistributionSummary batchProcessingCommands;
     final var commandsDoc = StreamMetricsDoc.BATCH_PROCESSING_COMMANDS;
     batchProcessingCommands =
@@ -77,7 +135,7 @@ public class ProcessingMetrics {
     return batchProcessingCommands;
   }
 
-  private Counter registerBatchProcessingRetries(final MeterRegistry registry) {
+  private Counter registerBatchProcessingRetries() {
     final Counter batchProcessingRetries;
     final var retriesDoc = StreamMetricsDoc.BATCH_PROCESSING_RETRIES;
     batchProcessingRetries =
@@ -87,10 +145,51 @@ public class ProcessingMetrics {
     return batchProcessingRetries;
   }
 
-  private Timer registerTimer(final StreamMetricsDoc meterDoc, final MeterRegistry registry) {
+  private Timer registerTimer(final StreamMetricsDoc meterDoc) {
     return Timer.builder(meterDoc.getName())
         .description(meterDoc.getDescription())
         .serviceLevelObjectives(meterDoc.getTimerSLOs())
+        .register(registry);
+  }
+
+  private void registerLastProcessedPosition() {
+    final var meterDoc = StreamMetricsDoc.LAST_PROCESSED_POSITION;
+    Gauge.builder(meterDoc.getName(), lastProcessedPosition, AtomicLong::longValue)
+        .description(meterDoc.getDescription())
+        .register(registry);
+  }
+
+  private void event(final String action) {
+    countStreamProcessorEvent(action, 1);
+  }
+
+  private void countStreamProcessorEvent(final String action, final long count) {
+    streamProcessorEvents
+        .computeIfAbsent(action, this::registerStreamProcessorEventCounter)
+        .increment(count);
+  }
+
+  private Counter registerStreamProcessorEventCounter(final String action) {
+    final var meterDoc = StreamMetricsDoc.STREAM_PROCESSOR_EVENTS;
+    return Counter.builder(meterDoc.getName())
+        .description(meterDoc.getDescription())
+        .tag(StreamProcessorActionKeys.ACTION.asString(), action)
+        .register(registry);
+  }
+
+  private Timer registerProcessingLatency() {
+    final var meterDoc = StreamMetricsDoc.PROCESSING_LATENCY;
+    return Timer.builder(meterDoc.getName())
+        .description(meterDoc.getDescription())
+        .register(registry);
+  }
+
+  private Timer registerProcessingDurationTimer(final ValueType valueType, final Intent intent) {
+    final var meterDoc = StreamMetricsDoc.PROCESSING_DURATION;
+    return Timer.builder(meterDoc.getName())
+        .description(meterDoc.getDescription())
+        .tag(ProcessingDurationKeys.VALUE_TYPE.asString(), valueType.name())
+        .tag(ProcessingDurationKeys.INTENT.asString(), intent.name())
         .register(registry);
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamMetricsDoc.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamMetricsDoc.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.impl.metrics;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter.Type;
+import java.time.Duration;
+
+/** Documentation for all stream platform related metrics */
+@SuppressWarnings("NullableProblems")
+public enum StreamMetricsDoc implements ExtendedMeterDocumentation {
+  /** Time spent in batch processing (in seconds) */
+  BATCH_PROCESSING_DURATION {
+    private static final Duration[] BUCKETS = {
+      Duration.ofNanos(100_000), // 100 micros
+      Duration.ofMillis(1),
+      Duration.ofMillis(10),
+      Duration.ofMillis(100),
+      Duration.ofMillis(250),
+      Duration.ofMillis(500),
+      Duration.ofSeconds(1),
+      Duration.ofSeconds(2)
+    };
+
+    @Override
+    public String getDescription() {
+      return "Time spent in batch processing (in seconds)";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.stream.processor.batch.processing.duration";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+  },
+
+  /** Records the distribution of commands in a batch over time */
+  BATCH_PROCESSING_COMMANDS {
+    private static final double[] BUCKETS = {1, 2, 4, 8, 16, 32, 64, 128};
+
+    @Override
+    public String getDescription() {
+      return "Records the distribution of commands in a batch over time";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.stream.processor.batch.processing.commands";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.DISTRIBUTION_SUMMARY;
+    }
+
+    @Override
+    public double[] getDistributionSLOs() {
+      return BUCKETS;
+    }
+  },
+
+  /** Time spent in executing post commit tasks after batch processing (in seconds) */
+  BATCH_PROCESSING_POST_COMMIT_TASKS {
+    private static final Duration[] BUCKETS = {
+      Duration.ofNanos(100_000), // 100 micros
+      Duration.ofMillis(1),
+      Duration.ofMillis(10),
+      Duration.ofMillis(100),
+      Duration.ofMillis(250),
+      Duration.ofMillis(500),
+      Duration.ofSeconds(1),
+      Duration.ofSeconds(2)
+    };
+
+    @Override
+    public String getDescription() {
+      return "Time spent in executing post commit tasks after batch processing (in seconds)";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.stream.processor.batch.processing.post.commit.tasks";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+  },
+
+  /** Number of times batch processing failed due to reaching batch limit and was retried */
+  BATCH_PROCESSING_RETRIES {
+    @Override
+    public String getDescription() {
+      return "Number of times batch processing failed due to reaching batch limit and was retried";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.stream.processor.batch.processing.retry";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+  },
+
+  /**
+   * The current phase of error handling the processor is in; see {@link
+   * io.camunda.zeebe.stream.impl.ProcessingStateMachine.ErrorHandlingPhase} for possible values.
+   */
+  ERROR_HANDLING_PHASE {
+    @Override
+    public String getDescription() {
+      return "The current phase of error handling the processor is in";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.stream.processor.error.handling.phase";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return ErrorHandlingPhaseKeys.values();
+    }
+  };
+
+  public enum ErrorHandlingPhaseKeys implements KeyName {
+    /**
+     * Tag/key value specifying the current error handling phase in a human-readable way. This is
+     * exactly the metric name for backwards compatibility with Prometheus' Enumeration metric.
+     *
+     * <p>Possible values are the names (as is) of the enum {@link
+     * io.camunda.zeebe.stream.impl.ProcessingStateMachine.ErrorHandlingPhase}.
+     */
+    ERROR_HANDLING_PHASE {
+      @Override
+      public String asString() {
+        return "zeebe_stream_processor_error_handling_phase";
+      }
+    }
+  }
+}

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamMetricsDoc.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamMetricsDoc.java
@@ -204,6 +204,119 @@ public enum StreamMetricsDoc implements ExtendedMeterDocumentation {
     public Type getType() {
       return Type.TIMER;
     }
+  },
+
+  /** Number of records processed by stream processor */
+  STREAM_PROCESSOR_EVENTS {
+    @Override
+    public String getDescription() {
+      return "Number of records processed by stream processor";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.stream.processor.records.total";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return StreamProcessorActionKeys.values();
+    }
+  },
+
+  /** The last position the stream processor has processed */
+  LAST_PROCESSED_POSITION {
+    @Override
+    public String getDescription() {
+      return "The last position the stream processor has processed";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.stream.processor.last.processed.position";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+  },
+
+  /** Time between a command is written until it is picked up for processing (in seconds) */
+  PROCESSING_LATENCY {
+    @Override
+    public String getDescription() {
+      return "Time between a command is written until it is picked up for processing (in seconds)";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.stream.processor.latency";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+  },
+
+  /** Time for processing a record (in seconds) */
+  PROCESSING_DURATION {
+    @Override
+    public String getDescription() {
+      return "Time for processing a record (in seconds)";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.stream.processor.processing.duration";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+  },
+
+  /** Time taken for startup and recovery of stream processor (in ms) */
+  STARTUP_RECOVERY_TIME {
+    @Override
+    public String getDescription() {
+      return "Time taken for startup and recovery of stream processor (in ms)";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.stream.processor.startup.recovery.time";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+  },
+
+  /** Describes the state of the stream processor, namely if it is active or paused */
+  PROCESSOR_STATE {
+    @Override
+    public String getDescription() {
+      return "Describes the state of the stream processor, namely if it is active or paused";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.stream.processor.state";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
   };
 
   public enum ErrorHandlingPhaseKeys implements KeyName {
@@ -220,5 +333,35 @@ public enum StreamMetricsDoc implements ExtendedMeterDocumentation {
         return "zeebe_stream_processor_error_handling_phase";
       }
     }
+  }
+
+  /** The action counted by the given {@link #STREAM_PROCESSOR_EVENTS} series */
+  public enum StreamProcessorActionKeys implements KeyName {
+    /** Denotes the actual action applied to the event: one of written, skipped, or processed. */
+    ACTION {
+      @Override
+      public String asString() {
+        return "action";
+      }
+    }
+  }
+
+  /** The value type and intent combination denoting the command which was measured */
+  public enum ProcessingDurationKeys implements KeyName {
+    /** The value type of the record whose processing duration was just measured */
+    VALUE_TYPE {
+      @Override
+      public String asString() {
+        return "valueType";
+      }
+    },
+
+    /** The intent of the record whose processing duration was just measured */
+    INTENT {
+      @Override
+      public String asString() {
+        return "intent";
+      }
+    },
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamMetricsDoc.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamMetricsDoc.java
@@ -150,6 +150,60 @@ public enum StreamMetricsDoc implements ExtendedMeterDocumentation {
     public KeyName[] getKeyNames() {
       return ErrorHandlingPhaseKeys.values();
     }
+  },
+
+  /** Number of events replayed by the stream processor */
+  REPLAY_EVENTS_COUNT {
+    @Override
+    public String getDescription() {
+      return "Number of events replayed by the stream processor";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.replay.events.total";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+  },
+
+  /** The last source position the stream processor has replayed */
+  LAST_SOURCE_POSITION {
+    @Override
+    public String getDescription() {
+      return "The last source position the stream processor has replayed";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.replay.last.source.position";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+  },
+
+  /** Time for replay a batch of events (in seconds) */
+  REPLAY_DURATION {
+    @Override
+    public String getDescription() {
+      return "Time for replay a batch of events (in seconds)";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.replay.event.batch.replay.duration";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
   };
 
   public enum ErrorHandlingPhaseKeys implements KeyName {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamProcessorMetrics.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamProcessorMetrics.java
@@ -7,78 +7,28 @@
  */
 package io.camunda.zeebe.stream.impl.metrics;
 
-import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.impl.StreamProcessor.Phase;
-import io.prometheus.client.Counter;
-import io.prometheus.client.Gauge;
-import io.prometheus.client.Histogram;
+import io.camunda.zeebe.util.CloseableSilently;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.TimeGauge;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 public final class StreamProcessorMetrics {
 
-  private static final String LABEL_NAME_PARTITION = "partition";
-  private static final String LABEL_NAME_ACTION = "action";
+  private final AtomicLong startupRecoveryTime = new AtomicLong();
+  private final AtomicInteger processorState = new AtomicInteger();
 
-  private static final String LABEL_WRITTEN = "written";
-  private static final String LABEL_SKIPPED = "skipped";
-  private static final String LABEL_PROCESSED = "processed";
-  private static final String NAMESPACE = "zeebe";
+  private final MeterRegistry registry;
 
-  private static final Counter STREAM_PROCESSOR_EVENTS =
-      Counter.build()
-          .namespace(NAMESPACE)
-          .name("stream_processor_records_total")
-          .help("Number of records processed by stream processor")
-          .labelNames(LABEL_NAME_ACTION, LABEL_NAME_PARTITION)
-          .register();
+  public StreamProcessorMetrics(final MeterRegistry registry) {
+    this.registry = registry;
 
-  private static final Gauge LAST_PROCESSED_POSITION =
-      Gauge.build()
-          .namespace(NAMESPACE)
-          .name("stream_processor_last_processed_position")
-          .help("The last position the stream processor has processed.")
-          .labelNames(LABEL_NAME_PARTITION)
-          .register();
-
-  private static final Histogram PROCESSING_LATENCY =
-      Histogram.build()
-          .namespace(NAMESPACE)
-          .name("stream_processor_latency")
-          .help(
-              "Time between a command is written until it is picked up for processing (in seconds)")
-          .labelNames(LABEL_NAME_PARTITION)
-          .register();
-  private static final String LABEL_NAME_VALUE_TYPE = "valueType";
-  private static final String LABEL_NAME_INTENT = "intent";
-  private static final Histogram PROCESSING_DURATION =
-      Histogram.build()
-          .namespace(NAMESPACE)
-          .name("stream_processor_processing_duration")
-          .help("Time for processing a record (in seconds)")
-          .labelNames(LABEL_NAME_PARTITION, LABEL_NAME_VALUE_TYPE, LABEL_NAME_INTENT)
-          .register();
-
-  private static final Gauge STARTUP_RECOVERY_TIME =
-      Gauge.build()
-          .namespace(NAMESPACE)
-          .name("stream_processor_startup_recovery_time")
-          .help("Time taken for startup and recovery of stream processor (in ms)")
-          .labelNames(LABEL_NAME_PARTITION)
-          .register();
-
-  private static final Gauge PROCESSOR_STATE =
-      Gauge.build()
-          .namespace(NAMESPACE)
-          .name("stream_processor_state")
-          .help("Describes the state of the stream processor, namely if it is active or paused.")
-          .labelNames(LABEL_NAME_PARTITION)
-          .register();
-  private final String partitionIdLabel;
-  private final Gauge.Child processorState;
-
-  public StreamProcessorMetrics(final int partitionId) {
-    partitionIdLabel = String.valueOf(partitionId);
-    processorState = PROCESSOR_STATE.labels(partitionIdLabel);
+    registerStartupRecoveryTime();
+    registerProcessorState();
   }
 
   public void setStreamProcessorInitial() {
@@ -101,49 +51,9 @@ public final class StreamProcessorMetrics {
     processorState.set(4);
   }
 
-  private void event(final String action) {
-    STREAM_PROCESSOR_EVENTS.labels(action, partitionIdLabel).inc();
-  }
-
-  public void processingLatency(final long written, final long processed) {
-    PROCESSING_LATENCY.labels(partitionIdLabel).observe((processed - written) / 1000f);
-  }
-
-  public Histogram.Timer startProcessingDurationTimer(
-      final ValueType valueType, final Intent intent) {
-    return PROCESSING_DURATION
-        .labels(partitionIdLabel, valueType.name(), intent.name())
-        .startTimer();
-  }
-
-  /** We only process commands. */
-  public void commandsProcessed() {
-    event(LABEL_PROCESSED);
-  }
-
-  /**
-   * We write various type of records. The positions are always increasing and incremented by 1 for
-   * one record.
-   */
-  public void recordsWritten(final long amount) {
-    if (amount < 1) {
-      return;
-    }
-
-    STREAM_PROCESSOR_EVENTS.labels(LABEL_WRITTEN, partitionIdLabel).inc(amount);
-  }
-
-  /** We skip events on processing. */
-  public void eventSkipped() {
-    event(LABEL_SKIPPED);
-  }
-
-  public Gauge.Timer startRecoveryTimer() {
-    return STARTUP_RECOVERY_TIME.labels(partitionIdLabel).startTimer();
-  }
-
-  public void setLastProcessedPosition(final long position) {
-    LAST_PROCESSED_POSITION.labels(partitionIdLabel).set(position);
+  public CloseableSilently startRecoveryTimer() {
+    return MicrometerUtil.timer(
+        startupRecoveryTime::set, TimeUnit.MILLISECONDS, registry.config().clock());
   }
 
   public void initializeProcessorPhase(final Phase phase) {
@@ -163,5 +73,20 @@ public final class StreamProcessorMetrics {
       default:
         setStreamProcessorFailed();
     }
+  }
+
+  private void registerStartupRecoveryTime() {
+    final var meterDoc = StreamMetricsDoc.PROCESSOR_STATE;
+    TimeGauge.builder(
+            meterDoc.getName(), startupRecoveryTime, TimeUnit.MILLISECONDS, AtomicLong::longValue)
+        .description(meterDoc.getDescription())
+        .register(registry);
+  }
+
+  private void registerProcessorState() {
+    final var meterDoc = StreamMetricsDoc.PROCESSOR_STATE;
+    Gauge.builder(meterDoc.getName(), processorState, AtomicInteger::intValue)
+        .description(meterDoc.getDescription())
+        .register(registry);
   }
 }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/EnumMeter.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/EnumMeter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util.micrometer;
+
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * An {@link EnumMeter} is a set of {@link Gauge}, one for each state in the given enum type {@link
+ * T}, with the guarantee that only one of these gauges is 1 at any given time, and all others are
+ * 0.
+ *
+ * <p>When you set the state to a particular value, it will zero out all others, and set that one to
+ * 1.
+ *
+ * <p>Can be useful in combination with Grafana's state timeline.
+ *
+ * @param <T> the enum type of the possible states
+ */
+public final class EnumMeter<T extends Enum<T>> {
+  private final Map<T, AtomicBoolean> states;
+
+  private EnumMeter(final Map<T, AtomicBoolean> states) {
+    this.states = states;
+  }
+
+  /**
+   * Returns a new builder for an enumeration meter.
+   *
+   * @param stateClass the enum defining the possible states
+   * @param documentation the documentation for this meter
+   * @param stateTag the tag which will be set to the state name
+   * @return a new builder for this enumeration
+   * @param <T> the expected state type
+   */
+  public static <T extends Enum<T>> EnumMeter<T> register(
+      final Class<T> stateClass,
+      final ExtendedMeterDocumentation documentation,
+      final KeyName stateTag,
+      final MeterRegistry registry) {
+    final Map<T, AtomicBoolean> states = new HashMap<>();
+    for (final var state : stateClass.getEnumConstants()) {
+      final var value = new AtomicBoolean(false);
+      states.put(state, value);
+      Gauge.builder(documentation.getName(), value, bool -> bool.get() ? 1 : 0)
+          .description(documentation.getDescription())
+          .tag(stateTag.asString(), state.name())
+          .register(registry);
+    }
+
+    return new EnumMeter<>(states);
+  }
+
+  public void state(final T state) {
+    for (final var entry : states.entrySet()) {
+      entry.getValue().set(entry.getKey() == state);
+    }
+  }
+}

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/ExtendedMeterDocumentation.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/ExtendedMeterDocumentation.java
@@ -17,14 +17,20 @@ import java.time.Duration;
  */
 public interface ExtendedMeterDocumentation extends MeterDocumentation {
 
+  double[] EMPTY_DISTRIBUTION_SLOS = new double[0];
+
   /** Returns the description (also known as {@code help} in some systems) for the given meter. */
   String getDescription();
 
-  /**
-   * Returns the buckets to be used if the meter type is a {@link Meter.Type#TIMER} or {@link
-   * Meter.Type#DISTRIBUTION_SUMMARY}.
-   */
-  default Duration[] getServiceLevelObjectives() {
+  /** Returns the buckets to be used if the meter type is a {@link Meter.Type#TIMER}. */
+  default Duration[] getTimerSLOs() {
     return MicrometerUtil.defaultPrometheusBuckets();
+  }
+
+  /**
+   * Returns the buckets to be used if the meter type is a {@link Meter.Type#DISTRIBUTION_SUMMARY}.
+   */
+  default double[] getDistributionSLOs() {
+    return EMPTY_DISTRIBUTION_SLOS;
   }
 }

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/EnumMeterTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/EnumMeterTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util.micrometer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter.Type;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NullableProblems")
+final class EnumMeterTest {
+  private static final ExtendedMeterDocumentation DOC =
+      new ExtendedMeterDocumentation() {
+        @Override
+        public String getDescription() {
+          return "Test metric";
+        }
+
+        @Override
+        public String getName() {
+          return "metric";
+        }
+
+        @Override
+        public Type getType() {
+          return Type.GAUGE;
+        }
+      };
+  private static final KeyName TAG =
+      new KeyName() {
+        @Override
+        public String asString() {
+          return "foo";
+        }
+      };
+
+  private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+  @Test
+  void shouldRegisterGaugeForAllValues() {
+    // given/when
+    EnumMeter.register(States.class, DOC, TAG, registry);
+
+    // then
+    assertThat(registry.get(DOC.getName()).tagKeys(TAG.asString()).gauges())
+        .hasSameSizeAs(States.values());
+    assertThat(registry.get(DOC.getName()).tag(TAG.asString(), "A").gauge())
+        .returns(0.0, Gauge::value);
+    assertThat(registry.get(DOC.getName()).tag(TAG.asString(), "B").gauge())
+        .returns(0.0, Gauge::value);
+    assertThat(registry.get(DOC.getName()).tag(TAG.asString(), "C").gauge())
+        .returns(0.0, Gauge::value);
+  }
+
+  @Test
+  void shouldSetState() {
+    // given
+    final var meter = EnumMeter.register(States.class, DOC, TAG, registry);
+
+    // when
+    meter.state(States.B);
+
+    // then
+    final var gauge = registry.get(DOC.getName()).tag(TAG.asString(), "B").gauge();
+    assertThat(gauge).returns(1.0, Gauge::value);
+  }
+
+  @Test
+  void shouldResetOtherStatesToZero() {
+    // given
+    final var meter = EnumMeter.register(States.class, DOC, TAG, registry);
+    meter.state(States.A);
+
+    // when
+    meter.state(States.B);
+
+    // then
+    assertThat(registry.get(DOC.getName()).tag(TAG.asString(), "A").gauge())
+        .returns(0.0, Gauge::value);
+    assertThat(registry.get(DOC.getName()).tag(TAG.asString(), "B").gauge())
+        .returns(1.0, Gauge::value);
+    assertThat(registry.get(DOC.getName()).tag(TAG.asString(), "C").gauge())
+        .returns(0.0, Gauge::value);
+  }
+
+  private enum States {
+    A,
+    B,
+    C
+  }
+}


### PR DESCRIPTION
## Description

This PR migrates the `ProcessingMetrics` class from the stream platform to Micrometer. To ease migration, it adds a new helper, `EnumMeter`, which is inspired by Prometheus' `Enumeration` meter.

> [!Note]
> An `Enumeration` is essentially a series of gauges with the same name, one for every value of a specific `enum`. The enum value is specified as a label/tag on the metric. Every gauge is always 0, except the one which is currently the active state, which will be set to 1.

The two histograms in there had their names changed (i.e. with the `_seconds` suffix), so I've updated the dashboard consequently to use the union of both series.

## Related issues

related #26078
