### PR TITLE
Provide per-partition startup and transition/role meter registries

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
@@ -32,11 +32,7 @@ import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthReport;
-import io.camunda.zeebe.util.micrometer.MicrometerUtil;
-import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
@@ -69,7 +65,7 @@ public final class RaftPartition implements Partition, HealthMonitorable {
     this.partitionMetadata = partitionMetadata;
     this.config = config;
     this.dataDirectory = dataDirectory;
-    this.meterRegistry = createMeterRegistry(meterRegistry);
+    this.meterRegistry = meterRegistry;
   }
 
   public void addRoleChangeListener(final RaftRoleChangeListener listener) {
@@ -283,28 +279,10 @@ public final class RaftPartition implements Partition, HealthMonitorable {
   }
 
   public CompletableFuture<Void> stop() {
-    // close the registry regardless of errors in server.stop()
-    return server
-        .stop()
-        .whenComplete(
-            (unused, error) -> {
-              MicrometerUtil.closeRegistry(meterRegistry);
-            });
+    return server.stop();
   }
 
   public RaftPartitionConfig getPartitionConfig() {
     return config;
-  }
-
-  private MeterRegistry createMeterRegistry(final MeterRegistry meterRegistry) {
-    final var registry = new CompositeMeterRegistry();
-    registry.add(meterRegistry);
-    registry
-        .config()
-        .commonTags(
-            Tags.of(
-                PartitionKeyNames.PARTITION.asString(),
-                Integer.toString(partitionMetadata.id().id())));
-    return registry;
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -48,7 +48,6 @@ import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.File;
@@ -170,7 +169,8 @@ public final class RaftRule extends ExternalResource {
     memberLog = null;
     position = 0;
     directory = null;
-    MicrometerUtil.closeRegistry(meterRegistry);
+    meterRegistry.clear();
+    meterRegistry.close();
   }
 
   /**

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/Partition.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/Partition.java
@@ -11,6 +11,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.raft.cluster.RaftMember.Type;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.broker.partitioning.startup.PartitionStartupContext;
+import io.camunda.zeebe.broker.partitioning.startup.steps.MetricsStep;
 import io.camunda.zeebe.broker.partitioning.startup.steps.PartitionDirectoryStep;
 import io.camunda.zeebe.broker.partitioning.startup.steps.PartitionRegistrationStep;
 import io.camunda.zeebe.broker.partitioning.startup.steps.RaftBootstrapStep;
@@ -67,6 +68,7 @@ final class Partition {
         new StartupProcess<>(
             LOGGER,
             List.of(
+                new MetricsStep(),
                 new PartitionDirectoryStep(),
                 new SnapshotStoreStep(),
                 new RaftBootstrapStep(),
@@ -79,6 +81,7 @@ final class Partition {
         context,
         new StartupProcess<>(
             List.of(
+                new MetricsStep(),
                 new PartitionDirectoryStep(),
                 new SnapshotStoreStep(),
                 new RaftJoinStep(),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/PartitionStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/PartitionStartupContext.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.nio.file.Path;
 
 public final class PartitionStartupContext {
@@ -31,9 +32,11 @@ public final class PartitionStartupContext {
   private final RaftPartitionFactory raftPartitionFactory;
   private final ZeebePartitionFactory zeebePartitionFactory;
   private final BrokerCfg brokerConfig;
+  private final MeterRegistry brokerMeterRegistry;
 
   private Path partitionDirectory;
 
+  private MeterRegistry partitionMeterRegistry;
   private FileBasedSnapshotStore snapshotStore;
   private RaftPartition raftPartition;
   private ZeebePartition zeebePartition;
@@ -48,7 +51,8 @@ public final class PartitionStartupContext {
       final PartitionMetadata partitionMetadata,
       final RaftPartitionFactory raftPartitionFactory,
       final ZeebePartitionFactory zeebePartitionFactory,
-      final BrokerCfg brokerConfig) {
+      final BrokerCfg brokerConfig,
+      final MeterRegistry brokerMeterRegistry) {
     this.schedulingService = schedulingService;
     this.topologyManager = topologyManager;
     this.concurrencyControl = concurrencyControl;
@@ -59,6 +63,7 @@ public final class PartitionStartupContext {
     this.raftPartitionFactory = raftPartitionFactory;
     this.zeebePartitionFactory = zeebePartitionFactory;
     this.brokerConfig = brokerConfig;
+    this.brokerMeterRegistry = brokerMeterRegistry;
   }
 
   @Override
@@ -140,5 +145,19 @@ public final class PartitionStartupContext {
   public PartitionStartupContext partitionDirectory(final Path partitionDirectory) {
     this.partitionDirectory = partitionDirectory;
     return this;
+  }
+
+  public PartitionStartupContext partitionMeterRegistry(
+      final MeterRegistry partitionMeterRegistry) {
+    this.partitionMeterRegistry = partitionMeterRegistry;
+    return this;
+  }
+
+  public MeterRegistry partitionMeterRegistry() {
+    return partitionMeterRegistry;
+  }
+
+  public MeterRegistry brokerMeterRegistry() {
+    return brokerMeterRegistry;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
@@ -30,14 +30,13 @@ public final class RaftPartitionFactory {
   public static final String GROUP_NAME = "raft-partition";
 
   private final BrokerCfg brokerCfg;
-  private final MeterRegistry meterRegistry;
 
-  public RaftPartitionFactory(final BrokerCfg brokerCfg, final MeterRegistry meterRegistry) {
+  public RaftPartitionFactory(final BrokerCfg brokerCfg) {
     this.brokerCfg = brokerCfg;
-    this.meterRegistry = meterRegistry;
   }
 
-  public RaftPartition createRaftPartition(final PartitionMetadata partitionMetadata) {
+  public RaftPartition createRaftPartition(
+      final PartitionMetadata partitionMetadata, final MeterRegistry partitionMeterRegistry) {
     final var partitionDirectory =
         Paths.get(brokerCfg.getData().getDirectory())
             .resolve(GROUP_NAME)
@@ -48,11 +47,13 @@ public final class RaftPartitionFactory {
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
     }
-    return createRaftPartition(partitionMetadata, partitionDirectory);
+    return createRaftPartition(partitionMetadata, partitionDirectory, partitionMeterRegistry);
   }
 
   public RaftPartition createRaftPartition(
-      final PartitionMetadata partitionMetadata, final Path partitionDirectory) {
+      final PartitionMetadata partitionMetadata,
+      final Path partitionDirectory,
+      final MeterRegistry partitionMeterRegistry) {
     final var storageConfig = new RaftStorageConfig();
     final var partitionConfig = new RaftPartitionConfig();
 
@@ -98,7 +99,7 @@ public final class RaftPartitionFactory {
         brokerCfg.getExperimental().getRaft().getPreferSnapshotReplicationThreshold());
 
     return new RaftPartition(
-        partitionMetadata, partitionConfig, partitionDirectory.toFile(), meterRegistry);
+        partitionMetadata, partitionConfig, partitionDirectory.toFile(), partitionMeterRegistry);
   }
 
   private RaftLogFlusher.Factory createFlusherFactory(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -103,7 +103,6 @@ public final class ZeebePartitionFactory {
   private final TopologyManagerImpl topologyManager;
   private final FeatureFlags featureFlags;
   private final List<PartitionRaftListener> partitionRaftListeners;
-  private final MeterRegistry meterRegistry;
 
   public ZeebePartitionFactory(
       final ActorSchedulingService actorSchedulingService,
@@ -118,8 +117,7 @@ public final class ZeebePartitionFactory {
       final List<PartitionListener> partitionListeners,
       final List<PartitionRaftListener> partitionRaftListeners,
       final TopologyManagerImpl topologyManager,
-      final FeatureFlags featureFlags,
-      final MeterRegistry meterRegistry) {
+      final FeatureFlags featureFlags) {
     this.actorSchedulingService = actorSchedulingService;
     this.brokerCfg = brokerCfg;
     this.localBroker = localBroker;
@@ -133,11 +131,12 @@ public final class ZeebePartitionFactory {
     this.partitionRaftListeners = partitionRaftListeners;
     this.topologyManager = topologyManager;
     this.featureFlags = featureFlags;
-    this.meterRegistry = meterRegistry;
   }
 
   public ZeebePartition constructPartition(
-      final RaftPartition raftPartition, final FileBasedSnapshotStore snapshotStore) {
+      final RaftPartition raftPartition,
+      final FileBasedSnapshotStore snapshotStore,
+      final MeterRegistry partitionMeterRegistry) {
     final var communicationService = clusterServices.getCommunicationService();
     final var membershipService = clusterServices.getMembershipService();
     final var typedRecordProcessorsFactory = createFactory(localBroker, featureFlags);
@@ -169,7 +168,7 @@ public final class ZeebePartitionFactory {
             diskSpaceUsageMonitor,
             gatewayBrokerTransport,
             topologyManager,
-            meterRegistry);
+            partitionMeterRegistry);
 
     final PartitionTransition newTransitionBehavior = new PartitionTransitionImpl(TRANSITION_STEPS);
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/MetricsStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/MetricsStep.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.partitioning.startup.steps;
+
+import io.camunda.zeebe.broker.partitioning.startup.PartitionStartupContext;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.scheduler.startup.StartupStep;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+
+public class MetricsStep implements StartupStep<PartitionStartupContext> {
+
+  @Override
+  public String getName() {
+    return "Partition Metrics Startup Step";
+  }
+
+  @Override
+  public ActorFuture<PartitionStartupContext> startup(final PartitionStartupContext context) {
+    final var brokerRegistry = context.brokerMeterRegistry();
+    final var partitionRegistry = new CompositeMeterRegistry();
+    final Integer partitionId = context.partitionMetadata().id().id();
+    partitionRegistry
+        .config()
+        .commonTags(PartitionKeyNames.PARTITION.asString(), partitionId.toString());
+
+    partitionRegistry.add(brokerRegistry);
+    context.partitionMeterRegistry(partitionRegistry);
+
+    return CompletableActorFuture.completed(context);
+  }
+
+  @Override
+  public ActorFuture<PartitionStartupContext> shutdown(final PartitionStartupContext context) {
+    final var brokerRegistry = context.brokerMeterRegistry();
+    final var partitionRegistry = context.partitionMeterRegistry();
+
+    if (partitionRegistry != null) {
+      partitionRegistry.clear();
+      partitionRegistry.close();
+
+      if (brokerRegistry instanceof final CompositeMeterRegistry parent) {
+        parent.remove(partitionRegistry);
+      }
+
+      context.partitionMeterRegistry(null);
+    }
+
+    return CompletableActorFuture.completed(context);
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/RaftBootstrapStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/RaftBootstrapStep.java
@@ -25,7 +25,10 @@ public final class RaftBootstrapStep implements StartupStep<PartitionStartupCont
     final var partition =
         context
             .raftPartitionFactory()
-            .createRaftPartition(context.partitionMetadata(), context.partitionDirectory());
+            .createRaftPartition(
+                context.partitionMetadata(),
+                context.partitionDirectory(),
+                context.partitionMeterRegistry());
 
     // Immediately save the partition to the context, so that it can be closed in case of an error.
     context.raftPartition(partition);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/RaftJoinStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/RaftJoinStep.java
@@ -25,7 +25,10 @@ public class RaftJoinStep implements StartupStep<PartitionStartupContext> {
     final var partition =
         context
             .raftPartitionFactory()
-            .createRaftPartition(context.partitionMetadata(), context.partitionDirectory());
+            .createRaftPartition(
+                context.partitionMetadata(),
+                context.partitionDirectory(),
+                context.partitionMeterRegistry());
 
     // Immediately save the partition to the context, so that it can be closed in case of an error.
     context.raftPartition(partition);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/ZeebePartitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/ZeebePartitionStep.java
@@ -25,7 +25,8 @@ public final class ZeebePartitionStep implements StartupStep<PartitionStartupCon
     final var zeebePartition =
         context
             .zeebePartitionFactory()
-            .constructPartition(context.raftPartition(), context.snapshotStore());
+            .constructPartition(
+                context.raftPartition(), context.snapshotStore(), context.partitionMeterRegistry());
     final var submit = context.schedulingService().submitActor(zeebePartition);
     context
         .concurrencyControl()

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/HealthMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/HealthMetrics.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.broker.system.monitoring;
 
-import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -15,11 +14,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 public final class HealthMetrics {
   private final AtomicInteger health = new AtomicInteger();
 
-  public HealthMetrics(final MeterRegistry registry, final int partitionId) {
+  public HealthMetrics(final MeterRegistry registry) {
     final var meterDoc = HealthMetricsDoc.HEALTH;
     Gauge.builder(meterDoc.getName(), health, AtomicInteger::intValue)
         .description(meterDoc.getDescription())
-        .tag(PartitionKeyNames.PARTITION.asString(), String.valueOf(partitionId))
         .register(registry);
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -106,8 +106,8 @@ public class PartitionStartupAndTransitionContextImpl
   private BackupStore backupStore;
   private AdminApiRequestHandler adminApiService;
   private PartitionAdminAccess adminAccess;
-  private final MeterRegistry brokerMeterRegistry;
-  private MeterRegistry partitionMeterRegistry;
+  private final MeterRegistry startupMeterRegistry;
+  private MeterRegistry transitionMeterRegistry;
 
   public PartitionStartupAndTransitionContextImpl(
       final int nodeId,
@@ -129,7 +129,7 @@ public class PartitionStartupAndTransitionContextImpl
       final DiskSpaceUsageMonitor diskSpaceUsageMonitor,
       final AtomixServerTransport gatewayBrokerTransport,
       final TopologyManager topologyManager,
-      final MeterRegistry brokerMeterRegistry) {
+      final MeterRegistry startupMeterRegistry) {
     this.nodeId = nodeId;
     this.clusterCommunicationService = clusterCommunicationService;
     this.raftPartition = raftPartition;
@@ -151,8 +151,10 @@ public class PartitionStartupAndTransitionContextImpl
     this.diskSpaceUsageMonitor = diskSpaceUsageMonitor;
     this.gatewayBrokerTransport = gatewayBrokerTransport;
     this.topologyManager = topologyManager;
-    this.brokerMeterRegistry = new CompositeMeterRegistry().add(brokerMeterRegistry);
-    this.brokerMeterRegistry.config().commonTags(Tags.of("partition", String.valueOf(partitionId)));
+    this.startupMeterRegistry = new CompositeMeterRegistry().add(startupMeterRegistry);
+    this.startupMeterRegistry
+        .config()
+        .commonTags(Tags.of("partition", String.valueOf(partitionId)));
   }
 
   public PartitionAdminControl getPartitionAdminControl() {
@@ -369,18 +371,18 @@ public class PartitionStartupAndTransitionContextImpl
   }
 
   @Override
-  public MeterRegistry getBrokerMeterRegistry() {
-    return brokerMeterRegistry;
+  public MeterRegistry getPartitionStartupMeterRegistry() {
+    return startupMeterRegistry;
   }
 
   @Override
-  public MeterRegistry getPartitionMeterRegistry() {
-    return partitionMeterRegistry;
+  public MeterRegistry getPartitionTransitionMeterRegistry() {
+    return transitionMeterRegistry;
   }
 
   @Override
-  public void setPartitionMeterRegistry(final MeterRegistry partitionMeterRegistry) {
-    this.partitionMeterRegistry = partitionMeterRegistry;
+  public void setPartitionTransitionMeterRegistry(final MeterRegistry transitionMeterRegistry) {
+    this.transitionMeterRegistry = transitionMeterRegistry;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -46,6 +46,7 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.health.HealthMonitor;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
@@ -154,7 +155,7 @@ public class PartitionStartupAndTransitionContextImpl
     this.startupMeterRegistry = new CompositeMeterRegistry().add(startupMeterRegistry);
     this.startupMeterRegistry
         .config()
-        .commonTags(Tags.of("partition", String.valueOf(partitionId)));
+        .commonTags(Tags.of(PartitionKeyNames.PARTITION.asString(), String.valueOf(partitionId)));
   }
 
   public PartitionAdminControl getPartitionAdminControl() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -136,9 +136,24 @@ public interface PartitionTransitionContext extends PartitionContext {
 
   void setBackupStore(BackupStore backupStore);
 
-  MeterRegistry getBrokerMeterRegistry();
+  /**
+   * Returns a meter registry which already has some common tags for the partition (so you can omit
+   * adding it manually to your metrics), and which is created when the partition is bootstrapped or
+   * joined, and closed when the partition is left or stopped.
+   *
+   * <p>Only use this if the state represented by the metrics is independent of the transition/role
+   * of the partition.
+   */
+  MeterRegistry getPartitionStartupMeterRegistry();
 
-  MeterRegistry getPartitionMeterRegistry();
+  /**
+   * Returns a meter registry which wraps around the {@link #getPartitionStartupMeterRegistry()},
+   * and is created/closed along with partition transitions.
+   *
+   * <p>This is very useful to add metrics which depend on objects/state recreated during a
+   * transition, and is typically the registry you want to use.
+   */
+  MeterRegistry getPartitionTransitionMeterRegistry();
 
-  void setPartitionMeterRegistry(MeterRegistry partitionMeterRegistry);
+  void setPartitionTransitionMeterRegistry(MeterRegistry transitionMeterRegistry);
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -85,8 +85,7 @@ public final class ZeebePartition extends Actor
         new CriticalComponentsHealthMonitor(
             "Partition-" + transitionContext.getPartitionId(), actor, LOG));
     zeebePartitionHealth = new ZeebePartitionHealth(transitionContext.getPartitionId(), transition);
-    healthMetrics =
-        new HealthMetrics(transitionContext.getPartitionStartupMeterRegistry(), partitionId);
+    healthMetrics = new HealthMetrics(transitionContext.getPartitionStartupMeterRegistry());
     healthMetrics.setUnhealthy();
     failureListeners = new ArrayList<>();
     roleMetrics =

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -85,12 +85,14 @@ public final class ZeebePartition extends Actor
         new CriticalComponentsHealthMonitor(
             "Partition-" + transitionContext.getPartitionId(), actor, LOG));
     zeebePartitionHealth = new ZeebePartitionHealth(transitionContext.getPartitionId(), transition);
