### PR TITLE
[Backport stable/8.7] fix: pull camunda from artifactory instead of gh

### DIFF
--- a/c8run/.env
+++ b/c8run/.env
@@ -1,6 +1,11 @@
 ELASTICSEARCH_VERSION=8.13.4
-CAMUNDA_RELEASE_TAG=8.7.0-alpha3
-CAMUNDA_VERSION=8.7.0-alpha3
-CONNECTORS_VERSION=8.7.0-alpha3.2
+# set the tag after [...]/downloads - e.g. https://github.com/camunda/camunda/releases/download/untagged-ff729de4cb31db7bb2e9/camunda-zeebe-8.8.0-alpha1.tar.gz
+# --> untagged-ff729de4cb31db7bb2e9
+CAMUNDA_RELEASE_TAG=untagged-ff729de4cb31db7bb2e9
+# this is the version of camunda/ zeebe
+CAMUNDA_VERSION=8.8.0-alpha1
+# Look here: https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/
+CONNECTORS_VERSION=8.8.0-alpha1
+# version of docker compose artifact (used for --docker option)
 COMPOSE_TAG=8.7-alpha3
 COMPOSE_EXTRACTED_FOLDER=camunda-platform-8.7-alpha3

--- a/c8run/.env
+++ b/c8run/.env
@@ -1,8 +1,6 @@
 ELASTICSEARCH_VERSION=8.13.4
-# this is the version of camunda/ zeebe
-CAMUNDA_VERSION=8.8.0-alpha1
-# Look here: https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/
-CONNECTORS_VERSION=8.8.0-alpha1
-# version of docker compose artifact (used for --docker option)
+CAMUNDA_RELEASE_TAG=8.7.0-alpha3
+CAMUNDA_VERSION=8.7.0-alpha3
+CONNECTORS_VERSION=8.7.0-alpha3.2
 COMPOSE_TAG=8.7-alpha3
 COMPOSE_EXTRACTED_FOLDER=camunda-platform-8.7-alpha3

--- a/c8run/.env
+++ b/c8run/.env
@@ -1,7 +1,4 @@
 ELASTICSEARCH_VERSION=8.13.4
-# set the tag after [...]/downloads - e.g. https://github.com/camunda/camunda/releases/download/untagged-ff729de4cb31db7bb2e9/camunda-zeebe-8.8.0-alpha1.tar.gz
-# --> untagged-ff729de4cb31db7bb2e9
-CAMUNDA_RELEASE_TAG=untagged-ff729de4cb31db7bb2e9
 # this is the version of camunda/ zeebe
 CAMUNDA_VERSION=8.8.0-alpha1
 # Look here: https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/

--- a/c8run/main.go
+++ b/c8run/main.go
@@ -295,7 +295,6 @@ func main() {
 	}
 
 	elasticsearchVersion := os.Getenv("ELASTICSEARCH_VERSION")
-	camundaReleaseTag := os.Getenv("CAMUNDA_RELEASE_TAG")
 	camundaVersion := os.Getenv("CAMUNDA_VERSION")
 	connectorsVersion := os.Getenv("CONNECTORS_VERSION")
 	composeTag := os.Getenv("COMPOSE_TAG")
