### PR TITLE
test: use broker instead of single application

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/CamundaMultiDBExtension.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/CamundaMultiDBExtension.java
@@ -17,6 +17,7 @@ import io.camunda.qa.util.cluster.TestSimpleCamundaApplication;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import java.io.IOException;
@@ -116,7 +117,7 @@ public class CamundaMultiDBExtension
   private final HttpClient httpClient;
 
   public CamundaMultiDBExtension() {
-    this(new TestSimpleCamundaApplication());
+    this(new TestStandaloneBroker());
     closeables.add(testApplication);
     testApplication
         .withBrokerConfig(cfg -> cfg.getGateway().setEnable(true))


### PR DESCRIPTION
## Description

 * This is to reduce the scope of several MultiDbTests, which are mostly related to Engine, Exporter and REST API 
   * For these tests Broker usage is sufficient
   * Without this RDBMS tests are not possible yet, as Operate/Tasklist can't start with RDBMS just yet.
 * We need to make sure to add additional tests, validation single application, as a whole, but it doesnt need to be for all tests

### Context

See related discussion on slack https://camunda.slack.com/archives/C07KBQY7H0C/p1738846164439659?thread_ts=1737973581.465969&cid=C07KBQY7H0C

### Execution

Not that this was the goal, but the Broker only tests reduce execution time per test by 1-2 seconds

![brokeronlytest](https://github.com/user-attachments/assets/0b09d2bb-23ba-408b-87b4-c8f5c89d6d81)


## Related issues

related #26896 
