### PR TITLE
test: remove .withUnauthenticatedAccess usage

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/client/CreateDocumentBatchTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/CreateDocumentBatchTest.java
@@ -31,7 +31,7 @@ public class CreateDocumentBatchTest {
 
   @SuppressWarnings("unused")
   static void initTestStandaloneCamunda() {
-    testStandaloneCamunda = new TestStandaloneCamunda().withUnauthenticatedAccess();
+    testStandaloneCamunda = new TestStandaloneCamunda();
   }
 
   @Test

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/CreateDocumentLinkTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/CreateDocumentLinkTest.java
@@ -32,7 +32,7 @@ public class CreateDocumentLinkTest {
 
   @SuppressWarnings("unused")
   static void initTestStandaloneCamunda() {
-    testStandaloneCamunda = new TestStandaloneCamunda().withUnauthenticatedAccess();
+    testStandaloneCamunda = new TestStandaloneCamunda();
   }
 
   @BeforeAll

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/CreateDocumentTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/CreateDocumentTest.java
@@ -34,7 +34,7 @@ public class CreateDocumentTest {
 
   @SuppressWarnings("unused")
   static void initTestStandaloneCamunda() {
-    testStandaloneCamunda = new TestStandaloneCamunda().withUnauthenticatedAccess();
+    testStandaloneCamunda = new TestStandaloneCamunda();
   }
 
   @Test

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/DecisionQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/DecisionQueryTest.java
@@ -49,7 +49,7 @@ class DecisionQueryTest {
 
   @SuppressWarnings("unused")
   static void initTestStandaloneCamunda() {
-    testStandaloneCamunda = new TestStandaloneCamunda().withUnauthenticatedAccess();
+    testStandaloneCamunda = new TestStandaloneCamunda();
   }
 
   @BeforeAll

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/DeleteDocumentTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/DeleteDocumentTest.java
@@ -33,7 +33,7 @@ public class DeleteDocumentTest {
 
   @SuppressWarnings("unused")
   static void initTestStandaloneCamunda() {
-    testStandaloneCamunda = new TestStandaloneCamunda().withUnauthenticatedAccess();
+    testStandaloneCamunda = new TestStandaloneCamunda();
   }
 
   @BeforeEach

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/GetDocumentContentTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/GetDocumentContentTest.java
@@ -33,7 +33,7 @@ public class GetDocumentContentTest {
 
   @SuppressWarnings("unused")
   static void initTestStandaloneCamunda() {
-    testStandaloneCamunda = new TestStandaloneCamunda().withUnauthenticatedAccess();
+    testStandaloneCamunda = new TestStandaloneCamunda();
   }
 
   @BeforeAll

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentQueryTest.java
@@ -45,7 +45,7 @@ class IncidentQueryTest {
 
   @SuppressWarnings("unused")
   static void initTestStandaloneCamunda() {
-    testStandaloneCamunda = new TestStandaloneCamunda().withUnauthenticatedAccess();
+    testStandaloneCamunda = new TestStandaloneCamunda();
   }
 
   @BeforeAll

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessDefinitionQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessDefinitionQueryTest.java
@@ -42,8 +42,7 @@ public class ProcessDefinitionQueryTest {
   private static TestStandaloneCamunda testStandaloneCamunda;
 
   static void initTestStandaloneCamunda() {
-    testStandaloneCamunda =
-        new TestStandaloneCamunda().withCamundaExporter().withUnauthenticatedAccess();
+    testStandaloneCamunda = new TestStandaloneCamunda().withCamundaExporter();
   }
 
   @BeforeAll

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
@@ -47,7 +47,7 @@ class UserTaskQueryTest {
 
   @SuppressWarnings("unused")
   static void initTestStandaloneCamunda() {
-    testStandaloneCamunda = new TestStandaloneCamunda().withUnauthenticatedAccess();
+    testStandaloneCamunda = new TestStandaloneCamunda();
   }
 
   @BeforeAll

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/VariableQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/VariableQueryTest.java
@@ -38,7 +38,7 @@ class VariableQueryTest {
 
   @SuppressWarnings("unused")
   static void initTestStandaloneCamunda() {
-    testStandaloneCamunda = new TestStandaloneCamunda().withUnauthenticatedAccess();
+    testStandaloneCamunda = new TestStandaloneCamunda();
   }
 
   @BeforeAll


### PR DESCRIPTION
## Description

> Follow up from https://github.com/camunda/camunda/pull/27618

@megglos you missed some tests, which are still causing conflicts for https://github.com/camunda/camunda/pull/27342

This PR removes usage on Client tests.

### Details


 * Unauthenticated is default, for now, reduce boiler plate and bring back previous set up of client tests

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
