### PR TITLE
[Backport stable/8.6] refactor: use default SLOs for backwards compat

### DIFF
--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/ReplayMetrics.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/ReplayMetrics.java
@@ -36,6 +36,7 @@ public final class ReplayMetrics {
     final var meterDoc = StreamMetricsDoc.REPLAY_DURATION;
     return Timer.builder(meterDoc.getName())
         .description(meterDoc.getDescription())
+        .serviceLevelObjectives(meterDoc.getTimerSLOs())
         .register(registry);
   }
 


### PR DESCRIPTION
# Description
Backport of #27797 to `stable/8.6`.

relates to 
original author: @npepinpe