### PR TITLE
refactor: use default SLOs for backwards compat

### DIFF
--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/ProcessingMetrics.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/ProcessingMetrics.java
@@ -181,6 +181,7 @@ public class ProcessingMetrics {
     final var meterDoc = StreamMetricsDoc.PROCESSING_LATENCY;
     return Timer.builder(meterDoc.getName())
         .description(meterDoc.getDescription())
+        .serviceLevelObjectives(meterDoc.getTimerSLOs())
         .register(registry);
   }
 
@@ -188,6 +189,7 @@ public class ProcessingMetrics {
     final var meterDoc = StreamMetricsDoc.PROCESSING_DURATION;
     return Timer.builder(meterDoc.getName())
         .description(meterDoc.getDescription())
+        .serviceLevelObjectives(meterDoc.getTimerSLOs())
         .tag(ProcessingDurationKeys.VALUE_TYPE.asString(), valueType.name())
         .tag(ProcessingDurationKeys.INTENT.asString(), intent.name())
         .register(registry);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/ReplayMetrics.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/ReplayMetrics.java
@@ -36,6 +36,7 @@ public final class ReplayMetrics {
     final var meterDoc = StreamMetricsDoc.REPLAY_DURATION;
     return Timer.builder(meterDoc.getName())
         .description(meterDoc.getDescription())
+        .serviceLevelObjectives(meterDoc.getTimerSLOs())
         .register(registry);
   }
 


### PR DESCRIPTION
## Description

This PR adds SLO/buckets to migrated Micrometer metrics that were missing them, to bring them inline with the old Prometheus metrics.