### PR TITLE
refactor: return cmd settings in its own function

### DIFF
--- a/c8run/main.go
+++ b/c8run/main.go
@@ -285,8 +285,6 @@ func getBaseCommandSettings(baseCommand string) (C8RunSettings, error) {
 		if err != nil {
 			return settings, fmt.Errorf("error parsing stop argument: %w", err)
 		}
-	default:
-		return settings, fmt.Errorf("unsupported base command: %s", baseCommand)
 	}
 
 	return settings, nil

--- a/c8run/main.go
+++ b/c8run/main.go
@@ -268,6 +268,52 @@ func handleDockerCommand(settings C8RunSettings, baseCommand string, composeExtr
 	return nil // This line will never be reached, but it's required to satisfy the function signature
 }
 
+func getBaseCommandSettings(baseCommand string) (C8RunSettings, error) {
+	var settings C8RunSettings
+
+	startFlagSet := createStartFlagSet(&settings)
+	stopFlagSet := createStopFlagSet(&settings)
+
+	switch baseCommand {
+	case "start":
+		err := startFlagSet.Parse(os.Args[2:])
+		if err != nil {
+			return settings, fmt.Errorf("error parsing start argument: %w", err)
+		}
+	case "stop":
+		err := stopFlagSet.Parse(os.Args[2:])
+		if err != nil {
+			return settings, fmt.Errorf("error parsing stop argument: %w", err)
+		}
+	default:
+		return settings, fmt.Errorf("unsupported base command: %s", baseCommand)
+	}
+
+	return settings, nil
+}
+
+func createStartFlagSet(settings *C8RunSettings) *flag.FlagSet {
+	startFlagSet := flag.NewFlagSet("start", flag.ExitOnError)
+	startFlagSet.StringVar(&settings.config, "config", "", "Applies the specified configuration file.")
+	startFlagSet.BoolVar(&settings.detached, "detached", false, "Starts Camunda Run as a detached process")
+	startFlagSet.IntVar(&settings.port, "port", 8080, "Port to run Camunda on")
+	startFlagSet.StringVar(&settings.keystore, "keystore", "", "Provide a JKS filepath to enable TLS")
+	startFlagSet.StringVar(&settings.keystorePassword, "keystorePassword", "", "Provide a password to unlock your JKS keystore")
+	startFlagSet.StringVar(&settings.logLevel, "log-level", "", "Adjust the log level of Camunda")
+	startFlagSet.BoolVar(&settings.disableElasticsearch, "disable-elasticsearch", false, "Do not start or stop Elasticsearch (still requires Elasticsearch to be running outside of c8run)")
+	startFlagSet.BoolVar(&settings.docker, "docker", false, "Run Camunda from docker-compose.")
+	startFlagSet.StringVar(&settings.username, "username", "demo", "Change the first users username (default: demo)")
+	startFlagSet.StringVar(&settings.password, "password", "demo", "Change the first users password (default: demo)")
+	return startFlagSet
+}
+
+func createStopFlagSet(settings *C8RunSettings) *flag.FlagSet {
+	stopFlagSet := flag.NewFlagSet("stop", flag.ExitOnError)
+	stopFlagSet.BoolVar(&settings.disableElasticsearch, "disable-elasticsearch", false, "Do not stop Elasticsearch")
+	stopFlagSet.BoolVar(&settings.docker, "docker", false, "Stop docker-compose distribution of camunda.")
+	return stopFlagSet
+}
+
 func main() {
 	c8 := getC8RunPlatform()
 	baseDir, _ := os.Getwd()
@@ -298,42 +344,15 @@ func main() {
 
 	// classPath := filepath.Join(parentDir, "configuration", "userlib") + "," + filepath.Join(parentDir, "configuration", "keystore")
 
-	var settings C8RunSettings
-	startFlagSet := flag.NewFlagSet("start", flag.ExitOnError)
-	startFlagSet.StringVar(&settings.config, "config", "", "Applies the specified configuration file.")
-	startFlagSet.BoolVar(&settings.detached, "detached", false, "Starts Camunda Run as a detached process")
-	startFlagSet.IntVar(&settings.port, "port", 8080, "Port to run Camunda on")
-	startFlagSet.StringVar(&settings.keystore, "keystore", "", "Provide a JKS filepath to enable TLS")
-	startFlagSet.StringVar(&settings.keystorePassword, "keystorePassword", "", "Provide a password to unlock your JKS keystore")
-	startFlagSet.StringVar(&settings.logLevel, "log-level", "", "Adjust the log level of Camunda")
-	startFlagSet.BoolVar(&settings.disableElasticsearch, "disable-elasticsearch", false, "Do not start or stop Elasticsearch (still requires Elasticsearch to be running outside of c8run)")
-	startFlagSet.BoolVar(&settings.docker, "docker", false, "Run Camunda from docker-compose.")
-	startFlagSet.StringVar(&settings.username, "username", "demo", "Change the first users username (default: demo)")
-	startFlagSet.StringVar(&settings.password, "password", "demo", "Change the first users password (default: demo)")
-
-	stopFlagSet := flag.NewFlagSet("stop", flag.ExitOnError)
-	stopFlagSet.BoolVar(&settings.disableElasticsearch, "disable-elasticsearch", false, "Do not stop Elasticsearch")
-	stopFlagSet.BoolVar(&settings.docker, "docker", false, "Stop docker-compose distribution of camunda.")
-
 	baseCommand, err := getBaseCommand()
 	if err != nil {
 		fmt.Println(err.Error())
 	}
 
-	switch baseCommand {
-	case "start":
-		err := startFlagSet.Parse(os.Args[2:])
-		if err != nil {
-			fmt.Println(err.Error())
-			os.Exit(1)
-		}
-
-	case "stop":
-		err := stopFlagSet.Parse(os.Args[2:])
-		if err != nil {
-			fmt.Println(err.Error())
-			os.Exit(1)
-		}
+	settings, err := getBaseCommandSettings(baseCommand)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
 	}
 
 	if settings.logLevel != "" {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The goal of the PR is to make the c8Run main.go more readable and put everything related to the base command settings into the separate function `getBaseCommandSettings()`. I also moved the `startFlagSet` and `stopFlagSet` in their own functions to increase readability (for the stable/8.6 I will remove the non-existent options).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
