### PR TITLE
feat: Support `JobResult` (deny and corrections) in `updating` task listeners

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -46,6 +46,9 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
   private static final String USER_TASK_ASSIGNMENT_REJECTION =
       "Assignment of the User Task with key '%d' was denied by Task Listener";
 
+  private static final String USER_TASK_UPDATE_REJECTION =
+      "Update of the User Task with key '%d' was denied by Task Listener";
+
   private final UserTaskCommandProcessors commandProcessors;
   private final ProcessState processState;
   private final MutableUserTaskState userTaskState;
@@ -136,6 +139,8 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
           writeRejectionForCommand(command, persistedRecord, UserTaskIntent.COMPLETION_DENIED);
       case ASSIGNING, CLAIMING ->
           writeRejectionForCommand(command, persistedRecord, UserTaskIntent.ASSIGNMENT_DENIED);
+      case UPDATING ->
+          writeRejectionForCommand(command, persistedRecord, UserTaskIntent.UPDATE_DENIED);
       default ->
           throw new IllegalArgumentException(
               "Expected to reject operation for user task: '%d', but operation could not be determined from the task's current lifecycle state: '%s'"
@@ -283,6 +288,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
     return switch (intent) {
       case COMPLETION_DENIED -> UserTaskIntent.COMPLETE;
       case ASSIGNMENT_DENIED -> UserTaskIntent.ASSIGN;
+      case UPDATE_DENIED -> UserTaskIntent.UPDATE;
       default ->
           throw new IllegalArgumentException("Unexpected user task intent: '%s'".formatted(intent));
     };
@@ -293,6 +299,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
     return switch (intent) {
       case COMPLETION_DENIED -> USER_TASK_COMPLETION_REJECTION.formatted(userTaskKey);
       case ASSIGNMENT_DENIED -> USER_TASK_ASSIGNMENT_REJECTION.formatted(userTaskKey);
+      case UPDATE_DENIED -> USER_TASK_UPDATE_REJECTION.formatted(userTaskKey);
       default ->
           throw new IllegalArgumentException("Unexpected user task intent: '%s'".formatted(intent));
     };

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -431,6 +431,7 @@ public final class EventAppliers implements EventApplier {
     register(UserTaskIntent.CORRECTED, new UserTaskCorrectedApplier(state));
     register(UserTaskIntent.COMPLETION_DENIED, new UserTaskCompletionDeniedApplier(state));
     register(UserTaskIntent.ASSIGNMENT_DENIED, new UserTaskAssignmentDeniedApplier(state));
+    register(UserTaskIntent.UPDATE_DENIED, new UserTaskUpdateDeniedApplier(state));
   }
 
   private void registerCompensationSubscriptionApplier(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskUpdateDeniedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskUpdateDeniedApplier.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+
+public class UserTaskUpdateDeniedApplier
+    implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
+
+  private final MutableUserTaskState userTaskState;
+
+  private final MutableElementInstanceState elementInstanceState;
+
+  public UserTaskUpdateDeniedApplier(final MutableProcessingState processingState) {
+    userTaskState = processingState.getUserTaskState();
+    elementInstanceState = processingState.getElementInstanceState();
+  }
+
+  @Override
+  public void applyState(final long key, final UserTaskRecord value) {
+    userTaskState.updateUserTaskLifecycleState(key, LifecycleState.CREATED);
+    userTaskState.deleteIntermediateState(key);
+    userTaskState.deleteRecordRequestMetadata(key);
+
+    final long elementInstanceKey = value.getElementInstanceKey();
+    final ElementInstance elementInstance = elementInstanceState.getInstance(elementInstanceKey);
+
+    if (elementInstance != null) {
+      final long scopeKey = elementInstance.getValue().getFlowScopeKey();
+      final ElementInstance scopeInstance = elementInstanceState.getInstance(scopeKey);
+
+      if (scopeInstance != null && scopeInstance.isActive()) {
+        elementInstance.resetTaskListenerIndices();
+        elementInstanceState.updateInstance(elementInstance);
+      }
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -417,7 +417,7 @@ public class TaskListenerTest {
   }
 
   @Test
-  public void shouldRejectUserTaskAssignmentWhenTaskListenerRejectsTheOperation() {
+  public void shouldRejectUserTaskAssignmentWhenTaskListenerDeniesTheTransition() {
     // given
     final long processInstanceKey =
         createProcessInstance(createProcessWithAssigningTaskListeners(listenerType));
@@ -430,7 +430,7 @@ public class TaskListenerTest {
         .withResult(new JobResult().setDenied(true))
         .complete();
 
-    // then: ensure that `REJECT_TASK_LISTENER` and `ASSIGNMENT_DENIED`
+    // then: ensure that `DENY_TASK_LISTENER` and `ASSIGNMENT_DENIED`
     // are written after `ASSIGNING` event
     assertUserTaskIntentsSequence(
         UserTaskIntent.ASSIGNING,
@@ -449,7 +449,7 @@ public class TaskListenerTest {
 
   @Test
   public void
-      shouldCompleteAllAssignmentTaskListenersWhenFirstTaskListenerAcceptOperationAfterRejection() {
+      shouldCompleteAllAssignmentTaskListenersWhenFirstTaskListenerAcceptTransitionAfterDenial() {
     // given
     final long processInstanceKey =
         createProcessInstance(
@@ -490,7 +490,7 @@ public class TaskListenerTest {
   }
 
   @Test
-  public void shouldUpdateTaskWhenTaskListenerAcceptsOperationAfterRejection() {
+  public void shouldUpdateTaskWhenUpdatingTaskListenerAcceptsTransitionAfterDenial() {
     // given
     final long processInstanceKey =
         createProcessInstance(
@@ -502,7 +502,7 @@ public class TaskListenerTest {
         .ofInstance(processInstanceKey)
         .update(new UserTaskRecord().setPriority(80).setPriorityChanged());
 
-    // and: task listener rejects the first update attempt
+    // and: task listener denies the first update attempt
     ENGINE
         .job()
         .ofInstance(processInstanceKey)
@@ -1383,7 +1383,7 @@ public class TaskListenerTest {
   }
 
   @Test
-  public void shouldRejectUserTaskUpdateWhenTaskListenerDeniesTheOperation() {
+  public void shouldRejectUserTaskUpdateWhenUpdatingTaskListenerDeniesTheTransition() {
     // given
     final long processInstanceKey =
         createProcessInstance(
@@ -1409,7 +1409,7 @@ public class TaskListenerTest {
   }
 
   @Test
-  public void shouldRejectUserTaskCompletionWhenTaskListenerRejectsTheOperation() {
+  public void shouldRejectUserTaskCompletionWhenCompletingTaskListenerDeniesTheTransition() {
     // given
     final long processInstanceKey =
         createProcessInstance(createProcessWithCompletingTaskListeners(listenerType));
@@ -1422,7 +1422,7 @@ public class TaskListenerTest {
         .withResult(new JobResult().setDenied(true))
         .complete();
 
-    // then: ensure that `REJECT_TASK_LISTENER` and `COMPLETION_DENIED`
+    // then: ensure that `DENY_TASK_LISTENER` and `COMPLETION_DENIED`
     // are written after `COMPLETING` event
     assertUserTaskIntentsSequence(
         UserTaskIntent.COMPLETING,
@@ -1431,7 +1431,7 @@ public class TaskListenerTest {
   }
 
   @Test
-  public void shouldCompleteTaskWhenTaskListenerAcceptsOperationAfterRejection() {
+  public void shouldCompleteTaskWhenCompletingTaskListenerAcceptsTransitionAfterDenial() {
     // given
     final long processInstanceKey =
         createProcessInstance(createProcessWithCompletingTaskListeners(listenerType));
@@ -1449,7 +1449,7 @@ public class TaskListenerTest {
     completeRecreatedJobWithType(ENGINE, processInstanceKey, listenerType);
 
     // then: ensure that `COMPLETING` `COMPLETE_TASK_LISTENER` and `COMPLETED events
-    // are present after `REJECT_TASK_LISTENER` and `COMPLETION_DENIED` events
+    // are present after `DENY_TASK_LISTENER` and `COMPLETION_DENIED` events
     assertUserTaskIntentsSequence(
         UserTaskIntent.COMPLETING,
         UserTaskIntent.DENY_TASK_LISTENER,
@@ -1461,7 +1461,7 @@ public class TaskListenerTest {
   }
 
   @Test
-  public void shouldCompleteAllTaskListenersWhenFirstTaskListenerAcceptOperationAfterRejection() {
+  public void shouldCompleteAllTaskListenersWhenFirstTaskListenerAcceptTransitionAfterDenial() {
     // given
     final long processInstanceKey =
         createProcessInstance(
@@ -1495,7 +1495,7 @@ public class TaskListenerTest {
   }
 
   @Test
-  public void shouldAssignAndCompleteTaskAfterTaskListenerRejectsTheCompletion() {
+  public void shouldAssignAndCompleteTaskAfterTaskListenerDeniesTheCompletion() {
     // given
     final long processInstanceKey =
         createProcessInstance(createProcessWithCompletingTaskListeners(listenerType));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -1559,6 +1559,15 @@ public class TaskListenerTest {
   }
 
   @Test
+  public void shouldAppendUserTaskCorrectedWhenUpdatingTaskListenerCompletesWithCorrections() {
+    testAppendUserTaskCorrectedWhenTaskListenerCompletesWithCorrections(
+        ZeebeTaskListenerEventType.updating,
+        u -> u,
+        userTask -> userTask.update(new UserTaskRecord()),
+        "update");
+  }
+
+  @Test
   public void shouldAppendUserTaskCorrectedWhenCompletingTaskListenerCompletesWithCorrections() {
     testAppendUserTaskCorrectedWhenTaskListenerCompletesWithCorrections(
         ZeebeTaskListenerEventType.completing, u -> u, UserTaskClient::complete, "complete");
@@ -1739,6 +1748,29 @@ public class TaskListenerTest {
             UserTaskIntent.CORRECTED,
             UserTaskIntent.COMPLETE_TASK_LISTENER,
             UserTaskIntent.ASSIGNED));
+  }
+
+  @Test
+  public void shouldPropagateCorrectedDataToUpdatingListenerJobHeaders() {
+    verifyUserTaskDataPropagationAcrossListenerJobHeaders(
+        ZeebeTaskListenerEventType.updating,
+        false,
+        userTask ->
+            userTask.update(
+                new UserTaskRecord()
+                    .setCandidateUsersList(List.of("initial_candidate_user"))
+                    .setCandidateGroupsList(List.of("initial_candidate_group"))
+                    .setDueDate("2085-09-21T11:22:33+02:00")
+                    .setFollowUpDate("2095-09-21T11:22:33+02:00")),
+        List.of(
+            UserTaskIntent.UPDATE,
+            UserTaskIntent.UPDATING,
+            UserTaskIntent.COMPLETE_TASK_LISTENER,
+            UserTaskIntent.CORRECTED,
+            UserTaskIntent.COMPLETE_TASK_LISTENER,
+            UserTaskIntent.CORRECTED,
+            UserTaskIntent.COMPLETE_TASK_LISTENER,
+            UserTaskIntent.UPDATED));
   }
 
   @Test
@@ -1931,6 +1963,15 @@ public class TaskListenerTest {
         false,
         userTask -> userTask.withAssignee("initial_assignee").claim(),
         UserTaskIntent.ASSIGNED);
+  }
+
+  @Test
+  public void shouldTrackChangedAttributesOnlyForActuallyCorrectedValuesOnTaskUpdate() {
+    verifyChangedAttributesAreTrackedOnlyForActuallyCorrectedValues(
+        ZeebeTaskListenerEventType.updating,
+        false,
+        userTask -> userTask.update(new UserTaskRecord()),
+        UserTaskIntent.UPDATED);
   }
 
   @Test
@@ -2204,6 +2245,15 @@ public class TaskListenerTest {
         u -> u,
         userTask -> userTask.withAssignee("initial_assignee").claim(),
         UserTaskIntent.ASSIGNED);
+  }
+
+  @Test
+  public void shouldPersistCorrectedUserTaskDataWhenUpdatingTaskListenerCompletes() {
+    testPersistCorrectedUserTaskDataWhenAllTaskListenersCompleted(
+        ZeebeTaskListenerEventType.updating,
+        u -> u,
+        userTask -> userTask.update(new UserTaskRecord()),
+        UserTaskIntent.UPDATED);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskUpdateDeniedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskUpdateDeniedApplierTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public class UserTaskUpdateDeniedApplierTest {
+
+  /** Injected by {@link ProcessingStateExtension} */
+  private MutableProcessingState processingState;
+
+  /** The class under test. */
+  private UserTaskUpdateDeniedApplier userTaskUpdateDeniedApplier;
+
+  /** Used for state */
+  private MutableUserTaskState userTaskState;
+
+  /** For setting up the state before testing the applier. */
+  private TestSetup testSetup;
+
+  @BeforeEach
+  public void setup() {
+    userTaskUpdateDeniedApplier = new UserTaskUpdateDeniedApplier(processingState);
+    userTaskState = processingState.getUserTaskState();
+    testSetup = new TestSetup(processingState);
+  }
+
+  @Test
+  public void shouldRevertUpdatesToTheTaskIfTransitionWasDenied() {
+    // given
+    final long userTaskKey = 1;
+    final int initialPriority = 40;
+    final int newPriority = 85;
+
+    // Initial state of the User Task before an update attempt
+    final var initialState =
+        new UserTaskRecord()
+            .setUserTaskKey(userTaskKey)
+            .setCandidateUsersList(List.of("initial_user"))
+            .setCandidateGroupsList(List.of("initial_group"))
+            .setFollowUpDate("initial_follow_up_date")
+            .setDueDate("initial_due_date")
+            .setPriority(initialPriority);
+
+    // Apply initial task creation
+    testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATING, initialState);
+    testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATED, initialState);
+
+    // Simulate an update event with changes
+    final var updateAttempt =
+        new UserTaskRecord()
+            .setUserTaskKey(userTaskKey)
+            .setCandidateUsersList(List.of("update_user"))
+            .setDueDate("update_due_date")
+            .setPriority(newPriority)
+            .setCandidateUsersChanged()
+            .setDueDateChanged()
+            .setPriorityChanged();
+    testSetup.applyEventToState(userTaskKey, UserTaskIntent.UPDATING, updateAttempt);
+
+    // Ensure the state has the new changes
+    Assertions.assertThat(userTaskState.getIntermediateState(userTaskKey).getRecord())
+        .describedAs("Expect that intermediate state holds the pending update")
+        .hasCandidateUsersList("update_user")
+        .hasDueDate("update_due_date")
+        .hasPriority(newPriority)
+        .hasNoCandidateGroupsList()
+        .hasFollowUpDate("");
+
+    assertThat(userTaskState.getLifecycleState(userTaskKey))
+        .describedAs("Expect lifecycle state to be 'UPDATING' before denial")
+        .isEqualTo(LifecycleState.UPDATING);
+
+    // when
+    userTaskUpdateDeniedApplier.applyState(userTaskKey, initialState);
+
+    // then
+    assertThat(userTaskState.getIntermediateState(userTaskKey))
+        .describedAs("Expect that intermediate state is cleared after denial")
+        .isNull();
+
+    Assertions.assertThat(userTaskState.getUserTask(userTaskKey))
+        .describedAs("Expect user task to retain original values after update was denied")
+        .hasCandidateUsersList("initial_user")
+        .hasCandidateGroupsList("initial_group")
+        .hasFollowUpDate("initial_follow_up_date")
+        .hasDueDate("initial_due_date")
+        .hasPriority(initialPriority);
+
+    assertThat(userTaskState.getLifecycleState(userTaskKey))
+        .describedAs("Expect lifecycle state to be reverted to 'CREATED' after denial")
+        .isEqualTo(LifecycleState.CREATED);
+  }
+
+  private static final class TestSetup {
+
+    private final EventAppliers eventAppliers;
+
+    TestSetup(final MutableProcessingState processingState) {
+      eventAppliers = new EventAppliers();
+      eventAppliers.registerEventAppliers(processingState);
+    }
+
+    /**
+     * Applies the event of the given intent to the state.
+     *
+     * @param userTaskKey the key of the user task
+     * @param intent the intent of the event to apply
+     * @param userTaskRecord data of the event to apply
+     * @implNote applies the event using the latest version of the record.
+     */
+    private void applyEventToState(
+        final long userTaskKey, final UserTaskIntent intent, final UserTaskRecord userTaskRecord) {
+      final int latestVersion = eventAppliers.getLatestVersion(intent);
+      eventAppliers.applyState(userTaskKey, intent, userTaskRecord, latestVersion);
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskUpdateDeniedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskUpdateDeniedApplierTest.java
@@ -85,6 +85,12 @@ public class UserTaskUpdateDeniedApplierTest {
         .hasNoCandidateGroupsList()
         .hasFollowUpDate("");
 
+    // Ensure that the actual user task state hasn't been updated yet
+    assertThat(userTaskState.getUserTask(userTaskKey))
+        .describedAs(
+            "Expect the actual user task state to remain unchanged while the update is in progress")
+        .isEqualTo(initialState);
+
     assertThat(userTaskState.getLifecycleState(userTaskKey))
         .describedAs("Expect lifecycle state to be 'UPDATING' before denial")
         .isEqualTo(LifecycleState.UPDATING);
@@ -97,13 +103,9 @@ public class UserTaskUpdateDeniedApplierTest {
         .describedAs("Expect that intermediate state is cleared after denial")
         .isNull();
 
-    Assertions.assertThat(userTaskState.getUserTask(userTaskKey))
-        .describedAs("Expect user task to retain original values after update was denied")
-        .hasCandidateUsersList("initial_user")
-        .hasCandidateGroupsList("initial_group")
-        .hasFollowUpDate("initial_follow_up_date")
-        .hasDueDate("initial_due_date")
-        .hasPriority(initialPriority);
+    assertThat(userTaskState.getUserTask(userTaskKey))
+        .describedAs("Expect user task to retain initial values after update was denied")
+        .isEqualTo(initialState);
 
     assertThat(userTaskState.getLifecycleState(userTaskKey))
         .describedAs("Expect lifecycle state to be reverted to 'CREATED' after denial")

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserTaskIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserTaskIntent.java
@@ -91,7 +91,18 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
    * This intent is written during the processing of a CLAIM command and marks the User Task with
    * the `CLAIMING` lifecycle state.
    */
-  CLAIMING(20);
+  CLAIMING(20),
+
+  /**
+   * Represents the intent indicating that the User Task update will not be applied, and the task
+   * will be reverted to the `CREATED` lifecycle state. This occurs when an `updating` task listener
+   * denies the transition, preventing any modifications to the user task attributes.
+   *
+   * <p>Once this intent is written, the processing of the user task is halted, all previous
+   * corrections within the same update transition are discarded, and the user task remains in its
+   * prior state.
+   */
+  UPDATE_DENIED(21);
 
   private final short value;
   private final boolean shouldBanInstance;
@@ -153,6 +164,8 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
         return ASSIGNMENT_DENIED;
       case 20:
         return CLAIMING;
+      case 21:
+        return UPDATE_DENIED;
       default:
         return UNKNOWN;
     }
@@ -181,6 +194,7 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
       case CORRECTED:
       case ASSIGNMENT_DENIED:
       case CLAIMING:
+      case UPDATE_DENIED:
         return true;
       default:
         return false;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
@@ -40,6 +40,7 @@ import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.hc.core5.http.HttpStatus;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -282,6 +283,46 @@ public class UserTaskListenersTest {
   }
 
   @Test
+  void shouldRejectUserTaskUpdateWhenUpdatingTaskListenerDeniesTheWork() {
+    // given
+    final var listenerType = "complete_with_denial";
+    final var userTaskKey =
+        resourcesHelper.createSingleUserTask(
+            t -> t.zeebeTaskListener(l -> l.updating().type(listenerType)));
+
+    final JobHandler completeJobWithDenialHandler =
+        (jobClient, job) -> client.newCompleteCommand(job).withResult().deny(true).send().join();
+    client.newWorker().jobType(listenerType).handler(completeJobWithDenialHandler).open();
+
+    // when: invoke `UPDATE` user task command
+    final var updateUserTaskFuture =
+        client.newUserTaskUpdateCommand(userTaskKey).candidateUsers("user123").send();
+
+    // then: TL job should be successfully completed with the result "denied" set correctly
+    ZeebeAssertHelper.assertJobCompleted(
+        listenerType,
+        userTaskListener -> assertThat(userTaskListener.getResult().isDenied()).isTrue());
+
+    // and: verify the rejection
+    final var rejectionReason =
+        String.format(
+            "Command 'UPDATE' rejected with code 'INVALID_STATE': Update of the User Task with key '%s' was denied by Task Listener",
+            userTaskKey);
+    assertThatExceptionOfType(ProblemException.class)
+        .isThrownBy(updateUserTaskFuture::join)
+        .satisfies(
+            ex -> {
+              assertThat(ex.details().getTitle()).isEqualTo(RejectionType.INVALID_STATE.name());
+              assertThat(ex.details().getDetail()).isEqualTo(rejectionReason);
+              assertThat(ex.details().getStatus()).isEqualTo(HttpStatus.SC_CONFLICT);
+            });
+
+    // and: verify the expected sequence of User Task intents
+    assertUserTaskIntentsSequence(
+        UserTaskIntent.UPDATING, UserTaskIntent.DENY_TASK_LISTENER, UserTaskIntent.UPDATE_DENIED);
+  }
+
+  @Test
   public void shouldRejectUserTaskCompletionWhenTaskListenerDeniesTheWork() {
     // given
     final var listenerType = "my_listener";
@@ -302,9 +343,7 @@ public class UserTaskListenersTest {
     // TL job should be successfully completed with the result "denied" set correctly
     ZeebeAssertHelper.assertJobCompleted(
         listenerType,
-        (userTaskListener) -> {
-          assertThat(userTaskListener.getResult().isDenied()).isTrue();
-        });
+        userTaskListener -> assertThat(userTaskListener.getResult().isDenied()).isTrue());
 
     final var rejectionReason =
         String.format(
@@ -326,6 +365,168 @@ public class UserTaskListenersTest {
         UserTaskIntent.COMPLETING,
         UserTaskIntent.DENY_TASK_LISTENER,
         UserTaskIntent.COMPLETION_DENIED);
+  }
+
+  @Test
+  void shouldUpdateUserTaskWithUpdatingTaskListenerWithCorrections() {
+    // given
+    final var listenerType = "complete_updating_listener_with_corrections";
+    final var userTaskKey =
+        resourcesHelper.createSingleUserTask(
+            t ->
+                t.zeebeTaskListener(l -> l.updating().type(listenerType))
+                    .zeebeCandidateGroups("initial_group_A, initial_group_B")
+                    .zeebeTaskPriority("22"));
+
+    final JobHandler completeJobWithCorrectionsHandler =
+        (jobClient, job) ->
+            client
+                .newCompleteCommand(job)
+                .withResult()
+                .correctAssignee("new_assignee")
+                .correctDueDate("new_due_date")
+                .correctFollowUpDate("new_follow_up_date")
+                .correctCandidateUsers(List.of("new_user_A", "new_user_B"))
+                .correctCandidateGroups(List.of("new_group_C"))
+                .correctPriority(99)
+                .send()
+                .join();
+
+    client.newWorker().jobType(listenerType).handler(completeJobWithCorrectionsHandler).open();
+
+    // when: invoke `UPDATE` user task command
+    final var updateUserTaskFuture =
+        client.newUserTaskUpdateCommand(userTaskKey).priority(55).action("escalate").send();
+
+    final JobResult expectedResult =
+        new JobResult()
+            .setDenied(false)
+            .setCorrections(
+                new JobResultCorrections()
+                    .setAssignee("new_assignee")
+                    .setDueDate("new_due_date")
+                    .setFollowUpDate("new_follow_up_date")
+                    .setCandidateUsersList(List.of("new_user_A", "new_user_B"))
+                    .setCandidateGroupsList(List.of("new_group_C"))
+                    .setPriority(99))
+            .setCorrectedAttributes(
+                Arrays.asList(
+                    UserTaskRecord.ASSIGNEE,
+                    UserTaskRecord.DUE_DATE,
+                    UserTaskRecord.FOLLOW_UP_DATE,
+                    UserTaskRecord.CANDIDATE_USERS,
+                    UserTaskRecord.CANDIDATE_GROUPS,
+                    UserTaskRecord.PRIORITY));
+
+    // TL job should be successfully completed with expected JobResult
+    ZeebeAssertHelper.assertJobCompleted(
+        listenerType, tl -> assertThat(tl.getResult()).isEqualTo(expectedResult));
+
+    // wait for successful `UPDATE` user task command completion
+    assertThatCode(updateUserTaskFuture::join).doesNotThrowAnyException();
+
+    // then: verify the state of `UPDATED` user task record
+    ZeebeAssertHelper.assertUserTaskUpdated(
+        userTaskKey,
+        (userTask) -> {
+          assertThat(userTask.getAssignee()).isEqualTo("new_assignee");
+          assertThat(userTask.getDueDate()).isEqualTo("new_due_date");
+          assertThat(userTask.getFollowUpDate()).isEqualTo("new_follow_up_date");
+          assertThat(userTask.getCandidateUsersList()).containsExactly("new_user_A", "new_user_B");
+          assertThat(userTask.getCandidateGroupsList()).containsExactly("new_group_C");
+          assertThat(userTask.getPriority()).isEqualTo(99);
+        });
+  }
+
+  @Test
+  void shouldUpdateUserTaskWithUpdatingTaskListenerWithPartialCorrections() {
+    // given
+    final var listenerType = "updating_listener_with_partial_corrections";
+    final var initialDueDate = "2015-01-02T15:35+02:00";
+    final var updatedDueDate = "2016-01-02T15:35+02:00";
+    final var correctedDueDate = "2017-01-02T15:35+02:00";
+    final var initialFollowUpDate = "2020-02-02T15:35+02:00";
+    final var correctedFollowUpDate = "2021-02-02T15:35+02:00";
+
+    final var userTaskKey =
+        resourcesHelper.createSingleUserTask(
+            t ->
+                t.zeebeTaskListener(l -> l.updating().type(listenerType))
+                    .zeebeAssignee("initial_assignee")
+                    .zeebeDueDate(initialDueDate)
+                    .zeebeFollowUpDate(initialFollowUpDate)
+                    .zeebeCandidateUsers("initial_user_a, initial_user_b")
+                    .zeebeCandidateGroups("initial_group_a, initial_group_b")
+                    .zeebeTaskPriority("10"));
+
+    // Define a task listener handler that applies corrections (some overriding the update request)
+    final JobHandler completeJobWithCorrectionsHandler =
+        (jobClient, job) ->
+            client
+                .newCompleteCommand(job)
+                .withResult()
+                .correctAssignee("corrected_assignee")
+                .correctDueDate(correctedDueDate) // overrides the update
+                .correctFollowUpDate(correctedFollowUpDate)
+                .correctCandidateUsers(List.of("corrected_user_a", "corrected_user_b"))
+                .correctPriority(10) // resets to the initial value, overriding the update
+                .send()
+                .join();
+
+    client.newWorker().jobType(listenerType).handler(completeJobWithCorrectionsHandler).open();
+
+    // when: send an `UPDATE` command with explicit changes
+    final var updateUserTaskFuture =
+        client
+            .newUserTaskUpdateCommand(userTaskKey)
+            .dueDate(updatedDueDate)
+            .candidateGroups("updated_group")
+            .priority(99) // will be reset to the initial value by correction
+            .send();
+
+    // wait for successful `UPDATE` command execution
+    assertThatCode(updateUserTaskFuture::join).doesNotThrowAnyException();
+
+    // then: verify the state of `UPDATED` user task record
+    ZeebeAssertHelper.assertUserTaskUpdated(
+        userTaskKey,
+        (userTask) -> {
+          // Verify attributes that were updated successfully
+          assertThat(userTask.getCandidateGroupsList())
+              .describedAs("Candidate groups should reflect the requested update")
+              .containsExactly("updated_group");
+
+          // Verify attributes that were corrected by the task listener
+          assertThat(userTask.getAssignee())
+              .describedAs("Assignee should be updated based on correction")
+              .isEqualTo("corrected_assignee");
+
+          assertThat(userTask.getDueDate())
+              .describedAs("Due date should reflect correction (overriding the update request)")
+              .isEqualTo(correctedDueDate);
+
+          assertThat(userTask.getFollowUpDate())
+              .describedAs("Follow-up date should be set based on correction")
+              .isEqualTo(correctedFollowUpDate);
+
+          assertThat(userTask.getCandidateUsersList())
+              .describedAs("Candidate users should match corrected values")
+              .containsExactly("corrected_user_a", "corrected_user_b");
+
+          assertThat(userTask.getChangedAttributes())
+              .describedAs("Changed attributes should reflect only actual modifications")
+              .containsExactly(
+                  UserTaskRecord.ASSIGNEE,
+                  UserTaskRecord.CANDIDATE_GROUPS,
+                  UserTaskRecord.CANDIDATE_USERS,
+                  UserTaskRecord.DUE_DATE,
+                  UserTaskRecord.FOLLOW_UP_DATE);
+
+          // Verify unchanged attribute
+          assertThat(userTask.getPriority())
+              .describedAs("Priority should have the initial value as it was reset by correction")
+              .isEqualTo(10);
+        });
   }
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
@@ -48,6 +48,11 @@ import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+// Suppressing resource warning because JobWorker instances are managed and closed automatically
+// by `CamundaClient#close()`, which is invoked via the JUnit 5 extension due to the `client`
+// being annotated with `@AutoClose`. This ensures proper cleanup without requiring explicit
+// try-with-resources statements in each test.
+@SuppressWarnings("resource")
 @ZeebeIntegration
 public class UserTaskListenersTest {
 


### PR DESCRIPTION
## Description
This PR enhances `updating` task listeners by introducing **job result** support, allowing them to:  
1. **Deny** the update transition.  
2. **Correct** user task attributes (added test only to validate that corrections function as expected).  

These improvements align `updating` listeners with existing behavior for `assigning` and `completing` events, ensuring that update transition can be denied or user task attributes can be corrected.  

### Key changes:
#### Support for `JobResult.deny`: 
- Introduced `UPDATE_DENIED` intent.  
- Implemented `UserTaskUpdateDeniedApplier` to handle `UPDATE_DENIED` events and revert user task to the `CREATED` state.  
- Extended `UserTaskProcessor` to:  
  - Trigger `UPDATE_DENIED` events when `updating` listener job was completed with `JobResult.deny=true`.  
  - Provide a dedicated rejection messages using `USER_TASK_UPDATE_REJECTION`.  

#### Verify the support for `JobResult.correction` by `updating` listeners:
- Correction functionality was already supported:  
  - As all changed attributes by corrections are listed in `changedAttributes` and `UserTaskUpdatedV2Applier` fully relies on it to apply both `UPDATE` command changes and corrections on top of the persisted user task.  
- This PR increases only test coverage to validate that:  
  - Corrections are correctly applied and tracked.  
  - Corrected attributes are visible to subsequent task listener jobs.  
  - Only actually modified attributes are included in corrected events.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #27558 
