### PR TITLE
Add `AuthorizationDeletedHandler` to `CamundaExporter`

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -17,6 +17,7 @@ import io.camunda.exporter.errorhandling.Error;
 import io.camunda.exporter.errorhandling.ErrorHandler;
 import io.camunda.exporter.errorhandling.ErrorHandlers;
 import io.camunda.exporter.handlers.AuthorizationCreatedUpdatedHandler;
+import io.camunda.exporter.handlers.AuthorizationDeletedHandler;
 import io.camunda.exporter.handlers.DecisionEvaluationHandler;
 import io.camunda.exporter.handlers.DecisionHandler;
 import io.camunda.exporter.handlers.DecisionRequirementsHandler;
@@ -171,6 +172,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(UserIndex.class).getFullQualifiedName()),
             new UserDeletedHandler(indexDescriptors.get(UserIndex.class).getFullQualifiedName()),
             new AuthorizationCreatedUpdatedHandler(
+                indexDescriptors.get(AuthorizationIndex.class).getFullQualifiedName()),
+            new AuthorizationDeletedHandler(
                 indexDescriptors.get(AuthorizationIndex.class).getFullQualifiedName()),
             new TenantCreateUpdateHandler(
                 indexDescriptors.get(TenantIndex.class).getFullQualifiedName()),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationDeletedHandler.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.usermanagement.AuthorizationEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
