### PR TITLE
fix: ensure all `assigning` task listeners are executed on repeated assign operations

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -176,6 +176,51 @@ public class TaskListenerTest {
   }
 
   @Test
+  public void shouldExecuteAllAssigningListenersOnUnassignmentAfterSuccessfulAssignment() {
+    // given: a user task with multiple `assigning` task listeners
+    final long processInstanceKey =
+        createProcessInstance(
+            createUserTaskWithTaskListeners(
+                ZeebeTaskListenerEventType.assigning,
+                listenerType,
+                listenerType + "_2",
+                listenerType + "_3"));
+
+    // when: assign the user task to "me" and complete all `assigning` listener jobs
+    ENGINE.userTask().ofInstance(processInstanceKey).withAssignee("me").assign();
+    completeJobs(processInstanceKey, listenerType, listenerType + "_2", listenerType + "_3");
+
+    // and: unassign the user task and complete all `assigning` listener jobs again
+    ENGINE.userTask().ofInstance(processInstanceKey).unassign();
+    completeRecreatedJobs(
+        processInstanceKey, listenerType, listenerType + "_2", listenerType + "_3");
+
+    // then: all `assigning` listeners should be executed for both assign and unassign operations
+    assertTaskListenerJobsCompletionSequence(
+        processInstanceKey,
+        JobListenerEventType.ASSIGNING,
+        listenerType,
+        listenerType + "_2",
+        listenerType + "_3",
+        listenerType,
+        listenerType + "_2",
+        listenerType + "_3");
+
+    // and: user task should be correctly assigned and unassigned
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(2))
+        .describedAs(
+            "Expected user task assignment and unassignment actions to be recorded correctly")
+        .extracting(r -> r.getValue().getAssignee(), r -> r.getValue().getAction())
+        .containsExactly(
+            tuple("me", "assign"), // First assignment
+            tuple("", "unassign") // Unassignment
+            );
+  }
+
+  @Test
   public void shouldCancelTaskListenerJobWhenTerminatingElementInstance() {
     // given
     final long processInstanceKey =
@@ -2228,6 +2273,12 @@ public class TaskListenerTest {
   private void completeJobs(final long processInstanceKey, final String... jobTypes) {
     for (final String jobType : jobTypes) {
       ENGINE.job().ofInstance(processInstanceKey).withType(jobType).complete();
+    }
+  }
+
+  private void completeRecreatedJobs(final long processInstanceKey, final String... jobTypes) {
+    for (final String jobType : jobTypes) {
+      completeRecreatedJobWithType(ENGINE, processInstanceKey, jobType);
     }
   }
 


### PR DESCRIPTION
## Description

This PR fixes an issue where only the first `assigning` task listener was executed during repeated assign, unassign, or claim operations on a user task. 

Previously, when multiple `assigning` listeners were configured, they executed correctly on the first assignment, but on subsequent assign/unassign/claim operations, only the first listener job was created and executed, while the remaining listeners were skipped.  

#### Fix  
- Updated `UserTaskAssignedV2Applier` to reset the `assigning` task listener index after each successful assign/unassign/claim operation.

#### Tests  
- Added test to verify that all `assigning` listeners are executed correctly during assign and subsequent unassign operation.   

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #27559
