### PR TITLE
[Backport main] [Backport stable/8.7] deps: Update dependency org.apache.httpcomponents.core5:httpcore5 to v5.3 (main)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -61,7 +61,11 @@
     <version.hamcrest>3.0</version.hamcrest>
     <version.httpasyncclient>4.1.5</version.httpasyncclient>
     <version.httpclient>4.5.14</version.httpclient>
+<<<<<<< HEAD
     <version.httpclient5>5.4.1</version.httpclient5>
+=======
+    <version.httpclient5>5.3.1</version.httpclient5>
+>>>>>>> b415d29b (deps: Update dependency org.apache.httpcomponents.core5:httpcore5 to v5.3)
     <version.httpcore5>5.3</version.httpcore5>
     <version.httpcomponents>4.4.16</version.httpcomponents>
     <version.identity>8.6.7</version.identity>


### PR DESCRIPTION
# Description
Backport of #27764 to `main`.

relates to #22241
original author: @backport-action