### PR TITLE
[Backport stable/8.7] fix: filepath .env included in c8run package

### DIFF
--- a/c8run/package.go
+++ b/c8run/package.go
@@ -119,6 +119,7 @@ func PackageWindows(camundaVersion string, elasticsearchVersion string, connecto
 		filepath.Join("c8run", "log"),
 		filepath.Join("c8run", "camunda-zeebe-"+camundaVersion),
 		filepath.Join("c8run", "package.bat"),
+		filepath.Join("c8run", ".env"),
 		filepath.Join("c8run", composeExtractionPath),
 	}
 	err = archive.ZipSource(filesToArchive, filepath.Join("c8run", "camunda8-run-"+camundaVersion+"-windows-x86_64.zip"))
@@ -206,6 +207,7 @@ func PackageUnix(camundaVersion string, elasticsearchVersion string, connectorsV
 		filepath.Join("c8run", "start.sh"),
 		filepath.Join("c8run", "shutdown.sh"),
 		filepath.Join("c8run", "package.sh"),
+		filepath.Join("c8run", ".env"),
 		filepath.Join("c8run", composeExtractionPath),
 	}
 	outputArchive, err := os.Create(filepath.Join("c8run", "camunda8-run-"+camundaVersion+"-"+runtime.GOOS+"-"+architecture+".tar.gz"))


### PR DESCRIPTION
# Description
Backport of #27736 to `stable/8.7`.

relates to 
original author: @jessesimpson36