### PR TITLE
ci: properly push tags and version updates on optimize release

### DIFF
--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -184,12 +184,6 @@ jobs:
             --fail-at-end \
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
-      - name: Push changes
-        if: env.IS_DRY_RUN == 'false'
-        run: |
-          git push --tags
-          git push --all
-
       - name: Perform release
         run: |
           ./mvnw -f optimize \

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -109,6 +109,15 @@ jobs:
         id: define-values
         uses: ./.github/actions/git-environment
 
+      - name: Should Push Changes
+        id: should-push
+        run: |
+          should_push="false"
+          if [ "${{ steps.release-type.outputs.IS_DRY_RUN }}" = "false" ]; then
+            should_push="true"
+          fi
+          echo "should_push=should_push" >> "$GITHUB_OUTPUT"
+
       - name: Expose common variables as Env
         run: |
           {
@@ -122,6 +131,7 @@ jobs:
             echo "IS_ALPHA=${{ steps.release-type.outputs.is_alpha }}"
             echo "IS_RC=${{ steps.release-type.outputs.is_rc }}"
             echo "IS_DRY_RUN=${{ github.event.inputs.IS_DRY_RUN || 'true' }}"
+            echo "SHOULD_PUSH=${{ steps.release-type.outputs.should_push }}"
             echo "TAG=${{ github.event.inputs.RELEASE_VERSION || '0.0.0' }}-optimize"
           } >> "$GITHUB_ENV"
 
@@ -159,8 +169,9 @@ jobs:
 
       - name: Prepare release
         run: |
-          ./mvnw -f optimize \
-            -DpushChanges=false \
+          mvn -f optimize \
+            -DpushChanges="${{ env.SHOULD_PUSH }}" \
+            -DremoteTagging="${{ env.SHOULD_PUSH }}" \
             -DskipTests=true \
             -DignoreSnapshots=true \
             -Prelease,runAssembly \

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -109,15 +109,6 @@ jobs:
         id: define-values
         uses: ./.github/actions/git-environment
 
-      - name: Should Push Changes
-        id: should-push
-        run: |
-          should_push="false"
-          if [ "${{ steps.release-type.outputs.IS_DRY_RUN }}" = "false" ]; then
-            should_push="true"
-          fi
-          echo "should_push=should_push" >> "$GITHUB_OUTPUT"
-
       - name: Expose common variables as Env
         run: |
           {
@@ -131,7 +122,6 @@ jobs:
             echo "IS_ALPHA=${{ steps.release-type.outputs.is_alpha }}"
             echo "IS_RC=${{ steps.release-type.outputs.is_rc }}"
             echo "IS_DRY_RUN=${{ github.event.inputs.IS_DRY_RUN || 'true' }}"
-            echo "SHOULD_PUSH=${{ steps.release-type.outputs.should_push }}"
             echo "TAG=${{ github.event.inputs.RELEASE_VERSION || '0.0.0' }}-optimize"
           } >> "$GITHUB_ENV"
 
@@ -170,8 +160,8 @@ jobs:
       - name: Prepare release
         run: |
           mvn -f optimize \
-            -DpushChanges="${{ env.SHOULD_PUSH }}" \
-            -DremoteTagging="${{ env.SHOULD_PUSH }}" \
+            -DpushChanges="${{ github.event.inputs.IS_DRY_RUN != 'true' }}" \
+            -DremoteTagging="${{ github.event.inputs.IS_DRY_RUN != 'true' }}" \
             -DskipTests=true \
             -DignoreSnapshots=true \
             -Prelease,runAssembly \


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Optimize is not properly updating its version in pom.xml file when a release is run. This has lead to having our 8.6.5 release have 8.6.4 versions in its pom.xml

I noticed that `DpushChanges` and `DremoteTagging` were always `false` when the release job was run. I updated the script to properly set these options when the job is run

Some context for this problem and how it was found: https://camunda.slack.com/archives/C071KP5BTHB/p1739179242814939

This is also aligning `main` and `stable` branches. `stable` was using the `mvn` command to do the tagging, whereas `main` was not. The change to `stable` was made to work around some `git` issues, and this change apparenrtly did not properly make it to `main`

https://camunda.slack.com/archives/C071KP5BTHB/p1736345765024329

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
