### PR TITLE
 Migrate replay metrics of stream platform to micrometer

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -9113,7 +9113,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(increase(zeebe_replay_event_batch_replay_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_replay_event_batch_replay_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or increase(zeebe_replay_event_batch_replay_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
@@ -106,7 +106,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
     streamProcessorMode = context.getProcessorMode();
     logStream = context.getLogStream();
     logStreamBatchReader = new LogStreamBatchReaderImpl(context.getLogStreamReader());
-    replayMetrics = new ReplayMetrics(logStream.getPartitionId());
+    replayMetrics = new ReplayMetrics(context.getMeterRegistry());
   }
 
   /**

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamMetricsDoc.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamMetricsDoc.java
@@ -150,6 +150,60 @@ public enum StreamMetricsDoc implements ExtendedMeterDocumentation {
     public KeyName[] getKeyNames() {
       return ErrorHandlingPhaseKeys.values();
     }
+  },
+
+  /** Number of events replayed by the stream processor */
+  REPLAY_EVENTS_COUNT {
+    @Override
+    public String getDescription() {
+      return "Number of events replayed by the stream processor";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.replay.events.total";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+  },
+
+  /** The last source position the stream processor has replayed */
+  LAST_SOURCE_POSITION {
+    @Override
+    public String getDescription() {
+      return "The last source position the stream processor has replayed";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.replay.last.source.position";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+  },
+
+  /** Time for replay a batch of events (in seconds) */
+  REPLAY_DURATION {
+    @Override
+    public String getDescription() {
+      return "Time for replay a batch of events (in seconds)";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.replay.event.batch.replay.duration";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
   };
 
   public enum ErrorHandlingPhaseKeys implements KeyName {


### PR DESCRIPTION
## Description

This PR migrates the replay metrics of the stream platform to Micrometer. The replay batch event duration metric's name was changed (since it's a histogram, and Micrometer adds the _seconds suffix), and the dashboard adapted for it.

> Same as PR #27561 but targeting main branch

## Related issues

relates #26078
