### PR TITLE
Migrate ProcessingMetrics from stream platform to Micrometer 

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -9195,7 +9195,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_stream_processor_batch_processing_post_commit_tasks_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_stream_processor_batch_processing_post_commit_tasks_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval]) or increase(zeebe_stream_processor_batch_processing_post_commit_tasks_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "legendFormat": "{{le}}",
@@ -9277,7 +9277,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
-              "expr": "sum(increase(zeebe_stream_processor_batch_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_stream_processor_batch_processing_duration_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval]) or increase(zeebe_stream_processor_batch_processing_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "legendFormat": "{{le}}",

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetrics.java
@@ -147,7 +147,7 @@ public final class ExporterMetrics {
     final var meterDoc = ExporterMetricsDoc.EXPORTING_DURATION;
     return Timer.builder(meterDoc.getName())
         .description(meterDoc.getDescription())
-        .serviceLevelObjectives(meterDoc.getServiceLevelObjectives())
+        .serviceLevelObjectives(meterDoc.getTimerSLOs())
         .tag(LABEL_NAME_VALUE_TYPE, valueType.name())
         .tag(LABEL_NAME_EXPORTER, exporterId)
         .register(meterRegistry);
@@ -157,7 +157,7 @@ public final class ExporterMetrics {
     final var meterDoc = ExporterMetricsDoc.EXPORTING_LATENCY;
     return Timer.builder(meterDoc.getName())
         .description(meterDoc.getDescription())
-        .serviceLevelObjectives(meterDoc.getServiceLevelObjectives())
+        .serviceLevelObjectives(meterDoc.getTimerSLOs())
         .tag(LABEL_NAME_VALUE_TYPE, valueType.name())
         .register(meterRegistry);
   }

--- a/zeebe/stream-platform/pom.xml
+++ b/zeebe/stream-platform/pom.xml
@@ -90,6 +90,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-commons</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -195,7 +195,7 @@ public final class ProcessingStateMachine {
     metrics.initializeProcessorPhase(context.getStreamProcessorPhase());
     streamProcessorListener = context.getStreamProcessorListener();
 
-    processingMetrics = new ProcessingMetrics(Integer.toString(partitionId));
+    processingMetrics = new ProcessingMetrics(context.getMeterRegistry());
 
     processingFilter =
         new MetadataEventFilter(

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamMetricsDoc.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamMetricsDoc.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.impl.metrics;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter.Type;
+import java.time.Duration;
+
+/** Documentation for all stream platform related metrics */
+@SuppressWarnings("NullableProblems")
+public enum StreamMetricsDoc implements ExtendedMeterDocumentation {
+  /** Time spent in batch processing (in seconds) */
+  BATCH_PROCESSING_DURATION {
+    private static final Duration[] BUCKETS = {
+      Duration.ofNanos(100_000), // 100 micros
+      Duration.ofMillis(1),
+      Duration.ofMillis(10),
+      Duration.ofMillis(100),
+      Duration.ofMillis(250),
+      Duration.ofMillis(500),
+      Duration.ofSeconds(1),
+      Duration.ofSeconds(2)
+    };
+
+    @Override
+    public String getDescription() {
+      return "Time spent in batch processing (in seconds)";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.stream.processor.batch.processing.duration";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+  },
+
+  /** Records the distribution of commands in a batch over time */
+  BATCH_PROCESSING_COMMANDS {
+    private static final double[] BUCKETS = {1, 2, 4, 8, 16, 32, 64, 128};
+
+    @Override
+    public String getDescription() {
+      return "Records the distribution of commands in a batch over time";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.stream.processor.batch.processing.commands";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.DISTRIBUTION_SUMMARY;
+    }
+
+    @Override
+    public double[] getDistributionSLOs() {
+      return BUCKETS;
+    }
+  },
+
+  /** Time spent in executing post commit tasks after batch processing (in seconds) */
+  BATCH_PROCESSING_POST_COMMIT_TASKS {
+    private static final Duration[] BUCKETS = {
+      Duration.ofNanos(100_000), // 100 micros
+      Duration.ofMillis(1),
+      Duration.ofMillis(10),
+      Duration.ofMillis(100),
+      Duration.ofMillis(250),
+      Duration.ofMillis(500),
+      Duration.ofSeconds(1),
+      Duration.ofSeconds(2)
+    };
+
+    @Override
+    public String getDescription() {
+      return "Time spent in executing post commit tasks after batch processing (in seconds)";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.stream.processor.batch.processing.post.commit.tasks";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+  },
+
+  /** Number of times batch processing failed due to reaching batch limit and was retried */
+  BATCH_PROCESSING_RETRIES {
+    @Override
+    public String getDescription() {
+      return "Number of times batch processing failed due to reaching batch limit and was retried";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.stream.processor.batch.processing.retry";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+  },
+
+  /**
+   * The current phase of error handling the processor is in; see {@link
+   * io.camunda.zeebe.stream.impl.ProcessingStateMachine.ErrorHandlingPhase} for possible values.
+   */
+  ERROR_HANDLING_PHASE {
+    @Override
+    public String getDescription() {
+      return "The current phase of error handling the processor is in";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.stream.processor.error.handling.phase";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return ErrorHandlingPhaseKeys.values();
+    }
+  };
+
+  public enum ErrorHandlingPhaseKeys implements KeyName {
+    /**
+     * Tag/key value specifying the current error handling phase in a human-readable way. This is
+     * exactly the metric name for backwards compatibility with Prometheus' Enumeration metric.
+     *
+     * <p>Possible values are the names (as is) of the enum {@link
+     * io.camunda.zeebe.stream.impl.ProcessingStateMachine.ErrorHandlingPhase}.
+     */
+    ERROR_HANDLING_PHASE {
+      @Override
+      public String asString() {
+        return "zeebe_stream_processor_error_handling_phase";
+      }
+    }
+  }
+}

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/EnumMeter.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/EnumMeter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util.micrometer;
+
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * An {@link EnumMeter} is a set of {@link Gauge}, one for each state in the given enum type {@link
+ * T}, with the guarantee that only one of these gauges is 1 at any given time, and all others are
+ * 0.
+ *
+ * <p>When you set the state to a particular value, it will zero out all others, and set that one to
+ * 1.
+ *
+ * <p>Can be useful in combination with Grafana's state timeline.
+ *
+ * @param <T> the enum type of the possible states
+ */
+public final class EnumMeter<T extends Enum<T>> {
+  private final Map<T, AtomicBoolean> states;
+
+  private EnumMeter(final Map<T, AtomicBoolean> states) {
+    this.states = states;
+  }
+
+  /**
+   * Returns a new builder for an enumeration meter.
+   *
+   * @param stateClass the enum defining the possible states
+   * @param documentation the documentation for this meter
+   * @param stateTag the tag which will be set to the state name
+   * @return a new builder for this enumeration
+   * @param <T> the expected state type
+   */
+  public static <T extends Enum<T>> EnumMeter<T> register(
+      final Class<T> stateClass,
+      final ExtendedMeterDocumentation documentation,
+      final KeyName stateTag,
+      final MeterRegistry registry) {
+    final Map<T, AtomicBoolean> states = new HashMap<>();
+    for (final var state : stateClass.getEnumConstants()) {
+      final var value = new AtomicBoolean(false);
+      states.put(state, value);
+      Gauge.builder(documentation.getName(), value, bool -> bool.get() ? 1 : 0)
+          .description(documentation.getDescription())
+          .tag(stateTag.asString(), state.name())
+          .register(registry);
+    }
+
+    return new EnumMeter<>(states);
+  }
+
+  public void state(final T state) {
+    for (final var entry : states.entrySet()) {
+      entry.getValue().set(entry.getKey() == state);
+    }
+  }
+}

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/ExtendedMeterDocumentation.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/ExtendedMeterDocumentation.java
@@ -17,14 +17,20 @@ import java.time.Duration;
  */
 public interface ExtendedMeterDocumentation extends MeterDocumentation {
 
+  double[] EMPTY_DISTRIBUTION_SLOS = new double[0];
+
   /** Returns the description (also known as {@code help} in some systems) for the given meter. */
   String getDescription();
 
-  /**
-   * Returns the buckets to be used if the meter type is a {@link Meter.Type#TIMER} or {@link
-   * Meter.Type#DISTRIBUTION_SUMMARY}.
-   */
-  default Duration[] getServiceLevelObjectives() {
+  /** Returns the buckets to be used if the meter type is a {@link Meter.Type#TIMER}. */
+  default Duration[] getTimerSLOs() {
     return MicrometerUtil.defaultPrometheusBuckets();
+  }
+
+  /**
+   * Returns the buckets to be used if the meter type is a {@link Meter.Type#DISTRIBUTION_SUMMARY}.
+   */
+  default double[] getDistributionSLOs() {
+    return EMPTY_DISTRIBUTION_SLOS;
   }
 }

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/EnumMeterTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/EnumMeterTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util.micrometer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter.Type;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("NullableProblems")
+final class EnumMeterTest {
+  private static final ExtendedMeterDocumentation DOC =
+      new ExtendedMeterDocumentation() {
+        @Override
+        public String getDescription() {
+          return "Test metric";
+        }
+
+        @Override
+        public String getName() {
+          return "metric";
+        }
+
+        @Override
+        public Type getType() {
+          return Type.GAUGE;
+        }
+      };
+  private static final KeyName TAG =
+      new KeyName() {
+        @Override
+        public String asString() {
+          return "foo";
+        }
+      };
+
+  private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+  @Test
+  void shouldRegisterGaugeForAllValues() {
+    // given/when
+    EnumMeter.register(States.class, DOC, TAG, registry);
+
+    // then
+    assertThat(registry.get(DOC.getName()).tagKeys(TAG.asString()).gauges())
+        .hasSameSizeAs(States.values());
+    assertThat(registry.get(DOC.getName()).tag(TAG.asString(), "A").gauge())
+        .returns(0.0, Gauge::value);
+    assertThat(registry.get(DOC.getName()).tag(TAG.asString(), "B").gauge())
+        .returns(0.0, Gauge::value);
+    assertThat(registry.get(DOC.getName()).tag(TAG.asString(), "C").gauge())
+        .returns(0.0, Gauge::value);
+  }
+
+  @Test
+  void shouldSetState() {
+    // given
+    final var meter = EnumMeter.register(States.class, DOC, TAG, registry);
+
+    // when
+    meter.state(States.B);
+
+    // then
+    final var gauge = registry.get(DOC.getName()).tag(TAG.asString(), "B").gauge();
+    assertThat(gauge).returns(1.0, Gauge::value);
+  }
+
+  @Test
+  void shouldResetOtherStatesToZero() {
+    // given
+    final var meter = EnumMeter.register(States.class, DOC, TAG, registry);
+    meter.state(States.A);
+
+    // when
+    meter.state(States.B);
+
+    // then
+    assertThat(registry.get(DOC.getName()).tag(TAG.asString(), "A").gauge())
+        .returns(0.0, Gauge::value);
+    assertThat(registry.get(DOC.getName()).tag(TAG.asString(), "B").gauge())
+        .returns(1.0, Gauge::value);
+    assertThat(registry.get(DOC.getName()).tag(TAG.asString(), "C").gauge())
+        .returns(0.0, Gauge::value);
+  }
+
+  private enum States {
+    A,
+    B,
+    C
+  }
+}


### PR DESCRIPTION
## Description

This PR migrates the `ProcessingMetrics` class from the stream platform to Micrometer. To ease migration, it adds a new helper, `EnumMeter`, which is inspired by Prometheus' `Enumeration` meter.

> [!Note]
> An `Enumeration` is essentially a series of gauges with the same name, one for every value of a specific `enum`. The enum value is specified as a label/tag on the metric. Every gauge is always 0, except the one which is currently the active state, which will be set to 1.

The two histograms in there had their names changed (i.e. with the `_seconds` suffix), so I've updated the dashboard consequently to use the union of both series.

> Original PR was 27556, but it was merged to the wrong branch

## Related issues

related #26078