### PR TITLE
deps: update Zeebe and Identity versions

### DIFF
--- a/operate/config/docker-compose.identity.yml
+++ b/operate/config/docker-compose.identity.yml
@@ -57,7 +57,7 @@ services:
     depends_on:
       - keycloak
     container_name: identity
-    image: camunda/identity:8.5.11
+    image: camunda/identity:8.5.13
     ports:
       - "8080:8080"
     volumes:
@@ -92,7 +92,7 @@ services:
       start_period: 30s
   zeebe:
     container_name: zeebe
-    image: camunda/zeebe:8.5.11
+    image: camunda/zeebe:8.5.13
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}
@@ -106,7 +106,7 @@ services:
       - 8000:8000
     restart: always
   operate:
-    image: camunda/operate:8.5.9
+    image: camunda/operate:8.5.11
     container_name: operate
     environment:
       - SERVER_PORT=8081
@@ -134,7 +134,7 @@ services:
       - zeebe
       - identity
   tasklist:
-    image: camunda/tasklist:8.5.7
+    image: camunda/tasklist:8.5.12
     container_name: tasklist
     environment:
       - SERVER_PORT=8082

--- a/operate/config/docker-compose.mt.yml
+++ b/operate/config/docker-compose.mt.yml
@@ -58,7 +58,7 @@ services:
       keycloak:
         condition: service_healthy
     container_name: identity
-    image: camunda/identity:8.5.11
+    image: camunda/identity:8.5.13
     ports:
       - "8080:8080"
     volumes:
@@ -101,7 +101,7 @@ services:
       start_period: 30s
   zeebe:
     container_name: zeebe
-    image: camunda/zeebe:8.5.11
+    image: camunda/zeebe:8.5.13
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}
@@ -123,7 +123,7 @@ services:
       - 9600:9600
     restart: always
   operate:
-    image: camunda/operate:8.5.9
+    image: camunda/operate:8.5.11
     container_name: operate
     environment:
       - SERVER_PORT=8081

--- a/operate/config/docker-compose.opensearch-identity.yml
+++ b/operate/config/docker-compose.opensearch-identity.yml
@@ -67,7 +67,7 @@ services:
     depends_on:
       - keycloak
     container_name: identity
-    image: camunda/identity:8.5.11
+    image: camunda/identity:8.5.13
     ports:
       - "8080:8080"
     volumes:
@@ -110,7 +110,7 @@ services:
       start_period: 30s
   zeebe:
     container_name: zeebe
-    image: camunda/zeebe:8.5.11
+    image: camunda/zeebe:8.5.13
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}
@@ -131,7 +131,7 @@ services:
       - "9600:9600"
     restart: always
   operate:
-    image: camunda/operate:8.5.9
+    image: camunda/operate:8.5.11
     container_name: operate
     environment:
       - SERVER_PORT=8081

--- a/operate/config/docker-compose.test.yml
+++ b/operate/config/docker-compose.test.yml
@@ -23,7 +23,7 @@ services:
       - ./els-snapshots:/usr/local/els-snapshots
   zeebe:
     container_name: zeebe
-    image: camunda/zeebe:8.5.11
+    image: camunda/zeebe:8.5.13
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}
@@ -37,7 +37,7 @@ services:
       - 8000:8000
     restart: always
   operate:
-    image: camunda/operate:8.5.9
+    image: camunda/operate:8.5.11
     container_name: operate
     environment:
       - SERVER_PORT=8081
@@ -54,7 +54,7 @@ services:
       - elasticsearch
       - zeebe
   tasklist:
-    image: camunda/tasklist:8.5.11
+    image: camunda/tasklist:8.5.12
     container_name: tasklist
     environment:
       - SERVER_PORT=8082

--- a/operate/docker-compose.opensearch-identity.yml
+++ b/operate/docker-compose.opensearch-identity.yml
@@ -58,7 +58,7 @@ services:
     depends_on:
       - keycloak
     container_name: identity
-    image: camunda/identity:8.5.11
+    image: camunda/identity:8.5.13
     ports:
       - "8080:8080"
     volumes:
@@ -101,7 +101,7 @@ services:
       start_period: 30s
   zeebe:
     container_name: zeebe
-    image: camunda/zeebe:8.5.11
+    image: camunda/zeebe:8.5.13
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}
@@ -123,7 +123,7 @@ services:
       - "8000:8000"
     restart: always
   operate:
-    image: camunda/operate:8.5.9
+    image: camunda/operate:8.5.11
     container_name: operate
     environment:
       - SERVER_PORT=8081

--- a/operate/docker-compose.opensearch.yml
+++ b/operate/docker-compose.opensearch.yml
@@ -26,7 +26,7 @@ services:
       - ./os-snapshots:/usr/local/os-snapshots
   zeebe-opensearch:
     container_name: zeebe-opensearch
-    image: camunda/zeebe:8.5.11
+    image: camunda/zeebe:8.5.13
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}
@@ -41,7 +41,7 @@ services:
       - 8000:8000
     restart: always
   operate-opensearch:
-    image: camunda/operate:8.5.9
+    image: camunda/operate:8.5.11
     container_name: operate-opensearch
     environment:
       - SERVER_PORT=8080

--- a/operate/docker-compose.yml
+++ b/operate/docker-compose.yml
@@ -31,7 +31,7 @@ services:
 
   zeebe:
     container_name: zeebe
-    image: camunda/zeebe:8.5.11
+    image: camunda/zeebe:8.5.13
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}
@@ -47,7 +47,7 @@ services:
 
   zeebe-e2e:
     container_name: zeebe-e2e
-    image: camunda/zeebe:8.5.11
+    image: camunda/zeebe:8.5.13
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -67,9 +67,9 @@
     <commons-lang3.version>3.14.0</commons-lang3.version>
 
     <!-- Library versions not provided by spring boot -->
-    <version.zeebe>8.5.11</version.zeebe>
+    <version.zeebe>8.5.13</version.zeebe>
     <version.camunda>7.20.0</version.camunda>
-    <version.identity>8.5.11</version.identity>
+    <version.identity>8.5.13</version.identity>
     <version.parsson>1.1.7</version.parsson>
     <version.opensearch>2.5.0</version.opensearch>
     <version.springdoc>2.2.0</version.springdoc>

--- a/operate/qa/pom.xml
+++ b/operate/qa/pom.xml
@@ -30,8 +30,8 @@
 
     <!-- properties for ImportSeveralVersionsTest and import-old-zeebe-tests module -->
     <version.zeebe.old>8.1.0</version.zeebe.old>
-    <version.zeebe.docker.current>8.5.11</version.zeebe.docker.current>
-    <version.identity.docker.current>8.5.11</version.identity.docker.current>
+    <version.zeebe.docker.current>8.5.13</version.zeebe.docker.current>
+    <version.identity.docker.current>8.5.13</version.identity.docker.current>
 
   </properties>
 


### PR DESCRIPTION
- for Operate 8.5.11 release
- based on https://github.com/camunda/camunda/pull/26703