### PR TITLE
[Backport stable/8.5] Migrate partition role metrics to Micrometer

### DIFF
--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.util.micrometer;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.Timer.Builder;
+import io.micrometer.core.instrument.Timer.Sample;
 import java.time.Duration;
 
 /** Collection of disparate convenience methods for Micrometer. */
@@ -65,6 +66,24 @@ public final class MicrometerUtil {
     return new CloseableTimer(timer, sample);
   }
 
+<<<<<<< HEAD
+=======
+  /**
+   * Returns a convenience object to measure the duration of a try/catch block targeting a timer
+   * represented by a gauge. If using a normal timer (i.e. histogram), use {@link #timer(Timer,
+   * Sample)}.
+   *
+   * @param setter the gauge state modifier
+   * @param unit the time unit for the time gauge, as declared when it was registered
+   * @param clock the associated registry's clock
+   * @return a closeable which will record the duration of a try/catch block on close
+   */
+  public static CloseableSilently timer(
+      final LongConsumer setter, final TimeUnit unit, final Clock clock) {
+    return new CloseableGaugeTimer(setter, unit, clock, clock.monotonicTime());
+  }
+
+>>>>>>> deaa25f8 (refactor: document convenience method)
   private record CloseableTimer(Timer timer, Timer.Sample sample) implements CloseableSilently {
     @Override
     public void close() {


### PR DESCRIPTION
# Description
Backport of #27539 to `stable/8.5`.

relates to #26078
original author: @npepinpe