### PR TITLE
migrate RaftRequestMetrics to micrometer

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftRequestMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftRequestMetrics.java
@@ -16,35 +16,59 @@
  */
 package io.atomix.raft.metrics;
 
-import io.prometheus.client.Counter;
+import static io.atomix.raft.metrics.RaftRequestMetricsDoc.*;
+
+import io.camunda.zeebe.util.collection.Table;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.HashMap;
+import java.util.Map;
 
 public class RaftRequestMetrics extends RaftMetrics {
 
-  private static final Counter RAFT_MESSAGES_RECEIVED =
-      Counter.build()
-          .namespace(NAMESPACE)
-          .name("raft_messages_received")
-          .help("Number of raft requests received")
-          .labelNames("type", PARTITION_GROUP_NAME_LABEL, PARTITION_LABEL)
-          .register();
+  private final Map<String, Counter> raftMessagesReceived;
+  private final MeterRegistry registry;
+  private final Table<String, String, Counter> raftMessagesSend;
 
-  private static final Counter RAFT_MESSAGES_SEND =
-      Counter.build()
-          .namespace(NAMESPACE)
-          .name("raft_messages_send")
-          .help("Number of raft requests send")
-          .labelNames("to", "type", PARTITION_GROUP_NAME_LABEL, PARTITION_LABEL)
-          .register();
-
-  public RaftRequestMetrics(final String partitionName) {
+  public RaftRequestMetrics(final String partitionName, final MeterRegistry registry) {
     super(partitionName);
+    raftMessagesReceived = new HashMap<>(32);
+    raftMessagesSend = Table.simple();
+    this.registry = registry;
   }
 
   public void receivedMessage(final String type) {
-    RAFT_MESSAGES_RECEIVED.labels(type, partitionGroupName, partition).inc();
+    getMessageReceived(type).increment();
   }
 
   public void sendMessage(final String memberId, final String type) {
-    RAFT_MESSAGES_SEND.labels(memberId, type, partitionGroupName, partition).inc();
+    getMessageSent(memberId, type).increment();
+  }
+
+  private Counter getMessageReceived(final String type) {
+    return raftMessagesReceived.computeIfAbsent(
+        type,
+        tpe ->
+            Counter.builder(RAFT_MESSAGE_RECEIVED.getName())
+                .description(RAFT_MESSAGE_RECEIVED.getDescription())
+                .tags(RaftKeyNames.TYPE.asString(), RaftKeyNames.PARTITION_GROUP.asString())
+                .register(registry));
+  }
+
+  private Counter getMessageSent(final String memberId, final String type) {
+    return raftMessagesSend.computeIfAbsent(
+        memberId,
+        type,
+        (member, tpe) ->
+            Counter.builder(RAFT_MESSAGE_SEND.getName())
+                .description(RAFT_MESSAGE_SEND.getDescription())
+                .tags(
+                    RaftKeyNames.TO.asString(),
+                    member,
+                    RaftKeyNames.TYPE.asString(),
+                    tpe,
+                    RaftKeyNames.PARTITION_GROUP.asString(),
+                    partitionGroupName)
+                .register(registry));
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftRequestMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftRequestMetrics.java
@@ -51,7 +51,11 @@ public class RaftRequestMetrics extends RaftMetrics {
         tpe ->
             Counter.builder(RAFT_MESSAGE_RECEIVED.getName())
                 .description(RAFT_MESSAGE_RECEIVED.getDescription())
-                .tags(RaftKeyNames.TYPE.asString(), type, RaftKeyNames.PARTITION_GROUP.asString(), partitionGroupName)
+                .tags(
+                    RaftKeyNames.TYPE.asString(),
+                    type,
+                    RaftKeyNames.PARTITION_GROUP.asString(),
+                    partitionGroupName)
                 .register(registry));
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftRequestMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftRequestMetrics.java
@@ -51,7 +51,7 @@ public class RaftRequestMetrics extends RaftMetrics {
         tpe ->
             Counter.builder(RAFT_MESSAGE_RECEIVED.getName())
                 .description(RAFT_MESSAGE_RECEIVED.getDescription())
-                .tags(RaftKeyNames.TYPE.asString(), RaftKeyNames.PARTITION_GROUP.asString())
+                .tags(RaftKeyNames.TYPE.asString(), type, RaftKeyNames.PARTITION_GROUP.asString(), partitionGroupName)
                 .register(registry));
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftRequestMetricsDoc.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftRequestMetricsDoc.java
@@ -58,7 +58,7 @@ public enum RaftRequestMetricsDoc implements ExtendedMeterDocumentation {
     @Override
     public KeyName[] getKeyNames() {
       return new KeyName[] {
-        RaftKeyNames.TYPE,
+        RaftKeyNames.TO,
         RaftKeyNames.TYPE,
         RaftKeyNames.PARTITION_GROUP,
         PartitionKeyNames.PARTITION

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftRequestMetricsDoc.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftRequestMetricsDoc.java
@@ -8,8 +8,11 @@
 package io.atomix.raft.metrics;
 
 import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
+import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Meter.Type;
 
+@SuppressWarnings("NullableProblems")
 public enum RaftRequestMetricsDoc implements ExtendedMeterDocumentation {
   /** Number of raft requests received */
   RAFT_MESSAGE_RECEIVED {
@@ -27,6 +30,13 @@ public enum RaftRequestMetricsDoc implements ExtendedMeterDocumentation {
     public String getDescription() {
       return "Number of raft requests received";
     }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {
+        RaftKeyNames.TYPE, RaftKeyNames.PARTITION_GROUP, PartitionKeyNames.PARTITION
+      };
+    }
   },
   /** Number of raft requests send */
   RAFT_MESSAGE_SEND {
@@ -43,6 +53,16 @@ public enum RaftRequestMetricsDoc implements ExtendedMeterDocumentation {
     @Override
     public String getDescription() {
       return "Number of raft requests send";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {
+        RaftKeyNames.TYPE,
+        RaftKeyNames.TYPE,
+        RaftKeyNames.PARTITION_GROUP,
+        PartitionKeyNames.PARTITION
+      };
     }
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftRequestMetricsDoc.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftRequestMetricsDoc.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft.metrics;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.micrometer.core.instrument.Meter.Type;
+
+public enum RaftRequestMetricsDoc implements ExtendedMeterDocumentation {
+  /** Number of raft requests received */
+  RAFT_MESSAGE_RECEIVED {
+    @Override
+    public String getName() {
+      return "atomix.raft.messages.received";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Number of raft requests received";
+    }
+  },
+  /** Number of raft requests send */
+  RAFT_MESSAGE_SEND {
+    @Override
+    public String getName() {
+      return "atomix.raft.messages.send";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Number of raft requests send";
+    }
+  }
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -325,7 +325,8 @@ public class RaftPartitionServer implements HealthMonitorable {
         clusterCommunicator,
         requestTimeout,
         snapshotRequestTimeout,
-        configurationChangeTimeout);
+        configurationChangeTimeout,
+        meterRegistry);
   }
 
   public CompletableFuture<Void> stepDown() {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftServerCommunicator.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftServerCommunicator.java
@@ -44,6 +44,7 @@ import io.atomix.raft.protocol.VersionedAppendRequest;
 import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.utils.serializer.Serializer;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -65,7 +66,8 @@ public class RaftServerCommunicator implements RaftServerProtocol {
       final ClusterCommunicationService clusterCommunicator,
       final Duration requestTimeout,
       final Duration snapshotRequestTimeout,
-      final Duration configurationChangeTimeout) {
+      final Duration configurationChangeTimeout,
+      final MeterRegistry meterRegistry) {
     context = new RaftMessageContext(prefix);
     this.serializer = Preconditions.checkNotNull(serializer, "serializer cannot be null");
     this.clusterCommunicator =
@@ -73,7 +75,7 @@ public class RaftServerCommunicator implements RaftServerProtocol {
     this.requestTimeout = requestTimeout;
     this.snapshotRequestTimeout = snapshotRequestTimeout;
     this.configurationChangeTimeout = configurationChangeTimeout;
-    metrics = new RaftRequestMetrics(prefix);
+    metrics = new RaftRequestMetrics(prefix, meterRegistry);
   }
 
   @Override


### PR DESCRIPTION
## Description
migrate RaftRequestMetrics to micrometer. No dashboard changes expected


To be merged in main after #27754
## Related issues
relates #27608
