### PR TITLE
Rename field `permissions` to `permissionTypes`

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateAuthorizationCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateAuthorizationCommandStep1.java
@@ -19,7 +19,6 @@ import io.camunda.client.api.response.CreateAuthorizationResponse;
 import io.camunda.client.protocol.rest.OwnerTypeEnum;
 import io.camunda.client.protocol.rest.PermissionTypeEnum;
 import io.camunda.client.protocol.rest.ResourceTypeEnum;
-import java.util.List;
 
 public interface CreateAuthorizationCommandStep1 {
 
@@ -67,20 +66,12 @@ public interface CreateAuthorizationCommandStep1 {
   interface CreateAuthorizationCommandStep5 {
 
     /**
-     * List the permissions for the authorization.
+     * List the permission types for the authorization.
      *
-     * @param permissions the permissions
+     * @param permissionTypes the permission types
      * @return the builder for this command
      */
-    CreateAuthorizationCommandStep6 permissions(List<PermissionTypeEnum> permissions);
-
-    /**
-     * Adds a permission to the authorization.
-     *
-     * @param permission the permission
-     * @return the builder for this command
-     */
-    CreateAuthorizationCommandStep6 permission(PermissionTypeEnum permission);
+    CreateAuthorizationCommandStep6 permissionTypes(PermissionTypeEnum... permissionTypes);
   }
 
   interface CreateAuthorizationCommandStep6

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateAuthorizationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateAuthorizationCommandImpl.java
@@ -90,16 +90,16 @@ public class CreateAuthorizationCommandImpl
   public CreateAuthorizationCommandStep6 permissions(final List<PermissionTypeEnum> permissions) {
     ArgumentUtil.ensureNotNull("permissions", permissions);
     ArgumentUtil.ensureNotEmpty("permissions", permissions);
-    request.setPermissions(permissions);
+    request.setPermissionTypes(permissions);
     return this;
   }
 
   @Override
   public CreateAuthorizationCommandStep6 permission(final PermissionTypeEnum permission) {
     ArgumentUtil.ensureNotNull("permission", permission);
-    final List<PermissionTypeEnum> permissions = request.getPermissions();
+    final List<PermissionTypeEnum> permissions = request.getPermissionTypes();
     permissions.add(permission);
-    request.setPermissions(permissions);
+    request.setPermissionTypes(permissions);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateAuthorizationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateAuthorizationCommandImpl.java
@@ -32,7 +32,7 @@ import io.camunda.client.protocol.rest.OwnerTypeEnum;
 import io.camunda.client.protocol.rest.PermissionTypeEnum;
 import io.camunda.client.protocol.rest.ResourceTypeEnum;
 import java.time.Duration;
-import java.util.List;
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
@@ -87,19 +87,10 @@ public class CreateAuthorizationCommandImpl
   }
 
   @Override
-  public CreateAuthorizationCommandStep6 permissions(final List<PermissionTypeEnum> permissions) {
-    ArgumentUtil.ensureNotNull("permissions", permissions);
-    ArgumentUtil.ensureNotEmpty("permissions", permissions);
-    request.setPermissionTypes(permissions);
-    return this;
-  }
-
-  @Override
-  public CreateAuthorizationCommandStep6 permission(final PermissionTypeEnum permission) {
-    ArgumentUtil.ensureNotNull("permission", permission);
-    final List<PermissionTypeEnum> permissions = request.getPermissionTypes();
-    permissions.add(permission);
-    request.setPermissionTypes(permissions);
+  public CreateAuthorizationCommandStep6 permissionTypes(
+      final PermissionTypeEnum... permissionTypes) {
+    ArgumentUtil.ensureNotNull("permissionTypes", permissionTypes);
+    request.setPermissionTypes(Arrays.asList(permissionTypes));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UpdateAuthorizationCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UpdateAuthorizationCommandImpl.java
@@ -91,7 +91,7 @@ public class UpdateAuthorizationCommandImpl
   public UpdateAuthorizationCommandStep6 permissionTypes(
       final PermissionTypeEnum... permissionTypes) {
     ArgumentUtil.ensureNotNull("permissionTypes", permissionTypes);
-    request.setPermissions(Arrays.asList(permissionTypes));
+    request.setPermissionTypes(Arrays.asList(permissionTypes));
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/client/authorization/CreateAuthorizationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/authorization/CreateAuthorizationTest.java
@@ -48,7 +48,7 @@ public class CreateAuthorizationTest extends ClientRestTest {
     assertThat(request.getOwnerType()).isEqualTo(OwnerTypeEnum.USER);
     assertThat(request.getResourceId()).isEqualTo("resourceId");
     assertThat(request.getResourceType()).isEqualTo(ResourceTypeEnum.RESOURCE);
-    assertThat(request.getPermissions())
+    assertThat(request.getPermissionTypes())
         .containsExactly(PermissionTypeEnum.CREATE, PermissionTypeEnum.READ);
   }
 

--- a/clients/java/src/test/java/io/camunda/client/authorization/CreateAuthorizationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/authorization/CreateAuthorizationTest.java
@@ -23,8 +23,6 @@ import io.camunda.client.protocol.rest.OwnerTypeEnum;
 import io.camunda.client.protocol.rest.PermissionTypeEnum;
 import io.camunda.client.protocol.rest.ResourceTypeEnum;
 import io.camunda.client.util.ClientRestTest;
-import java.util.ArrayList;
-import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 public class CreateAuthorizationTest extends ClientRestTest {
@@ -38,7 +36,7 @@ public class CreateAuthorizationTest extends ClientRestTest {
         .ownerType(OwnerTypeEnum.USER)
         .resourceId("resourceId")
         .resourceType(ResourceTypeEnum.RESOURCE)
-        .permissions(Arrays.asList(PermissionTypeEnum.CREATE, PermissionTypeEnum.READ))
+        .permissionTypes(PermissionTypeEnum.CREATE, PermissionTypeEnum.READ)
         .send()
         .join();
 
@@ -63,7 +61,7 @@ public class CreateAuthorizationTest extends ClientRestTest {
                     .ownerType(OwnerTypeEnum.USER)
                     .resourceId("resourceId")
                     .resourceType(ResourceTypeEnum.RESOURCE)
-                    .permissions(Arrays.asList(PermissionTypeEnum.CREATE, PermissionTypeEnum.READ))
+                    .permissionTypes(PermissionTypeEnum.CREATE, PermissionTypeEnum.READ)
                     .send()
                     .join())
         .isInstanceOf(IllegalArgumentException.class)
@@ -81,7 +79,7 @@ public class CreateAuthorizationTest extends ClientRestTest {
                     .ownerType(OwnerTypeEnum.USER)
                     .resourceId("resourceId")
                     .resourceType(ResourceTypeEnum.RESOURCE)
-                    .permissions(Arrays.asList(PermissionTypeEnum.CREATE, PermissionTypeEnum.READ))
+                    .permissionTypes(PermissionTypeEnum.CREATE, PermissionTypeEnum.READ)
                     .send()
                     .join())
         .isInstanceOf(IllegalArgumentException.class)
@@ -99,7 +97,7 @@ public class CreateAuthorizationTest extends ClientRestTest {
                     .ownerType(null)
                     .resourceId("resourceId")
                     .resourceType(ResourceTypeEnum.RESOURCE)
-                    .permissions(Arrays.asList(PermissionTypeEnum.CREATE, PermissionTypeEnum.READ))
+                    .permissionTypes(PermissionTypeEnum.CREATE, PermissionTypeEnum.READ)
                     .send()
                     .join())
         .isInstanceOf(IllegalArgumentException.class)
@@ -117,7 +115,7 @@ public class CreateAuthorizationTest extends ClientRestTest {
                     .ownerType(OwnerTypeEnum.USER)
                     .resourceId(null)
                     .resourceType(ResourceTypeEnum.RESOURCE)
-                    .permissions(Arrays.asList(PermissionTypeEnum.CREATE, PermissionTypeEnum.READ))
+                    .permissionTypes(PermissionTypeEnum.CREATE, PermissionTypeEnum.READ)
                     .send()
                     .join())
         .isInstanceOf(IllegalArgumentException.class)
@@ -135,7 +133,7 @@ public class CreateAuthorizationTest extends ClientRestTest {
                     .ownerType(OwnerTypeEnum.USER)
                     .resourceId("")
                     .resourceType(ResourceTypeEnum.RESOURCE)
-                    .permissions(Arrays.asList(PermissionTypeEnum.CREATE, PermissionTypeEnum.READ))
+                    .permissionTypes(PermissionTypeEnum.CREATE, PermissionTypeEnum.READ)
                     .send()
                     .join())
         .isInstanceOf(IllegalArgumentException.class)
@@ -153,7 +151,7 @@ public class CreateAuthorizationTest extends ClientRestTest {
                     .ownerType(OwnerTypeEnum.USER)
                     .resourceId("resourceId")
                     .resourceType(null)
-                    .permissions(Arrays.asList(PermissionTypeEnum.CREATE, PermissionTypeEnum.READ))
+                    .permissionTypes(PermissionTypeEnum.CREATE, PermissionTypeEnum.READ)
                     .send()
                     .join())
         .isInstanceOf(IllegalArgumentException.class)
@@ -171,46 +169,10 @@ public class CreateAuthorizationTest extends ClientRestTest {
                     .ownerType(OwnerTypeEnum.USER)
                     .resourceId("resourceId")
                     .resourceType(ResourceTypeEnum.RESOURCE)
-                    .permissions(null)
+                    .permissionTypes(null)
                     .send()
                     .join())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("permissions must not be null");
-  }
-
-  @Test
-  void shouldRaiseExceptionOnEmptyPermissions() {
-    // when then
-    assertThatThrownBy(
-            () ->
-                client
-                    .newCreateAuthorizationCommand()
-                    .ownerId("ownerId")
-                    .ownerType(OwnerTypeEnum.USER)
-                    .resourceId("resourceId")
-                    .resourceType(ResourceTypeEnum.RESOURCE)
-                    .permissions(new ArrayList<>())
-                    .send()
-                    .join())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("permissions must not be empty");
-  }
-
-  @Test
-  void shouldRaiseExceptionOnNullPermission() {
-    // when then
-    assertThatThrownBy(
-            () ->
-                client
-                    .newCreateAuthorizationCommand()
-                    .ownerId("ownerId")
-                    .ownerType(OwnerTypeEnum.USER)
-                    .resourceId("resourceId")
-                    .resourceType(ResourceTypeEnum.RESOURCE)
-                    .permission(null)
-                    .send()
-                    .join())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("permission must not be null");
+        .hasMessageContaining("permissionTypes must not be null");
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/authorization/UpdateAuthorizationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/authorization/UpdateAuthorizationTest.java
@@ -46,7 +46,7 @@ public class UpdateAuthorizationTest extends ClientRestTest {
     assertThat(request.getOwnerType()).isEqualTo(OwnerTypeEnum.USER);
     assertThat(request.getResourceId()).isEqualTo("resourceId");
     assertThat(request.getResourceType()).isEqualTo(ResourceTypeEnum.RESOURCE);
-    assertThat(request.getPermissions())
+    assertThat(request.getPermissionTypes())
         .containsExactly(PermissionTypeEnum.CREATE, PermissionTypeEnum.READ);
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/CamundaClientTestFactory.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/CamundaClientTestFactory.java
@@ -117,7 +117,7 @@ public final class CamundaClientTestFactory implements AutoCloseable {
           .ownerType(OwnerTypeEnum.USER)
           .resourceId("*")
           .resourceType(permission.resourceType())
-          .permission(permission.permissionType())
+          .permissionTypes(permission.permissionType())
           .send()
           .join();
     }

--- a/service/src/main/java/io/camunda/service/AuthorizationServices.java
+++ b/service/src/main/java/io/camunda/service/AuthorizationServices.java
@@ -117,7 +117,7 @@ public class AuthorizationServices
             .setOwnerType(request.ownerType())
             .setResourceType(request.resourceType())
             .setResourceId(request.resourceId())
-            .setPermissionTypes(request.permissionType());
+            .setPermissionTypes(request.permissionTypes());
     return sendBrokerRequest(brokerRequest);
   }
 
@@ -135,7 +135,7 @@ public class AuthorizationServices
             .setOwnerType(request.ownerType())
             .setResourceId(request.resourceId())
             .setResourceType(request.resourceType())
-            .setPermissionTypes(request.permissions());
+            .setPermissionTypes(request.permissionTypes());
     return sendBrokerRequest(brokerRequest);
   }
 
@@ -144,7 +144,7 @@ public class AuthorizationServices
       AuthorizationOwnerType ownerType,
       String resourceId,
       AuthorizationResourceType resourceType,
-      Set<PermissionType> permissionType) {}
+      Set<PermissionType> permissionTypes) {}
 
   public record UpdateAuthorizationRequest(
       long authorizationKey,
@@ -152,5 +152,5 @@ public class AuthorizationServices
       AuthorizationOwnerType ownerType,
       String resourceId,
       AuthorizationResourceType resourceType,
-      Set<PermissionType> permissions) {}
+      Set<PermissionType> permissionTypes) {}
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6098,9 +6098,9 @@ components:
           type: object
           allOf:
             - $ref: "#/components/schemas/ResourceTypeEnum"
-        permissions:
+        permissionTypes:
           type: array
-          description: The permissions to add.
+          description: The permission types to add.
           items:
             type: string
             allOf:
@@ -6110,7 +6110,7 @@ components:
         - ownerType
         - resourceId
         - resourceType
-        - permissions
+        - permissionTypes
     AuthorizationCreateResponse:
       deprecated: true
       type: object

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -324,7 +324,7 @@ public class RequestMapper {
                 AuthorizationOwnerType.valueOf(request.getOwnerType().name()),
                 request.getResourceId(),
                 AuthorizationResourceType.valueOf(request.getResourceType().name()),
-                transfomPermissions(request.getPermissions())));
+                transformPermissionTypes(request.getPermissionTypes())));
   }
 
   public static Either<ProblemDetail, UpdateAuthorizationRequest> toUpdateAuthorizationRequest(
@@ -338,12 +338,12 @@ public class RequestMapper {
                 AuthorizationOwnerType.valueOf(request.getOwnerType().name()),
                 request.getResourceId(),
                 AuthorizationResourceType.valueOf(request.getResourceType().name()),
-                transfomPermissions(request.getPermissions())));
+                transformPermissionTypes(request.getPermissionTypes())));
   }
 
