### PR TITLE
[Backport stable/8.7] refactor: use batch document upload endpoint instead of single document upload

### DIFF
--- a/tasklist/client/src/modules/api.ts
+++ b/tasklist/client/src/modules/api.ts
@@ -8,7 +8,7 @@
 
 import type {Form, Task, TasksSearchBody, Variable} from './types';
 import {mergePathname} from './utils/mergePathname';
-
+import {buildDocumentMultipart} from './utils/buildDocumentMultipart';
 const BASENAME = window.clientConfig?.contextPath ?? '/';
 const BASE_REQUEST_OPTIONS: RequestInit = {
   credentials: 'include',
@@ -318,15 +318,14 @@ const api = {
         },
       });
     },
-    uploadDocuments: ({files}: {files: File[]}) => {
-      const body = new FormData();
-
-      files.forEach((file) => body.append('files', file));
+    uploadDocuments: ({files}: {files: Map<string, File[]>}) => {
+      const {body, headers} = buildDocumentMultipart(files);
 
       return new Request(getFullURL('/v2/documents/batch'), {
         ...BASE_REQUEST_OPTIONS,
         method: 'POST',
         body,
+        headers,
       });
     },
     getDocument: (id: string) => {

--- a/tasklist/client/src/modules/api.ts
+++ b/tasklist/client/src/modules/api.ts
@@ -318,12 +318,12 @@ const api = {
         },
       });
     },
-    uploadDocuments: ({file}: {file: File}) => {
+    uploadDocuments: ({files}: {files: File[]}) => {
       const body = new FormData();
 
-      body.append('file', file);
+      files.forEach((file) => body.append('files', file));
 
-      return new Request(getFullURL('/v2/documents'), {
+      return new Request(getFullURL('/v2/documents/batch'), {
         ...BASE_REQUEST_OPTIONS,
         method: 'POST',
         body,

--- a/tasklist/client/src/modules/components/FormJSRenderer/index.tsx
+++ b/tasklist/client/src/modules/components/FormJSRenderer/index.tsx
@@ -16,7 +16,7 @@ import {usePrefersReducedMotion} from 'modules/hooks/usePrefersReducedMotion';
 import styles from './styles.module.scss';
 import '@bpmn-io/form-js-viewer/dist/assets/form-js-base.css';
 import '@bpmn-io/form-js-carbon-styles/src/carbon-styles.scss';
-import type {FileUploadMetadata} from 'modules/mutations/useUploadDocuments';
+import type {SuccessDocument} from 'modules/mutations/useUploadDocuments';
 import set from 'lodash/set';
 import {api} from 'modules/api';
 import {FormLevelErrorMessage} from './FormLevelErrorMessage';
@@ -34,7 +34,7 @@ type Props = {
   handleSubmit: (variables: Variable[]) => Promise<void>;
   handleFileUpload?: (
     files: Map<string, File[]>,
-  ) => Promise<Map<string, FileUploadMetadata[]>>;
+  ) => Promise<Map<string, SuccessDocument[]>>;
   schema: string;
   data?: Record<string, unknown>;
   readOnly?: boolean;
@@ -149,7 +149,7 @@ function extractFilePath(data: object, path: string = ''): Map<string, string> {
 
 function injectFileMetadataIntoData(options: {
   data: Record<string, unknown>;
-  fileMetadata: Map<string, FileUploadMetadata[]>;
+  fileMetadata: Map<string, SuccessDocument[]>;
   pathsToInject: Map<string, string>;
 }): Record<string, unknown> {
   const {data, fileMetadata, pathsToInject} = options;

--- a/tasklist/client/src/modules/utils/buildDocumentMultipart.test.ts
+++ b/tasklist/client/src/modules/utils/buildDocumentMultipart.test.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {buildDocumentMultipart} from 'modules/utils/buildDocumentMultipart';
+
+async function blobToString(blob: Blob): Promise<string> {
+  return new Promise<string>((resolve) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.readAsText(blob);
+  });
+}
+
+describe('buildDocumentMultipart', () => {
+  it('should build a multipart/form-data body and headers', async () => {
+    const files = new Map([
+      ['foobar', [new File(['test'], 'test.txt', {type: 'text/plain'})]],
+    ]);
+    const {body, headers} = buildDocumentMultipart(files);
+
+    expect(headers['Content-Type']).toMatch(
+      /^multipart\/form-data.*boundary=.+/,
+    );
+
+    const content = await blobToString(body);
+
+    expect(content).toContain(
+      'Content-Disposition: form-data; name="files"; filename="test.txt"',
+    );
+    expect(content).toContain('Content-Type: text/plain');
+    expect(content).toContain(
+      'X-Document-Metadata: {"customProperties":{"pickerKey":"foobar"}}',
+    );
+    expect(content).toContain('test');
+  });
+});

--- a/tasklist/client/src/modules/utils/buildDocumentMultipart.ts
+++ b/tasklist/client/src/modules/utils/buildDocumentMultipart.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+function buildDocumentMultipart(files: Map<string, File[]>): {
+  body: Blob;
+  headers: Record<string, string>;
+} {
+  const boundary = `----FormBoundary${Math.random().toString(36).substring(2)}`;
+  const contentType = `multipart/form-data; boundary=${boundary}`;
+  const startBoundary = `--${boundary}`;
+  const endBoundary = `--${boundary}--`;
+  const CRLF = '\r\n';
+  const parts = Array.from(files.entries())
+    .map(([key, files]) => {
+      const metadata = {
+        customProperties: {
+          [PICKER_KEY]: key,
+        },
+      };
+
+      const pickerParts = files.map((file) => {
+        const header = [
+          startBoundary,
+          `Content-Disposition: form-data; name="files"; filename="${file.name}"`,
+          `Content-Type: ${file.type}`,
+          `X-Document-Metadata: ${JSON.stringify(metadata)}`,
+          '',
+          '',
+        ].join(CRLF);
+
+        return new Blob([header, file, CRLF], {type: file.type});
+      });
+
+      pickerParts.push(new Blob([CRLF, startBoundary, CRLF]));
+
+      return pickerParts;
+    })
+    .flat();
+
+  parts.pop();
+  parts.push(new Blob([endBoundary]));
+
+  const body = new Blob(parts, {
+    type: contentType,
+  });
+
+  return {
+    body,
+    headers: {
+      'Content-Type': contentType,
+    },
+  };
+}
+
+const PICKER_KEY = 'pickerKey';
+
+export {buildDocumentMultipart, PICKER_KEY};


### PR DESCRIPTION
# Description
Backport of #27611 to `stable/8.7`.

relates to 
original author: @vsgoulart