### PR TITLE
feat: implement get all users for tenant

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserReader.java
@@ -21,11 +21,11 @@ public class UserReader extends AbstractEntityReader<UserEntity> {
 
   private static final Logger LOG = LoggerFactory.getLogger(UserReader.class);
 
-  private final UserMapper processDefinitionMapper;
+  private final UserMapper userMapper;
 
-  public UserReader(final UserMapper processDefinitionMapper) {
+  public UserReader(final UserMapper userMapper) {
     super(UserSearchColumn::findByProperty);
-    this.processDefinitionMapper = processDefinitionMapper;
+    this.userMapper = userMapper;
   }
 
   public Optional<UserEntity> findOne(final long userKey) {
@@ -40,8 +40,8 @@ public class UserReader extends AbstractEntityReader<UserEntity> {
             b -> b.filter(query.filter()).sort(dbSort).page(convertPaging(dbSort, query.page())));
 
     LOG.trace("[RDBMS DB] Search for users with filter {}", dbQuery);
-    final var totalHits = processDefinitionMapper.count(dbQuery);
-    final var hits = processDefinitionMapper.search(dbQuery);
+    final var totalHits = userMapper.count(dbQuery);
+    final var hits = userMapper.search(dbQuery);
     return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 }

--- a/db/rdbms/src/main/resources/mapper/TenantMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/TenantMapper.xml
@@ -76,7 +76,7 @@
     parameterType="io.camunda.db.rdbms.write.domain.TenantMemberDbModel"
     flushCache="true">
     INSERT INTO ${prefix}TENANT_MEMBER (TENANT_ID, ENTITY_ID, ENTITY_TYPE)
-    VALUES (#{tenantId}, #{entityID}, #{entityType})
+    VALUES (#{tenantId}, #{entityId}, #{entityType})
   </insert>
 
   <delete

--- a/db/rdbms/src/main/resources/mapper/UserMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserMapper.xml
@@ -12,19 +12,26 @@
 
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.UserDbQuery">
     SELECT COUNT(*)
-    FROM ${prefix}USERS
+    FROM ${prefix}USERS t
+    <if test="filter.tenantId != null">
+      JOIN ${prefix}TENANT_MEMBER tm ON t.USERNAME = tm.ENTITY_ID
+    </if>
     <include refid="io.camunda.db.rdbms.sql.UserMapper.searchFilter"/>
   </select>
 
   <select id="search" parameterType="io.camunda.db.rdbms.read.domain.UserDbQuery"
     resultMap="io.camunda.db.rdbms.sql.UserMapper.searchResultMap">
-    SELECT * FROM (
+    SELECT
+    * FROM (
     SELECT USER_KEY,
     USERNAME,
     NAME,
     EMAIL,
     PASSWORD
-    FROM ${prefix}USERS
+    FROM ${prefix}USERS t
+    <if test="filter.tenantId != null">
+    JOIN ${prefix}TENANT_MEMBER tm ON t.USERNAME = tm.ENTITY_ID
+    </if>
     <include refid="io.camunda.db.rdbms.sql.UserMapper.searchFilter"/>
     ) t
     <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
@@ -35,10 +42,11 @@
   <sql id="searchFilter">
     WHERE 1 = 1
     <!-- basic filters -->
-    <if test="filter.key != null">AND USER_KEY = #{filter.key}</if>
-    <if test="filter.username != null">AND USERNAME = #{filter.username}</if>
-    <if test="filter.name != null">AND NAME = #{filter.name}</if>
-    <if test="filter.email != null">AND EMAIL = #{filter.email}</if>
+    <if test="filter.key != null">AND t.USER_KEY = #{filter.key}</if>
+    <if test="filter.username != null">AND t.USERNAME = #{filter.username}</if>
+    <if test="filter.name != null">AND t.NAME = #{filter.name}</if>
+    <if test="filter.email != null">AND t.EMAIL = #{filter.email}</if>
+    <if test="filter.tenantId != null">AND tm.TENANT_ID = #{filter.tenantId}</if>
   </sql>
 
   <resultMap id="searchResultMap" type="io.camunda.search.entities.UserEntity">

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/user/UserSpecificFilterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/user/UserSpecificFilterIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.it.rdbms.db.user;
 
+import static io.camunda.it.rdbms.db.fixtures.TenantFixtures.createAndSaveTenant;
 import static io.camunda.it.rdbms.db.fixtures.UserFixtures.createAndSaveRandomUsers;
 import static io.camunda.it.rdbms.db.fixtures.UserFixtures.createAndSaveUser;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -15,15 +16,19 @@ import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.UserReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
+import io.camunda.db.rdbms.write.domain.TenantMemberDbModel;
+import io.camunda.it.rdbms.db.fixtures.TenantFixtures;
 import io.camunda.it.rdbms.db.fixtures.UserFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
 import io.camunda.search.filter.UserFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.UserQuery;
 import io.camunda.search.sort.UserSort;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,6 +53,38 @@ public class UserSpecificFilterIT {
   @BeforeEach
   public void beforeAll() {
     rdbmsWriter = rdbmsService.createWriter(0L);
+  }
+
+  @Test
+  public void shouldFilterUsersForTenant() {
+    final var tenant = TenantFixtures.createRandomized(b -> b);
+    final var anotherTenant = TenantFixtures.createRandomized(b -> b);
+    createAndSaveTenant(rdbmsWriter, tenant);
+    createAndSaveTenant(rdbmsWriter, anotherTenant);
+
+    Arrays.asList("user-abc", "user-123", "user-1337")
+        .forEach(
+            username ->
+                createAndSaveUser(
+                    rdbmsWriter,
+                    UserFixtures.createRandomized(
+                        b ->
+                            b.name("User 1337")
+                                .username(username)
+                                .email(username + "@camunda-test.com"))));
+
+    addUserToTenant(tenant.tenantId(), "user-1337");
+    addUserToTenant(anotherTenant.tenantId(), "user-abc");
+    addUserToTenant(anotherTenant.tenantId(), "user-123");
+
+    final var users =
+        userReader.search(
+            new UserQuery(
+                new UserFilter.Builder().tenantId(tenant.tenantId()).build(),
+                UserSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(users.total()).isEqualTo(1);
   }
 
   @ParameterizedTest
@@ -78,5 +115,10 @@ public class UserSpecificFilterIT {
         new UserFilter.Builder().username("user-1337").build(),
         new UserFilter.Builder().name("User 1337").build(),
         new UserFilter.Builder().email("user-1337@camunda-test.com").build());
+  }
+
+  private void addUserToTenant(final String tenantId, final String entityId) {
+    rdbmsWriter.getTenantWriter().addMember(new TenantMemberDbModel(tenantId, entityId, "USER"));
+    rdbmsWriter.flush();
   }
 }

--- a/search/search-client-query-transformer/pom.xml
+++ b/search/search-client-query-transformer/pom.xml
@@ -37,6 +37,10 @@
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-util</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+    </dependency>
 
     <!-- Testing -->
     <dependency>

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.search.clients;
 
-import static io.camunda.search.entities.TenantMemberEntity.TenantMemberType.USER;
+import static io.camunda.zeebe.protocol.record.value.EntityType.USER;
 
 import io.camunda.search.clients.auth.DocumentAuthorizationQueryStrategy;
 import io.camunda.search.clients.transformers.ServiceTransformers;

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.search.clients;
 
-import static io.camunda.search.entities.TenantMemberEntity.MemberType.USER;
+import static io.camunda.search.entities.TenantMemberEntity.TenantMemberType.USER;
 
 import io.camunda.search.clients.auth.DocumentAuthorizationQueryStrategy;
 import io.camunda.search.clients.transformers.ServiceTransformers;

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
@@ -251,8 +251,7 @@ public class SearchClients
 
     final var overlayQuery = injectUsernamesIntoQuery(usernames, userQuery);
 
-    return getSearchExecutor()
-        .search(overlayQuery, io.camunda.webapps.schema.entities.usermanagement.UserEntity.class);
+    return searchUsers(overlayQuery);
   }
 
   @Override
@@ -317,17 +316,8 @@ public class SearchClients
 
   private UserQuery injectUsernamesIntoQuery(
       final Set<String> usernames, final UserQuery userQuery) {
-    return UserQuery.of(
-        builder ->
-            builder
-                .filter(
-                    f ->
-                        f.name(userQuery.filter().name())
-                            .email(userQuery.filter().email())
-                            .key(userQuery.filter().key())
-                            .username(userQuery.filter().username())
-                            .usernames(usernames))
-                .sort(userQuery.sort())
-                .page(userQuery.page()));
+    return userQuery.toBuilder()
+        .filter(userQuery.filter().toBuilder().usernames(usernames).build())
+        .build();
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
@@ -243,7 +243,7 @@ public class SearchClients
         getSearchExecutor()
             .findAll(
                 new TenantQuery.Builder()
-                    .filter(f -> f.joinParentId(userQuery.filter().tenantId()).memberType("USER"))
+                    .filter(f -> f.joinParentId(userQuery.filter().tenantId()).memberType(USER))
                     .build(),
                 io.camunda.webapps.schema.entities.usermanagement.TenantMemberEntity.class);
     final var usernames =

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
@@ -240,7 +240,7 @@ public class SearchClients
         getSearchExecutor()
             .findAll(
                 new TenantQuery.Builder()
-                    .filter(f -> f.joinParentId(userQuery.filter().tenantId()).memberType(USER))
+                    .filter(f -> f.joinParentId(userQuery.filter().tenantId()).memberType("USER"))
                     .build(),
                 io.camunda.webapps.schema.entities.usermanagement.TenantMemberEntity.class);
     final var usernames =

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -22,6 +22,7 @@ import io.camunda.search.clients.transformers.entity.ProcessDefinitionEntityTran
 import io.camunda.search.clients.transformers.entity.ProcessInstanceEntityTransformer;
 import io.camunda.search.clients.transformers.entity.RoleEntityTransformer;
 import io.camunda.search.clients.transformers.entity.TenantEntityTransformer;
+import io.camunda.search.clients.transformers.entity.TenantMemberEntityTransformer;
 import io.camunda.search.clients.transformers.entity.UsageMetricsEntityTransformer;
 import io.camunda.search.clients.transformers.entity.UserEntityTransformer;
 import io.camunda.search.clients.transformers.entity.UserTaskEntityTransformer;
@@ -162,6 +163,7 @@ import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
 import io.camunda.webapps.schema.entities.usermanagement.MappingEntity;
 import io.camunda.webapps.schema.entities.usermanagement.RoleEntity;
 import io.camunda.webapps.schema.entities.usermanagement.TenantEntity;
+import io.camunda.webapps.schema.entities.usermanagement.TenantMemberEntity;
 import io.camunda.webapps.schema.entities.usermanagement.UserEntity;
 import java.util.HashMap;
 import java.util.Map;
@@ -247,6 +249,7 @@ public final class ServiceTransformers {
     mappers.put(AuthorizationEntity.class, new AuthorizationEntityTransformer());
     mappers.put(RoleEntity.class, new RoleEntityTransformer());
     mappers.put(TenantEntity.class, new TenantEntityTransformer());
+    mappers.put(TenantMemberEntity.class, new TenantMemberEntityTransformer());
     mappers.put(GroupEntity.class, new GroupEntityTransformer());
     mappers.put(UserEntity.class, new UserEntityTransformer());
     mappers.put(MappingEntity.class, new MappingEntityTransformer());

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/TenantMemberEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/TenantMemberEntityTransformer.java
@@ -9,7 +9,6 @@ package io.camunda.search.clients.transformers.entity;
 
 import io.camunda.search.clients.transformers.ServiceTransformer;
 import io.camunda.search.entities.TenantMemberEntity;
-import io.camunda.search.entities.TenantMemberEntity.TenantMemberType;
 
 public class TenantMemberEntityTransformer
     implements ServiceTransformer<
@@ -17,7 +16,6 @@ public class TenantMemberEntityTransformer
   @Override
   public TenantMemberEntity apply(
       final io.camunda.webapps.schema.entities.usermanagement.TenantMemberEntity source) {
-    return new TenantMemberEntity(
-        source.getMemberId(), TenantMemberType.valueOf(source.getMemberType().name()));
+    return new TenantMemberEntity(source.getMemberId(), source.getMemberType());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/TenantMemberEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/TenantMemberEntityTransformer.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.entity;
+
+import io.camunda.search.clients.transformers.ServiceTransformer;
+import io.camunda.search.entities.TenantMemberEntity;
+import io.camunda.search.entities.TenantMemberEntity.MemberType;
+
+public class TenantMemberEntityTransformer
+    implements ServiceTransformer<
+        io.camunda.webapps.schema.entities.usermanagement.TenantMemberEntity, TenantMemberEntity> {
+  @Override
+  public TenantMemberEntity apply(
+      final io.camunda.webapps.schema.entities.usermanagement.TenantMemberEntity source) {
+    return new TenantMemberEntity(
+        source.getMemberId(), MemberType.valueOf(source.getMemberType().name()));
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/TenantMemberEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/TenantMemberEntityTransformer.java
@@ -9,7 +9,7 @@ package io.camunda.search.clients.transformers.entity;
 
 import io.camunda.search.clients.transformers.ServiceTransformer;
 import io.camunda.search.entities.TenantMemberEntity;
-import io.camunda.search.entities.TenantMemberEntity.MemberType;
+import io.camunda.search.entities.TenantMemberEntity.TenantMemberType;
 
 public class TenantMemberEntityTransformer
     implements ServiceTransformer<
@@ -18,6 +18,6 @@ public class TenantMemberEntityTransformer
   public TenantMemberEntity apply(
       final io.camunda.webapps.schema.entities.usermanagement.TenantMemberEntity source) {
     return new TenantMemberEntity(
-        source.getMemberId(), MemberType.valueOf(source.getMemberType().name()));
+        source.getMemberId(), TenantMemberType.valueOf(source.getMemberType().name()));
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantFilterTransformer.java
@@ -8,7 +8,10 @@
 package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.hasChildQuery;
 import static io.camunda.search.clients.query.SearchQueryBuilders.hasParentQuery;
+import static io.camunda.search.clients.query.SearchQueryBuilders.longTerms;
+import static io.camunda.search.clients.query.SearchQueryBuilders.matchNone;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex.KEY;
 import static io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex.NAME;
@@ -32,6 +35,13 @@ public class TenantFilterTransformer extends IndexFilterTransformer<TenantFilter
         filter.key() == null ? null : term(KEY, filter.key()),
         filter.tenantId() == null ? null : term(TENANT_ID, filter.tenantId()),
         filter.name() == null ? null : term(NAME, filter.name()),
+        filter.memberKeys() == null || filter.memberKeys().isEmpty()
+            ? null
+            : filter.memberKeys().isEmpty()
+                ? matchNone()
+                : hasChildQuery(
+                    IdentityJoinRelationshipType.MEMBER.getType(),
+                    longTerms(TenantIndex.MEMBER_KEY, filter.memberKeys())),
         filter.entityType() == null
             ? null
             : term(TenantIndex.MEMBER_TYPE, filter.entityType().name()),

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantFilterTransformer.java
@@ -29,7 +29,6 @@ public class TenantFilterTransformer extends IndexFilterTransformer<TenantFilter
   @Override
   public SearchQuery toSearchQuery(final TenantFilter filter) {
     return and(
-        term(TenantIndex.JOIN, IdentityJoinRelationshipType.TENANT.getType()),
         filter.key() == null ? null : term(KEY, filter.key()),
         filter.tenantId() == null ? null : term(TENANT_ID, filter.tenantId()),
         filter.name() == null ? null : term(NAME, filter.name()),

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantFilterTransformer.java
@@ -32,9 +32,9 @@ public class TenantFilterTransformer extends IndexFilterTransformer<TenantFilter
         filter.key() == null ? null : term(KEY, filter.key()),
         filter.tenantId() == null ? null : term(TENANT_ID, filter.tenantId()),
         filter.name() == null ? null : term(NAME, filter.name()),
-        filter.tenantMemberType() == null
+        filter.entityType() == null
             ? null
-            : term(TenantIndex.MEMBER_TYPE, filter.tenantMemberType().name()),
+            : term(TenantIndex.MEMBER_TYPE, filter.entityType().name()),
         filter.joinParentId() == null
             ? term(TenantIndex.JOIN, IdentityJoinRelationshipType.TENANT.getType())
             : hasParentQuery(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantFilterTransformer.java
@@ -32,9 +32,9 @@ public class TenantFilterTransformer extends IndexFilterTransformer<TenantFilter
         filter.key() == null ? null : term(KEY, filter.key()),
         filter.tenantId() == null ? null : term(TENANT_ID, filter.tenantId()),
         filter.name() == null ? null : term(NAME, filter.name()),
-        filter.memberType() == null
+        filter.tenantMemberType() == null
             ? null
-            : term(TenantIndex.MEMBER_TYPE, filter.memberType().name()),
+            : term(TenantIndex.MEMBER_TYPE, filter.tenantMemberType().name()),
         filter.joinParentId() == null
             ? term(TenantIndex.JOIN, IdentityJoinRelationshipType.TENANT.getType())
             : hasParentQuery(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantFilterTransformer.java
@@ -8,9 +8,7 @@
 package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
-import static io.camunda.search.clients.query.SearchQueryBuilders.hasChildQuery;
-import static io.camunda.search.clients.query.SearchQueryBuilders.longTerms;
-import static io.camunda.search.clients.query.SearchQueryBuilders.matchNone;
+import static io.camunda.search.clients.query.SearchQueryBuilders.hasParentQuery;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex.KEY;
 import static io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex.NAME;
@@ -35,12 +33,13 @@ public class TenantFilterTransformer extends IndexFilterTransformer<TenantFilter
         filter.key() == null ? null : term(KEY, filter.key()),
         filter.tenantId() == null ? null : term(TENANT_ID, filter.tenantId()),
         filter.name() == null ? null : term(NAME, filter.name()),
-        filter.memberKeys() == null
+        filter.memberType() == null
             ? null
-            : filter.memberKeys().isEmpty()
-                ? matchNone()
-                : hasChildQuery(
-                    IdentityJoinRelationshipType.MEMBER.getType(),
-                    longTerms(TenantIndex.MEMBER_KEY, filter.memberKeys())));
+            : term(TenantIndex.MEMBER_TYPE, filter.memberType().name()),
+        filter.joinParentId() == null
+            ? term(TenantIndex.JOIN, IdentityJoinRelationshipType.TENANT.getType())
+            : hasParentQuery(
+                IdentityJoinRelationshipType.TENANT.getType(),
+                term(TENANT_ID, filter.joinParentId())));
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserFilterTransformer.java
@@ -8,6 +8,7 @@
 package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.matchNone;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.webapps.schema.descriptors.usermanagement.index.UserIndex.EMAIL;
@@ -31,7 +32,11 @@ public class UserFilterTransformer extends IndexFilterTransformer<UserFilter> {
     return and(
         filter.key() == null ? null : term(KEY, filter.key()),
         filter.username() == null ? null : term(USERNAME, filter.username()),
-        filter.usernames() == null ? null : stringTerms(USERNAME, filter.usernames()),
+        filter.usernames() == null
+            ? null
+            : filter.usernames().isEmpty()
+                ? matchNone()
+                : stringTerms(USERNAME, filter.usernames()),
         filter.email() == null ? null : term(EMAIL, filter.email()),
         filter.name() == null ? null : term(NAME, filter.name()));
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserFilterTransformer.java
@@ -8,6 +8,7 @@
 package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.webapps.schema.descriptors.usermanagement.index.UserIndex.EMAIL;
 import static io.camunda.webapps.schema.descriptors.usermanagement.index.UserIndex.KEY;
@@ -30,6 +31,7 @@ public class UserFilterTransformer extends IndexFilterTransformer<UserFilter> {
     return and(
         filter.key() == null ? null : term(KEY, filter.key()),
         filter.username() == null ? null : term(USERNAME, filter.username()),
+        filter.usernames() == null ? null : stringTerms(USERNAME, filter.usernames()),
         filter.email() == null ? null : term(EMAIL, filter.email()),
         filter.name() == null ? null : term(NAME, filter.name()));
   }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/TenantQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/TenantQueryTransformerTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.search.clients.transformers.filter;
 
+import static io.camunda.search.entities.TenantMemberEntity.MemberType.USER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.search.clients.query.SearchQuery;
@@ -83,8 +84,21 @@ public class TenantQueryTransformerTest extends AbstractTransformerTest {
                                     SearchQuery.of(
                                         q1 -> q.term(t -> t.field("join").value("tenant"))),
                                     SearchQuery.of(
-                                        q1 ->
-                                            q.term(t -> t.field("name").value("TestTenant"))))))));
+                                        q1 -> q.term(t -> t.field("join").value("tenant"))))))));
+  }
+
+  @Test
+  public void shouldQueryMembersByTenantId() {
+    // given
+    final var filter =
+        FilterBuilders.tenant((f) -> f.joinParentId("test-parent-id").memberType(USER));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    assertThat(searchRequest)
+        .isEqualTo(generateSearchQueryForParent("test-parent-id", USER.name()));
   }
 
   @Test

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/TenantQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/TenantQueryTransformerTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.search.clients.transformers.filter;
 
-import static io.camunda.search.entities.TenantMemberEntity.MemberType.USER;
+import static io.camunda.search.entities.TenantMemberEntity.TenantMemberType.USER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.search.clients.query.SearchQuery;

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/TenantQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/TenantQueryTransformerTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.search.clients.transformers.filter;
 
-import static io.camunda.search.entities.TenantMemberEntity.TenantMemberType.USER;
+import static io.camunda.zeebe.protocol.record.value.EntityType.USER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.search.clients.query.SearchQuery;

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/TenantQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/TenantQueryTransformerTest.java
@@ -34,10 +34,9 @@ public class TenantQueryTransformerTest extends AbstractTransformerTest {
                         b ->
                             b.must(
                                 List.of(
+                                    SearchQuery.of(q1 -> q.term(t -> t.field("key").value(12345L))),
                                     SearchQuery.of(
-                                        q1 -> q.term(t -> t.field("join").value("tenant"))),
-                                    SearchQuery.of(
-                                        q1 -> q.term(t -> t.field("key").value(12345L))))))));
+                                        q1 -> q.term(t -> t.field("join").value("tenant"))))))));
   }
 
   @Test
