### PR TITLE
Backport CI linter and fixes to stable/8.7

### DIFF
--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -50,8 +50,14 @@ runs:
         secrets: |
           secret/data/products/zeebe/ci/ci-analytics gcloud_sa_key;
 
+    - name: Check secrets availability
+      if: ${{ steps.secrets.outputs.gcloud_sa_key == '' }}
+      shell: bash
+      run: echo "::warning::Not sending any CI health metrics since no access to GHA secrets!"
+
     - name: Get build duration in milliseconds
       id: get-build-duration-millis
+      if: ${{ steps.secrets.outputs.gcloud_sa_key != '' }}
       shell: bash
       run: |
         duration=$(expr $(date +'%s') - $(date -r "$GITHUB_ACTION_PATH" +"%s"))

--- a/.github/conftest-gha-best-practices.rego
+++ b/.github/conftest-gha-best-practices.rego
@@ -44,6 +44,39 @@ deny[msg] {
 }
 
 deny[msg] {
+    # only enforced on Unified CI since it is specific to detect-changes job
+    input.name == "CI"
+
+    count(get_jobs_not_needing_detectchanges(input.jobs)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs in Unified CI that don't depend on detect-changes job! Affected job IDs: %s",
+        [concat(", ", get_jobs_not_needing_detectchanges(input.jobs))])
+}
+
+deny[msg] {
+    # only enforced on Unified CI since it is specific to check-results job
+    input.name == "CI"
+
+    jobs_that_should_fail_checkresults := { job_id |
+        job := input.jobs[job_id]
+
+        # no Unified CI jobs that are part of change detection control flow structure
+        job_id != "detect-changes"
+        job_id != "check-results"
+
+        # no Unified CI jobs running after "check-results" job
+        not startswith(job_id, "deploy-")
+    }
+
+    jobs_that_actually_fail_checkresults := {x | x := input.jobs["check-results"].needs[_]}
+
+    jobs_that_should_fail_checkresults != jobs_that_actually_fail_checkresults
+
+    msg := sprintf("There are GitHub Actions jobs in Unified CI that check-results job doesn't depend on! Affected job IDs: %s",
+        [concat(", ", jobs_that_should_fail_checkresults - jobs_that_actually_fail_checkresults)])
+}
+
+deny[msg] {
     # The "on" key gets transformed by conftest into "true" due to some legacy
     # YAML standards, see https://stackoverflow.com/q/42283732/2148786 - so
     # "on.push" becomes "true.push" which is why below statements use "true"
@@ -149,5 +182,25 @@ get_jobs_with_usesbutnosecrets(jobInput) = jobs_with_usesbutnosecrets {
         # check jobs that invoke other reusable workflows but don't specify "secrets: inherit"
         job.uses
         not job.secrets
+    }
+}
+
+get_jobs_not_needing_detectchanges(jobInput) = jobs_not_needing_detectchanges {
+    jobs_not_needing_detectchanges := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on Unified CI jobs that are part of change detection control flow structure
+        job_id != "detect-changes"
+        job_id != "check-results"
+
+        # not enforced on Unified CI jobs running after "check-results" job
+        not startswith(job_id, "deploy-")
+
+        # check if job declares dependency on "detect-changes" job anywhere
+        job_needs_detectchanges := { need |
+            need := job.needs[_]
+            need == "detect-changes"
+        }
+        count(job_needs_detectchanges) == 0
     }
 }

--- a/.github/conftest-gha-best-practices.rego
+++ b/.github/conftest-gha-best-practices.rego
@@ -114,6 +114,16 @@ deny[msg] {
         [concat(", ", get_jobs_with_setupnodecaching(input.jobs))])
 }
 
