### PR TITLE
[CPT] feat: Print active elements if a test fails

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultCollector.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultCollector.java
@@ -16,6 +16,7 @@
 package io.camunda.process.test.impl.testresult;
 
 import io.camunda.client.api.search.response.FlowNodeInstance;
+import io.camunda.client.api.search.response.FlowNodeInstanceState;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
 import io.camunda.process.test.impl.client.IncidentDto;
@@ -65,6 +66,7 @@ public class CamundaProcessTestResultCollector {
     result.setProcessId(processInstance.getProcessDefinitionId());
     result.setVariables(collectVariables(processInstanceKey));
     result.setOpenIncidents(collectOpenIncidents(processInstanceKey));
+    result.setActiveFlowNodeInstances(collectActiveFlowNodeInstances(processInstanceKey));
 
     return result;
   }
@@ -106,5 +108,20 @@ public class CamundaProcessTestResultCollector {
       openIncident.setMessage("?");
     }
     return openIncident;
+  }
+
+  private List<FlowNodeInstance> collectActiveFlowNodeInstances(final long processInstanceKey) {
+    try {
+      return dataSource.getFlowNodeInstancesByProcessInstanceKey(processInstanceKey).stream()
+          .filter(
+              flowNodeInstance -> flowNodeInstance.getState().equals(FlowNodeInstanceState.ACTIVE))
+          .collect(Collectors.toList());
+    } catch (final IOException e) {
+      LOG.warn(
+          "Failed to collect flow-node instances for process instance with key '{}'",
+          processInstanceKey,
+          e);
+    }
+    return Collections.emptyList();
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultPrinter.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultPrinter.java
@@ -15,8 +15,10 @@
  */
 package io.camunda.process.test.impl.testresult;
 
+import io.camunda.client.api.search.response.FlowNodeInstance;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -60,6 +62,9 @@ public class CamundaProcessTestResultPrinter {
 
     return formattedProcessInstance
         + "\n\n"
+        + "Active elements:\n"
+        + formatFlowNodeInstances(result.getActiveFlowNodeInstances())
+        + "\n\n"
         + "Variables:\n"
         + formatVariables(result.getVariables())
         + "\n\n"
@@ -99,5 +104,20 @@ public class CamundaProcessTestResultPrinter {
     return String.format(
         "- '%s' [type: %s] \"%s\"",
         incident.getFlowNodeId(), incident.getType(), abbreviate(incident.getMessage()));
+  }
+
+  private static String formatFlowNodeInstances(final List<FlowNodeInstance> flowNodeInstances) {
+    if (flowNodeInstances.isEmpty()) {
+      return NO_ENTRIES;
+    } else {
+      return flowNodeInstances.stream()
+          .map(CamundaProcessTestResultPrinter::formatFlowNodeInstance)
+          .collect(Collectors.joining("\n"));
+    }
+  }
+
+  private static String formatFlowNodeInstance(final FlowNodeInstance flowNodeInstance) {
+    final String name = Optional.ofNullable(flowNodeInstance.getFlowNodeName()).orElse("");
+    return String.format("- '%s' [name: '%s']", flowNodeInstance.getFlowNodeId(), name);
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/ProcessInstanceResult.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/ProcessInstanceResult.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.process.test.impl.testresult;
 
+import io.camunda.client.api.search.response.FlowNodeInstance;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -28,6 +29,8 @@ public class ProcessInstanceResult {
   private Map<String, String> variables = new HashMap<>();
 
   private List<OpenIncident> openIncidents = new ArrayList<>();
+
+  private List<FlowNodeInstance> activeFlowNodeInstances = new ArrayList<>();
 
   public long getProcessInstanceKey() {
     return processInstanceKey;
@@ -59,5 +62,13 @@ public class ProcessInstanceResult {
 
   public void setOpenIncidents(final List<OpenIncident> openIncidents) {
     this.openIncidents = openIncidents;
+  }
+
+  public List<FlowNodeInstance> getActiveFlowNodeInstances() {
+    return activeFlowNodeInstances;
+  }
+
+  public void setActiveFlowNodeInstances(final List<FlowNodeInstance> activeFlowNodeInstances) {
+    this.activeFlowNodeInstances = activeFlowNodeInstances;
   }
 }


### PR DESCRIPTION
## Description

Extend the result collector to include the active elements in the test output:

```
Process test results:
=====================

Process instance: 2251799813685256 [process-id: 'process']

Active elements:
- 'userTask_fbcd14bc-d477-4f50-a5f8-8e2e0031bd0e' [name: 'task']

Variables:
- 'status': "active"

Open incidents:
<None>
=====================
```

This implements a basic version of #23136 without printing the elements as an element instance tree (i.e. no subprocess hierarchy). 

## Related issues

contributes to #23136 
