### PR TITLE
[Backport stable/8.6] ci: run backend jobs of Operate/Tasklist/Optimize/Zeebe when `webapps**` change

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -73,6 +73,7 @@ outputs:
       ${{
         github.event_name == 'push' ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-zeebe.outputs.zeebe-change == 'true'
       }}

--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -43,7 +43,9 @@ outputs:
       ${{
         github.event_name == 'push' ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
-        steps.filter-optimize.outputs.optimize-backend-change == 'true'
+        steps.filter-optimize.outputs.optimize-backend-change == 'true' ||
+        steps.filter-common.outputs.webapps-change == 'true' ||
+        steps.filter-common.outputs.maven-change == 'true'
       }}
   camunda-docker-tests:
     description: Output whether Camunda Docker tests should be run based on GitHub event and files changed
@@ -120,6 +122,11 @@ runs:
 
         markdown-change:
           - '**/*.md'
+
+        webapps-change:
+          - 'webapps-backup/**'
+          - 'webapps-common/**'
+          - 'webapps-schema/**'
 
         frontend-change:
           - 'operate/client/**'


### PR DESCRIPTION
# Description
Backport of #25906 to `stable/8.6`.

relates to 
original author: @cmur2