### PR TITLE
fix: ensure we always close background async client

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -200,11 +200,6 @@ public final class ElasticsearchArchiverRepository extends ElasticsearchReposito
             executor);
   }
 
-  @Override
-  public void close() throws Exception {
-    client._transport().close();
-  }
-
   private SearchRequest createFinishedInstancesSearchRequest(final Aggregation aggregation) {
     final var endDateQ =
         QueryBuilders.range(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepository.java
@@ -233,11 +233,6 @@ public final class OpenSearchArchiverRepository extends OpensearchRepository
             executor);
   }
 
-  @Override
-  public void close() throws Exception {
-    client._transport().close();
-  }
-
   private SearchRequest createFinishedBatchOperationsSearchRequest(final Aggregation aggregation) {
     final var endDateQ =
         QueryBuilders.range()

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/ElasticsearchBatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/ElasticsearchBatchOperationUpdateRepository.java
@@ -168,7 +168,4 @@ public class ElasticsearchBatchOperationUpdateRepository extends ElasticsearchRe
                     .params(parameters))
         .build();
   }
-
-  @Override
-  public void close() throws Exception {}
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/OpensearchBatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/OpensearchBatchOperationUpdateRepository.java
@@ -179,7 +179,4 @@ public class OpensearchBatchOperationUpdateRepository extends OpensearchReposito
         .map(b -> new OperationsAggData(b.key(), b.docCount()))
         .collect(Collectors.toList());
   }
-
-  @Override
-  public void close() throws Exception {}
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -82,11 +82,6 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
   }
 
   @Override
-  public void close() throws Exception {
-    client._transport().close();
-  }
-
-  @Override
   public CompletionStage<PendingIncidentUpdateBatch> getPendingIncidentsBatch(
       final long fromPosition, final int size) {
     final var query = createPendingIncidentsBatchQuery(fromPosition);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
@@ -83,11 +83,6 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
   }
 
   @Override
-  public void close() throws Exception {
-    client._transport().close();
-  }
-
-  @Override
   public CompletionStage<PendingIncidentUpdateBatch> getPendingIncidentsBatch(
       final long fromPosition, final int size) {
     final var query = createPendingIncidentsBatchQuery(fromPosition);


### PR DESCRIPTION
## Description

This PR closes the ES/OS async client for the batch operations repository. It also moves this behavior to the shared repository to ensure we always close it.