### PR TITLE
feat: allocate a partition MeterRegistry in RaftPartition

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
@@ -13,6 +13,7 @@ import io.camunda.application.commons.configuration.BrokerBasedConfiguration;
 import io.camunda.application.commons.configuration.WorkingDirectoryConfiguration;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,15 +39,18 @@ public class RestoreApp implements ApplicationRunner {
   private long backupId;
 
   private final RestoreConfiguration restoreConfiguration;
+  private final MeterRegistry meterRegistry;
 
   @Autowired
   public RestoreApp(
       final BrokerBasedConfiguration configuration,
       final BackupStore backupStore,
-      final RestoreConfiguration restoreConfiguration) {
+      final RestoreConfiguration restoreConfiguration,
+      final MeterRegistry meterRegistry) {
     this.configuration = configuration.config();
     this.backupStore = backupStore;
     this.restoreConfiguration = restoreConfiguration;
+    this.meterRegistry = meterRegistry;
   }
 
   public static void main(final String[] args) {
@@ -65,7 +69,7 @@ public class RestoreApp implements ApplicationRunner {
   @Override
   public void run(final ApplicationArguments args) {
     LOG.info("Starting to restore from backup {}", backupId);
-    new RestoreManager(configuration, backupStore)
+    new RestoreManager(configuration, backupStore, meterRegistry)
         .restore(backupId, restoreConfiguration.validateConfig())
         .join();
     LOG.info("Successfully restored broker from backup {}", backupId);

--- a/zeebe/atomix/cluster/pom.xml
+++ b/zeebe/atomix/cluster/pom.xml
@@ -139,6 +139,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-dns</artifactId>
     </dependency>

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
@@ -33,7 +33,9 @@ import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.raft.zeebe.EntryValidator;
 import io.atomix.raft.zeebe.EntryValidator.NoopEntryValidator;
+import io.atomix.utils.Builder;
 import io.camunda.zeebe.util.health.FailureListener;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
@@ -464,6 +466,7 @@ public interface RaftServer {
     protected RaftElectionConfig electionConfig = RaftElectionConfig.ofDefaultElection();
     protected RaftPartitionConfig partitionConfig = new RaftPartitionConfig();
     protected int partitionId;
+    protected MeterRegistry meterRegistry;
 
     protected Builder(final MemberId localMemberId) {
       this.localMemberId = checkNotNull(localMemberId, "localMemberId cannot be null");
@@ -546,6 +549,11 @@ public interface RaftServer {
 
     public Builder withPartitionId(final int partitionId) {
       this.partitionId = partitionId;
+      return this;
+    }
+
+    public Builder withMeterRegistry(final MeterRegistry meterRegistry) {
+      this.meterRegistry = meterRegistry;
       return this;
     }
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -257,7 +257,8 @@ public class DefaultRaftServer implements RaftServer {
               singleThreadFactory,
               randomSupplier,
               electionConfig,
-              partitionConfig);
+              partitionConfig,
+              meterRegistry);
       raft.setEntryValidator(entryValidator);
 
       return new DefaultRaftServer(raft);

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -757,6 +757,10 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     }
   }
 
+  public MeterRegistry getMeterRegistry() {
+    return meterRegistry;
+  }
+
   private void startTransition() {
     ongoingTransition = true;
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -83,6 +83,7 @@ import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthReport;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
@@ -163,6 +164,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   private long lastHeartbeat;
   private final RaftPartitionConfig partitionConfig;
   private final int partitionId;
+  private final MeterRegistry meterRegistry;
 
   // after firstCommitIndex is set it will be null
   private AwaitingReadyCommitListener awaitingReadyCommitListener;
@@ -177,13 +179,15 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
       final RaftThreadContextFactory threadContextFactory,
       final Supplier<Random> randomFactory,
       final RaftElectionConfig electionConfig,
-      final RaftPartitionConfig partitionConfig) {
+      final RaftPartitionConfig partitionConfig,
+      final MeterRegistry meterRegistry) {
     this.name = checkNotNull(name, "name cannot be null");
     this.membershipService = checkNotNull(membershipService, "membershipService cannot be null");
     this.protocol = checkNotNull(protocol, "protocol cannot be null");
     this.storage = checkNotNull(storage, "storage cannot be null");
     random = randomFactory.get();
     this.partitionId = partitionId;
+    this.meterRegistry = meterRegistry;
     health = HealthReport.healthy(this);
 
     raftRoleMetrics = new RaftRoleMetrics(name);

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -187,7 +187,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     this.storage = checkNotNull(storage, "storage cannot be null");
     random = randomFactory.get();
     this.partitionId = partitionId;
-    this.meterRegistry = meterRegistry;
+    this.meterRegistry = checkNotNull(meterRegistry, "meterRegistry cannot be null");
     health = HealthReport.healthy(this);
 
     raftRoleMetrics = new RaftRoleMetrics(name);

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
@@ -302,7 +302,8 @@ public final class RaftPartition implements Partition, HealthMonitorable {
         .config()
         .commonTags(
             Tags.of(
-                PartitionKeyNames.PARTITION.asString(), Integer.toString(partitionMetadata.id().id())));
+                PartitionKeyNames.PARTITION.asString(),
+                Integer.toString(partitionMetadata.id().id())));
     return registry;
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
@@ -32,6 +32,7 @@ import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthReport;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
@@ -286,8 +287,7 @@ public final class RaftPartition implements Partition, HealthMonitorable {
         .stop()
         .whenComplete(
             (unused, error) -> {
-              meterRegistry.clear();
-              meterRegistry.close();
+              MicrometerUtil.closeRegistry(meterRegistry);
             });
   }
 
@@ -302,7 +302,7 @@ public final class RaftPartition implements Partition, HealthMonitorable {
         .config()
         .commonTags(
             Tags.of(
-                PartitionKeyNames.PARTITION.name(), Integer.toString(partitionMetadata.id().id())));
+                PartitionKeyNames.PARTITION.asString(), Integer.toString(partitionMetadata.id().id())));
     return registry;
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -48,6 +48,8 @@ import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -97,6 +99,7 @@ public final class RaftRule extends ExternalResource {
   private Map<String, TestSnapshotStore> snapshotStores;
   private final Configurator configurator;
   private final Random random = new Random();
+  private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
   private RaftRule(final int nodeCount, final Configurator configurator) {
     this.nodeCount = nodeCount;
@@ -166,6 +169,8 @@ public final class RaftRule extends ExternalResource {
     memberLog = null;
     position = 0;
     directory = null;
+    meterRegistry.clear();
+    meterRegistry.close();
   }
 
   /**
@@ -530,6 +535,7 @@ public final class RaftRule extends ExternalResource {
             .withMembershipService(mock(ClusterMembershipService.class))
             .withProtocol(protocol)
             .withEntryValidator(entryValidator)
+            .withMeterRegistry(meterRegistry)
             .withStorage(storage);
     configurator.configure(memberId, builder);
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
@@ -50,6 +50,8 @@ import io.atomix.utils.concurrent.ThreadContext;
 import io.camunda.zeebe.journal.CorruptedJournalException;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthReport;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.File;
 import java.net.ConnectException;
 import java.nio.ByteBuffer;
@@ -78,6 +80,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,6 +98,7 @@ public class RaftTest extends ConcurrentTestCase {
   private volatile long position = 0;
   private Path directory;
   private final Map<MemberId, TestRaftServerProtocol> serverProtocols = Maps.newConcurrentMap();
+  @AutoClose private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
   @Before
   @After
@@ -183,7 +187,8 @@ public class RaftTest extends ConcurrentTestCase {
             .withPartitionConfig(
                 new RaftPartitionConfig()
                     .setElectionTimeout(Duration.ofSeconds(1))
-                    .setHeartbeatInterval(Duration.ofMillis(100)));
+                    .setHeartbeatInterval(Duration.ofMillis(100)))
+            .withMeterRegistry(meterRegistry);
 
     final RaftServer server = configurator.apply(defaults).build();
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -27,6 +27,8 @@ import io.atomix.raft.zeebe.ZeebeLogAppender.AppendListener;
 import io.atomix.utils.concurrent.SingleThreadContext;
 import io.atomix.utils.net.Address;
 import io.camunda.zeebe.util.FileUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
@@ -46,6 +48,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -55,6 +58,7 @@ final class ReconfigurationTest {
   private final SingleThreadContext context = new SingleThreadContext("raft-%d");
   private final TestRaftProtocolFactory protocolFactory = new TestRaftProtocolFactory();
   private final List<RaftServer> servers = new LinkedList<>();
+  @AutoClose private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
   @AfterEach
   void cleanup() {
@@ -145,6 +149,7 @@ final class ReconfigurationTest {
                 new RaftPartitionConfig()
                     .setElectionTimeout(Duration.ofMillis(500))
                     .setHeartbeatInterval(Duration.ofMillis(100)))
+            .withMeterRegistry(meterRegistry)
             .build();
     servers.add(server);
     return server;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/StepDownIfNotPrimaryTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/partition/StepDownIfNotPrimaryTest.java
@@ -11,16 +11,21 @@ import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.raft.partition.impl.RaftPartitionServer;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 final class StepDownIfNotPrimaryTest {
+  @AutoClose MeterRegistry meterRegistry = new SimpleMeterRegistry();
+
   @Test
   void shouldStepDownIfNotPrimary(@TempDir final Path tempDir) throws IllegalAccessException {
     // given
@@ -29,7 +34,8 @@ final class StepDownIfNotPrimaryTest {
     final var metadata = new PartitionMetadata(partitionId, Set.of(), Map.of(), 1, primaryMemberId);
 
     final var raftPartitionConfig = new RaftPartitionConfig();
-    final var partition = new RaftPartition(metadata, raftPartitionConfig, tempDir.toFile());
+    final var partition =
+        new RaftPartition(metadata, raftPartitionConfig, tempDir.toFile(), meterRegistry);
     final var mockRaftPartitionServer = Mockito.mock(RaftPartitionServer.class);
     Mockito.when(mockRaftPartitionServer.getMemberId()).thenReturn(new MemberId("1"));
 
@@ -50,7 +56,8 @@ final class StepDownIfNotPrimaryTest {
     final var primaryMemberId = new MemberId("1");
     final var raftPartitionConfig = new RaftPartitionConfig();
     final var metadata = new PartitionMetadata(partitionId, Set.of(), Map.of(), 1, primaryMemberId);
-    final var partition = new RaftPartition(metadata, raftPartitionConfig, tempDir.toFile());
+    final var partition =
+        new RaftPartition(metadata, raftPartitionConfig, tempDir.toFile(), meterRegistry);
 
     final var mockRaftPartitionServer = Mockito.mock(RaftPartitionServer.class);
     Mockito.when(mockRaftPartitionServer.getMemberId()).thenReturn(new MemberId("1"));
@@ -73,7 +80,8 @@ final class StepDownIfNotPrimaryTest {
     final var raftPartitionConfig = new RaftPartitionConfig();
     final var primaryMemberId = new MemberId("2");
     final var metadata = new PartitionMetadata(partitionId, Set.of(), Map.of(), 1, primaryMemberId);
-    final var partition = new RaftPartition(metadata, raftPartitionConfig, tempDir.toFile());
+    final var partition =
+        new RaftPartition(metadata, raftPartitionConfig, tempDir.toFile(), meterRegistry);
     final var mockRaftPartitionServer = Mockito.mock(RaftPartitionServer.class);
     Mockito.when(mockRaftPartitionServer.getMemberId()).thenReturn(new MemberId("1"));
 
@@ -95,7 +103,8 @@ final class StepDownIfNotPrimaryTest {
     final MemberId primaryMemberId = null;
     final var raftPartitionConfig = new RaftPartitionConfig();
     final var metadata = new PartitionMetadata(partitionId, Set.of(), Map.of(), 1, primaryMemberId);
-    final var partition = new RaftPartition(metadata, raftPartitionConfig, tempDir.toFile());
+    final var partition =
+        new RaftPartition(metadata, raftPartitionConfig, tempDir.toFile(), meterRegistry);
     final var mockRaftPartitionServer = Mockito.mock(RaftPartitionServer.class);
     Mockito.when(mockRaftPartitionServer.getMemberId()).thenReturn(new MemberId("1"));
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/zeebe/ZeebeIT.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/zeebe/ZeebeIT.java
@@ -23,6 +23,8 @@ import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.zeebe.util.TestAppender;
 import io.atomix.raft.zeebe.util.ZeebeTestHelper;
 import io.atomix.raft.zeebe.util.ZeebeTestNode;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -44,6 +46,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -53,10 +56,10 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class ZeebeIT {
 
+  @AutoClose static MeterRegistry meterRegistry = new SimpleMeterRegistry();
   // rough estimate of how many entries we'd need to write to fill a segment
   // segments are configured for 1kb, and one entry takes ~30 bytes (plus some metadata I guess)
   private static final int ENTRIES_PER_SEGMENT = (1024 / 30) + 1;
-
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
   @Parameter public String name;
 
@@ -78,7 +81,7 @@ public class ZeebeIT {
   }
 
   private static Function<TemporaryFolder, ZeebeTestNode> provideNode(final int id) {
-    return tmp -> new ZeebeTestNode(id, newFolderUnchecked(tmp, id));
+    return tmp -> new ZeebeTestNode(id, newFolderUnchecked(tmp, id), meterRegistry);
   }
 
   private static File newFolderUnchecked(final TemporaryFolder tmp, final int id) {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/zeebe/ZeebeLogAppenderTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/zeebe/ZeebeLogAppenderTest.java
@@ -23,6 +23,8 @@ import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.zeebe.util.TestAppender;
 import io.atomix.raft.zeebe.util.ZeebeTestHelper;
 import io.atomix.raft.zeebe.util.ZeebeTestNode;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Set;
@@ -30,6 +32,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,6 +41,7 @@ import org.slf4j.LoggerFactory;
 public class ZeebeLogAppenderTest {
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
+  @AutoClose MeterRegistry meterRegistry = new SimpleMeterRegistry();
   private final Logger logger = LoggerFactory.getLogger(getClass());
   private final Stopwatch stopwatch = Stopwatch.createUnstarted();
   private final TestAppender appenderListener = new TestAppender();
@@ -47,7 +51,7 @@ public class ZeebeLogAppenderTest {
 
   @Before
   public void setUp() throws Exception {
-    node = new ZeebeTestNode(0, temporaryFolder.newFolder("0"));
+    node = new ZeebeTestNode(0, temporaryFolder.newFolder("0"), meterRegistry);
 
     final Set<ZeebeTestNode> nodes = Collections.singleton(node);
     helper = new ZeebeTestHelper(nodes);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestNode.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/ZeebeTestNode.java
@@ -30,6 +30,7 @@ import io.atomix.raft.partition.RaftPartitionConfig;
 import io.atomix.raft.partition.RaftStorageConfig;
 import io.atomix.raft.partition.impl.RaftPartitionServer;
 import io.atomix.raft.zeebe.EntryValidator.NoopEntryValidator;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.io.File;
 import java.util.Collection;
 import java.util.List;
@@ -48,8 +49,10 @@ public class ZeebeTestNode {
   private final File directory;
   private AtomixCluster cluster;
   private List<RaftPartition> partitions;
+  private final MeterRegistry meterRegistry;
 
-  public ZeebeTestNode(final int id, final File directory) {
+  public ZeebeTestNode(final int id, final File directory, final MeterRegistry meterRegistry) {
+    this.meterRegistry = meterRegistry;
     final String textualId = String.valueOf(id);
 
     this.directory = directory;
@@ -111,7 +114,8 @@ public class ZeebeTestNode {
               return new RaftPartition(
                   partitionMetadata,
                   raftPartitionConfig,
-                  new File(new File(directory, "log"), "" + member.id()));
+                  new File(new File(directory, "log"), "" + member.id()),
+                  meterRegistry);
             })
         .toList();
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -127,7 +127,7 @@ public final class PartitionManagerImpl
     managementService =
         new DefaultPartitionManagementService(
             clusterServices.getMembershipService(), clusterServices.getCommunicationService());
-    raftPartitionFactory = new RaftPartitionFactory(brokerCfg);
+    raftPartitionFactory = new RaftPartitionFactory(brokerCfg, meterRegistry);
   }
 
   public void start() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ExperimentalCfg;
 import io.camunda.zeebe.broker.system.configuration.RaftCfg.FlushConfig;
 import io.camunda.zeebe.util.FileUtil;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
@@ -30,9 +31,11 @@ public final class RaftPartitionFactory {
   public static final String GROUP_NAME = "raft-partition";
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
   private final BrokerCfg brokerCfg;
+  private final MeterRegistry meterRegistry;
 
-  public RaftPartitionFactory(final BrokerCfg brokerCfg) {
+  public RaftPartitionFactory(final BrokerCfg brokerCfg, final MeterRegistry meterRegistry) {
     this.brokerCfg = brokerCfg;
+    this.meterRegistry = meterRegistry;
   }
 
   public RaftPartition createRaftPartition(final PartitionMetadata partitionMetadata) {
@@ -104,7 +107,8 @@ public final class RaftPartitionFactory {
     partitionConfig.setPreferSnapshotReplicationThreshold(
         brokerCfg.getExperimental().getRaft().getPreferSnapshotReplicationThreshold());
 
-    return new RaftPartition(partitionMetadata, partitionConfig, partitionDirectory.toFile());
+    return new RaftPartition(
+        partitionMetadata, partitionConfig, partitionDirectory.toFile(), meterRegistry);
   }
 
   private RaftLogFlusher.Factory createFlusherFactory(

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
@@ -33,6 +33,8 @@ import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl;
 import io.camunda.zeebe.test.DynamicAutoCloseable;
 import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.buffer.DirectBufferWriter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -45,6 +47,7 @@ import java.util.concurrent.CompletableFuture;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -61,6 +64,7 @@ public class ConcurrentBackupCompactionTest extends DynamicAutoCloseable {
   private static final Logger LOG = LoggerFactory.getLogger(ConcurrentBackupCompactionTest.class);
   private static final String SNAPSHOT_FILE_NAME = "file1";
   @TempDir Path dataDirectory;
+  @AutoClose MeterRegistry meterRegistry = new SimpleMeterRegistry();
   private ActorScheduler actorScheduler;
   private SegmentedJournal journal;
   private FileBasedSnapshotStore snapshotStore;
@@ -85,7 +89,8 @@ public class ConcurrentBackupCompactionTest extends DynamicAutoCloseable {
     final var partitionMetadata =
         new PartitionMetadata(
             PartitionId.from("raft", partitionId), Set.of(), Map.of(), 1, new MemberId("1"));
-    final var raftPartition = new RaftPartition(partitionMetadata, null, dataDirectory.toFile());
+    final var raftPartition =
+        new RaftPartition(partitionMetadata, null, dataDirectory.toFile(), meterRegistry);
 
     journal =
         manage(

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionFactoryTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionFactoryTest.java
@@ -15,15 +15,19 @@ import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.broker.partitioning.startup.RaftPartitionFactory;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.util.unit.DataSize;
 
 public final class RaftPartitionFactoryTest {
+  @AutoClose MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
   @Test
   void shouldSetElectionTimeout() {
@@ -223,7 +227,7 @@ public final class RaftPartitionFactoryTest {
   }
 
   private RaftPartition buildRaftPartition(final BrokerCfg brokerCfg) {
-    return new RaftPartitionFactory(brokerCfg)
+    return new RaftPartitionFactory(brokerCfg, meterRegistry)
         .createRaftPartition(
             new PartitionMetadata(
                 PartitionId.from("test", 1),

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftRolesTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftRolesTest.java
@@ -22,6 +22,7 @@ import io.atomix.raft.partition.RaftPartition;
 import io.atomix.raft.partition.RaftPartitionConfig;
 import io.atomix.raft.partition.RaftStorageConfig;
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -37,10 +38,13 @@ import java.util.stream.IntStream;
 import org.agrona.LangUtil;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AutoClose;
 
 public final class RaftRolesTest {
 
   @Rule public AtomixClusterRule atomixClusterRule = new AtomixClusterRule();
+
+  @AutoClose MeterRegistry meterRegistry;
 
   @Test
   public void testRoleChangedListener() throws Exception {
@@ -161,7 +165,8 @@ public final class RaftRolesTest {
                   return new RaftPartition(
                       metadata,
                       raftPartitionConfig,
-                      new File(new File(atomixClusterRule.getDataDir(), "log"), "" + nodeId));
+                      new File(new File(atomixClusterRule.getDataDir(), "log"), "" + nodeId),
+                      meterRegistry);
                 })
             .toList();
 

--- a/zeebe/restore/pom.xml
+++ b/zeebe/restore/pom.xml
@@ -96,6 +96,10 @@
       <artifactId>agrona</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
 
   </dependencies>
   <build>

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.db.impl.rocksdb.ChecksumProviderRocksDBImpl;
 import io.camunda.zeebe.restore.PartitionRestoreService.BackupValidator;
 import io.camunda.zeebe.util.FileUtil;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Path;
@@ -32,10 +33,15 @@ public class RestoreManager {
   private static final Logger LOG = LoggerFactory.getLogger(RestoreManager.class);
   private final BrokerCfg configuration;
   private final BackupStore backupStore;
+  private final MeterRegistry meterRegistry;
 
-  public RestoreManager(final BrokerCfg configuration, final BackupStore backupStore) {
+  public RestoreManager(
+      final BrokerCfg configuration,
+      final BackupStore backupStore,
+      final MeterRegistry meterRegistry) {
     this.configuration = configuration;
     this.backupStore = backupStore;
+    this.meterRegistry = meterRegistry;
   }
 
   public CompletableFuture<Void> restore(final long backupId, final boolean validateConfig) {
@@ -110,7 +116,7 @@ public class RestoreManager {
         new PartitionDistribution(
             StaticConfigurationGenerator.getStaticConfiguration(configuration, localMember)
                 .generatePartitionDistribution());
-    final var raftPartitionFactory = new RaftPartitionFactory(configuration);
+    final var raftPartitionFactory = new RaftPartitionFactory(configuration, meterRegistry);
 
     return clusterTopology.partitions().stream()
         .filter(partitionMetadata -> partitionMetadata.members().contains(localMember))

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -30,6 +30,8 @@ import io.camunda.zeebe.snapshots.SnapshotException.CorruptedSnapshotException;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
 import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.buffer.DirectBufferWriter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -45,6 +47,7 @@ import java.util.stream.Collectors;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -58,6 +61,7 @@ class PartitionRestoreServiceTest {
   private static final String SNAPSHOT_FILE_NAME = "file1";
   @TempDir Path dataDirectory;
   @TempDir Path dataDirectoryToRestore;
+  @AutoClose MeterRegistry meterRegistry = new SimpleMeterRegistry();
   private TestRestorableBackupStore backupStore;
   private SegmentedJournal journal;
   private PartitionRestoreService restoreService;
@@ -89,7 +93,7 @@ class PartitionRestoreServiceTest {
         new PartitionMetadata(
             PartitionId.from("raft", partitionId), Set.of(), Map.of(), 1, new MemberId("1"));
     final var raftPartition =
-        new RaftPartition(partitionMetadata, null, dataDirectoryToRestore.toFile());
+        new RaftPartition(partitionMetadata, null, dataDirectoryToRestore.toFile(), meterRegistry);
     restoreService =
         new PartitionRestoreService(backupStore, raftPartition, nodeId, snapshotPath -> Map.of());
 

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
@@ -77,9 +77,10 @@ public final class MicrometerUtil {
 
   /**
    * Closes the registry after clearing it. In this way all metrics registered are removed.
+   *
    * @param registry the registry to clear and close.
    */
-  public static void closeRegistry(final MeterRegistry registry){
+  public static void closeRegistry(final MeterRegistry registry) {
     registry.clear();
     registry.close();
   }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.util.micrometer;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.Timer.Builder;
 import java.time.Duration;
@@ -72,6 +73,15 @@ public final class MicrometerUtil {
   public static CloseableSilently timer(
       final LongConsumer setter, final TimeUnit unit, final Clock clock) {
     return new CloseableGaugeTimer(setter, unit, clock, clock.monotonicTime());
+  }
+
+  /**
+   * Closes the registry after clearing it. In this way all metrics registered are removed.
+   * @param registry the registry to clear and close.
+   */
+  public static void closeRegistry(final MeterRegistry registry){
+    registry.clear();
+    registry.close();
   }
 
   private record CloseableTimer(Timer timer, Timer.Sample sample) implements CloseableSilently {


### PR DESCRIPTION
## Description

A MeterRegistry with tag "partition" is allocated in RaftPartition constructor.
The registry is then passed everywhere and closed when RaftPartition.stop() method is called.

## Related issues
relates #26078 
