### PR TITLE
test: remove redundant unauthenticated setup

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/cluster/ClusterPurgeIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/cluster/ClusterPurgeIT.java
@@ -49,7 +49,6 @@ public class ClusterPurgeIT {
           .withReplicationFactor(REPLICATION_FACTOR)
           .withEmbeddedGateway(true)
           .withBrokerConfig(TestStandaloneBroker::withRdbmsExporter)
-          .withUnauthenticatedAccess()
           .build();
 
   @AutoClose CamundaClient client;

--- a/qa/integration-tests/src/test/java/io/camunda/it/migration/util/ZeebeMigrationHelper.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/migration/util/ZeebeMigrationHelper.java
@@ -137,8 +137,7 @@ public class ZeebeMigrationHelper {
             .withRecordingExporter(true)
             .withBrokerConfig(cfg -> cfg.getGateway().setEnable(true))
             .withExporter("CamundaExporter", exporterConfig)
-            .withWorkingDirectory(zeebeDataPath.resolve("usr/local/zeebe"))
-            .withUnauthenticatedAccess();
+            .withWorkingDirectory(zeebeDataPath.resolve("usr/local/zeebe"));
     final Map<String, String> env =
         databaseType.equals(DatabaseType.ELASTICSEARCH)
             ? zeebe87ElasticsearchDefaultConfig()

--- a/qa/integration-tests/src/test/java/io/camunda/it/operate/OperatePermissionsIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/operate/OperatePermissionsIT.java
@@ -50,11 +50,7 @@ public class OperatePermissionsIT {
 
   @SuppressWarnings("unused")
   static void initTestStandaloneCamunda() {
-    testInstance =
-        new TestStandaloneCamunda()
-            .withCamundaExporter()
-            .withUnauthenticatedAccess()
-            .withAuthorizationsEnabled();
+    testInstance = new TestStandaloneCamunda().withCamundaExporter().withAuthorizationsEnabled();
   }
 
   @BeforeAll

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistAssignUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistAssignUserTaskAuthorizationIT.java
@@ -59,8 +59,7 @@ public class TasklistAssignUserTaskAuthorizationIT {
   private TestStandaloneCamunda standaloneCamunda =
       new TestStandaloneCamunda()
           .withCamundaExporter()
-          .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true))
-          .withUnauthenticatedAccess();
+          .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true));
 
   @BeforeEach
   public void beforeAll() {

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistCompleteUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistCompleteUserTaskAuthorizationIT.java
@@ -58,8 +58,7 @@ public class TasklistCompleteUserTaskAuthorizationIT {
   private TestStandaloneCamunda standaloneCamunda =
       new TestStandaloneCamunda()
           .withCamundaExporter()
-          .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true))
-          .withUnauthenticatedAccess();
+          .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true));
 
   @BeforeEach
   public void beforeAll() {

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistCreateProcessInstanceAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistCreateProcessInstanceAuthorizationIT.java
@@ -48,8 +48,7 @@ public class TasklistCreateProcessInstanceAuthorizationIT {
   private final TestStandaloneCamunda standaloneCamunda =
       new TestStandaloneCamunda()
           .withCamundaExporter()
-          .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true))
-          .withUnauthenticatedAccess();
+          .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true));
 
   @BeforeEach
   public void beforeAll() {

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistUnassignUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistUnassignUserTaskAuthorizationIT.java
@@ -57,8 +57,7 @@ public class TasklistUnassignUserTaskAuthorizationIT {
   private TestStandaloneCamunda standaloneCamunda =
       new TestStandaloneCamunda()
           .withCamundaExporter()
-          .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true))
-          .withUnauthenticatedAccess();
+          .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true));
 
   @BeforeEach
   public void beforeAll() {

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistAssignUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistAssignUserTaskAuthorizationIT.java
@@ -60,8 +60,7 @@ public class CompatibilityTasklistAssignUserTaskAuthorizationIT {
       new TestStandaloneCamunda()
           .withCamundaExporter()
           .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true))