+import java.util.HashSet;
+import java.util.List;
+
+public class AuthorizationDeletedHandler
+    implements ExportHandler<AuthorizationEntity, AuthorizationRecordValue> {
+  private final String indexName;
+
+  public AuthorizationDeletedHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.AUTHORIZATION;
+  }
+
+  @Override
+  public Class<AuthorizationEntity> getEntityType() {
+    return AuthorizationEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<AuthorizationRecordValue> record) {
+    return getHandledValueType().equals(record.getValueType())
+        && record.getIntent().equals(AuthorizationIntent.DELETED);
+  }
+
+  @Override
+  public List<String> generateIds(final Record<AuthorizationRecordValue> record) {
+    return List.of(String.valueOf(record.getValue().getAuthorizationKey()));
+  }
+
+  @Override
+  public AuthorizationEntity createNewEntity(final String id) {
+    return new AuthorizationEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<AuthorizationRecordValue> record, final AuthorizationEntity entity) {
+    final AuthorizationRecordValue value = record.getValue();
+    entity
+        .setAuthorizationKey(entity.getAuthorizationKey())
+        .setOwnerId(value.getOwnerId())
+        .setOwnerType(value.getOwnerType().name())
+        .setResourceType(value.getResourceType().name())
+        .setResourceId(value.getResourceId())
+        .setPermissionTypes(new HashSet<>(value.getAuthorizationPermissions()));
+  }
+
+  @Override
+  public void flush(final AuthorizationEntity entity, final BatchRequest batchRequest)
+      throws PersistenceException {
+    batchRequest.delete(getIndexName(), entity.getId());
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandlerTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.usermanagement.AuthorizationEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+public class AuthorizationCreatedUpdatedHandlerTest {
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-authentication";
+  private final AuthorizationCreatedUpdatedHandler underTest =
+      new AuthorizationCreatedUpdatedHandler(indexName);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.AUTHORIZATION);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(AuthorizationEntity.class);
+  }
+
+  @Test
+  void shouldHandleCreatedRecord() {
+    // given
+    final Record<AuthorizationRecordValue> authorizationRecord =
+        factory.generateRecordWithIntent(ValueType.AUTHORIZATION, AuthorizationIntent.CREATED);
+
+    // when - then
+    assertThat(underTest.handlesRecord(authorizationRecord)).isTrue();
+  }
+
+  @Test
+  void shouldHandleUpdatedRecord() {
+    // given
+    final Record<AuthorizationRecordValue> authorizationRecord =
+        factory.generateRecordWithIntent(ValueType.AUTHORIZATION, AuthorizationIntent.UPDATED);
+
+    // when - then
+    assertThat(underTest.handlesRecord(authorizationRecord)).isTrue();
+  }
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final Record<AuthorizationRecordValue> authorizationRecord =
+        factory.generateRecordWithIntent(ValueType.AUTHORIZATION, AuthorizationIntent.CREATED);
+
+    // when
+    final var idList = underTest.generateIds(authorizationRecord);
+
+    // then
+    assertThat(idList)
+        .containsExactly(String.valueOf(authorizationRecord.getValue().getAuthorizationKey()));
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecord() {
+    // given
+    final long recordKey = 123L;
+
+    final var authorizationRecordValue =
+        ImmutableAuthorizationRecordValue.builder()
+            .from(factory.generateObject(AuthorizationRecordValue.class))
+            .withAuthorizationKey(recordKey)
+            .withOwnerId("foo")
+            .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceId("*")
+            .withAuthorizationPermissions(List.of(PermissionType.CREATE, PermissionType.DELETE))
+            .build();
+
+    final Record<AuthorizationRecordValue> authorizationRecord =
+        factory.generateRecord(
+            ValueType.AUTHORIZATION,
+            r ->
+                r.withIntent(AuthorizationIntent.CREATED)
+                    .withValue(authorizationRecordValue)
+                    .withKey(recordKey));
+
+    // when
+    final var authorizationEntity =
+        new AuthorizationEntity()
+            .setAuthorizationKey(recordKey)
+            .setOwnerId("bar")
+            .setOwnerType(AuthorizationOwnerType.GROUP.name())
+            .setResourceId("resourceId")
+            .setPermissionTypes(Set.of(PermissionType.UPDATE));
+    underTest.updateEntity(authorizationRecord, authorizationEntity);
+
+    // then
+    assertThat(authorizationEntity.getAuthorizationKey())
+        .isEqualTo(authorizationRecordValue.getAuthorizationKey());
+    assertThat(authorizationEntity.getOwnerId()).isEqualTo(authorizationRecordValue.getOwnerId());
+    assertThat(authorizationEntity.getOwnerType())
+        .isEqualTo(authorizationRecordValue.getOwnerType().name());
+    assertThat(authorizationEntity.getResourceId())
+        .isEqualTo(authorizationRecordValue.getResourceId());
+    assertThat(authorizationEntity.getPermissionTypes())
+        .isEqualTo(authorizationRecordValue.getAuthorizationPermissions());
+  }
+
+  @Test
+  void shouldAddEntityOnFlush() throws PersistenceException {
+    // given
+    final var inputEntity = new AuthorizationEntity().setId("111");
+    final var mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1)).add(indexName, inputEntity);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationDeletedHandlerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.usermanagement.AuthorizationEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+public class AuthorizationDeletedHandlerTest {
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-authentication";
+  private final AuthorizationDeletedHandler underTest = new AuthorizationDeletedHandler(indexName);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.AUTHORIZATION);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(AuthorizationEntity.class);
+  }
+
+  @Test
+  void shouldHandleRecord() {
+    // given
+    final Record<AuthorizationRecordValue> authorizationRecord =
+        factory.generateRecordWithIntent(ValueType.AUTHORIZATION, AuthorizationIntent.DELETED);
+
+    // when - then
+    assertThat(underTest.handlesRecord(authorizationRecord)).isTrue();
+  }
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final Record<AuthorizationRecordValue> authorizationRecord =
+        factory.generateRecordWithIntent(ValueType.AUTHORIZATION, AuthorizationIntent.DELETED);
+
+    // when
+    final var idList = underTest.generateIds(authorizationRecord);
+
+    // then
+    assertThat(idList)
+        .containsExactly(String.valueOf(authorizationRecord.getValue().getAuthorizationKey()));
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldDeleteEntityOnFlush() throws PersistenceException {
+    // given
+    final AuthorizationEntity inputEntity = new AuthorizationEntity().setId("111");
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1)).delete(indexName, inputEntity.getId());
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds a handler to delete authorizations upon receiving an `Authorization.DELETED` event.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #27724 
