### PR TITLE
ci: ask people to consider backporting CI changes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,7 @@
 - [ ] for CI changes:
   - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
   - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
+  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)
 
 ## Related issues
 


### PR DESCRIPTION
## Description

Amend PR template with checkbox to remind people (authors and reviewers) to follow the new [backporting guidelines for CI changes](https://github.com/camunda/camunda/wiki/CI-&-Automation#backporting-guidelines) to avoid CI pipelines on `stable/*` branches becoming unmaintained/stale missing crucial reliability or observability features.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Related #27158 
