### PR TITLE
fix: fix startup.recovery.time metric in StreamProcessorMetrics

### DIFF
--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamProcessorMetrics.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/StreamProcessorMetrics.java
@@ -76,7 +76,7 @@ public final class StreamProcessorMetrics {
   }
 
   private void registerStartupRecoveryTime() {
-    final var meterDoc = StreamMetricsDoc.PROCESSOR_STATE;
+    final var meterDoc = StreamMetricsDoc.STARTUP_RECOVERY_TIME;
     TimeGauge.builder(
             meterDoc.getName(), startupRecoveryTime, TimeUnit.MILLISECONDS, AtomicLong::longValue)
         .description(meterDoc.getDescription())


### PR DESCRIPTION
## Description
Wrong metric name was used for startupRecoveryTime, unfortunately I didn't realize yesterday when reviewing it.

## Related issues

relates #26708