-  private static Set<PermissionType> transfomPermissions(
-      final List<PermissionTypeEnum> permissions) {
-    return permissions.stream()
+  private static Set<PermissionType> transformPermissionTypes(
+      final List<PermissionTypeEnum> permissionTypes) {
+    return permissionTypes.stream()
         .map(permission -> PermissionType.valueOf(permission.name()))
         .collect(Collectors.toSet());
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/AuthorizationRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/AuthorizationRequestValidator.java
@@ -37,8 +37,8 @@ public final class AuthorizationRequestValidator {
           }
 
           // permissions validation
-          if (request.getPermissions() == null || request.getPermissions().isEmpty()) {
-            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("permissions"));
+          if (request.getPermissionTypes() == null || request.getPermissionTypes().isEmpty()) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("permissionTypes"));
           }
         });
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
@@ -67,7 +67,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
             .ownerType(OwnerTypeEnum.USER)
             .resourceId(resourceId)
             .resourceType(ResourceTypeEnum.PROCESS_DEFINITION)
-            .permissions(List.of(PermissionTypeEnum.CREATE));
+            .permissionTypes(List.of(PermissionTypeEnum.CREATE));
 
     final var authorizationRecord =
         new AuthorizationRecord()
@@ -105,9 +105,9 @@ public class AuthorizationControllerTest extends RestControllerTest {
     assertEquals(authorizationRecord.getOwnerType(), capturedRequest.ownerType());
     assertEquals(resourceId, capturedRequest.resourceId());
     assertEquals(authorizationRecord.getResourceType(), capturedRequest.resourceType());
-    assertEquals(1, capturedRequest.permissionType().size());
+    assertEquals(1, capturedRequest.permissionTypes().size());
     assertEquals(
-        authorizationRecord.getAuthorizationPermissions(), capturedRequest.permissionType());
+        authorizationRecord.getAuthorizationPermissions(), capturedRequest.permissionTypes());
   }
 
   @ParameterizedTest
