### PR TITLE
ci: make check-results depend on detect-changes for failure propagation

### DIFF
--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -66,11 +66,8 @@ deny[msg] {
     jobs_that_should_fail_checkresults := { job_id |
         job := input.jobs[job_id]
 
-        # no Unified CI jobs that are part of change detection control flow structure
-        job_id != "detect-changes"
+        # no Unified CI jobs running after (and including) "check-results" job
         job_id != "check-results"
-
-        # no Unified CI jobs running after "check-results" job
         not startswith(job_id, "deploy-")
     }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -831,14 +831,15 @@ jobs:
     timeout-minutes: 3
     permissions:
       checks: read
-    needs:
+    needs:  # BELOW LIST IS IN ALPHABETICAL ORDER
       - actionlint
       - build-operate-backend
       - build-platform-frontend
       - build-tasklist-backend
+      - detect-changes
       - docker-checks
-      - identity-frontend-tests
       - elasticsearch-integration-tests
+      - identity-frontend-tests
       - integration-tests
       - java-checks
       - java-unit-tests


### PR DESCRIPTION
## Description

Implement [proposal from Houssain](https://camunda.slack.com/archives/C071KP5BTHB/p1738839873527079?thread_ts=1738839220.134809&cid=C071KP5BTHB) to improve robustness of the `detect-changes` Unified CI job, e.g. in cases of errors affecting `detect-changes` job it could lead to skipping the `check-results` job and thus circumventing the GitHub required status check for PRs: https://github.com/camunda/camunda/actions/runs/13175687213/job/36774459329?pr=26187

I plan to backport this reliability improvement to all branches that have the Unified CI.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [x] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Related to https://app.incident.io/camunda/incidents/2313
