### PR TITLE
fix: suppress connection issues for background tasks

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/ReschedulingTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/ReschedulingTask.java
@@ -8,12 +8,18 @@
 package io.camunda.exporter.tasks;
 
 import io.camunda.zeebe.util.ExponentialBackoff;
+import java.net.ConnectException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 
 public final class ReschedulingTask implements Runnable {
+  private static final Set<Class<? extends Exception>> BACKGROUND_SUPPRESSED_EXCEPTIONS =
+      Set.of(SocketTimeoutException.class, ConnectException.class, SocketException.class);
   private final BackgroundTask task;
   private final int minimumWorkCount;
   private final ScheduledExecutorService executor;
@@ -70,13 +76,17 @@ public final class ReschedulingTask implements Runnable {
   }
 
   private long onError(final Throwable error) {
+    final String logMessage =
+        "Error occurred while performing a background task; operation will be retried";
     errorDelayMs = errorStrategy.applyAsLong(errorDelayMs);
 
-    // TODO: it's likely in some cases, we do want to log things as errors, but we need to
-    //  distinguish this from "normal" cases (e.g. missing data in ES, or ES temporarily
-    //  unavailable, etc.)
-    logger.warn(
-        "Error occurred while performing a background task; operation will be retried", error);
+    if (BACKGROUND_SUPPRESSED_EXCEPTIONS.contains(error.getCause().getClass())
+        && !logger.isDebugEnabled()) {
+      logger.warn("{}. `{}`", logMessage, error.getCause().getMessage());
+    } else {
+      logger.error(logMessage, error);
+    }
+
     return errorDelayMs;
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/ReschedulingTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/ReschedulingTask.java
@@ -80,8 +80,7 @@ public final class ReschedulingTask implements Runnable {
         "Error occurred while performing a background task; operation will be retried";
     errorDelayMs = errorStrategy.applyAsLong(errorDelayMs);
 
-    if (BACKGROUND_SUPPRESSED_EXCEPTIONS.contains(error.getCause().getClass())
-        && !logger.isDebugEnabled()) {
+    if (BACKGROUND_SUPPRESSED_EXCEPTIONS.contains(error.getCause().getClass())) {
       logger.warn("{}. `{}`", logMessage, error.getCause().getMessage());
     } else {
       logger.error(logMessage, error);


### PR DESCRIPTION
## Description
Suppress stacktraces for  a collection of connection exceptions for Exporter background tasks. The actual stacktrace will still be available when requiring `DEBUG` logs. 
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #25631
