### PR TITLE
[Backport stable/8.6] Migrate bounded command cache metrics to Micrometer

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -142,7 +142,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
         List.of(engine, context.getCheckpointProcessor());
     final var scheduledCommandCache =
         BoundedScheduledCommandCache.ofIntent(
-            new BoundedCommandCacheMetrics(context.getPartitionId()),
+            new BoundedCommandCacheMetrics(context.getPartitionMeterRegistry()),
             TimerIntent.TRIGGER,
             JobIntent.TIME_OUT,
             JobIntent.RECUR_AFTER_BACKOFF,


### PR DESCRIPTION
# Description
Backport of #27536 to `stable/8.6`.

relates to #26078
original author: @npepinpe