### PR TITLE
[CPT] Assert that a process instance has an element in a given state for a given amount of times

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
@@ -120,6 +120,78 @@ public interface ProcessInstanceAssert {
   ProcessInstanceAssert hasTerminatedElements(ElementSelector... elementSelectors);
 
   /**
+   * Verifies that the BPMN element is active the given amount of times. The verification fails if
+   * the element is not active or not exactly the given amount of times.
+   *
+   * <p>The assertion waits until the element is active the given amount of times.
+   *
+   * @param elementId the BPMN element ID
+   * @param times the expected amount of times
+   * @return the assertion object
+   */
+  ProcessInstanceAssert hasActiveElement(String elementId, int times);
+
+  /**
+   * Verifies that the BPMN element is active the given amount of times. The verification fails if
+   * the element is not active or not exactly the given amount of times.
+   *
+   * <p>The assertion waits until the element is active the given amount of times.
+   *
+   * @param elementSelector the selectors for the BPMN element
+   * @param times the expected amount of times
+   * @return the assertion object
+   */
+  ProcessInstanceAssert hasActiveElement(ElementSelector elementSelector, int times);
+
+  /**
+   * Verifies that the BPMN element is completed the given amount of times. The verification fails
+   * if the element is not completed or not exactly the given amount of times.
+   *
+   * <p>The assertion waits until the element is completed the given amount of times.
+   *
+   * @param elementId the BPMN element ID
+   * @param times the expected amount of times
+   * @return the assertion object
+   */
+  ProcessInstanceAssert hasCompletedElement(String elementId, int times);
+
+  /**
+   * Verifies that the BPMN element is completed the given amount of times. The verification fails
+   * if the element is not completed or not exactly the given amount of times.
+   *
+   * <p>The assertion waits until the element is completed the given amount of times.
+   *
+   * @param elementSelector the selectors for the BPMN element
+   * @param times the expected amount of times
+   * @return the assertion object
+   */
+  ProcessInstanceAssert hasCompletedElement(ElementSelector elementSelector, int times);
+
+  /**
+   * Verifies that the BPMN element is terminated the given amount of times. The verification fails
+   * if the element is not terminated or not exactly the given amount of times.
+   *
+   * <p>The assertion waits until the element is terminated the given amount of times.
+   *
+   * @param elementId the BPMN element ID
+   * @param times the expected amount of times
+   * @return the assertion object
+   */
+  ProcessInstanceAssert hasTerminatedElement(String elementId, int times);
+
+  /**
+   * Verifies that the BPMN element is terminated the given amount of times. The verification fails
+   * if the element is not terminated or not exactly the given amount of times.
+   *
+   * <p>The assertion waits until the element is terminated the given amount of times.
+   *
+   * @param elementSelector the selectors for the BPMN element
+   * @param times the expected amount of times
+   * @return the assertion object
+   */
+  ProcessInstanceAssert hasTerminatedElement(ElementSelector elementSelector, int times);
+
+  /**
    * Verifies that the process instance has the given variables. The verification fails if at least
    * one variable doesn't exist.
    *

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -123,6 +123,45 @@ public class ProcessInstanceAssertj
   }
 
   @Override
+  public ProcessInstanceAssert hasActiveElement(final String elementId, final int times) {
+    elementAssertj.hasActiveElement(getProcessInstanceKey(), elementId, times);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert hasActiveElement(
+      final ElementSelector elementSelector, final int times) {
+    elementAssertj.hasActiveElement(getProcessInstanceKey(), elementSelector, times);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert hasCompletedElement(final String elementId, final int times) {
+    elementAssertj.hasCompletedElement(getProcessInstanceKey(), elementId, times);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert hasCompletedElement(
+      final ElementSelector elementSelector, final int times) {
+    elementAssertj.hasCompletedElement(getProcessInstanceKey(), elementSelector, times);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert hasTerminatedElement(final String elementId, final int times) {
+    elementAssertj.hasTerminatedElement(getProcessInstanceKey(), elementId, times);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert hasTerminatedElement(
+      final ElementSelector elementSelector, final int times) {
+    elementAssertj.hasTerminatedElement(getProcessInstanceKey(), elementSelector, times);
+    return this;
+  }
+
+  @Override
   public ProcessInstanceAssert hasVariableNames(final String... variableNames) {
     variableAssertj.hasVariableNames(getProcessInstanceKey(), variableNames);
     return this;


### PR DESCRIPTION
## Description

Add new element assertions to verify that a given BPMN element is in a given state for a given amount of times.

```
assertThat(processInstanceEvent).hasActiveElement("A", 2);
assertThat(processInstanceEvent).hasCompletedElement("B", 3);
assertThat(processInstanceEvent).hasTerminatedElement("C", 4);
```

## Related issues

closes #23189 
