### PR TITLE
fix: CriticalComponentsHealthMonitor unregisterRelationship incorrectly

### DIFF
--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/management/HealthTreeTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/management/HealthTreeTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 
 public class HealthTreeTest {
   @Test
-  public void unhealthyComponentsArePropagatedUpperwards() {
+  public void unhealthyComponentsArePropagatedUpwards() {
     final var root =
         new HealthReport(
             "A",

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitor.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitor.java
@@ -104,7 +104,7 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
           if (monitoredComponent != null) {
             componentHealth.remove(componentName);
             monitoredComponent.component.removeFailureListener(monitoredComponent);
-            graphListener.unregisterRelationship(name, componentName);
+            graphListener.unregisterRelationship(componentName, name);
             graphListener.unregisterNode(monitoredComponent.component);
             log.trace("Unregistered edge {}:{}", name, componentName);
           }

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitorTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitorTest.java
@@ -165,10 +165,14 @@ public class CriticalComponentsHealthMonitorTest {
     final ControllableComponent component = new ControllableComponent("test");
     monitor.registerComponent(component);
     Awaitility.await().until(() -> monitor.getHealthReport().getStatus() == HealthStatus.HEALTHY);
+    verify(graphListener).registerNode(monitor, Optional.of(parentComponent));
+    verify(graphListener).registerNode(component, Optional.of(monitor.componentName()));
 
     // when
     monitor.removeComponent(component);
     waitUntilAllDone();
+    verify(graphListener)
+        .unregisterRelationship(component.componentName(), monitor.componentName());
     component.setUnhealthy();
     waitUntilAllDone();
 


### PR DESCRIPTION
## Description
`unregisterRelationship` was called with parent/child swapped.
Added an assertion in `CriticalComponentsHealthMonitorTest` to verify it.
## Related issues

closes #27592