@@ -545,13 +544,13 @@ func main() {
 
 	if baseCommand == "package" {
 		if runtime.GOOS == "windows" {
-			err := PackageWindows(camundaVersion, elasticsearchVersion, connectorsVersion, camundaReleaseTag, composeTag)
+			err := PackageWindows(camundaVersion, elasticsearchVersion, connectorsVersion, composeTag)
 			if err != nil {
 				fmt.Printf("%+v", err)
 				os.Exit(1)
 			}
 		} else if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
-			err := PackageUnix(camundaVersion, elasticsearchVersion, connectorsVersion, camundaReleaseTag, composeTag)
+			err := PackageUnix(camundaVersion, elasticsearchVersion, connectorsVersion, composeTag)
 			if err != nil {
 				fmt.Printf("%+v", err)
 				os.Exit(1)

--- a/c8run/package.go
+++ b/c8run/package.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"github.com/camunda/camunda/c8run/internal/archive"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
@@ -41,25 +40,11 @@ func downloadAndExtract(filePath, url, extractDir string, authToken string, extr
 	return nil
 }
 
-func downloadGHArtifact(camundaVersion string, camundaFilePath string) error {
-	_, err := exec.LookPath("gh")
-	if err != nil {
-		// This is not an error because there is another way to download camunda releases
-		return nil
-	}
-	cmd := exec.Command("gh", "release", "download", "--repo", "camunda/camunda", camundaVersion, "-p", camundaFilePath)
-	err = cmd.Run()
-	if err != nil {
-		return fmt.Errorf("downloadGHArtifact: failed to download artifact %w\n%s", err, debug.Stack())
-	}
-	return nil
-}
-
-func PackageWindows(camundaVersion string, elasticsearchVersion string, connectorsVersion string, camundaReleaseTag string, composeTag string) error {
+func PackageWindows(camundaVersion string, elasticsearchVersion string, connectorsVersion string, composeTag string) error {
 	elasticsearchUrl := "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-" + elasticsearchVersion + "-windows-x86_64.zip"
 	elasticsearchFilePath := "elasticsearch-" + elasticsearchVersion + ".zip"
 	camundaFilePath := "camunda-zeebe-" + camundaVersion + ".zip"
-	camundaUrl := "https://github.com/camunda/camunda/releases/download/" + camundaReleaseTag + "/" + camundaFilePath
+	camundaUrl := "https://repository.nexus.camunda.cloud/content/groups/internal/io/camunda/camunda-zeebe/" + camundaVersion + "/camunda-zeebe-" + camundaVersion + ".tar.gz"
 	connectorsFilePath := "connector-runtime-bundle-" + connectorsVersion + "-with-dependencies.jar"
 	connectorsUrl := "https://repository.nexus.camunda.cloud/content/groups/internal/io/camunda/connector/connector-runtime-bundle/" + connectorsVersion + "/" + connectorsFilePath
 	composeUrl := "https://github.com/camunda/camunda-platform/archive/refs/tags/" + composeTag + ".zip"
@@ -83,12 +68,7 @@ func PackageWindows(camundaVersion string, elasticsearchVersion string, connecto
 		return fmt.Errorf("PackageWindows: failed to fetch elasticsearch: %w\n%s", err, debug.Stack())
 	}
 
-	err = downloadGHArtifact(camundaVersion, camundaFilePath)
-	if err != nil {
-		return fmt.Errorf("PackageWindows: failed to download camunda with gh: %w\n%s", err, debug.Stack())
-	}
-
-	err = downloadAndExtract(camundaFilePath, camundaUrl, "camunda-zeebe-"+camundaVersion, authToken, archive.UnzipSource)
+	err = downloadAndExtract(camundaFilePath, camundaUrl, "camunda-zeebe-"+camundaVersion, javaArtifactsToken, archive.UnzipSource)
 	if err != nil {
 		return fmt.Errorf("PackageWindows: failed to fetch camunda: %w\n%s", err, debug.Stack())
 	}
@@ -133,7 +113,7 @@ func PackageWindows(camundaVersion string, elasticsearchVersion string, connecto
 	return nil
 }
 
-func PackageUnix(camundaVersion string, elasticsearchVersion string, connectorsVersion string, camundaReleaseTag string, composeTag string) error {
+func PackageUnix(camundaVersion string, elasticsearchVersion string, connectorsVersion string, composeTag string) error {
 	var architecture string
 	if runtime.GOARCH == "amd64" {
 		architecture = "x86_64"
@@ -144,7 +124,7 @@ func PackageUnix(camundaVersion string, elasticsearchVersion string, connectorsV
 	elasticsearchUrl := "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-" + elasticsearchVersion + "-" + runtime.GOOS + "-" + architecture + ".tar.gz"
 	elasticsearchFilePath := "elasticsearch-" + elasticsearchVersion + ".tar.gz"
 	camundaFilePath := "camunda-zeebe-" + camundaVersion + ".tar.gz"
-	camundaUrl := "https://github.com/camunda/camunda/releases/download/" + camundaReleaseTag + "/" + camundaFilePath
+	camundaUrl := "https://repository.nexus.camunda.cloud/content/groups/internal/io/camunda/camunda-zeebe/" + camundaVersion + "/camunda-zeebe-" + camundaVersion + ".tar.gz"
 	connectorsFilePath := "connector-runtime-bundle-" + connectorsVersion + "-with-dependencies.jar"
 	connectorsUrl := "https://repository.nexus.camunda.cloud/content/groups/internal/io/camunda/connector/connector-runtime-bundle/" + connectorsVersion + "/" + connectorsFilePath
 
@@ -169,12 +149,7 @@ func PackageUnix(camundaVersion string, elasticsearchVersion string, connectorsV
 		return fmt.Errorf("PackageUnix: failed to fetch elasticsearch %w\n%s", err, debug.Stack())
 	}
 
-	err = downloadGHArtifact(camundaVersion, camundaFilePath)
-	if err != nil {
-		return fmt.Errorf("PackageWindows: failed to download camunda with gh: %w\n%s", err, debug.Stack())
-	}
-
-	err = downloadAndExtract(camundaFilePath, camundaUrl, "camunda-zeebe-"+camundaVersion, authToken, archive.ExtractTarGzArchive)
+	err = downloadAndExtract(camundaFilePath, camundaUrl, "camunda-zeebe-"+camundaVersion, javaArtifactsToken, archive.ExtractTarGzArchive)
 	if err != nil {
 		return fmt.Errorf("PackageUnix: failed to fetch camunda %w\n%s", err, debug.Stack())
 	}

--- a/c8run/package.go
+++ b/c8run/package.go
@@ -44,7 +44,7 @@ func PackageWindows(camundaVersion string, elasticsearchVersion string, connecto
 	elasticsearchUrl := "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-" + elasticsearchVersion + "-windows-x86_64.zip"
 	elasticsearchFilePath := "elasticsearch-" + elasticsearchVersion + ".zip"
 	camundaFilePath := "camunda-zeebe-" + camundaVersion + ".zip"
-	camundaUrl := "https://repository.nexus.camunda.cloud/content/groups/internal/io/camunda/camunda-zeebe/" + camundaVersion + "/camunda-zeebe-" + camundaVersion + ".tar.gz"
+	camundaUrl := "https://repository.nexus.camunda.cloud/content/groups/internal/io/camunda/camunda-zeebe/" + camundaVersion + "/camunda-zeebe-" + camundaVersion + ".zip"
 	connectorsFilePath := "connector-runtime-bundle-" + connectorsVersion + "-with-dependencies.jar"
 	connectorsUrl := "https://repository.nexus.camunda.cloud/content/groups/internal/io/camunda/connector/connector-runtime-bundle/" + connectorsVersion + "/" + connectorsFilePath
 	composeUrl := "https://github.com/camunda/camunda-platform/archive/refs/tags/" + composeTag + ".zip"


### PR DESCRIPTION
# Description
Backport of #27955 to `stable/8.7`.

relates to 
original author: @hisImminence