### PR TITLE
Allow task listener to provide reason to deny: protocol changes

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -106,6 +106,9 @@
                     "denied": {
                       "type": "boolean"
                     },
+                    "deniedReason": {
+                      "type": "text"
+                    },
                     "correctedAttributes": {
                       "type": "text"
                     },

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -87,6 +87,9 @@
                 "denied": {
                   "type": "boolean"
                 },
+                "deniedReason": {
+                  "type": "text"
+                },
                 "correctedAttributes": {
                   "type": "text"
                 },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -106,6 +106,9 @@
                     "denied": {
                       "type": "boolean"
                     },
+                    "deniedReason": {
+                      "type": "text"
+                    },
                     "correctedAttributes": {
                       "type": "text"
                     },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -87,6 +87,9 @@
                 "denied": {
                   "type": "boolean"
                 },
+                "deniedReason": {
+                  "type": "text"
+                },
                 "correctedAttributes": {
                   "type": "text"
                 },

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -169,7 +169,9 @@ public final class RequestMapper extends RequestUtil {
     }
 
     if (!request.getResult().hasCorrections()) {
-      return new JobResult().setDenied(request.getResult().getDenied());
+      return new JobResult()
+          .setDenied(request.getResult().getDenied())
+          .setDeniedReason(request.getResult().getDeniedReason());
     }
 
     final JobResultCorrections corrections = new JobResultCorrections();
@@ -205,6 +207,7 @@ public final class RequestMapper extends RequestUtil {
 
     return new JobResult()
         .setDenied(request.getResult().getDenied())
+        .setDeniedReason(request.getResult().getDeniedReason())
         .setCorrections(corrections)
         .setCorrectedAttributes(correctedAttributes);
   }

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -123,6 +123,8 @@ message JobResult{
   //   * `priority` - minimum 0, maximum 100, default 50
   //  Omitting any of the attributes will preserve the persisted attribute's value.
   optional JobResultCorrections corrections = 2;
+  // The reason provided by the user task listener for denying the work.
+  optional string deniedReason = 3;
 }
 
 message JobResultCorrections {

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6095,6 +6095,10 @@ components:
             As a result, the completion request is rejected and the task remains active.
             Defaults to false.
           nullable: true
+        deniedReason:
+          type: string
+          description: The reason provided by the user task listener for denying the work.
+          nullable: true
         corrections:
           $ref: "#/components/schemas/JobResultCorrections"
     JobResultCorrections:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -828,6 +828,7 @@ public class RequestMapper {
 
     final JobResult jobResult = new JobResult();
     jobResult.setDenied(getBooleanOrDefault(request, r -> r.getResult().getDenied(), false));
+    jobResult.setDeniedReason(getStringOrEmpty(request, r -> r.getResult().getDeniedReason()));
 
     final var jobResultCorrections = request.getResult().getCorrections();
     if (jobResultCorrections == null) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -27,7 +27,6 @@ import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -349,7 +348,7 @@ public class JobControllerTest extends RestControllerTest {
         ArgumentCaptor.forClass(JobResult.class);
     Mockito.verify(jobServices)
         .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture());
-    Assertions.assertTrue(jobResultArgumentCaptor.getValue().isDenied());
+    assertThat(jobResultArgumentCaptor.getValue().isDenied()).isTrue();
   }
 
   @Test
@@ -384,7 +383,7 @@ public class JobControllerTest extends RestControllerTest {
         ArgumentCaptor.forClass(JobResult.class);
     Mockito.verify(jobServices)
         .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture());
-    Assertions.assertTrue(jobResultArgumentCaptor.getValue().isDenied());
+    assertThat(jobResultArgumentCaptor.getValue().isDenied()).isTrue();
     assertThat(jobResultArgumentCaptor.getValue().getDeniedReason())
         .isEqualTo("Reason to deny lifecycle transition");
   }
@@ -584,7 +583,7 @@ public class JobControllerTest extends RestControllerTest {
         ArgumentCaptor.forClass(JobResult.class);
     Mockito.verify(jobServices)
         .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture());
-    Assertions.assertFalse(jobResultArgumentCaptor.getValue().isDenied());
+    assertThat(jobResultArgumentCaptor.getValue().isDenied()).isFalse();
     assertThat(jobResultArgumentCaptor.getValue().getDeniedReason()).isEqualTo("");
   }
 
@@ -619,7 +618,7 @@ public class JobControllerTest extends RestControllerTest {
         ArgumentCaptor.forClass(JobResult.class);
     Mockito.verify(jobServices)
         .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture());
