### PR TITLE
fix: get name from token before falling back to username and id

### DIFF
--- a/.github/workflows/optimize-check-c4.yml
+++ b/.github/workflows/optimize-check-c4.yml
@@ -32,7 +32,7 @@ jobs:
         run: corepack enable
 
       - name: Setup NodeJS
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
         with:
           node-version: ${{ steps.pom_info.outputs.x_version_node }}
 

--- a/.github/workflows/optimize-publish-c4.yml
+++ b/.github/workflows/optimize-publish-c4.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
       - name: Setup Node
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
         with:
           node-version: ${{ steps.pom_info.outputs.x_version_node }}
       - uses: camunda/infra-global-github-actions/setup-yarn-cache@main

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/security/CCSMTokenService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/security/CCSMTokenService.java
@@ -208,7 +208,7 @@ public class CCSMTokenService {
         verifyToken(extractTokenFromAuthorizationValue(accessToken)).getUserDetails();
     return new UserDto(
         userId,
-        userDetails.getName().orElse(userId),
+        userDetails.getName().orElseGet(() -> userDetails.getUsername().orElse(userId)),
         userDetails.getEmail().orElse(userId),
         Collections.emptyList());
   }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/security/CCSMTokenServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/security/CCSMTokenServiceTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.service.security;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.google.common.collect.ImmutableList;
+import io.camunda.identity.sdk.Identity;
+import io.camunda.identity.sdk.authentication.AccessToken;
+import io.camunda.identity.sdk.authentication.Authentication;
+import io.camunda.identity.sdk.authentication.UserDetails;
+import io.camunda.optimize.dto.optimize.UserDto;
+import io.camunda.optimize.rest.exceptions.NotAuthorizedException;
+import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class CCSMTokenServiceTest {
+
+  private static final String ACCESS_TOKEN_VALUE = "accessToken";
+  private static final String OPTIMIZE_PERMISSION = "write:*";
+
+  private static final String EMAIL = "user@example.com";
+  private static final String ID = "user123";
+  private static final String NAME = "name";
+  private static final String USERNAME = "username";
+
+  @Mock private AuthCookieService authCookieService;
+  @Mock private ConfigurationService configurationService;
+  @Mock private Identity identity;
+  @Mock private Authentication authentication;
+  @Mock private AccessToken accessToken;
+  @Mock private UserDetails userDetails;
+
+  private CCSMTokenService ccsmTokenService;
+
+  @BeforeEach
+  void setUp() {
+    when(identity.authentication()).thenReturn(authentication);
+    when(authentication.verifyToken(ACCESS_TOKEN_VALUE)).thenReturn(accessToken);
+    when(accessToken.getPermissions()).thenReturn(ImmutableList.of(OPTIMIZE_PERMISSION));
+
+    ccsmTokenService = new CCSMTokenService(authCookieService, configurationService, identity);
+  }
+
+  @Test
+  void getUserInfoFromToken_validToken_returnsUserDto() {
+    when(accessToken.getUserDetails()).thenReturn(userDetails);
+    when(userDetails.getName()).thenReturn(Optional.of(NAME));
+    when(userDetails.getEmail()).thenReturn(Optional.of(EMAIL));
+
+    final UserDto result = ccsmTokenService.getUserInfoFromToken(ID, ACCESS_TOKEN_VALUE);
+
+    assertEquals(ID, result.getId());
+    assertEquals(NAME, result.getFirstName());
+    assertEquals(EMAIL, result.getEmail());
+  }
+
+  @Test
+  void getUserInfoFromToken_missingName_returnsUsername() {
+    when(accessToken.getUserDetails()).thenReturn(userDetails);
+    when(userDetails.getName()).thenReturn(Optional.empty());
+    when(userDetails.getUsername()).thenReturn(Optional.of(USERNAME));
+    when(userDetails.getEmail()).thenReturn(Optional.of(EMAIL));
+
+    final UserDto result = ccsmTokenService.getUserInfoFromToken(ID, ACCESS_TOKEN_VALUE);
+
+    assertEquals(ID, result.getId());
+    assertEquals(USERNAME, result.getFirstName());
+    assertEquals(EMAIL, result.getEmail());
+  }
+
+  @Test
+  void getUserInfoFromToken_missingNameAndUsername_returnsUserIdAsUsername() {
+    when(accessToken.getUserDetails()).thenReturn(userDetails);
+    when(userDetails.getName()).thenReturn(Optional.empty());
+    when(userDetails.getUsername()).thenReturn(Optional.empty());
+    when(userDetails.getEmail()).thenReturn(Optional.of(EMAIL));
+
+    final UserDto result = ccsmTokenService.getUserInfoFromToken(ID, ACCESS_TOKEN_VALUE);
+
+    assertEquals(ID, result.getId());
+    assertEquals(ID, result.getFirstName());
+    assertEquals(EMAIL, result.getEmail());
+  }
+
+  @Test
+  void getUserInfoFromToken_missingEmail_returnsUserIdAsEmail() {
+    when(accessToken.getUserDetails()).thenReturn(userDetails);
+    when(userDetails.getName()).thenReturn(Optional.of(NAME));
+    when(userDetails.getEmail()).thenReturn(Optional.empty());
+
+    final UserDto result = ccsmTokenService.getUserInfoFromToken(ID, ACCESS_TOKEN_VALUE);
+
+    assertEquals(ID, result.getId());
+    assertEquals(ID, result.getEmail());
+    assertEquals(NAME, result.getFirstName());
+  }
+
+  @Test
+  void getUserInfoFromToken_invalidToken_throwsNotAuthorizedException() {
+    when(accessToken.getPermissions()).thenReturn(ImmutableList.of());
+
+    assertThrows(
+        NotAuthorizedException.class,
+        () -> ccsmTokenService.getUserInfoFromToken(ID, ACCESS_TOKEN_VALUE));
+  }
+}

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/security/CCSMTokenServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/security/CCSMTokenServiceTest.java
@@ -55,7 +55,7 @@ public class CCSMTokenServiceTest {
   }
 
   @Test
