### PR TITLE
[Backport stable/8.7] Migrate RaftReplicationMetrics to micrometer

### DIFF
--- a/zeebe/atomix/cluster/pom.xml
+++ b/zeebe/atomix/cluster/pom.xml
@@ -144,6 +144,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-commons</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-dns</artifactId>
     </dependency>

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -249,7 +249,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     this.partitionConfig = partitionConfig;
     cluster = new RaftClusterContext(localMemberId, this);
 
-    replicationMetrics = new RaftReplicationMetrics(name);
+    replicationMetrics = new RaftReplicationMetrics(name, meterRegistry);
     replicationMetrics.setAppendIndex(raftLog.getLastIndex());
     lastHeartbeat = System.currentTimeMillis();
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftKeyNames.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftKeyNames.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft.metrics;
+
+import io.micrometer.common.docs.KeyName;
+
+public enum RaftKeyNames implements KeyName {
+  /** partitionGroupName */
+  PARTITION_GROUP {
+    @Override
+    public String asString() {
+      return "partitionGroupName";
+    }
+  }
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftReplicationMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftReplicationMetrics.java
@@ -33,10 +33,12 @@ public class RaftReplicationMetrics extends RaftMetrics {
     appendIndex = new AtomicLong(0L);
 
     Gauge.builder(COMMIT_INDEX.getName(), commitIndex::get)
-        .tags(PARTITION_GROUP_NAME_LABEL, partitionName)
+        .description(COMMIT_INDEX.getDescription())
+        .tags(RaftKeyNames.PARTITION_GROUP.asString(), partitionName)
         .register(registry);
     Gauge.builder(APPEND_INDEX.getName(), appendIndex::get)
-        .tags(PARTITION_GROUP_NAME_LABEL, partitionName)
+        .description(APPEND_INDEX.getDescription())
+        .tags(RaftKeyNames.PARTITION_GROUP.asString(), partitionName)
         .register(registry);
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftReplicationMetricsDoc.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftReplicationMetricsDoc.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
 import io.micrometer.core.instrument.Meter.Type;
 
 public enum RaftReplicationMetricsDoc implements ExtendedMeterDocumentation {
+  /** The commit index */
   COMMIT_INDEX {
     @Override
     public String getName() {
@@ -27,6 +28,7 @@ public enum RaftReplicationMetricsDoc implements ExtendedMeterDocumentation {
       return "The commit index";
     }
   },
+  /** The index of last entry appended to the log */
   APPEND_INDEX {
     @Override
     public String getName() {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftReplicationMetricsDoc.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftReplicationMetricsDoc.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft.metrics;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.micrometer.core.instrument.Meter.Type;
+
+public enum RaftReplicationMetricsDoc implements ExtendedMeterDocumentation {
+  COMMIT_INDEX {
+    @Override
+    public String getName() {
+      return "partition.raft.commit.index";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public String getDescription() {
+      return "The commit index";
+    }
+  },
+  APPEND_INDEX {
+    @Override
+    public String getName() {
+      return "partition.raft.append.index";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public String getDescription() {
+      return "The index of last entry appended to the log";
+    }
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftRolesTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftRolesTest.java
@@ -23,6 +23,7 @@ import io.atomix.raft.partition.RaftPartitionConfig;
 import io.atomix.raft.partition.RaftStorageConfig;
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -44,7 +45,7 @@ public final class RaftRolesTest {
 
   @Rule public AtomixClusterRule atomixClusterRule = new AtomixClusterRule();
 
-  @AutoClose MeterRegistry meterRegistry;
+  @AutoClose MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
   @Test
   public void testRoleChangedListener() throws Exception {


### PR DESCRIPTION
# Description
Backport of #27732 to `stable/8.7`.

relates to #26708
original author: @entangled90