-          .withProperty("camunda.tasklist.zeebe.compatibility.enabled", true)
-          .withUnauthenticatedAccess();
+          .withProperty("camunda.tasklist.zeebe.compatibility.enabled", true);
 
   @BeforeEach
   public void beforeAll() {

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistCompleteUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistCompleteUserTaskAuthorizationIT.java
@@ -57,8 +57,7 @@ public class CompatibilityTasklistCompleteUserTaskAuthorizationIT {
       new TestStandaloneCamunda()
           .withCamundaExporter()
           .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true))
-          .withProperty("camunda.tasklist.zeebe.compatibility.enabled", true)
-          .withUnauthenticatedAccess();
+          .withProperty("camunda.tasklist.zeebe.compatibility.enabled", true);
 
   @BeforeEach
   public void beforeAll() {

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistCreateProcessInstanceAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistCreateProcessInstanceAuthorizationIT.java
@@ -49,8 +49,7 @@ public class CompatibilityTasklistCreateProcessInstanceAuthorizationIT {
       new TestStandaloneCamunda()
           .withCamundaExporter()
           .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true))
-          .withProperty("camunda.tasklist.zeebe.compatibility.enabled", true)
-          .withUnauthenticatedAccess();
+          .withProperty("camunda.tasklist.zeebe.compatibility.enabled", true);
 
   @BeforeEach
   public void beforeAll() {

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistUnassignUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistUnassignUserTaskAuthorizationIT.java
@@ -57,8 +57,7 @@ public class CompatibilityTasklistUnassignUserTaskAuthorizationIT {
       new TestStandaloneCamunda()
           .withCamundaExporter()
           .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true))
-          .withProperty("camunda.tasklist.zeebe.compatibility.enabled", true)
-          .withUnauthenticatedAccess();
+          .withProperty("camunda.tasklist.zeebe.compatibility.enabled", true);
 
   @BeforeEach
   public void beforeAll() {

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/BrokerITInvocationProvider.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/BrokerITInvocationProvider.java
@@ -159,7 +159,6 @@ public class BrokerITInvocationProvider
                               "http://" + elasticsearchContainer.getHttpHostAddress())
                           .withAdditionalProperties(additionalProperties)
                           .withAdditionalProfiles(additionalProfiles)
-                          .withUnauthenticatedAccess()
                           .start();
                   closeables.add(testBroker);
                   testBrokers.put(exporterType, testBroker);
@@ -179,7 +178,6 @@ public class BrokerITInvocationProvider
                           .withRdbmsExporter()
                           .withAdditionalProperties(additionalProperties)
                           .withAdditionalProfiles(additionalProfiles)
-                          .withUnauthenticatedAccess()
                           .start();
                   closeables.add(testBroker);
                   testBrokers.put(exporterType, testBroker);

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestSimpleCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestSimpleCamundaApplication.java
@@ -101,8 +101,7 @@ public final class TestSimpleCamundaApplication
         .withAdditionalProfile(Profile.BROKER)
         .withAdditionalProfile(Profile.OPERATE)
         .withAdditionalProfile(Profile.TASKLIST)