-    healthMetrics = new HealthMetrics(transitionContext.getBrokerMeterRegistry(), partitionId);
+    healthMetrics =
+        new HealthMetrics(transitionContext.getPartitionStartupMeterRegistry(), partitionId);
     healthMetrics.setUnhealthy();
     failureListeners = new ArrayList<>();
     roleMetrics =
         new RoleMetrics(
-            transitionContext.getBrokerMeterRegistry(), transitionContext.getPartitionId());
+            transitionContext.getPartitionStartupMeterRegistry(),
+            transitionContext.getPartitionId());
   }
 
   public PartitionAdminAccess getAdminAccess() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
@@ -108,7 +108,7 @@ public final class BackupServiceTransitionStep implements PartitionTransitionSte
             context.getPersistedSnapshotStore(),
             context.getRaftPartition().dataDirectory().toPath(),
             index -> context.getRaftPartition().getServer().getTailSegments(index),
-            context.getPartitionMeterRegistry());
+            context.getPartitionTransitionMeterRegistry());
 
     final ActorFuture<Void> installed = context.getConcurrencyControl().createFuture();
     context
@@ -130,7 +130,7 @@ public final class BackupServiceTransitionStep implements PartitionTransitionSte
       final PartitionTransitionContext context, final BackupManager backupManager) {
     final CheckpointRecordsProcessor checkpointRecordsProcessor =
         new CheckpointRecordsProcessor(
-            backupManager, context.getPartitionId(), context.getPartitionMeterRegistry());
+            backupManager, context.getPartitionId(), context.getPartitionTransitionMeterRegistry());
     context.setCheckpointProcessor(checkpointRecordsProcessor);
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -100,7 +100,7 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
             .descriptors(exporterDescriptors)
             .exporterMode(exporterMode)
             .positionsToSkipFilter(exporterFilter)
