### PR TITLE
Fix: add name to java-deprecated/pom.

### DIFF
--- a/clients/java-deprecated/pom.xml
+++ b/clients/java-deprecated/pom.xml
@@ -8,7 +8,7 @@
     <version>8.8.0-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
-
+  <name>Zeebe Client Java</name>
   <artifactId>zeebe-client-java</artifactId>
   <version>8.8.0-SNAPSHOT</version>
   <distributionManagement>

--- a/clients/java-deprecated/pom.xml
+++ b/clients/java-deprecated/pom.xml
@@ -8,9 +8,9 @@
     <version>8.8.0-SNAPSHOT</version>
     <relativePath>../../parent/pom.xml</relativePath>
   </parent>
-  <name>Zeebe Client Java</name>
   <artifactId>zeebe-client-java</artifactId>
   <version>8.8.0-SNAPSHOT</version>
+  <name>Zeebe Client Java</name>
   <distributionManagement>
     <relocation>
       <artifactId>camunda-client-java</artifactId>


### PR DESCRIPTION
## Description

The name is missing in this deprecated Zeebe Client Java pom, which is still used in some workflows and causes them to fail.
https://github.com/camunda/camunda/actions/runs/13135499397/job/36649880843
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
