### PR TITLE
fix: use forwardslash for unix+linux in c8run release GHA

### DIFF
--- a/.github/workflows/c8run-release.yaml
+++ b/.github/workflows/c8run-release.yaml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Build c8run
         run: go build
-        working-directory: .\c8run
+        working-directory: ./c8run
 
       - name: make a package
         run: ./c8run package


### PR DESCRIPTION
## Description

This fixes a bug where an instance of a forwardslash was used instead of a backward slash.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