@@ -168,7 +168,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
             .ownerType(OwnerTypeEnum.USER)
             .resourceId(resourceId)
             .resourceType(ResourceTypeEnum.PROCESS_DEFINITION)
-            .permissions(List.of(PermissionTypeEnum.CREATE));
+            .permissionTypes(List.of(PermissionTypeEnum.CREATE));
 
     final var authorizationRecord =
         new AuthorizationRecord()
@@ -202,8 +202,9 @@ public class AuthorizationControllerTest extends RestControllerTest {
     assertEquals(authorizationRecord.getOwnerType(), capturedRequest.ownerType());
     assertEquals(resourceId, capturedRequest.resourceId());
     assertEquals(authorizationRecord.getResourceType(), capturedRequest.resourceType());
-    assertEquals(1, capturedRequest.permissions().size());
-    assertEquals(authorizationRecord.getAuthorizationPermissions(), capturedRequest.permissions());
+    assertEquals(1, capturedRequest.permissionTypes().size());
+    assertEquals(
+        authorizationRecord.getAuthorizationPermissions(), capturedRequest.permissionTypes());
   }
 
   @ParameterizedTest
@@ -237,7 +238,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
                 .ownerType(OwnerTypeEnum.USER)
                 .resourceId("resourceId")
                 .resourceType(ResourceTypeEnum.RESOURCE)
