### PR TITLE
Fix setting bounded cache size metric

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/ScheduledCommandCacheMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/ScheduledCommandCacheMetrics.java
@@ -9,11 +9,15 @@ package io.camunda.zeebe.broker.engine.impl;
 
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
+import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntConsumer;
 
 /** Defines metrics for scheduled command cache implementations. */
@@ -30,6 +34,7 @@ public interface ScheduledCommandCacheMetrics {
    * io.camunda.zeebe.broker.engine.impl.BoundedScheduledCommandCache}.
    */
   class BoundedCommandCacheMetrics implements ScheduledCommandCacheMetrics {
+    private final Map<Intent, AtomicInteger> sizes = new HashMap<>();
     private final MeterRegistry registry;
 
     public BoundedCommandCacheMetrics(final MeterRegistry registry) {
@@ -38,15 +43,19 @@ public interface ScheduledCommandCacheMetrics {
 
     @Override
     public IntConsumer forIntent(final Intent intent) {
+      return sizes.computeIfAbsent(intent, this::registerSizeReporter)::set;
+    }
+
+    private AtomicInteger registerSizeReporter(final Intent intent) {
       final var intentLabelValue = intent.getClass().getSimpleName() + "." + intent.name();
       final var meterDoc = BoundedCacheMetricsDoc.SIZE;
-      final var sizeTracker = new AtomicLong();
-      Gauge.builder(meterDoc.getName(), sizeTracker, Number::longValue)
+      final var sizeTracker = new AtomicInteger();
+      Gauge.builder(meterDoc.getName(), sizeTracker, AtomicInteger::intValue)
           .description(meterDoc.getDescription())
-          .tag("intent", intentLabelValue)
+          .tag(SizeKeys.INTENT.asString(), intentLabelValue)
           .register(registry);
 
-      return sizeTracker::set;
+      return sizeTracker;
     }
   }
 
@@ -72,6 +81,27 @@ public interface ScheduledCommandCacheMetrics {
       public String getDescription() {
         return "Reports the size of each bounded cache per partition and intent";
       }
+
+      @Override
+      public KeyName[] getKeyNames() {
+        return SizeKeys.values();
+      }
+
+      @Override
+      public KeyName[] getAdditionalKeyNames() {
+        return PartitionKeyNames.values();
+      }
     },
+  }
+
+  @SuppressWarnings("NullableProblems")
+  enum SizeKeys implements KeyName {
+    /** The specific command intent for this cached keyy */
+    INTENT {
+      @Override
+      public String asString() {
+        return "intent";
+      }
+    }
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/ScheduledCommandCacheMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/ScheduledCommandCacheMetrics.java
@@ -46,7 +46,7 @@ public interface ScheduledCommandCacheMetrics {
           .tag("intent", intentLabelValue)
           .register(registry);
 
-      return sizeTracker::addAndGet;
+      return sizeTracker::set;
     }
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCacheMetricsTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCacheMetricsTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.engine.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.broker.engine.impl.ScheduledCommandCacheMetrics.BoundedCommandCacheMetrics;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.function.IntConsumer;
+import org.junit.jupiter.api.Test;
+
+final class BoundedCommandCacheMetricsTest {
+  @Test
+  void shouldReportSizeForIntent() {
+    // given
+    final var registry = new SimpleMeterRegistry();
+    final var metrics = new BoundedCommandCacheMetrics(registry);
+    final IntConsumer timeout = metrics.forIntent(JobIntent.TIME_OUT);
+    final IntConsumer recur = metrics.forIntent(JobIntent.RECUR_AFTER_BACKOFF);
+
+    // when
+    timeout.accept(10);
+    recur.accept(20);
+    timeout.accept(30);
+
+    // then
+    final var timeoutGauge =
+        registry
+            .get("zeebe.stream.processor.scheduled.command.cache.size")
+            .tag("intent", "JobIntent.TIME_OUT")
+            .gauge();
+    final var recurGauge =
+        registry
+            .get("zeebe.stream.processor.scheduled.command.cache.size")
+            .tag("intent", "JobIntent.RECUR_AFTER_BACKOFF")
+            .gauge();
+    assertThat(timeoutGauge).returns(30.0, Gauge::value);
+    assertThat(recurGauge).returns(20.0, Gauge::value);
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCacheTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCacheTest.java
@@ -103,8 +103,6 @@ final class BoundedScheduledCommandCacheTest {
     cache.add(JobIntent.TIME_OUT, 1);
     cache.add(TimerIntent.TRIGGER, 1);
     cache.add(TimerIntent.TRIGGER, 2);
-    cache.add(TimerIntent.TRIGGER, 3);
-    cache.remove(TimerIntent.TRIGGER, 3);
 
     // then
     assertThat(metrics.get(TimerIntent.TRIGGER)).hasValue(2);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCacheTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCacheTest.java
@@ -103,6 +103,8 @@ final class BoundedScheduledCommandCacheTest {
     cache.add(JobIntent.TIME_OUT, 1);
     cache.add(TimerIntent.TRIGGER, 1);
     cache.add(TimerIntent.TRIGGER, 2);
+    cache.add(TimerIntent.TRIGGER, 3);
+    cache.remove(TimerIntent.TRIGGER, 3);
 
     // then
     assertThat(metrics.get(TimerIntent.TRIGGER)).hasValue(2);


### PR DESCRIPTION
## Description

While migrating the metrics, I mistakenly made the bounded cache size metric increment always instead of setting the size, resulting in alarmingly huge cache sizes (but not actually).
