### PR TITLE
Migrate process engine metrics to Micrometer

### DIFF
--- a/zeebe/engine/pom.xml
+++ b/zeebe/engine/pom.xml
@@ -136,6 +136,11 @@
       <artifactId>micrometer-core</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-commons</artifactId>
+    </dependency>
+
     <!-- TEST DEPENDENCIES -->
     <dependency>
       <groupId>io.camunda</groupId>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/EngineMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/EngineMetricsDoc.java
@@ -16,7 +16,7 @@ import io.micrometer.core.instrument.Meter.Type;
 @SuppressWarnings("NullableProblems")
 public enum EngineMetricsDoc implements ExtendedMeterDocumentation {
   /** Number of created (root) process instances */
-  ROOT_PROCESS_INSTANCE_COUNT {
+  CREATED_ROOT_PROCESS_INSTANCES {
     private static final KeyName[] KEY_NAMES = new KeyName[] {EngineKeyNames.CREATION_MODE};
 
     @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/EngineMetricsDoc.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/EngineMetricsDoc.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.metrics;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter.Type;
+
+/** {@link EngineMetricsDoc} documents all workflow engine specific metrics. */
+@SuppressWarnings("NullableProblems")
+public enum EngineMetricsDoc implements ExtendedMeterDocumentation {
+  /** Number of created (root) process instances */
+  ROOT_PROCESS_INSTANCE_COUNT {
+    private static final KeyName[] KEY_NAMES = new KeyName[] {EngineKeyNames.CREATION_MODE};
+
+    @Override
+    public String getName() {
+      return "zeebe.process.instance.creations.total";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Number of created (root) process instances";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return KEY_NAMES;
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+
+  /** Number of process element instance events */
+  ELEMENT_INSTANCE_EVENTS {
+    private static final KeyName[] KEY_NAMES =
+        new KeyName[] {
+          EngineKeyNames.ACTION, EngineKeyNames.ELEMENT_TYPE, EngineKeyNames.EVENT_TYPE
+        };
+
+    @Override
+    public String getDescription() {
+      return "Number of process element instance events";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.element.instance.events.total";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return KEY_NAMES;
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+
+  /** Number of executed (root) process instances */
+  EXECUTED_EVENTS {
+    private static final KeyName[] KEY_NAMES =
+        new KeyName[] {
+          EngineKeyNames.ACTION, EngineKeyNames.ELEMENT_TYPE, EngineKeyNames.ORGANIZATION_ID
+        };
+
+    @Override
+    public String getDescription() {
+      return "Number of executed (root) process instances";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.executed.instances.total";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return KEY_NAMES;
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+  /** Number of evaluated DMN elements including required decisions */
+  EVALUATED_DMN_ELEMENTS {
+    private static final KeyName[] KEY_NAMES =
+        new KeyName[] {EngineKeyNames.ACTION, EngineKeyNames.ORGANIZATION_ID};
+
+    @Override
+    public String getDescription() {
+      return "Number of evaluated DMN elements including required decisions";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.evaluated.dmn.elements.total";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return KEY_NAMES;
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  };
+
+  /** Tags/label values possibly used by the engine metrics. */
+  public enum EngineKeyNames implements KeyName {
+    /**
+     * Specifies the way in which the root process instance was created, e.g. at a specific element,
+     * at the default start event, etc.
+     *
+     * <p>See {@link CreationMode} for possible values.
+     */
+    CREATION_MODE {
+      @Override
+      public String asString() {
+        return "creation_mode";
+      }
+    },
+
+    /**
+     * The processing action that modified the given series; see {@link EngineAction} for possible
+     * values.
+     */
+    ACTION {
+      @Override
+      public String asString() {
+        return "action";
+      }
+    },
+
+    /**
+     * The BPMN element type which trigger the modification of the given meter. See {@link
+     * io.camunda.zeebe.protocol.record.value.BpmnElementType} for values.
+     */
+    ELEMENT_TYPE {
+      @Override
+      public String asString() {
+        return "type";
+      }
+    },
+
+    /**
+     * The {@link io.camunda.zeebe.protocol.record.value.BpmnEventType} which triggered the
+     * modification to the meter.
+     */
+    EVENT_TYPE {
+      @Override
+      public String asString() {
+        return "eventType";
+      }
+    },
+
+    /**
+     * Metrics that are annotated with this label are vitally important for usage tracking and
+     * data-based decision-making as part of Camunda's SaaS offering.
+     *
+     * <p>DO NOT REMOVE this label from existing metrics without previous discussion within the
+     * team.
+     *
+     * <p>At the same time, NEW METRICS MAY NOT NEED THIS label. In that case, it is preferable to
+     * not add this label to a metric as Prometheus best practices warn against using labels with a
+     * high cardinality of possible values.
+     */
+    ORGANIZATION_ID {
+      @Override
+      public String asString() {
+        return "organizationId";
+      }
+    }
+  }
+
+  public enum CreationMode {
+    CREATION_AT_DEFAULT_START_EVENT,
+    CREATION_AT_GIVEN_ELEMENT;
+
+    @Override
+    public String toString() {
+      return name().toLowerCase();
+    }
+  }
+
+  public enum EngineAction {
+    ACTIVATED,
+    COMPLETED,
+    TERMINATED,
+    EVALUATED_SUCCESSFULLY,
+    EVALUATED_FAILED;
+
+    @Override
+    public String toString() {
+      return name().toLowerCase();
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
@@ -28,7 +28,8 @@ public final class ProcessEngineMetrics {
       System.getenv().getOrDefault("CAMUNDA_CLOUD_ORGANIZATION_ID", "null");
   private final MeterRegistry registry;
 
-  private final Map<CreationMode, Counter> rootProcessInstances = new EnumMap<>(CreationMode.class);
+  private final Map<CreationMode, Counter> createdRootProcessInstances =
+      new EnumMap<>(CreationMode.class);
   private final Map3D<EngineAction, BpmnElementType, BpmnEventType, Counter> elementInstanceEvents =
       Map3D.ofEnum(EngineAction.class, BpmnElementType.class, BpmnEventType.class, Counter[]::new);
   private final Map<EngineAction, Counter> executedEvents = new EnumMap<>(EngineAction.class);
@@ -44,8 +45,8 @@ public final class ProcessEngineMetrics {
             ? CreationMode.CREATION_AT_GIVEN_ELEMENT
             : CreationMode.CREATION_AT_DEFAULT_START_EVENT;
 
-    rootProcessInstances
-        .computeIfAbsent(creationMode, this::registerRootProcessInstanceCounter)
+    createdRootProcessInstances
+        .computeIfAbsent(creationMode, this::registerCreatedRootProcessInstanceCounter)
         .increment();
   }
 
@@ -120,8 +121,8 @@ public final class ProcessEngineMetrics {
     return eventType != null ? eventType : BpmnEventType.UNSPECIFIED;
   }
 
-  private Counter registerRootProcessInstanceCounter(final CreationMode creationMode) {
-    final var meterDoc = EngineMetricsDoc.ROOT_PROCESS_INSTANCE_COUNT;
+  private Counter registerCreatedRootProcessInstanceCounter(final CreationMode creationMode) {
+    final var meterDoc = EngineMetricsDoc.CREATED_ROOT_PROCESS_INSTANCES;
     return Counter.builder(meterDoc.getName())
         .description(meterDoc.getDescription())
         .tag(EngineKeyNames.CREATION_MODE.asString(), creationMode.toString())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/ProcessEngineMetrics.java
@@ -7,76 +7,35 @@
  */
 package io.camunda.zeebe.engine.metrics;
 
+import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.CreationMode;
+import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.EngineAction;
+import io.camunda.zeebe.engine.metrics.EngineMetricsDoc.EngineKeyNames;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
+import io.camunda.zeebe.util.collection.Map3D;
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.prometheus.client.Counter;
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.Objects;
 
 public final class ProcessEngineMetrics {
 
-  private static final String NAMESPACE = "zeebe";
-
-  /**
-   * Metrics that are annotated with this label are vitally important for usage tracking and
-   * data-based decision-making as part of Camunda's SaaS offering.
-   *
-   * <p>DO NOT REMOVE this label from existing metrics without previous discussion within the team.
-   *
-   * <p>At the same time, NEW METRICS MAY NOT NEED THIS label. In that case, it is preferable to not
-   * add this label to a metric as Prometheus best practices warn against using labels with a high
-   * cardinality of possible values.
-   */
-  private static final String ORGANIZATION_ID_LABEL = "organizationId";
-
-  private static final String PARTITION_LABEL = "partition";
-  private static final String ACTION_LABEL = "action";
-  static final Counter EVALUATED_DMN_ELEMENTS =
-      Counter.build()
-          .namespace(NAMESPACE)
-          .name("evaluated_dmn_elements_total")
-          .help("Number of evaluated DMN elements including required decisions")
-          .labelNames(ORGANIZATION_ID_LABEL, ACTION_LABEL, PARTITION_LABEL)
-          .register();
-  private static final String EVENT_TYPE = "eventType";
-  private static final String TYPE_LABEL = "type";
-  static final Counter EXECUTED_INSTANCES =
-      Counter.build()
-          .namespace(NAMESPACE)
-          .name("executed_instances_total")
-          .help("Number of executed (root) process instances")
-          .labelNames(ORGANIZATION_ID_LABEL, TYPE_LABEL, ACTION_LABEL, PARTITION_LABEL)
-          .register();
+  public static final String EXECUTED_EVENT_ELEMENT_TYPE_VALUE = "ROOT_PROCESS_INSTANCE";
   private static final String ORGANIZATION_ID =
       System.getenv().getOrDefault("CAMUNDA_CLOUD_ORGANIZATION_ID", "null");
-  private static final String ACTION_ACTIVATED = "activated";
-  private static final String ACTION_COMPLETED = "completed";
-  private static final String ACTION_TERMINATED = "terminated";
-  private static final String ACTION_EVALUATED_SUCCESSFULLY = "evaluated_successfully";
-  private static final String ACTION_EVALUATED_FAILED = "evaluated_failed";
-  private static final Counter ELEMENT_INSTANCE_EVENTS =
-      Counter.build()
-          .namespace(NAMESPACE)
-          .name("element_instance_events_total")
-          .help("Number of process element instance events")
-          .labelNames(ACTION_LABEL, TYPE_LABEL, PARTITION_LABEL, EVENT_TYPE)
-          .register();
-  private static final String CREATION_MODE_LABEL = "creation_mode";
-  static final Counter CREATED_PROCESS_INSTANCES =
-      Counter.build()
-          .namespace(NAMESPACE)
-          .name("process_instance_creations_total")
-          .help("Number of created (root) process instances")
-          .labelNames(PARTITION_LABEL, CREATION_MODE_LABEL)
-          .register();
   private final MeterRegistry registry;
-  private final String partitionIdLabel;
 
-  public ProcessEngineMetrics(final MeterRegistry registry, final int partitionId) {
+  private final Map<CreationMode, Counter> rootProcessInstances = new EnumMap<>(CreationMode.class);
+  private final Map3D<EngineAction, BpmnElementType, BpmnEventType, Counter> elementInstanceEvents =
+      Map3D.ofEnum(EngineAction.class, BpmnElementType.class, BpmnEventType.class, Counter[]::new);
+  private final Map<EngineAction, Counter> executedEvents = new EnumMap<>(EngineAction.class);
+  private final Map<EngineAction, Counter> evaluatedDmnElements = new EnumMap<>(EngineAction.class);
+
+  public ProcessEngineMetrics(final MeterRegistry registry) {
     this.registry = Objects.requireNonNull(registry, "must specify a registry");
-    partitionIdLabel = String.valueOf(partitionId);
   }
 
   public void processInstanceCreated(final ProcessInstanceCreationRecord instanceCreationRecord) {
@@ -85,51 +44,67 @@ public final class ProcessEngineMetrics {
             ? CreationMode.CREATION_AT_GIVEN_ELEMENT
             : CreationMode.CREATION_AT_DEFAULT_START_EVENT;
 
-    CREATED_PROCESS_INSTANCES.labels(partitionIdLabel, creationMode.toString()).inc();
-  }
-
-  private void elementInstanceEvent(
-      final String action, final BpmnElementType elementType, final String eventType) {
-    ELEMENT_INSTANCE_EVENTS.labels(action, elementType.name(), partitionIdLabel, eventType).inc();
-  }
-
-  private void increaseRootProcessInstance(final String action) {
-    EXECUTED_INSTANCES
-        .labels(ORGANIZATION_ID, "ROOT_PROCESS_INSTANCE", action, partitionIdLabel)
-        .inc();
+    rootProcessInstances
+        .computeIfAbsent(creationMode, this::registerRootProcessInstanceCounter)
+        .increment();
   }
 
   public void elementInstanceActivated(
       final BpmnElementContext context, final BpmnEventType eventType) {
     final var elementType = context.getBpmnElementType();
-    final String eventTypeName = extractEventTypeName(eventType);
-    elementInstanceEvent(ACTION_ACTIVATED, elementType, eventTypeName);
+    final var eventTypeName = extractEventTypeName(eventType);
+    elementInstanceEvent(EngineAction.ACTIVATED, elementType, eventTypeName);
 
     if (isRootProcessInstance(elementType, context.getParentProcessInstanceKey())) {
-      increaseRootProcessInstance(ACTION_ACTIVATED);
+      increaseRootProcessInstance(EngineAction.ACTIVATED);
     }
   }
 
   public void elementInstanceCompleted(
       final BpmnElementContext context, final BpmnEventType eventType) {
     final var elementType = context.getBpmnElementType();
-    final String eventTypeName = extractEventTypeName(eventType);
-    elementInstanceEvent(ACTION_COMPLETED, elementType, eventTypeName);
+    final var eventTypeName = extractEventTypeName(eventType);
+    elementInstanceEvent(EngineAction.COMPLETED, elementType, eventTypeName);
 
     if (isRootProcessInstance(elementType, context.getParentProcessInstanceKey())) {
-      increaseRootProcessInstance(ACTION_COMPLETED);
+      increaseRootProcessInstance(EngineAction.COMPLETED);
     }
   }
 
   public void elementInstanceTerminated(
       final BpmnElementContext context, final BpmnEventType eventType) {
     final var elementType = context.getBpmnElementType();
-    final String eventTypeName = extractEventTypeName(eventType);
-    elementInstanceEvent(ACTION_TERMINATED, elementType, eventTypeName);
+    final var eventTypeName = extractEventTypeName(eventType);
+    elementInstanceEvent(EngineAction.TERMINATED, elementType, eventTypeName);
 
     if (isRootProcessInstance(elementType, context.getParentProcessInstanceKey())) {
-      increaseRootProcessInstance(ACTION_TERMINATED);
+      increaseRootProcessInstance(EngineAction.TERMINATED);
     }
+  }
+
+  public void increaseSuccessfullyEvaluatedDmnElements(final int amount) {
+    increaseEvaluatedDmnElements(EngineAction.EVALUATED_SUCCESSFULLY, amount);
+  }
+
+  public void increaseFailedEvaluatedDmnElements(final int amount) {
+    increaseEvaluatedDmnElements(EngineAction.EVALUATED_FAILED, amount);
+  }
+
+  private void elementInstanceEvent(
+      final EngineAction action, final BpmnElementType elementType, final BpmnEventType eventType) {
+    elementInstanceEvents
+        .computeIfAbsent(action, elementType, eventType, this::registerElementInstanceEventCounter)
+        .increment();
+  }
+
+  private void increaseRootProcessInstance(final EngineAction action) {
+    executedEvents.computeIfAbsent(action, this::registerExecutedEventCounter).increment();
+  }
+
+  private void increaseEvaluatedDmnElements(final EngineAction action, final int amount) {
+    evaluatedDmnElements
+        .computeIfAbsent(action, this::registerEvaluatedDmnElementCounter)
+        .increment(amount);
   }
 
   private boolean isProcessInstance(final BpmnElementType elementType) {
@@ -141,29 +116,48 @@ public final class ProcessEngineMetrics {
     return isProcessInstance(elementType) && parentProcessInstanceKey == -1;
   }
 
-  public void increaseSuccessfullyEvaluatedDmnElements(final int amount) {
-    increaseEvaluatedDmnElements(ACTION_EVALUATED_SUCCESSFULLY, amount);
+  private BpmnEventType extractEventTypeName(final BpmnEventType eventType) {
+    return eventType != null ? eventType : BpmnEventType.UNSPECIFIED;
   }
 
-  public void increaseFailedEvaluatedDmnElements(final int amount) {
-    increaseEvaluatedDmnElements(ACTION_EVALUATED_FAILED, amount);
+  private Counter registerRootProcessInstanceCounter(final CreationMode creationMode) {
+    final var meterDoc = EngineMetricsDoc.ROOT_PROCESS_INSTANCE_COUNT;
+    return Counter.builder(meterDoc.getName())
+        .description(meterDoc.getDescription())
+        .tag(EngineKeyNames.CREATION_MODE.asString(), creationMode.toString())
+        .tag(EngineKeyNames.ORGANIZATION_ID.asString(), ORGANIZATION_ID)
+        .register(registry);
   }
 
-  private void increaseEvaluatedDmnElements(final String action, final int amount) {
-    EVALUATED_DMN_ELEMENTS.labels(ORGANIZATION_ID, action, partitionIdLabel).inc(amount);
+  private Counter registerElementInstanceEventCounter(
+      final EngineAction engineAction,
+      final BpmnElementType bpmnElementType,
+      final BpmnEventType bpmnEventType) {
+    final var meterDoc = EngineMetricsDoc.ELEMENT_INSTANCE_EVENTS;
+    return Counter.builder(meterDoc.getName())
+        .description(meterDoc.getDescription())
+        .tag(EngineKeyNames.ACTION.asString(), engineAction.toString())
+        .tag(EngineKeyNames.ELEMENT_TYPE.asString(), bpmnElementType.name())
+        .tag(EngineKeyNames.EVENT_TYPE.asString(), bpmnEventType.name())
+        .register(registry);
   }
 
-  private String extractEventTypeName(final BpmnEventType eventType) {
-    return eventType != null ? eventType.name() : BpmnEventType.UNSPECIFIED.name();
+  private Counter registerExecutedEventCounter(final EngineAction engineAction) {
+    final var meterDoc = EngineMetricsDoc.EXECUTED_EVENTS;
+    return Counter.builder(meterDoc.getName())
+        .description(meterDoc.getDescription())
+        .tag(EngineKeyNames.ACTION.asString(), engineAction.toString())
+        .tag(EngineKeyNames.ELEMENT_TYPE.asString(), EXECUTED_EVENT_ELEMENT_TYPE_VALUE)
+        .tag(EngineKeyNames.ORGANIZATION_ID.asString(), ORGANIZATION_ID)
+        .register(registry);
   }
 
-  private enum CreationMode {
-    CREATION_AT_DEFAULT_START_EVENT,
-    CREATION_AT_GIVEN_ELEMENT;
-
-    @Override
-    public String toString() {
-      return name().toLowerCase();
-    }
+  private Counter registerEvaluatedDmnElementCounter(final EngineAction engineAction) {
+    final var meterDoc = EngineMetricsDoc.EVALUATED_DMN_ELEMENTS;
+    return Counter.builder(meterDoc.getName())
+        .description(meterDoc.getDescription())
+        .tag(EngineKeyNames.ACTION.asString(), engineAction.toString())
+        .tag(EngineKeyNames.ORGANIZATION_ID.asString(), ORGANIZATION_ID)
+        .register(registry);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -110,8 +110,7 @@ public final class EngineProcessors {
 
     final var jobMetrics = new JobMetrics(partitionId);
     final var processEngineMetrics =
-        new ProcessEngineMetrics(
-            typedRecordProcessorContext.getMeterRegistry(), processingState.getPartitionId());
+        new ProcessEngineMetrics(typedRecordProcessorContext.getMeterRegistry());
 
     subscriptionCommandSender.setWriters(writers);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -66,6 +66,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import io.camunda.zeebe.util.FeatureFlags;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -310,6 +311,14 @@ public final class EngineRule extends ExternalResource {
 
   public StreamClock getStreamClock(final int partitionId) {
     return environmentRule.getStreamClock(partitionId);
+  }
+
+  public MeterRegistry getMeterRegistry() {
+    return getMeterRegistry(PARTITION_ID);
+  }
+
+  public MeterRegistry getMeterRegistry(final int partitionId) {
+    return environmentRule.getMeterRegistry(partitionId);
   }
 
   public long getLastProcessedPosition() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.stream.api.StreamClock;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.stream.impl.StreamProcessorBuilder;
 import io.camunda.zeebe.stream.impl.StreamProcessorListener;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.Random;
@@ -142,6 +143,10 @@ public class StreamProcessingComposite implements CommandWriter {
 
   public StreamClock getStreamClock(final int partitionId) {
     return streams.getStreamClock(getLogName(partitionId));
+  }
+
+  public MeterRegistry getMeterRegistry(final int partitionId) {
+    return streams.getMeterRegistry(getLogName(partitionId));
   }
 
   public MutableProcessingState getProcessingState() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.stream.impl.StreamProcessorMode;
 import io.camunda.zeebe.test.util.AutoCloseableRule;
 import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.allocation.DirectBufferAllocator;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.io.File;
 import java.io.IOException;
 import java.util.Optional;
@@ -172,6 +173,10 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
 
   public StreamClock getStreamClock(final int partitionId) {
     return streamProcessingComposite.getStreamClock(partitionId);
+  }
+
+  public MeterRegistry getMeterRegistry(final int partitionId) {
+    return streamProcessingComposite.getMeterRegistry(partitionId);
   }
 
   public TestLogStream getLogStream(final int partitionId) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -54,6 +54,9 @@ import io.camunda.zeebe.stream.impl.TypedEventRegistry;
 import io.camunda.zeebe.test.util.AutoCloseableRule;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.FileUtil;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -277,6 +280,13 @@ public final class TestStreams {
     final var streamProcessorListeners = new ArrayList<StreamProcessorListener>();
     streamProcessorListenerOpt.ifPresent(streamProcessorListeners::add);
 
+    final var meterRegistry = new SimpleMeterRegistry();
+    meterRegistry
+        .config()
+        .commonTags(
+            Tags.of(
+                PartitionKeyNames.PARTITION.asString(), String.valueOf(stream.getPartitionId())));
+
     final var builder =
         StreamProcessor.builder()
             .logStream(stream)
@@ -291,7 +301,7 @@ public final class TestStreams {
             .streamProcessorMode(streamProcessorMode)
             .maxCommandsInBatch(maxCommandsInBatch)
             .partitionCommandSender(mock(InterPartitionCommandSender.class))
-            .meterRegistry(new SimpleMeterRegistry())
+            .meterRegistry(meterRegistry)
             .clock(StreamClock.controllable(clock));
 
     processorConfiguration.accept(builder);
@@ -315,7 +325,8 @@ public final class TestStreams {
             storage,
             snapshot,
             streamClockRef.get(),
-            processingStateRef.get());
+            processingStateRef.get(),
+            meterRegistry);
     streamContextMap.put(logName, processorContext);
     closeables.manage(processorContext);
 
@@ -338,6 +349,10 @@ public final class TestStreams {
   public void resumeProcessing(final String streamName) {
     streamContextMap.get(streamName).streamProcessor.resumeProcessing();
     LOG.info("Resume processing for stream {}", streamName);
+  }
+
+  public MeterRegistry getMeterRegistry(final String streamName) {
+    return streamContextMap.get(streamName).meterRegistry;
   }
 
   public void resetLog() {
@@ -513,6 +528,7 @@ public final class TestStreams {
     private final Path snapshotPath;
     private final StreamClock streamClock;
     private final MutableProcessingState processingState;
+    private final MeterRegistry meterRegistry;
     private boolean closed = false;
 
     private ProcessorContext(
@@ -521,13 +537,15 @@ public final class TestStreams {
         final Path runtimePath,
         final Path snapshotPath,
         final StreamClock streamClock,
-        final MutableProcessingState processingState) {
+        final MutableProcessingState processingState,
+        final MeterRegistry meterRegistry) {
       this.streamProcessor = streamProcessor;
       this.zeebeDb = zeebeDb;
       this.runtimePath = runtimePath;
       this.snapshotPath = snapshotPath;
       this.streamClock = streamClock;
       this.processingState = processingState;
+      this.meterRegistry = meterRegistry;
     }
 
     public static ProcessorContext createStreamContext(
@@ -536,9 +554,16 @@ public final class TestStreams {
         final Path runtimePath,
         final Path snapshotPath,
         final StreamClock streamClock,
-        final MutableProcessingState processingState) {
+        final MutableProcessingState processingState,
+        final MeterRegistry meterRegistry) {
       return new ProcessorContext(
-          streamProcessor, zeebeDb, runtimePath, snapshotPath, streamClock, processingState);
+          streamProcessor,
+          zeebeDb,
+          runtimePath,
+          snapshotPath,
+          streamClock,
+          processingState,
+          meterRegistry);
     }
 
     public void snapshot() {


### PR DESCRIPTION
## Description

This PR migrates the `ProcessEngineMetrics` to Micrometer. As they were all counters, none of the dashboards had to be changed (since no names or labels have changed).

I introduced a new enum - `EngineAction` - to replace the usage of plain string constants for the actions that was previously used.

## Related issues

related to #26078
