### PR TITLE
refactor: move getBaseCommand in own function

### DIFF
--- a/c8run/main.go
+++ b/c8run/main.go
@@ -242,6 +242,29 @@ func setEnvVars() error {
 	return nil
 }
 
+func getBaseCommand() (string, error) {
+	if len(os.Args) == 1 {
+		usage(1)
+	}
+
+	switch os.Args[1] {
+	case "start":
+		return "start", nil
+	case "stop":
+		return "stop", nil
+	case "package":
+		return "package", nil
+	case "clean":
+		return "clean", nil
+	case "-h", "--help":
+		usage(0)
+	default:
+		return "", fmt.Errorf("unsupported operation: %s", os.Args[1])
+	}
+
+	return "", nil
+}
+
 func main() {
 	c8 := getC8RunPlatform()
 	baseDir, _ := os.Getwd()
@@ -272,26 +295,6 @@ func main() {
 
 	// classPath := filepath.Join(parentDir, "configuration", "userlib") + "," + filepath.Join(parentDir, "configuration", "keystore")
 
-	baseCommand := ""
-	// insideConfigFlag := false
-
-	if len(os.Args) == 1 {
-		usage(1)
-	} else if os.Args[1] == "start" {
-		baseCommand = "start"
-	} else if os.Args[1] == "stop" {
-		baseCommand = "stop"
-	} else if os.Args[1] == "package" {
-		baseCommand = "package"
-	} else if os.Args[1] == "clean" {
-		baseCommand = "clean"
-	} else if os.Args[1] == "-h" || os.Args[1] == "--help" {
-		usage(0)
-	} else {
-		panic(fmt.Sprintln("Unsupported operation", os.Args[1]))
-	}
-	fmt.Print("Command: " + baseCommand + "\n")
-
 	var settings C8RunSettings
 	startFlagSet := flag.NewFlagSet("start", flag.ExitOnError)
 	startFlagSet.StringVar(&settings.config, "config", "", "Applies the specified configuration file.")
@@ -308,6 +311,11 @@ func main() {
 	stopFlagSet := flag.NewFlagSet("stop", flag.ExitOnError)
 	stopFlagSet.BoolVar(&settings.disableElasticsearch, "disable-elasticsearch", false, "Do not stop Elasticsearch")
 	stopFlagSet.BoolVar(&settings.docker, "docker", false, "Stop docker-compose distribution of camunda.")
+
+	baseCommand, err := getBaseCommand()
+	if err != nil {
+		fmt.Println(err.Error())
+	}
 
 	switch baseCommand {
 	case "start":


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR aims to simplify the main.go function for C8Run by creating the `getBaseCommand()` func to get the base command. I also used a switch case structure and added a default in case no argument fits.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
