### PR TITLE
feat: add new command processor for fetching resources

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -49,7 +49,7 @@ public class Engine implements RecordProcessor {
       "Expected to process record '%s' without errors, but exception occurred with message '%s'.";
 
   private static final EnumSet<ValueType> SUPPORTED_VALUETYPES =
-      EnumSet.range(ValueType.JOB, ValueType.AUTHORIZATION);
+      EnumSet.range(ValueType.JOB, ValueType.RESOURCE);
 
   private EventApplier eventApplier;
   private RecordProcessorMap recordProcessorMap;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -35,6 +35,7 @@ import io.camunda.zeebe.engine.processing.job.JobEventProcessors;
 import io.camunda.zeebe.engine.processing.message.MessageEventProcessors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.resource.ResourceDeletionDeleteProcessor;
+import io.camunda.zeebe.engine.processing.resource.ResourceFetchProcessor;
 import io.camunda.zeebe.engine.processing.signal.SignalBroadcastProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
@@ -56,6 +57,7 @@ import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
+import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
@@ -224,6 +226,8 @@ public final class EngineProcessors {
 
     AuthorizationProcessors.addAuthorizationProcessors(
         keyGenerator, typedRecordProcessors, processingState, writers, commandDistributionBehavior);
+
+    addResourceFetchProcessors(typedRecordProcessors, writers, processingState);
 
     return typedRecordProcessors;
   }
@@ -400,6 +404,15 @@ public final class EngineProcessors {
             bpmnBehaviors);
     typedRecordProcessors.onCommand(
         ValueType.RESOURCE_DELETION, ResourceDeletionIntent.DELETE, resourceDeletionProcessor);
+  }
+
+  private static void addResourceFetchProcessors(
+      final TypedRecordProcessors typedRecordProcessors,
+      final Writers writers,
+      final ProcessingState processingState) {
+    final var resourceFetchProcessor = new ResourceFetchProcessor(writers, processingState);
+    typedRecordProcessors.onCommand(
+        ValueType.RESOURCE, ResourceIntent.FETCH, resourceFetchProcessor);
   }
 
   private static void addSignalBroadcastProcessors(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchProcessor.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.resource;
+
+import io.camunda.zeebe.auth.impl.Authorization;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.deployment.PersistedResource;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.immutable.ResourceState;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
+
+public class ResourceFetchProcessor implements TypedRecordProcessor<ResourceRecord> {
+
+  private final TypedResponseWriter responseWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final StateWriter stateWriter;
+  private final ResourceState resourceState;
+
+  public ResourceFetchProcessor(final Writers writers, final ProcessingState processingState) {
+    responseWriter = writers.response();
+    rejectionWriter = writers.rejection();
+    stateWriter = writers.state();
+    resourceState = processingState.getResourceState();
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<ResourceRecord> command) {
+    final var resourceKey = command.getValue().getResourceKey();
+    for (final var tenantId : getAuthorizedTenants(command)) {
+      final var optionalResource = resourceState.findResourceByKey(resourceKey, tenantId);
+      if (optionalResource.isPresent()) {
+        final var record = asResourceRecord(optionalResource.get());
+        stateWriter.appendFollowUpEvent(resourceKey, ResourceIntent.FETCHED, record);
+        responseWriter.writeEventOnCommand(resourceKey, ResourceIntent.FETCHED, record, command);
+        return;
+      }
+    }
+    throw new NoSuchResourceException(resourceKey);
+  }
+
+  @Override
+  public ProcessingError tryHandleError(
+      final TypedRecord<ResourceRecord> command, final Throwable error) {
+    if (error instanceof final NoSuchResourceException exception) {
+      rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, exception.getMessage());
+      responseWriter.writeRejectionOnCommand(
+          command, RejectionType.NOT_FOUND, exception.getMessage());
+      return ProcessingError.EXPECTED_ERROR;
+    }
+    return ProcessingError.UNEXPECTED_ERROR;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static List<String> getAuthorizedTenants(final TypedRecord<ResourceRecord> command) {
+    return (List<String>)
+        command.getAuthorizations().getOrDefault(Authorization.AUTHORIZED_TENANTS, List.of());
+  }
+
+  private static ResourceRecord asResourceRecord(final PersistedResource resource) {
+    return new ResourceRecord()
+        .setResource(BufferUtil.wrapString(resource.getResource()))
+        .setResourceKey(resource.getResourceKey())
+        .setResourceId(resource.getResourceId())
+        .setResourceName(resource.getResourceName())
+        .setVersion(resource.getVersion())
+        .setVersionTag(resource.getVersionTag())
+        .setTenantId(resource.getTenantId())
+        .setDeploymentKey(resource.getDeploymentKey())
+        .setChecksum(resource.getChecksum());
+  }
+
+  private static final class NoSuchResourceException extends IllegalStateException {
+    private static final String ERROR_MESSAGE_RESOURCE_NOT_FOUND =
+        "Expected to fetch resource but no resource found with key `%d`";
+
+    private NoSuchResourceException(final long resourceKey) {
+      super(String.format(ERROR_MESSAGE_RESOURCE_NOT_FOUND, resourceKey));
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -380,6 +380,7 @@ public final class EventAppliers implements EventApplier {
   private void registerResourceAppliers(final MutableProcessingState state) {
     register(ResourceIntent.CREATED, new ResourceCreatedApplier(state.getResourceState()));
     register(ResourceIntent.DELETED, new ResourceDeletedApplier(state.getResourceState()));
+    register(ResourceIntent.FETCHED, NOOP_EVENT_APPLIER);
   }
 
   private void registerUserTaskAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareResourceFetchTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareResourceFetchTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.multitenancy;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceRecord;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.ResourceAssert;
+import io.camunda.zeebe.stream.api.CommandResponseWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.stubbing.Answer;
+
+public class TenantAwareResourceFetchTest {
+
+  private static final String TEST_RESOURCE = "/resource/test-rpa-1-with-version-tag-v1.rpa";
+
+  private static final String TENANT_A = "tenant-a";
+  private static final String TENANT_B = "tenant-b";
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  private CommandResponseWriter mockCommandResponseWriter;
+  private ResourceRecord resourceResponse;
+
+  @Before
+  public void setUp() {
+    mockCommandResponseWriter = engine.getCommandResponseWriter();
+    interceptResponseWriter();
+  }
+
+  @Test
+  public void shouldFetchResourceForAuthorizedTenant() throws Exception {
+    // given
+    final var resourceBytes = readFile(TEST_RESOURCE);
+    final var deployment =
+        engine
+            .deployment()
+            .withJsonResource(resourceBytes, "test.rpa")
+            .withTenantId(TENANT_B)
+            .deploy();
+    final var resourceMetadata = deployment.getValue().getResourceMetadata().getFirst();
+    final var resourceKey = resourceMetadata.getResourceKey();
+
+    // when
+    final var record =
+        engine
+            .resourceFetch()
+            .withResourceKey(resourceKey)
+            .withAuthorizedTenantIds(TENANT_A, TENANT_B)
+            .fetch();
+
+    // then
+    ResourceAssert.assertThat(record.getValue())
+        .isNotNull()
+        .hasResourceProp(new String(resourceBytes))
+        .hasResourceKey(resourceKey)
+        .hasResourceId("Rpa_0w7r08e")
+        .hasResourceName("test.rpa")
+        .hasVersion(1)
+        .hasVersionTag("v1.0")
+        .hasDeploymentKey(deployment.getKey())
+        .hasChecksum(resourceMetadata.getChecksum())
+        .hasTenantId(TENANT_B);
+    verify(mockCommandResponseWriter).intent(ResourceIntent.FETCHED);
+    verify(mockCommandResponseWriter).valueType(ValueType.RESOURCE);
+    verify(mockCommandResponseWriter).key(resourceKey);
+    ResourceAssert.assertThat(resourceResponse)
+        .isNotNull()
+        .hasResourceProp(new String(resourceBytes))
+        .hasResourceKey(resourceKey)
+        .hasResourceId("Rpa_0w7r08e")
+        .hasResourceName("test.rpa")
+        .hasVersion(1)
+        .hasVersionTag("v1.0")
+        .hasDeploymentKey(deployment.getKey())
+        .hasChecksum(resourceMetadata.getChecksum())
+        .hasTenantId(TENANT_B);
+  }
+
+  @Test
+  public void shouldNotFetchResourceForUnauthorizedTenant() throws Exception {
+    // given
+    final var resourceBytes = readFile(TEST_RESOURCE);
+    final var deployment =
+        engine
+            .deployment()
+            .withJsonResource(resourceBytes, "test.rpa")
+            .withTenantId(TENANT_B)
+            .deploy();
+    final var resourceKey = deployment.getValue().getResourceMetadata().getFirst().getResourceKey();
+
+    // when
+    final var rejection =
+        engine
+            .resourceFetch()
+            .withResourceKey(resourceKey)
+            .withAuthorizedTenantIds(TENANT_A)
+            .expectRejection()
+            .fetch();
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            "Expected to fetch resource but no resource found with key `%d`"
+                .formatted(resourceKey));
+  }
+
+  private static byte[] readFile(final String name) throws Exception {
+    final var path = Path.of(TenantAwareResourceFetchTest.class.getResource(name).toURI());
+    return Files.readAllBytes(path);
+  }
+
+  private void interceptResponseWriter() {
+    doAnswer(
+            (Answer<CommandResponseWriter>)
+                (invocation -> {
+                  final var arguments = invocation.getArguments();
+                  if (arguments != null
+                      && arguments.length == 1
+                      && arguments[0] instanceof final ResourceRecord resourceRecord) {
+                    resourceResponse = resourceRecord;
+                  }
+                  return mockCommandResponseWriter;
+                }))
+        .when(mockCommandResponseWriter)
+        .valueWriter(any());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.resource;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceRecord;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.ResourceAssert;
+import io.camunda.zeebe.stream.api.CommandResponseWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.stubbing.Answer;
+
+public class ResourceFetchTest {
+
+  private static final String TEST_RESOURCE = "/resource/test-rpa-1-with-version-tag-v1.rpa";
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  private CommandResponseWriter mockCommandResponseWriter;
+  private ResourceRecord resourceResponse;
+
+  @Before
+  public void setUp() {
+    mockCommandResponseWriter = engine.getCommandResponseWriter();
+    interceptResponseWriter();
+  }
+
+  @Test
+  public void shouldFetchResource() throws Exception {
+    // given
+    final var resourceBytes = readFile(TEST_RESOURCE);
+    final var deployment = engine.deployment().withJsonResource(resourceBytes, "test.rpa").deploy();
+    final var resourceMetadata = deployment.getValue().getResourceMetadata().getFirst();
+    final var resourceKey = resourceMetadata.getResourceKey();
+
+    // when
+    final var record =
+        engine
+            .resourceFetch()
+            .withResourceKey(resourceKey)
+            .withRequestStreamId(10)
+            .withRequestId(123456789L)
+            .fetch();
+
+    // then
+    ResourceAssert.assertThat(record.getValue())
+        .isNotNull()
+        .hasResourceProp(new String(resourceBytes))
+        .hasResourceKey(resourceKey)
+        .hasResourceId("Rpa_0w7r08e")
+        .hasResourceName("test.rpa")
+        .hasVersion(1)
+        .hasVersionTag("v1.0")
+        .hasDeploymentKey(deployment.getKey())
+        .hasChecksum(resourceMetadata.getChecksum());
+    verify(mockCommandResponseWriter).intent(ResourceIntent.FETCHED);
+    verify(mockCommandResponseWriter).valueType(ValueType.RESOURCE);
+    verify(mockCommandResponseWriter).key(resourceKey);
+    verify(mockCommandResponseWriter).tryWriteResponse(10, 123456789L);
+    ResourceAssert.assertThat(resourceResponse)
+        .isNotNull()
+        .hasResourceProp(new String(resourceBytes))
+        .hasResourceKey(resourceKey)
+        .hasResourceId("Rpa_0w7r08e")
+        .hasResourceName("test.rpa")
+        .hasVersion(1)
+        .hasVersionTag("v1.0")
+        .hasDeploymentKey(deployment.getKey())
+        .hasChecksum(resourceMetadata.getChecksum());
+  }
+
+  @Test
+  public void shouldRejectIfResourceNotFound() {
+    // given
+    final var unknownResourceKey = 123456789L;
+
+    // when
+    final var rejection =
+        engine.resourceFetch().withResourceKey(unknownResourceKey).expectRejection().fetch();
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            "Expected to fetch resource but no resource found with key `%d`"
+                .formatted(unknownResourceKey));
+  }
+
+  private static byte[] readFile(final String name) throws Exception {
+    final var path = Path.of(ResourceFetchTest.class.getResource(name).toURI());
+    return Files.readAllBytes(path);
+  }
+
+  private void interceptResponseWriter() {
+    doAnswer(
+            (Answer<CommandResponseWriter>)
+                (invocation -> {
+                  final var arguments = invocation.getArguments();
+                  if (arguments != null
+                      && arguments.length == 1
+                      && arguments[0] instanceof final ResourceRecord resourceRecord) {
+                    resourceResponse = resourceRecord;
+                  }
+                  return mockCommandResponseWriter;
+                }))
+        .when(mockCommandResponseWriter)
+        .valueWriter(any());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.engine.util.client.MessageCorrelationClient;
 import io.camunda.zeebe.engine.util.client.ProcessInstanceClient;
 import io.camunda.zeebe.engine.util.client.PublishMessageClient;
 import io.camunda.zeebe.engine.util.client.ResourceDeletionClient;
+import io.camunda.zeebe.engine.util.client.ResourceFetchClient;
 import io.camunda.zeebe.engine.util.client.SignalClient;
 import io.camunda.zeebe.engine.util.client.UserClient;
 import io.camunda.zeebe.engine.util.client.UserTaskClient;
@@ -337,6 +338,10 @@ public final class EngineRule extends ExternalResource {
 
   public ResourceDeletionClient resourceDeletion() {
     return new ResourceDeletionClient(environmentRule);
+  }
+
+  public ResourceFetchClient resourceFetch() {
+    return new ResourceFetchClient(environmentRule);
   }
 
   public SignalClient signal() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -227,6 +227,25 @@ public class StreamProcessingComposite implements CommandWriter {
   }
 
   @Override
+  public long writeCommand(
+      final int requestStreamId,
+      final long requestId,
+      final Intent intent,
+      final UnifiedRecordValue value,
+      final String... authorizedTenants) {
+    final var writer =
+        streams
+            .newRecord(getLogName(partitionId))
+            .recordType(RecordType.COMMAND)
+            .requestId(requestId)
+            .requestStreamId(requestStreamId)
+            .intent(intent)
+            .authorizations(authorizedTenants)
+            .event(value);
+    return writeActor.submit(writer::write).join();
+  }
+
+  @Override
   public long writeCommandOnPartition(
       final int partitionId, final UnaryOperator<FluentLogWriter> builder) {
     final var writer =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -249,6 +249,17 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
   }
 
   @Override
+  public long writeCommand(
+      final int requestStreamId,
+      final long requestId,
+      final Intent intent,
+      final UnifiedRecordValue value,
+      final String... authorizedTenants) {
+    return streamProcessingComposite.writeCommand(
+        requestStreamId, requestId, intent, value, authorizedTenants);
+  }
+
+  @Override
   public long writeCommandOnPartition(
       final int partitionId, final UnaryOperator<FluentLogWriter> builder) {
     return streamProcessingComposite.writeCommandOnPartition(partitionId, builder);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/CommandWriter.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/CommandWriter.java
@@ -33,6 +33,13 @@ public interface CommandWriter {
       final Intent intent,
       final UnifiedRecordValue value);
 
+  long writeCommand(
+      final int requestStreamId,
+      final long requestId,
+      final Intent intent,
+      final UnifiedRecordValue value,
+      String... authorizedTenants);
+
   long writeCommandOnPartition(int partitionId, final UnaryOperator<FluentLogWriter> builder);
 
   long writeCommandOnPartition(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ResourceFetchClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ResourceFetchClient.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.util.client;
+
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ResourceIntent;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.protocol.record.value.deployment.Resource;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.List;
+import java.util.function.Function;
+
+public class ResourceFetchClient {
+
+  private static final Function<Long, Record<Resource>> SUCCESS_EXPECTATION =
+      (position) ->
+          RecordingExporter.resourceRecords()
+              .withIntent(ResourceIntent.FETCHED)
+              .withSourceRecordPosition(position)
+              .getFirst();
+  private static final Function<Long, Record<Resource>> REJECTION_EXPECTATION =
+      (position) ->
+          RecordingExporter.resourceRecords()
+              .onlyCommandRejections()
+              .withIntent(ResourceIntent.FETCH)
+              .withSourceRecordPosition(position)
+              .getFirst();
+
+  private final CommandWriter writer;
+  private final ResourceRecord resourceRecord = new ResourceRecord();
+  private Function<Long, Record<Resource>> expectation = SUCCESS_EXPECTATION;
+  private List<String> authorizedTenantIds = List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private int requestStreamId = 1;
+  private long requestId = 1L;
+
+  public ResourceFetchClient(final CommandWriter writer) {
+    this.writer = writer;
+  }
+
+  public ResourceFetchClient withResourceKey(final long resourceKey) {
+    resourceRecord.setResourceKey(resourceKey);
+    return this;
+  }
+
+  public ResourceFetchClient withAuthorizedTenantIds(final String... tenantIds) {
+    authorizedTenantIds = List.of(tenantIds);
+    return this;
+  }
+
+  public ResourceFetchClient withRequestStreamId(final int requestStreamId) {
+    this.requestStreamId = requestStreamId;
+    return this;
+  }
+
+  public ResourceFetchClient withRequestId(final long requestId) {
+    this.requestId = requestId;
+    return this;
+  }
+
+  public Record<Resource> fetch() {
+    final long position =
+        writer.writeCommand(
+            requestStreamId,
+            requestId,
+            ResourceIntent.FETCH,
+            resourceRecord,
+            authorizedTenantIds.toArray(new String[0]));
+    return expectation.apply(position);
+  }
+
+  public ResourceFetchClient expectRejection() {
+    expectation = REJECTION_EXPECTATION;
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ResourceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ResourceRecord.java
@@ -22,14 +22,14 @@ import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
 public class ResourceRecord extends UnifiedRecordValue implements Resource {
-  private final StringProperty resourceIdProp = new StringProperty("resourceId");
-  private final IntegerProperty versionProp = new IntegerProperty("version");
-  private final LongProperty resourceKeyProp = new LongProperty("resourceKey");
+  private final StringProperty resourceIdProp = new StringProperty("resourceId", "");
+  private final IntegerProperty versionProp = new IntegerProperty("version", -1);
+  private final LongProperty resourceKeyProp = new LongProperty("resourceKey", -1L);
   private final BinaryProperty checksumProp = new BinaryProperty("checksum", new UnsafeBuffer());
-  private final StringProperty resourceNameProp = new StringProperty("resourceName");
+  private final StringProperty resourceNameProp = new StringProperty("resourceName", "");
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-  private final LongProperty deploymentKeyProp = new LongProperty("deploymentKey", -1);
+  private final LongProperty deploymentKeyProp = new LongProperty("deploymentKey", -1L);
   private final StringProperty versionTagProp = new StringProperty("versionTag", "");
   private final BinaryProperty resourceProp = new BinaryProperty("resource", new UnsafeBuffer());
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ResourceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ResourceRecord.java
@@ -186,6 +186,10 @@ public class ResourceRecord extends UnifiedRecordValue implements Resource {
     return bufferAsString(resourceProp.getValue());
   }
 
+  public ResourceRecord setResource(final DirectBuffer resource) {
+    return setResource(resource, 0, resource.capacity());
+  }
+
   public ResourceRecord setResource(
       final DirectBuffer resource, final int offset, final int length) {
     resourceProp.setValue(resource, offset, length);

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ResourceIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ResourceIntent.java
@@ -17,7 +17,9 @@ package io.camunda.zeebe.protocol.record.intent;
 
 public enum ResourceIntent implements Intent {
   CREATED((short) 0),
-  DELETED((short) 1);
+  DELETED((short) 1),
+  FETCH((short) 2),
+  FETCHED((short) 3);
 
   private final short value;
 
@@ -35,6 +37,10 @@ public enum ResourceIntent implements Intent {
         return CREATED;
       case 1:
         return DELETED;
+      case 2:
+        return FETCH;
+      case 3:
+        return FETCHED;
       default:
         return UNKNOWN;
     }
@@ -47,6 +53,13 @@ public enum ResourceIntent implements Intent {
 
   @Override
   public boolean isEvent() {
-    return true;
+    switch (this) {
+      case CREATED:
+      case DELETED:
+      case FETCHED:
+        return true;
+      default:
+        return false;
+    }
   }
 }


### PR DESCRIPTION
## Description
Adds a new command processor that allows to fetch a deployed (RPA) resource from the Zeebe state by resource key.

**Notes**:
- ~The issue title suggested to add a new enum constant `FETCH` to the existing `ResourceIntent`. However, I figured it would be more appropriate to have a dedicated `ResourceFetchIntent.FETCH`, to ensure a unique mapping between intent, value type (`ValueType.RESOURCE_FETCH`) and record (`ResourceFetchRecord`) – similar to how it's done for resource deletion.~
  - see https://github.com/camunda/camunda/pull/27981#pullrequestreview-2615807004
- I used `stable/8.7` as the base branch because the overall RPA feature needs to be ready for the 8.7 release. So it has higher priority to get the changes included there (they will be forward-ported to `main`).

## Related issues
closes #24773