### PR TITLE
refactor: move docker cmd hanlding in own function

### DIFF
--- a/c8run/main.go
+++ b/c8run/main.go
@@ -245,7 +245,7 @@ func getBaseCommand() (string, error) {
 	return "", nil
 }
 
-func handleDockerCommand(settings C8RunSettings, baseCommand, composeExtractedFolder string) error {
+func handleDockerCommand(settings C8RunSettings, baseCommand string, composeExtractedFolder string) error {
 	if !settings.docker {
 		return nil
 	}

--- a/c8run/main.go
+++ b/c8run/main.go
@@ -167,10 +167,10 @@ func validateKeystore(settings C8RunSettings, parentDir string) error {
 	return nil
 }
 
-func startDocker(extractedComposePath string) error {
-	err := os.Chdir(extractedComposePath)
+func runDockerCommand(composeExtractedFolder string, args ...string) error {
+	err := os.Chdir(composeExtractedFolder)
 	if err != nil {
-		return fmt.Errorf("startDocker: failed to chdir %w", err)
+		return fmt.Errorf("failed to chdir to %s: %w", composeExtractedFolder, err)
 	}
 
 	_, err = exec.LookPath("docker")
@@ -178,40 +178,20 @@ func startDocker(extractedComposePath string) error {
 		return err
 	}
 
-	composeCmd := exec.Command("docker", "compose", "up", "-d")
+	composeCmd := exec.Command("docker", append([]string{"compose"}, args...)...)
 	composeCmd.Stdout = os.Stdout
 	composeCmd.Stderr = os.Stderr
-	err = composeCmd.Run()
-	if err != nil {
-		return err
-	}
-	err = os.Chdir("..")
-	if err != nil {
-		return fmt.Errorf("startDocker: failed to chdir %w", err)
-	}
-	return nil
-}
 
-func stopDocker(extractedComposePath string) error {
-	err := os.Chdir(extractedComposePath)
-	if err != nil {
-		return fmt.Errorf("stopDocker: failed to chdir %w", err)
-	}
-	_, err = exec.LookPath("docker")
-	if err != nil {
-		return err
-	}
-	composeCmd := exec.Command("docker", "compose", "down")
-	composeCmd.Stdout = os.Stdout
-	composeCmd.Stderr = os.Stderr
 	err = composeCmd.Run()
 	if err != nil {
 		return err
 	}
+
 	err = os.Chdir("..")
 	if err != nil {
-		return fmt.Errorf("stopDocker: failed to chdir %w", err)
+		return fmt.Errorf("failed to chdir back: %w", err)
 	}
+
 	return nil
 }
 
@@ -263,6 +243,25 @@ func getBaseCommand() (string, error) {
 	}
 
 	return "", nil
+}
+
+func handleDockerCommand(settings C8RunSettings, baseCommand, composeExtractedFolder string) error {
+	if !settings.docker {
+		return nil
+	}
+
+	var err error
+	switch baseCommand {
+	case "start":
+		err = runDockerCommand(composeExtractedFolder, "up", "-d")
+	case "stop":
+		err = runDockerCommand(composeExtractedFolder, "down")
+	default:
+		err = fmt.Errorf("No valid command. Only start and stop supported.")
+	}
+	os.Exit(0)
+
+	return err
 }
 
 func main() {
@@ -343,22 +342,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	if settings.docker && baseCommand == "start" {
-		err = startDocker(composeExtractedFolder)
-		if err != nil {
-			fmt.Println(err.Error())
-			os.Exit(1)
-		}
-		os.Exit(0)
-	}
-
-	if settings.docker && baseCommand == "stop" {
-		err = stopDocker(composeExtractedFolder)
-		if err != nil {
-			fmt.Println(err.Error())
-			os.Exit(1)
-		}
-		os.Exit(0)
+	err = handleDockerCommand(settings, baseCommand, composeExtractedFolder)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
 	}
 
 	javaHome := os.Getenv("JAVA_HOME")

--- a/c8run/main.go
+++ b/c8run/main.go
@@ -259,9 +259,13 @@ func handleDockerCommand(settings C8RunSettings, baseCommand, composeExtractedFo
 	default:
 		err = fmt.Errorf("No valid command. Only start and stop supported.")
 	}
-	os.Exit(0)
 
-	return err
+	if err != nil {
+		return err
+	}
+
+	os.Exit(0)
+	return nil // This line will never be reached, but it's required to satisfy the function signature
 }
 
 func main() {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Refactoring the docker compose handling in main.go for c8run. This refactor tries to simplify the main.go function:
- In creating a handleDockerCompose function, which is sharing code logic for the start and stop cmd
- Unifying the name of composeExtractedFolder by renaming composeExtractedPath to composeExtractedFolder (as its passed the same variable name)

This PR will need to get back ported to 8.7 as well.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
