### PR TITLE
[Backport stable/8.6] ci: make check-results depend on detect-changes for failure propagation

### DIFF
--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -66,11 +66,8 @@ deny[msg] {
     jobs_that_should_fail_checkresults := { job_id |
         job := input.jobs[job_id]
 
-        # no Unified CI jobs that are part of change detection control flow structure
-        job_id != "detect-changes"
+        # no Unified CI jobs running after (and including) "check-results" job
         job_id != "check-results"
-
-        # no Unified CI jobs running after "check-results" job
         not startswith(job_id, "deploy-")
     }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -572,18 +572,19 @@ jobs:
     timeout-minutes: 3
     permissions:
       checks: read
-    needs:
+    needs:  # BELOW LIST IS IN ALPHABETICAL ORDER
       - actionlint
-      - java-unit-tests
+      - build-platform-frontend
+      - detect-changes
       - docker-checks
       - identity-frontend-tests
       - integration-tests
       - java-checks
-      - build-platform-frontend
-      - zeebe-ci
+      - java-unit-tests
       - optimize-frontend-unit-tests
       - optimize-backend-unit-tests
       - protobuf-checks
+      - zeebe-ci
     steps:
       - uses: actions/checkout@v4
       - name: Check for aborted jobs


### PR DESCRIPTION
# Description
Backport of #27767 to `stable/8.6`.

relates to 
original author: @cmur2