### PR TITLE
[Tasklist CI] Make use of `current-test` docker image in IT

### DIFF
--- a/.github/workflows/tasklist-ci-test-reusable.yml
+++ b/.github/workflows/tasklist-ci-test-reusable.yml
@@ -45,7 +45,6 @@ jobs:
       fail-fast: false
       matrix:
         database: [ elasticsearch, opensearch ]
-
         include:
           - database: elasticsearch
             testProfile: docker-es
@@ -53,6 +52,15 @@ jobs:
           - database: opensearch
             testProfile: docker-os
             url: http://localhost:9200
+    env:
+      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe
+      ZEEBE_TEST_DOCKER_IMAGE_TAG: current-test
+    services:
+      # local registry is used as this job needs to push its docker image to be used by IT
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     steps:
       # Setup: checkout branch
       - name: Checkout '${{ inputs.branch }}' branch
@@ -71,14 +79,34 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-
-      - name: Build backend
-        run: ./mvnw -B -T1C -DskipChecks -DskipTests -P skipFrontendBuild clean install
+      - uses: ./.github/actions/build-zeebe
+        id: build-camunda
+        with:
+          maven-extra-args: -PskipFrontendBuild
+      - uses: ./.github/actions/build-platform-docker
+        id: build-camunda-docker
+        with:
+          # we use a local registry for pushing
+          repository: ${{ env.ZEEBE_TEST_DOCKER_IMAGE }}
+          distball: ${{ steps.build-camunda.outputs.distball }}
+          version: ${{ env.ZEEBE_TEST_DOCKER_IMAGE_TAG }}
+          dockerfile: camunda.Dockerfile
+          # push is needed to make accessible for integration tests
+          push: true
 
       # Run integration tests in parallel
       - name: Run Integration Tests
         run: |
-          ./mvnw -f tasklist -T${{ env.LIMITS_CPU }} verify -P ${{ matrix.testProfile }},skipFrontendBuild -B --fail-at-end -Dfailsafe.rerunFailingTestsCount=2 -Dcamunda.tasklist.database=${{ matrix.database }} -Dcamunda.database.url=${{ matrix.url }}
+          ./mvnw verify \
+            -f tasklist \
+            -T${{ env.LIMITS_CPU }} \
+            -P ${{ matrix.testProfile }},skipFrontendBuild \
+            -B --fail-at-end \
+            -Dfailsafe.rerunFailingTestsCount=2 \
+            -Dcamunda.tasklist.database=${{ matrix.database }} \
+            -Dcamunda.database.url=${{ matrix.url }} \
+            -Dzeebe.currentVersion.docker.tag=${{ env.ZEEBE_TEST_DOCKER_IMAGE_TAG }} \
+            -Dzeebe.currentVersion.docker.repo=${{ env.ZEEBE_TEST_DOCKER_IMAGE }}
 
       # Sanitize the branch name to replace non alphanumeric characters with `-`
       - id: sanitize

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtension.java
@@ -122,11 +122,17 @@ public abstract class TasklistZeebeExtension
     final String zeebeVersion =
         ContainerVersionsUtil.readProperty(
             ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME);
+    final String zeebeRepo =
+        ContainerVersionsUtil.readProperty(
+            ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_REPO_PROPERTY_NAME);
     final String indexPrefix = indexPrefixHolder.getIndexPrefix();
     LOGGER.info(
-        "************ Starting Zeebe:{}, indexPrefix={} ************", zeebeVersion, indexPrefix);
+        "************ Starting Zeebe - {}:{}, indexPrefix={} ************",
+        zeebeRepo,
+        zeebeVersion,
+        indexPrefix);
     final ZeebeContainer zContainer =
-        new ZeebeContainer(DockerImageName.parse("camunda/zeebe").withTag(zeebeVersion))
+        new ZeebeContainer(DockerImageName.parse(zeebeRepo).withTag(zeebeVersion))
             .withEnv(getDatabaseEnvironmentVariables(indexPrefix))
             .withEnv("JAVA_OPTS", "-Xss256k -XX:+TieredCompilation -XX:TieredStopAtLevel=1")
             .withEnv("ZEEBE_LOG_LEVEL", "ERROR")

--- a/tasklist/qa/pom.xml
+++ b/tasklist/qa/pom.xml
@@ -21,6 +21,7 @@
 
   <properties>
     <version.zeebe.docker.current>SNAPSHOT</version.zeebe.docker.current>
+    <version.zeebe.docker.repo>camunda/zeebe</version.zeebe.docker.repo>
     <version.identity.docker.current>SNAPSHOT</version.identity.docker.current>
   </properties>
 

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/ContainerVersionsUtil.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/ContainerVersionsUtil.java
@@ -15,19 +15,20 @@ import java.util.Properties;
 public class ContainerVersionsUtil {
 
   public static final String ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME =
-      "zeebe.currentVersion.docker";
-
+      "zeebe.currentVersion.docker.tag";
+  public static final String ZEEBE_CURRENTVERSION_DOCKER_REPO_PROPERTY_NAME =
+      "zeebe.currentVersion.docker.repo";
   public static final String IDENTITY_CURRENTVERSION_DOCKER_PROPERTY_NAME =
       "identity.currentVersion.docker";
   private static final String VERSIONS_FILE = "container-versions.properties";
 
-  public static String readProperty(String propertyName) {
-    try (InputStream propsFile =
+  public static String readProperty(final String propertyName) {
+    try (final InputStream propsFile =
         ContainerVersionsUtil.class.getClassLoader().getResourceAsStream(VERSIONS_FILE)) {
       final Properties props = new Properties();
       props.load(propsFile);
       return props.getProperty(propertyName);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new TasklistRuntimeException(
           "Unable to read the list of supported Zeebe zeebeVersions.", e);
     }

--- a/tasklist/qa/util/src/main/resources/container-versions.properties
+++ b/tasklist/qa/util/src/main/resources/container-versions.properties
@@ -1,2 +1,3 @@
 identity.currentVersion.docker=${version.identity.docker.current}
-zeebe.currentVersion.docker=${version.zeebe.docker.current}
+zeebe.currentVersion.docker.tag=${version.zeebe.docker.current}
+zeebe.currentVersion.docker.repo=${version.zeebe.docker.repo}


### PR DESCRIPTION
## Description

For Tasklist CI:

 * Build a branch corresponding docker image for Zeebe (introduce separate step)
 * Add new property to override the docker repo, so we can use local repo
 * Make use of `current-test` docker image for Zeebe test container
   * Current solution also allows to run test locally still with `SNAPSHOT`


## Related issues

closes https://github.com/camunda/camunda/issues/27909

See for context: https://camunda.slack.com/archives/C06F0GLJNFM/p1739174602278719?thread_ts=1739172753.912819&cid=C06F0GLJNFM

This is to at least make sure that we better test changes, but limit our efforts/work in refactoring the Tasklist CI/IT, as this covered in a follow up PDP
