### PR TITLE
fix: filepath .env included in c8run package

### DIFF
--- a/c8run/package.go
+++ b/c8run/package.go
@@ -123,6 +123,7 @@ func PackageWindows(camundaVersion string, elasticsearchVersion string, connecto
 		filepath.Join("c8run", "log"),
 		filepath.Join("c8run", "camunda-zeebe-"+camundaVersion),
 		filepath.Join("c8run", "package.bat"),
+		filepath.Join("c8run", ".env"),
 		filepath.Join("c8run", composeExtractionPath),
 	}
 	err = archive.ZipSource(filesToArchive, filepath.Join("c8run", "camunda8-run-"+camundaVersion+"-windows-x86_64.zip"))
@@ -210,6 +211,7 @@ func PackageUnix(camundaVersion string, elasticsearchVersion string, connectorsV
 		filepath.Join("c8run", "start.sh"),
 		filepath.Join("c8run", "shutdown.sh"),
 		filepath.Join("c8run", "package.sh"),
+		filepath.Join("c8run", ".env"),
 		filepath.Join("c8run", composeExtractionPath),
 	}
 	outputArchive, err := os.Create(filepath.Join("c8run", "camunda8-run-"+camundaVersion+"-"+runtime.GOOS+"-"+architecture+".tar.gz"))


### PR DESCRIPTION
## Description

A recent PR introduced a .env file in the c8run project, but this was not included as part of the package function.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
