### PR TITLE
[Backport stable/8.7] Drop usage of old Prometheus simple client for benchmarks module

### DIFF
--- a/zeebe/benchmarks/project/pom.xml
+++ b/zeebe/benchmarks/project/pom.xml
@@ -67,7 +67,7 @@
 
     <dependency>
       <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient_httpserver</artifactId>
+      <artifactId>prometheus-metrics-exporter-httpserver</artifactId>
     </dependency>
 
     <dependency>
@@ -92,12 +92,7 @@
 
     <dependency>
       <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient</artifactId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
     </dependency>
 
     <dependency>

--- a/zeebe/benchmarks/project/pom.xml
+++ b/zeebe/benchmarks/project/pom.xml
@@ -71,6 +71,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>prometheus-metrics-model</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -99,6 +104,7 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/App.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/App.java
@@ -23,16 +23,15 @@ import io.camunda.zeebe.config.AppConfigLoader;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
 import io.grpc.ClientInterceptor;
 import io.micrometer.core.instrument.binder.grpc.MetricCollectingClientInterceptor;
-import io.micrometer.prometheus.PrometheusConfig;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
-import io.micrometer.prometheus.PrometheusRenameFilter;
-import io.prometheus.client.exporter.HTTPServer;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusRenameFilter;
+import io.prometheus.metrics.exporter.httpserver.HTTPServer;
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.function.Function;
 import org.slf4j.Logger;
@@ -62,10 +61,10 @@ abstract class App implements Runnable {
     try {
       // you can set the daemon flag to false if you want the server to block
       monitoringServer =
-          new HTTPServer(
-              new InetSocketAddress(appCfg.getMonitoringPort()),
-              prometheusRegistry.getPrometheusRegistry(),
-              true);
+          HTTPServer.builder()
+              .port(appCfg.getMonitoringPort())
+              .registry(prometheusRegistry.getPrometheusRegistry())
+              .buildAndStart();
     } catch (final IOException e) {
       LOG.error("Problem on starting monitoring server.", e);
     }

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/App.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/App.java
@@ -23,6 +23,11 @@ import io.camunda.zeebe.config.AppConfigLoader;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
 import io.grpc.ClientInterceptor;
 import io.micrometer.core.instrument.binder.grpc.MetricCollectingClientInterceptor;
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
 import io.micrometer.prometheusmetrics.PrometheusConfig;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import io.micrometer.prometheusmetrics.PrometheusRenameFilter;
@@ -40,7 +45,7 @@ import org.slf4j.LoggerFactory;
 abstract class App implements Runnable {
 
   protected static ClientInterceptor monitoringInterceptor;
-  protected static PrometheusMeterRegistry prometheusRegistry;
+  protected static PrometheusMeterRegistry registry;
   private static final Logger THROTTLED_LOGGER =
       new ThrottledLogger(LoggerFactory.getLogger(App.class), Duration.ofSeconds(5));
   private static final Logger LOG = LoggerFactory.getLogger(App.class);
@@ -55,21 +60,31 @@ abstract class App implements Runnable {
   }
 
   private static void startMonitoringServer(final AppCfg appCfg) {
-    prometheusRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
-    prometheusRegistry.config().meterFilter(new PrometheusRenameFilter());
+    registry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+    registry.config().meterFilter(new PrometheusRenameFilter());
 
     try {
       // you can set the daemon flag to false if you want the server to block
       monitoringServer =
           HTTPServer.builder()
               .port(appCfg.getMonitoringPort())
-              .registry(prometheusRegistry.getPrometheusRegistry())
+              .registry(registry.getPrometheusRegistry())
               .buildAndStart();
     } catch (final IOException e) {
       LOG.error("Problem on starting monitoring server.", e);
     }
 
-    monitoringInterceptor = new MetricCollectingClientInterceptor(prometheusRegistry);
+    monitoringInterceptor = new MetricCollectingClientInterceptor(registry);
+    registerDefaultInstrumentation();
+  }
+
+  @SuppressWarnings("resource") // closeable metrics will be closed when the registry is closed
+  private static void registerDefaultInstrumentation() {
+    new ClassLoaderMetrics().bindTo(registry);
+    new JvmMemoryMetrics().bindTo(registry);
+    new JvmGcMetrics().bindTo(registry);
+    new ProcessorMetrics().bindTo(registry);
+    new JvmThreadMetrics().bindTo(registry);
   }
 
   private static void stopMonitoringServer() {

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/Worker.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/Worker.java
@@ -54,7 +54,7 @@ public class Worker extends App {
     final ZeebeClient client = createZeebeClient();
     final JobWorkerMetrics metrics =
         JobWorkerMetrics.micrometer()
-            .withMeterRegistry(prometheusRegistry)
+            .withMeterRegistry(registry)
             .withTags(Tags.of("workerName", workerCfg.getWorkerName(), "jobType", jobType))
             .build();
     printTopology(client);


### PR DESCRIPTION
# Description
Backport of #27493 to `stable/8.7`.

relates to #26078
original author: @npepinpe