### PR TITLE
Partial authorization update is not supported

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.authorization.PersistedAuthorization;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
@@ -55,9 +54,6 @@ public class AuthorizationUpdateProcessor
             authorizationRecord ->
                 permissionsBehavior.authorizationExists(
                     authorizationRecord, AUTHORIZATION_DOES_NOT_EXIST_ERROR_MESSAGE_UPDATE))
-        .map(
-            persistedAuthorization ->
-                overlayAuthorization(command.getValue(), persistedAuthorization))
         .flatMap(
             record ->
                 permissionsBehavior.hasValidPermissionTypes(
@@ -98,28 +94,5 @@ public class AuthorizationUpdateProcessor
         .distribute(command);
     responseWriter.writeEventOnCommand(
         key, AuthorizationIntent.UPDATED, authorizationRecord, command);
-  }
-
-  // Create the new record with the persisted values if not changed by the user
-  private AuthorizationRecord overlayAuthorization(
-      final AuthorizationRecord newAuthorization,
-      final PersistedAuthorization persistedAuthorization) {
-    final var changeset = newAuthorization.getChangedAttributes();
-    if (!changeset.contains(AuthorizationRecord.OWNER_ID)) {
-      newAuthorization.setOwnerId(persistedAuthorization.getOwnerId());
-    }
-    if (!changeset.contains(AuthorizationRecord.OWNER_TYPE)) {
-      newAuthorization.setOwnerType(persistedAuthorization.getOwnerType());
-    }
-    if (!changeset.contains(AuthorizationRecord.RESOURCE_ID)) {
-      newAuthorization.setResourceId(persistedAuthorization.getResourceId());
-    }
-    if (!changeset.contains(AuthorizationRecord.RESOURCE_TYPE)) {
-      newAuthorization.setResourceType(persistedAuthorization.getResourceType());
-    }
-    if (!changeset.contains(AuthorizationRecord.PERMISSIONS)) {
-      newAuthorization.setAuthorizationPermissions(persistedAuthorization.getPermissions());
-    }
-    return newAuthorization;
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationUpdateAuthorizationTest.java
@@ -70,7 +70,7 @@ public class AuthorizationUpdateAuthorizationTest {
     // then
     assertThat(
             RecordingExporter.authorizationRecords(AuthorizationIntent.UPDATED)
-                .withOwnerId(user.getUsername())
+                .withAuthorizationKey(authorizationKey)
                 .exists())
         .isTrue();
   }
@@ -103,7 +103,7 @@ public class AuthorizationUpdateAuthorizationTest {
     // then
     assertThat(
             RecordingExporter.authorizationRecords(AuthorizationIntent.UPDATED)
-                .withOwnerId(user.getUsername())
+                .withAuthorizationKey(authorizationKey)
                 .exists())
         .isTrue();
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationMultipartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationMultipartitionTest.java
@@ -12,7 +12,6 @@ import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
 import io.camunda.zeebe.engine.util.EngineRule;
-import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -25,7 +24,6 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.junit.Rule;
@@ -57,12 +55,7 @@ public class UpdateAuthorizationMultipartitionTest {
             .getValue()
             .getAuthorizationKey();
 
-    engine
-        .authorization()
-        .updateAuthorization(key)
-        .withOwnerType(AuthorizationOwnerType.GROUP)
-        .withChangeset(Set.of(AuthorizationRecord.OWNER_TYPE))
-        .update();
+    engine.authorization().updateAuthorization(key).update();
 
     RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
         .withDistributionIntent(AuthorizationIntent.CREATE)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationTest.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.engine.processing.authorization;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
-import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
@@ -52,8 +51,11 @@ public class UpdateAuthorizationTest {
         engine
             .authorization()
             .updateAuthorization(authorizationKey)
+            .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.GROUP)
-            .withChangeset(Set.of(AuthorizationRecord.OWNER_TYPE))
+            .withResourceId("resourceId")
+            .withResourceType(AuthorizationResourceType.RESOURCE)
+            .withPermissions(PermissionType.CREATE)
             .update()
             .getValue();
 
@@ -111,8 +113,11 @@ public class UpdateAuthorizationTest {
         engine
             .authorization()
             .updateAuthorization(authorizationKey)
+            .withOwnerId("ownerId")
+            .withOwnerType(AuthorizationOwnerType.GROUP)
+            .withResourceId("resourceId")
+            .withResourceType(AuthorizationResourceType.RESOURCE)
             .withPermissions(PermissionType.ACCESS)
-            .withChangeset(Set.of(AuthorizationRecord.PERMISSIONS))
             .expectRejection()
             .update();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AuthorizationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AuthorizationClient.java
@@ -328,11 +328,6 @@ public final class AuthorizationClient {
       return this;
     }
 
-    public AuthorizationUpdateClient withChangeset(final Set<String> changeset) {
-      authorizationUpdateRecord.setChangedAttributes(changeset);
-      return this;
-    }
-
     public AuthorizationUpdateClient expectRejection() {
       expectRejection = true;
       return this;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/AuthorizationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/AuthorizationRecord.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 public final class AuthorizationRecord extends UnifiedRecordValue
     implements AuthorizationRecordValue {
@@ -51,8 +50,6 @@ public final class AuthorizationRecord extends UnifiedRecordValue
   // TODO: rename in: https://github.com/camunda/camunda/issues/26883
   private final ArrayProperty<StringValue> authorizationPermissionsProp =
       new ArrayProperty<>("authorizationPermissions", StringValue::new);
-  private final ArrayProperty<StringValue> changedAttributesProp =
-      new ArrayProperty<>("changedAttributes", StringValue::new);
 
   public AuthorizationRecord() {
     super(9);
@@ -63,8 +60,7 @@ public final class AuthorizationRecord extends UnifiedRecordValue
         .declareProperty(resourceIdProp)
         .declareProperty(resourceTypeProp)
         .declareProperty(permissionsProp)
-        .declareProperty(authorizationPermissionsProp)
-        .declareProperty(changedAttributesProp);
+        .declareProperty(authorizationPermissionsProp);
   }
 
   @Override
@@ -142,21 +138,6 @@ public final class AuthorizationRecord extends UnifiedRecordValue
     permissions.forEach(
         permission ->
             authorizationPermissionsProp.add().wrap(BufferUtil.wrapString(permission.name())));
-    return this;
-  }
-
-  @Override
-  public Set<String> getChangedAttributes() {
-    return StreamSupport.stream(changedAttributesProp.spliterator(), false)
-        .map(StringValue::getValue)
-        .map(BufferUtil::bufferAsString)
-        .collect(Collectors.toSet());
-  }
-
-  public AuthorizationRecord setChangedAttributes(final Set<String> changedAttributes) {
-    changedAttributesProp.reset();
-    changedAttributes.forEach(
-        attribute -> changedAttributesProp.add().wrap(BufferUtil.wrapString(attribute)));
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/AuthorizationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/AuthorizationRecord.java
@@ -27,12 +27,6 @@ import java.util.stream.Collectors;
 public final class AuthorizationRecord extends UnifiedRecordValue
     implements AuthorizationRecordValue {
 
-  public static final String OWNER_ID = "ownerId";
-  public static final String OWNER_TYPE = "ownerType";
-  public static final String RESOURCE_ID = "resourceId";
-  public static final String RESOURCE_TYPE = "resourceType";
-  public static final String PERMISSIONS = "authorizationPermissions";
-
   private final LongProperty authorizationKeyProp = new LongProperty("authorizationKey", -1L);
   private final StringProperty ownerIdProp = new StringProperty("ownerId", "");
   // TODO: remove in: https://github.com/camunda/camunda/issues/26883
@@ -52,7 +46,7 @@ public final class AuthorizationRecord extends UnifiedRecordValue
       new ArrayProperty<>("authorizationPermissions", StringValue::new);
 
   public AuthorizationRecord() {
-    super(9);
+    super(8);
     declareProperty(authorizationKeyProp)
         .declareProperty(ownerIdProp)
         .declareProperty(ownerTypeProp)

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2714,8 +2714,7 @@ final class JsonSerializableToJsonTest {
                             .addResourceId("bpmnProcessId:foo"))
                     .addPermission(
                         new Permission().setPermissionType(PermissionType.READ).addResourceId("*"))
-                    .setAuthorizationPermissions(Set.of(PermissionType.CREATE))
-                    .setChangedAttributes(Set.of(AuthorizationRecord.OWNER_TYPE)),
+                    .setAuthorizationPermissions(Set.of(PermissionType.CREATE)),
         """
         {
           "authorizationKey": 1,
@@ -2736,9 +2735,6 @@ final class JsonSerializableToJsonTest {
           ],
           "authorizationPermissions": [
             "CREATE"
-          ],
-          "changedAttributes": [
-            "ownerType"
           ]
         }
         """
@@ -2762,8 +2758,7 @@ final class JsonSerializableToJsonTest {
           "resourceId": "",
           "resourceType": "RESOURCE",
           "permissions": [],
-          "authorizationPermissions": [],
-          "changedAttributes": []
+          "authorizationPermissions": []
         }
         """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationRecordValue.java
@@ -41,8 +41,6 @@ public interface AuthorizationRecordValue extends RecordValue {
 
   Set<PermissionType> getAuthorizationPermissions();
 
-  Set<String> getChangedAttributes();
-
   @Value.Immutable
   @ImmutableProtocol(builder = ImmutablePermissionValue.Builder.class)
   interface PermissionValue {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Based on this [discussion](https://camunda.slack.com/archives/C06UYJMMETZ/p1738580108815709) on slack we should support only full record updates, and NOT partial records update (PATCH)

## Related issues

related to https://github.com/camunda/camunda/issues/27286