-                .permissions(permissions),
+                .permissionTypes(permissions),
             "No ownerId provided."),
         Arguments.of(
             new AuthorizationRequest()
@@ -245,21 +246,21 @@ public class AuthorizationControllerTest extends RestControllerTest {
                 .ownerType(OwnerTypeEnum.USER)
                 .resourceId("resourceId")
                 .resourceType(ResourceTypeEnum.RESOURCE)
-                .permissions(permissions),
+                .permissionTypes(permissions),
             "No ownerId provided."),
         Arguments.of(
             new AuthorizationRequest()
                 .ownerId("ownerId")
                 .resourceId("resourceId")
                 .resourceType(ResourceTypeEnum.RESOURCE)
-                .permissions(permissions),
+                .permissionTypes(permissions),
             "No ownerType provided."),
         Arguments.of(
             new AuthorizationRequest()
                 .ownerId("ownerId")
                 .ownerType(OwnerTypeEnum.USER)
                 .resourceType(ResourceTypeEnum.RESOURCE)
-                .permissions(permissions),
+                .permissionTypes(permissions),
             "No resourceId provided."),
         Arguments.of(
             new AuthorizationRequest()
@@ -267,14 +268,14 @@ public class AuthorizationControllerTest extends RestControllerTest {
                 .ownerType(OwnerTypeEnum.USER)
                 .resourceId("")
                 .resourceType(ResourceTypeEnum.RESOURCE)
-                .permissions(permissions),
+                .permissionTypes(permissions),
             "No resourceId provided."),
         Arguments.of(
             new AuthorizationRequest()
                 .ownerId("ownerId")
                 .ownerType(OwnerTypeEnum.USER)
                 .resourceId("resourceId")
-                .permissions(permissions),
+                .permissionTypes(permissions),
             "No resourceType provided."),
         Arguments.of(
             new AuthorizationRequest()
@@ -282,14 +283,14 @@ public class AuthorizationControllerTest extends RestControllerTest {
                 .ownerType(OwnerTypeEnum.USER)
                 .resourceId("resourceId")
                 .resourceType(ResourceTypeEnum.RESOURCE),
-            "No permissions provided."),
+            "No permissionTypes provided."),
         Arguments.of(
             new AuthorizationRequest()
                 .ownerId("ownerId")
                 .ownerType(OwnerTypeEnum.USER)
                 .resourceId("resourceId")
                 .resourceType(ResourceTypeEnum.RESOURCE)
-                .permissions(List.of()),
-            "No permissions provided."));
+                .permissionTypes(List.of()),
+            "No permissionTypes provided."));
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverGrpcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverGrpcIT.java
@@ -229,7 +229,7 @@ public class OidcAuthOverGrpcIT {
         .ownerType(OwnerTypeEnum.MAPPING)
         .resourceId("*")
         .resourceType(ResourceTypeEnum.RESOURCE)
-        .permission(PermissionTypeEnum.CREATE)
+        .permissionTypes(PermissionTypeEnum.CREATE)
         .send()
         .join();
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestIT.java
@@ -229,7 +229,7 @@ public class OidcAuthOverRestIT {
         .ownerType(OwnerTypeEnum.MAPPING)
         .resourceId("*")
         .resourceType(ResourceTypeEnum.RESOURCE)
-        .permission(PermissionTypeEnum.CREATE)
+        .permissionTypes(PermissionTypeEnum.CREATE)
         .send()
         .join();
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/AuthorizationsUtil.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/AuthorizationsUtil.java
@@ -89,7 +89,7 @@ public class AuthorizationsUtil implements CloseableSilently {
             .ownerType(OwnerTypeEnum.USER)
             .resourceId(resourceId)
             .resourceType(permission.resourceType())
-            .permission(permission.permissionType())
+            .permissionTypes(permission.permissionType())
             .send()
             .join();
       }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR change the name of the `permissions` field to `permissionTypes`. It also refactor the create authorization client command to use varargs instead of provide a list of arguments

## Related issues

related to https://github.com/camunda/camunda/issues/27000
