### PR TITLE
[Backport stable/8.7] migrate MetaStoreMetrics/SnapshotReplicationMetrics  to prometheus

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -14178,7 +14178,7 @@
                 "uid": "$DS_PROMETHEUS"
               },
               "editorMode": "code",
-              "expr": "sum(increase(atomix_last_flushed_index_update_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(atomix_last_flushed_index_update_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval]) or increase(atomix_last_flushed_index_update_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "intervalFactor": 1,
               "legendFormat": "{{le}}",

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -237,7 +237,7 @@ public class DefaultRaftServer implements RaftServer {
       // If the storage is not configured, create a new Storage instance with the configured
       // serializer.
       if (storage == null) {
-        storage = RaftStorage.builder().build();
+        storage = RaftStorage.builder(meterRegistry).build();
       }
 
       final RaftThreadContextFactory singleThreadFactory =

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/MetaStoreMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/MetaStoreMetrics.java
@@ -26,6 +26,7 @@ public final class MetaStoreMetrics extends RaftMetrics {
     lastFlushedIndexUpdate =
         Timer.builder(LAST_FLUSHED_INDEX.getName())
             .description(LAST_FLUSHED_INDEX.getDescription())
+            .serviceLevelObjectives(LAST_FLUSHED_INDEX.getTimerSLOs())
             .tag(RaftKeyNames.PARTITION_GROUP.asString(), partitionName)
             .register(registry);
     clock = registry.config().clock();

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/MetaStoreMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/MetaStoreMetrics.java
@@ -26,9 +26,7 @@ public final class MetaStoreMetrics extends RaftMetrics {
     lastFlushedIndexUpdate =
         Timer.builder(LAST_FLUSHED_INDEX.getName())
             .description(LAST_FLUSHED_INDEX.getDescription())
-            // FIXME use KeyNames
-            .tag(PARTITION_GROUP_NAME_LABEL, partitionName)
-            // FIXME add SLOs
+            .tag(RaftKeyNames.PARTITION_GROUP.asString(), partitionName)
             .register(registry);
     clock = registry.config().clock();
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/MetaStoreMetricsDoc.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/MetaStoreMetricsDoc.java
@@ -18,7 +18,7 @@ public enum MetaStoreMetricsDoc implements ExtendedMeterDocumentation {
   LAST_FLUSHED_INDEX {
     @Override
     public String getName() {
-      return "atomix.last_flushed_index_update";
+      return "atomix.last.flushed.index.update";
     }
 
     @Override
@@ -38,7 +38,7 @@ public enum MetaStoreMetricsDoc implements ExtendedMeterDocumentation {
 
     @Override
     public KeyName[] getKeyNames() {
-      return PartitionKeyNames.values();
+      return new KeyName[] {PartitionKeyNames.PARTITION, RaftKeyNames.PARTITION_GROUP};
     }
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/MetaStoreMetricsDoc.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/MetaStoreMetricsDoc.java
@@ -8,8 +8,11 @@
 package io.atomix.raft.metrics;
 
 import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
+import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Meter.Type;
 
+@SuppressWarnings("NullableProblems")
 public enum MetaStoreMetricsDoc implements ExtendedMeterDocumentation {
   /** Time it takes to update the last flushed index */
   LAST_FLUSHED_INDEX {
@@ -31,6 +34,11 @@ public enum MetaStoreMetricsDoc implements ExtendedMeterDocumentation {
     @Override
     public String getBaseUnit() {
       return "ms";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return PartitionKeyNames.values();
     }
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/MetaStoreMetricsDoc.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/MetaStoreMetricsDoc.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft.metrics;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.micrometer.core.instrument.Meter.Type;
+
+public enum MetaStoreMetricsDoc implements ExtendedMeterDocumentation {
+  /** Time it takes to update the last flushed index */
+  LAST_FLUSHED_INDEX {
+    @Override
+    public String getName() {
+      return "last_flushed_index_update";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Time it takes to update the last flushed index";
+    }
+
+    @Override
+    public String getBaseUnit() {
+      return "ms";
+    }
+  }
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/MetaStoreMetricsDoc.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/MetaStoreMetricsDoc.java
@@ -15,7 +15,7 @@ public enum MetaStoreMetricsDoc implements ExtendedMeterDocumentation {
   LAST_FLUSHED_INDEX {
     @Override
     public String getName() {
-      return "last_flushed_index_update";
+      return "atomix.last_flushed_index_update";
     }
 
     @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftKeyNames.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftKeyNames.java
@@ -9,12 +9,34 @@ package io.atomix.raft.metrics;
 
 import io.micrometer.common.docs.KeyName;
 
+@SuppressWarnings("NullableProblems")
 public enum RaftKeyNames implements KeyName {
   /** partitionGroupName */
   PARTITION_GROUP {
     @Override
     public String asString() {
       return "partitionGroupName";
+    }
+  },
+  /** follower */
+  FOLLOWER {
+    @Override
+    public String asString() {
+      return "follower";
+    }
+  },
+  /** member of the cluster the message is sent */
+  TO {
+    @Override
+    public String asString() {
+      return "to";
+    }
+  },
+  /** type of the message received */
+  TYPE {
+    @Override
+    public String asString() {
+      return "type";
     }
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/SnapshotReplicationMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/SnapshotReplicationMetrics.java
@@ -15,39 +15,41 @@
  */
 package io.atomix.raft.metrics;
 
-import io.prometheus.client.Gauge;
+import static io.atomix.raft.metrics.SnapshotReplicationMetricsDoc.*;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class SnapshotReplicationMetrics extends RaftMetrics {
-  private static final Gauge COUNT =
-      Gauge.build()
-          .namespace(NAMESPACE)
-          .labelNames(PARTITION_GROUP_NAME_LABEL, PARTITION_LABEL)
-          .help("Count of ongoing snapshot replication")
-          .name("snapshot_replication_count")
-          .register();
-  private static final Gauge DURATION =
-      Gauge.build()
-          .namespace(NAMESPACE)
-          .labelNames(PARTITION_GROUP_NAME_LABEL, PARTITION_LABEL)
-          .help("Approximate duration of replication in milliseconds")
-          .name("snapshot_replication_duration_milliseconds")
-          .register();
 
-  private final Gauge.Child count;
-  private final Gauge.Child duration;
+  private final AtomicLong count;
+  private final AtomicLong duration;
 
-  public SnapshotReplicationMetrics(final String partitionName) {
+  public SnapshotReplicationMetrics(final String partitionName, final MeterRegistry meterRegistry) {
     super(partitionName);
-    count = COUNT.labels(partitionGroupName, partition);
-    duration = DURATION.labels(partitionGroupName, partition);
+    Objects.requireNonNull(meterRegistry, "meterRegistry cannot be null");
+
+    count = new AtomicLong(0L);
+    Gauge.builder(COUNT.getName(), count::get)
+        .description(COUNT.getDescription())
+        .tags(PARTITION_GROUP_NAME_LABEL, partitionName)
+        .register(meterRegistry);
+
+    duration = new AtomicLong(0L);
+    Gauge.builder(DURATION.getName(), duration::get)
+        .description(DURATION.getDescription())
+        .tags(PARTITION_GROUP_NAME_LABEL, partitionName)
+        .register(meterRegistry);
   }
 
   public void incrementCount() {
-    count.inc();
+    count.incrementAndGet();
   }
 
   public void decrementCount() {
-    count.dec();
+    count.decrementAndGet();
   }
 
   public void setCount(final int value) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/SnapshotReplicationMetricsDoc.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/SnapshotReplicationMetricsDoc.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft.metrics;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.micrometer.core.instrument.Meter.Type;
+
+public enum SnapshotReplicationMetricsDoc implements ExtendedMeterDocumentation {
+  /** Count of ongoing snapshot replication */
+  COUNT {
+    @Override
+    public String getName() {
+      return "atomix.snapshot.replication.count";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Count of ongoing snapshot replication";
+    }
+  },
+  /** Approximate duration of replication in milliseconds */
+  DURATION {
+    @Override
+    public String getName() {
+      return "atomix.snapshot.replication.duration.milliseconds";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Approximate duration of replication in milliseconds";
+    }
+
+    @Override
+    public String getBaseUnit() {
+      return "ms";
+    }
+  }
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/SnapshotReplicationMetricsDoc.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/SnapshotReplicationMetricsDoc.java
@@ -8,8 +8,11 @@
 package io.atomix.raft.metrics;
 
 import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
+import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Meter.Type;
 
+@SuppressWarnings("NullableProblems")
 public enum SnapshotReplicationMetricsDoc implements ExtendedMeterDocumentation {
   /** Count of ongoing snapshot replication */
   COUNT {
@@ -26,6 +29,11 @@ public enum SnapshotReplicationMetricsDoc implements ExtendedMeterDocumentation 
     @Override
     public String getDescription() {
       return "Count of ongoing snapshot replication";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {PartitionKeyNames.PARTITION, RaftKeyNames.PARTITION_GROUP};
     }
   },
   /** Approximate duration of replication in milliseconds */
@@ -48,6 +56,11 @@ public enum SnapshotReplicationMetricsDoc implements ExtendedMeterDocumentation 
     @Override
     public String getBaseUnit() {
       return "ms";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {PartitionKeyNames.PARTITION, RaftKeyNames.PARTITION_GROUP};
     }
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -74,6 +74,7 @@ public class RaftPartitionServer implements HealthMonitorable {
 
   private final ReceivableSnapshotStore persistedSnapshotStore;
   private final RaftServer server;
+  private final MeterRegistry meterRegistry;
 
   public RaftPartitionServer(
       final RaftPartition partition,
@@ -89,6 +90,7 @@ public class RaftPartitionServer implements HealthMonitorable {
     this.localMemberId = localMemberId;
     this.membershipService = membershipService;
     this.clusterCommunicator = clusterCommunicator;
+    this.meterRegistry = meterRegistry;
     log =
         ContextualLoggerFactory.getLogger(
             getClass(),
@@ -308,6 +310,7 @@ public class RaftPartitionServer implements HealthMonitorable {
         .withSnapshotStore(persistedSnapshotStore)
         .withJournalIndexDensity(storageConfig.getJournalIndexDensity())
         .withPreallocateSegmentFiles(storageConfig.isPreallocateSegmentFiles())
+        .withMeterRegistry(meterRegistry)
         .build();
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -300,7 +300,7 @@ public class RaftPartitionServer implements HealthMonitorable {
 
   private RaftStorage createRaftStorage() {
     final RaftStorageConfig storageConfig = config.getStorageConfig();
-    return RaftStorage.builder()
+    return RaftStorage.builder(meterRegistry)
         .withPrefix(partition.name())
         .withPartitionId(partition.id().id())
         .withDirectory(partition.dataDirectory())
@@ -310,7 +310,6 @@ public class RaftPartitionServer implements HealthMonitorable {
         .withSnapshotStore(persistedSnapshotStore)
         .withJournalIndexDensity(storageConfig.getJournalIndexDensity())
         .withPreallocateSegmentFiles(storageConfig.isPreallocateSegmentFiles())
-        .withMeterRegistry(meterRegistry)
         .build();
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -78,7 +78,8 @@ public class PassiveRole extends InactiveRole {
     super(context);
 
     snapshotChunkSize = context.getSnapshotChunkSize();
-    snapshotReplicationMetrics = new SnapshotReplicationMetrics(context.getName());
+    snapshotReplicationMetrics =
+        new SnapshotReplicationMetrics(context.getName(), context.getMeterRegistry());
     snapshotReplicationMetrics.setCount(0);
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/RaftStorage.java
@@ -36,6 +36,7 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
+import java.util.Objects;
 
 /**
  * Immutable log configuration and {@link RaftLog} factory.
@@ -102,8 +103,8 @@ public final class RaftStorage {
    *
    * @return A new storage builder.
    */
-  public static Builder builder() {
-    return new Builder();
+  public static Builder builder(final MeterRegistry meterRegistry) {
+    return new Builder(meterRegistry);
   }
 
   /**
@@ -265,9 +266,11 @@ public final class RaftStorage {
     private int journalIndexDensity = DEFAULT_JOURNAL_INDEX_DENSITY;
     private boolean preallocateSegmentFiles = DEFAULT_PREALLOCATE_SEGMENT_FILES;
     private int partitionId = DEFAULT_PARTITION_ID;
-    private MeterRegistry meterRegistry;
+    private final MeterRegistry meterRegistry;
 
-    private Builder() {}
+    private Builder(final MeterRegistry meterRegistry) {
+      this.meterRegistry = Objects.requireNonNull(meterRegistry, "meterRegistry cannot be null");
+    }
 
     /**
      * Sets the storage prefix.
@@ -377,12 +380,6 @@ public final class RaftStorage {
      */
     public Builder withPartitionId(final int partitionId) {
       this.partitionId = partitionId;
-      return this;
-    }
-
-    /** MeterRegistry to use for metrics */
-    public Builder withMeterRegistry(final MeterRegistry meterRegistry) {
-      this.meterRegistry = checkNotNull(meterRegistry, "meterRegistry cannot be null");
       return this;
     }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStore.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStore.java
@@ -25,6 +25,7 @@ import io.atomix.raft.storage.StorageException;
 import io.atomix.raft.storage.serializer.MetaEncoder;
 import io.atomix.raft.storage.serializer.MetaStoreSerializer;
 import io.camunda.zeebe.journal.JournalMetaStore;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -62,13 +63,14 @@ public class MetaStore implements JournalMetaStore, AutoCloseable {
   // volatile to avoid synchronizing on the whole meta store when reading this single value
   private volatile long lastFlushedIndex;
 
-  public MetaStore(final RaftStorage storage) throws IOException {
+  public MetaStore(final RaftStorage storage, final MeterRegistry meterRegistry)
+      throws IOException {
     if (!(storage.directory().isDirectory() || storage.directory().mkdirs())) {
       throw new IllegalArgumentException(
           String.format("Can't create storage directory [%s].", storage.directory()));
     }
 
-    metrics = new MetaStoreMetrics(String.valueOf(storage.partitionId()));
+    metrics = new MetaStoreMetrics(String.valueOf(storage.partitionId()), meterRegistry);
 
     // Note that for raft safety, irrespective of the storage level, <term, vote> metadata is always
     // persisted on disk.

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -97,11 +97,10 @@ public final class ControllableRaftContexts {
   private final NavigableMap<Long, MemberId> leadersAtTerms = new TreeMap<>();
   private final AppendListener appendListener = mock(AppendListener.class);
   private final DataLossChecker dataLossChecker = new DataLossChecker(appendListener);
-  private final SimpleMeterRegistry meterRegistry;
+  private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
 
   public ControllableRaftContexts(final int nodeCount) {
     this.nodeCount = nodeCount;
-    meterRegistry = new SimpleMeterRegistry();
   }
 
   public Map<MemberId, RaftContext> getRaftServers() {
@@ -222,7 +221,7 @@ public final class ControllableRaftContexts {
       final Function<RaftStorage.Builder, RaftStorage.Builder> configurator) {
     final var memberDirectory = getMemberDirectory(directory, memberId.toString());
     final RaftStorage.Builder defaults =
-        RaftStorage.builder()
+        RaftStorage.builder(meterRegistry)
             .withDirectory(memberDirectory)
             .withMaxSegmentSize(1024 * 10)
             .withFreeDiskSpace(100);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftFlushErrorTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftFlushErrorTest.java
@@ -120,7 +120,7 @@ public class RaftFlushErrorTest {
         final var storage = builder.storage;
         Objects.requireNonNull(storage);
         builder.withStorage(
-            RaftStorage.builder()
+            RaftStorage.builder(builder.meterRegistry)
                 .withDirectory(storage.directory())
                 .withSnapshotStore(storage.getPersistedSnapshotStore())
                 .withFlusherFactory(faultyFlusher(faultyWhen, notifyFaultyFlush))

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -48,6 +48,7 @@ import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.File;
@@ -169,8 +170,7 @@ public final class RaftRule extends ExternalResource {
     memberLog = null;
     position = 0;
     directory = null;
-    meterRegistry.clear();
-    meterRegistry.close();
+    MicrometerUtil.closeRegistry(meterRegistry);
   }
 
   /**
@@ -535,11 +535,12 @@ public final class RaftRule extends ExternalResource {
     configurator.configure(snapshotStore);
 
     final var builder =
-        RaftStorage.builder()
+        RaftStorage.builder(meterRegistry)
             .withDirectory(memberDirectory)
             .withMaxSegmentSize(1024 * 10)
             .withFreeDiskSpace(100)
             .withSnapshotStore(snapshotStore);
+
     return builder.build();
   }
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
@@ -206,7 +206,7 @@ public class RaftTest extends ConcurrentTestCase {
       final Function<RaftStorage.Builder, RaftStorage.Builder> configurator) {
     final var directory = new File(this.directory.toFile(), memberId.toString());
     final RaftStorage.Builder defaults =
-        RaftStorage.builder()
+        RaftStorage.builder(meterRegistry)
             .withDirectory(directory)
             .withSnapshotStore(new TestSnapshotStore(new AtomicReference<>()))
             .withMaxSegmentSize(1024 * 10);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -135,7 +135,7 @@ final class ReconfigurationTest {
     final var memberId = membershipService.getLocalMember().id();
     final var protocol = protocolFactory.newServerProtocol(memberId);
     final var storage =
-        RaftStorage.builder()
+        RaftStorage.builder(meterRegistry)
             .withDirectory(dir.resolve(memberId.toString()).toFile())
             .withSnapshotStore(new TestSnapshotStore(new AtomicReference<>()))
             .withMaxSegmentSize(1024 * 10)

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -39,6 +39,8 @@ import io.camunda.zeebe.journal.JournalException;
 import io.camunda.zeebe.journal.JournalException.InvalidChecksum;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
@@ -46,6 +48,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.rules.Timeout;
 
 public class PassiveRoleTest {
@@ -54,6 +57,7 @@ public class PassiveRoleTest {
   private RaftLog log;
   private PassiveRole role;
   private RaftContext ctx;
+  @AutoClose private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
   @Before
   public void setup() throws IOException {
@@ -76,6 +80,8 @@ public class PassiveRoleTest {
     when(ctx.getPersistedSnapshotStore()).thenReturn(store);
     when(ctx.getTerm()).thenReturn(1L);
     when(ctx.getReplicationMetrics()).thenReturn(mock(RaftReplicationMetrics.class));
+    when(ctx.getMeterRegistry()).thenReturn(meterRegistry);
+    when(ctx.getName()).thenReturn("partition-1");
 
     role = new PassiveRole(ctx);
   }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/RaftStorageTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/RaftStorageTest.java
@@ -20,21 +20,25 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.raft.storage.log.RaftLogFlusher;
 import io.camunda.zeebe.util.FileUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.After;
 import org.junit.Test;
+import org.junit.jupiter.api.AutoClose;
 
 /** Raft storage test. */
 public class RaftStorageTest {
 
   private static final Path PATH = Paths.get("target/test-logs/");
+  @AutoClose private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
   @Test
   public void testDefaultConfiguration() {
-    final RaftStorage storage = RaftStorage.builder().build();
+    final RaftStorage storage = RaftStorage.builder(meterRegistry).build();
     assertThat(storage.prefix()).isEqualTo("atomix");
     assertThat(storage.directory()).isEqualTo(new File(System.getProperty("user.dir")));
   }
@@ -42,7 +46,7 @@ public class RaftStorageTest {
   @Test
   public void testCustomConfiguration() {
     final RaftStorage storage =
-        RaftStorage.builder()
+        RaftStorage.builder(meterRegistry)
             .withPrefix("foo")
             .withDirectory(new File(PATH.toFile(), "foo"))
             .withMaxSegmentSize(1024 * 1024)
@@ -59,7 +63,7 @@ public class RaftStorageTest {
 
     // when
     final RaftStorage storage1 =
-        RaftStorage.builder().withDirectory(PATH.toFile()).withPrefix("test").build();
+        RaftStorage.builder(meterRegistry).withDirectory(PATH.toFile()).withPrefix("test").build();
 
     // then
     assertThat(storage1.lock("a")).isTrue();
@@ -69,12 +73,12 @@ public class RaftStorageTest {
   public void cannotLockAlreadyLockedDirectory() {
     // given
     final RaftStorage storage1 =
-        RaftStorage.builder().withDirectory(PATH.toFile()).withPrefix("test").build();
+        RaftStorage.builder(meterRegistry).withDirectory(PATH.toFile()).withPrefix("test").build();
     storage1.lock("a");
 
     // when
     final RaftStorage storage2 =
-        RaftStorage.builder().withDirectory(PATH.toFile()).withPrefix("test").build();
+        RaftStorage.builder(meterRegistry).withDirectory(PATH.toFile()).withPrefix("test").build();
 
     // then
     assertThat(storage2.lock("b")).isFalse();
@@ -84,12 +88,12 @@ public class RaftStorageTest {
   public void canAcquireLockOnDirectoryLockedBySameNode() {
     // given
     final RaftStorage storage1 =
-        RaftStorage.builder().withDirectory(PATH.toFile()).withPrefix("test").build();
+        RaftStorage.builder(meterRegistry).withDirectory(PATH.toFile()).withPrefix("test").build();
     storage1.lock("a");
 
     // when
     final RaftStorage storage3 =
-        RaftStorage.builder().withDirectory(PATH.toFile()).withPrefix("test").build();
+        RaftStorage.builder(meterRegistry).withDirectory(PATH.toFile()).withPrefix("test").build();
 
     // then
     assertThat(storage3.lock("a")).isTrue();

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
@@ -23,6 +23,8 @@ import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.cluster.RaftMember.Type;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import io.atomix.raft.storage.RaftStorage;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -31,6 +33,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -41,13 +44,14 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class MetaStoreTest {
   @TempDir Path temporaryFolder;
+  @AutoClose MeterRegistry meterRegistry = new SimpleMeterRegistry();
   private MetaStore metaStore;
   private RaftStorage storage;
 
   @BeforeEach
   public void setup() throws IOException {
     storage = RaftStorage.builder().withDirectory(temporaryFolder.toFile()).build();
-    metaStore = new MetaStore(storage);
+    metaStore = new MetaStore(storage, meterRegistry);
   }
 
   @AfterEach
@@ -83,7 +87,7 @@ class MetaStoreTest {
 
       // when
       metaStore.close();
-      metaStore = new MetaStore(storage);
+      metaStore = new MetaStore(storage, meterRegistry);
 
       // then
       assertThat(metaStore.loadTerm()).isEqualTo(2L);
@@ -96,7 +100,7 @@ class MetaStoreTest {
 
       // when
       metaStore.close();
-      metaStore = new MetaStore(storage);
+      metaStore = new MetaStore(storage, meterRegistry);
 
       // then
       assertThat(metaStore.loadVote().id()).isEqualTo("id");
@@ -130,7 +134,7 @@ class MetaStoreTest {
 
       // when
       metaStore.close();
-      metaStore = new MetaStore(storage);
+      metaStore = new MetaStore(storage, meterRegistry);
 
       // then
       assertThat(metaStore.loadTerm()).isEqualTo(3L);
@@ -153,7 +157,7 @@ class MetaStoreTest {
 
       // when
       metaStore.close();
-      metaStore = new MetaStore(storage);
+      metaStore = new MetaStore(storage, meterRegistry);
 
       // then
       assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(5L);
@@ -174,7 +178,7 @@ class MetaStoreTest {
       metaStore.storeLastFlushedIndex(8L);
 
       metaStore.close();
-      metaStore = new MetaStore(storage);
+      metaStore = new MetaStore(storage, meterRegistry);
 
       // then
       assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(8L);
@@ -224,7 +228,7 @@ class MetaStoreTest {
 
       // when
       metaStore.close();
-      metaStore = new MetaStore(storage);
+      metaStore = new MetaStore(storage, meterRegistry);
 
       // then
       final Configuration readConfig = metaStore.loadConfiguration();
@@ -242,7 +246,7 @@ class MetaStoreTest {
 
       // when
       metaStore.close();
-      metaStore = new MetaStore(storage);
+      metaStore = new MetaStore(storage, meterRegistry);
       final Configuration readConfig = metaStore.loadConfiguration();
 
       // then

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
@@ -50,7 +50,7 @@ class MetaStoreTest {
 
   @BeforeEach
   public void setup() throws IOException {
-    storage = RaftStorage.builder().withDirectory(temporaryFolder.toFile()).build();
+    storage = RaftStorage.builder(meterRegistry).withDirectory(temporaryFolder.toFile()).build();
     metaStore = new MetaStore(storage, meterRegistry);
   }
 


### PR DESCRIPTION
# Description
Backport of #27754 to `stable/8.7`.

relates to #26708
original author: @entangled90