### PR TITLE
[Backport stable/8.5] Elasticsearch metrics now export using micrometer core library

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/pom.xml
+++ b/zeebe/exporters/elasticsearch-exporter/pom.xml
@@ -57,11 +57,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-util</artifactId>
     </dependency>

--- a/zeebe/exporters/elasticsearch-exporter/pom.xml
+++ b/zeebe/exporters/elasticsearch-exporter/pom.xml
@@ -62,6 +62,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -26,7 +26,7 @@ import io.camunda.zeebe.exporter.dto.PutIndexTemplateResponse;
 import io.camunda.zeebe.exporter.dto.Template;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.prometheus.client.Histogram;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Optional;
@@ -43,23 +43,20 @@ class ElasticsearchClient implements AutoCloseable {
   private final TemplateReader templateReader;
   private final RecordIndexRouter indexRouter;
   private final BulkIndexRequest bulkIndexRequest;
+  private final MeterRegistry meterRegistry;
 
   private ElasticsearchMetrics metrics;
 
-  ElasticsearchClient(final ElasticsearchExporterConfiguration configuration) {
-    this(configuration, new BulkIndexRequest());
-  }
-
   ElasticsearchClient(
-      final ElasticsearchExporterConfiguration configuration,
-      final BulkIndexRequest bulkIndexRequest) {
+      final ElasticsearchExporterConfiguration configuration, final MeterRegistry meterRegistry) {
     this(
         configuration,
-        bulkIndexRequest,
+        new BulkIndexRequest(),
         RestClientFactory.of(configuration),
         new RecordIndexRouter(configuration.index),
         new TemplateReader(configuration),
-        null);
+        null,
+        meterRegistry);
   }
 
   ElasticsearchClient(
@@ -68,13 +65,15 @@ class ElasticsearchClient implements AutoCloseable {
       final RestClient client,
       final RecordIndexRouter indexRouter,
       final TemplateReader templateReader,
-      final ElasticsearchMetrics metrics) {
+      final ElasticsearchMetrics metrics,
+      final MeterRegistry meterRegistry) {
     this.configuration = configuration;
     this.bulkIndexRequest = bulkIndexRequest;
     this.client = client;
     this.indexRouter = indexRouter;
     this.templateReader = templateReader;
     this.metrics = metrics;
+    this.meterRegistry = meterRegistry;
   }
 
   @Override
@@ -92,7 +91,7 @@ class ElasticsearchClient implements AutoCloseable {
    */
   public boolean index(final Record<?> record, final RecordSequence recordSequence) {
     if (metrics == null) {
-      metrics = new ElasticsearchMetrics(record.getPartitionId());
+      metrics = new ElasticsearchMetrics(record.getPartitionId(), meterRegistry);
     }
 
     final BulkIndexAction action =

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -115,15 +115,17 @@ class ElasticsearchClient implements AutoCloseable {
     metrics.recordBulkSize(bulkIndexRequest.size());
     metrics.recordBulkMemorySize(bulkIndexRequest.memoryUsageBytes());
 
-    try (final Histogram.Timer ignored = metrics.measureFlushDuration()) {
-      exportBulk();
+    metrics.measureFlushDuration(
+        () -> {
+          try {
+            exportBulk();
 
-      // all records where flushed, create new bulk request, otherwise retry next time
-      bulkIndexRequest.clear();
-    } catch (final ElasticsearchExporterException e) {
-      metrics.recordFailedFlush();
-      throw e;
-    }
+            bulkIndexRequest.clear();
+          } catch (final ElasticsearchExporterException e) {
+            metrics.recordFailedFlush();
+            throw e;
+          }
+        });
   }
 
   /**

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.ZoneOffset;
@@ -51,6 +52,7 @@ public class ElasticsearchExporter implements Exporter {
   private ElasticsearchExporterConfiguration configuration;
   private ElasticsearchClient client;
   private ElasticsearchRecordCounters recordCounters;
+  private MeterRegistry registry;
 
   private long lastPosition = -1;
   private boolean indexTemplatesCreated;
@@ -66,6 +68,7 @@ public class ElasticsearchExporter implements Exporter {
 
     context.setFilter(new ElasticsearchRecordFilter(configuration));
     indexTemplatesCreated = false;
+    registry = context.getMeterRegistry();
   }
 
   @Override
@@ -175,7 +178,7 @@ public class ElasticsearchExporter implements Exporter {
 
   // TODO: remove this and instead allow client to be inject-able for testing
   protected ElasticsearchClient createClient() {
-    return new ElasticsearchClient(configuration);
+    return new ElasticsearchClient(configuration, registry);
   }
 
   private void flushAndReschedule() {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchMetrics.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchMetrics.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.exporter;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.Histogram;
@@ -49,9 +51,11 @@ public class ElasticsearchMetrics {
           .register();
 
   private final String partitionIdLabel;
+  private final MeterRegistry meterRegistry;
 
-  public ElasticsearchMetrics(final int partitionId) {
+  public ElasticsearchMetrics(final int partitionId, final MeterRegistry registry) {
     partitionIdLabel = String.valueOf(partitionId);
+    meterRegistry = registry;
   }
 
   public Histogram.Timer measureFlushDuration() {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchMetrics.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchMetrics.java
@@ -7,70 +7,71 @@
  */
 package io.camunda.zeebe.exporter;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
-import io.prometheus.client.Counter;
-import io.prometheus.client.Gauge;
-import io.prometheus.client.Histogram;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class ElasticsearchMetrics {
-  private static final String NAMESPACE = "zeebe_elasticsearch_exporter";
+  private static final String NAMESPACE = "zeebe.elasticsearch.exporter";
   private static final String PARTITION_LABEL = "partition";
-
-  private static final Histogram FLUSH_DURATION =
-      Histogram.build()
-          .namespace(NAMESPACE)
-          .name("flush_duration_seconds")
-          .help("Flush duration of bulk exporters in seconds")
-          .labelNames(PARTITION_LABEL)
-          .register();
-
-  private static final Counter FAILED_FLUSH =
-      Counter.build()
-          .namespace(NAMESPACE)
-          .name("failed_flush")
-          .help("Number of failed flush operations")
-          .labelNames(PARTITION_LABEL)
-          .register();
-
-  private static final Histogram BULK_SIZE =
-      Histogram.build()
-          .namespace(NAMESPACE)
-          .name("bulk_size")
-          .help("Exporter bulk size")
-          .buckets(10, 100, 1_000, 10_000, 100_000)
-          .labelNames(PARTITION_LABEL)
-          .register();
-
-  private static final Gauge BULK_MEMORY_SIZE =
-      Gauge.build()
-          .namespace(NAMESPACE)
-          .name("bulk_memory_size")
-          .help("Exporter bulk memory size")
-          .labelNames(PARTITION_LABEL)
-          .register();
 
   private final String partitionIdLabel;
   private final MeterRegistry meterRegistry;
+  private final AtomicInteger BULK_MEMORY_SIZE = new AtomicInteger(0);
+  private final Timer FLUSH_DURATION;
+  private final DistributionSummary BULK_SIZE;
+  private final Counter FAILED_FLUSH;
 
   public ElasticsearchMetrics(final int partitionId, final MeterRegistry registry) {
     partitionIdLabel = String.valueOf(partitionId);
     meterRegistry = registry;
+
+    Gauge.builder(meterName("bulk.memory.size"), BULK_MEMORY_SIZE, AtomicInteger::get)
+        .tags(PARTITION_LABEL, partitionIdLabel)
+        .description("Exporter bulk memory size")
+        .register(meterRegistry);
+
+    FLUSH_DURATION =
+        Timer.builder(meterName("flush.duration.seconds"))
+            .description("Flush duration of bulk exporters in seconds")
+            .tags(PARTITION_LABEL, partitionIdLabel)
+            .publishPercentileHistogram()
+            .register(meterRegistry);
+
+    BULK_SIZE =
+        DistributionSummary.builder(meterName("bulk.size"))
+            .description("Exporter bulk size")
+            .tags(PARTITION_LABEL, partitionIdLabel)
+            .serviceLevelObjectives(10, 100, 1_000, 10_000, 100_000)
+            .register(meterRegistry);
+
+    FAILED_FLUSH =
+        Counter.builder(meterName("failed.flush"))
+            .description("Number of failed flush operations")
+            .tags(PARTITION_LABEL, partitionIdLabel)
+            .register(meterRegistry);
   }
 
-  public Histogram.Timer measureFlushDuration() {
-    return FLUSH_DURATION.labels(partitionIdLabel).startTimer();
+  public void measureFlushDuration(final Runnable flushFunction) {
+    FLUSH_DURATION.record(flushFunction);
   }
 
   public void recordBulkSize(final int bulkSize) {
-    BULK_SIZE.labels(partitionIdLabel).observe(bulkSize);
+    BULK_SIZE.record(bulkSize);
   }
 
   public void recordBulkMemorySize(final int bulkMemorySize) {
-    BULK_MEMORY_SIZE.labels(partitionIdLabel).set(bulkMemorySize);
+    BULK_MEMORY_SIZE.set(bulkMemorySize);
   }
 
   public void recordFailedFlush() {
-    FAILED_FLUSH.labels(partitionIdLabel).inc();
+    FAILED_FLUSH.increment();
+  }
+
+  private String meterName(final String name) {
+    return NAMESPACE + "." + name;
   }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
@@ -17,6 +17,8 @@ import io.camunda.zeebe.exporter.TestClient.IndexTemplatesDto.IndexTemplateWrapp
 import io.camunda.zeebe.exporter.dto.Template;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.util.Map;
 import java.util.UUID;
@@ -50,6 +52,7 @@ final class ElasticsearchClientIT {
   private final TemplateReader templateReader = new TemplateReader(config);
   private final RecordIndexRouter indexRouter = new RecordIndexRouter(config.index);
   private final BulkIndexRequest bulkRequest = new BulkIndexRequest();
+  private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
   private TestClient testClient;
   private ElasticsearchClient client;
@@ -68,7 +71,8 @@ final class ElasticsearchClientIT {
             RestClientFactory.of(config),
             indexRouter,
             templateReader,
-            new ElasticsearchMetrics(PARTITION_ID));
+            null,
+            new SimpleMeterRegistry());
   }
 
   @AfterEach
@@ -156,7 +160,7 @@ final class ElasticsearchClientIT {
 
     // when
     // force recreating the client
-    final var authenticatedClient = new ElasticsearchClient(config, bulkRequest);
+    final var authenticatedClient = new ElasticsearchClient(config, meterRegistry);
     authenticatedClient.putComponentTemplate();
 
     // then

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.exporter.dto.Template;
 import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
@@ -64,7 +65,8 @@ final class ElasticsearchClientTest {
           restClient,
           indexRouter,
           templateReader,
-          new ElasticsearchMetrics(PARTITION_ID));
+          null,
+          new SimpleMeterRegistry());
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("io.camunda.zeebe.exporter.TestSupport#provideValueTypes")


### PR DESCRIPTION
# Description
Backport of #20590 to `stable/8.5`.

relates to #18467
original author: @EuroLew