### PR TITLE
feat: remove old fields from authorizationrecord

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -661,7 +661,7 @@ class RdbmsExporterIT {
             recordValue.getOwnerType(),
             recordValue.getResourceType(),
             recordValue.getResourceId(),
-            recordValue.getAuthorizationPermissions());
+            recordValue.getPermissionTypes());
 
     // when
     exporter.export(authorizationDeletedRecord);

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -404,7 +404,7 @@ public class RecordFixtures {
                 .withOwnerType(ownerType)
                 .withResourceType(resourceType)
                 .withResourceId(resourceId)
-                .withAuthorizationPermissions(permissionTypes)
+                .withPermissionTypes(permissionTypes)
                 .build())
         .build();
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
@@ -56,7 +56,7 @@ public class AuthorizationCreateProcessor
             record ->
                 permissionsBehavior.hasValidPermissionTypes(
                     record,
-                    record.getAuthorizationPermissions(),
+                    record.getPermissionTypes(),
                     record.getResourceType(),
                     "Expected to create authorization with permission types '%s' and resource type '%s', but these permissions are not supported. Supported permission types are: '%s'"))
         .flatMap(permissionsBehavior::permissionsAlreadyExist)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationUpdateProcessor.java
@@ -58,7 +58,7 @@ public class AuthorizationUpdateProcessor
             record ->
                 permissionsBehavior.hasValidPermissionTypes(
                     command.getValue(),
-                    command.getValue().getAuthorizationPermissions(),
+                    command.getValue().getPermissionTypes(),
                     record.getResourceType(),
                     "Expected to update authorization with permission types '%s' and resource type '%s', but these permissions are not supported. Supported permission types are: '%s'"))
         .ifRightOrLeft(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
@@ -251,7 +251,7 @@ public final class IdentitySetupInitializeProcessor
               .setOwnerType(AuthorizationOwnerType.ROLE)
               .setResourceType(resourceType)
               .setResourceId(WILDCARD_PERMISSION)
-              .setAuthorizationPermissions(resourceType.getSupportedPermissionTypes());
+              .setPermissionTypes(resourceType.getSupportedPermissionTypes());
 
       stateWriter.appendFollowUpEvent(authorizationKey, AuthorizationIntent.CREATED, record);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -86,9 +86,7 @@ public class PermissionsBehavior {
       final Set<PermissionType> permissionTypes,
       final AuthorizationResourceType resourceType,
       final String rejectionMessage) {
-    if (resourceType
-        .getSupportedPermissionTypes()
-        .containsAll(record.getAuthorizationPermissions())) {
+    if (resourceType.getSupportedPermissionTypes().containsAll(record.getPermissionTypes())) {
       return Either.right(record);
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -64,7 +64,7 @@ public class PermissionsBehavior {
 
   public Either<Rejection, AuthorizationRecord> permissionsAlreadyExist(
       final AuthorizationRecord record) {
-    for (final PermissionType permission : record.getAuthorizationPermissions()) {
+    for (final PermissionType permission : record.getPermissionTypes()) {
       final var addedResourceId = record.getResourceId();
       final var currentResourceIds =
           authCheckBehavior.getDirectAuthorizedResourceIdentifiers(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
@@ -120,7 +120,7 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
             .setOwnerType(AuthorizationOwnerType.USER)
             .setResourceType(AuthorizationResourceType.USER)
             .setResourceId(username)
-            .setAuthorizationPermissions(Set.of(PermissionType.READ, PermissionType.UPDATE));
+            .setPermissionTypes(Set.of(PermissionType.READ, PermissionType.UPDATE));
 
     commandWriter.appendFollowUpCommand(key, AuthorizationIntent.CREATE, authorizationRecord);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
@@ -116,7 +116,6 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
   private void addUserPermissions(final long key, final String username) {
     final var authorizationRecord =
         new AuthorizationRecord()
-            .setOwnerKey(key)
             .setOwnerId(username)
             .setOwnerType(AuthorizationOwnerType.USER)
             .setResourceType(AuthorizationResourceType.USER)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
@@ -93,7 +93,7 @@ public class DbAuthorizationState implements MutableAuthorizationState {
             .orElse(new Permissions());
 
     authorization
-        .getAuthorizationPermissions()
+        .getPermissionTypes()
         .forEach(
             permissionType -> {
               permissions.addResourceIdentifier(permissionType, authorization.getResourceId());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedAuthorization.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedAuthorization.java
@@ -53,7 +53,7 @@ public class PersistedAuthorization extends UnpackedObject implements DbValue {
         .setOwnerType(authorizationRecord.getOwnerType())
         .setResourceId(authorizationRecord.getResourceId())
         .setResourceType(authorizationRecord.getResourceType())
-        .setPermissionTypes(authorizationRecord.getAuthorizationPermissions());
+        .setPermissionTypes(authorizationRecord.getPermissionTypes());
   }
 
   public long getAuthorizationKey() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AnonymousAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AnonymousAuthorizationTest.java
@@ -77,7 +77,6 @@ public class AnonymousAuthorizationTest {
         .withPermissions(PermissionType.CREATE)
         .withResourceType(AuthorizationResourceType.RESOURCE)
         .withResourceId("*")
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .create();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -719,7 +719,6 @@ public class AuthorizationCheckBehaviorTest {
         .authorization()
         .newAuthorization()
         .withPermissions(permissionType)
-        .withOwnerKey(groupKey)
         .withOwnerId(String.valueOf(groupKey))
         .withOwnerType(AuthorizationOwnerType.GROUP)
         .withResourceType(resourceType)
@@ -756,7 +755,6 @@ public class AuthorizationCheckBehaviorTest {
     engine
         .authorization()
         .newAuthorization()
-        .withOwnerKey(roleKey)
         .withOwnerId(String.valueOf(roleKey))
         .withOwnerType(AuthorizationOwnerType.ROLE)
         .withResourceType(resourceType)
@@ -823,7 +821,6 @@ public class AuthorizationCheckBehaviorTest {
     engine
         .authorization()
         .newAuthorization()
-        .withOwnerKey(firstMappingKey)
         .withOwnerId(String.valueOf(firstMappingKey))
         .withOwnerType(AuthorizationOwnerType.MAPPING)
         .withResourceType(resourceType)
@@ -833,7 +830,6 @@ public class AuthorizationCheckBehaviorTest {
     engine
         .authorization()
         .newAuthorization()
-        .withOwnerKey(secondMappingKey)
         .withOwnerId(String.valueOf(secondMappingKey))
         .withOwnerType(AuthorizationOwnerType.MAPPING)
         .withResourceType(resourceType)
@@ -899,7 +895,6 @@ public class AuthorizationCheckBehaviorTest {
     engine
         .authorization()
         .newAuthorization()
-        .withOwnerKey(firstMappingKey)
         .withOwnerId(String.valueOf(firstMappingKey))
         .withOwnerType(AuthorizationOwnerType.MAPPING)
         .withResourceType(resourceType)
@@ -909,7 +904,6 @@ public class AuthorizationCheckBehaviorTest {
     engine
         .authorization()
         .newAuthorization()
-        .withOwnerKey(secondMappingKey)
         .withOwnerId(String.valueOf(secondMappingKey))
         .withOwnerType(AuthorizationOwnerType.MAPPING)
         .withResourceType(resourceType)
@@ -1134,7 +1128,6 @@ public class AuthorizationCheckBehaviorTest {
           .authorization()
           .newAuthorization()
           .withPermissions(permissionType)
-          .withOwnerKey(ownerKey)
           .withOwnerId(ownerId)
           .withOwnerType(ownerType)
           .withResourceType(resourceType)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationMultipartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationMultipartitionTest.java
@@ -45,8 +45,6 @@ public class CreateAuthorizationMultipartitionTest {
         engine
             .authorization()
             .newAuthorization()
-            // TODO: remove with https://github.com/camunda/camunda/issues/26883
-            .withOwnerKey(1L)
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceId("resourceId")
@@ -110,8 +108,6 @@ public class CreateAuthorizationMultipartitionTest {
     engine
         .authorization()
         .newAuthorization()
-        // TODO: remove with https://github.com/camunda/camunda/issues/26883
-        .withOwnerKey(1L)
         .withOwnerId("ownerId")
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceId("resourceId")
@@ -147,8 +143,6 @@ public class CreateAuthorizationMultipartitionTest {
     engine
         .authorization()
         .newAuthorization()
-        // TODO: remove with https://github.com/camunda/camunda/issues/26883
-        .withOwnerKey(1L)
         .withOwnerId("ownerId")
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceId("resourceId")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationTest.java
@@ -35,8 +35,6 @@ public class CreateAuthorizationTest {
         engine
             .authorization()
             .newAuthorization()
-            // TODO: remove with https://github.com/camunda/camunda/issues/26883
-            .withOwnerKey(1L)
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceId("resourceId")
@@ -67,8 +65,6 @@ public class CreateAuthorizationTest {
     engine
         .authorization()
         .newAuthorization()
-        // TODO: remove with https://github.com/camunda/camunda/issues/26883
-        .withOwnerKey(1L)
         .withOwnerId("ownerId")
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceId("resourceId")
@@ -79,8 +75,6 @@ public class CreateAuthorizationTest {
     engine
         .authorization()
         .newAuthorization()
-        // TODO: remove with https://github.com/camunda/camunda/issues/26883
-        .withOwnerKey(1L)
         .withOwnerId("ownerId")
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceId("anotherResourceId")
@@ -93,8 +87,6 @@ public class CreateAuthorizationTest {
         engine
             .authorization()
             .newAuthorization()
-            // TODO: remove with https://github.com/camunda/camunda/issues/26883
-            .withOwnerKey(1L)
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceId("resourceId")
@@ -122,8 +114,6 @@ public class CreateAuthorizationTest {
         engine
             .authorization()
             .newAuthorization()
-            // TODO: remove with https://github.com/camunda/camunda/issues/26883
-            .withOwnerKey(1L)
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceId("resourceId")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationTest.java
@@ -50,7 +50,7 @@ public class CreateAuthorizationTest {
             AuthorizationRecordValue::getOwnerType,
             AuthorizationRecordValue::getResourceId,
             AuthorizationRecordValue::getResourceType,
-            AuthorizationRecordValue::getAuthorizationPermissions)
+            AuthorizationRecordValue::getPermissionTypes)
         .containsExactly(
             "ownerId",
             AuthorizationOwnerType.USER,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/DeleteAuthorizationMultipartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/DeleteAuthorizationMultipartitionTest.java
@@ -44,8 +44,6 @@ public class DeleteAuthorizationMultipartitionTest {
         engine
             .authorization()
             .newAuthorization()
-            // TODO: remove with https://github.com/camunda/camunda/issues/26883
-            .withOwnerKey(1L)
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceId("resourceId")
@@ -115,8 +113,6 @@ public class DeleteAuthorizationMultipartitionTest {
         engine
             .authorization()
             .newAuthorization()
-            // TODO: remove with https://github.com/camunda/camunda/issues/26883
-            .withOwnerKey(1L)
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceId("resourceId")
@@ -147,8 +143,6 @@ public class DeleteAuthorizationMultipartitionTest {
         engine
             .authorization()
             .newAuthorization()
-            // TODO: remove with https://github.com/camunda/camunda/issues/26883
-            .withOwnerKey(1L)
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceId("resourceId")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/DeleteAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/DeleteAuthorizationTest.java
@@ -31,8 +31,6 @@ public class DeleteAuthorizationTest {
         engine
             .authorization()
             .newAuthorization()
-            // TODO: remove with https://github.com/camunda/camunda/issues/26883
-            .withOwnerKey(1L)
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceId("resourceId")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
@@ -383,7 +383,7 @@ public class IdentitySetupInitializeTest {
       Assertions.assertThat(addedPermissions)
           .filteredOn(record -> record.getResourceType() == resourceType)
           .describedAs("Added supported permission types for resource type %s", resourceType)
-          .flatMap(AuthorizationRecordValue::getAuthorizationPermissions)
+          .flatMap(AuthorizationRecordValue::getPermissionTypes)
           .containsOnly(expectedPermissions.get(resourceType).toArray(new PermissionType[0]));
     }
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationMultipartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationMultipartitionTest.java
@@ -44,8 +44,6 @@ public class UpdateAuthorizationMultipartitionTest {
         engine
             .authorization()
             .newAuthorization()
-            // TODO: remove with https://github.com/camunda/camunda/issues/26883
-            .withOwnerKey(1L)
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceId("resourceId")
@@ -115,8 +113,6 @@ public class UpdateAuthorizationMultipartitionTest {
         engine
             .authorization()
             .newAuthorization()
-            // TODO: remove with https://github.com/camunda/camunda/issues/26883
-            .withOwnerKey(1L)
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceId("resourceId")
@@ -147,8 +143,6 @@ public class UpdateAuthorizationMultipartitionTest {
         engine
             .authorization()
             .newAuthorization()
-            // TODO: remove with https://github.com/camunda/camunda/issues/26883
-            .withOwnerKey(1L)
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceId("resourceId")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationTest.java
@@ -65,7 +65,7 @@ public class UpdateAuthorizationTest {
             AuthorizationRecordValue::getOwnerType,
             AuthorizationRecordValue::getResourceId,
             AuthorizationRecordValue::getResourceType,
-            AuthorizationRecordValue::getAuthorizationPermissions)
+            AuthorizationRecordValue::getPermissionTypes)
         .containsExactly(
             authorizationKey,
             "ownerId",

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateAuthorizationTest.java
@@ -35,8 +35,6 @@ public class UpdateAuthorizationTest {
         engine
             .authorization()
             .newAuthorization()
-            // TODO: remove with https://github.com/camunda/camunda/issues/26883
-            .withOwnerKey(1L)
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceId("resourceId")
@@ -98,8 +96,6 @@ public class UpdateAuthorizationTest {
         engine
             .authorization()
             .newAuthorization()
-            // TODO: remove with https://github.com/camunda/camunda/issues/26883
-            .withOwnerKey(1L)
             .withOwnerId("ownerId")
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceId("resourceId")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clock/ClockPinAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clock/ClockPinAuthorizationTest.java
@@ -108,7 +108,6 @@ public class ClockPinAuthorizationTest {
         .authorization()
         .newAuthorization()
         .withPermissions(permissionType)
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateAuthorizationTest.java
@@ -128,7 +128,6 @@ public class DeploymentCreateAuthorizationTest {
         .authorization()
         .newAuthorization()
         .withPermissions(permissionType)
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -141,7 +141,6 @@ public class CommandDistributionIdempotencyTest {
                   ENGINE
                       .authorization()
                       .newAuthorization()
-                      .withOwnerKey(user.getKey())
                       .withOwnerId(user.getValue().getUsername())
                       .withResourceId("*")
                       .withResourceType(AuthorizationResourceType.USER)
@@ -162,7 +161,6 @@ public class CommandDistributionIdempotencyTest {
                       ENGINE
                           .authorization()
                           .newAuthorization()
-                          .withOwnerKey(user.getKey())
                           .withOwnerId(user.getValue().getUsername())
                           .withResourceId("*")
                           .withResourceType(AuthorizationResourceType.USER)
@@ -187,7 +185,6 @@ public class CommandDistributionIdempotencyTest {
                       ENGINE
                           .authorization()
                           .newAuthorization()
-                          .withOwnerKey(user.getKey())
                           .withOwnerId(user.getValue().getUsername())
                           .withResourceId("*")
                           .withResourceType(AuthorizationResourceType.USER)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluateAuthorizationTest.java
@@ -123,7 +123,6 @@ public class DecisionEvaluationEvaluateAuthorizationTest {
     engine
         .authorization()
         .newAuthorization()
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveAuthorizationTest.java
@@ -137,7 +137,6 @@ public class IncidentResolveAuthorizationTest {
         .authorization()
         .newAuthorization()
         .withPermissions(permissionType)
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
@@ -76,7 +76,6 @@ public final class CompleteJobTest {
         .withPermissions(PermissionType.UPDATE_PROCESS_INSTANCE)
         .withResourceId(PROCESS_ID)
         .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
-        .withOwnerKey(userKey)
         .withOwnerId(username)
         .withOwnerType(AuthorizationOwnerType.USER)
         .create();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
@@ -83,7 +83,6 @@ public final class FailJobTest {
         .withPermissions(PermissionType.UPDATE_PROCESS_INSTANCE)
         .withResourceId(PROCESS_ID)
         .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
-        .withOwnerKey(userKey)
         .withOwnerId(username)
         .withOwnerType(AuthorizationOwnerType.USER)
         .create();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateAuthorizationTest.java
@@ -154,7 +154,6 @@ public class JobBatchActivateAuthorizationTest {
           .authorization()
           .newAuthorization()
           .withPermissions(permissionType)
-          .withOwnerKey(user.getUserKey())
           .withOwnerId(user.getUsername())
           .withOwnerType(AuthorizationOwnerType.USER)
           .withResourceType(authorization)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobCompleteAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobCompleteAuthorizationTest.java
@@ -126,7 +126,6 @@ public class JobCompleteAuthorizationTest {
         .authorization()
         .newAuthorization()
         .withPermissions(permissionType)
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobFailAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobFailAuthorizationTest.java
@@ -125,7 +125,6 @@ public class JobFailAuthorizationTest {
         .authorization()
         .newAuthorization()
         .withPermissions(permissionType)
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorTest.java
@@ -70,7 +70,6 @@ public final class JobThrowErrorTest {
         .withPermissions(PermissionType.UPDATE_PROCESS_INSTANCE)
         .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
         .withResourceId(PROCESS_ID)
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .create();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateAuthorizationTest.java
@@ -133,7 +133,6 @@ public class JobUpdateAuthorizationTest {
         .authorization()
         .newAuthorization()
         .withPermissions(permissionType)
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesTest.java
@@ -64,7 +64,6 @@ public final class JobUpdateRetriesTest {
         .withPermissions(PermissionType.UPDATE_PROCESS_INSTANCE)
         .withResourceId(PROCESS_ID)
         .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
-        .withOwnerKey(userKey)
         .withOwnerId(username)
         .withOwnerType(AuthorizationOwnerType.USER)
         .create();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutTest.java
@@ -73,7 +73,6 @@ public class JobUpdateTimeoutTest {
         .withPermissions(PermissionType.UPDATE_PROCESS_INSTANCE)
         .withResourceId(PROCESS_ID)
         .withResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
-        .withOwnerKey(userKey)
         .withOwnerId(username)
         .withOwnerType(AuthorizationOwnerType.USER)
         .create();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingCreateAuthorizationTest.java
@@ -126,7 +126,6 @@ public class MappingCreateAuthorizationTest {
         .authorization()
         .newAuthorization()
         .withPermissions(permissionType)
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateAuthorizationTest.java
@@ -274,7 +274,6 @@ public class MessageCorrelationCorrelateAuthorizationTest {
         .authorization()
         .newAuthorization()
         .withPermissions(permissionType)
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessagePublishAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessagePublishAuthorizationTest.java
@@ -157,7 +157,6 @@ public class MessagePublishAuthorizationTest {
         .authorization()
         .newAuthorization()
         .withPermissions(permissionType)
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelAuthorizationTest.java
@@ -136,7 +136,6 @@ public class ProcessInstanceCancelAuthorizationTest {
         .authorization()
         .newAuthorization()
         .withPermissions(permissionType)
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreateAuthorizationTest.java
@@ -198,7 +198,6 @@ public class ProcessInstanceCreateAuthorizationTest {
         .authorization()
         .newAuthorization()
         .withPermissions(permissionType)
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyAuthorizationTest.java
@@ -163,7 +163,6 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
         .authorization()
         .newAuthorization()
         .withPermissions(permissionType)
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/ProcessInstanceMigrationMigrateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/ProcessInstanceMigrationMigrateAuthorizationTest.java
@@ -176,7 +176,6 @@ public class ProcessInstanceMigrationMigrateAuthorizationTest {
         .authorization()
         .newAuthorization()
         .withPermissions(permissionType)
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationTest.java
@@ -242,7 +242,6 @@ public class ResourceDeletionAuthorizationTest {
         .authorization()
         .newAuthorization()
         .withPermissions(permissionType)
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleCreateAuthorizationTest.java
@@ -106,7 +106,6 @@ public class RoleCreateAuthorizationTest {
         .authorization()
         .newAuthorization()
         .withPermissions(permissionType)
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastAuthorizationTest.java
@@ -158,7 +158,6 @@ public class SignalBroadcastAuthorizationTest {
         .authorization()
         .newAuthorization()
         .withPermissions(permissionType)
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateUserTest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.processing.user;
 
 import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -98,26 +97,23 @@ public class CreateUserTest {
     final var username = UUID.randomUUID().toString();
 
     // when
-    final var userKey =
-        ENGINE
-            .user()
-            .newUser(username)
-            .withName("Foo Bar")
-            .withEmail("foo@bar.com")
-            .withPassword("password")
-            .create()
-            .getKey();
+    ENGINE
+        .user()
+        .newUser(username)
+        .withName("Foo Bar")
+        .withEmail("foo@bar.com")
+        .withPassword("password")
+        .create();
 
     // then
     assertThat(
             RecordingExporter.authorizationRecords(AuthorizationIntent.CREATED)
-                .withOwnerKey(userKey)
+                .withOwnerId(username)
                 .getFirst()
                 .getValue())
-        .hasOwnerKey(userKey)
         .hasOwnerType(AuthorizationOwnerType.USER)
         .hasResourceType(AuthorizationResourceType.USER)
         .hasResourceId(username)
-        .hasAuthorizationPermissions(PermissionType.READ, PermissionType.UPDATE);
+        .hasOnlyAuthorizationPermissions(PermissionType.READ, PermissionType.UPDATE);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateUserTest.java
@@ -10,14 +10,17 @@ package io.camunda.zeebe.engine.processing.user;
 import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -97,23 +100,59 @@ public class CreateUserTest {
     final var username = UUID.randomUUID().toString();
 
     // when
-    ENGINE
-        .user()
-        .newUser(username)
-        .withName("Foo Bar")
-        .withEmail("foo@bar.com")
-        .withPassword("password")
-        .create();
+    final long userKey =
+        ENGINE
+            .user()
+            .newUser(username)
+            .withName("Foo Bar")
+            .withEmail("foo@bar.com")
+            .withPassword("password")
+            .create()
+            .getKey();
 
     // then
-    assertThat(
-            RecordingExporter.authorizationRecords(AuthorizationIntent.CREATED)
-                .withOwnerId(username)
-                .getFirst()
-                .getValue())
+    final var createdAuthorizationRecord =
+        RecordingExporter.authorizationRecords(AuthorizationIntent.CREATED)
+            .withOwnerId(username)
+            .getFirst()
+            .getValue();
+
+    final long authorizationKey =
+        RecordingExporter.authorizationRecords(AuthorizationIntent.CREATED)
+            .withOwnerId(username)
+            .getFirst()
+            .getKey();
+
+    // Verify authorization key is set and different from the user key
+    Assertions.assertThat(authorizationKey)
+        .describedAs("Authorization key should be different from user key")
+        .isNotEqualTo(userKey);
+
+    assertThat(createdAuthorizationRecord)
         .hasOwnerType(AuthorizationOwnerType.USER)
         .hasResourceType(AuthorizationResourceType.USER)
         .hasResourceId(username)
-        .hasOnlyAuthorizationPermissions(PermissionType.READ, PermissionType.UPDATE);
+        .hasOnlyPermissionTypes(PermissionType.READ, PermissionType.UPDATE);
+
+    // Verify that UserIntent.CREATE and UserIntent.CREATED events exist
+    final var intents =
+        RecordingExporter.userRecords()
+            .withUsername(username)
+            .limit(2)
+            .map(Record::getIntent)
+            .collect(Collectors.toList());
+
+    Assertions.assertThat(intents).containsExactly(UserIntent.CREATE, UserIntent.CREATED);
+
+    // Verify that AuthorizationIntent.CREATE and AuthorizationIntent.CREATED events exist
+    final var authorizationIntents =
+        RecordingExporter.authorizationRecords()
+            .withOwnerId(username)
+            .withAuthorizationKey(authorizationKey)
+            .limit(2)
+            .map(Record::getIntent)
+            .toList();
+    Assertions.assertThat(authorizationIntents)
+        .containsExactly(AuthorizationIntent.CREATE, AuthorizationIntent.CREATED);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UserCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UserCreateAuthorizationTest.java
@@ -117,7 +117,6 @@ public class UserCreateAuthorizationTest {
         .authorization()
         .newAuthorization()
         .withPermissions(permissionType)
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskAssignAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskAssignAuthorizationTest.java
@@ -150,7 +150,6 @@ public class UserTaskAssignAuthorizationTest {
         .authorization()
         .newAuthorization()
         .withPermissions(permissionType)
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimAuthorizationTest.java
@@ -151,7 +151,6 @@ public class UserTaskClaimAuthorizationTest {
         .authorization()
         .newAuthorization()
         .withPermissions(permissionType)
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCompleteAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCompleteAuthorizationTest.java
@@ -151,7 +151,6 @@ public class UserTaskCompleteAuthorizationTest {
         .authorization()
         .newAuthorization()
         .withPermissions(permissionType)
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskUpdateAuthorizationTest.java
@@ -149,7 +149,6 @@ public class UserTaskUpdateAuthorizationTest {
         .authorization()
         .newAuthorization()
         .withPermissions(permissionType)
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateAuthorizationTest.java
@@ -150,7 +150,6 @@ public class VariableDocumentUpdateAuthorizationTest {
         .authorization()
         .newAuthorization()
         .withPermissions(permissionType)
-        .withOwnerKey(user.getUserKey())
         .withOwnerId(user.getUsername())
         .withOwnerType(AuthorizationOwnerType.USER)
         .withResourceType(authorization)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
@@ -103,7 +103,7 @@ public class MappingAppliersTest {
     authorizationState.create(
         5L,
         new AuthorizationRecord()
-            .setAuthorizationPermissions(Set.of(PermissionType.READ))
+            .setPermissionTypes(Set.of(PermissionType.READ))
             .setResourceId("process")
             .setResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
             .setOwnerType(AuthorizationOwnerType.MAPPING)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/RoleAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/RoleAppliersTest.java
@@ -116,7 +116,7 @@ public class RoleAppliersTest {
             .setAuthorizationKey(1L)
             .setResourceId("role1")
             .setResourceType(AuthorizationResourceType.ROLE)
-            .setAuthorizationPermissions(Set.of(PermissionType.DELETE))
+            .setPermissionTypes(Set.of(PermissionType.DELETE))
             .setOwnerType(AuthorizationOwnerType.ROLE)
             .setOwnerId(roleId));
     authorizationState.create(
@@ -125,7 +125,7 @@ public class RoleAppliersTest {
             .setAuthorizationKey(2L)
             .setResourceId("role2")
             .setResourceType(AuthorizationResourceType.ROLE)
-            .setAuthorizationPermissions(Set.of(PermissionType.DELETE))
+            .setPermissionTypes(Set.of(PermissionType.DELETE))
             .setOwnerType(AuthorizationOwnerType.ROLE)
             .setOwnerId(roleId));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserDeletedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserDeletedApplierTest.java
@@ -61,7 +61,7 @@ public class UserDeletedApplierTest {
             .setResourceType(PROCESS_DEFINITION)
             .setOwnerId(userRecord.getUsername())
             .setOwnerType(AuthorizationOwnerType.USER)
-            .setAuthorizationPermissions(Set.of(CREATE)));
+            .setPermissionTypes(Set.of(CREATE)));
     authorizationState.create(
         2L,
         new AuthorizationRecord()
@@ -70,7 +70,7 @@ public class UserDeletedApplierTest {
             .setResourceType(PROCESS_DEFINITION)
             .setOwnerId(userRecord.getUsername())
             .setOwnerType(AuthorizationOwnerType.USER)
-            .setAuthorizationPermissions(Set.of(CREATE)));
+            .setPermissionTypes(Set.of(CREATE)));
     authorizationState.create(
         3L,
         new AuthorizationRecord()
@@ -79,7 +79,7 @@ public class UserDeletedApplierTest {
             .setResourceType(DECISION_DEFINITION)
             .setOwnerId(userRecord.getUsername())
             .setOwnerType(AuthorizationOwnerType.USER)
-            .setAuthorizationPermissions(Set.of(DELETE)));
+            .setPermissionTypes(Set.of(DELETE)));
 
     assertThat(
             authorizationState.getResourceIdentifiers(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
@@ -62,7 +62,7 @@ public class AuthorizationStateTest {
             .setOwnerType(ownerType)
             .setResourceId(resourceId)
             .setResourceType(resourceType)
-            .setAuthorizationPermissions(permissions);
+            .setPermissionTypes(permissions);
 
     // when
     authorizationState.create(authorizationKey, authorizationRecord);
@@ -102,7 +102,7 @@ public class AuthorizationStateTest {
             .setOwnerType(ownerType)
             .setResourceId(resourceId)
             .setResourceType(resourceType)
-            .setAuthorizationPermissions(permissions);
+            .setPermissionTypes(permissions);
 
     authorizationState.create(authorizationKey, authorizationRecord);
 
@@ -114,7 +114,7 @@ public class AuthorizationStateTest {
             .setOwnerType(ownerType)
             .setResourceId("anotherResourceId")
             .setResourceType(resourceType)
-            .setAuthorizationPermissions(Set.of(PermissionType.READ, PermissionType.ACCESS));
+            .setPermissionTypes(Set.of(PermissionType.READ, PermissionType.ACCESS));
     authorizationState.update(authorizationKey, updatedAuthorizationRecord);
 
     // then
@@ -169,7 +169,7 @@ public class AuthorizationStateTest {
             .setOwnerType(ownerType)
             .setResourceId(resourceId)
             .setResourceType(resourceType)
-            .setAuthorizationPermissions(permissions);
+            .setPermissionTypes(permissions);
 
     authorizationState.create(authorizationKey, authorizationRecord);
 
@@ -181,7 +181,7 @@ public class AuthorizationStateTest {
             .setOwnerType(ownerType)
             .setResourceId("anotherResourceId")
             .setResourceType(resourceType)
-            .setAuthorizationPermissions(permissions);
+            .setPermissionTypes(permissions);
     authorizationState.update(authorizationKey, updatedAuthorizationRecord);
 
     // then
@@ -238,7 +238,7 @@ public class AuthorizationStateTest {
             .setOwnerType(ownerType)
             .setResourceId(resourceId)
             .setResourceType(resourceType)
-            .setAuthorizationPermissions(permissions);
+            .setPermissionTypes(permissions);
 
     authorizationState.create(authorizationKey, authorizationRecord);
 
@@ -250,7 +250,7 @@ public class AuthorizationStateTest {
             .setOwnerType(ownerType)
             .setResourceId(resourceId)
             .setResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
-            .setAuthorizationPermissions(permissions);
+            .setPermissionTypes(permissions);
     authorizationState.update(authorizationKey, updatedAuthorizationRecord);
 
     // then
@@ -311,7 +311,7 @@ public class AuthorizationStateTest {
             .setOwnerType(ownerType)
             .setResourceId(resourceId)
             .setResourceType(resourceType)
-            .setAuthorizationPermissions(permissions);
+            .setPermissionTypes(permissions);
 
     authorizationState.create(authorizationKey, authorizationRecord);
 
@@ -322,7 +322,7 @@ public class AuthorizationStateTest {
             .setOwnerType(ownerType)
             .setResourceId("resourceId2")
             .setResourceType(resourceType)
-            .setAuthorizationPermissions(permissions);
+            .setPermissionTypes(permissions);
 
     authorizationState.create(2L, anotherRecord);
 
@@ -334,7 +334,7 @@ public class AuthorizationStateTest {
             .setOwnerType(ownerType)
             .setResourceId(resourceId)
             .setResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
-            .setAuthorizationPermissions(Set.of(PermissionType.READ_PROCESS_DEFINITION));
+            .setPermissionTypes(Set.of(PermissionType.READ_PROCESS_DEFINITION));
     authorizationState.update(authorizationKey, updatedAuthorizationRecord);
 
     // then
@@ -388,7 +388,7 @@ public class AuthorizationStateTest {
             .setOwnerType(ownerType)
             .setResourceId(resourceId)
             .setResourceType(resourceType)
-            .setAuthorizationPermissions(permissions);
+            .setPermissionTypes(permissions);
 
     authorizationState.create(authorizationKey, authorizationRecord);
 
@@ -428,7 +428,7 @@ public class AuthorizationStateTest {
             .setOwnerType(ownerType1)
             .setResourceId(resourceId1)
             .setResourceType(resourceType1)
-            .setAuthorizationPermissions(permissions1);
+            .setPermissionTypes(permissions1);
 
     final var authorizationKey2 = 2L;
     final String ownerId2 = "ownerId2";
@@ -443,7 +443,7 @@ public class AuthorizationStateTest {
             .setOwnerType(ownerType2)
             .setResourceId(resourceId2)
             .setResourceType(resourceType2)
-            .setAuthorizationPermissions(permissions2);
+            .setPermissionTypes(permissions2);
 
     authorizationState.create(authorizationKey1, authorizationRecord1);
     authorizationState.create(authorizationKey2, authorizationRecord2);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AuthorizationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AuthorizationClient.java
@@ -86,7 +86,7 @@ public final class AuthorizationClient {
     }
 
     public AuthorizationCreateClient withPermissions(final PermissionType... permissions) {
-      authorizationCreationRecord.setAuthorizationPermissions(Set.of(permissions));
+      authorizationCreationRecord.setPermissionTypes(Set.of(permissions));
       return this;
     }
 
@@ -204,7 +204,7 @@ public final class AuthorizationClient {
     }
 
     public AuthorizationUpdateClient withPermissions(final PermissionType... permissions) {
-      authorizationUpdateRecord.setAuthorizationPermissions(Set.of(permissions));
+      authorizationUpdateRecord.setPermissionTypes(Set.of(permissions));
       return this;
     }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AuthorizationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AuthorizationClient.java
@@ -64,11 +64,6 @@ public final class AuthorizationClient {
       authorizationCreationRecord = new AuthorizationRecord();
     }
 
-    public AuthorizationCreateClient withOwnerKey(final Long ownerKey) {
-      authorizationCreationRecord.setOwnerKey(ownerKey);
-      return this;
-    }
-
     public AuthorizationCreateClient withOwnerId(final String ownerId) {
       authorizationCreationRecord.setOwnerId(ownerId);
       return this;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandler.java
@@ -65,7 +65,7 @@ public class AuthorizationCreatedUpdatedHandler
         .setOwnerType(value.getOwnerType().name())
         .setResourceType(value.getResourceType().name())
         .setResourceId(value.getResourceId())
-        .setPermissionTypes(new HashSet<>(value.getAuthorizationPermissions()));
+        .setPermissionTypes(new HashSet<>(value.getPermissionTypes()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationDeletedHandler.java
@@ -61,7 +61,7 @@ public class AuthorizationDeletedHandler
         .setOwnerType(value.getOwnerType().name())
         .setResourceType(value.getResourceType().name())
         .setResourceId(value.getResourceId())
-        .setPermissionTypes(new HashSet<>(value.getAuthorizationPermissions()));
+        .setPermissionTypes(new HashSet<>(value.getPermissionTypes()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandlerTest.java
@@ -99,7 +99,7 @@ public class AuthorizationCreatedUpdatedHandlerTest {
             .withOwnerId("foo")
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceId("*")
-            .withAuthorizationPermissions(List.of(PermissionType.CREATE, PermissionType.DELETE))
+            .withPermissionTypes(List.of(PermissionType.CREATE, PermissionType.DELETE))
             .build();
 
     final Record<AuthorizationRecordValue> authorizationRecord =
@@ -129,7 +129,7 @@ public class AuthorizationCreatedUpdatedHandlerTest {
     assertThat(authorizationEntity.getResourceId())
         .isEqualTo(authorizationRecordValue.getResourceId());
     assertThat(authorizationEntity.getPermissionTypes())
-        .isEqualTo(authorizationRecordValue.getAuthorizationPermissions());
+        .isEqualTo(authorizationRecordValue.getPermissionTypes());
   }
 
   @Test

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/AuthorizationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/AuthorizationExportHandler.java
@@ -50,7 +50,7 @@ public class AuthorizationExportHandler implements RdbmsExportHandler<Authorizat
         .ownerType(authorization.getOwnerType().name())
         .resourceType(authorization.getResourceType().name())
         .resourceId(authorization.getResourceId())
-        .permissionTypes(authorization.getAuthorizationPermissions())
+        .permissionTypes(authorization.getPermissionTypes())
         .build();
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
@@ -76,7 +76,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
             .setOwnerType(AuthorizationOwnerType.USER)
             .setResourceId(resourceId)
             .setResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
-            .setAuthorizationPermissions(Set.of(PermissionType.CREATE));
+            .setPermissionTypes(Set.of(PermissionType.CREATE));
 
     when(authorizationServices.createAuthorization(any(CreateAuthorizationRequest.class)))
         .thenReturn(CompletableFuture.completedFuture(authorizationRecord));
@@ -106,8 +106,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
     assertEquals(resourceId, capturedRequest.resourceId());
     assertEquals(authorizationRecord.getResourceType(), capturedRequest.resourceType());
     assertEquals(1, capturedRequest.permissionTypes().size());
-    assertEquals(
-        authorizationRecord.getAuthorizationPermissions(), capturedRequest.permissionTypes());
+    assertEquals(authorizationRecord.getPermissionTypes(), capturedRequest.permissionTypes());
   }
 
   @ParameterizedTest
@@ -177,7 +176,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
             .setOwnerType(AuthorizationOwnerType.USER)
             .setResourceId(resourceId)
             .setResourceType(AuthorizationResourceType.PROCESS_DEFINITION)
-            .setAuthorizationPermissions(Set.of(PermissionType.CREATE));
+            .setPermissionTypes(Set.of(PermissionType.CREATE));
 
     when(authorizationServices.updateAuthorization(any()))
         .thenReturn(CompletableFuture.completedFuture(authorizationRecord));
@@ -203,8 +202,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
     assertEquals(resourceId, capturedRequest.resourceId());
     assertEquals(authorizationRecord.getResourceType(), capturedRequest.resourceType());
     assertEquals(1, capturedRequest.permissionTypes().size());
-    assertEquals(
-        authorizationRecord.getAuthorizationPermissions(), capturedRequest.permissionTypes());
+    assertEquals(authorizationRecord.getPermissionTypes(), capturedRequest.permissionTypes());
   }
 
   @ParameterizedTest

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerAuthorizationRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerAuthorizationRequest.java
@@ -53,7 +53,7 @@ public class BrokerAuthorizationRequest extends BrokerExecuteCommand<Authorizati
   }
 
   public BrokerAuthorizationRequest setPermissionTypes(final Set<PermissionType> permissionTypes) {
-    requestDto.setAuthorizationPermissions(permissionTypes);
+    requestDto.setPermissionTypes(permissionTypes);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/AuthorizationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/AuthorizationRecord.java
@@ -35,8 +35,8 @@ public final class AuthorizationRecord extends UnifiedRecordValue
   private final EnumProperty<AuthorizationResourceType> resourceTypeProp =
       new EnumProperty<>(
           "resourceType", AuthorizationResourceType.class, AuthorizationResourceType.UNSPECIFIED);
-  private final ArrayProperty<StringValue> permissionTypes =
-      new ArrayProperty<>("authorizationPermissions", StringValue::new);
+  private final ArrayProperty<StringValue> permissionTypesProp =
+      new ArrayProperty<>("permissionTypes", StringValue::new);
 
   public AuthorizationRecord() {
     super(6);
@@ -45,7 +45,7 @@ public final class AuthorizationRecord extends UnifiedRecordValue
         .declareProperty(ownerTypeProp)
         .declareProperty(resourceIdProp)
         .declareProperty(resourceTypeProp)
-        .declareProperty(permissionTypes);
+        .declareProperty(permissionTypesProp);
   }
 
   @Override
@@ -89,18 +89,18 @@ public final class AuthorizationRecord extends UnifiedRecordValue
   }
 
   @Override
-  public Set<PermissionType> getAuthorizationPermissions() {
-    return permissionTypes.stream()
+  public Set<PermissionType> getPermissionTypes() {
+    return permissionTypesProp.stream()
         .map(StringValue::getValue)
         .map(BufferUtil::bufferAsString)
         .map(PermissionType::valueOf)
         .collect(Collectors.toSet());
   }
 
-  public AuthorizationRecord setAuthorizationPermissions(final Set<PermissionType> permissions) {
-    permissionTypes.reset();
+  public AuthorizationRecord setPermissionTypes(final Set<PermissionType> permissions) {
+    permissionTypesProp.reset();
     permissions.forEach(
-        permission -> permissionTypes.add().wrap(BufferUtil.wrapString(permission.name())));
+        permission -> permissionTypesProp.add().wrap(BufferUtil.wrapString(permission.name())));
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/AuthorizationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/AuthorizationRecord.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -29,8 +28,6 @@ public final class AuthorizationRecord extends UnifiedRecordValue
 
   private final LongProperty authorizationKeyProp = new LongProperty("authorizationKey", -1L);
   private final StringProperty ownerIdProp = new StringProperty("ownerId", "");
-  // TODO: remove in: https://github.com/camunda/camunda/issues/26883
-  private final LongProperty ownerKeyProp = new LongProperty("ownerKey", -1L);
   private final EnumProperty<AuthorizationOwnerType> ownerTypeProp =
       new EnumProperty<>(
           "ownerType", AuthorizationOwnerType.class, AuthorizationOwnerType.UNSPECIFIED);
@@ -38,23 +35,17 @@ public final class AuthorizationRecord extends UnifiedRecordValue
   private final EnumProperty<AuthorizationResourceType> resourceTypeProp =
       new EnumProperty<>(
           "resourceType", AuthorizationResourceType.class, AuthorizationResourceType.UNSPECIFIED);
-  // TODO: remove in: https://github.com/camunda/camunda/issues/26883
-  private final ArrayProperty<Permission> permissionsProp =
-      new ArrayProperty<>("permissions", Permission::new);
-  // TODO: rename in: https://github.com/camunda/camunda/issues/26883
-  private final ArrayProperty<StringValue> authorizationPermissionsProp =
+  private final ArrayProperty<StringValue> permissionTypes =
       new ArrayProperty<>("authorizationPermissions", StringValue::new);
 
   public AuthorizationRecord() {
-    super(8);
+    super(6);
     declareProperty(authorizationKeyProp)
         .declareProperty(ownerIdProp)
         .declareProperty(ownerTypeProp)
-        .declareProperty(ownerKeyProp)
         .declareProperty(resourceIdProp)
         .declareProperty(resourceTypeProp)
-        .declareProperty(permissionsProp)
-        .declareProperty(authorizationPermissionsProp);
+        .declareProperty(permissionTypes);
   }
 
   @Override
@@ -74,16 +65,6 @@ public final class AuthorizationRecord extends UnifiedRecordValue
 
   public AuthorizationRecord setOwnerId(final String ownerId) {
     ownerIdProp.setValue(ownerId);
-    return this;
-  }
-
-  @Override
-  public Long getOwnerKey() {
-    return ownerKeyProp.getValue();
-  }
-
-  public AuthorizationRecord setOwnerKey(final Long ownerKey) {
-    ownerKeyProp.setValue(ownerKey);
     return this;
   }
 
@@ -108,19 +89,8 @@ public final class AuthorizationRecord extends UnifiedRecordValue
   }
 
   @Override
-  public List<PermissionValue> getPermissions() {
-    return permissionsProp.stream()
-        .map(
-            permission -> {
-              final var copy = new Permission().copy(permission);
-              return (PermissionValue) copy;
-            })
-        .toList();
-  }
-
-  @Override
   public Set<PermissionType> getAuthorizationPermissions() {
-    return authorizationPermissionsProp.stream()
+    return permissionTypes.stream()
         .map(StringValue::getValue)
         .map(BufferUtil::bufferAsString)
         .map(PermissionType::valueOf)
@@ -128,10 +98,9 @@ public final class AuthorizationRecord extends UnifiedRecordValue
   }
 
   public AuthorizationRecord setAuthorizationPermissions(final Set<PermissionType> permissions) {
-    authorizationPermissionsProp.reset();
+    permissionTypes.reset();
     permissions.forEach(
-        permission ->
-            authorizationPermissionsProp.add().wrap(BufferUtil.wrapString(permission.name())));
+        permission -> permissionTypes.add().wrap(BufferUtil.wrapString(permission.name())));
     return this;
   }
 
@@ -142,11 +111,6 @@ public final class AuthorizationRecord extends UnifiedRecordValue
 
   public AuthorizationRecord setOwnerType(final AuthorizationOwnerType ownerType) {
     ownerTypeProp.setValue(ownerType);
-    return this;
-  }
-
-  public AuthorizationRecord addPermission(final PermissionValue permission) {
-    permissionsProp.add().copy(permission);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.protocol.impl.record.VersionInfo;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
-import io.camunda.zeebe.protocol.impl.record.value.authorization.Permission;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
@@ -2702,37 +2701,18 @@ final class JsonSerializableToJsonTest {
             () ->
                 new AuthorizationRecord()
                     .setAuthorizationKey(1L)
-                    .setOwnerKey(1L)
                     .setOwnerId("ownerId")
                     .setOwnerType(AuthorizationOwnerType.USER)
                     .setResourceId("resourceId")
                     .setResourceType(AuthorizationResourceType.RESOURCE)
-                    .addPermission(
-                        new Permission()
-                            .setPermissionType(PermissionType.CREATE)
-                            .addResourceId("*")
-                            .addResourceId("bpmnProcessId:foo"))
-                    .addPermission(
-                        new Permission().setPermissionType(PermissionType.READ).addResourceId("*"))
                     .setAuthorizationPermissions(Set.of(PermissionType.CREATE)),
         """
         {
           "authorizationKey": 1,
-          "ownerKey": 1,
           "ownerId": "ownerId",
           "ownerType": "USER",
           "resourceId": "resourceId",
           "resourceType": "RESOURCE",
-          "permissions": [
-            {
-              "permissionType": "CREATE",
-              "resourceIds": ["bpmnProcessId:foo", "*"]
-            },
-            {
-              "permissionType": "READ",
-              "resourceIds": ["*"]
-            }
-          ],
           "authorizationPermissions": [
             "CREATE"
           ]
@@ -2745,19 +2725,14 @@ final class JsonSerializableToJsonTest {
       {
         "Empty AuthorizationRecord",
         (Supplier<AuthorizationRecord>)
-            () ->
-                new AuthorizationRecord()
-                    .setOwnerKey(1L)
-                    .setResourceType(AuthorizationResourceType.RESOURCE),
+            () -> new AuthorizationRecord().setResourceType(AuthorizationResourceType.RESOURCE),
         """
         {
           "authorizationKey": -1,
           "ownerId": "",
-          "ownerKey": 1,
           "ownerType": "UNSPECIFIED",
           "resourceId": "",
           "resourceType": "RESOURCE",
-          "permissions": [],
           "authorizationPermissions": []
         }
         """

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2705,7 +2705,7 @@ final class JsonSerializableToJsonTest {
                     .setOwnerType(AuthorizationOwnerType.USER)
                     .setResourceId("resourceId")
                     .setResourceType(AuthorizationResourceType.RESOURCE)
-                    .setAuthorizationPermissions(Set.of(PermissionType.CREATE)),
+                    .setPermissionTypes(Set.of(PermissionType.CREATE)),
         """
         {
           "authorizationKey": 1,
@@ -2713,7 +2713,7 @@ final class JsonSerializableToJsonTest {
           "ownerType": "USER",
           "resourceId": "resourceId",
           "resourceType": "RESOURCE",
-          "authorizationPermissions": [
+          "permissionTypes": [
             "CREATE"
           ]
         }
@@ -2724,16 +2724,15 @@ final class JsonSerializableToJsonTest {
       /////////////////////////////////////////////////////////////////////////////////////////////
       {
         "Empty AuthorizationRecord",
-        (Supplier<AuthorizationRecord>)
-            () -> new AuthorizationRecord().setResourceType(AuthorizationResourceType.RESOURCE),
+        (Supplier<AuthorizationRecord>) AuthorizationRecord::new,
         """
         {
           "authorizationKey": -1,
           "ownerId": "",
           "ownerType": "UNSPECIFIED",
           "resourceId": "",
-          "resourceType": "RESOURCE",
-          "authorizationPermissions": []
+          "resourceType": "UNSPECIFIED",
+          "permissionTypes": []
         }
         """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationRecordValue.java
@@ -34,7 +34,7 @@ public interface AuthorizationRecordValue extends RecordValue {
 
   AuthorizationResourceType getResourceType();
 
-  Set<PermissionType> getAuthorizationPermissions();
+  Set<PermissionType> getPermissionTypes();
 
   @Value.Immutable
   @ImmutableProtocol(builder = ImmutablePermissionValue.Builder.class)

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationRecordValue.java
@@ -17,7 +17,6 @@ package io.camunda.zeebe.protocol.record.value;
 
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
-import java.util.List;
 import java.util.Set;
 import org.immutables.value.Value;
 
@@ -29,15 +28,11 @@ public interface AuthorizationRecordValue extends RecordValue {
 
   String getOwnerId();
 
-  Long getOwnerKey();
-
   AuthorizationOwnerType getOwnerType();
 
   String getResourceId();
 
   AuthorizationResourceType getResourceType();
-
-  List<PermissionValue> getPermissions();
 
   Set<PermissionType> getAuthorizationPermissions();
 

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AuthorizationRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AuthorizationRecordStream.java
@@ -24,10 +24,6 @@ public class AuthorizationRecordStream
     return new AuthorizationRecordStream(wrappedStream);
   }
 
-  public AuthorizationRecordStream withOwnerKey(final long ownerKey) {
-    return valueFilter(v -> v.getOwnerKey() == ownerKey);
-  }
-
   public AuthorizationRecordStream withOwnerId(final String ownerId) {
     return valueFilter(v -> v.getOwnerId().equals(ownerId));
   }


### PR DESCRIPTION
## Description
 
 -  Remove ownerKeyProp
 - Remove permissionsProp
 - Rename authorizationPermissionsProp - rename to permissionTypes

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #26883

