### PR TITLE
Fail test on unexpected user task command rejection

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateUserTaskTest.java
@@ -398,13 +398,13 @@ public class MigrateUserTaskTest {
     // Note that while the user task is migrated, it's properties did not change even though they're
     // different in the target process. Because re-evaluation of these expressions is not yet
     // supported.
-    ENGINE.userTask().ofInstance(processInstanceKey).withKey(userTaskKey).unassign();
     ENGINE
         .userTask()
         .ofInstance(processInstanceKey)
         .withKey(userTaskKey)
         .withAssignee("user2")
         .assign();
+    ENGINE.userTask().ofInstance(processInstanceKey).withKey(userTaskKey).unassign();
     ENGINE
         .userTask()
         .ofInstance(processInstanceKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskUpdateAuthorizationTest.java
@@ -118,6 +118,7 @@ public class UserTaskUpdateAuthorizationTest {
         engine
             .userTask()
             .ofInstance(processInstanceKey)
+            .expectRejection()
             .update(new UserTaskRecord(), user.getUsername());
 
     // then

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
@@ -29,7 +29,10 @@ public final class UserTaskClient {
 
   private static final Function<Long, Record<UserTaskRecordValue>> SUCCESS_SUPPLIER =
       (position) ->
-          RecordingExporter.userTaskRecords().withSourceRecordPosition(position).getFirst();
+          RecordingExporter.userTaskRecords()
+              .onlyEvents()
+              .withSourceRecordPosition(position)
+              .getFirst();
 
   private static final Function<Long, Record<UserTaskRecordValue>> REJECTION_SUPPLIER =
       (position) ->


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The `SUCCESS_SUPPLIER` (success expectation) of the user task test client only failed if no records were written as a result. However, typically we fail it also if a rejection was written.

## Related issues

NA

I encountered this while working on #27525 