### PR TITLE
[CPT] feat: Assert that a process instance is started

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
@@ -51,6 +51,16 @@ public interface ProcessInstanceAssert {
   ProcessInstanceAssert isTerminated();
 
   /**
+   * Verifies that the process instance is created (i.e. active, completed, or terminated). The
+   * verification fails if the process instance is not created.
+   *
+   * <p>The assertion waits until the process instance is created.
+   *
+   * @return the assertion object
+   */
+  ProcessInstanceAssert isCreated();
+
+  /**
    * Verifies that the given BPMN elements are active. The verification fails if at least one
    * element is completed, terminated, or not entered.
    *

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -179,7 +179,7 @@ public class ProcessInstanceAssertj
           Optional.ofNullable(actualProcessInstance.get())
               .map(ProcessInstanceDto::getProcessInstanceState)
               .map(ProcessInstanceAssertj::formatState)
-              .orElse("not activated");
+              .orElse("not created");
 
       final String failureMessage =
           String.format(
@@ -226,7 +226,7 @@ public class ProcessInstanceAssertj
 
   private static String formatState(final ProcessInstanceState state) {
     if (state == null || state == ProcessInstanceState.UNKNOWN_ENUM_VALUE) {
-      return "not activated";
+      return "not created";
     } else if (state == ProcessInstanceState.CANCELED) {
       return "terminated";
     } else {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -70,19 +70,33 @@ public class ProcessInstanceAssertj
 
   @Override
   public ProcessInstanceAssert isActive() {
-    hasProcessInstanceInState(ProcessInstanceState.ACTIVE, Objects::nonNull);
+    hasProcessInstanceInState("active", ProcessInstanceState.ACTIVE::equals, Objects::nonNull);
     return this;
   }
 
   @Override
   public ProcessInstanceAssert isCompleted() {
-    hasProcessInstanceInState(ProcessInstanceState.COMPLETED, ProcessInstanceAssertj::isEnded);
+    hasProcessInstanceInState(
+        "completed", ProcessInstanceState.COMPLETED::equals, ProcessInstanceAssertj::isEnded);
     return this;
   }
 
   @Override
   public ProcessInstanceAssert isTerminated() {
-    hasProcessInstanceInState(ProcessInstanceState.CANCELED, ProcessInstanceAssertj::isEnded);
+    hasProcessInstanceInState(
+        "terminated", ProcessInstanceState.CANCELED::equals, ProcessInstanceAssertj::isEnded);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert isCreated() {
+    hasProcessInstanceInState(
+        "created",
+        state ->
+            state == ProcessInstanceState.ACTIVE
+                || state == ProcessInstanceState.COMPLETED
+                || state == ProcessInstanceState.CANCELED,
+        Objects::nonNull);
     return this;
   }
 
@@ -141,7 +155,9 @@ public class ProcessInstanceAssertj
   }
 
   private void hasProcessInstanceInState(
-      final ProcessInstanceState expectedState, final Predicate<ProcessInstanceDto> waitCondition) {
+      final String expectedState,
+      final Predicate<ProcessInstanceState> expectedStateMatcher,
+      final Predicate<ProcessInstanceDto> waitCondition) {
     // reset cached process instance
     actualProcessInstance.set(null);
 
@@ -154,7 +170,7 @@ public class ProcessInstanceAssertj
                 final ProcessInstanceDto processInstance = findProcessInstance();
                 actualProcessInstance.set(processInstance);
 
-                assertThat(processInstance.getProcessInstanceState()).isEqualTo(expectedState);
+                assertThat(processInstance.getProcessInstanceState()).matches(expectedStateMatcher);
               });
 
     } catch (final ConditionTimeoutException | TerminalFailureException e) {
@@ -167,8 +183,7 @@ public class ProcessInstanceAssertj
 
       final String failureMessage =
           String.format(
-              "%s should be %s but was %s.",
-              failureMessagePrefix, formatState(expectedState), actualState);
+              "%s should be %s but was %s.", failureMessagePrefix, expectedState, actualState);
       fail(failureMessage);
     }
   }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -475,6 +475,68 @@ public class ProcessInstanceAssertTest {
   }
 
   @Nested
+  class IsCreated {
+
+    @Test
+    void shouldBeCreatedIfActive() throws IOException {
+      // given
+      final ProcessInstanceDto processInstance = newActiveProcessInstance(PROCESS_INSTANCE_KEY);
+      when(camundaDataSource.findProcessInstances())
+          .thenReturn(Collections.singletonList(processInstance));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThat(processInstanceEvent).isCreated();
+    }
+
+    @Test
+    void shouldBeCreatedIfCompleted() throws IOException {
+      // given
+      final ProcessInstanceDto processInstance = newCompletedProcessInstance(PROCESS_INSTANCE_KEY);
+      when(camundaDataSource.findProcessInstances())
+          .thenReturn(Collections.singletonList(processInstance));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThat(processInstanceEvent).isCreated();
+    }
+
+    @Test
+    void shouldBeCreatedIfTerminated() throws IOException {
+      // given
+      final ProcessInstanceDto processInstance = newTerminatedProcessInstance(PROCESS_INSTANCE_KEY);
+      when(camundaDataSource.findProcessInstances())
+          .thenReturn(Collections.singletonList(processInstance));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThat(processInstanceEvent).isCreated();
+    }
+
+    @Test
+    void shouldFailIfNotCreated() throws IOException {
+      // given
+      when(camundaDataSource.findProcessInstances()).thenReturn(Collections.emptyList());
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      Assertions.assertThatThrownBy(
+              () -> CamundaAssert.assertThat(processInstanceEvent).isCreated())
+          .hasMessage(
+              "Process instance [key: %d] should be created but was not activated.",
+              PROCESS_INSTANCE_KEY);
+    }
+  }
+
+  @Nested
   class FluentAssertions {
 
     private final FlowNodeInstanceDto activeFlowNodeInstance = new FlowNodeInstanceDto();

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -281,7 +281,7 @@ public class ProcessInstanceAssertTest {
       // then
       Assertions.assertThatThrownBy(() -> CamundaAssert.assertThat(processInstanceEvent).isActive())
           .hasMessage(
-              "Process instance [key: %d] should be active but was not activated.",
+              "Process instance [key: %d] should be active but was not created.",
               PROCESS_INSTANCE_KEY);
     }
   }
@@ -375,7 +375,7 @@ public class ProcessInstanceAssertTest {
       Assertions.assertThatThrownBy(
               () -> CamundaAssert.assertThat(processInstanceEvent).isCompleted())
           .hasMessage(
-              "Process instance [key: %d] should be completed but was not activated.",
+              "Process instance [key: %d] should be completed but was not created.",
               PROCESS_INSTANCE_KEY);
     }
   }
@@ -469,7 +469,7 @@ public class ProcessInstanceAssertTest {
       Assertions.assertThatThrownBy(
               () -> CamundaAssert.assertThat(processInstanceEvent).isTerminated())
           .hasMessage(
-              "Process instance [key: %d] should be terminated but was not activated.",
+              "Process instance [key: %d] should be terminated but was not created.",
               PROCESS_INSTANCE_KEY);
     }
   }
@@ -531,7 +531,7 @@ public class ProcessInstanceAssertTest {
       Assertions.assertThatThrownBy(
               () -> CamundaAssert.assertThat(processInstanceEvent).isCreated())
           .hasMessage(
-              "Process instance [key: %d] should be created but was not activated.",
+              "Process instance [key: %d] should be created but was not created.",
               PROCESS_INSTANCE_KEY);
     }
   }


### PR DESCRIPTION
## Description

Add a new assertion to verify that a process instance is created. This is an addition to `isActive`, `isCompleted`, and
`isTerminated`.

```
assertThat(processInstance).isCreated();
```

## Related issues

closes #23187 
