### PR TITLE
refactor: move set envVars in single function

### DIFF
--- a/c8run/main.go
+++ b/c8run/main.go
@@ -220,6 +220,28 @@ func usage(exitcode int) {
 	os.Exit(exitcode)
 }
 
+func setEnvVars() error {
+	envVars := map[string]string{
+		"CAMUNDA_OPERATE_CSRFPREVENTIONENABLED":                  "false",
+		"CAMUNDA_OPERATE_IMPORTER_READERBACKOFF":                 "1000",
+		"CAMUNDA_REST_QUERY_ENABLED":                             "true",
+		"CAMUNDA_TASKLIST_CSRFPREVENTIONENABLED":                 "false",
+		"ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_DELAY":   "1",
+		"ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_SIZE":    "1",
+		"ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_PREFIX": "zeebe-record",
+		"ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL":          "http://localhost:9200",
+		"ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME":         "io.camunda.zeebe.exporter.ElasticsearchExporter",
+	}
+
+	for key, value := range envVars {
+		if err := os.Setenv(key, value); err != nil {
+			return fmt.Errorf("failed to set environment variable %s: %w", key, err)
+		}
+	}
+
+	return nil
+}
+
 func main() {
 	c8 := getC8RunPlatform()
 	baseDir, _ := os.Getwd()
@@ -243,20 +265,10 @@ func main() {
 	connectorsPidPath := filepath.Join(baseDir, "connectors.pid")
 	camundaPidPath := filepath.Join(baseDir, "camunda.pid")
 
-	os.Setenv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME", "io.camunda.zeebe.exporter.ElasticsearchExporter")
-	os.Setenv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL", "http://localhost:9200")
-	os.Setenv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_PREFIX", "zeebe-record")
-
-	os.Setenv("CAMUNDA_REST_QUERY_ENABLED", "true")
-	os.Setenv("CAMUNDA_OPERATE_CSRFPREVENTIONENABLED", "false")
-	os.Setenv("CAMUNDA_TASKLIST_CSRFPREVENTIONENABLED", "false")
-	os.Setenv("CAMUNDA_OPERATE_IMPORTER_READERBACKOFF", "1000")
-	os.Setenv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_DELAY", "1")
-	os.Setenv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_SIZE", "1")
-
-	os.Setenv("CAMUNDA_OPERATE_IMPORTER_READERBACKOFF", "1000")
-	os.Setenv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_DELAY", "1")
-	os.Setenv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_SIZE", "1")
+	err = setEnvVars()
+	if err != nil {
+		fmt.Println("Failed to set envVars:", err)
+	}
 
 	// classPath := filepath.Join(parentDir, "configuration", "userlib") + "," + filepath.Join(parentDir, "configuration", "keystore")
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR aims to make the main.go function more lean by moving the envVar setting into a dedicated function outside of main.go (increases readability of main). I also assign the envVars via a for loop and add error handling in case an envVar can not be set.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
