### PR TITLE
Update authorizations

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
@@ -76,7 +76,9 @@ public class AuthorizationUpdateProcessor
         .ifRightOrLeft(
             ignored ->
                 stateWriter.appendFollowUpEvent(
-                    command.getKey(), AuthorizationIntent.UPDATED, command.getValue()),
+                    command.getValue().getAuthorizationKey(),
+                    AuthorizationIntent.UPDATED,
+                    command.getValue()),
             rejection ->
                 rejectionWriter.appendRejection(command, rejection.type(), rejection.reason()));
 
@@ -87,12 +89,18 @@ public class AuthorizationUpdateProcessor
       final TypedRecord<AuthorizationRecord> command,
       final AuthorizationRecord authorizationRecord) {
     final long key = keyGenerator.nextKey();
-    stateWriter.appendFollowUpEvent(key, AuthorizationIntent.UPDATED, authorizationRecord);
+    stateWriter.appendFollowUpEvent(
+        authorizationRecord.getAuthorizationKey(),
+        AuthorizationIntent.UPDATED,
+        authorizationRecord);
     distributionBehavior
         .withKey(key)
         .inQueue(DistributionQueue.IDENTITY.getQueueId())
         .distribute(command);
     responseWriter.writeEventOnCommand(
-        key, AuthorizationIntent.UPDATED, authorizationRecord, command);
+        authorizationRecord.getAuthorizationKey(),
+        AuthorizationIntent.UPDATED,
+        authorizationRecord,
+        command);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AuthorizationUpdatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/AuthorizationUpdatedApplier.java
@@ -23,7 +23,6 @@ public class AuthorizationUpdatedApplier
 
   @Override
   public void applyState(final long key, final AuthorizationRecord value) {
-    // TODO: add update method call once https://github.com/camunda/camunda/issues/27203 is
-    // implemented
+    authorizationState.update(key, value);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
@@ -148,11 +148,6 @@ public class DbAuthorizationState implements MutableAuthorizationState {
     final var persistedAuthorization =
         authorizationByAuthorizationKeyColumnFamily.get(this.authorizationKey);
 
-    if (persistedAuthorization == null) {
-      // if there are no persisted authorization, we should not update the authorization
-      return;
-    }
-
     // remove the old permissions
     persistedAuthorization
         .getPermissionTypes()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
@@ -144,25 +144,8 @@ public class DbAuthorizationState implements MutableAuthorizationState {
 
   @Override
   public void update(final long authorizationKey, final AuthorizationRecord authorization) {
-    this.authorizationKey.wrapLong(authorizationKey);
-    final var persistedAuthorization =
-        authorizationByAuthorizationKeyColumnFamily.get(this.authorizationKey);
-
-    // remove the old permissions
-    persistedAuthorization
-        .getPermissionTypes()
-        .forEach(
-            permissionType -> {
-              removePermission(
-                  persistedAuthorization.getOwnerType(),
-                  persistedAuthorization.getOwnerId(),
-                  persistedAuthorization.getResourceType(),
-                  permissionType,
-                  Set.of(persistedAuthorization.getResourceId()));
-            });
-
-    // delete the old authorization record
-    authorizationByAuthorizationKeyColumnFamily.deleteExisting(this.authorizationKey);
+    // delete old authorization record
+    delete(authorizationKey);
 
     // create the new authorization record
     create(authorizationKey, authorization);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedAuthorization.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedAuthorization.java
@@ -34,8 +34,8 @@ public class PersistedAuthorization extends UnpackedObject implements DbValue {
   private final StringProperty resourceIdProp = new StringProperty("resourceId");
   private final EnumProperty<AuthorizationResourceType> resourceTypeProp =
       new EnumProperty<>("resourceType", AuthorizationResourceType.class);
-  private final ArrayProperty<StringValue> permissionsProp =
-      new ArrayProperty<>("permissions", StringValue::new);
+  private final ArrayProperty<StringValue> permissionTypesProp =
+      new ArrayProperty<>("permissionTypes", StringValue::new);
 
   public PersistedAuthorization() {
     super(6);
@@ -44,7 +44,7 @@ public class PersistedAuthorization extends UnpackedObject implements DbValue {
         .declareProperty(ownerTypeProp)
         .declareProperty(resourceIdProp)
         .declareProperty(resourceTypeProp)
-        .declareProperty(permissionsProp);
+        .declareProperty(permissionTypesProp);
   }
 
   public void wrap(final AuthorizationRecord authorizationRecord) {
@@ -53,7 +53,7 @@ public class PersistedAuthorization extends UnpackedObject implements DbValue {
         .setOwnerType(authorizationRecord.getOwnerType())
         .setResourceId(authorizationRecord.getResourceId())
         .setResourceType(authorizationRecord.getResourceType())
-        .setPermissions(authorizationRecord.getAuthorizationPermissions());
+        .setPermissionTypes(authorizationRecord.getAuthorizationPermissions());
   }
 
   public long getAuthorizationKey() {
@@ -101,23 +101,23 @@ public class PersistedAuthorization extends UnpackedObject implements DbValue {
     return this;
   }
 
-  public Set<PermissionType> getPermissions() {
-    return StreamSupport.stream(permissionsProp.spliterator(), false)
+  public Set<PermissionType> getPermissionTypes() {
+    return StreamSupport.stream(permissionTypesProp.spliterator(), false)
         .map(StringValue::getValue)
         .map(BufferUtil::bufferAsString)
         .map(PermissionType::valueOf)
         .collect(Collectors.toSet());
   }
 
-  public PersistedAuthorization setPermissions(final Set<PermissionType> permissions) {
-    permissionsProp.reset();
-    permissions.forEach(
-        permission -> permissionsProp.add().wrap(BufferUtil.wrapString(permission.name())));
+  public PersistedAuthorization setPermissionTypes(final Set<PermissionType> permissionTypes) {
+    permissionTypesProp.reset();
+    permissionTypes.forEach(
+        permission -> permissionTypesProp.add().wrap(BufferUtil.wrapString(permission.name())));
     return this;
   }
 
   public PersistedAuthorization addPermission(final PermissionType permission) {
-    permissionsProp.add().wrap(BufferUtil.wrapString(permission.name()));
+    permissionTypesProp.add().wrap(BufferUtil.wrapString(permission.name()));
     return this;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableAuthorizationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableAuthorizationState.java
@@ -71,6 +71,14 @@ public interface MutableAuthorizationState extends AuthorizationState {
       final AuthorizationOwnerType ownerType, final String ownerId);
 
   /**
+   * Updates the provided authorization in the state.
+   *
+   * @param authorizationKey the key of the authorization
+   * @param authorization the authorization record to update
+   */
+  void update(final long authorizationKey, final AuthorizationRecord authorization);
+
+  /**
    * Removes the authorization with the provided key.
    *
    * @param authorizationKey the key of the authorization to remove

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
@@ -276,7 +276,7 @@ public class AuthorizationStateTest {
   }
 
   @Test
-  void shouldUpdateAuthorization() {
+  void shouldUpdateAuthorizationChangingPermissions() {
     // given
     final var authorizationKey = 1L;
     final String ownerId = "ownerId";
@@ -340,7 +340,7 @@ public class AuthorizationStateTest {
   }
 
   @Test
-  void shouldUpdateAuthorizationChangingPermissionsKey() {
+  void shouldUpdateAuthorizationChangingOwnerIdAndResourceId() {
     // given
     final var authorizationKey = 1L;
     final String ownerId = "ownerId";
@@ -367,7 +367,7 @@ public class AuthorizationStateTest {
             .setOwnerType(ownerType)
             .setResourceId("anotherResourceId")
             .setResourceType(resourceType)
-            .setAuthorizationPermissions(Set.of(PermissionType.READ));
+            .setAuthorizationPermissions(permissions);
     authorizationState.update(authorizationKey, updatedAuthorizationRecord);
 
     // then
@@ -379,34 +379,31 @@ public class AuthorizationStateTest {
     assertThat(authorization.getOwnerType()).isEqualTo(ownerType);
     assertThat(authorization.getResourceId()).isEqualTo("anotherResourceId");
     assertThat(authorization.getResourceType()).isEqualTo(resourceType);
-    assertThat(authorization.getPermissions())
-        .containsExactlyInAnyOrderElementsOf(Set.of(PermissionType.READ));
+    assertThat(authorization.getPermissions()).containsExactlyInAnyOrderElementsOf(permissions);
 
     final var resourceIdentifiers =
         authorizationState.getResourceIdentifiers(
-            ownerType, "anotherOwnerId", resourceType, PermissionType.READ);
+            ownerType, "anotherOwnerId", resourceType, PermissionType.CREATE);
     assertThat(resourceIdentifiers).containsExactly("anotherResourceId");
 
     final var anotherResourceIdentifiers =
         authorizationState.getResourceIdentifiers(
-            ownerType, "anotherOwnerId", resourceType, PermissionType.CREATE);
-    assertThat(anotherResourceIdentifiers).isEmpty();
+            ownerType, "anotherOwnerId", resourceType, PermissionType.DELETE);
+    assertThat(anotherResourceIdentifiers).containsExactly("anotherResourceId");
+
     final var anotherResourceIdentifiers2 =
         authorizationState.getResourceIdentifiers(
             ownerType, ownerId, resourceType, PermissionType.CREATE);
     assertThat(anotherResourceIdentifiers2).isEmpty();
+
     final var anotherResourceIdentifiers3 =
         authorizationState.getResourceIdentifiers(
-            ownerType, ownerId, resourceType, PermissionType.READ);
-    assertThat(anotherResourceIdentifiers3).isEmpty();
-    final var anotherResourceIdentifiers4 =
-        authorizationState.getResourceIdentifiers(
             ownerType, ownerId, resourceType, PermissionType.DELETE);
-    assertThat(anotherResourceIdentifiers4).isEmpty();
+    assertThat(anotherResourceIdentifiers3).isEmpty();
   }
 
   @Test
-  void shouldUpdateAuthorizationChangingPermission() {
+  void shouldUpdateAuthorizationChangingResourceType() {
     // given
     final var authorizationKey = 1L;
     final String ownerId = "ownerId";
@@ -433,7 +430,7 @@ public class AuthorizationStateTest {
             .setOwnerType(ownerType)
             .setResourceId(resourceId)
             .setResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
-            .setAuthorizationPermissions(Set.of(PermissionType.READ_PROCESS_DEFINITION));
+            .setAuthorizationPermissions(permissions);
     authorizationState.update(authorizationKey, updatedAuthorizationRecord);
 
     // then
@@ -446,26 +443,33 @@ public class AuthorizationStateTest {
     assertThat(authorization.getResourceId()).isEqualTo(resourceId);
     assertThat(authorization.getResourceType())
         .isEqualTo(AuthorizationResourceType.PROCESS_DEFINITION);
-    assertThat(authorization.getPermissions())
-        .containsExactlyInAnyOrderElementsOf(Set.of(PermissionType.READ_PROCESS_DEFINITION));
+    assertThat(authorization.getPermissions()).containsExactlyInAnyOrderElementsOf(permissions);
 
     final var resourceIdentifiers =
         authorizationState.getResourceIdentifiers(
             ownerType,
             ownerId,
             AuthorizationResourceType.PROCESS_DEFINITION,
-            PermissionType.READ_PROCESS_DEFINITION);
+            PermissionType.CREATE);
     assertThat(resourceIdentifiers).containsExactly("resourceId");
 
     final var anotherResourceIdentifiers =
         authorizationState.getResourceIdentifiers(
-            ownerType, ownerId, AuthorizationResourceType.RESOURCE, PermissionType.CREATE);
-    assertThat(anotherResourceIdentifiers).isEmpty();
+            ownerType,
+            ownerId,
+            AuthorizationResourceType.PROCESS_DEFINITION,
+            PermissionType.DELETE);
+    assertThat(anotherResourceIdentifiers).containsExactly("resourceId");
 
     final var anotherResourceIdentifiers2 =
         authorizationState.getResourceIdentifiers(
-            ownerType, ownerId, AuthorizationResourceType.RESOURCE, PermissionType.DELETE);
+            ownerType, ownerId, AuthorizationResourceType.RESOURCE, PermissionType.CREATE);
     assertThat(anotherResourceIdentifiers2).isEmpty();
+
+    final var anotherResourceIdentifiers3 =
+        authorizationState.getResourceIdentifiers(
+            ownerType, ownerId, AuthorizationResourceType.RESOURCE, PermissionType.DELETE);
+    assertThat(anotherResourceIdentifiers3).isEmpty();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
@@ -76,7 +76,7 @@ public class AuthorizationStateTest {
     assertThat(authorization.getOwnerType()).isEqualTo(ownerType);
     assertThat(authorization.getResourceId()).isEqualTo(resourceId);
     assertThat(authorization.getResourceType()).isEqualTo(resourceType);
-    assertThat(authorization.getPermissions()).containsExactlyInAnyOrderElementsOf(permissions);
+    assertThat(authorization.getPermissionTypes()).containsExactlyInAnyOrderElementsOf(permissions);
     final var resourceIdentifiers =
         authorizationState.getResourceIdentifiers(
             ownerType, ownerId, resourceType, PermissionType.CREATE);
@@ -315,7 +315,7 @@ public class AuthorizationStateTest {
     assertThat(authorization.getOwnerType()).isEqualTo(ownerType);
     assertThat(authorization.getResourceId()).isEqualTo("anotherResourceId");
     assertThat(authorization.getResourceType()).isEqualTo(resourceType);
-    assertThat(authorization.getPermissions())
+    assertThat(authorization.getPermissionTypes())
         .containsExactlyInAnyOrderElementsOf(Set.of(PermissionType.READ, PermissionType.ACCESS));
 
     final var resourceIdentifiers =
@@ -379,7 +379,7 @@ public class AuthorizationStateTest {
     assertThat(authorization.getOwnerType()).isEqualTo(ownerType);
     assertThat(authorization.getResourceId()).isEqualTo("anotherResourceId");
     assertThat(authorization.getResourceType()).isEqualTo(resourceType);
-    assertThat(authorization.getPermissions()).containsExactlyInAnyOrderElementsOf(permissions);
+    assertThat(authorization.getPermissionTypes()).containsExactlyInAnyOrderElementsOf(permissions);
 
     final var resourceIdentifiers =
         authorizationState.getResourceIdentifiers(
@@ -443,7 +443,7 @@ public class AuthorizationStateTest {
     assertThat(authorization.getResourceId()).isEqualTo(resourceId);
     assertThat(authorization.getResourceType())
         .isEqualTo(AuthorizationResourceType.PROCESS_DEFINITION);
-    assertThat(authorization.getPermissions()).containsExactlyInAnyOrderElementsOf(permissions);
+    assertThat(authorization.getPermissionTypes()).containsExactlyInAnyOrderElementsOf(permissions);
 
     final var resourceIdentifiers =
         authorizationState.getResourceIdentifiers(
@@ -524,7 +524,7 @@ public class AuthorizationStateTest {
     assertThat(authorization.getResourceId()).isEqualTo(resourceId);
     assertThat(authorization.getResourceType())
         .isEqualTo(AuthorizationResourceType.PROCESS_DEFINITION);
-    assertThat(authorization.getPermissions())
+    assertThat(authorization.getPermissionTypes())
         .containsExactlyInAnyOrderElementsOf(Set.of(PermissionType.READ_PROCESS_DEFINITION));
 
     final var resourceIdentifiers =


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds a method in the state to update an authorization record. In order to update also the permission related to an authorization record, the easiest way to go is by deleting the old authorization record and permission and re-create them with the new provided values

## Related issues

closes #27203 
