### PR TITLE
refactor: remove nested if in validateKeystore

### DIFF
--- a/c8run/main.go
+++ b/c8run/main.go
@@ -154,16 +154,18 @@ func adjustJavaOpts(javaOpts string, settings C8RunSettings) string {
 }
 
 func validateKeystore(settings C8RunSettings, parentDir string) error {
-	if settings.keystore != "" {
-		if settings.keystorePassword == "" {
-			return fmt.Errorf("You must provide a password with --keystorePassword to unlock your keystore.")
-		}
-		if settings.keystore != "" {
-			if !strings.HasPrefix(settings.keystore, "/") {
-				settings.keystore = filepath.Join(parentDir, settings.keystore)
-			}
-		}
+	if settings.keystore == "" {
+		return nil
 	}
+
+	if settings.keystorePassword == "" {
+		return fmt.Errorf("you must provide a password with --keystorePassword to unlock your keystore")
+	}
+
+	if !strings.HasPrefix(settings.keystore, "/") {
+		settings.keystore = filepath.Join(parentDir, settings.keystore)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This is a small refactoring for c8Runs validateKeystore function. It simply removes the nested if statement and returns nil instead if `settings.keystore == ""`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
