### PR TITLE
fix: allow unauthenticated api access by default

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
@@ -39,7 +39,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
     classes = {CommonsModuleConfiguration.class},
     properties = {
       "spring.profiles.active=consolidated-auth",
-      "camunda.security.authentication.method=basic"
+      "camunda.security.authentication.method=basic",
+      "camunda.security.authentication.basic.allow-unauthenticated-api-access=false"
     })
 @WebAppConfiguration
 @AutoConfigureMockMvc

--- a/security/security-core/src/main/java/io/camunda/security/configuration/BasicAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/BasicAuthenticationConfiguration.java
@@ -8,7 +8,7 @@
 package io.camunda.security.configuration;
 
 public class BasicAuthenticationConfiguration {
-  private boolean allowUnauthenticatedApiAccess = false;
+  private boolean allowUnauthenticatedApiAccess = true;
 
   public boolean getAllowUnauthenticatedApiAccess() {
     return allowUnauthenticatedApiAccess;


### PR DESCRIPTION
This should fix the failing tests in CI, caused by changing the default to have basic auth enabled done with https://github.com/camunda/camunda/pull/26960 previously.

Context see this thread https://camunda.slack.com/archives/C06UYJMMETZ/p1738600178706609?thread_ts=1738594463.864289&cid=C06UYJMMETZ


