### PR TITLE
feat: set fallback for tasklist multitenancy

### DIFF
--- a/dist/src/main/resources/application-tasklist.properties
+++ b/dist/src/main/resources/application-tasklist.properties
@@ -31,3 +31,5 @@ spring.config.activate.on-profile=dev
 spring.config.activate.on-profile=standalone
 # Fallback authorizations configuration for deprecated env variable naming
 camunda.security.authorizations.enabled=${camunda.tasklist.identity.resourcePermissionsEnabled:false}
+# Fallback multitenancy configuration for deprecated env variable naming
+camunda.security.multiTenancy.enabled=${camunda.tasklist.multiTenancy.enabled:false}


### PR DESCRIPTION
## Description

Set fall back for multitenancy deprecated env variable naming

relates to #https://github.com/camunda/camunda/issues/24665