+deny[msg] {
+    # This rule prevents usage of forbidden "self-hosted" label in a "runs-on"
+    # clause as described by Infra team: https://confluence.camunda.com/x/_IlZBw
+
+    count(get_jobs_with_selfhostedlabel(input.jobs)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs using forbidden 'self-hosted' label in 'runs-on' clause! Affected job IDs: %s",
+        [concat(", ", get_jobs_with_selfhostedlabel(input.jobs))])
+}
+
 warn[msg] {
     # This rule warns in situations where no "secrets: inherit" is passed on
     # calling other workflows as this is usually an oversight that prevents
@@ -183,6 +193,31 @@ get_jobs_with_setupnodecaching(jobInput) = jobs_with_setupnodecaching {
             step["with"].cache == "yarn"
         }
         count(setupnodecaching_steps) > 0
+    }
+}
+
+get_jobs_with_selfhostedlabel(jobInput) = jobs_with_selfhostedlabel1 | jobs_with_selfhostedlabel2 {
+    # expression to check for jobs using "runs-on: self-hosted" notation (without array)
+    jobs_with_selfhostedlabel1 := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
+        not job.uses
+
+        job["runs-on"] == "self-hosted"
+    }
+    # expression to check for jobs using "runs-on: [self-hosted, ...]" notation (array)
+    jobs_with_selfhostedlabel2 := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
+        not job.uses
+
+        selfhosted_labels := { label |
+            label := job["runs-on"][_]
+            label == "self-hosted"
+        }
+        count(selfhosted_labels) > 0
     }
 }
 

--- a/.github/conftest-gha-best-practices.rego
+++ b/.github/conftest-gha-best-practices.rego
@@ -1,5 +1,8 @@
 package main
 
+# This file contains rules checking GitHub Action workflow files for
+# opinionated best practices in the C8 monorepo.
+
 # The `input` variable is a data structure that contains a YAML file's contents
 # as objects and arrays. See https://www.openpolicyagent.org/docs/latest/philosophy/#how-does-opa-work
 
