### PR TITLE
Migrate log stream metrics to Micrometer for stable/8.5

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -8429,7 +8429,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "histogram_quantile(0.90, rate(zeebe_log_appender_commit_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "histogram_quantile(0.90, rate(zeebe_log_appender_commit_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or rate(zeebe_log_appender_commit_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]))",
               "format": "time_series",
               "interval": "30s",
               "intervalFactor": 1,
@@ -8440,7 +8440,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "histogram_quantile(0.99, rate(zeebe_log_appender_commit_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "histogram_quantile(0.99, rate(zeebe_log_appender_commit_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or rate(zeebe_log_appender_commit_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]))",
               "hide": false,
               "interval": "",
               "legendFormat": "p99 partition {{partition}}",
@@ -8450,7 +8450,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "histogram_quantile(0.50, rate(zeebe_log_appender_commit_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "histogram_quantile(0.50, rate(zeebe_log_appender_commit_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or rate(zeebe_log_appender_commit_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]))",
               "hide": false,
               "interval": "",
               "legendFormat": "MEDIAN partition {{partition}} ",
@@ -8460,7 +8460,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "sum(rate(zeebe_log_appender_commit_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (partition) / sum(rate(zeebe_log_appender_commit_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (partition) ",
+              "expr": "sum(rate(zeebe_log_appender_commit_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (partition) / sum(rate(zeebe_log_appender_commit_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (partition) or sum(rate(zeebe_log_appender_commit_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (partition) / sum(rate(zeebe_log_appender_commit_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (partition) ",
               "hide": false,
               "interval": "",
               "legendFormat": "AVG partition {{partition}}",
@@ -8546,7 +8546,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "histogram_quantile(0.90, rate(zeebe_log_appender_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "histogram_quantile(0.90, rate(zeebe_log_appender_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or rate(zeebe_log_appender_append_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]))",
               "format": "time_series",
               "interval": "30s",
               "intervalFactor": 1,
@@ -8557,7 +8557,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "histogram_quantile(0.99, rate(zeebe_log_appender_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "histogram_quantile(0.99, rate(zeebe_log_appender_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or rate(zeebe_log_appender_append_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]))",
               "hide": false,
               "interval": "",
               "legendFormat": "p99 partition {{partition}}",
@@ -8567,7 +8567,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "histogram_quantile(0.50, rate(zeebe_log_appender_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]))",
+              "expr": "histogram_quantile(0.50, rate(zeebe_log_appender_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]) or rate(zeebe_log_appender_append_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval]))",
               "hide": false,
               "interval": "",
               "legendFormat": "MEDIAN partition {{partition}} ",
@@ -8577,7 +8577,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "sum(rate(zeebe_log_appender_append_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (partition) / sum(rate(zeebe_log_appender_append_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (partition) ",
+              "expr": "sum(rate(zeebe_log_appender_append_latency_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (partition) / sum(rate(zeebe_log_appender_append_latency_count{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (partition) or sum(rate(zeebe_log_appender_append_latency_seconds_sum{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (partition) / sum(rate(zeebe_log_appender_append_latency_seconds_count{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (partition)  ",
               "hide": false,
               "interval": "",
               "legendFormat": "AVG partition {{partition}}",
@@ -8701,7 +8701,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "sum(increase(zeebe_log_appender_commit_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_log_appender_commit_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le) or sum(increase(zeebe_log_appender_commit_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,
@@ -8812,7 +8812,7 @@
               "datasource": {
                 "uid": "$DS_PROMETHEUS"
               },
-              "expr": "sum(increase(zeebe_log_appender_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
+              "expr": "sum(increase(zeebe_log_appender_append_latency_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le) or sum(increase(zeebe_log_appender_append_latency_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",partition=~\"$partition\",pod=~\"$pod\"}[$__rate_interval])) by (le)",
               "format": "heatmap",
               "interval": "30s",
               "intervalFactor": 1,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
@@ -96,6 +96,7 @@ public final class LogStreamPartitionTransitionStep implements PartitionTransiti
         .withPartitionId(context.getPartitionId())
         .withMaxFragmentSize(context.getMaxFragmentSize())
         .withActorSchedulingService(context.getActorSchedulingService())
+        .withMeterRegistry(context.getPartitionMeterRegistry())
         .buildAsync();
   }
 

--- a/zeebe/logstreams/pom.xml
+++ b/zeebe/logstreams/pom.xml
@@ -58,6 +58,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-msgpack-value</artifactId>
     </dependency>

--- a/zeebe/logstreams/pom.xml
+++ b/zeebe/logstreams/pom.xml
@@ -53,13 +53,13 @@
     </dependency>
 
     <dependency>