-            .meterRegistry(context.getPartitionMeterRegistry());
+            .meterRegistry(context.getPartitionTransitionMeterRegistry());
 
     final ExporterDirector director = new ExporterDirector(exporterCtx, !context.shouldExport());
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
@@ -96,7 +96,7 @@ public final class LogStreamPartitionTransitionStep implements PartitionTransiti
         .withPartitionId(context.getPartitionId())
         .withMaxFragmentSize(context.getMaxFragmentSize())
         .withActorSchedulingService(context.getActorSchedulingService())
-        .withMeterRegistry(context.getPartitionMeterRegistry())
+        .withMeterRegistry(context.getPartitionTransitionMeterRegistry())
         .buildAsync();
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MetricsStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MetricsStep.java
@@ -18,19 +18,19 @@ public final class MetricsStep implements PartitionTransitionStep {
   @Override
   public ActorFuture<Void> prepareTransition(
       final PartitionTransitionContext context, final long term, final Role targetRole) {
-    final var partitionMeterRegistry =
+    final var transitionMeterRegistry =
         (CompositeMeterRegistry) context.getPartitionTransitionMeterRegistry();
-    final var brokerMeterRegistry = context.getPartitionStartupMeterRegistry();
-    if (partitionMeterRegistry != null) {
+    final var startupMeterRegistry = context.getPartitionStartupMeterRegistry();
+    if (transitionMeterRegistry != null) {
       // Clear all meters from the partition registry. Their values are invalid after the
       // transition.
-      partitionMeterRegistry.clear();
+      transitionMeterRegistry.clear();
       // Remove the backing broker registry from the partition registry so that we can close the
       // partition registry without closing the broker registry.
       // This also increases reliability in case something holds on to the partition registry
       // because any new meters will no longer be forwarded to the broker registry.
-      partitionMeterRegistry.remove(brokerMeterRegistry);
-      partitionMeterRegistry.close();
+      transitionMeterRegistry.remove(startupMeterRegistry);
+      transitionMeterRegistry.close();
       context.setPartitionTransitionMeterRegistry(null);
     }
     return context.getConcurrencyControl().createCompletedFuture();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MetricsStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MetricsStep.java
@@ -39,14 +39,13 @@ public final class MetricsStep implements PartitionTransitionStep {
   @Override
   public ActorFuture<Void> transitionTo(
       final PartitionTransitionContext context, final long term, final Role targetRole) {
-    final var brokerRegistry = context.getPartitionStartupMeterRegistry();
+    final var startupMeterRegistry = context.getPartitionStartupMeterRegistry();
+    final var transitionRegistry = new CompositeMeterRegistry();
 
-    // Create a new registry that already has the partition tag defined.
-    final var partitionRegistry = new CompositeMeterRegistry();
     // Wrap over the broker registry so that all meters are forwarded to the broker registry.
-    partitionRegistry.add(brokerRegistry);
+    transitionRegistry.add(startupMeterRegistry);
 
-    context.setPartitionTransitionMeterRegistry(partitionRegistry);
+    context.setPartitionTransitionMeterRegistry(transitionRegistry);
     return context.getConcurrencyControl().createCompletedFuture();
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MetricsStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MetricsStep.java
@@ -11,7 +11,6 @@ import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 
 public final class MetricsStep implements PartitionTransitionStep {
@@ -19,8 +18,9 @@ public final class MetricsStep implements PartitionTransitionStep {
   @Override
   public ActorFuture<Void> prepareTransition(
       final PartitionTransitionContext context, final long term, final Role targetRole) {
-    final var partitionMeterRegistry = (CompositeMeterRegistry) context.getPartitionMeterRegistry();
-    final var brokerMeterRegistry = context.getBrokerMeterRegistry();
+    final var partitionMeterRegistry =
+        (CompositeMeterRegistry) context.getPartitionTransitionMeterRegistry();
+    final var brokerMeterRegistry = context.getPartitionStartupMeterRegistry();
     if (partitionMeterRegistry != null) {
       // Clear all meters from the partition registry. Their values are invalid after the
       // transition.
@@ -31,7 +31,7 @@ public final class MetricsStep implements PartitionTransitionStep {
       // because any new meters will no longer be forwarded to the broker registry.
       partitionMeterRegistry.remove(brokerMeterRegistry);
       partitionMeterRegistry.close();
-      context.setPartitionMeterRegistry(null);
+      context.setPartitionTransitionMeterRegistry(null);
     }
     return context.getConcurrencyControl().createCompletedFuture();
   }
@@ -39,17 +39,14 @@ public final class MetricsStep implements PartitionTransitionStep {
   @Override
   public ActorFuture<Void> transitionTo(
       final PartitionTransitionContext context, final long term, final Role targetRole) {
-    final var brokerRegistry = context.getBrokerMeterRegistry();
+    final var brokerRegistry = context.getPartitionStartupMeterRegistry();
 
     // Create a new registry that already has the partition tag defined.
     final var partitionRegistry = new CompositeMeterRegistry();
-    partitionRegistry
-        .config()
-        .commonTags(Tags.of("partition", Integer.toString(context.getPartitionId())));
     // Wrap over the broker registry so that all meters are forwarded to the broker registry.
     partitionRegistry.add(brokerRegistry);
 
-    context.setPartitionMeterRegistry(partitionRegistry);
+    context.setPartitionTransitionMeterRegistry(partitionRegistry);
     return context.getConcurrencyControl().createCompletedFuture();
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -143,7 +143,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
         List.of(engine, context.getCheckpointProcessor());
     final var scheduledCommandCache =
         BoundedScheduledCommandCache.ofIntent(
-            new BoundedCommandCacheMetrics(context.getPartitionMeterRegistry()),
+            new BoundedCommandCacheMetrics(context.getPartitionTransitionMeterRegistry()),
             TimerIntent.TRIGGER,
             JobIntent.TIME_OUT,
             JobIntent.RECUR_AFTER_BACKOFF,
@@ -152,7 +152,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
         SkipPositionsFilter.of(context.getBrokerCfg().getProcessing().skipPositions());
 
     return StreamProcessor.builder()
-        .meterRegistry(context.getPartitionMeterRegistry())
+        .meterRegistry(context.getPartitionTransitionMeterRegistry())
         .logStream(context.getLogStream())
         .actorSchedulingService(context.getActorSchedulingService())
         .zeebeDb(context.getZeebeDb())

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionFactoryTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/RaftPartitionFactoryTest.java
@@ -212,13 +212,14 @@ public final class RaftPartitionFactoryTest {
   }
 
   private RaftPartition buildRaftPartition(final BrokerCfg brokerCfg) {
-    return new RaftPartitionFactory(brokerCfg, meterRegistry)
+    return new RaftPartitionFactory(brokerCfg)
         .createRaftPartition(
             new PartitionMetadata(
                 PartitionId.from("test", 1),
                 Set.of(MemberId.from("1")),
                 Map.of(),
                 1,
-                MemberId.from("1")));
+                MemberId.from("1")),
+            meterRegistry);
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -53,7 +53,7 @@ import java.util.function.Consumer;
 
 public class TestPartitionTransitionContext implements PartitionTransitionContext {
 
-  private final CompositeMeterRegistry brokerMeterRegistry = new CompositeMeterRegistry();
+  private final CompositeMeterRegistry startupMeterRegistry = new CompositeMeterRegistry();
 
   private RaftPartition raftPartition;
   private Role currentRole;
@@ -79,13 +79,13 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   private BackupManager backupManager;
   private CheckpointRecordsProcessor checkpointRecordsProcessor;
   private BackupStore backupStore;
-  private MeterRegistry partitionMeterRegistry;
+  private MeterRegistry transitionMeterRegistry;
 
   public TestPartitionTransitionContext() {
-    partitionMeterRegistry = new SimpleMeterRegistry();
-    partitionMeterRegistry.config().commonTags("partitionId", "1");
+    transitionMeterRegistry = new SimpleMeterRegistry();
+    transitionMeterRegistry.config().commonTags("partitionId", "1");
 
-    brokerMeterRegistry.add(partitionMeterRegistry);
+    startupMeterRegistry.add(transitionMeterRegistry);
   }
 
   @Override
@@ -300,18 +300,18 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   }
 
   @Override
-  public MeterRegistry getBrokerMeterRegistry() {
-    return brokerMeterRegistry;
+  public MeterRegistry getPartitionStartupMeterRegistry() {
+    return startupMeterRegistry;
   }
 
   @Override
-  public MeterRegistry getPartitionMeterRegistry() {
-    return partitionMeterRegistry;
+  public MeterRegistry getPartitionTransitionMeterRegistry() {
+    return transitionMeterRegistry;
   }
 
   @Override
-  public void setPartitionMeterRegistry(final MeterRegistry partitionMeterRegistry) {
-    this.partitionMeterRegistry = partitionMeterRegistry;
+  public void setPartitionTransitionMeterRegistry(final MeterRegistry transitionMeterRegistry) {
+    this.transitionMeterRegistry = transitionMeterRegistry;
   }
 
   public void setGatewayBrokerTransport(final AtomixServerTransport gatewayBrokerTransport) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
@@ -78,7 +78,7 @@ public class ZeebePartitionTest {
     when(ctx.getPartitionContext()).thenReturn(ctx);
     when(ctx.getComponentHealthMonitor()).thenReturn(healthMonitor);
     when(ctx.createTransitionContext()).thenReturn(ctx);
-    when(ctx.getBrokerMeterRegistry()).thenReturn(new SimpleMeterRegistry());
+    when(ctx.getPartitionStartupMeterRegistry()).thenReturn(new SimpleMeterRegistry());
 
     partition = new ZeebePartition(ctx, transition, List.of(new NoopStartupStep()));
   }


### PR DESCRIPTION
## Description

This PR introduces a root, per-partition meter registry using a common partition tag, which is created on partition startup (bootstrap and join). This is distinguished from the `ZeebePartition`'s per transition meter registry, which is used when we have metrics that report the state of objects recreated during a transition.

> [!Note]
> As @entangled90 raised, there are probably nicer ways to do this, and we may not want to have a per-transition registry, but it was outside of scope here.

This is in preparation to migrating the snapshot metrics.

## Related issues

related to #26078 
