### PR TITLE
refactor: use set for clarity

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerStepMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerStepMetrics.java
@@ -32,14 +32,14 @@ public class BrokerStepMetrics {
         startup.computeIfAbsent(
             stepName, name -> registerMetric(BrokerStepMetricsDoc.STARTUP, name));
     return MicrometerUtil.timer(
-        timerTracker::addAndGet, TimeUnit.MILLISECONDS, registry.config().clock());
+        timerTracker::set, TimeUnit.MILLISECONDS, registry.config().clock());
   }
 
   public CloseableSilently createCloseTimer(final String stepName) {
     final var timerTracker =
         close.computeIfAbsent(stepName, name -> registerMetric(BrokerStepMetricsDoc.CLOSE, name));
     return MicrometerUtil.timer(
-        timerTracker::addAndGet, TimeUnit.MILLISECONDS, registry.config().clock());
+        timerTracker::set, TimeUnit.MILLISECONDS, registry.config().clock());
   }
 
   private AtomicLong registerMetric(final BrokerStepMetricsDoc meterDoc, final String stepName) {


### PR DESCRIPTION
## Description

While not strictly necessary (because the broker step metrics are only updated once), use `AtomicLong::set` instead of `AtomicLong::addAndGet` for clarify (i.e. we're setting, not adding).

This is purely for metrics.