### PR TITLE
build: disable SVE in JAVA_OPTS for IT Mac M4 compatibility

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/ZeebeExtension.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/ZeebeExtension.java
@@ -11,6 +11,7 @@ import static io.camunda.optimize.AbstractCCSMIT.isZeebeVersionPre85;
 import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_ELASTICSEARCH_EXPORTER;
 import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_OPENSEARCH_EXPORTER;
 
+import com.google.common.collect.ImmutableMap;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.CompleteJobCommandStep1;
 import io.camunda.client.api.command.CreateProcessInstanceCommandStep1;
@@ -282,7 +283,11 @@ public class ZeebeExtension implements BeforeEachCallback, AfterEachCallback {
   private void setZeebeRecordPrefixForTest() {
     zeebeContainer =
         zeebeContainer.withEnv(
-            "ZEEBE_BROKER_EXPORTERS_OPTIMIZE_ARGS_INDEX_PREFIX", zeebeRecordPrefix);
+            ImmutableMap.of(
+                "ZEEBE_BROKER_EXPORTERS_OPTIMIZE_ARGS_INDEX_PREFIX",
+                zeebeRecordPrefix,
+                "JAVA_OPTS",
+                "-XX:UseSVE=0"));
   }
 
   private void destroyClient() {


### PR DESCRIPTION
## Description

This issue is related to the one seen in #27251 

There's been an issue with a recent MacOS 15.2 version update for M4 chips. This PR applies the changes recommended in [this camunda blog post](https://forum.camunda.io/t/camunda-installation/58173/6) to prevent the error happening in the future for M4 users running integration tests locally. The env configs should not affect other OS like Windows.