@@ -11,79 +14,6 @@ deny[msg] {
     not input.name
 
     msg := "This GitHub Actions workflow has no name property!"
-}
-
-deny[msg] {
-    # only enforced on Unified CI and related workflows
-    input.name == ["CI", "Zeebe CI"][_]
-
-    count(get_jobs_without_timeoutminutes(input.jobs)) > 0
-
-    msg := sprintf("There are GitHub Actions jobs without timeout-minutes! Affected job IDs: %s",
-        [concat(", ", get_jobs_without_timeoutminutes(input.jobs))])
-}
-
-warn[msg] {
-    # only enforced on Unified CI and related workflows
-    input.name == ["CI", "Zeebe CI"][_]
-
-    count(get_jobs_with_timeoutminutes_higher_than(input.jobs, 15)) > 0
-
-    msg := sprintf("There are GitHub Actions jobs with too high (>15) timeout-minutes! Affected job IDs: %s",
-        [concat(", ", get_jobs_with_timeoutminutes_higher_than(input.jobs, 15))])
-}
-
-deny[msg] {
-    # only enforced on Unified CI and related workflows
-    input.name == ["CI", "Zeebe CI"][_]
-
-    count(get_jobs_without_cihealth(input.jobs)) > 0
-
-    msg := sprintf("There are GitHub Actions jobs that don't send CI Health metrics! Affected job IDs: %s",
-        [concat(", ", get_jobs_without_cihealth(input.jobs))])
-}
-
-deny[msg] {
-    # only enforced on Unified CI since it is specific to detect-changes job
-    input.name == "CI"
-
-    count(get_jobs_not_needing_detectchanges(input.jobs)) > 0
-
-    msg := sprintf("There are GitHub Actions jobs in Unified CI that don't depend on detect-changes job! Affected job IDs: %s",
-        [concat(", ", get_jobs_not_needing_detectchanges(input.jobs))])
-}
-
-deny[msg] {
-    # only enforced on Unified CI and related workflows
-    input.name == ["CI", "Tasklist Frontend Jobs", "Zeebe CI"][_]
-
-    count(get_jobs_without_permissions(input.jobs)) > 0
-
-    msg := sprintf("There are GitHub Actions jobs using default GITHUB_TOKEN permissions which are too wide! Affected job IDs: %s",
-        [concat(", ", get_jobs_without_permissions(input.jobs))])
-}
-
-deny[msg] {
-    # only enforced on Unified CI since it is specific to check-results job
-    input.name == "CI"
-
-    jobs_that_should_fail_checkresults := { job_id |
-        job := input.jobs[job_id]
-
-        # no Unified CI jobs that are part of change detection control flow structure
-        job_id != "detect-changes"
-        job_id != "check-results"
-
-        # no Unified CI jobs running after "check-results" job
-        not startswith(job_id, "deploy-")
-    }
-
-    jobs_that_actually_fail_checkresults := {x | x := input.jobs["check-results"].needs[_]}
-
-    jobs_that_should_fail_checkresults != jobs_that_actually_fail_checkresults
-
-    msg := sprintf("There are GitHub Actions jobs in Unified CI that check-results job doesn't depend on! Affected job IDs: %s",
-        [concat(", ", jobs_that_should_fail_checkresults - jobs_that_actually_fail_checkresults)])
 }
 
 deny[msg] {
@@ -137,52 +67,6 @@ warn[msg] {
 
 ###########################   RULE HELPERS   ##################################
 
-get_jobs_without_timeoutminutes(jobInput) = jobs_without_timeoutminutes {
-    jobs_without_timeoutminutes := { job_id |
-        job := jobInput[job_id]
-
-        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
-        not job.uses
-
-        # check if there is timeout-minutes specified
-        not job["timeout-minutes"]
-    }
-}
-
-get_jobs_with_timeoutminutes_higher_than(jobInput, max_timeout) = jobs_without_timeoutminutes {
-    jobs_without_timeoutminutes := { job_id |
-        job := jobInput[job_id]
-
-        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
-        not job.uses
-
-        # check if timeout-minutes is higher than allowed maximum
-        job["timeout-minutes"] > max_timeout
-    }
-}
-
-get_jobs_without_cihealth(jobInput) = jobs_without_cihealth {
-    jobs_without_cihealth := { job_id |
-        job := jobInput[job_id]
-
-        # not enforced on "special" jobs needed for control flow in Unified CI
-        job_id != "detect-changes"
-        job_id != "check-results"
-        job_id != "test-summary"
-
-        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
-        not job.uses
-
-        # check that there is at least one step that invokes CI Health metric submission helper action
-        cihealth_steps := { step |
-            step := job.steps[_]
-            step.name == "Observe build status"
-            step.uses == "./.github/actions/observe-build-status"
-        }
-        count(cihealth_steps) < 1
-    }
-}
-
 get_jobs_with_setupnodecaching(jobInput) = jobs_with_setupnodecaching {
     jobs_with_setupnodecaching := { job_id |
         job := jobInput[job_id]
@@ -228,36 +112,5 @@ get_jobs_with_usesbutnosecrets(jobInput) = jobs_with_usesbutnosecrets {
         # check jobs that invoke other reusable workflows but don't specify "secrets: inherit"
         job.uses
         not job.secrets
-    }
-}
-
-get_jobs_not_needing_detectchanges(jobInput) = jobs_not_needing_detectchanges {
-    jobs_not_needing_detectchanges := { job_id |
-        job := jobInput[job_id]
-
-        # not enforced on Unified CI jobs that are part of change detection control flow structure
-        job_id != "detect-changes"
-        job_id != "check-results"
-
-        # not enforced on Unified CI jobs running after "check-results" job
-        not startswith(job_id, "deploy-")
-
-        # check if job declares dependency on "detect-changes" job anywhere
-        job_needs_detectchanges := { need |
-            need := job.needs[_]
-            need == "detect-changes"
-        }
-        count(job_needs_detectchanges) == 0
-    }
-}
-
-get_jobs_without_permissions(jobInput) = jobs_without_permissions {
-    jobs_without_permissions := { job_id |
-        job := jobInput[job_id]
-
-        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
-        not job.uses
-
-        not job.permissions
     }
 }

--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -66,11 +66,8 @@ deny[msg] {
     jobs_that_should_fail_checkresults := { job_id |
         job := input.jobs[job_id]
 
-        # no Unified CI jobs that are part of change detection control flow structure
-        job_id != "detect-changes"
+        # no Unified CI jobs running after (and including) "check-results" job
         job_id != "check-results"
-
-        # no Unified CI jobs running after "check-results" job
         not startswith(job_id, "deploy-")
     }
 

--- a/.github/conftest-unified-ci-rules.rego
+++ b/.github/conftest-unified-ci-rules.rego
@@ -1,0 +1,162 @@
+package main
+
+# This file contains rules checking GHA workflow files of the Unified CI to be
+# aligned with the inclusion criteria and best practices:
+# See https://github.com/camunda/camunda/wiki/CI-&-Automation#unified-ci
+
+unified_ci_workflow_names = ["CI", "Tasklist Frontend Jobs", "Zeebe CI"]
+
+# The `input` variable is a data structure that contains a YAML file's contents
+# as objects and arrays. See https://www.openpolicyagent.org/docs/latest/philosophy/#how-does-opa-work
+
+deny[msg] {
+    # only enforced on Unified CI and related workflows
+    input.name == unified_ci_workflow_names[_]
+
+    count(get_jobs_without_timeoutminutes(input.jobs)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs without timeout-minutes! Affected job IDs: %s",
+        [concat(", ", get_jobs_without_timeoutminutes(input.jobs))])
+}
+
+warn[msg] {
+    # only enforced on Unified CI and related workflows
+    input.name == unified_ci_workflow_names[_]
+
+    count(get_jobs_with_timeoutminutes_higher_than(input.jobs, 15)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs with too high (>15) timeout-minutes! Affected job IDs: %s",
+        [concat(", ", get_jobs_with_timeoutminutes_higher_than(input.jobs, 15))])
+}
+
+deny[msg] {
+    # only enforced on Unified CI and related workflows
+    input.name == unified_ci_workflow_names[_]
+
+    count(get_jobs_without_cihealth(input.jobs)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs that don't send CI Health metrics! Affected job IDs: %s",
+        [concat(", ", get_jobs_without_cihealth(input.jobs))])
+}
+
+deny[msg] {
+    # only enforced on Unified CI and related workflows
+    input.name == unified_ci_workflow_names[_]
+
+    count(get_jobs_without_permissions(input.jobs)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs using default GITHUB_TOKEN permissions which are too wide! Affected job IDs: %s",
+        [concat(", ", get_jobs_without_permissions(input.jobs))])
+}
+
+deny[msg] {
+    # only enforced on Unified CI since it is specific to detect-changes job
+    input.name == "CI"
+
+    count(get_jobs_not_needing_detectchanges(input.jobs)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs in Unified CI that don't depend on detect-changes job! Affected job IDs: %s",
+        [concat(", ", get_jobs_not_needing_detectchanges(input.jobs))])
+}
+
+deny[msg] {
+    # only enforced on Unified CI since it is specific to check-results job
+    input.name == "CI"
+
+    jobs_that_should_fail_checkresults := { job_id |
+        job := input.jobs[job_id]
+
+        # no Unified CI jobs that are part of change detection control flow structure
+        job_id != "detect-changes"
+        job_id != "check-results"
+
+        # no Unified CI jobs running after "check-results" job
+        not startswith(job_id, "deploy-")
+    }
+
+    jobs_that_actually_fail_checkresults := {x | x := input.jobs["check-results"].needs[_]}
+
+    jobs_that_should_fail_checkresults != jobs_that_actually_fail_checkresults
+
+    msg := sprintf("There are GitHub Actions jobs in Unified CI that check-results job doesn't depend on! Affected job IDs: %s",
+        [concat(", ", jobs_that_should_fail_checkresults - jobs_that_actually_fail_checkresults)])
+}
+
+###########################   RULE HELPERS   ##################################
+
+get_jobs_without_timeoutminutes(jobInput) = jobs_without_timeoutminutes {
+    jobs_without_timeoutminutes := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
+        not job.uses
+
+        # check if there is timeout-minutes specified
+        not job["timeout-minutes"]
+    }
+}
+
+get_jobs_with_timeoutminutes_higher_than(jobInput, max_timeout) = jobs_without_timeoutminutes {
+    jobs_without_timeoutminutes := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
+        not job.uses
+
+        # check if timeout-minutes is higher than allowed maximum
+        job["timeout-minutes"] > max_timeout
+    }
+}
+
+get_jobs_without_cihealth(jobInput) = jobs_without_cihealth {
+    jobs_without_cihealth := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on "special" jobs needed for control flow in Unified CI
+        job_id != "detect-changes"
+        job_id != "check-results"
+        job_id != "test-summary"
+
+        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
+        not job.uses
+
+        # check that there is at least one step that invokes CI Health metric submission helper action
+        cihealth_steps := { step |
+            step := job.steps[_]
+            step.name == "Observe build status"
+            step.uses == "./.github/actions/observe-build-status"
+        }
+        count(cihealth_steps) < 1
+    }
+}
+
+get_jobs_without_permissions(jobInput) = jobs_without_permissions {
+    jobs_without_permissions := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
+        not job.uses
+
+        not job.permissions
+    }
+}
+
+get_jobs_not_needing_detectchanges(jobInput) = jobs_not_needing_detectchanges {
+    jobs_not_needing_detectchanges := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on Unified CI jobs that are part of change detection control flow structure
+        job_id != "detect-changes"
+        job_id != "check-results"
+
+        # not enforced on Unified CI jobs running after "check-results" job
+        not startswith(job_id, "deploy-")
+
+        # check if job declares dependency on "detect-changes" job anywhere
+        job_needs_detectchanges := { need |
+            need := job.needs[_]
+            need == "detect-changes"
+        }
+        count(job_needs_detectchanges) == 0
+    }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           ./actionlint -shellcheck '' -ignore 'property "vault_.+" is not defined in object type' -ignore 'object type "{}" cannot be filtered by object filtering `.*` since it has no object element'
       - run: |
           curl -s -L "https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz" | tar xvz conftest
