### PR TITLE
[Backport stable/8.6] ci: yarn install mutex on all yarn 1.x usages

### DIFF
--- a/operate/client/pom.xml
+++ b/operate/client/pom.xml
@@ -63,6 +63,7 @@
             <configuration>
               <failOnError>false</failOnError>
               <skip>${skip.fe.build}</skip>
+              <arguments>install --mutex file:/tmp/.yarn-mutex</arguments>
             </configuration>
           </execution>
 

--- a/optimize/client/pom.xml
+++ b/optimize/client/pom.xml
@@ -42,6 +42,7 @@
             <configuration>
               <failOnError>false</failOnError>
               <skip>${skip.fe.build}</skip>
+              <arguments>install --mutex file:/tmp/.yarn-mutex</arguments>
             </configuration>
           </execution>
 

--- a/tasklist/client/pom.xml
+++ b/tasklist/client/pom.xml
@@ -57,6 +57,7 @@
             <configuration>
               <failOnError>false</failOnError>
               <skip>${skip.fe.build}</skip>
+              <arguments>install --mutex file:/tmp/.yarn-mutex</arguments>
             </configuration>
           </execution>
 


### PR DESCRIPTION
# Description
Backport of #26409 to `stable/8.6`.

relates to 
original author: @megglos