-        .withAdditionalInitializer(new WebappsConfigurationInitializer())
-        .withUnauthenticatedAccess();
+        .withAdditionalInitializer(new WebappsConfigurationInitializer());
   }
 
   @Override

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/AzureBackupAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/AzureBackupAcceptanceIT.java
@@ -56,7 +56,6 @@ final class AzureBackupAcceptanceIT implements BackupAcceptance {
           .withReplicationFactor(1)
           .withPartitionsCount(2)
           .withEmbeddedGateway(false)
-          .withUnauthenticatedAccess()
           .build();
 
   private AzureBackupStore store;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupMultiPartitionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupMultiPartitionTest.java
@@ -91,7 +91,6 @@ class BackupMultiPartitionTest {
           .withPartitionsCount(2)
           .withReplicationFactor(1)
           .withBrokerConfig(b -> b.withBrokerConfig(this::configureBackupStore))
-          .withUnauthenticatedAccess()
           .build();
 
   private void configureBackupStore(final BrokerCfg config) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ClusteredBackupRestoreTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ClusteredBackupRestoreTest.java
@@ -65,7 +65,6 @@ public class ClusteredBackupRestoreTest {
             .withPartitionsCount(3)
             .withReplicationFactor(1)
             .withBrokerConfig(broker -> configureBackupStore(broker.brokerConfig()))
-            .withUnauthenticatedAccess()
             .build()
             .start()
             .awaitCompleteTopology()) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/GcsBackupAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/GcsBackupAcceptanceIT.java
@@ -58,7 +58,6 @@ final class GcsBackupAcceptanceIT implements BackupAcceptance {
           .withEmbeddedGateway(false)
           .withBrokerConfig(this::configureBroker)
           .withNodeConfig(this::configureNode)
-          .withUnauthenticatedAccess()
           .build();
 
   @AutoClose private CamundaClient client;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptance.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptance.java
@@ -52,7 +52,6 @@ public interface RestoreAcceptance {
     try (final var zeebe =
         new TestStandaloneBroker()
             .withBrokerConfig(this::configureBackupStore)
-            .withUnauthenticatedAccess()
             .start()
             .awaitCompleteTopology()) {
       final var actuator = BackupActuator.of(zeebe);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/S3BackupAcceptanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/S3BackupAcceptanceIT.java
@@ -61,7 +61,6 @@ final class S3BackupAcceptanceIT implements BackupAcceptance {
           .withPartitionsCount(2)
           .withEmbeddedGateway(false)
           .withNodeConfig(this::configureNode)
-          .withUnauthenticatedAccess()
           .build();
 
   private S3BackupStore store;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/SecurityTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/SecurityTest.java
@@ -40,7 +40,6 @@ public final class SecurityTest {
           .withPartitionsCount(1)
           .withReplicationFactor(1)
           .withGatewayConfig(this::configureGatewayForTls)
-          .withUnauthenticatedAccess()
           .build();
 
   @BeforeEach

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ActivateJobsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ActivateJobsTest.java
@@ -33,7 +33,6 @@ class ActivateJobsTest {
   final TestStandaloneBroker zeebe =
       new TestStandaloneBroker()
           .withRecordingExporter(true)
-          .withUnauthenticatedAccess()
           .withGatewayConfig(c -> c.getLongPolling().setEnabled(false));
 
   ZeebeResourcesHelper resourcesHelper;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateDeploymentTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateDeploymentTest.java
@@ -41,7 +41,6 @@ public final class CreateDeploymentTest {
   @TestZeebe
   final TestStandaloneBroker zeebe =
       new TestStandaloneBroker()
-          .withUnauthenticatedAccess()
           .withRecordingExporter(true)
           .withBrokerConfig(b -> b.getNetwork().setMaxMessageSize(DataSize.ofMegabytes(1)));
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateLargeDeploymentTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateLargeDeploymentTest.java
@@ -35,7 +35,6 @@ public final class CreateLargeDeploymentTest {
   @TestZeebe
   final TestStandaloneBroker zeebe =
       new TestStandaloneBroker()
-          .withUnauthenticatedAccess()
           .withRecordingExporter(true)
           .withBrokerConfig(
               b -> b.getNetwork().setMaxMessageSize(DataSize.ofMegabytes(MAX_MSG_SIZE_MB)));

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/LongPollingActivateJobsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/LongPollingActivateJobsTest.java
@@ -33,7 +33,6 @@ public class LongPollingActivateJobsTest {
   @TestZeebe
   final TestStandaloneBroker zeebe =
       new TestStandaloneBroker()
-          .withUnauthenticatedAccess()
           .withRecordingExporter(true)
           .withGatewayConfig(c -> c.getLongPolling().setEnabled(true));
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/FixedPartitionDistributionIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/FixedPartitionDistributionIT.java
@@ -34,7 +34,6 @@ final class FixedPartitionDistributionIT {
             .withPartitionsCount(3)
             .withReplicationFactor(2)
             .withBrokerConfig(this::configureBroker)
-            .withUnauthenticatedAccess()
             .build();
     cluster.start().awaitCompleteTopology();
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/GossipClusteringIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/GossipClusteringIT.java
@@ -38,7 +38,6 @@ final class GossipClusteringIT {
                               .setProbeInterval(Duration.ofMillis(250))))
           .withBrokersCount(3)
           .withReplicationFactor(3)
-          .withUnauthenticatedAccess()
           .build();
 
   @AutoClose private CamundaClient client;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/JobStreamLifecycleIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/JobStreamLifecycleIT.java
@@ -46,7 +46,6 @@ final class JobStreamLifecycleIT {
             .withBrokersCount(2)
             .withGatewaysCount(2)
             .withEmbeddedGateway(false)
-            .withUnauthenticatedAccess()
             .build();
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/LongPollingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/LongPollingIT.java
@@ -39,7 +39,6 @@ final class LongPollingIT {
           .withPartitionsCount(1)
           .withEmbeddedGateway(false)
           .withGatewayConfig(this::configureGateway)
-          .withUnauthenticatedAccess()
           .build();
 
   @BeforeEach

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/SnapshotWithExportersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/SnapshotWithExportersTest.java
@@ -141,7 +141,6 @@ final class SnapshotWithExportersTest {
       try (final var zeebe =
           new TestStandaloneBroker()
               .withRecordingExporter(true)
-              .withUnauthenticatedAccess()
               .start()
               .awaitCompleteTopology()
               .withUnauthenticatedAccess()) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/CancelChangeTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/CancelChangeTest.java
@@ -24,7 +24,6 @@ final class CancelChangeTest {
           .useRecordingExporter(true)
           .withEmbeddedGateway(true)
           .withBrokersCount(1)
-          .withUnauthenticatedAccess()
           .build();
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ClusterEndpointResponseIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ClusterEndpointResponseIT.java
@@ -27,7 +27,6 @@ final class ClusterEndpointResponseIT {
   static void initTestStandaloneBroker() {
     broker =
         new TestStandaloneBroker()
-            .withUnauthenticatedAccess()
             .withBrokerConfig(
                 cfg -> cfg.getExperimental().getFeatures().setEnablePartitionScaling(true));
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/DynamicClusterConfigurationServiceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/DynamicClusterConfigurationServiceTest.java
@@ -41,7 +41,6 @@ final class DynamicClusterConfigurationServiceTest {
           .withBrokersCount(3)
           .withPartitionsCount(PARTITIONS_COUNT)
           .withReplicationFactor(1)
-          .withUnauthenticatedAccess()
           .withBrokerConfig(this::configureDynamicClusterTopology)
           .build();
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ForceScaleDownBrokersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ForceScaleDownBrokersTest.java
@@ -94,7 +94,6 @@ class ForceScaleDownBrokersTest {
                         // the default values.
                         .setSyncInterval(Duration.ofSeconds(1))
                         .setFailureTimeout(Duration.ofSeconds(2)))
-            .withUnauthenticatedAccess()
             .build()
             .start();
     cluster.awaitCompleteTopology();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PartitionJoinTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PartitionJoinTest.java
@@ -74,7 +74,6 @@ final class PartitionJoinTest {
         .withReplicationFactor(conf.replicationFactor())
         .withPartitionsCount(conf.partitionCount())
         .withGatewaysCount(1)
-        .withUnauthenticatedAccess()
         .build()
         .start()
         .awaitCompleteTopology();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PartitionLeaveTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PartitionLeaveTest.java
@@ -87,7 +87,6 @@ final class PartitionLeaveTest {
         .withReplicationFactor(conf.replicationFactor())
         .withPartitionsCount(conf.partitionCount())
         .withGatewaysCount(1)
-        .withUnauthenticatedAccess()
         .build()
         .start()
         .awaitCompleteTopology();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleDownBrokersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleDownBrokersTest.java
@@ -44,7 +44,6 @@ final class ScaleDownBrokersTest {
           .withBrokersCount(CLUSTER_SIZE)
           .withPartitionsCount(PARTITIONS_COUNT)
           .withReplicationFactor(1)
-          .withUnauthenticatedAccess()
           .withBrokerConfig(
               b ->
                   b.brokerConfig()

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleResiliencyTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleResiliencyTest.java
@@ -73,7 +73,6 @@ class ScaleResiliencyTest {
                   b.withWorkingDirectory(
                       getDataDirectory(tmpDir, b.brokerConfig().getCluster().getNodeId()));
                 })
-            .withUnauthenticatedAccess()
             .build();
     cluster.start();
     cluster.awaitCompleteTopology();
@@ -149,7 +148,6 @@ class ScaleResiliencyTest {
         final Path dataDirectory) {
       final var newBroker =
           new TestStandaloneBroker()
-              .withUnauthenticatedAccess()
               .withBrokerConfig(
                   b -> {
                     b.getCluster().setClusterSize(newClusterSize);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpBrokersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpBrokersTest.java
@@ -51,7 +51,6 @@ final class ScaleUpBrokersTest {
           .withBrokersCount(1)
           .withPartitionsCount(PARTITIONS_COUNT)
           .withReplicationFactor(1)
-          .withUnauthenticatedAccess()
           .build();
 
   @BeforeEach
@@ -232,7 +231,6 @@ final class ScaleUpBrokersTest {
       final int newClusterSize, final int newBrokerId, final Optional<Path> dataDirectory) {
     final var newBroker =
         new TestStandaloneBroker()
-            .withUnauthenticatedAccess()
             .withBrokerConfig(
                 b -> {
                   b.getCluster().setClusterSize(newClusterSize);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/SnapshotAfterScalingTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/SnapshotAfterScalingTest.java
@@ -35,7 +35,6 @@ final class SnapshotAfterScalingTest {
           .withReplicationFactor(1)
           .withPartitionsCount(2)
           .withGatewaysCount(1)
-          .withUnauthenticatedAccess()
           .build()
           .start()
           .awaitCompleteTopology();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/TopologyCoordinatorTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/TopologyCoordinatorTest.java
@@ -48,7 +48,6 @@ final class TopologyCoordinatorTest {
                       // default values.
                       .setSyncInterval(Duration.ofSeconds(1))
                       .setFailureTimeout(Duration.ofSeconds(2)))
-          .withUnauthenticatedAccess()
           .build();
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/topology/TopologyClusterTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/topology/TopologyClusterTest.java
@@ -42,7 +42,6 @@ public final class TopologyClusterTest {
           .withBrokersCount(3)
           .withPartitionsCount(3)
           .withReplicationFactor(3)
-          .withUnauthenticatedAccess()
           .build();
 
   @BeforeAll

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterDisableTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterDisableTest.java
@@ -44,7 +44,6 @@ final class ExporterDisableTest {
           // We have to restart brokers in the test. So use standalone gateway to avoid potentially
           // accessing an unavailable broker
           .withGatewaysCount(1)
-          .withUnauthenticatedAccess()
           .build();
 
   @AutoClose private CamundaClient client;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterEnableTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterEnableTest.java
@@ -62,7 +62,6 @@ final class ExporterEnableTest {
                       .withExporter(
                           EXPORTER_ID_2,
                           config -> config.setClassName(TestExporter.class.getName())))
-          .withUnauthenticatedAccess()
           .build();
 
   @AutoClose private CamundaClient client;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsIT.java
@@ -21,7 +21,6 @@ public class ExporterMetricsIT {
   @TestZeebe
   private final TestStandaloneBroker zeebe =
       new TestStandaloneBroker()
-          .withUnauthenticatedAccess()
           .withExporter(
               "foo", cfg -> cfg.setClassName(ExporterMetricsTestExporter.class.getName()));
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationNoneIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationNoneIT.java
@@ -120,7 +120,6 @@ public class GatewayAuthenticationNoneIT {
   @TestZeebe(autoStart = false) // must configure in BeforeAll once containers have been started
   private final TestStandaloneBroker zeebe =
       new TestStandaloneBroker()
-          .withUnauthenticatedAccess()
           .withAdditionalProfile(Profile.IDENTITY_AUTH)
           .withProperty("zeebe.gateway.security.authentication.mode", "none")
           .withProperty("camunda.identity.issuerBackendUrl", getKeycloakRealmAddress())

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayHealthProbeIntegrationTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayHealthProbeIntegrationTest.java
@@ -35,11 +35,7 @@ public class GatewayHealthProbeIntegrationTest {
   final class WithBrokerTest {
     @TestZeebe
     private final TestCluster cluster =
-        TestCluster.builder()
-            .withEmbeddedGateway(false)
-            .withGatewaysCount(1)
-            .withUnauthenticatedAccess()
-            .build();
+        TestCluster.builder().withEmbeddedGateway(false).withGatewaysCount(1).build();
 
     @Test
     void shouldReportLivenessUpIfConnectedToBroker() {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayIntegrationTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayIntegrationTest.java
@@ -29,7 +29,6 @@ final class GatewayIntegrationTest {
           .withEmbeddedGateway(false)
           .withGatewaysCount(1)
           .withBrokersCount(1)
-          .withUnauthenticatedAccess()
           .build();
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GracefulShutdownIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GracefulShutdownIT.java
@@ -29,7 +29,6 @@ final class GracefulShutdownIT {
           .withBrokersCount(1)
           .withGatewaysCount(1)
           .withEmbeddedGateway(false)
-          .withUnauthenticatedAccess()
           .withGatewayConfig(
               cfg -> cfg.withProperty("spring.lifecycle.timeout-per-shutdown-phase", "20s"))
           .build();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/rest/FilterIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/rest/FilterIT.java
@@ -32,7 +32,6 @@ public class FilterIT {
           .withEmbeddedGateway(false)
           .withGatewaysCount(1)
           .withBrokersCount(1)
-          .withUnauthenticatedAccess()
           .withGatewayConfig(
               (memberId, testGateway) -> {
                 final var firstFilterCfg = new FilterCfg();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/BrokerMonitoringEndpointTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/BrokerMonitoringEndpointTest.java
@@ -33,10 +33,7 @@ public final class BrokerMonitoringEndpointTest {
 
   @SuppressWarnings("unused")
   static void initTestStandaloneBroker() {
-    broker =
-        new TestStandaloneBroker()
-            .withProperty("management.server.base-path", "/foo")
-            .withUnauthenticatedAccess();
+    broker = new TestStandaloneBroker().withProperty("management.server.base-path", "/foo");
   }
 
   @BeforeAll

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ActorClockEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ActorClockEndpointIT.java
@@ -36,7 +36,6 @@ public class ActorClockEndpointIT {
             .withBrokerConfig(
                 testStandaloneBroker ->
                     testStandaloneBroker.withProperty("zeebe.clock.controlled", true))
-            .withUnauthenticatedAccess()
             .build();
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BanningEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BanningEndpointIT.java
@@ -35,7 +35,6 @@ public class BanningEndpointIT {
             .withBrokersCount(2)
             .withPartitionsCount(1)
             .withReplicationFactor(2)
-            .withUnauthenticatedAccess()
             .build();
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BrokerAdminServiceEndpointTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BrokerAdminServiceEndpointTest.java
@@ -32,9 +32,7 @@ public class BrokerAdminServiceEndpointTest {
 
   @TestZeebe
   private static final TestStandaloneBroker BROKER =
-      new TestStandaloneBroker()
-          .withProperty("management.server.base-path", "/foo")
-          .withUnauthenticatedAccess();
+      new TestStandaloneBroker().withProperty("management.server.base-path", "/foo");
 
   private static final String EXPECTED_PARTITIONS_JSON =
       // language=JSON

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
@@ -237,7 +237,6 @@ final class ClusterEndpointIT {
         .withReplicationFactor(replicationFactor)
         .withBrokerConfig(
             b -> b.brokerConfig().getExperimental().getFeatures().setEnablePartitionScaling(true))
-        .withUnauthenticatedAccess()
         .build()
         .start();
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ControlledActorClockEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ControlledActorClockEndpointIT.java
@@ -45,8 +45,7 @@ final class ControlledActorClockEndpointIT {
   private final TestStandaloneBroker broker =
       new TestStandaloneBroker()
           .withRecordingExporter(true)
-          .withProperty("zeebe.clock.controlled", true)
-          .withUnauthenticatedAccess();
+          .withProperty("zeebe.clock.controlled", true);
 
   @AutoClose private final CamundaClient camundaClient = broker.newClientBuilder().build();
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportersEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportersEndpointIT.java
@@ -44,7 +44,6 @@ final class ExportersEndpointIT {
           .withPartitionsCount(1)
           .withReplicationFactor(1)
           .withEmbeddedGateway(true)
-          .withUnauthenticatedAccess()
           .build();
 
   @AutoClose private CamundaClient client;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
@@ -45,7 +45,6 @@ final class ExportingEndpointIT {
             .withPartitionsCount(2)
             .withReplicationFactor(1)
             .withEmbeddedGateway(true)
-            .withUnauthenticatedAccess()
             .build();
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/FlowControlEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/FlowControlEndpointIT.java
@@ -30,7 +30,6 @@ final class FlowControlEndpointIT {
             .withPartitionsCount(2)
             .withReplicationFactor(1)
             .withEmbeddedGateway(true)
-            .withUnauthenticatedAccess()
             .build();
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/JobStreamEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/JobStreamEndpointIT.java
@@ -32,12 +32,7 @@ final class JobStreamEndpointIT {
 
   @SuppressWarnings("unused")
   static void initTestCluster() {
-    cluster =
-        TestCluster.builder()
-            .withGatewaysCount(2)
-            .withEmbeddedGateway(false)
-            .withUnauthenticatedAccess()
-            .build();
+    cluster = TestCluster.builder().withGatewaysCount(2).withEmbeddedGateway(false).build();
   }
 
   @AfterEach

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/RebalancingEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/RebalancingEndpointIT.java
@@ -36,7 +36,6 @@ final class RebalancingEndpointIT {
           .withBrokersCount(3)
           .withPartitionsCount(3)
           .withReplicationFactor(3)
-          .withUnauthenticatedAccess()
           .build();
 
   @AutoClose private CamundaClient client;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/AdvertisedAddressTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/AdvertisedAddressTest.java
@@ -56,7 +56,6 @@ final class AdvertisedAddressTest {
           .withReplicationFactor(3)
           .withBrokerConfig(this::configureBroker)
           .withGatewayConfig(this::configureGateway)
-          .withUnauthenticatedAccess()
           .build();
 
   /**

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/SecureClusteredMessagingIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/SecureClusteredMessagingIT.java
@@ -47,7 +47,6 @@ final class SecureClusteredMessagingIT {
           .withBrokersCount(2)
           .withGatewaysCount(1)
           .withEmbeddedGateway(false)
-          .withUnauthenticatedAccess()
           .build();
 
   @ParameterizedTest

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/BannedInstanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/BannedInstanceIT.java
@@ -39,8 +39,7 @@ final class BannedInstanceIT {
   private static final TestStandaloneBroker ZEEBE =
       new TestStandaloneBroker()
           .withRecordingExporter(true)
-          .withProperty("zeebe.clock.controlled", true)
-          .withUnauthenticatedAccess();
+          .withProperty("zeebe.clock.controlled", true);
 
   private final BanningActuator actuator = BanningActuator.of(ZEEBE);
   private final ActorClockActuator clock = ActorClockActuator.of(ZEEBE);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/IdentitySetupInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/IdentitySetupInitializerIT.java
@@ -226,7 +226,6 @@ final class IdentitySetupInitializerIT {
             .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(authorizationsEnabled))
             .withSecurityConfig(securityCfg)
             .withBrokerConfig(cfg -> cfg.getCluster().setPartitionsCount(partitionCount))
-            .withUnauthenticatedAccess()
             .withRecordingExporter(true);
 
     if (tempDir != null) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/MultipleInvalidResourceDeletionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/MultipleInvalidResourceDeletionTest.java
@@ -29,8 +29,7 @@ public class MultipleInvalidResourceDeletionTest {
       new TestStandaloneBroker()
           // disable long polling to increase the load in streamprocessor
           .withGatewayConfig(cfg -> cfg.getLongPolling().setEnabled(false))
-          .withRecordingExporter(true)
-          .withUnauthenticatedAccess();
+          .withRecordingExporter(true);
 
   private final PartitionsActuator partitions = PartitionsActuator.of(zeebe);
   @AutoClose private CamundaClient client;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/queryapi/QueryApiIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/queryapi/QueryApiIT.java
@@ -59,7 +59,6 @@ final class QueryApiIT {
     broker =
         new TestStandaloneBroker()
             .withBrokerConfig(cfg -> cfg.getExperimental().getQueryApi().setEnabled(true))
-            .withUnauthenticatedAccess()
             .withBrokerConfig(
                 cfg -> {
                   final var config = new InterceptorCfg();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/RestAPIContextPathIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/RestAPIContextPathIT.java
@@ -22,9 +22,7 @@ import org.junit.jupiter.api.Test;
 public final class RestAPIContextPathIT {
   @TestZeebe
   private final TestStandaloneBroker zeebe =
-      new TestStandaloneBroker()
-          .withProperty("server.servlet.context-path", "/zeebe")
-          .withUnauthenticatedAccess();
+      new TestStandaloneBroker().withProperty("server.servlet.context-path", "/zeebe");
 
   @Test
   void shouldConnectWithContextPath() {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceTest.java
@@ -46,7 +46,6 @@ public class BrokerAdminServiceTest {
   private final TestStandaloneBroker zeebe =
       new TestStandaloneBroker()
           .withRecordingExporter(true)
-          .withUnauthenticatedAccess()
           .withBrokerConfig(cfg -> cfg.getData().setLogIndexDensity(1));
 
   @AutoClose private ZeebeResourcesHelper resourcesHelper;

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestClusterBuilder.java
@@ -34,7 +34,6 @@ public final class TestClusterBuilder {
   private Consumer<TestApplication<?>> nodeConfig = node -> {};
   private BiConsumer<MemberId, TestStandaloneBroker> brokerConfig = (id, broker) -> {};
   private BiConsumer<MemberId, TestStandaloneGateway> gatewayConfig = (id, gateway) -> {};
-  private boolean allowUnauthenticatedAccess = false;
 
   private final Map<MemberId, TestStandaloneGateway> gateways = new HashMap<>();
   private final Map<MemberId, TestStandaloneBroker> brokers = new HashMap<>();
@@ -250,12 +249,6 @@ public final class TestClusterBuilder {
     return this;
   }
 
-  /** Configures the cluster to allow unauthenticated access to the gateway. */
-  public TestClusterBuilder withUnauthenticatedAccess() {
-    allowUnauthenticatedAccess = true;
-    return this;
-  }
-
   /**
    * Builds a new Zeebe cluster. Will create {@link #brokersCount} brokers (accessible later via
    * {@link TestCluster#brokers()}) and {@link #gatewaysCount} standalone gateways (accessible later
@@ -355,7 +348,7 @@ public final class TestClusterBuilder {
                 })
             .withBrokerConfig(cfg -> cfg.getGateway().setEnable(useEmbeddedGateway))
             .withRecordingExporter(useRecordingExporter);
-    return allowUnauthenticatedAccess ? broker.withUnauthenticatedAccess() : broker;
+    return broker;
   }
 
   private void createGateways() {
@@ -379,7 +372,7 @@ public final class TestClusterBuilder {
                   cluster.setClusterName(name);
                   cluster.setInitialContactPoints(getInitialContactPoints());
                 });
-    return allowUnauthenticatedAccess ? gateway.withUnauthenticatedAccess() : gateway;
+    return gateway;
   }
 
   private List<String> getInitialContactPoints() {


### PR DESCRIPTION
## Description
Unauthenticated API access is the default right now - since #27608- so the setup is redundant.

The default will be revisited with a dedicated task in https://github.com/camunda/camunda/issues/26789

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
