### PR TITLE
[Backport stable/8.6] migrate RaftServiceMetrics & RaftStartupMetrics to micrometer

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -14066,7 +14066,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "sum(increase(atomix_compaction_time_ms_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(atomix_compaction_time_ms_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval]) or increase(atomix_compaction_time_ms_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\", pod=~\"$pod\", partition=~\"$partition\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "intervalFactor": 1,
               "legendFormat": "{{le}}",

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -240,7 +240,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
             threadContext,
             raftLog,
             partitionConfig.getPreferSnapshotReplicationThreshold(),
-            new RaftServiceMetrics(name),
+            new RaftServiceMetrics(name, meterRegistry),
             ContextualLoggerFactory.getLogger(
                 LogCompactor.class, LoggerContext.builder(getClass()).addValue(name).build()));
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/MetaStoreMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/MetaStoreMetrics.java
@@ -27,7 +27,7 @@ public final class MetaStoreMetrics extends RaftMetrics {
         Timer.builder(LAST_FLUSHED_INDEX.getName())
             .description(LAST_FLUSHED_INDEX.getDescription())
             .serviceLevelObjectives(LAST_FLUSHED_INDEX.getTimerSLOs())
-            .tag(RaftKeyNames.PARTITION_GROUP.asString(), partitionName)
+            .tag(RaftKeyNames.PARTITION_GROUP.asString(), partitionGroupName)
             .register(registry);
     clock = registry.config().clock();
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftReplicationMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftReplicationMetrics.java
@@ -34,11 +34,11 @@ public class RaftReplicationMetrics extends RaftMetrics {
 
     Gauge.builder(COMMIT_INDEX.getName(), commitIndex::get)
         .description(COMMIT_INDEX.getDescription())
-        .tags(RaftKeyNames.PARTITION_GROUP.asString(), partitionName)
+        .tags(RaftKeyNames.PARTITION_GROUP.asString(), partitionGroupName)
         .register(registry);
     Gauge.builder(APPEND_INDEX.getName(), appendIndex::get)
         .description(APPEND_INDEX.getDescription())
-        .tags(RaftKeyNames.PARTITION_GROUP.asString(), partitionName)
+        .tags(RaftKeyNames.PARTITION_GROUP.asString(), partitionGroupName)
         .register(registry);
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftServiceMetricsDoc.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftServiceMetricsDoc.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft.metrics;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter.Type;
+
+@SuppressWarnings("NullableProblems")
+public enum RaftServiceMetricsDoc implements ExtendedMeterDocumentation {
+  /** Time spend to compact */
+  COMPACTION_TIME {
+    @Override
+    public String getName() {
+      return "atomix.compaction.time.ms";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Time spend to compact";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {RaftKeyNames.PARTITION_GROUP, PartitionKeyNames.PARTITION};
+    }
+
+    @Override
+    public String getBaseUnit() {
+      return "ms";
+    }
+  }
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftStartupMetricsDoc.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftStartupMetricsDoc.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft.metrics;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter.Type;
+
+@SuppressWarnings("NullableProblems")
+public enum RaftStartupMetricsDoc implements ExtendedMeterDocumentation {
+  /** Time taken to bootstrap the partition server (in ms) */
+  BOOTSTRAP_DURATION {
+    @Override
+    public String getName() {
+      return "atomix.partition.server.bootstrap.time";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Time taken to bootstrap the partition server (in ms)";
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {RaftKeyNames.PARTITION_GROUP, PartitionKeyNames.PARTITION};
+    }
+
+    @Override
+    public String getBaseUnit() {
+      return "ms";
+    }
+  },
+  /* Time taken for the partition server to join (in ms) */
+  JOIN_DURATION {
+    @Override
+    public String getName() {
+      return "atomix.partition.server.join.time";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {RaftKeyNames.PARTITION_GROUP, PartitionKeyNames.PARTITION};
+    }
+
+    @Override
+    public String getDescription() {
+      return "Time taken for the partition server to join (in ms)";
+    }
+
+    @Override
+    public String getBaseUnit() {
+      return "ms";
+    }
+  }
+}

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/SnapshotReplicationMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/SnapshotReplicationMetrics.java
@@ -34,13 +34,13 @@ public class SnapshotReplicationMetrics extends RaftMetrics {
     count = new AtomicLong(0L);
     Gauge.builder(COUNT.getName(), count::get)
         .description(COUNT.getDescription())
-        .tags(PARTITION_GROUP_NAME_LABEL, partitionName)
+        .tags(PARTITION_GROUP_NAME_LABEL, partitionGroupName)
         .register(meterRegistry);
 
     duration = new AtomicLong(0L);
     Gauge.builder(DURATION.getName(), duration::get)
         .description(DURATION.getDescription())
-        .tags(PARTITION_GROUP_NAME_LABEL, partitionName)
+        .tags(PARTITION_GROUP_NAME_LABEL, partitionGroupName)
         .register(meterRegistry);
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -104,7 +104,8 @@ public class RaftPartitionServer implements HealthMonitorable {
   }
 
   public CompletableFuture<RaftPartitionServer> bootstrap() {
-    final RaftStartupMetrics raftStartupMetrics = new RaftStartupMetrics(partition.name());
+    final RaftStartupMetrics raftStartupMetrics =
+        new RaftStartupMetrics(partition.name(), meterRegistry);
     log.info("Server bootstrapping partition {}", partition.id());
     final long bootstrapStartTime = System.currentTimeMillis();
     return server
@@ -126,7 +127,7 @@ public class RaftPartitionServer implements HealthMonitorable {
   }
 
   public CompletableFuture<RaftPartitionServer> join() {
-    final var metrics = new RaftStartupMetrics(partition.name());
+    final var metrics = new RaftStartupMetrics(partition.name(), meterRegistry);
     final long joinStartTime = System.currentTimeMillis();
     log.info("Server joining partition {}", partition.id());
     return server

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/impl/LogCompactorTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/impl/LogCompactorTest.java
@@ -14,9 +14,12 @@ import io.atomix.raft.snapshot.InMemorySnapshot;
 import io.atomix.raft.snapshot.TestSnapshotStore;
 import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.utils.concurrent.ThreadContext;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
@@ -29,6 +32,7 @@ final class LogCompactorTest {
   private ThreadContext threadContext;
   private RaftLog raftLog;
   private LogCompactor compactor;
+  @AutoClose private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
   @BeforeEach
   void beforeEach() {
@@ -48,7 +52,7 @@ final class LogCompactorTest {
             threadContext,
             raftLog,
             5,
-            new RaftServiceMetrics("1"),
+            new RaftServiceMetrics("1", meterRegistry),
             LoggerFactory.getLogger(getClass()));
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
@@ -75,7 +75,7 @@ public class ConcurrentBackupCompactionTest extends DynamicAutoCloseable {
   private LogCompactor logCompactor;
   private final ThreadContext threadContext = new InlineThreadContext();
   @Mock private RaftLog raftLog;
-  private final RaftServiceMetrics raftMetrics = new RaftServiceMetrics("1");
+  private final RaftServiceMetrics raftMetrics = new RaftServiceMetrics("1", meterRegistry);
 
   @BeforeEach
   void setUp() {


### PR DESCRIPTION
# Description
Backport of #27830 to `stable/8.6`.

relates to #26078
original author: @entangled90