-      <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient</artifactId>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-core</artifactId>
+      <artifactId>micrometer-commons</artifactId>
     </dependency>
 
     <dependency>

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/AppendMetricsDoc.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/AppendMetricsDoc.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.logstreams.impl.flowcontrol;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter.Type;
+
+/** Flow control metrics for the log storage appender. */
+@SuppressWarnings("NullableProblems")
+public enum AppendMetricsDoc implements ExtendedMeterDocumentation {
+  /** Number of deferred appends due to backpressure */
+  TOTAL_DEFERRED_APPEND_COUNT {
+    @Override
+    public String getDescription() {
+      return "Number of deferred appends due to backpressure";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.deferred.append.count.total";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+  },
+  /** Number of tries to append */
+  TOTAL_APPEND_TRY_COUNT {
+    @Override
+    public String getDescription() {
+      return "Number of tries to append";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.try.to.append.total";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+  },
+  /** Current number of append inflight */
+  CURRENT_INFLIGHT {
+    @Override
+    public String getDescription() {
+      return "Current number of append inflight";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.backpressure.inflight.append.count";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+  },
+  /** Current limit for number of inflight appends */
+  CURRENT_LIMIT {
+    @Override
+    public String getDescription() {
+      return "Current limit for number of inflight appends";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.backpressure.append.limit";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+  },
+  /** The last committed position */
+  LAST_COMMITTED_POSITION {
+    @Override
+    public String getDescription() {
+      return "The last committed position";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.log.appender.last.committed.position";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+  },
+  /** The last appended position by the appender */
+  LAST_WRITTEN_POSITION {
+    @Override
+    public String getDescription() {
+      return "The last appended position by the appender";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.log.appender.last.appended.position";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+  },
+  /** Latency to append an event to the log in seconds */
+  WRITE_LATENCY {
+    @Override
+    public String getDescription() {
+      return "Latency to append an event to the log in seconds";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.log.appender.append.latency";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+  },
+  /** Latency to commit an event to the log in seconds */
+  COMMIT_LATENCY {
+    @Override
+    public String getDescription() {
+      return "Latency to commit an event to the log in seconds";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.log.appender.commit.latency";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+  },
+  /** Count of records appended per partition, record type, value type, and intent */
+  RECORD_APPENDED {
+    @Override
+    public String getDescription() {
+      return "Count of records appended per partition, record type, value type, and intent";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.log.appender.record.appended";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return RecordAppendedKeyNames.values();
+    }
+  };
+
+  /** Tags/labels associated with the {@link #RECORD_APPENDED} metric. */
+  public enum RecordAppendedKeyNames implements KeyName {
+    /**
+     * The record type of the appended record; see {@link
+     * io.camunda.zeebe.protocol.record.RecordType} for possible values
+     */
+    RECORD_TYPE {
+      @Override
+      public String asString() {
+        return "recordType";
+      }
+    },
+
+    /**
+     * The value type of the record value of the appended record; see {@link
+     * io.camunda.zeebe.protocol.record.ValueType} for possible values
+     */
+    VALUE_TYPE {
+      @Override
+      public String asString() {
+        return "valueType";
+      }
+    },
+
+    /**
+     * The intent of the command or event that was appended; could be any value from one of the many
+     * enums which implement {@link io.camunda.zeebe.protocol.record.intent.Intent}
+     */
+    INTENT {
+      @Override
+      public String asString() {
+        return "intent";
+      }
+    }
+  }
+}

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/AppendMetricsDoc.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/AppendMetricsDoc.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.logstreams.impl.flowcontrol;
 
 import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Meter.Type;
 
@@ -30,6 +31,11 @@ public enum AppendMetricsDoc implements ExtendedMeterDocumentation {
     public Type getType() {
       return Type.COUNTER;
     }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {PartitionKeyNames.PARTITION};
+    }
   },
   /** Number of tries to append */
   TOTAL_APPEND_TRY_COUNT {
@@ -46,6 +52,11 @@ public enum AppendMetricsDoc implements ExtendedMeterDocumentation {
     @Override
     public Type getType() {
       return Type.COUNTER;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {PartitionKeyNames.PARTITION};
     }
   },
   /** Current number of append inflight */
@@ -64,6 +75,11 @@ public enum AppendMetricsDoc implements ExtendedMeterDocumentation {
     public Type getType() {
       return Type.GAUGE;
     }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {PartitionKeyNames.PARTITION};
+    }
   },
   /** Current limit for number of inflight appends */
   CURRENT_LIMIT {
@@ -80,6 +96,11 @@ public enum AppendMetricsDoc implements ExtendedMeterDocumentation {
     @Override
     public Type getType() {
       return Type.GAUGE;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {PartitionKeyNames.PARTITION};
     }
   },
   /** The last committed position */
@@ -98,6 +119,11 @@ public enum AppendMetricsDoc implements ExtendedMeterDocumentation {
     public Type getType() {
       return Type.GAUGE;
     }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {PartitionKeyNames.PARTITION};
+    }
   },
   /** The last appended position by the appender */
   LAST_WRITTEN_POSITION {
@@ -114,6 +140,11 @@ public enum AppendMetricsDoc implements ExtendedMeterDocumentation {
     @Override
     public Type getType() {
       return Type.GAUGE;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {PartitionKeyNames.PARTITION};
     }
   },
   /** Latency to append an event to the log in seconds */
@@ -132,6 +163,11 @@ public enum AppendMetricsDoc implements ExtendedMeterDocumentation {
     public Type getType() {
       return Type.TIMER;
     }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {PartitionKeyNames.PARTITION};
+    }
   },
   /** Latency to commit an event to the log in seconds */
   COMMIT_LATENCY {
@@ -148,6 +184,11 @@ public enum AppendMetricsDoc implements ExtendedMeterDocumentation {
     @Override
     public Type getType() {
       return Type.TIMER;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return new KeyName[] {PartitionKeyNames.PARTITION};
     }
   },
   /** Count of records appended per partition, record type, value type, and intent */
@@ -169,7 +210,8 @@ public enum AppendMetricsDoc implements ExtendedMeterDocumentation {
 
     @Override
     public KeyName[] getKeyNames() {
-      return RecordAppendedKeyNames.values();
+      return KeyName.merge(
+          RecordAppendedKeyNames.values(), new KeyName[] {PartitionKeyNames.PARTITION});
     }
   };
 

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/AppenderMetrics.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/AppenderMetrics.java
@@ -7,115 +7,86 @@
  */
 package io.camunda.zeebe.logstreams.impl.flowcontrol;
 
+import static io.camunda.zeebe.logstreams.impl.flowcontrol.AppendMetricsDoc.COMMIT_LATENCY;
+import static io.camunda.zeebe.logstreams.impl.flowcontrol.AppendMetricsDoc.CURRENT_INFLIGHT;
+import static io.camunda.zeebe.logstreams.impl.flowcontrol.AppendMetricsDoc.CURRENT_LIMIT;
+import static io.camunda.zeebe.logstreams.impl.flowcontrol.AppendMetricsDoc.LAST_COMMITTED_POSITION;
+import static io.camunda.zeebe.logstreams.impl.flowcontrol.AppendMetricsDoc.LAST_WRITTEN_POSITION;
+import static io.camunda.zeebe.logstreams.impl.flowcontrol.AppendMetricsDoc.RECORD_APPENDED;
+import static io.camunda.zeebe.logstreams.impl.flowcontrol.AppendMetricsDoc.RecordAppendedKeyNames.INTENT;
+import static io.camunda.zeebe.logstreams.impl.flowcontrol.AppendMetricsDoc.RecordAppendedKeyNames.RECORD_TYPE;
+import static io.camunda.zeebe.logstreams.impl.flowcontrol.AppendMetricsDoc.RecordAppendedKeyNames.VALUE_TYPE;
+import static io.camunda.zeebe.logstreams.impl.flowcontrol.AppendMetricsDoc.TOTAL_APPEND_TRY_COUNT;
+import static io.camunda.zeebe.logstreams.impl.flowcontrol.AppendMetricsDoc.TOTAL_DEFERRED_APPEND_COUNT;
+import static io.camunda.zeebe.logstreams.impl.flowcontrol.AppendMetricsDoc.WRITE_LATENCY;
+
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
-import io.prometheus.client.Counter;
-import io.prometheus.client.Gauge;
-import io.prometheus.client.Histogram;
-import io.prometheus.client.Histogram.Timer;
+import io.camunda.zeebe.util.CloseableSilently;
+import io.camunda.zeebe.util.collection.Map3D;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.concurrent.atomic.AtomicLong;
 
 public final class AppenderMetrics {
-  private static final Counter TOTAL_DEFERRED_APPEND_COUNT =
-      Counter.build()
-          .namespace("zeebe")
-          .name("deferred_append_count_total")
-          .help("Number of deferred appends due to backpressure")
-          .labelNames("partition")
-          .register();
 
-  private static final Counter TOTAL_APPEND_TRY_COUNT =
-      Counter.build()
-          .namespace("zeebe")
-          .name("try_to_append_total")
-          .help("Number of tries to append")
-          .labelNames("partition")
-          .register();
+  private final Map3D<RecordType, ValueType, Intent, Counter> recordAppended = Map3D.simple();
+  private final AtomicLong inflightAppends = new AtomicLong();
+  private final AtomicLong inflightLimit = new AtomicLong();
+  private final AtomicLong lastCommitted = new AtomicLong();
+  private final AtomicLong lastWritten = new AtomicLong();
 
-  private static final Gauge CURRENT_INFLIGHT =
-      Gauge.build()
-          .namespace("zeebe")
-          .name("backpressure_inflight_append_count")
-          .help("Current number of append inflight")
-          .labelNames("partition")
-          .register();
+  private final MeterRegistry registry;
+  private final Counter deferredAppends;
+  private final Counter triedAppends;
+  private final Timer commitLatency;
+  private final Timer appendLatency;
 
-  private static final Gauge CURRENT_LIMIT =
-      Gauge.build()
-          .namespace("zeebe")
-          .name("backpressure_append_limit")
-          .help("Current limit for number of inflight appends")
-          .labelNames("partition")
-          .register();
+  public AppenderMetrics(final MeterRegistry meterRegistry) {
+    registry = meterRegistry;
+    deferredAppends =
+        Counter.builder(TOTAL_DEFERRED_APPEND_COUNT.getName())
+            .description(TOTAL_DEFERRED_APPEND_COUNT.getDescription())
+            .register(registry);
+    triedAppends =
+        Counter.builder(TOTAL_APPEND_TRY_COUNT.getName())
+            .description(TOTAL_APPEND_TRY_COUNT.getDescription())
+            .register(registry);
+    commitLatency =
+        Timer.builder(COMMIT_LATENCY.getName())
+            .description(COMMIT_LATENCY.getDescription())
+            .serviceLevelObjectives(COMMIT_LATENCY.getTimerSLOs())
+            .register(registry);
+    appendLatency =
+        Timer.builder(WRITE_LATENCY.getName())
+            .description(WRITE_LATENCY.getDescription())
+            .serviceLevelObjectives(WRITE_LATENCY.getTimerSLOs())
+            .register(registry);
 
-  private static final Gauge LAST_COMMITTED_POSITION =
-      Gauge.build()
-          .namespace("zeebe")
-          .name("log_appender_last_committed_position")
-          .help("The last committed position.")
-          .labelNames("partition")
-          .register();
-
-  private static final Gauge LAST_WRITTEN_POSITION =
-      Gauge.build()
-          .namespace("zeebe")
-          .name("log_appender_last_appended_position")
-          .help("The last appended position by the appender.")
-          .labelNames("partition")
-          .register();
-
-  private static final Histogram WRITE_LATENCY =
-      Histogram.build()
-          .namespace("zeebe")
-          .name("log_appender_append_latency")
-          .help("Latency to append an event to the log in seconds")
-          .labelNames("partition")
-          .register();
-  private static final Histogram COMMIT_LATENCY =
-      Histogram.build()
-          .namespace("zeebe")
-          .name("log_appender_commit_latency")
-          .help("Latency to commit an event to the log in seconds")
-          .labelNames("partition")
-          .register();
-
-  private static final Counter RECORD_APPENDED =
-      Counter.build()
-          .namespace("zeebe")
-          .subsystem("log_appender")
-          .name("record_appended")
-          .labelNames("partition", "recordType", "valueType", "intent")
-          .help("Count of records appended per partition, record type, value type, and intent")
-          .register();
-
-  private final Counter.Child deferredAppends;
-  private final Counter.Child triedAppends;
-  private final Gauge.Child inflightAppends;
-  private final Gauge.Child inflightLimit;
-  private final Gauge.Child lastCommitted;
-  private final Gauge.Child lastWritten;
-  private final Histogram.Child commitLatency;
-  private final Histogram.Child appendLatency;
-  private final String partitionLabel;
-
-  public AppenderMetrics(final int partitionId) {
-    partitionLabel = String.valueOf(partitionId);
-    deferredAppends = TOTAL_DEFERRED_APPEND_COUNT.labels(partitionLabel);
-    triedAppends = TOTAL_APPEND_TRY_COUNT.labels(partitionLabel);
-    inflightAppends = CURRENT_INFLIGHT.labels(partitionLabel);
-    inflightLimit = CURRENT_LIMIT.labels(partitionLabel);
-    lastCommitted = LAST_COMMITTED_POSITION.labels(partitionLabel);
-    lastWritten = LAST_WRITTEN_POSITION.labels(partitionLabel);
-    commitLatency = COMMIT_LATENCY.labels(partitionLabel);
-    appendLatency = WRITE_LATENCY.labels(partitionLabel);
+    Gauge.builder(CURRENT_INFLIGHT.getName(), inflightAppends, Number::longValue)
+        .description(CURRENT_INFLIGHT.getDescription())
+        .register(registry);
+    Gauge.builder(CURRENT_LIMIT.getName(), inflightLimit, Number::longValue)
+        .description(CURRENT_LIMIT.getDescription())
+        .register(registry);
+    Gauge.builder(LAST_COMMITTED_POSITION.getName(), lastCommitted, Number::longValue)
+        .description(LAST_COMMITTED_POSITION.getDescription())
+        .register(registry);
+    Gauge.builder(LAST_WRITTEN_POSITION.getName(), lastWritten, Number::longValue)
+        .description(LAST_WRITTEN_POSITION.getDescription())
+        .register(registry);
   }
 
   public void increaseInflight() {
-    inflightAppends.inc();
+    inflightAppends.incrementAndGet();
   }
 
   public void decreaseInflight() {
-    inflightAppends.dec();
+    inflightAppends.decrementAndGet();
   }
 
   public void setInflightLimit(final long limit) {
@@ -123,19 +94,19 @@ public final class AppenderMetrics {
   }
 
   public void increaseTriedAppends() {
-    triedAppends.inc();
+    triedAppends.increment();
   }
 
   public void increaseDeferredAppends() {
-    deferredAppends.inc();
+    deferredAppends.increment();
   }
 
-  public Timer startWriteTimer() {
-    return appendLatency.startTimer();
+  public CloseableSilently startWriteTimer() {
+    return MicrometerUtil.timer(appendLatency, Timer.start(registry));
   }
 
-  public Timer startCommitTimer() {
-    return commitLatency.startTimer();
+  public CloseableSilently startCommitTimer() {
+    return MicrometerUtil.timer(commitLatency, Timer.start(registry));
   }
 
   public void setLastWrittenPosition(final long position) {
@@ -151,8 +122,18 @@ public final class AppenderMetrics {
       final RecordType recordType,
       final ValueType valueType,
       final Intent intent) {
-    RECORD_APPENDED
-        .labels(partitionLabel, recordType.name(), valueType.name(), intent.name())
-        .inc(amount);
+    recordAppended
+        .computeIfAbsent(recordType, valueType, intent, this::registerRecordAppendedCounter)
+        .increment(amount);
+  }
+
+  private Counter registerRecordAppendedCounter(
+      final RecordType recordType, final ValueType valueType, final Intent intent) {
+    return Counter.builder(RECORD_APPENDED.getName())
+        .description(RECORD_APPENDED.getDescription())
+        .tag(RECORD_TYPE.asString(), recordType.name())
+        .tag(VALUE_TYPE.asString(), valueType.name())
+        .tag(INTENT.asString(), intent.name())
+        .register(registry);
   }
 }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppender.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppender.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthReport;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -47,12 +48,13 @@ final class LogStorageAppender extends Actor implements HealthMonitorable, Appen
       final String name,
       final int partitionId,
       final LogStorage logStorage,
-      final Sequencer sequencer) {
+      final Sequencer sequencer,
+      final MeterRegistry registry) {
     this.name = name;
     this.partitionId = partitionId;
     this.logStorage = logStorage;
     this.sequencer = sequencer;
-    metrics = new AppenderMetrics(partitionId);
+    metrics = new AppenderMetrics(registry);
     flowControl = new AppenderFlowControl(this, metrics);
     closeFuture = new CompletableActorFuture<>();
   }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -310,7 +310,11 @@ public final class LogStreamImpl extends Actor
   private ActorFuture<Void> createAndScheduleLogStorageAppender(final Sequencer sequencer) {
     appender =
         new LogStorageAppender(
-            buildActorName("LogAppender", partitionId), partitionId, logStorage, sequencer);
+            buildActorName("LogAppender", partitionId),
+            partitionId,
+            logStorage,
+            sequencer,
+            meterRegistry);
     return actorSchedulingService.submitActor(appender);
   }
 

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencerMetrics.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencerMetrics.java
@@ -117,7 +117,7 @@ final class SequencerMetrics {
 
       @Override
       public String getBaseUnit() {
-        return "bytes";
+        return "KiB";
       }
 
       @Override

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencerMetrics.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencerMetrics.java
@@ -7,46 +7,38 @@
  */
 package io.camunda.zeebe.logstreams.impl.log;
 
-import io.prometheus.client.Gauge;
-import io.prometheus.client.Histogram;
+import static io.camunda.zeebe.logstreams.impl.log.SequencerMetrics.SequencerMetricsDoc.BATCH_LENGTH_BYTES;
+import static io.camunda.zeebe.logstreams.impl.log.SequencerMetrics.SequencerMetricsDoc.BATCH_SIZE;
+import static io.camunda.zeebe.logstreams.impl.log.SequencerMetrics.SequencerMetricsDoc.QUEUE_SIZE;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter.Type;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.concurrent.atomic.AtomicLong;
 
 final class SequencerMetrics {
-  private static final Gauge QUEUE_SIZE =
-      Gauge.build()
-          .namespace("zeebe")
-          .name("sequencer_queue_size")
-          .help(
-              "Current length of queue, i.e. how many entry batches are available to the appender")
-          .labelNames("partition")
-          .register();
 
-  private static final Histogram BATCH_SIZE =
-      Histogram.build()
-          .namespace("zeebe")
-          .name("sequencer_batch_size")
-          .help("Histogram over the number of entries in each batch that is appended")
-          .buckets(1, 2, 3, 5, 10, 25, 50, 100, 500, 1000)
-          .labelNames("partition")
-          .register();
+  private final AtomicLong queueSize = new AtomicLong();
+  private final DistributionSummary batchSize;
+  private final DistributionSummary batchLengthBytes;
 
-  private static final Histogram BATCH_LENGTH_BYTES =
-      Histogram.build()
-          .namespace("zeebe")
-          .name("sequencer_batch_length_bytes")
-          .help("Histogram over the size, in Kilobytes, of the sequenced batches")
-          .buckets(0.256, 0.512, 1, 4, 8, 32, 128, 512, 1024, 4096)
-          .labelNames("partition")
-          .register();
+  SequencerMetrics(final MeterRegistry meterRegistry) {
+    Gauge.builder(QUEUE_SIZE.getName(), queueSize, Number::longValue)
+        .description(QUEUE_SIZE.getDescription())
+        .register(meterRegistry);
 
-  private final Gauge.Child queueSize;
-  private final Histogram.Child batchSize;
-  private final Histogram.Child batchLengthBytes;
-
-  SequencerMetrics(final int partitionId) {
-    final var partitionLabel = String.valueOf(partitionId);
-    queueSize = QUEUE_SIZE.labels(partitionLabel);
-    batchSize = BATCH_SIZE.labels(partitionLabel);
-    batchLengthBytes = BATCH_LENGTH_BYTES.labels(partitionLabel);
+    batchSize =
+        DistributionSummary.builder(BATCH_SIZE.getName())
+            .description(BATCH_SIZE.getDescription())
+            .serviceLevelObjectives(BATCH_SIZE.getDistributionSLOs())
+            .register(meterRegistry);
+    batchLengthBytes =
+        DistributionSummary.builder(BATCH_LENGTH_BYTES.getName())
+            .description(BATCH_LENGTH_BYTES.getDescription())
+            .serviceLevelObjectives(BATCH_LENGTH_BYTES.getDistributionSLOs())
+            .register(meterRegistry);
   }
 
   void setQueueSize(final int length) {
@@ -54,11 +46,89 @@ final class SequencerMetrics {
   }
 
   void observeBatchSize(final int size) {
-    batchSize.observe(size);
+    batchSize.record(size);
   }
 
   void observeBatchLengthBytes(final int lengthBytes) {
     final int batchLengthKiloBytes = Math.floorDiv(lengthBytes, 1024);
-    batchLengthBytes.observe(batchLengthKiloBytes);
+    batchLengthBytes.record(batchLengthKiloBytes);
+  }
+
+  @SuppressWarnings("NullableProblems")
+  public enum SequencerMetricsDoc implements ExtendedMeterDocumentation {
+    /** Current length of queue, i.e. how many entry batches are available to the appender */
+    QUEUE_SIZE {
+      @Override
+      public String getDescription() {
+        return "Current length of queue, i.e. how many entry batches are available to the appender";
+      }
+
+      @Override
+      public String getName() {
+        return "zeebe.sequencer.queue.size";
+      }
+
+      @Override
+      public Type getType() {
+        return Type.GAUGE;
+      }
+    },
+
+    /** Histogram over the number of entries in each batch that is appended */
+    BATCH_SIZE {
+
+      public static final double[] BUCKETS = {1, 2, 3, 5, 10, 25, 50, 100, 500, 1000};
+
+      @Override
+      public String getDescription() {
+        return "Histogram over the number of entries in each batch that is appended";
+      }
+
+      @Override
+      public String getName() {
+        return "zeebe.sequencer.batch.size";
+      }
+
+      @Override
+      public Type getType() {
+        return Type.DISTRIBUTION_SUMMARY;
+      }
+
+      @Override
+      public double[] getDistributionSLOs() {
+        return BUCKETS;
+      }
+    },
+
+    /** Histogram over the size, in Kilobytes, of the sequenced batches */
+    BATCH_LENGTH_BYTES {
+
+      public static final double[] BUCKETS = {0.256, 0.512, 1, 4, 8, 32, 128, 512, 1024, 4096};
+
+      @Override
+      public String getDescription() {
+        return "Histogram over the size, in Kilobytes, of the sequenced batches";
+      }
+
+      @Override
+      public String getName() {
+        return "zeebe.sequencer.batch.length.bytes";
+      }
+
+      @Override
+      public String getBaseUnit() {
+        return "bytes";
+      }
+
+      @Override
+      public Type getType() {
+        return Type.DISTRIBUTION_SUMMARY;
+      }
+
+      @Override
+      public double[] getDistributionSLOs() {
+        return BUCKETS;
+      }
+    }
   }
 }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBuilder.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBuilder.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.logstreams.log;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.micrometer.core.instrument.MeterRegistry;
 
 /** Builder pattern for the {@link LogStream} */
 public interface LogStreamBuilder {
@@ -63,6 +64,14 @@ public interface LogStreamBuilder {
    * @return this builder
    */
   LogStreamBuilder withLogName(String logName);
+
+  /**
+   * Sets the meter registry to collect metrics on.
+   *
+   * @param meterRegistry the new meter registry to collect metrics on
+   * @return this builder
+   */
+  LogStreamBuilder withMeterRegistry(final MeterRegistry meterRegistry);
 
   /**
    * Returns a future which, when completed, contains a log stream that can be read from/written to.

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/AppenderFlowControlTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/AppenderFlowControlTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.netflix.concurrency.limits.Limit;
 import com.netflix.concurrency.limits.Limiter.Listener;
 import com.netflix.concurrency.limits.limit.SettableLimit;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.LinkedList;
@@ -34,7 +35,8 @@ final class AppenderFlowControlTest {
   void callsErrorHandlerOnWriteError() {
     // given
     final var errorHandler = Mockito.mock(AppendErrorHandler.class);
-    final var flow = new AppenderFlowControl(errorHandler, new AppenderMetrics(1));
+    final var flow =
+        new AppenderFlowControl(errorHandler, new AppenderMetrics(new SimpleMeterRegistry()));
     final var error = new RuntimeException();
     // when
     final var inFlight = flow.tryAcquire().orElseThrow();
@@ -47,7 +49,8 @@ final class AppenderFlowControlTest {
   void callsErrorHandlerOnCommitError() {
     // given
     final var errorHandler = Mockito.mock(AppendErrorHandler.class);
-    final var flow = new AppenderFlowControl(errorHandler, new AppenderMetrics(1));
+    final var flow =
+        new AppenderFlowControl(errorHandler, new AppenderMetrics(new SimpleMeterRegistry()));
     final var error = new RuntimeException();
     // when
     final var inFlight = flow.tryAcquire().orElseThrow();
@@ -60,7 +63,8 @@ final class AppenderFlowControlTest {
   void eventuallyRejects() {
     // given
     final var errorHandler = Mockito.mock(AppendErrorHandler.class);
-    final var flow = new AppenderFlowControl(errorHandler, new AppenderMetrics(1));
+    final var flow =
+        new AppenderFlowControl(errorHandler, new AppenderMetrics(new SimpleMeterRegistry()));
 
     // when - then
     Awaitility.await("Rejects new appends")
@@ -73,7 +77,8 @@ final class AppenderFlowControlTest {
   void recoversWhenCompletingAppends() {
     // given
     final var errorHandler = Mockito.mock(AppendErrorHandler.class);
-    final var flow = new AppenderFlowControl(errorHandler, new AppenderMetrics(1));
+    final var flow =
+        new AppenderFlowControl(errorHandler, new AppenderMetrics(new SimpleMeterRegistry()));
     // when
     boolean rejecting = false;
     final var inFlight = new LinkedList<InFlightAppend>();
@@ -98,7 +103,7 @@ final class AppenderFlowControlTest {
     final int poolSize = 300;
     final int limit = 100;
     final Limit myLimit = new SettableLimit(limit);
-    final AppenderMetrics appenderMetrics = new AppenderMetrics(1);
+    final AppenderMetrics appenderMetrics = new AppenderMetrics(new SimpleMeterRegistry());
     appenderMetrics.setInflightLimit(limit);
     final AppendLimiter myRateLimiter =
         AppendLimiter.builder().limit(myLimit).metrics(appenderMetrics).build();

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderHealthTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderHealthTest.java
@@ -37,10 +37,13 @@ public final class LogStorageAppenderHealthTest {
 
   @Before
   public void setUp() {
+    final var meterRegistry = new SimpleMeterRegistry();
     failingLogStorage = new ControllableLogStorage();
-    sequencer = new Sequencer(0, 4 * 1024 * 1024, new SequencerMetrics(new SimpleMeterRegistry()));
+    sequencer = new Sequencer(0, 4 * 1024 * 1024, new SequencerMetrics(meterRegistry));
 
-    appender = new LogStorageAppender("appender", PARTITION_ID, failingLogStorage, sequencer);
+    appender =
+        new LogStorageAppender(
+            "appender", PARTITION_ID, failingLogStorage, sequencer, meterRegistry);
   }
 
   @After

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderHealthTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderHealthTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import io.camunda.zeebe.util.health.HealthStatus;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.BiConsumer;
 import org.junit.After;
@@ -37,7 +38,7 @@ public final class LogStorageAppenderHealthTest {
   @Before
   public void setUp() {
     failingLogStorage = new ControllableLogStorage();
-    sequencer = new Sequencer(0, 4 * 1024 * 1024, new SequencerMetrics(1));
+    sequencer = new Sequencer(0, 4 * 1024 * 1024, new SequencerMetrics(new SimpleMeterRegistry()));
 
     appender = new LogStorageAppender("appender", PARTITION_ID, failingLogStorage, sequencer);
   }

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.logstreams.storage.LogStorage.AppendListener;
 import io.camunda.zeebe.logstreams.util.ListLogStorage;
 import io.camunda.zeebe.logstreams.util.TestEntry;
 import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -55,7 +56,9 @@ final class LogStorageAppenderTest {
   @BeforeEach
   void beforeEach() {
     scheduler.start();
-    sequencer = new Sequencer(INITIAL_POSITION, 4 * 1024 * 1024, new SequencerMetrics(1));
+    sequencer =
+        new Sequencer(
+            INITIAL_POSITION, 4 * 1024 * 1024, new SequencerMetrics(new SimpleMeterRegistry()));
     appender = new LogStorageAppender("appender", PARTITION_ID, logStorage, sequencer);
     reader = new LogStreamReaderImpl(logStorage.newReader());
   }

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
@@ -55,11 +55,13 @@ final class LogStorageAppenderTest {
 
   @BeforeEach
   void beforeEach() {
+    final var meterRegistry = new SimpleMeterRegistry();
+
     scheduler.start();
     sequencer =
-        new Sequencer(
-            INITIAL_POSITION, 4 * 1024 * 1024, new SequencerMetrics(new SimpleMeterRegistry()));
-    appender = new LogStorageAppender("appender", PARTITION_ID, logStorage, sequencer);
+        new Sequencer(INITIAL_POSITION, 4 * 1024 * 1024, new SequencerMetrics(meterRegistry));
+    appender =
+        new LogStorageAppender("appender", PARTITION_ID, logStorage, sequencer, meterRegistry);
     reader = new LogStreamReaderImpl(logStorage.newReader());
   }
 

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
@@ -12,6 +12,9 @@ import io.camunda.zeebe.logstreams.log.LogStreamWriter.WriteFailure;
 import io.camunda.zeebe.logstreams.util.TestEntry;
 import io.camunda.zeebe.scheduler.ActorCondition;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.List;
@@ -26,12 +29,15 @@ import org.mockito.Mockito;
 
 @SuppressWarnings("resource")
 @Execution(ExecutionMode.CONCURRENT)
+@AutoCloseResources
 final class SequencerTest {
+
+  @AutoCloseResource private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
   @Test
   void notifiesConsumerOnWrite() {
     // given
-    final var sequencer = new Sequencer(0, 16, new SequencerMetrics(new SimpleMeterRegistry()));
+    final var sequencer = new Sequencer(0, 16, new SequencerMetrics(meterRegistry));
     final var consumer = Mockito.mock(ActorCondition.class);
 
     // when
@@ -45,7 +51,7 @@ final class SequencerTest {
   @Test
   void notifiesConsumerOnBatchWrite() {
     // given
-    final var sequencer = new Sequencer(0, 16, new SequencerMetrics(new SimpleMeterRegistry()));
+    final var sequencer = new Sequencer(0, 16, new SequencerMetrics(meterRegistry));
     final var consumer = Mockito.mock(ActorCondition.class);
 
     // when
@@ -59,7 +65,7 @@ final class SequencerTest {
   @Test
   void canReadAfterSingleWrite() {
     // given
-    final var sequencer = new Sequencer(1, 16, new SequencerMetrics(new SimpleMeterRegistry()));
+    final var sequencer = new Sequencer(1, 16, new SequencerMetrics(meterRegistry));
     final var entry = TestEntry.ofDefaults();
 
     // when
@@ -73,7 +79,7 @@ final class SequencerTest {
   @Test
   void canReadAfterBatchWrite() {
     // given
-    final var sequencer = new Sequencer(1, 16, new SequencerMetrics(new SimpleMeterRegistry()));
+    final var sequencer = new Sequencer(1, 16, new SequencerMetrics(meterRegistry));
     final var entries =
         List.of(TestEntry.ofDefaults(), TestEntry.ofDefaults(), TestEntry.ofDefaults());
 
@@ -88,8 +94,7 @@ final class SequencerTest {
   @Test
   void cannotReadEmpty() {
     // given
-    final var sequencer =
-        new Sequencer(1, 16 * 1024 * 1024, new SequencerMetrics(new SimpleMeterRegistry()));
+    final var sequencer = new Sequencer(1, 16 * 1024 * 1024, new SequencerMetrics(meterRegistry));
 
     // then
     final var read = sequencer.tryRead();
@@ -99,8 +104,7 @@ final class SequencerTest {
   @Test
   void eventuallyRejectsWritesWithoutReader() {
     // given
-    final var sequencer =
-        new Sequencer(1, 16 * 1024 * 1024, new SequencerMetrics(new SimpleMeterRegistry()));
+    final var sequencer = new Sequencer(1, 16 * 1024 * 1024, new SequencerMetrics(meterRegistry));
 
     // then
     Awaitility.await("sequencer rejects writes")
@@ -114,8 +118,7 @@ final class SequencerTest {
   @Test
   void eventuallyRejectsBatchWritesWithoutReader() {
     // given
-    final var sequencer =
-        new Sequencer(1, 16 * 1024 * 1024, new SequencerMetrics(new SimpleMeterRegistry()));
+    final var sequencer = new Sequencer(1, 16 * 1024 * 1024, new SequencerMetrics(meterRegistry));
 
     // then
     Awaitility.await("sequencer rejects writes")
@@ -131,8 +134,7 @@ final class SequencerTest {
     // given
     final long initialPosition = 1L;
     final var sequencer =
-        new Sequencer(
-            initialPosition, 16 * 1024 * 1024, new SequencerMetrics(new SimpleMeterRegistry()));
+        new Sequencer(initialPosition, 16 * 1024 * 1024, new SequencerMetrics(meterRegistry));
 
     // when
     final var result = sequencer.tryWrite(TestEntry.ofDefaults());
@@ -146,8 +148,7 @@ final class SequencerTest {
     // given
     final long initialPosition = 1L;
     final var sequencer =
-        new Sequencer(
-            initialPosition, 16 * 1024 * 1024, new SequencerMetrics(new SimpleMeterRegistry()));
+        new Sequencer(initialPosition, 16 * 1024 * 1024, new SequencerMetrics(meterRegistry));
     final var entries =
         List.of(TestEntry.ofDefaults(), TestEntry.ofDefaults(), TestEntry.ofDefaults());
     // when
@@ -163,8 +164,7 @@ final class SequencerTest {
   @Test
   void notifiesReaderWhenRejectingWriteDueToFullQueue() {
     // given
-    final var sequencer =
-        new Sequencer(1, 16 * 1024 * 1024, new SequencerMetrics(new SimpleMeterRegistry()));
+    final var sequencer = new Sequencer(1, 16 * 1024 * 1024, new SequencerMetrics(meterRegistry));
     Awaitility.await("sequencer rejects writes")
         .pollInSameThread()
         .pollInterval(Duration.ZERO)
@@ -185,8 +185,7 @@ final class SequencerTest {
   @Test
   void notifiesReaderWhenRejectingBatchWriteDueToFullQueue() {
     // given
-    final var sequencer =
-        new Sequencer(1, 16 * 1024 * 1024, new SequencerMetrics(new SimpleMeterRegistry()));
+    final var sequencer = new Sequencer(1, 16 * 1024 * 1024, new SequencerMetrics(meterRegistry));
     Awaitility.await("sequencer rejects writes")
         .pollInSameThread()
         .pollInterval(Duration.ZERO)
@@ -210,8 +209,7 @@ final class SequencerTest {
     final var initialPosition = 1L;
     final var entriesToWrite = 10_000L;
     final var sequencer =
-        new Sequencer(
-            initialPosition, 16 * 1024 * 1024, new SequencerMetrics(new SimpleMeterRegistry()));
+        new Sequencer(initialPosition, 16 * 1024 * 1024, new SequencerMetrics(meterRegistry));
     final var batch = List.of(TestEntry.ofKey(1));
     final var reader = newReaderThread(sequencer, initialPosition, entriesToWrite);
     final var writer = newWriterThread(sequencer, initialPosition, entriesToWrite, batch, true);
@@ -234,8 +232,7 @@ final class SequencerTest {
     final var entriesToWrite = 10_000L;
     final var entriesToRead = writers * entriesToWrite;
     final var sequencer =
-        new Sequencer(
-            initialPosition, 16 * 1024 * 1024, new SequencerMetrics(new SimpleMeterRegistry()));
+        new Sequencer(initialPosition, 16 * 1024 * 1024, new SequencerMetrics(meterRegistry));
     final var reader = newReaderThread(sequencer, initialPosition, entriesToRead);
     final var batch = List.of(TestEntry.ofKey(1));
     final var writerThreads =
@@ -269,8 +266,7 @@ final class SequencerTest {
     final var batchesToWrite = 10_000L;
     final var batchesToRead = writers * batchesToWrite;
     final var sequencer =
-        new Sequencer(
-            initialPosition, 16 * 1024 * 1024, new SequencerMetrics(new SimpleMeterRegistry()));
+        new Sequencer(initialPosition, 16 * 1024 * 1024, new SequencerMetrics(meterRegistry));
     final var reader = newReaderThread(sequencer, initialPosition, batchesToRead);
     final var batch =
         List.of(TestEntry.ofKey(1), TestEntry.ofKey(1), TestEntry.ofKey(1), TestEntry.ofKey(1));

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/SyncLogStreamBuilder.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/SyncLogStreamBuilder.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Objects;
 
 public final class SyncLogStreamBuilder implements LogStreamBuilder {
@@ -64,6 +65,12 @@ public final class SyncLogStreamBuilder implements LogStreamBuilder {
   public SyncLogStreamBuilder withLogName(final String logName) {
     delegate.withLogName(logName);
     return this;
+  }
+
+  @Override
+  public LogStreamBuilder withMeterRegistry(final MeterRegistry meterRegistry) {
+    delegate.withMeterRegistry(meterRegistry);
+    return null;
   }
 
   @Override

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/SyncLogStreamBuilder.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/SyncLogStreamBuilder.java
@@ -70,7 +70,7 @@ public final class SyncLogStreamBuilder implements LogStreamBuilder {
   @Override
   public LogStreamBuilder withMeterRegistry(final MeterRegistry meterRegistry) {
     delegate.withMeterRegistry(meterRegistry);
-    return null;
+    return this;
   }
 
   @Override


### PR DESCRIPTION
## Description

This PR migrates all log stream metrics to Micrometer. Nothing has changed - while there are two timers which technically have new names, we were not using them in any dashboard, as they're mostly used on demand for debugging.

## Related issues

related to #26078 
