### PR TITLE
test: re-enable adding report to dashboard Optimize e2e

### DIFF
--- a/optimize/client/e2e/sm-tests/Dashboard.js
+++ b/optimize/client/e2e/sm-tests/Dashboard.js
@@ -463,6 +463,43 @@ test('version selection', async (t) => {
   await t.expect(Common.option('Test alert').exists).notOk();
 });
 
+test('add a report from the dashboard', async (t) => {
+  await u.createNewDashboard(t);
+
+  await t
+    .click(Common.addButton)
+    .click(e.createTileModalReportOptions)
+    .click(Common.carbonOption('New report from a template'))
+    .click(e.addTileButton);
+
+  await t.expect(Common.templateModalProcessField.visible).ok();
+  await t
+    .click(Common.templateModalProcessField)
+    .click(Common.carbonOption('Order process'))
+    .click(e.blankReportButton)
+    .click(Common.modalConfirmButton)
+    .hover(Common.addButton)
+    .click('.DashboardRenderer');
+
+  await t
+    .click(Common.addButton)
+    .click(e.createTileModalReportOptions)
+    .click(Common.carbonOption('New report from a template'))
+    .click(e.addTileButton);
+
+  await t.expect(Common.templateModalProcessField.visible).ok();
+  await t.click(Common.templateModalProcessField);
+
+  await t.expect(Common.selectedOption('Order process').exists).ok();
+
+  await t.click(Common.modalConfirmButton).hover(Common.addButton).click('.DashboardRenderer');
+
+  await u.save(t);
+
+  await t.expect(e.reportTile.nth(0).textContent).contains('Blank report');
+  await t.expect(e.reportTile.nth(1).textContent).contains('Locate bottlenecks on a heatmap');
+});
+
 test('add, edit and remove dashboards description', async (t) => {
   await u.createNewDashboard(t);
 


### PR DESCRIPTION
## Description

After investigation of the `add a report from the dashboard` e2e test, it turns out the flakiness is mainly happening at 
```
await t.click(Common.modalConfirmButton).hover(Common.addButton).click('.DashboardRenderer');
```

In order to counter this, I've added `await t.expect(Common.templateModalProcessField.visible).ok();` before we interact with `Common.templateModalProcessField` so that we ensure that the element is visible before interacting with it. This is quite common in async e2e testing unfortunately because of rendering time or network delays.

- Before : The test would fail 50% of the time (on about 10 runs)
- Now : 10 consecutive successful runs

## Related issues

related to #26711
