### PR TITLE
[Backport stable/8.7] fix: rest-address is not mapped properly

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/resources/application-camunda-saas.yaml
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/resources/application-camunda-saas.yaml
@@ -8,7 +8,7 @@ camunda:
     zeebe:
       enabled: true
       audience: zeebe.camunda.io
-      base-url: https://${camunda.client.region}.zeebe.camunda.io/${camunda.client.cluster-id}
+      rest-address: https://${camunda.client.region}.zeebe.camunda.io/${camunda.client.cluster-id}
       grpc-address: https://${camunda.client.cluster-id}.${camunda.client.region}.zeebe.camunda.io
       prefer-rest-over-grpc: false
     identity:

--- a/clients/spring-boot-starter-camunda-sdk/src/main/resources/application-camunda-self-managed.yaml
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/resources/application-camunda-self-managed.yaml
@@ -7,7 +7,7 @@ camunda:
       issuer: http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
     zeebe:
       enabled: true
-      base-url: http://localhost:8086
+      rest-address: http://localhost:8086
       grpc-address: http://localhost:26500
       audience: zeebe-api
       prefer-rest-over-grpc: false

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationImplSaasTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationImplSaasTest.java
@@ -60,9 +60,15 @@ public class ZeebeClientConfigurationImplSaasTest {
   }
 
   @Test
-  void shouldHaveGatewayAddress() throws URISyntaxException {
+  void shouldHaveGrpcAddress() throws URISyntaxException {
     assertThat(zeebeClientConfiguration.getGrpcAddress())
         .isEqualTo(new URI("https://12345.bru-2.zeebe.camunda.io"));
+  }
+
+  @Test
+  void shouldHaveRestAddress() throws URISyntaxException {
+    assertThat(zeebeClientConfiguration.getRestAddress())
+        .isEqualTo(new URI("https://bru-2.zeebe.camunda.io/12345"));
   }
 
   @Test

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationImplSelfManagedTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationImplSelfManagedTest.java
@@ -55,8 +55,15 @@ public class ZeebeClientConfigurationImplSelfManagedTest {
   }
 
   @Test
-  void shouldHaveGatewayAddress() {
-    assertThat(zeebeClientConfiguration.getGatewayAddress()).isEqualTo("localhost:26500");
+  void shouldHaveGrpcAddress() {
+    assertThat(zeebeClientConfiguration.getGrpcAddress().toString())
+        .isEqualTo("http://localhost:26500");
+  }
+
+  @Test
+  void shouldHaveRestAddress() {
+    assertThat(zeebeClientConfiguration.getRestAddress().toString())
+        .isEqualTo("http://localhost:8086");
   }
 
   @Test

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientPropertiesSaasTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientPropertiesSaasTest.java
@@ -37,7 +37,7 @@ public class ZeebeClientPropertiesSaasTest {
   void shouldPopulateBaseUrlsForSaas() {
     assertThat(properties.getZeebe().getGrpcAddress().toString())
         .isEqualTo("https://my-cluster-id.bru-2.zeebe.camunda.io");
-    assertThat(properties.getZeebe().getBaseUrl().toString())
+    assertThat(properties.getZeebe().getRestAddress().toString())
         .isEqualTo("https://bru-2.zeebe.camunda.io/my-cluster-id");
     assertThat(properties.getZeebe().isPreferRestOverGrpc()).isEqualTo(false);
   }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientPropertiesSelfManagedTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientPropertiesSelfManagedTest.java
@@ -33,7 +33,8 @@ public class ZeebeClientPropertiesSelfManagedTest {
     assertThat(properties.getMode()).isEqualTo(ClientMode.selfManaged);
     assertThat(properties.getZeebe().getGrpcAddress().toString())
         .isEqualTo("http://localhost:26500");
-    assertThat(properties.getZeebe().getBaseUrl().toString()).isEqualTo("http://localhost:8086");
+    assertThat(properties.getZeebe().getRestAddress().toString())
+        .isEqualTo("http://localhost:8086");
     assertThat(properties.getZeebe().isPreferRestOverGrpc()).isEqualTo(false);
     assertThat(properties.getZeebe().getEnabled()).isEqualTo(true);
     assertThat(properties.getZeebe().getAudience()).isEqualTo("zeebe-api");


### PR DESCRIPTION
# Description
Backport of #27900 to `stable/8.7`.

relates to 
original author: @jonathanlukas