### PR TITLE
test: support ad-hoc subprocesses

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -421,8 +421,7 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-bpmn-model</artifactId>
-      <version>8.6.7</version>
-      <scope>test</scope>
+      <version>8.8.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/optimize/backend/src/it/java/io/camunda/optimize/util/ZeebeBpmnModels.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/util/ZeebeBpmnModels.java
@@ -9,12 +9,16 @@ package io.camunda.optimize.util;
 
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AdHocSubProcessBuilder;
 import io.camunda.zeebe.model.bpmn.builder.EndEventBuilder;
 import io.camunda.zeebe.model.bpmn.builder.ProcessBuilder;
 import java.time.Duration;
+import java.util.function.Consumer;
 
 public class ZeebeBpmnModels {
 
+  public static final String ACTIVATE_ELEMENTS = "activateElements";
+  public static final String ADHOC_SUB_PROCESS = "adhocSubProcess";
   public static final String START_EVENT = "startEvent";
   public static final String SERVICE_TASK = "service_task";
   public static final String SEND_TASK = "send_task";
@@ -48,6 +52,7 @@ public class ZeebeBpmnModels {
   public static final String SIGNAL_PROCESS_SECOND_SIGNAL = "interruptingBoundarySignal";
   public static final String SIGNAL_PROCESS_THIRD_SIGNAL = "eventBasedGatewaySignal";
   public static final String SERVICE_TASK_WITH_COMPENSATION_EVENT = "compensationEvent";
+  public static final String TASK = "task";
   public static final String COMPENSATION_EVENT_TASK = "compensationEventTask";
   public static final String VERSION_TAG = "v1";
 
@@ -82,6 +87,16 @@ public class ZeebeBpmnModels {
         .name(SERVICE_TASK)
         .endEvent(END_EVENT)
         .name(null)
+        .done();
+  }
+
+  public static BpmnModelInstance createAdHocSubProcess(
+      final String processName, final Consumer<AdHocSubProcessBuilder> modifier) {
+    return Bpmn.createExecutableProcess(processName)
+        .name(processName)
+        .startEvent(START_EVENT)
+        .adHocSubProcess(ADHOC_SUB_PROCESS, modifier)
+        .endEvent(END_EVENT)
         .done();
   }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/util/BpmnModelUtil.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/util/BpmnModelUtil.java
@@ -9,6 +9,13 @@ package io.camunda.optimize.service.util;
 
 import io.camunda.optimize.dto.optimize.FlowNodeDataDto;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.BaseElement;
+import io.camunda.zeebe.model.bpmn.instance.FlowNode;
+import io.camunda.zeebe.model.bpmn.instance.Process;
+import io.camunda.zeebe.model.bpmn.instance.SubProcess;
+import io.camunda.zeebe.model.bpmn.instance.UserTask;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -24,13 +31,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.camunda.bpm.model.bpmn.Bpmn;
-import org.camunda.bpm.model.bpmn.BpmnModelInstance;
-import org.camunda.bpm.model.bpmn.instance.BaseElement;
-import org.camunda.bpm.model.bpmn.instance.FlowNode;
-import org.camunda.bpm.model.bpmn.instance.Process;
-import org.camunda.bpm.model.bpmn.instance.SubProcess;
-import org.camunda.bpm.model.bpmn.instance.UserTask;
 import org.slf4j.Logger;
 
 public final class BpmnModelUtil {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/util/BpmnModelUtilTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/util/BpmnModelUtilTest.java
@@ -18,12 +18,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.optimize.dto.optimize.FlowNodeDataDto;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.assertj.core.groups.Tuple;
-import org.camunda.bpm.model.bpmn.BpmnModelInstance;
 import org.junit.jupiter.api.Test;
 
 public class BpmnModelUtilTest {

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -63,7 +63,7 @@
     <zeebe.version>8.6.0</zeebe.version>
     <identity.version>8.6.0</identity.version>
     <!-- We use this for the Zeebe test container version only -->
-    <zeebe.docker.version>${zeebe.version}</zeebe.docker.version>
+    <zeebe.docker.version>8.7.0-alpha3</zeebe.docker.version>
 
     <!-- maven plugins -->
     <surefire-plugin.version>3.5.2</surefire-plugin.version>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -63,7 +63,7 @@
     <zeebe.version>8.6.0</zeebe.version>
     <identity.version>8.6.0</identity.version>
     <!-- We use this for the Zeebe test container version only -->
-    <zeebe.docker.version>8.7.0-alpha3</zeebe.docker.version>
+    <zeebe.docker.version>8.7.0-alpha4</zeebe.docker.version>
 
     <!-- maven plugins -->
     <surefire-plugin.version>3.5.2</surefire-plugin.version>


### PR DESCRIPTION
## Description

In Camunda 8.7, a new BPMN element was introduced : the [ad-hoc subprocess](https://www.omg.org/spec/BPMN/2.0/PDF#13.2.5%20Ad-Hoc%20Sub-Process). It is supported in Zeebe but hasn't been tested in Optimize yet. This PR adds integration tests for the new element, to validate that an ad-hoc subprocess definition as well as process instances can be exported to Optimize for evaluation.

See [thread](https://camunda.slack.com/archives/CUZUYDMMG/p1739181377577979) for details on the test approach.

## Related issues

related to #25639 