@@ -58,10 +57,9 @@ public class TenantQueryTransformerTest extends AbstractTransformerTest {
                             b.must(
                                 List.of(
                                     SearchQuery.of(
-                                        q1 -> q.term(t -> t.field("join").value("tenant"))),
+                                        q1 -> q.term(t -> t.field("tenantId").value("tenant1"))),
                                     SearchQuery.of(
-                                        q1 ->
-                                            q.term(t -> t.field("tenantId").value("tenant1"))))))));
+                                        q1 -> q.term(t -> t.field("join").value("tenant"))))))));
   }
 
   @Test
@@ -82,7 +80,7 @@ public class TenantQueryTransformerTest extends AbstractTransformerTest {
                             b.must(
                                 List.of(
                                     SearchQuery.of(
-                                        q1 -> q.term(t -> t.field("join").value("tenant"))),
+                                        q1 -> q.term(t -> t.field("name").value("TestTenant"))),
                                     SearchQuery.of(
                                         q1 -> q.term(t -> t.field("join").value("tenant"))))))));
   }
@@ -119,12 +117,35 @@ public class TenantQueryTransformerTest extends AbstractTransformerTest {
                         b ->
                             b.must(
                                 List.of(
-                                    SearchQuery.of(
-                                        q -> q.term(t -> t.field("join").value("tenant"))),
                                     SearchQuery.of(q -> q.term(t -> t.field("key").value(12345L))),
                                     SearchQuery.of(
                                         q -> q.term(t -> t.field("tenantId").value("tenant1"))),
                                     SearchQuery.of(
-                                        q -> q.term(t -> t.field("name").value("TestTenant"))))))));
+                                        q -> q.term(t -> t.field("name").value("TestTenant"))),
+                                    SearchQuery.of(
+                                        q -> q.term(t -> t.field("join").value("tenant"))))))));
+  }
+
+  private SearchQuery generateSearchQueryForParent(final String parentId, final String memberType) {
+    return SearchQuery.of(
+        q ->
+            q.bool(
+                b ->
+                    b.must(
+                        List.of(
+                            SearchQuery.of(
+                                q1 -> q1.term(t -> t.field("memberType").value(memberType))),
+                            SearchQuery.of(
+                                q1 ->
+                                    q1.hasParent(
+                                        p ->
+                                            p.parentType("tenant")
+                                                .query(
+                                                    SearchQuery.of(
+                                                        q2 ->
+                                                            q2.term(
+                                                                t ->
+                                                                    t.field("tenantId")
+                                                                        .value(parentId))))))))));
   }
 }