-    Assertions.assertFalse(jobResultArgumentCaptor.getValue().isDenied());
+    assertThat(jobResultArgumentCaptor.getValue().isDenied()).isFalse();
     assertThat(jobResultArgumentCaptor.getValue().getDeniedReason()).isEqualTo("");
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResult.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResult.java
@@ -7,11 +7,15 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.job;
 
+import static io.camunda.zeebe.msgpack.value.StringValue.EMPTY_STRING;
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue.JobResultValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -31,12 +35,14 @@ public class JobResult extends UnpackedObject implements JobResultValue {
       new ArrayProperty<>("correctedAttributes", StringValue::new);
   private final ObjectProperty<JobResultCorrections> correctionsProp =
       new ObjectProperty<>("corrections", new JobResultCorrections());
+  private final StringProperty deniedReasonProp = new StringProperty("deniedReason", EMPTY_STRING);
 
   public JobResult() {
-    super(3);
+    super(4);
     declareProperty(deniedProp)
         .declareProperty(correctionsProp)
-        .declareProperty(correctedAttributesProp);
+        .declareProperty(correctedAttributesProp)
+        .declareProperty(deniedReasonProp);
   }
 
   /** Sets all properties to current instance from provided user task job data */
@@ -44,6 +50,7 @@ public class JobResult extends UnpackedObject implements JobResultValue {
     deniedProp.setValue(result.isDenied());
     setCorrectedAttributes(result.getCorrectedAttributes());
     setCorrections(result.getCorrections());
+    setDeniedReason(result.getDeniedReason());
   }
 
   @Override
@@ -53,6 +60,16 @@ public class JobResult extends UnpackedObject implements JobResultValue {
 
   public JobResult setDenied(final boolean denied) {
     deniedProp.setValue(denied);
+    return this;
+  }
+
+  @Override
+  public String getDeniedReason() {
+    return bufferAsString(deniedReasonProp.getValue());
+  }
+
+  public JobResult setDeniedReason(final String deniedReason) {
+    deniedReasonProp.setValue(deniedReason);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -684,6 +684,7 @@ final class JsonSerializableToJsonTest {
               final JobResult result =
                   new JobResult()
                       .setDenied(true)
+                      .setDeniedReason("Reason to deny lifecycle transition")
                       .setCorrections(
                           new JobResultCorrections()
                               .setAssignee("frodo")
@@ -758,6 +759,7 @@ final class JsonSerializableToJsonTest {
               "changedAttributes": ["bar", "foo"],
               "result": {
                 "denied": true,
+                "deniedReason": "Reason to deny lifecycle transition",
                 "correctedAttributes": [
                   "assignee",
                   "dueDate",
@@ -828,6 +830,7 @@ final class JsonSerializableToJsonTest {
               final JobResult result =
                   new JobResult()
                       .setDenied(true)
+                      .setDeniedReason("Reason to deny lifecycle transition")
                       .setCorrections(
                           new JobResultCorrections()
                               .setAssignee("frodo")
@@ -901,6 +904,7 @@ final class JsonSerializableToJsonTest {
           "changedAttributes": ["bar", "foo"],
           "result": {
             "denied": true,
+            "deniedReason": "Reason to deny lifecycle transition",
             "correctedAttributes": [
               "assignee",
               "dueDate",
@@ -953,6 +957,7 @@ final class JsonSerializableToJsonTest {
           "changedAttributes": [],
           "result": {
             "denied": false,
+            "deniedReason": "",
             "correctedAttributes": [],
             "corrections": {
               "assignee": "",
@@ -1003,6 +1008,7 @@ final class JsonSerializableToJsonTest {
           "changedAttributes": [],
           "result": {
             "denied": false,
+            "deniedReason": "",
             "correctedAttributes": [],
             "corrections": {
               "assignee": "",

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
@@ -141,6 +141,11 @@ public interface JobRecordValue
     boolean isDenied();
 
     /**
+     * @return a reason provided by Task Listener for denying the work
+     */
+    String getDeniedReason();
+
+    /**
      * May only contain the attribute names of {@link JobResultCorrectionsValue} as entries. Those
      * attributes that are contained in this list are the ones that were corrected by the worker.
      * Others are considered not corrected.


### PR DESCRIPTION
## Description

The first PR for [Allow task listener to provide reason to deny](https://github.com/camunda/camunda/issues/27141).

Task listeners can [deny the lifecycle transition](https://docs.camunda.io/docs/next/components/concepts/user-task-listeners/#denying-the-lifecycle-transition) that they responded to. For users, it must be clear why this happened.

Main changes in this PR:
- Updated `JobResult` to contain a new field `deniedReason` which is representing a reason provided by Task Listener for denying the work. 
- Updated `RequestMapper` for both REST and gRPC to set the new `deniedReason` field.
- Update existing tests and add new ones to `JobControllerTest` and `CompleteJobTest`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #27271
