### PR TITLE
[Backport stable/8.6] migrate LeaderMetrics to micrometer

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -11779,7 +11779,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "sum(increase(atomix_append_entries_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(atomix_append_entries_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval]) or increase(atomix_append_entries_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "",
               "intervalFactor": 1,
@@ -11888,7 +11888,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "sum(rate(atomix_append_entries_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) / sum(rate(atomix_append_entries_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval]))",
+              "expr": "sum(rate(atomix_append_entries_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval]) or rate(atomix_append_entries_latency_second_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) / sum(rate(atomix_append_entries_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval]) or rate(atomix_append_entries_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval]))",
               "interval": "",
               "legendFormat": "Avg",
               "refId": "A"
@@ -11898,7 +11898,7 @@
                 "type": "prometheus",
                 "uid": "${DS_PROMETHEUS}"
               },
-              "expr": "histogram_quantile(0.50, sum(rate(atomix_append_entries_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
+              "expr": "histogram_quantile(0.50, sum(rate(atomix_append_entries_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval]) or rate(atomix_append_entries_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le))",
               "hide": false,
               "interval": "",
               "legendFormat": "Median",

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/LeaderMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/LeaderMetrics.java
@@ -16,87 +16,111 @@
  */
 package io.atomix.raft.metrics;
 
