### PR TITLE
Migrate snapshot metrics to micrometer

### DIFF
--- a/monitor/grafana/zeebe.json
+++ b/monitor/grafana/zeebe.json
@@ -4178,6 +4178,18 @@
               "legendFormat": "{{le}}",
               "range": true,
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "uid": "$DS_PROMETHEUS"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(zeebe_snapshot_duration_seconds_bucket{cluster=~\"$cluster\", namespace=~\"$namespace\",pod=~\"$pod\",partition=~\"$partition\"}[$__rate_interval])) by (le)",
+              "format": "heatmap",
+              "interval": "",
+              "legendFormat": "{{le}}",
+              "range": true,
+              "refId": "B"
             }
           ],
           "title": "Snapshot Operation Duration",

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
@@ -29,7 +29,8 @@ public final class SnapshotStoreStep implements StartupStep<PartitionStartupCont
         new FileBasedSnapshotStore(
             context.partitionMetadata().id().id(),
             context.partitionDirectory(),
-            new ChecksumProviderRocksDBImpl());
+            new ChecksumProviderRocksDBImpl(),
+            context.partitionMeterRegistry());
 
     final var submit =
         context.schedulingService().submitActor(snapshotStore, SchedulingHints.ioBound());

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
@@ -82,7 +82,9 @@ public class ConcurrentBackupCompactionTest extends DynamicAutoCloseable {
     actorScheduler.start();
     backupStore = manage(new InMemoryMockBackupStore());
     snapshotStore =
-        manage(new FileBasedSnapshotStore(partitionId, dataDirectory, snapshotPath -> Map.of()));
+        manage(
+            new FileBasedSnapshotStore(
+                partitionId, dataDirectory, snapshotPath -> Map.of(), meterRegistry));
     actorScheduler.submitActor(snapshotStore, SchedulingHints.IO_BOUND);
 
     final var partitionMetadata =

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.test.util.AutoCloseableRule;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
@@ -62,7 +63,8 @@ public final class AsyncSnapshottingTest {
     final var rootDirectory = tempFolderRule.getRoot().toPath();
     final int partitionId = 1;
     persistedSnapshotStore =
-        new FileBasedSnapshotStore(partitionId, rootDirectory, snapshotPath -> Map.of());
+        new FileBasedSnapshotStore(
+            partitionId, rootDirectory, snapshotPath -> Map.of(), new SimpleMeterRegistry());
     actorSchedulerRule.submitActor(persistedSnapshotStore).join();
 
     snapshotController =

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.snapshots.SnapshotException.StateClosedException;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotId;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
 import io.camunda.zeebe.test.util.AutoCloseableRule;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -63,7 +64,10 @@ public final class StateControllerImplTest {
 
     store =
         new FileBasedSnapshotStore(
-            1, tempFolderRule.newFolder("data").toPath(), snapshotPath -> Map.of());
+            1,
+            tempFolderRule.newFolder("data").toPath(),
+            snapshotPath -> Map.of(),
+            new SimpleMeterRegistry());
     actorSchedulerRule.submitActor(store).join();
 
     runtimeDirectory = tempFolderRule.getRoot().toPath().resolve("runtime");

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/TestState.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/TestState.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
 import io.camunda.zeebe.util.FileUtil;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -46,7 +47,8 @@ final class TestState {
     actorScheduler.start();
 
     final var snapshotStore =
-        new FileBasedSnapshotStore(1, tempDirectory, snapshotPath -> Map.of());
+        new FileBasedSnapshotStore(
+            1, tempDirectory, snapshotPath -> Map.of(), new SimpleMeterRegistry());
     actorScheduler.submitActor(snapshotStore).join();
 
     generateSnapshot(snapshotStore, sizeInBytes);

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -110,7 +110,7 @@ public class RestoreManager {
 
     final var registry = partition.registry();
     return new PartitionRestoreService(
-            backupStore, raftPartition, new ChecksumProviderRocksDBImpl())
+            backupStore, raftPartition, new ChecksumProviderRocksDBImpl(), partition.registry())
         .restore(backupId, validator)
         .thenAccept(backup -> logSuccessfulRestore(backup, raftPartition.id().id(), backupId))
         .whenComplete(

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -86,7 +86,8 @@ class PartitionRestoreServiceTest {
     backupStore = new TestRestorableBackupStore();
 
     snapshotStore =
-        new FileBasedSnapshotStore(partitionId, dataDirectory, snapshotPath -> Map.of());
+        new FileBasedSnapshotStore(
+            partitionId, dataDirectory, snapshotPath -> Map.of(), meterRegistry);
     actorScheduler.submitActor(snapshotStore, SchedulingHints.IO_BOUND);
 
     final var partitionMetadata =
@@ -95,7 +96,8 @@ class PartitionRestoreServiceTest {
     final var raftPartition =
         new RaftPartition(partitionMetadata, null, dataDirectoryToRestore.toFile(), meterRegistry);
     restoreService =
-        new PartitionRestoreService(backupStore, raftPartition, snapshotPath -> Map.of());
+        new PartitionRestoreService(
+            backupStore, raftPartition, snapshotPath -> Map.of(), meterRegistry);
 
     journal =
         SegmentedJournal.builder(meterRegistry)

--- a/zeebe/snapshot/pom.xml
+++ b/zeebe/snapshot/pom.xml
@@ -27,8 +27,13 @@
     </dependency>
 
     <dependency>
-      <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient</artifactId>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-commons</artifactId>
     </dependency>
 
     <dependency>

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.snapshots.SnapshotId;
 import io.camunda.zeebe.snapshots.TransientSnapshot;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.FileUtil;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -84,7 +85,10 @@ public final class FileBasedSnapshotStore extends Actor
   private final int partitionId;
 
   public FileBasedSnapshotStore(
-      final int partitionId, final Path root, final ChecksumProvider checksumProvider) {
+      final int partitionId,
+      final Path root,
+      final ChecksumProvider checksumProvider,
+      final MeterRegistry meterRegistry) {
     snapshotsDirectory = root.resolve(SNAPSHOTS_DIRECTORY);
     pendingDirectory = root.resolve(PENDING_DIRECTORY);
 
@@ -95,7 +99,7 @@ public final class FileBasedSnapshotStore extends Actor
       throw new UncheckedIOException("Failed to create snapshot directories", e);
     }
 
-    snapshotMetrics = new SnapshotMetrics(String.valueOf(partitionId));
+    snapshotMetrics = new SnapshotMetrics(meterRegistry);
     receivingSnapshotStartCount = new AtomicLong();
 
     listeners = new CopyOnWriteArraySet<>();

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotMetricsDoc.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotMetricsDoc.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.snapshots.impl;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter.Type;
+
+@SuppressWarnings("NullableProblems")
+public enum SnapshotMetricsDoc implements ExtendedMeterDocumentation {
+  /** Total count of committed snapshots on disk */
+  SNAPSHOT_COUNT {
+    @Override
+    public String getDescription() {
+      return "Total count of committed snapshots on disk";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.snapshot.count";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.COUNTER;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+
+  /** Estimated snapshot size on disk */
+  SNAPSHOT_SIZE {
+    @Override
+    public String getDescription() {
+      return "Estimated snapshot size on disk";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.snapshot.size.bytes";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+
+  /** Number of chunks in the last snapshot */
+  SNAPSHOT_CHUNK_COUNT {
+    @Override
+    public String getDescription() {
+      return "Number of chunks in the last snapshot";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.snapshot.chunks.count";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+
+  /** Approximate duration of snapshot operation */
+  SNAPSHOT_DURATION {
+    @Override
+    public String getDescription() {
+      return "Approximate duration of snapshot operation";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.snapshot.duration";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+
+  /** Approximate duration of snapshot persist operation */
+  SNAPSHOT_PERSIST_DURATION {
+    @Override
+    public String getDescription() {
+      return "Approximate duration of snapshot persist operation";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.snapshot.persist.duration";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return PartitionKeyNames.values();
+    }
+  },
+  /** Approximate size of snapshot files */
+  SNAPSHOT_FILE_SIZE {
+    private static final double[] BUCKETS = {.01, .1, .5, 1, 5, 10, 25, 50, 100, 250, 500};
+
+    @Override
+    public String getDescription() {
+      return "Approximate size of snapshot files";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.snapshot.file.size.megabytes";
+    }
+
+    @Override
+    public String getBaseUnit() {
+      return "MB";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.DISTRIBUTION_SUMMARY;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return PartitionKeyNames.values();
+    }
+
+    @Override
+    public double[] getDistributionSLOs() {
+      return BUCKETS;
+    }
+  }
+}

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/PersistedSnapshotStoreTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/PersistedSnapshotStoreTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Rule;
@@ -30,7 +31,8 @@ public class PersistedSnapshotStoreTest {
     final var root = temporaryFolder.getRoot();
 
     final var snapshotStore =
-        new FileBasedSnapshotStore(partitionId, root.toPath(), snapshotPath -> Map.of());
+        new FileBasedSnapshotStore(
+            partitionId, root.toPath(), snapshotPath -> Map.of(), new SimpleMeterRegistry());
     scheduler.submitActor(snapshotStore).join();
     persistedSnapshotStore = snapshotStore;
   }

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.snapshots.SnapshotException.SnapshotAlreadyExistsExcepti
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
 import io.camunda.zeebe.snapshots.impl.SnapshotWriteException;
 import io.camunda.zeebe.util.FileUtil;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
@@ -52,11 +53,13 @@ public class ReceivedSnapshotTest {
     final var receiverDirectory = temporaryFolder.newFolder("receiver").toPath();
 
     senderSnapshotStore =
-        new FileBasedSnapshotStore(partitionId, senderDirectory, snapshotPath -> Map.of());
+        new FileBasedSnapshotStore(
+            partitionId, senderDirectory, snapshotPath -> Map.of(), new SimpleMeterRegistry());
     scheduler.get().submitActor((Actor) senderSnapshotStore).join();
 
     receiverSnapshotStore =
-        new FileBasedSnapshotStore(partitionId, receiverDirectory, snapshotPath -> Map.of());
+        new FileBasedSnapshotStore(
+            partitionId, receiverDirectory, snapshotPath -> Map.of(), new SimpleMeterRegistry());
 
     scheduler.get().submitActor((Actor) receiverSnapshotStore).join();
   }

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/TransientSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/TransientSnapshotTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.snapshots.SnapshotException.SnapshotAlreadyExistsExcepti
 import io.camunda.zeebe.snapshots.SnapshotException.SnapshotNotFoundException;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
 import io.camunda.zeebe.util.FileUtil;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -49,7 +50,8 @@ public class TransientSnapshotTest {
     final File root = temporaryFolder.getRoot();
 
     snapshotStore =
-        new FileBasedSnapshotStore(partitionId, root.toPath(), snapshotPath -> Map.of());
+        new FileBasedSnapshotStore(
+            partitionId, root.toPath(), snapshotPath -> Map.of(), new SimpleMeterRegistry());
     scheduler.submitActor(snapshotStore).join();
   }
 

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.snapshots.SnapshotChunk;
 import io.camunda.zeebe.snapshots.SnapshotChunkWrapper;
 import io.camunda.zeebe.test.util.asserts.DirectoryAssert;
 import io.camunda.zeebe.util.FileUtil;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
@@ -370,7 +371,9 @@ public class FileBasedReceivedSnapshotTest {
   }
 
   private FileBasedSnapshotStore createStore(final Path root) {
-    final var store = new FileBasedSnapshotStore(PARTITION_ID, root, snapshotPath -> Map.of());
+    final var store =
+        new FileBasedSnapshotStore(
+            PARTITION_ID, root, snapshotPath -> Map.of(), new SimpleMeterRegistry());
     scheduler.submitActor(store);
 
     return store;

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.snapshots.TestChecksumProvider;
 import io.camunda.zeebe.snapshots.TransientSnapshot;
 import io.camunda.zeebe.test.util.asserts.DirectoryAssert;
 import io.camunda.zeebe.util.FileUtil;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
@@ -61,7 +62,8 @@ public class FileBasedSnapshotStoreTest {
     final var root = temporaryFolder.getRoot().toPath();
 
     // when
-    final var store = new FileBasedSnapshotStore(1, root, snapshotPath -> Map.of());
+    final var store =
+        new FileBasedSnapshotStore(1, root, snapshotPath -> Map.of(), new SimpleMeterRegistry());
 
     // then
     assertThat(root.resolve(FileBasedSnapshotStore.SNAPSHOTS_DIRECTORY)).exists().isDirectory();
@@ -257,7 +259,9 @@ public class FileBasedSnapshotStoreTest {
     final var testChecksumProvider = new TestChecksumProvider(badChecksums);
 
     // when
-    final var store = new FileBasedSnapshotStore(1, rootDirectory, testChecksumProvider);
+    final var store =
+        new FileBasedSnapshotStore(
+            1, rootDirectory, testChecksumProvider, new SimpleMeterRegistry());
     scheduler.submitActor(store).join();
     final var takenSnapshot = (FileBasedSnapshot) takeTransientSnapshot(1, store).persist().join();
 
@@ -368,7 +372,10 @@ public class FileBasedSnapshotStoreTest {
 
     final var store =
         new FileBasedSnapshotStore(
-            PARTITION_ID, receiverStorePath, new TestChecksumProvider(fileChecksums));
+            PARTITION_ID,
+            receiverStorePath,
+            new TestChecksumProvider(fileChecksums),
+            new SimpleMeterRegistry());
     scheduler.submitActor(store);
 
     // when
@@ -388,7 +395,10 @@ public class FileBasedSnapshotStoreTest {
 
     final var restartedStore =
         new FileBasedSnapshotStore(
-            PARTITION_ID, receiverStorePath, new TestChecksumProvider(fileChecksums));
+            PARTITION_ID,
+            receiverStorePath,
+            new TestChecksumProvider(fileChecksums),
+            new SimpleMeterRegistry());
     scheduler.submitActor(restartedStore).join();
 
     assertThat(restartedStore.getLatestSnapshot())
@@ -423,7 +433,8 @@ public class FileBasedSnapshotStoreTest {
   }
 
   private FileBasedSnapshotStore createStore(final Path root) {
-    final var store = new FileBasedSnapshotStore(1, root, snapshotPath -> Map.of());
+    final var store =
+        new FileBasedSnapshotStore(1, root, snapshotPath -> Map.of(), new SimpleMeterRegistry());
     scheduler.submitActor(store).join();
 
     return store;

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
 import io.camunda.zeebe.snapshots.SnapshotMetadata;
 import io.camunda.zeebe.test.util.asserts.DirectoryAssert;
 import io.camunda.zeebe.util.FileUtil;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
@@ -357,8 +358,9 @@ public class FileBasedTransientSnapshotTest {
     return true;
   }
 
-  private FileBasedSnapshotStore createStore(final Path root) throws IOException {
-    final var store = new FileBasedSnapshotStore(1, root, snapshotPath -> Map.of());
+  private FileBasedSnapshotStore createStore(final Path root) {
+    final var store =
+        new FileBasedSnapshotStore(1, root, snapshotPath -> Map.of(), new SimpleMeterRegistry());
     scheduler.submitActor(store);
     return store;
   }


### PR DESCRIPTION
## Description

This PR migrates the snapshot metrics to Micrometer. Note that it depends on https://github.com/camunda/camunda/pull/28026.

There were two timers whose names changed, but only one was in use in a dashboard.

## Related issues

related #26078 
closes #27151 