-          ./conftest test -o github --policy .github/conftest-*.rego .github/workflows/*.yml
+          ./conftest test -o github --policy .github .github/workflows/*.yml
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
       protobuf-changes: ${{ steps.filter.outputs.protobuf-changes }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
       # Detect changes against the base branch
@@ -53,6 +55,7 @@ jobs:
     needs: [detect-changes]
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions: {}  # GITHUB_TOKEN unused in this job
     env:
       # renovate: datasource=github-releases depName=rhysd/actionlint
       ACTIONLINT_VERSION: '1.7.7'
@@ -82,6 +85,7 @@ jobs:
     needs: [detect-changes]
     name: Java checks
     timeout-minutes: 15
+    permissions: {}  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-8-default
     steps:
       - uses: actions/checkout@v4
@@ -107,7 +111,8 @@ jobs:
     if: needs.detect-changes.outputs.frontend-changes == 'true'
     needs: [detect-changes]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
+    permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-zeebe
@@ -146,6 +151,7 @@ jobs:
     needs: [detect-changes]
     runs-on: gcp-perf-core-16-default
     timeout-minutes: 30
+    permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-zeebe
@@ -197,6 +203,7 @@ jobs:
     name: "[IT] ${{ matrix.name }}"
     needs: [ detect-changes ]
     timeout-minutes: 25
+    permissions: {}  # GITHUB_TOKEN unused in this job
     runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
@@ -295,6 +302,8 @@ jobs:
     needs: [ detect-changes ]
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      security-events: write
     services:
       # local registry is used as this job needs to push as it builds multi-platform images
       registry:
@@ -377,6 +386,7 @@ jobs:
     needs: [detect-changes]
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions: {}  # GITHUB_TOKEN unused in this job
     defaults:
       run:
         working-directory: identity/client
@@ -421,6 +431,7 @@ jobs:
     needs: [detect-changes]
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions: {}  # GITHUB_TOKEN unused in this job
     defaults:
       run:
         working-directory: optimize/client
@@ -466,6 +477,7 @@ jobs:
     needs: [detect-changes]
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions: {}  # GITHUB_TOKEN unused in this job
     env:
       LIMITS_CPU: 4
     steps:
@@ -501,17 +513,19 @@ jobs:
 
   protobuf-checks:
     name: "Protobuf Backwards Compatibility"
-    timeout-minutes: 10
     needs: [detect-changes]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       # set the comparison based on the type of workflow trigger:
       #   - for PRs, we use the last commit of the base
       #   - for merge queues, we use the last commit of the target merge queue
       #   - for a push, we use the last commit before the push
       BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
-    if: |
-      needs.detect-changes.outputs.protobuf-changes == 'true'
+    if: needs.detect-changes.outputs.protobuf-changes == 'true'
     steps:
       - uses: actions/checkout@v4
       - id: pr-body
@@ -556,6 +570,8 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 3
+    permissions:
+      checks: read
     needs:  # BELOW LIST IS IN ALPHABETICAL ORDER
       - actionlint
       - build-platform-frontend
@@ -584,6 +600,7 @@ jobs:
     needs: [ check-results ]
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions: {}  # GITHUB_TOKEN unused in this job
     if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/stable/8.7'
     concurrency:
       group: deploy-maven-snapshot
@@ -655,6 +672,7 @@ jobs:
     needs: [ docker-checks, check-results ]
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions: {}  # GITHUB_TOKEN unused in this job
     if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/stable/8.7'
     concurrency:
       group: deploy-camunda-docker-snapshot

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
           ./actionlint -shellcheck '' -ignore 'property "vault_.+" is not defined in object type' -ignore 'object type "{}" cannot be filtered by object filtering `.*` since it has no object element'
       - run: |
           curl -s -L "https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz" | tar xvz conftest
-          ./conftest test -o github --policy .github .github/workflows/*.yml
+          ./conftest test -o github --policy .github .github/workflows/*.y*ml
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/tasklist-ci-fe-reusable.yml
+++ b/.github/workflows/tasklist-ci-fe-reusable.yml
@@ -7,6 +7,8 @@ jobs:
   fe-type-check:
     name: Type check
     runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions: {}  # GITHUB_TOKEN unused in this job
     defaults:
       run:
         working-directory: tasklist/client
@@ -35,6 +37,8 @@ jobs:
   fe-eslint:
     name: ESLint
     runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions: {}  # GITHUB_TOKEN unused in this job
     defaults:
       run:
         working-directory: tasklist/client
@@ -63,6 +67,8 @@ jobs:
   fe-stylelint:
     name: Stylelint
     runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions: {}  # GITHUB_TOKEN unused in this job
     defaults:
       run:
         working-directory: tasklist/client
@@ -91,6 +97,8 @@ jobs:
   fe-tests:
     name: Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}  # GITHUB_TOKEN unused in this job
     defaults:
       run:
         working-directory: tasklist/client
@@ -119,6 +127,8 @@ jobs:
   fe-visual-regression-tests:
     name: Visual regression tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions: {}  # GITHUB_TOKEN unused in this job
     container:
       image: mcr.microsoft.com/playwright:v1.49.1
       options: --user 1001:1000
@@ -162,6 +172,8 @@ jobs:
   fe-a11y-tests:
     name: a11y tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions: {}  # GITHUB_TOKEN unused in this job
     container:
       image: mcr.microsoft.com/playwright:v1.49.1
       options: --user 1001:1000

--- a/.github/workflows/tasklist-ci.yml
+++ b/.github/workflows/tasklist-ci.yml
@@ -58,6 +58,7 @@ jobs:
               echo 'src_changed=true' >> $GITHUB_OUTPUT
             fi
           fi
+
   run-build:
     name: run-build
     uses: ./.github/workflows/tasklist-ci-build-reusable.yml
@@ -77,3 +78,4 @@ jobs:
     needs: check_changes
     if: ${{ needs.check_changes.outputs.has_changed_frontend == 'true' }}
     uses: ./.github/workflows/tasklist-ci-fe-reusable.yml
+    secrets: inherit

--- a/.github/workflows/tasklist-merge-ci.yml
+++ b/.github/workflows/tasklist-merge-ci.yml
@@ -23,6 +23,7 @@ jobs:
   run-fe-ci:
     name: run-frontend-tests
     uses: ./.github/workflows/tasklist-ci-fe-reusable.yml
+    secrets: inherit
 
   tasklist-ci-test-summary:
     # Used by the merge queue to check all jobs.

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -17,6 +17,7 @@ jobs:
   smoke-tests:
     name: "[Smoke] ${{ matrix.os }} with ${{ matrix.arch }}"
     timeout-minutes: 20
+    permissions: {}  # GITHUB_TOKEN unused in this job
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -85,6 +86,7 @@ jobs:
     name: Property Tests
     runs-on: gcp-perf-core-8-default
     timeout-minutes: 30
+    permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-zeebe
@@ -131,6 +133,7 @@ jobs:
     name: Performance Tests
     runs-on: gcp-perf-core-16-default
     timeout-minutes: 30
+    permissions: {}  # GITHUB_TOKEN unused in this job
     env:
       ZEEBE_PERFORMANCE_TEST_RESULTS_DIR: "/tmp/jmh"
     steps:
@@ -191,6 +194,7 @@ jobs:
     name: Strace Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
       - uses: actions/checkout@v4
       - name: Install and allow strace tests
@@ -239,8 +243,10 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   docker-checks:
     name: Docker checks
-    timeout-minutes: 20
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      security-events: write
     services:
       # local registry is used as this job needs to push as it builds multi-platform images
       registry:
@@ -308,6 +314,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 3
+    permissions: {}  # GITHUB_TOKEN unused in this job
     needs:
       - smoke-tests
       - property-tests
@@ -321,6 +328,7 @@ jobs:
   deploy-docker-snapshot:
     name: Deploy snapshot Docker image
     timeout-minutes: 15
+    permissions: {}  # GITHUB_TOKEN unused in this job
     needs: [ test-summary ]
     runs-on: ubuntu-latest
     if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/stable/8.7'


### PR DESCRIPTION
## Description

Cumulative backporting PR including:

* https://github.com/camunda/camunda/pull/25658 B
* https://github.com/camunda/camunda/pull/25705 B
* https://github.com/camunda/camunda/pull/25759
* https://github.com/camunda/camunda/pull/25833
* https://github.com/camunda/camunda/pull/25926
* https://github.com/camunda/camunda/pull/26286
* https://github.com/camunda/camunda/pull/27010
* https://github.com/camunda/camunda/pull/25563

Important for this backport is that:

1. `actionlint` status check is still green (means no lint violations) -> https://github.com/camunda/camunda/actions/runs/13242116579/job/36959662032?pr=27791
2. all other touched Unified CI workflows still work (very likely since it works on `main`)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Related https://github.com/camunda/camunda/issues/27158
