### PR TITLE
[Backport stable/8.6]  Migrate partition role metrics to Micrometer 

### DIFF
--- a/zeebe/broker/pom.xml
+++ b/zeebe/broker/pom.xml
@@ -171,11 +171,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
     </dependency>

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -90,7 +90,9 @@ public final class ZeebePartition extends Actor
     healthMetrics = new HealthMetrics(transitionContext.getBrokerMeterRegistry(), partitionId);
     healthMetrics.setUnhealthy();
     failureListeners = new ArrayList<>();
-    roleMetrics = new RoleMetrics(transitionContext.getPartitionId());
+    roleMetrics =
+        new RoleMetrics(
+            transitionContext.getBrokerMeterRegistry(), transitionContext.getPartitionId());
   }
 
   public PartitionAdminAccess getAdminAccess() {

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
@@ -12,6 +12,7 @@ import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.Timer.Builder;
+import io.micrometer.core.instrument.Timer.Sample;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongConsumer;
@@ -69,6 +70,16 @@ public final class MicrometerUtil {
     return new CloseableTimer(timer, sample);
   }
 
+  /**
+   * Returns a convenience object to measure the duration of a try/catch block targeting a timer
+   * represented by a gauge. If using a normal timer (i.e. histogram), use {@link #timer(Timer,
+   * Sample)}.
+   *
+   * @param setter the gauge state modifier
+   * @param unit the time unit for the time gauge, as declared when it was registered
+   * @param clock the associated registry's clock
+   * @return a closeable which will record the duration of a try/catch block on close
+   */
   public static CloseableSilently timer(
       final LongConsumer setter, final TimeUnit unit, final Clock clock) {
     return new CloseableGaugeTimer(setter, unit, clock, clock.monotonicTime());


### PR DESCRIPTION
# Description
Backport of #27644 to `stable/8.6`.

relates to 
original author: @entangled90