### PR TITLE
refactor: revert client to long key search

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/DecisionInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/DecisionInstanceFilter.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.filter;
 
-import io.camunda.client.api.search.filter.builder.BasicStringProperty;
+import io.camunda.client.api.search.filter.builder.BasicLongProperty;
 import io.camunda.client.api.search.filter.builder.DateTimeProperty;
 import io.camunda.client.api.search.query.TypedSearchQueryRequest.SearchRequestFilter;
 import io.camunda.client.api.search.response.DecisionDefinitionType;
@@ -52,8 +52,8 @@ public interface DecisionInstanceFilter extends SearchRequestFilter {
   /** Filter by decisionDefinitionKey */
   DecisionInstanceFilter decisionDefinitionKey(long decisionDefinitionKey);
 
-  /** Filter by decisionDefinitionKey using {@link BasicStringProperty} consumer */
-  DecisionInstanceFilter decisionDefinitionKey(Consumer<BasicStringProperty> fn);
+  /** Filter by decisionDefinitionKey using {@link BasicLongProperty} consumer */
+  DecisionInstanceFilter decisionDefinitionKey(Consumer<BasicLongProperty> fn);
 
   /** Filter by decisionDefinitionId */
   DecisionInstanceFilter decisionDefinitionId(String decisionDefinitionId);

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilter.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.filter;
 
-import io.camunda.client.api.search.filter.builder.BasicStringProperty;
+import io.camunda.client.api.search.filter.builder.BasicLongProperty;
 import io.camunda.client.api.search.filter.builder.DateTimeProperty;
 import io.camunda.client.api.search.filter.builder.IntegerProperty;
 import io.camunda.client.api.search.filter.builder.ProcessInstanceStateProperty;
@@ -33,8 +33,8 @@ public interface ProcessInstanceFilter extends SearchRequestFilter {
   /** Filter by processInstanceKey */
   ProcessInstanceFilter processInstanceKey(final Long processInstanceKey);
 
-  /** Filter by processInstanceKey using {@link BasicStringProperty} consumer */
-  ProcessInstanceFilter processInstanceKey(final Consumer<BasicStringProperty> fn);
+  /** Filter by processInstanceKey using {@link BasicLongProperty} consumer */
+  ProcessInstanceFilter processInstanceKey(final Consumer<BasicLongProperty> fn);
 
   /** Filter by processDefinitionId */
   ProcessInstanceFilter processDefinitionId(final String processDefinitionId);
@@ -63,20 +63,20 @@ public interface ProcessInstanceFilter extends SearchRequestFilter {
   /** Filter by processDefinitionKey */
   ProcessInstanceFilter processDefinitionKey(final Long processDefinitionKey);
 
-  /** Filter by processDefinitionKey using {@link BasicStringProperty} consumer */
-  ProcessInstanceFilter processDefinitionKey(final Consumer<BasicStringProperty> fn);
+  /** Filter by processDefinitionKey using {@link BasicLongProperty} consumer */
+  ProcessInstanceFilter processDefinitionKey(final Consumer<BasicLongProperty> fn);
 
   /** Filter by parentProcessInstanceKey */
   ProcessInstanceFilter parentProcessInstanceKey(final Long parentProcessInstanceKey);
 
-  /** Filter by parentProcessInstanceKey using {@link BasicStringProperty} consumer */
-  ProcessInstanceFilter parentProcessInstanceKey(final Consumer<BasicStringProperty> fn);
+  /** Filter by parentProcessInstanceKey using {@link BasicLongProperty} consumer */
+  ProcessInstanceFilter parentProcessInstanceKey(final Consumer<BasicLongProperty> fn);
 
   /** Filter by parentFlowNodeInstanceKey */
   ProcessInstanceFilter parentFlowNodeInstanceKey(final Long parentFlowNodeInstanceKey);
 
-  /** Filter by parentFlowNodeInstanceKey using {@link BasicStringProperty} consumer */
-  ProcessInstanceFilter parentFlowNodeInstanceKey(final Consumer<BasicStringProperty> fn);
+  /** Filter by parentFlowNodeInstanceKey using {@link BasicLongProperty} consumer */
+  ProcessInstanceFilter parentFlowNodeInstanceKey(final Consumer<BasicLongProperty> fn);
 
   /** Filter by startDate */
   ProcessInstanceFilter startDate(final OffsetDateTime startDate);

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/VariableFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/VariableFilter.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.filter;
 
-import io.camunda.client.api.search.filter.builder.BasicStringProperty;
+import io.camunda.client.api.search.filter.builder.BasicLongProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.search.query.TypedSearchQueryRequest.SearchRequestFilter;
 import java.util.function.Consumer;
@@ -31,12 +31,12 @@ public interface VariableFilter extends SearchRequestFilter {
   VariableFilter variableKey(final Long key);
 
   /**
-   * Filters variables by the specified key using {@link BasicStringProperty} consumer.
+   * Filters variables by the specified key using {@link BasicLongProperty} consumer.
    *
-   * @param fn the key {@link BasicStringProperty} consumer of the variable
+   * @param fn the key {@link BasicLongProperty} consumer of the variable
    * @return the updated filter
    */
-  VariableFilter variableKey(final Consumer<BasicStringProperty> fn);
+  VariableFilter variableKey(final Consumer<BasicLongProperty> fn);
 
   /**
    * Filters variables by the specified value.
@@ -79,12 +79,12 @@ public interface VariableFilter extends SearchRequestFilter {
   VariableFilter scopeKey(final Long scopeKey);
 
   /**
-   * Filters variables by the specified scope key using {@link BasicStringProperty} consumer.
+   * Filters variables by the specified scope key using {@link BasicLongProperty} consumer.
    *
-   * @param fn the scope key {@link BasicStringProperty} consumer of the variable
+   * @param fn the scope key {@link BasicLongProperty} consumer of the variable
    * @return the updated filter
    */
-  VariableFilter scopeKey(final Consumer<BasicStringProperty> fn);
+  VariableFilter scopeKey(final Consumer<BasicLongProperty> fn);
 
   /**
    * Filters variables by the specified process instance key.
@@ -95,13 +95,13 @@ public interface VariableFilter extends SearchRequestFilter {
   VariableFilter processInstanceKey(final Long processInstanceKey);
 
   /**
-   * Filters variables by the specified process instance key using {@link BasicStringProperty}
+   * Filters variables by the specified process instance key using {@link BasicLongProperty}
    * consumer.
    *
-   * @param fn the process instance key {@link BasicStringProperty} consumer of the variable
+   * @param fn the process instance key {@link BasicLongProperty} consumer of the variable
    * @return the updated filter
    */
-  VariableFilter processInstanceKey(final Consumer<BasicStringProperty> fn);
+  VariableFilter processInstanceKey(final Consumer<BasicLongProperty> fn);
 
   /**
    * Filters variables by the specified tenant id.

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/BasicLongProperty.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/builder/BasicLongProperty.java
@@ -17,5 +17,5 @@ package io.camunda.client.api.search.filter.builder;
 
 import io.camunda.client.protocol.rest.BasicStringFilterProperty;
 
-public interface BasicStringProperty
-    extends PropertyBase<String, BasicStringFilterProperty, BasicStringProperty> {}
+public interface BasicLongProperty
+    extends PropertyBase<Long, BasicStringFilterProperty, BasicLongProperty> {}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/DecisionInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/DecisionInstanceFilterImpl.java
@@ -16,12 +16,12 @@
 package io.camunda.client.impl.search.filter;
 
 import io.camunda.client.api.search.filter.DecisionInstanceFilter;
-import io.camunda.client.api.search.filter.builder.BasicStringProperty;
+import io.camunda.client.api.search.filter.builder.BasicLongProperty;
 import io.camunda.client.api.search.filter.builder.DateTimeProperty;
 import io.camunda.client.api.search.response.DecisionDefinitionType;
 import io.camunda.client.api.search.response.DecisionInstanceState;
 import io.camunda.client.impl.search.TypedSearchRequestPropertyProvider;
-import io.camunda.client.impl.search.filter.builder.BasicStringPropertyImpl;
+import io.camunda.client.impl.search.filter.builder.BasicLongPropertyImpl;
 import io.camunda.client.impl.search.filter.builder.DateTimePropertyImpl;
 import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.DecisionDefinitionTypeEnum;
@@ -109,13 +109,13 @@ public class DecisionInstanceFilterImpl
 
   @Override
   public DecisionInstanceFilter decisionDefinitionKey(final long decisionDefinitionKey) {
-    decisionDefinitionKey(b -> b.eq(ParseUtil.keyToString(decisionDefinitionKey)));
+    decisionDefinitionKey(b -> b.eq(decisionDefinitionKey));
     return this;
   }
 
   @Override
-  public DecisionInstanceFilter decisionDefinitionKey(final Consumer<BasicStringProperty> fn) {
-    final BasicStringPropertyImpl property = new BasicStringPropertyImpl();
+  public DecisionInstanceFilter decisionDefinitionKey(final Consumer<BasicLongProperty> fn) {
+    final BasicLongPropertyImpl property = new BasicLongPropertyImpl();
     fn.accept(property);
     filter.setDecisionDefinitionKey(property.build());
     return this;

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessInstanceFilterImpl.java
@@ -16,19 +16,18 @@
 package io.camunda.client.impl.search.filter;
 
 import io.camunda.client.api.search.filter.ProcessInstanceFilter;
-import io.camunda.client.api.search.filter.builder.BasicStringProperty;
+import io.camunda.client.api.search.filter.builder.BasicLongProperty;
 import io.camunda.client.api.search.filter.builder.DateTimeProperty;
 import io.camunda.client.api.search.filter.builder.IntegerProperty;
 import io.camunda.client.api.search.filter.builder.ProcessInstanceStateProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.api.search.response.ProcessInstanceState;
 import io.camunda.client.impl.search.TypedSearchRequestPropertyProvider;
-import io.camunda.client.impl.search.filter.builder.BasicStringPropertyImpl;
+import io.camunda.client.impl.search.filter.builder.BasicLongPropertyImpl;
 import io.camunda.client.impl.search.filter.builder.DateTimePropertyImpl;
 import io.camunda.client.impl.search.filter.builder.IntegerPropertyImpl;
 import io.camunda.client.impl.search.filter.builder.ProcessInstanceStatePropertyImpl;
 import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
-import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.ProcessInstanceVariableFilterRequest;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -49,13 +48,13 @@ public class ProcessInstanceFilterImpl
 
   @Override
   public ProcessInstanceFilter processInstanceKey(final Long processInstanceKey) {
-    processInstanceKey(b -> b.eq(ParseUtil.keyToString(processInstanceKey)));
+    processInstanceKey(b -> b.eq(processInstanceKey));
     return this;
   }
 
   @Override
-  public ProcessInstanceFilter processInstanceKey(final Consumer<BasicStringProperty> fn) {
-    final BasicStringProperty property = new BasicStringPropertyImpl();
+  public ProcessInstanceFilter processInstanceKey(final Consumer<BasicLongProperty> fn) {
+    final BasicLongProperty property = new BasicLongPropertyImpl();
     fn.accept(property);
     filter.setProcessInstanceKey(property.build());
     return this;
@@ -120,13 +119,13 @@ public class ProcessInstanceFilterImpl
 
   @Override
   public ProcessInstanceFilter processDefinitionKey(final Long processDefinitionKey) {
-    processDefinitionKey(b -> b.eq(ParseUtil.keyToString(processDefinitionKey)));
+    processDefinitionKey(b -> b.eq(processDefinitionKey));
     return this;
   }
 
   @Override
-  public ProcessInstanceFilter processDefinitionKey(final Consumer<BasicStringProperty> fn) {
-    final BasicStringProperty property = new BasicStringPropertyImpl();
+  public ProcessInstanceFilter processDefinitionKey(final Consumer<BasicLongProperty> fn) {
+    final BasicLongProperty property = new BasicLongPropertyImpl();
     fn.accept(property);
     filter.setProcessDefinitionKey(property.build());
     return this;
@@ -134,13 +133,13 @@ public class ProcessInstanceFilterImpl
 
   @Override
   public ProcessInstanceFilter parentProcessInstanceKey(final Long parentProcessInstanceKey) {
-    parentProcessInstanceKey(b -> b.eq(ParseUtil.keyToString(parentProcessInstanceKey)));
+    parentProcessInstanceKey(b -> b.eq(parentProcessInstanceKey));
     return this;
   }
 
   @Override
-  public ProcessInstanceFilter parentProcessInstanceKey(final Consumer<BasicStringProperty> fn) {
-    final BasicStringProperty property = new BasicStringPropertyImpl();
+  public ProcessInstanceFilter parentProcessInstanceKey(final Consumer<BasicLongProperty> fn) {
+    final BasicLongProperty property = new BasicLongPropertyImpl();
     fn.accept(property);
     filter.setParentProcessInstanceKey(property.build());
     return this;
@@ -148,13 +147,13 @@ public class ProcessInstanceFilterImpl
 
   @Override
   public ProcessInstanceFilter parentFlowNodeInstanceKey(final Long parentFlowNodeInstanceKey) {
-    parentFlowNodeInstanceKey(b -> b.eq(ParseUtil.keyToString(parentFlowNodeInstanceKey)));
+    parentFlowNodeInstanceKey(b -> b.eq(parentFlowNodeInstanceKey));
     return this;
   }
 
   @Override
-  public ProcessInstanceFilter parentFlowNodeInstanceKey(final Consumer<BasicStringProperty> fn) {
-    final BasicStringProperty property = new BasicStringPropertyImpl();
+  public ProcessInstanceFilter parentFlowNodeInstanceKey(final Consumer<BasicLongProperty> fn) {
+    final BasicLongProperty property = new BasicLongPropertyImpl();
     fn.accept(property);
     filter.setParentFlowNodeInstanceKey(property.build());
     return this;

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/VariableFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/VariableFilterImpl.java
@@ -16,12 +16,11 @@
 package io.camunda.client.impl.search.filter;
 
 import io.camunda.client.api.search.filter.VariableFilter;
-import io.camunda.client.api.search.filter.builder.BasicStringProperty;
+import io.camunda.client.api.search.filter.builder.BasicLongProperty;
 import io.camunda.client.api.search.filter.builder.StringProperty;
 import io.camunda.client.impl.search.TypedSearchRequestPropertyProvider;
-import io.camunda.client.impl.search.filter.builder.BasicStringPropertyImpl;
+import io.camunda.client.impl.search.filter.builder.BasicLongPropertyImpl;
 import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
-import io.camunda.client.impl.util.ParseUtil;
 import java.util.function.Consumer;
 
 public class VariableFilterImpl
@@ -36,13 +35,13 @@ public class VariableFilterImpl
 
   @Override
   public VariableFilter variableKey(final Long key) {
-    variableKey(b -> b.eq(ParseUtil.keyToString(key)));
+    variableKey(b -> b.eq(key));
     return this;
   }
 
   @Override
-  public VariableFilter variableKey(final Consumer<BasicStringProperty> fn) {
-    final BasicStringProperty property = new BasicStringPropertyImpl();
+  public VariableFilter variableKey(final Consumer<BasicLongProperty> fn) {
+    final BasicLongProperty property = new BasicLongPropertyImpl();
     fn.accept(property);
     filter.setVariableKey(property.build());
     return this;
@@ -78,13 +77,13 @@ public class VariableFilterImpl
 
   @Override
   public VariableFilter scopeKey(final Long scopeKey) {
-    scopeKey(b -> b.eq(ParseUtil.keyToString(scopeKey)));
+    scopeKey(b -> b.eq(scopeKey));
     return this;
   }
 
   @Override
-  public VariableFilter scopeKey(final Consumer<BasicStringProperty> fn) {
-    final BasicStringProperty property = new BasicStringPropertyImpl();
+  public VariableFilter scopeKey(final Consumer<BasicLongProperty> fn) {
+    final BasicLongProperty property = new BasicLongPropertyImpl();
     fn.accept(property);
     filter.setScopeKey(property.build());
     return this;
@@ -92,13 +91,13 @@ public class VariableFilterImpl
 
   @Override
   public VariableFilter processInstanceKey(final Long processInstanceKey) {
-    processInstanceKey(b -> b.eq(ParseUtil.keyToString(processInstanceKey)));
+    processInstanceKey(b -> b.eq(processInstanceKey));
     return this;
   }
 
   @Override
-  public VariableFilter processInstanceKey(final Consumer<BasicStringProperty> fn) {
-    final BasicStringProperty property = new BasicStringPropertyImpl();
+  public VariableFilter processInstanceKey(final Consumer<BasicLongProperty> fn) {
+    final BasicLongProperty property = new BasicLongPropertyImpl();
     fn.accept(property);
     filter.setProcessInstanceKey(property.build());
     return this;

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/BasicLongPropertyImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/builder/BasicLongPropertyImpl.java
@@ -15,40 +15,41 @@
  */
 package io.camunda.client.impl.search.filter.builder;
 
-import io.camunda.client.api.search.filter.builder.BasicStringProperty;
+import io.camunda.client.api.search.filter.builder.BasicLongProperty;
 import io.camunda.client.impl.util.CollectionUtil;
 import io.camunda.client.protocol.rest.BasicStringFilterProperty;
 import java.util.List;
+import java.util.stream.Collectors;
 
-public class BasicStringPropertyImpl implements BasicStringProperty {
+public class BasicLongPropertyImpl implements BasicLongProperty {
   private final BasicStringFilterProperty filterProperty = new BasicStringFilterProperty();
 
   @Override
-  public BasicStringProperty eq(final String value) {
-    filterProperty.set$Eq(value);
+  public BasicLongProperty eq(final Long value) {
+    filterProperty.set$Eq(String.valueOf(value));
     return this;
   }
 
   @Override
-  public BasicStringProperty neq(final String value) {
-    filterProperty.set$Neq(value);
+  public BasicLongProperty neq(final Long value) {
+    filterProperty.set$Neq(String.valueOf(value));
     return this;
   }
 
   @Override
-  public BasicStringProperty exists(final boolean value) {
+  public BasicLongProperty exists(final boolean value) {
     filterProperty.set$Exists(value);
     return this;
   }
 
   @Override
-  public BasicStringProperty in(final List<String> values) {
-    filterProperty.set$In(values);
+  public BasicLongProperty in(final List<Long> values) {
+    filterProperty.set$In(values.stream().map(String::valueOf).collect(Collectors.toList()));
     return this;
   }
 
   @Override
-  public BasicStringProperty in(final String... values) {
+  public BasicLongProperty in(final Long... values) {
     return in(CollectionUtil.toList(values));
   }
 

--- a/clients/java/src/test/java/io/camunda/client/decision/SearchDecisionInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/decision/SearchDecisionInstanceTest.java
@@ -81,7 +81,7 @@ class SearchDecisionInstanceTest extends ClientRestTest {
     // when
     client
         .newDecisionInstanceQuery()
-        .filter(f -> f.decisionDefinitionKey(b -> b.in("1", "10")))
+        .filter(f -> f.decisionDefinitionKey(b -> b.in(1L, 10L)))
         .send()
         .join();
 

--- a/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
@@ -113,7 +113,7 @@ public class QueryProcessInstanceTest extends ClientRestTest {
     // when
     client
         .newProcessInstanceQuery()
-        .filter(f -> f.processInstanceKey(b -> b.in("1", "10")))
+        .filter(f -> f.processInstanceKey(b -> b.in(1L, 10L)))
         .send()
         .join();
 

--- a/clients/java/src/test/java/io/camunda/client/variable/SearchVariableTest.java
+++ b/clients/java/src/test/java/io/camunda/client/variable/SearchVariableTest.java
@@ -92,7 +92,7 @@ public class SearchVariableTest extends ClientRestTest {
     client
         .newVariableQuery()
         .sort(s -> s.processInstanceKey().asc().variableKey())
-        .filter(f -> f.processInstanceKey(b -> b.in("1", "10")))
+        .filter(f -> f.processInstanceKey(b -> b.in(1L, 10L)))
         .send()
         .join();
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/backup/DataGenerator.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/backup/DataGenerator.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 public class DataGenerator implements AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(DataGenerator.class);
   // process id -> process instance key
-  public final ConcurrentSkipListSet<String> instancekeys = new ConcurrentSkipListSet<>();
+  public final ConcurrentSkipListSet<Long> instancekeys = new ConcurrentSkipListSet<>();
   final String assignee = "user";
   private CamundaClient camundaClient;
   private final OneTaskProcess process;
@@ -165,7 +165,7 @@ public class DataGenerator implements AutoCloseable {
               .send()
               .join();
       LOGGER.debug("Process instance started with key {}", evt.getProcessInstanceKey());
-      instancekeys.add(String.valueOf(evt.getProcessInstanceKey()));
+      instancekeys.add(evt.getProcessInstanceKey());
     }
 
     private void deploy() {

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/DecisionInstanceQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/DecisionInstanceQueryTest.java
@@ -134,9 +134,7 @@ class DecisionInstanceQueryTest {
     final var result =
         camundaClient
             .newDecisionInstanceQuery()
-            .filter(
-                f ->
-                    f.decisionDefinitionKey(b -> b.in("-1", String.valueOf(decisionDefinitionKey))))
+            .filter(f -> f.decisionDefinitionKey(b -> b.in(Long.MAX_VALUE, decisionDefinitionKey)))
             .send()
             .join();
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceQueryTest.java
@@ -190,10 +190,9 @@ public class ProcessInstanceAndFlowNodeInstanceQueryTest {
   @Test
   void shouldQueryProcessInstancesByKeyFilterIn() {
     // given
-    final List<String> processInstanceKeys =
+    final List<Long> processInstanceKeys =
         PROCESS_INSTANCES.subList(0, 2).stream()
             .map(ProcessInstanceEvent::getProcessInstanceKey)
-            .map(String::valueOf)
             .toList();
 
     // when
@@ -208,7 +207,6 @@ public class ProcessInstanceAndFlowNodeInstanceQueryTest {
     assertThat(result.items().size()).isEqualTo(2);
     assertThat(result.items())
         .extracting("processInstanceKey")
-        .map(String::valueOf)
         .containsExactlyInAnyOrderElementsOf(processInstanceKeys);
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/VariableQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/VariableQueryTest.java
@@ -199,10 +199,7 @@ class VariableQueryTest {
     final var result =
         camundaClient
             .newVariableQuery()
-            .filter(
-                f ->
-                    f.processInstanceKey(
-                        b -> b.in(String.valueOf(variable.getProcessInstanceKey()))))
+            .filter(f -> f.processInstanceKey(b -> b.in(variable.getProcessInstanceKey())))
             .send()
             .join();
 


### PR DESCRIPTION
## Description

- Revert client key filter methods to long
- Convert keys to string in BasicLongProperty
- Adjust tests

## Related issues

related to https://github.com/camunda/camunda/issues/27169