-  void getUserInfoFromToken_validToken_returnsUserDto() {
+  void getUserInfoFromTokenValidTokenReturnsUserDto() {
     when(accessToken.getUserDetails()).thenReturn(userDetails);
     when(userDetails.getName()).thenReturn(Optional.of(NAME));
     when(userDetails.getEmail()).thenReturn(Optional.of(EMAIL));
@@ -68,7 +68,7 @@ public class CCSMTokenServiceTest {
   }
 
   @Test
-  void getUserInfoFromToken_missingName_returnsUsername() {
+  void getUserInfoFromTokenMissingNameReturnsUsername() {
     when(accessToken.getUserDetails()).thenReturn(userDetails);
     when(userDetails.getName()).thenReturn(Optional.empty());
     when(userDetails.getUsername()).thenReturn(Optional.of(USERNAME));
@@ -82,7 +82,7 @@ public class CCSMTokenServiceTest {
   }
 
   @Test
-  void getUserInfoFromToken_missingNameAndUsername_returnsUserIdAsUsername() {
+  void getUserInfoFromTokenMissingNameAndUsernameReturnsUserIdAsUsername() {
     when(accessToken.getUserDetails()).thenReturn(userDetails);
     when(userDetails.getName()).thenReturn(Optional.empty());
     when(userDetails.getUsername()).thenReturn(Optional.empty());
@@ -96,7 +96,7 @@ public class CCSMTokenServiceTest {
   }
 
   @Test
-  void getUserInfoFromToken_missingEmail_returnsUserIdAsEmail() {
+  void getUserInfoFromTokenMissingEmailReturnsUserIdAsEmail() {
     when(accessToken.getUserDetails()).thenReturn(userDetails);
     when(userDetails.getName()).thenReturn(Optional.of(NAME));
     when(userDetails.getEmail()).thenReturn(Optional.empty());
@@ -109,7 +109,7 @@ public class CCSMTokenServiceTest {
   }
 
   @Test
-  void getUserInfoFromToken_invalidToken_throwsNotAuthorizedException() {
+  void getUserInfoFromTokenInvalidTokenThrowsNotAuthorizedException() {
     when(accessToken.getPermissions()).thenReturn(ImmutableList.of());
 
     assertThrows(

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/security/CCSMTokenServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/security/CCSMTokenServiceTest.java
@@ -65,6 +65,8 @@ public class CCSMTokenServiceTest {
     assertEquals(ID, result.getId());
     assertEquals(NAME, result.getFirstName());
     assertEquals(EMAIL, result.getEmail());
+    assertNull(result.getLastName());
+    assertTrue(result.getRoles().isEmpty());
   }
 
   @Test
@@ -79,6 +81,8 @@ public class CCSMTokenServiceTest {
     assertEquals(ID, result.getId());
     assertEquals(USERNAME, result.getFirstName());
     assertEquals(EMAIL, result.getEmail());
+    assertNull(result.getLastName());
+    assertTrue(result.getRoles().isEmpty());
   }
 
   @Test
@@ -93,6 +97,8 @@ public class CCSMTokenServiceTest {
     assertEquals(ID, result.getId());
     assertEquals(ID, result.getFirstName());
     assertEquals(EMAIL, result.getEmail());
+    assertNull(result.getLastName());
+    assertTrue(result.getRoles().isEmpty());
   }
 
   @Test
@@ -106,6 +112,8 @@ public class CCSMTokenServiceTest {
     assertEquals(ID, result.getId());
     assertEquals(ID, result.getEmail());
     assertEquals(NAME, result.getFirstName());
+    assertNull(result.getLastName());
+    assertTrue(result.getRoles().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
## Description

When a user click on "Open User", they will see the `name` claim populated in the side tab, which falls back to the `id` claim. In some cases, the `name` claim is empty but not the `username` claim. In such case, we expect the side tab to first fall back to the `username` value before falling back to the bare user id.

This PR adds that additional fallback logic in the middle and adds unit tests for the `io.camunda.optimize.service.security.CCSMTokenService::getUserInfoFromToken` method.

I ran the service locally to validate with a user missing the `name` claim by tweaking the `KEYCLOAK_USERS_0_***` values.

## Related issues

related to #27379 
