### PR TITLE
[Backport stable/8.7] Pass and store meter registry down to ProcessEngineMetrics

### DIFF
--- a/zeebe/backup/pom.xml
+++ b/zeebe/backup/pom.xml
@@ -71,6 +71,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.stream.api.StreamClock;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.impl.RecordProcessorContextImpl;
 import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.nio.file.Path;
 import java.time.InstantSource;
 import java.util.concurrent.atomic.AtomicLong;
@@ -81,7 +82,8 @@ final class CheckpointRecordsProcessorTest {
         context,
         null,
         new DbKeyGenerator(1, zeebeDb, context),
-        StreamClock.controllable(InstantSource.system()));
+        StreamClock.controllable(InstantSource.system()),
+        new SimpleMeterRegistry());
   }
 
   @AfterEach

--- a/zeebe/engine/pom.xml
+++ b/zeebe/engine/pom.xml
@@ -273,7 +273,6 @@
       <scope>test</scope>
     </dependency>
 
-
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>

--- a/zeebe/engine/pom.xml
+++ b/zeebe/engine/pom.xml
@@ -126,6 +126,11 @@
       <artifactId>spring-security-crypto</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+
     <!-- TEST DEPENDENCIES -->
     <dependency>
       <groupId>io.camunda</groupId>
@@ -268,11 +273,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-core</artifactId>
-      <scope>test</scope>
-    </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.prometheus.client.Counter;
 
 public final class ProcessEngineMetrics {
@@ -69,9 +70,11 @@ public final class ProcessEngineMetrics {
           .help("Number of created (root) process instances")
           .labelNames(PARTITION_LABEL, CREATION_MODE_LABEL)
           .register();
+  private final MeterRegistry registry;
   private final String partitionIdLabel;
 
-  public ProcessEngineMetrics(final int partitionId) {
+  public ProcessEngineMetrics(final MeterRegistry registry, final int partitionId) {
+    this.registry = registry;
     partitionIdLabel = String.valueOf(partitionId);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.prometheus.client.Counter;
+import java.util.Objects;
 
 public final class ProcessEngineMetrics {
 
@@ -74,7 +75,7 @@ public final class ProcessEngineMetrics {
   private final String partitionIdLabel;
 
   public ProcessEngineMetrics(final MeterRegistry registry, final int partitionId) {
-    this.registry = registry;
+    this.registry = Objects.requireNonNull(registry, "must specify a registry");
     partitionIdLabel = String.valueOf(partitionId);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -67,12 +67,11 @@ public final class BpmnProcessors {
       final int partitionId,
       final RoutingInfo routingInfo,
       final InstantSource clock,
-      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState) {
+      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
+      final ProcessEngineMetrics processEngineMetrics) {
     final MutableProcessMessageSubscriptionState subscriptionState =
         processingState.getProcessMessageSubscriptionState();
     final var keyGenerator = processingState.getKeyGenerator();
-
-    final var processEngineMetrics = new ProcessEngineMetrics(processingState.getPartitionId());
 
     addProcessInstanceCommandProcessor(writers, typedRecordProcessors, processingState);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -166,7 +166,8 @@ public final class EngineProcessors {
             partitionId,
             routingInfo,
             clock,
-            transientProcessMessageSubscriptionState);
+            transientProcessMessageSubscriptionState,
+            processEngineMetrics);
 
     addDecisionProcessors(typedRecordProcessors, decisionBehavior, writers, processingState);
 
@@ -262,7 +263,8 @@ public final class EngineProcessors {
       final int partitionId,
       final RoutingInfo routingInfo,
       final InstantSource clock,
-      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState) {
+      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
+      final ProcessEngineMetrics processEngineMetrics) {
     return BpmnProcessors.addBpmnStreamProcessor(
         processingState,
         scheduledTaskState,
@@ -275,7 +277,8 @@ public final class EngineProcessors {
         partitionId,
         routingInfo,
         clock,
-        transientProcessMessageSubscriptionState);
+        transientProcessMessageSubscriptionState,
+        processEngineMetrics);
   }
 
   private static void addDeploymentRelatedProcessorAndServices(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -96,7 +96,9 @@ public final class EngineProcessors {
             scheduledTaskStateFactory.get().getTimerState(), featureFlags, clock);
 
     final var jobMetrics = new JobMetrics(partitionId);
-    final var processEngineMetrics = new ProcessEngineMetrics(processingState.getPartitionId());
+    final var processEngineMetrics =
+        new ProcessEngineMetrics(
+            typedRecordProcessorContext.getMeterRegistry(), processingState.getPartitionId());
 
     subscriptionCommandSender.setWriters(writers);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.function.Supplier;
 
 public interface TypedRecordProcessorContext {
@@ -37,4 +38,6 @@ public interface TypedRecordProcessorContext {
   ControllableStreamClock getClock();
 
   TransientPendingSubscriptionState getTransientProcessMessageSubscriptionState();
+
+  MeterRegistry getMeterRegistry();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.RecordProcessorContext;
 import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -34,6 +35,7 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   private final TransientPendingSubscriptionState transientMessageSubscriptionState;
   private final TransientPendingSubscriptionState transientProcessMessageSubscriptionState;
   private final ControllableStreamClock clock;
+  private final MeterRegistry meterRegistry;
 
   public TypedRecordProcessorContextImpl(
       final RecordProcessorContext context,
@@ -58,6 +60,7 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
     this.writers = writers;
     partitionCommandSender = context.getPartitionCommandSender();
     this.config = config;
+    meterRegistry = context.getMeterRegistry();
   }
 
   @Override
@@ -110,5 +113,10 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   @Override
   public TransientPendingSubscriptionState getTransientProcessMessageSubscriptionState() {
     return transientProcessMessageSubscriptionState;
+  }
+
+  @Override
+  public MeterRegistry getMeterRegistry() {
+    return meterRegistry;
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/RecordProcessorContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/RecordProcessorContext.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.List;
 
 public interface RecordProcessorContext {
@@ -33,4 +34,6 @@ public interface RecordProcessorContext {
   KeyGenerator getKeyGenerator();
 
   ControllableStreamClock getClock();
+
+  MeterRegistry getMeterRegistry();
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/RecordProcessorContextImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/RecordProcessorContextImpl.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.stream.api.state.KeyGeneratorControls;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -30,6 +31,7 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
   private final InterPartitionCommandSender partitionCommandSender;
   private final KeyGenerator keyGenerator;
   private final ControllableStreamClock clock;
+  private final MeterRegistry meterRegistry;
 
   public RecordProcessorContextImpl(
       final int partitionId,
@@ -38,14 +40,16 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
       final TransactionContext transactionContext,
       final InterPartitionCommandSender partitionCommandSender,
       final KeyGeneratorControls keyGeneratorControls,
-      final ControllableStreamClock clock) {
+      final ControllableStreamClock clock,
+      final MeterRegistry meterRegistry) {
     this.partitionId = partitionId;
     this.scheduleService = scheduleService;
     this.zeebeDb = zeebeDb;
     this.transactionContext = transactionContext;
     this.partitionCommandSender = partitionCommandSender;
     keyGenerator = keyGeneratorControls;
-    this.clock = Objects.requireNonNull(clock);
+    this.clock = Objects.requireNonNull(clock, "must specify a stream clock");
+    this.meterRegistry = Objects.requireNonNull(meterRegistry, "must specify a metrics registry");
   }
 
   @Override
@@ -91,5 +95,10 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
   @Override
   public ControllableStreamClock getClock() {
     return clock;
+  }
+
+  @Override
+  public MeterRegistry getMeterRegistry() {
+    return meterRegistry;
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -352,7 +352,8 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
             streamProcessorContext.getTransactionContext(),
             streamProcessorContext.getPartitionCommandSender(),
             streamProcessorContext.getKeyGeneratorControls(),
-            streamProcessorContext.getClock());
+            streamProcessorContext.getClock(),
+            streamProcessorContext.getMeterRegistry());
 
     recordProcessors.forEach(processor -> processor.init(processorContext));
 


### PR DESCRIPTION
# Description
Backport of #27686 to `stable/8.7`.

relates to #26078
original author: @npepinpe