### PR TITLE
[Backport stable/8.7] ci: make check-results depend on detect-changes for failure propagation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -556,18 +556,19 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 3
-    needs:
+    needs:  # BELOW LIST IS IN ALPHABETICAL ORDER
       - actionlint
-      - java-unit-tests
+      - build-platform-frontend
+      - detect-changes
       - docker-checks
       - identity-frontend-tests
       - integration-tests
       - java-checks
-      - build-platform-frontend
-      - zeebe-ci
+      - java-unit-tests
       - optimize-frontend-unit-tests
       - optimize-backend-unit-tests
       - protobuf-checks
+      - zeebe-ci
     steps:
       - uses: actions/checkout@v4
       - name: Check for aborted jobs


### PR DESCRIPTION
# Description
Backport of #27767 to `stable/8.7`.

relates to 
original author: @cmur2