### PR TITLE
[Backport stable/8.7] fix: zeebe-io references

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -304,7 +304,7 @@ jobs:
           location: ${{ inputs.cluster-region }}
       - name: Add camunda helm repo
         run: |
-          helm repo add zeebe-benchmark https://zeebe-io.github.io/benchmark-helm
+          helm repo add zeebe-benchmark https://camunda.github.io/zeebe-benchmark-helm
           helm repo update
 
       - name: Find previous Helm chart release version

--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -83,6 +83,7 @@ jobs:
         --set publisher.replicas=1
         --set publisher.rate=5
         --set camunda-platform.operate.enabled=true
+        -f https://raw.githubusercontent.com/camunda/zeebe-benchmark-helm/refs/heads/main/charts/zeebe-benchmark/values-realistic-benchmark.yaml
         --set camunda-platform.operate.image.repository=gcr.io/zeebe-io/operate
         --set camunda-platform.operate.image.tag=${{ needs.benchmark-data.outputs.operate }}
         --set camunda-platform.elasticsearch.master.persistence.size=128Gi

--- a/zeebe/benchmarks/setup/README.md
+++ b/zeebe/benchmarks/setup/README.md
@@ -34,7 +34,7 @@ to configure your benchmark.
 ### How to configure a Benchmark
 
 The benchmark configuration is completely done via the `values.yaml` file.
-If there is a property missing that you want to change please open an issue at https://github.com/zeebe-io/benchmark-helm
+If there is a property missing that you want to change please open an issue at https://github.com/camunda/zeebe-benchmark-helm
 
 #### Use different Zeebe Snapshot
 

--- a/zeebe/benchmarks/setup/newBenchmark.sh
+++ b/zeebe/benchmarks/setup/newBenchmark.sh
@@ -26,5 +26,5 @@ cd $namespace
 sed_inplace "s/default/$namespace/g" Makefile
 
 # get latest updates from zeebe repo
-helm repo add zeebe-benchmark https://zeebe-io.github.io/benchmark-helm # skips if already exists
+helm repo add zeebe-benchmark https://camunda.github.io/zeebe-benchmark-helm # skips if already exists
 helm repo update


### PR DESCRIPTION
## Description

Backport of https://github.com/camunda/camunda/pull/26777 to stable/8.7

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
