### PR TITLE
fix: Improve error logging for doc handling

### DIFF
--- a/document/api/src/main/java/io/camunda/document/api/DocumentError.java
+++ b/document/api/src/main/java/io/camunda/document/api/DocumentError.java
@@ -21,13 +21,8 @@ public sealed interface DocumentError {
   record DocumentHashMismatch(String documentId, String providedHash) implements DocumentError {}
 
   record UnknownDocumentError(String message, Throwable cause) implements DocumentError {
-
-    public UnknownDocumentError(final String message) {
-      this(message, null);
-    }
-
     public UnknownDocumentError(final Throwable cause) {
-      this(null, cause);
+      this(cause.getMessage(), cause);
     }
   }
 }

--- a/document/store/src/main/java/io/camunda/document/store/gcp/GcpDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/gcp/GcpDocumentStore.java
@@ -118,15 +118,15 @@ public class GcpDocumentStore implements DocumentStore {
     final String fullBlobName = getFullBlobName(documentId);
     final String fileName = Optional.ofNullable(request.metadata().fileName()).orElse(documentId);
 
-    Blob existingBlob = null;
     try {
-      existingBlob = storage.get(bucketName, fullBlobName);
+      final Blob existingBlob = storage.get(bucketName, fullBlobName);
+      if (existingBlob != null) {
+        return Either.left(new DocumentError.DocumentAlreadyExists(documentId));
+      }
     } catch (final Exception e) {
-      //      return Either.left(new UnknownDocumentError(e));
+      return Either.left(new UnknownDocumentError(e));
     }
-    if (existingBlob != null) {
-      return Either.left(new DocumentError.DocumentAlreadyExists(documentId));
-    }
+
     final BlobId blobId = BlobId.of(bucketName, fullBlobName);
     final var blobInfoBuilder = BlobInfo.newBuilder(blobId);
 

--- a/document/store/src/main/java/io/camunda/document/store/inmemory/InMemoryDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/inmemory/InMemoryDocumentStore.java
@@ -56,7 +56,7 @@ public class InMemoryDocumentStore implements DocumentStore {
     } catch (final Exception e) {
       // should never happen
       return CompletableFuture.completedFuture(
-          Either.left(new DocumentError.UnknownDocumentError("Failed to create document")));
+          Either.left(new DocumentError.UnknownDocumentError("Failed to create document", e)));
     }
     final DigestInputStream contentInputStream =
         new DigestInputStream(request.contentInputStream(), md);


### PR DESCRIPTION
An example of what would be printed (in this case the error was due to invalid GCP credentials)
```
io.camunda.service.DocumentServices - An unexpected error occurred
com.google.cloud.storage.StorageException: Invalid bucket name: 'camunda-saas-dev/camunda-saas-dev-test-document-storage'
	at com.google.cloud.storage.StorageException.translate(StorageException.java:179) ~[google-cloud-storage-2.47.0.jar:2.47.0]
	at com.google.cloud.storage.spi.v1.HttpStorageRpc.translate(HttpStorageRpc.java:330) ~[google-cloud-storage-2.47.0.jar:2.47.0]
	...
	at java.base/java.lang.Thread.run(Thread.java:1583) [?:?]
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 400 Bad Request
GET https://storage.googleapis.com/storage/v1/b/camunda-saas-dev%2Fcamunda-saas-dev-test-document-storage/o/temp%2F683e8fe8-2afe-4e71-93a8-8aec10cdf151?projection=full
{
  "code" : 400,
  "errors" : [ {
    "domain" : "global",
    "message" : "Invalid bucket name: 'camunda-saas-dev/camunda-saas-dev-test-document-storage'",
    "reason" : "invalid"
  } ],
  "message" : "Invalid bucket name: 'camunda-saas-dev/camunda-saas-dev-test-document-storage'"
}
	at com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:145) ~[google-api-client-2.7.1.jar:2.7.1]
	...
```


## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

1st PR towards closing https://github.com/camunda/camunda/issues/27794