--- a/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
+++ b/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
@@ -212,8 +212,10 @@ public class RdbmsSearchClient
   }
 
   @Override
-  public SearchQueryResult<UserEntity> searchUsers(final UserQuery filter) {
-    return null;
+  public SearchQueryResult<UserEntity> searchUsers(final UserQuery query) {
+    LOG.debug("[RDBMS Search Client] Search for users: {}", query);
+
+    return rdbmsService.getUserReader().search(query);
   }
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/UserSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/UserSearchClient.java
@@ -14,7 +14,7 @@ import io.camunda.security.auth.SecurityContext;
 
 public interface UserSearchClient {
 
-  SearchQueryResult<UserEntity> searchUsers(UserQuery filter);
+  SearchQueryResult<UserEntity> searchUsers(UserQuery userQuery);
 
   UserSearchClient withSecurityContext(SecurityContext securityContext);
 }

--- a/search/search-domain/pom.xml
+++ b/search/search-domain/pom.xml
@@ -36,6 +36,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/search/search-domain/src/main/java/io/camunda/search/entities/TenantMemberEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/TenantMemberEntity.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TenantMemberEntity(String id, MemberType memberType) {
+  public enum MemberType {
+    USER,
+    GROUP,
+    MAPPING,
+    UNSPECIFIED
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/TenantMemberEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/TenantMemberEntity.java
@@ -10,8 +10,8 @@ package io.camunda.search.entities;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record TenantMemberEntity(String id, MemberType memberType) {
-  public enum MemberType {
+public record TenantMemberEntity(String id, TenantMemberType tenantMemberType) {
+  public enum TenantMemberType {
     USER,
     GROUP,
     MAPPING,

--- a/search/search-domain/src/main/java/io/camunda/search/entities/TenantMemberEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/TenantMemberEntity.java
@@ -8,13 +8,7 @@
 package io.camunda.search.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record TenantMemberEntity(String id, TenantMemberType tenantMemberType) {
-  public enum TenantMemberType {
-    USER,
-    GROUP,
-    MAPPING,
-    UNSPECIFIED
-  }
-}
+public record TenantMemberEntity(String id, EntityType entityType) {}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/TenantFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/TenantFilter.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.search.filter;
 
-import io.camunda.search.entities.TenantMemberEntity.TenantMemberType;
 import io.camunda.util.ObjectBuilder;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -17,7 +17,7 @@ public record TenantFilter(
     String tenantId,
     String name,
     String joinParentId,
-    TenantMemberType tenantMemberType,
+    EntityType entityType,
     Set<Long> memberKeys)
     implements FilterBase {
 
@@ -31,7 +31,7 @@ public record TenantFilter(
     private String tenantId;
     private String name;
     private String joinParentId;
-    private TenantMemberType tenantMemberType;
+    private EntityType entityType;
     private Set<Long> memberKeys;
 
     public Builder key(final Long value) {
@@ -54,8 +54,8 @@ public record TenantFilter(
       return this;
     }
 
-    public Builder memberType(final TenantMemberType value) {
-      tenantMemberType = value;
+    public Builder memberType(final EntityType value) {
+      entityType = value;
       return this;
     }
 
@@ -70,7 +70,7 @@ public record TenantFilter(
 
     @Override
     public TenantFilter build() {
-      return new TenantFilter(key, tenantId, name, joinParentId, tenantMemberType, memberKeys);
+      return new TenantFilter(key, tenantId, name, joinParentId, entityType, memberKeys);
     }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/TenantFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/TenantFilter.java
@@ -7,11 +7,18 @@
  */
 package io.camunda.search.filter;
 
+import io.camunda.search.entities.TenantMemberEntity.MemberType;
 import io.camunda.util.ObjectBuilder;
 import java.util.Set;
 import java.util.function.Function;
 
-public record TenantFilter(Long key, String tenantId, String name, Set<Long> memberKeys)
+public record TenantFilter(
+    Long key,
+    String tenantId,
+    String name,
+    String joinParentId,
+    MemberType memberType,
+    Set<Long> memberKeys)
     implements FilterBase {
 
   public static TenantFilter of(final Function<Builder, Builder> builderFunction) {
@@ -23,6 +30,8 @@ public record TenantFilter(Long key, String tenantId, String name, Set<Long> mem
     private Long key;
     private String tenantId;
     private String name;
+    private String joinParentId;
+    private MemberType memberType;
     private Set<Long> memberKeys;
 
     public Builder key(final Long value) {
@@ -37,6 +46,16 @@ public record TenantFilter(Long key, String tenantId, String name, Set<Long> mem
 
     public Builder name(final String value) {
       name = value;
+      return this;
+    }
+
+    public Builder joinParentId(final String value) {
+      joinParentId = value;
+      return this;
+    }
+
+    public Builder memberType(final MemberType value) {
+      memberType = value;
       return this;
     }
 

--- a/search/search-domain/src/main/java/io/camunda/search/filter/TenantFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/TenantFilter.java
@@ -59,16 +59,6 @@ public record TenantFilter(
       return this;
     }
 
-    public Builder joinParentId(final String value) {
-      joinParentId = value;
-      return this;
-    }
-
-    public Builder memberType(final String value) {
-      memberType = value;
-      return this;
-    }
-
     public Builder memberKey(final Long value) {
       return memberKeys(Set.of(value));
     }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/TenantFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/TenantFilter.java
@@ -59,6 +59,16 @@ public record TenantFilter(
       return this;
     }
 
+    public Builder joinParentId(final String value) {
+      joinParentId = value;
+      return this;
+    }
+
+    public Builder memberType(final String value) {
+      memberType = value;
+      return this;
+    }
+
     public Builder memberKey(final Long value) {
       return memberKeys(Set.of(value));
     }
@@ -70,7 +80,7 @@ public record TenantFilter(
 
     @Override
     public TenantFilter build() {
-      return new TenantFilter(key, tenantId, name, memberKeys);
+      return new TenantFilter(key, tenantId, name, joinParentId, memberType, memberKeys);
     }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/TenantFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/TenantFilter.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.search.filter;
 
-import io.camunda.search.entities.TenantMemberEntity.MemberType;
+import io.camunda.search.entities.TenantMemberEntity.TenantMemberType;
 import io.camunda.util.ObjectBuilder;
 import java.util.Set;
 import java.util.function.Function;
@@ -17,7 +17,7 @@ public record TenantFilter(
     String tenantId,
     String name,
     String joinParentId,
-    MemberType memberType,
+    TenantMemberType tenantMemberType,
     Set<Long> memberKeys)
     implements FilterBase {
 
@@ -31,7 +31,7 @@ public record TenantFilter(
     private String tenantId;
     private String name;
     private String joinParentId;
-    private MemberType memberType;
+    private TenantMemberType tenantMemberType;
     private Set<Long> memberKeys;
 
     public Builder key(final Long value) {
@@ -54,8 +54,8 @@ public record TenantFilter(
       return this;
     }
 
-    public Builder memberType(final MemberType value) {
-      memberType = value;
+    public Builder memberType(final TenantMemberType value) {
+      tenantMemberType = value;
       return this;
     }
 
@@ -70,7 +70,7 @@ public record TenantFilter(
 
     @Override
     public TenantFilter build() {
-      return new TenantFilter(key, tenantId, name, joinParentId, memberType, memberKeys);
+      return new TenantFilter(key, tenantId, name, joinParentId, tenantMemberType, memberKeys);
     }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/UserFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/UserFilter.java
@@ -13,6 +13,16 @@ import java.util.Set;
 public record UserFilter(
     Long key, String username, Set<String> usernames, String name, String email, String tenantId)
     implements FilterBase {
+
+  public Builder toBuilder() {
+    return new Builder()
+        .username(username)
+        .usernames(usernames)
+        .name(name)
+        .email(email)
+        .tenantId(tenantId);
+  }
+
   public static final class Builder implements ObjectBuilder<UserFilter> {
     private Long key;
     private String username;
@@ -32,7 +42,7 @@ public record UserFilter(
     }
 
     public Builder usernames(final Set<String> value) {
-      usernames = value;
+      usernames = value == null ? Set.of() : value;
       return this;
     }
 

--- a/search/search-domain/src/main/java/io/camunda/search/filter/UserFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/UserFilter.java
@@ -8,14 +8,18 @@
 package io.camunda.search.filter;
 
 import io.camunda.util.ObjectBuilder;
+import java.util.Set;
 
-public record UserFilter(Long key, String username, String name, String email)
+public record UserFilter(
+    Long key, String username, Set<String> usernames, String name, String email, String tenantId)
     implements FilterBase {
   public static final class Builder implements ObjectBuilder<UserFilter> {
     private Long key;
     private String username;
+    private Set<String> usernames;
     private String name;
     private String email;
+    private String tenantId;
 
     public Builder key(final Long value) {
       key = value;
@@ -24,6 +28,11 @@ public record UserFilter(Long key, String username, String name, String email)
 
     public Builder username(final String value) {
       username = value;
+      return this;
+    }
+
+    public Builder usernames(final Set<String> value) {
+      usernames = value;
       return this;
     }
 
@@ -37,9 +46,14 @@ public record UserFilter(Long key, String username, String name, String email)
       return this;
     }
 
+    public Builder tenantId(final String value) {
+      tenantId = value;
+      return this;
+    }
+
     @Override
     public UserFilter build() {
-      return new UserFilter(key, username, name, email);
+      return new UserFilter(key, username, usernames, name, email, tenantId);
     }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/query/UserQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/UserQuery.java
@@ -22,6 +22,10 @@ public record UserQuery(UserFilter filter, UserSort sort, SearchQueryPage page)
     return fn.apply(new Builder()).build();
   }
 
+  public Builder toBuilder() {
+    return new Builder().filter(filter).sort(sort).page(page);
+  }
+
   public static final class Builder extends SearchQueryBase.AbstractQueryBuilder<Builder>
       implements TypedSearchQueryBuilder<UserQuery, UserQuery.Builder, UserFilter, UserSort> {
     private static final UserFilter EMPTY_FILTER = FilterBuilders.user().build();

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/TenantIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/TenantIndex.java
@@ -21,7 +21,8 @@ public class TenantIndex extends UserManagementIndexDescriptor implements Prio5B
   public static final String TENANT_ID = "tenantId";
   public static final String NAME = "name";
   public static final String JOIN = "join";
-  public static final String MEMBER_KEY = "memberKey";
+  public static final String MEMBER_TYPE = "memberType";
+  public static final String PARENT = "parent";
 
   public static final EntityJoinRelationFactory<String> JOIN_RELATION_FACTORY =
       new EntityJoinRelationFactory<>(

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/TenantIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/TenantIndex.java
@@ -22,6 +22,7 @@ public class TenantIndex extends UserManagementIndexDescriptor implements Prio5B
   public static final String NAME = "name";
   public static final String JOIN = "join";
   public static final String MEMBER_TYPE = "memberType";
+  public static final String MEMBER_KEY = "memberKey";
   public static final String PARENT = "parent";
 
   public static final EntityJoinRelationFactory<String> JOIN_RELATION_FACTORY =

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -578,13 +578,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UserSearchResponse"
+                $ref: "#/components/schemas/UserSearchResult"
             application/vnd.camunda.api.keys.number+json:
               schema:
-                $ref: "#/components/schemas/UserSearchResponse"
+                $ref: "#/components/schemas/UserSearchResult"
             application/vnd.camunda.api.keys.string+json:
               schema:
-                $ref: "#/components/schemas/UserSearchResponse"
+                $ref: "#/components/schemas/UserSearchResult"
 
   /tenants/{tenantKey}/users/{userKey}:
     delete:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -551,6 +551,41 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /tenants/{tenantId}/users/search:
+    post:
+      tags:
+        - Tenant
+        - User
+      operationId: searchUsersForTenant
+      summary: Query users for tenant
+      description: Retrieves a filtered and sorted list of users for a specified tenant.
+      parameters:
+        - name: tenantId
+          in: path
+          required: true
+          description: The unique identifier of the tenant.
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserSearchQueryRequest"
+      responses:
+        "200":
+          description: The search result of users for the tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserSearchResponse"
+            application/vnd.camunda.api.keys.number+json:
+              schema:
+                $ref: "#/components/schemas/UserSearchResponse"
+            application/vnd.camunda.api.keys.string+json:
+              schema:
+                $ref: "#/components/schemas/UserSearchResponse"
+
   /tenants/{tenantKey}/users/{userKey}:
     delete:
       tags:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -198,18 +198,9 @@ public class TenantController {
   }
 
   private UserQuery buildUserQuery(final String tenantId, final UserQuery userQuery) {
-    return UserQuery.of(
-        builder ->
-            builder
-                .filter(
-                    f ->
-                        f.name(userQuery.filter().name())
-                            .email(userQuery.filter().email())
-                            .key(userQuery.filter().key())
-                            .username(userQuery.filter().username())
-                            .tenantId(tenantId))
-                .sort(userQuery.sort())
-                .page(userQuery.page()));
+    return userQuery.toBuilder()
+        .filter(userQuery.filter().toBuilder().tenantId(tenantId).build())
+        .build();
   }
 
   private CompletableFuture<ResponseEntity<Object>> updateTenant(final TenantDTO tenantDTO) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -187,7 +187,10 @@ public class TenantController {
       final String tenantId, final UserQuery userQuery) {
     try {
       final var composedUserQuery = buildUserQuery(tenantId, userQuery);
-      final var result = userServices.search(composedUserQuery);
+      final var result =
+          userServices
+              .withAuthentication(RequestMapper.getAuthentication())
+              .search(composedUserQuery);
       return ResponseEntity.ok(SearchQueryResponseMapper.toUserSearchQueryResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.gateway.protocol.rest.TenantSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.TenantSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.TenantUpdateRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserSearchQueryRequest;
-import io.camunda.zeebe.gateway.protocol.rest.UserSearchResponse;
+import io.camunda.zeebe.gateway.protocol.rest.UserSearchResult;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.ResponseMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
@@ -95,7 +95,7 @@ public class TenantController {
   }
 
   @CamundaPostMapping(path = "/{tenantId}/users/search")
-  public ResponseEntity<UserSearchResponse> searchUsersInTenant(
+  public ResponseEntity<UserSearchResult> searchUsersInTenant(
       @PathVariable final String tenantId,
       @RequestBody(required = false) final UserSearchQueryRequest query) {
     return SearchQueryRequestMapper.toUserQuery(query)
@@ -183,7 +183,7 @@ public class TenantController {
     }
   }
 
-  private ResponseEntity<UserSearchResponse> searchUsersInTenant(
+  private ResponseEntity<UserSearchResult> searchUsersInTenant(
       final String tenantId, final UserQuery userQuery) {
     try {
       final var composedUserQuery = buildUserQuery(tenantId, userQuery);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.TenantServices;
 import io.camunda.service.TenantServices.TenantDTO;
+import io.camunda.service.UserServices;
 import io.camunda.service.exception.CamundaBrokerException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.gateway.protocol.rest.TenantCreateRequest;
@@ -42,6 +43,8 @@ public class TenantControllerTest extends RestControllerTest {
   private static final String TENANT_BASE_URL = "/v2/tenants";
 
   @MockBean private TenantServices tenantServices;
+
+  @MockBean private UserServices userServices;
 
   @BeforeEach
   void setup() {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -107,6 +107,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
   @BeforeEach
   void setup() {
     when(tenantServices.withAuthentication(any(Authentication.class))).thenReturn(tenantServices);
+    when(userServices.withAuthentication(any(Authentication.class))).thenReturn(userServices);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -20,6 +20,7 @@ import io.camunda.search.query.TenantQuery;
 import io.camunda.search.sort.TenantSort;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.TenantServices;
+import io.camunda.service.UserServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.util.List;
 import java.util.Set;
@@ -92,6 +93,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
           TENANT_ENTITIES.size());
 
   @MockBean private TenantServices tenantServices;
+  @MockBean private UserServices userServices;
 
   private static String formatSet(final Set<Long> set, final boolean asString) {
     return set.isEmpty()


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR introduces the endpoint that allows retrieving the users for a given tenant and searching within those users. There is support for both the ES/OS side and the RDBMS side (this is also reflected in the choices on where/how to handle the different access patterns of the data (two queries vs JOIN`).

## Related issues

closes #27217