-import io.prometheus.client.Counter;
-import io.prometheus.client.Gauge;
-import io.prometheus.client.Histogram;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class LeaderMetrics extends RaftMetrics {
   private static final String FOLLOWER_LABEL = "follower";
 
-  private static final Histogram APPEND_LATENCY =
-      Histogram.build()
-          .namespace(NAMESPACE)
-          .name("append_entries_latency")
-          .help("Latency to append an entry to a follower")
-          .labelNames(FOLLOWER_LABEL, PARTITION_GROUP_NAME_LABEL, PARTITION_LABEL)
-          .register();
+  private final MeterRegistry meterRegistry;
+  private final Map<String, Timer> appendLatency;
+  private final Map<String, Counter> appendDataRate;
+  private final Map<String, Counter> appendRate;
+  private final Counter commitRate;
+  private final AtomicLong nonCommittedEntriesValue;
+  private final Map<String, AtomicLong> nonReplicatedEntries;
 
-  private static final Counter APPEND_RATE =
-      Counter.build()
-          .namespace(NAMESPACE)
-          .name("append_entries_rate")
-          .help("The count of entries appended (counting entries, not their size)")
-          .labelNames(FOLLOWER_LABEL, PARTITION_GROUP_NAME_LABEL, PARTITION_LABEL)
-          .register();
-
-  private static final Counter APPEND_DATA_RATE =
-      Counter.build()
-          .namespace(NAMESPACE)
-          .name("append_entries_data_rate")
-          .help("The count of data replication in KiB")
-          .labelNames(FOLLOWER_LABEL, PARTITION_GROUP_NAME_LABEL, PARTITION_LABEL)
-          .register();
-
-  private static final Gauge NON_REPLICATED_ENTRIES =
-      Gauge.build()
-          .namespace(NAMESPACE)
-          .name("non_replicated_entries")
-          .help("The number of non-replicated entries for a given followers")
-          .labelNames(FOLLOWER_LABEL, PARTITION_GROUP_NAME_LABEL, PARTITION_LABEL)
-          .register();
-  private static final Counter COMMIT_RATE =
-      Counter.build()
-          .namespace(NAMESPACE)
-          .name("commit_entries_rate")
-          .help("The count of entries committed (counting entries, not their size)")
-          .labelNames(PARTITION_GROUP_NAME_LABEL, PARTITION_LABEL)
-          .register();
-  private static final Gauge NON_COMMITTED_ENTRIES =
-      Gauge.build()
-          .namespace(NAMESPACE)
-          .name("non_committed_entries")
-          .help("The number of non-committed entries on the leader")
-          .labelNames(PARTITION_GROUP_NAME_LABEL, PARTITION_LABEL)
-          .register();
-
-  private final Counter.Child commitRate;
-  private final Gauge.Child nonCommittedEntries;
-
-  public LeaderMetrics(final String partitionName) {
+  public LeaderMetrics(final String partitionName, final MeterRegistry meterRegistry) {
     super(partitionName);
-    commitRate = COMMIT_RATE.labels(partitionGroupName, partition);
-    nonCommittedEntries = NON_COMMITTED_ENTRIES.labels(partitionGroupName, partition);
+    this.meterRegistry = meterRegistry;
+    appendLatency = new HashMap<>();
+    appendDataRate = new HashMap<>();
+    appendRate = new HashMap<>();
+    nonReplicatedEntries = new HashMap<>();
+
+    commitRate =
+        Counter.builder(LeaderMetricsDoc.COMMIT_RATE.name())
+            .description(LeaderMetricsDoc.COMMIT_RATE.getDescription())
+            .tags(PARTITION_GROUP_NAME_LABEL, partitionGroupName)
+            .register(meterRegistry);
+
+    nonCommittedEntriesValue = new AtomicLong(0L);
+    Gauge.builder(LeaderMetricsDoc.NON_COMMITTED_ENTRIES.name(), nonCommittedEntriesValue::get)
+        .description(LeaderMetricsDoc.NON_COMMITTED_ENTRIES.getDescription())
+        .tags(PARTITION_GROUP_NAME_LABEL, partitionGroupName)
+        .register(meterRegistry);
   }
 
   public void appendComplete(final long latencyms, final String memberId) {
-    APPEND_LATENCY.labels(memberId, partitionGroupName, partition).observe(latencyms / 1000f);
+    getAppendLatency(memberId).record(latencyms, TimeUnit.MILLISECONDS);
   }
 
   public void observeAppend(
       final String memberId, final int appendedEntries, final int appendedBytes) {
-    APPEND_RATE.labels(memberId, partitionGroupName, partition).inc(appendedEntries);
-    APPEND_DATA_RATE.labels(memberId, partitionGroupName, partition).inc(appendedBytes / 1024f);
+    getAppendRate(memberId).increment(appendedEntries);
+    getAppendDataRate(memberId).increment(appendedBytes / 1024f);
   }
 
   public void observeCommit() {
-    commitRate.inc();
+    commitRate.increment();
   }
 
   public void observeNonCommittedEntries(final long remainingEntries) {
-    nonCommittedEntries.set(remainingEntries);
+    nonCommittedEntriesValue.set(remainingEntries);
   }
 
   public void observeRemainingEntries(final String memberId, final long remainingEntries) {
-    NON_REPLICATED_ENTRIES.labels(memberId, partitionGroupName, partition).set(remainingEntries);
+    getNonReplicatedEntries(memberId).set(remainingEntries);
+  }
+
+  private Timer getAppendLatency(final String memberId) {
+    return appendLatency.computeIfAbsent(
+        memberId,
+        id ->
+            Timer.builder(LeaderMetricsDoc.APPEND_ENTRIES_LATENCY.name())
+                .description(LeaderMetricsDoc.APPEND_ENTRIES_LATENCY.getDescription())
+                .serviceLevelObjectives(LeaderMetricsDoc.APPEND_ENTRIES_LATENCY.getTimerSLOs())
+                .tags(FOLLOWER_LABEL, memberId, PARTITION_GROUP_NAME_LABEL, partitionGroupName)
+                .register(meterRegistry));
+  }
+
+  private Counter getAppendDataRate(final String memberId) {
+    return appendDataRate.computeIfAbsent(
+        memberId,
+        id ->
+            Counter.builder(LeaderMetricsDoc.APPEND_DATA_RATE.name())
+                .description(LeaderMetricsDoc.APPEND_DATA_RATE.getDescription())
+                .tags(FOLLOWER_LABEL, id, PARTITION_GROUP_NAME_LABEL, partitionGroupName)
+                .register(meterRegistry));
+  }
+
+  private Counter getAppendRate(final String memberId) {
+    return appendRate.computeIfAbsent(
+        memberId,
+        id ->
+            Counter.builder(LeaderMetricsDoc.APPEND_RATE.name())
+                .description(LeaderMetricsDoc.APPEND_RATE.getDescription())
+                .tags(FOLLOWER_LABEL, id, PARTITION_GROUP_NAME_LABEL, partitionGroupName)
+                .register(meterRegistry));
+  }
+
+  private AtomicLong getNonReplicatedEntries(final String memberId) {
+    var inMap = nonReplicatedEntries.get(memberId);
+    if (inMap == null) {
+      inMap = new AtomicLong(0L);
+      // add new gauge for this entry
+      Gauge.builder(LeaderMetricsDoc.NON_REPLICATED_ENTRIES.name(), inMap::get)
+          .description(LeaderMetricsDoc.NON_REPLICATED_ENTRIES.getDescription())
+          .tags(FOLLOWER_LABEL, memberId, PARTITION_GROUP_NAME_LABEL, partitionGroupName)
+          .register(meterRegistry);
+      nonReplicatedEntries.put(memberId, inMap);
+    }
+    return inMap;
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/LeaderMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/LeaderMetrics.java
@@ -45,13 +45,13 @@ public class LeaderMetrics extends RaftMetrics {
     nonReplicatedEntries = new HashMap<>();
 
     commitRate =
-        Counter.builder(LeaderMetricsDoc.COMMIT_RATE.name())
+        Counter.builder(LeaderMetricsDoc.COMMIT_RATE.getName())
             .description(LeaderMetricsDoc.COMMIT_RATE.getDescription())
             .tags(PARTITION_GROUP_NAME_LABEL, partitionGroupName)
             .register(meterRegistry);
 
     nonCommittedEntriesValue = new AtomicLong(0L);
-    Gauge.builder(LeaderMetricsDoc.NON_COMMITTED_ENTRIES.name(), nonCommittedEntriesValue::get)
+    Gauge.builder(LeaderMetricsDoc.NON_COMMITTED_ENTRIES.getName(), nonCommittedEntriesValue::get)
         .description(LeaderMetricsDoc.NON_COMMITTED_ENTRIES.getDescription())
         .tags(PARTITION_GROUP_NAME_LABEL, partitionGroupName)
         .register(meterRegistry);
@@ -83,7 +83,7 @@ public class LeaderMetrics extends RaftMetrics {
     return appendLatency.computeIfAbsent(
         memberId,
         id ->
-            Timer.builder(LeaderMetricsDoc.APPEND_ENTRIES_LATENCY.name())
+            Timer.builder(LeaderMetricsDoc.APPEND_ENTRIES_LATENCY.getName())
                 .description(LeaderMetricsDoc.APPEND_ENTRIES_LATENCY.getDescription())
                 .serviceLevelObjectives(LeaderMetricsDoc.APPEND_ENTRIES_LATENCY.getTimerSLOs())
                 .tags(FOLLOWER_LABEL, memberId, PARTITION_GROUP_NAME_LABEL, partitionGroupName)
@@ -94,7 +94,7 @@ public class LeaderMetrics extends RaftMetrics {
     return appendDataRate.computeIfAbsent(
         memberId,
         id ->
-            Counter.builder(LeaderMetricsDoc.APPEND_DATA_RATE.name())
+            Counter.builder(LeaderMetricsDoc.APPEND_DATA_RATE.getName())
                 .description(LeaderMetricsDoc.APPEND_DATA_RATE.getDescription())
                 .tags(FOLLOWER_LABEL, id, PARTITION_GROUP_NAME_LABEL, partitionGroupName)
                 .register(meterRegistry));
@@ -104,7 +104,7 @@ public class LeaderMetrics extends RaftMetrics {
     return appendRate.computeIfAbsent(
         memberId,
         id ->
-            Counter.builder(LeaderMetricsDoc.APPEND_RATE.name())
+            Counter.builder(LeaderMetricsDoc.APPEND_RATE.getName())
                 .description(LeaderMetricsDoc.APPEND_RATE.getDescription())
                 .tags(FOLLOWER_LABEL, id, PARTITION_GROUP_NAME_LABEL, partitionGroupName)
                 .register(meterRegistry));
@@ -115,7 +115,7 @@ public class LeaderMetrics extends RaftMetrics {
     if (inMap == null) {
       inMap = new AtomicLong(0L);
       // add new gauge for this entry
-      Gauge.builder(LeaderMetricsDoc.NON_REPLICATED_ENTRIES.name(), inMap::get)
+      Gauge.builder(LeaderMetricsDoc.NON_REPLICATED_ENTRIES.getName(), inMap::get)
           .description(LeaderMetricsDoc.NON_REPLICATED_ENTRIES.getDescription())
           .tags(FOLLOWER_LABEL, memberId, PARTITION_GROUP_NAME_LABEL, partitionGroupName)
           .register(meterRegistry);

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/LeaderMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/LeaderMetrics.java
@@ -26,8 +26,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class LeaderMetrics extends RaftMetrics {
-  private static final String FOLLOWER_LABEL = "follower";
-
   private final MeterRegistry meterRegistry;
   private final Map<String, Timer> appendLatency;
   private final Map<String, Counter> appendDataRate;
@@ -86,7 +84,11 @@ public class LeaderMetrics extends RaftMetrics {
             Timer.builder(LeaderMetricsDoc.APPEND_ENTRIES_LATENCY.getName())
                 .description(LeaderMetricsDoc.APPEND_ENTRIES_LATENCY.getDescription())
                 .serviceLevelObjectives(LeaderMetricsDoc.APPEND_ENTRIES_LATENCY.getTimerSLOs())
-                .tags(FOLLOWER_LABEL, memberId, PARTITION_GROUP_NAME_LABEL, partitionGroupName)
+                .tags(
+                    RaftKeyNames.FOLLOWER.asString(),
+                    memberId,
+                    PARTITION_GROUP_NAME_LABEL,
+                    partitionGroupName)
                 .register(meterRegistry));
   }
 
@@ -96,7 +98,11 @@ public class LeaderMetrics extends RaftMetrics {
         id ->
             Counter.builder(LeaderMetricsDoc.APPEND_DATA_RATE.getName())
                 .description(LeaderMetricsDoc.APPEND_DATA_RATE.getDescription())
-                .tags(FOLLOWER_LABEL, id, PARTITION_GROUP_NAME_LABEL, partitionGroupName)
+                .tags(
+                    RaftKeyNames.FOLLOWER.asString(),
+                    id,
+                    PARTITION_GROUP_NAME_LABEL,
+                    partitionGroupName)
                 .register(meterRegistry));
   }
 
@@ -106,7 +112,11 @@ public class LeaderMetrics extends RaftMetrics {
         id ->
             Counter.builder(LeaderMetricsDoc.APPEND_RATE.getName())
                 .description(LeaderMetricsDoc.APPEND_RATE.getDescription())
-                .tags(FOLLOWER_LABEL, id, PARTITION_GROUP_NAME_LABEL, partitionGroupName)
+                .tags(
+                    RaftKeyNames.FOLLOWER.asString(),
+                    id,
+                    PARTITION_GROUP_NAME_LABEL,
+                    partitionGroupName)
                 .register(meterRegistry));
   }
 
@@ -117,7 +127,11 @@ public class LeaderMetrics extends RaftMetrics {
       // add new gauge for this entry
       Gauge.builder(LeaderMetricsDoc.NON_REPLICATED_ENTRIES.getName(), inMap::get)
           .description(LeaderMetricsDoc.NON_REPLICATED_ENTRIES.getDescription())
-          .tags(FOLLOWER_LABEL, memberId, PARTITION_GROUP_NAME_LABEL, partitionGroupName)
+          .tags(
+              RaftKeyNames.FOLLOWER.asString(),
+              memberId,
+              PARTITION_GROUP_NAME_LABEL,
+              partitionGroupName)
           .register(meterRegistry);
       nonReplicatedEntries.put(memberId, inMap);
     }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/LeaderMetricsDoc.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/LeaderMetricsDoc.java
@@ -8,8 +8,11 @@
 package io.atomix.raft.metrics;
 
 import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
+import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Meter.Type;
 
+@SuppressWarnings("NullableProblems")
 public enum LeaderMetricsDoc implements ExtendedMeterDocumentation {
   /** Latency to append an entry to a follower */
   APPEND_ENTRIES_LATENCY {
@@ -32,6 +35,13 @@ public enum LeaderMetricsDoc implements ExtendedMeterDocumentation {
     public String getDescription() {
       return "Latency to append an entry to a follower";
     }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {
+        PartitionKeyNames.PARTITION, RaftKeyNames.FOLLOWER, RaftKeyNames.PARTITION_GROUP
+      };
+    }
   },
   APPEND_RATE {
     @Override
@@ -47,6 +57,13 @@ public enum LeaderMetricsDoc implements ExtendedMeterDocumentation {
     @Override
     public String getDescription() {
       return "The count of entries appended (counting entries, not their size)";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {
+        PartitionKeyNames.PARTITION, RaftKeyNames.FOLLOWER, RaftKeyNames.PARTITION_GROUP
+      };
     }
   },
   /** The count of entries appended (counting entries, not their size) */
@@ -65,6 +82,13 @@ public enum LeaderMetricsDoc implements ExtendedMeterDocumentation {
     public String getDescription() {
       return "The count of entries appended (counting entries, not their size)";
     }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {
+        PartitionKeyNames.PARTITION, RaftKeyNames.FOLLOWER, RaftKeyNames.PARTITION_GROUP
+      };
+    }
   },
   /** The number of non-replicated entries for a given followers */
   NON_REPLICATED_ENTRIES {
@@ -81,6 +105,13 @@ public enum LeaderMetricsDoc implements ExtendedMeterDocumentation {
     @Override
     public String getDescription() {
       return "The number of non-replicated entries for a given followers";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {
+        PartitionKeyNames.PARTITION, RaftKeyNames.FOLLOWER, RaftKeyNames.PARTITION_GROUP
+      };
     }
   },
   /** The count of entries committed (counting entries, not their size) */
@@ -99,6 +130,11 @@ public enum LeaderMetricsDoc implements ExtendedMeterDocumentation {
     public String getDescription() {
       return "The count of entries committed (counting entries, not their size)";
     }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {RaftKeyNames.PARTITION_GROUP, PartitionKeyNames.PARTITION};
+    }
   },
   /** The number of non-committed entries on the leader */
   NON_COMMITTED_ENTRIES {
@@ -115,6 +151,11 @@ public enum LeaderMetricsDoc implements ExtendedMeterDocumentation {
     @Override
     public String getDescription() {
       return "The number of non-committed entries on the leader";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {RaftKeyNames.PARTITION_GROUP, PartitionKeyNames.PARTITION};
     }
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/LeaderMetricsDoc.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/LeaderMetricsDoc.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft.metrics;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.micrometer.core.instrument.Meter.Type;
+import java.time.Duration;
+
+public enum LeaderMetricsDoc implements ExtendedMeterDocumentation {
+  APPEND_ENTRIES_LATENCY {
+    // FIXME check values
+    private static final Duration[] BUCKETS = {
+      Duration.ofNanos(100_000), // 100 micros
+      Duration.ofMillis(1),
+      Duration.ofMillis(10),
+      Duration.ofMillis(100),
+      Duration.ofMillis(250),
+      Duration.ofMillis(500),
+      Duration.ofSeconds(1),
+      Duration.ofSeconds(2)
+    };
+
+    @Override
+    public String getBaseUnit() {
+      return "ms";
+    }
+
+    @Override
+    public String getName() {
+      return "atomix.append.entries.latency";
+    }
+
+    @Override
+    public Type getType() {
+      // FIXME CHECK
+      return Type.TIMER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Latency to append an entry to a follower";
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+  },
+  APPEND_RATE {
+    @Override
+    public String getName() {
+      return "atomix.append.entries.rate";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "The count of entries appended (counting entries, not their size)";
+    }
+  },
+  APPEND_DATA_RATE {
+    @Override
+    public String getName() {
+      return "atomix.append.entries.data.rate";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "The count of entries appended (counting entries, not their size)";
+    }
+  },
+  NON_REPLICATED_ENTRIES {
+    @Override
+    public String getName() {
+      return "atomix.non_replicated.entries";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public String getDescription() {
+      return "The number of non-replicated entries for a given followers";
+    }
+  },
+  COMMIT_RATE {
+    @Override
+    public String getName() {
+      return "atomix.commit.entries.rate";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "The count of entries committed (counting entries, not their size)";
+    }
+  },
+  NON_COMMITTED_ENTRIES {
+    @Override
+    public String getName() {
+      return "atomix.non_committed.entries";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public String getDescription() {
+      return "The number of non-committed entries on the leader";
+    }
+  }
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/LeaderMetricsDoc.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/LeaderMetricsDoc.java
@@ -9,22 +9,10 @@ package io.atomix.raft.metrics;
 
 import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
 import io.micrometer.core.instrument.Meter.Type;
-import java.time.Duration;
 
 public enum LeaderMetricsDoc implements ExtendedMeterDocumentation {
+  /** Latency to append an entry to a follower */
   APPEND_ENTRIES_LATENCY {
-    // FIXME check values
-    private static final Duration[] BUCKETS = {
-      Duration.ofNanos(100_000), // 100 micros
-      Duration.ofMillis(1),
-      Duration.ofMillis(10),
-      Duration.ofMillis(100),
-      Duration.ofMillis(250),
-      Duration.ofMillis(500),
-      Duration.ofSeconds(1),
-      Duration.ofSeconds(2)
-    };
-
     @Override
     public String getBaseUnit() {
       return "ms";
@@ -37,18 +25,12 @@ public enum LeaderMetricsDoc implements ExtendedMeterDocumentation {
 
     @Override
     public Type getType() {
-      // FIXME CHECK
       return Type.TIMER;
     }
 
     @Override
     public String getDescription() {
       return "Latency to append an entry to a follower";
-    }
-
-    @Override
-    public Duration[] getTimerSLOs() {
-      return BUCKETS;
     }
   },
   APPEND_RATE {
@@ -67,6 +49,7 @@ public enum LeaderMetricsDoc implements ExtendedMeterDocumentation {
       return "The count of entries appended (counting entries, not their size)";
     }
   },
+  /** The count of entries appended (counting entries, not their size) */
   APPEND_DATA_RATE {
     @Override
     public String getName() {
@@ -83,6 +66,7 @@ public enum LeaderMetricsDoc implements ExtendedMeterDocumentation {
       return "The count of entries appended (counting entries, not their size)";
     }
   },
+  /** The number of non-replicated entries for a given followers */
   NON_REPLICATED_ENTRIES {
     @Override
     public String getName() {
@@ -99,6 +83,7 @@ public enum LeaderMetricsDoc implements ExtendedMeterDocumentation {
       return "The number of non-replicated entries for a given followers";
     }
   },
+  /** The count of entries committed (counting entries, not their size) */
   COMMIT_RATE {
     @Override
     public String getName() {
@@ -115,6 +100,7 @@ public enum LeaderMetricsDoc implements ExtendedMeterDocumentation {
       return "The count of entries committed (counting entries, not their size)";
     }
   },
+  /** The number of non-committed entries on the leader */
   NON_COMMITTED_ENTRIES {
     @Override
     public String getName() {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -84,7 +84,7 @@ final class LeaderAppender {
     log =
         ContextualLoggerFactory.getLogger(
             getClass(), LoggerContext.builder(RaftServer.class).addValue(raft.getName()).build());
-    metrics = new LeaderMetrics(raft.getName());
+    metrics = new LeaderMetrics(raft.getName(), raft.getMeterRegistry());
     maxBatchSizePerAppend = raft.getMaxAppendBatchSize();
     leaderTime = System.currentTimeMillis();
     leaderIndex =


### PR DESCRIPTION
# Description
Backport of #27728 to `stable/8.6`.

relates to #26708
original author: @entangled90