### PR TITLE
Refactor the multi DB setup to clean up test data correctly

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/CamundaMultiDBExtension.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/CamundaMultiDBExtension.java
@@ -7,38 +7,20 @@
  */
 package io.camunda.it.utils;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.qa.util.cluster.TestSimpleCamundaApplication;
-import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
-import java.io.IOException;
 import java.lang.reflect.Field;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.Callable;
 import java.util.function.Predicate;
-import java.util.stream.StreamSupport;
 import org.agrona.CloseHelper;
 import org.awaitility.Awaitility;
-import org.awaitility.core.ThrowingRunnable;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -107,16 +89,14 @@ public class CamundaMultiDBExtension
   public static final String DEFAULT_OS_ADMIN_USER = "admin";
   public static final String DEFAULT_OS_ADMIN_PW = "yourStrongPassword123!";
   public static final Duration TIMEOUT_DATABASE_EXPORTER_READINESS = Duration.ofMinutes(1);
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  public static final Duration TIMEOUT_DATABASE_READINESS = Duration.ofMinutes(1);
   private static final Logger LOGGER = LoggerFactory.getLogger(CamundaMultiDBExtension.class);
-
   private final DatabaseType databaseType;
   private final List<AutoCloseable> closeables = new ArrayList<>();
   private final TestStandaloneApplication<?> testApplication;
   private String testPrefix;
   private final MultiDbConfigurator multiDbConfigurator;
-  private ThrowingRunnable databaseSetupReadinessWaitStrategy = () -> {};
-  private final HttpClient httpClient;
+  private MultiDbSetupHelper setupHelper = new NoopDBSetupHelper();
 
   public CamundaMultiDBExtension() {
     this(new TestStandaloneBroker());
@@ -134,8 +114,6 @@ public class CamundaMultiDBExtension
     final String property = System.getProperty(PROP_CAMUNDA_IT_DATABASE_TYPE);
     databaseType =
         property == null ? DatabaseType.LOCAL : DatabaseType.valueOf(property.toUpperCase());
-    httpClient = HttpClient.newHttpClient();
-    closeables.add(httpClient);
   }
 
   @Override
@@ -148,36 +126,39 @@ public class CamundaMultiDBExtension
       case LOCAL -> {
         final ElasticsearchContainer elasticsearchContainer = setupElasticsearch();
         final String elasticSearchUrl = "http://" + elasticsearchContainer.getHttpHostAddress();
-        validateESConnection(elasticSearchUrl);
         multiDbConfigurator.configureElasticsearchSupport(elasticSearchUrl, testPrefix);
         final var expectedDescriptors = new IndexDescriptors(testPrefix, true).all();
-        databaseSetupReadinessWaitStrategy =
-            () -> validateSchemaCreation(elasticSearchUrl, testPrefix, expectedDescriptors);
+        setupHelper = new ElasticOpenSearchSetupHelper(elasticSearchUrl, expectedDescriptors);
       }
       case ES -> {
-        validateESConnection(DEFAULT_ES_URL);
         multiDbConfigurator.configureElasticsearchSupport(DEFAULT_ES_URL, testPrefix);
         final var expectedDescriptors = new IndexDescriptors(testPrefix, true).all();
-        databaseSetupReadinessWaitStrategy =
-            () -> validateSchemaCreation(DEFAULT_ES_URL, testPrefix, expectedDescriptors);
+        setupHelper = new ElasticOpenSearchSetupHelper(DEFAULT_ES_URL, expectedDescriptors);
       }
       case OS -> {
-        validateESConnection(DEFAULT_OS_URL);
         multiDbConfigurator.configureOpenSearchSupport(
             DEFAULT_OS_URL, testPrefix, DEFAULT_OS_ADMIN_USER, DEFAULT_OS_ADMIN_PW);
         final var expectedDescriptors = new IndexDescriptors(testPrefix, true).all();
-        databaseSetupReadinessWaitStrategy =
-            () -> validateSchemaCreation(DEFAULT_ES_URL, testPrefix, expectedDescriptors);
+        setupHelper = new ElasticOpenSearchSetupHelper(DEFAULT_OS_URL, expectedDescriptors);
       }
       case RDBMS -> multiDbConfigurator.configureRDBMSSupport();
       default -> throw new RuntimeException("Unknown exporter type");
     }
+    // we need to close the test application before cleaning up
+    closeables.add(() -> setupHelper.cleanup(testPrefix));
+    closeables.add(setupHelper);
+
+    Awaitility.await("Await secondary storage connection")
+        .timeout(TIMEOUT_DATABASE_READINESS)
+        .until(setupHelper::validateConnection);
+
     testApplication.start();
     testApplication.awaitCompleteTopology();
 
-    Awaitility.await("Await database and exporter readiness")
+    Awaitility.await("Await exporter readiness")
         .timeout(TIMEOUT_DATABASE_EXPORTER_READINESS)
-        .untilAsserted(databaseSetupReadinessWaitStrategy);
+        .pollInterval(Duration.ofMillis(200))
+        .until(() -> setupHelper.validateSchemaCreation(testPrefix));
 
     injectFields(testClass, null, ModifierSupport::isStatic);
   }
@@ -188,85 +169,6 @@ public class CamundaMultiDBExtension
     elasticsearchContainer.start();
     closeables.add(elasticsearchContainer);
     return elasticsearchContainer;
-  }
-
-  /**
-   * Validate the schema creation. Expects harmonized indices to be created. Optimize indices and ES
-   * Exporter are not included.
-   *
-   * <p>ES exporter indices are only created, on first exporting, so we expect at least this amount
-   * or more (to fight race conditions).
-   *
-   * @param url the url to get actual indices
-   * @param testPrefix the test prefix of the actual indices
-   * @param expectedDescriptors expected descriptors
-   */
-  private void validateSchemaCreation(
-      final String url,
-      final String testPrefix,
-      final Collection<IndexDescriptor> expectedDescriptors) {
-    final HttpRequest httpRequest =
-        HttpRequest.newBuilder()
-            .GET()
-            .uri(URI.create(String.format("%s/%s*", url, testPrefix)))
-            .build();
-    try {
-      final HttpResponse<String> response = httpClient.send(httpRequest, BodyHandlers.ofString());
-      final int statusCode = response.statusCode();
-      assertThat(statusCode).isBetween(200, 299);
-
-      // Get how many indices with given prefix we have
-      final JsonNode jsonNode = OBJECT_MAPPER.readTree(response.body());
-      final int count = jsonNode.size();
-      final boolean reachedCount = expectedDescriptors.size() <= count;
-      if (reachedCount) {
-        // Expected indices reached
-        return;
-      }
-
-      LOGGER.debug(
-          "[{}/{}] indices with prefix {} in ES, retry...",
-          count,
-          expectedDescriptors.size(),
-          testPrefix);
-
-      final Iterator<String> stringIterator = jsonNode.fieldNames();
-      final Iterable<String> iterable = () -> stringIterator;
-      final List<String> actualIndices =
-          StreamSupport.stream(iterable.spliterator(), false).toList();
-
-      final var expectedIndexNames =
-          expectedDescriptors.stream().map(IndexDescriptor::getFullQualifiedName).toList();
-      assertThat(actualIndices).as("Missing indices").containsAll(expectedIndexNames);
-    } catch (final IOException | InterruptedException e) {
-      fail(
-          "Expected no exception on validating connection under: "
-              + url
-              + ", failed with: "
-              + e
-              + ": "
-              + e.getMessage(),
-          e);
-    }
-  }
-
-  private static void validateESConnection(final String url) {
-    final HttpRequest httpRequest =
-        HttpRequest.newBuilder().GET().uri(URI.create(String.format("%s/", url))).build();
-    try (final HttpClient httpClient = HttpClient.newHttpClient()) {
-      final HttpResponse<String> response = httpClient.send(httpRequest, BodyHandlers.ofString());
-      final int statusCode = response.statusCode();
-      assert statusCode / 100 == 2
-          : "Expected to have a running ES service available under: " + url;
-    } catch (final IOException | InterruptedException e) {
-      assert false
-          : "Expected no exception on validating connection under: "
-              + url
-              + ", failed with: "
-              + e
-              + ": "
-              + e.getMessage();
-    }
   }
 
   private void injectFields(
@@ -284,83 +186,9 @@ public class CamundaMultiDBExtension
     }
   }
 
-  private void withRetry(final Callable<Boolean> operation, final int maxAttempt) {
-    int attempt = 0;
-    boolean shouldRetry = true;
-    while (shouldRetry) {
-      try {
-        // if we succeed we don't want to retry
-        shouldRetry = !operation.call();
-      } catch (final Exception ex) {
-        LOGGER.debug(
-            "Failed to execute {}. Attempts: [{}/{}]", operation, attempt + 1, maxAttempt, ex);
-      } finally {
-        // if we reached the max attempt we stop
-        if (++attempt >= maxAttempt) {
-          shouldRetry = false;
-        }
-      }
-
-      if (shouldRetry) {
-        try {
-          // wait a little between retries
-          Thread.sleep(100);
-        } catch (final InterruptedException e) {
-          throw new RuntimeException(e);
-        }
-      }
-    }
-  }
-
   @Override
   public void afterAll(final ExtensionContext context) {
-    if (databaseType == DatabaseType.ES || databaseType == DatabaseType.OS) {
-      try (final HttpClient httpClient = HttpClient.newHttpClient()) {
-
-        // delete indices
-        // https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-delete-index.html
-        withRetry(
-            () -> {
-              final URI deleteIndicesEndpoint =
-                  URI.create(String.format("%s/%s-*", DEFAULT_ES_URL, testPrefix));
-              return sendHttpDeleteRequest(httpClient, deleteIndicesEndpoint);
-            },
-            5);
-
-        // Deleting index templates are separate from deleting indices, and we need to make sure
-        // that we also get rid of the template, so we can properly recreate them
-        // https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-delete-template.html
-        //
-        // See related CI incident https://github.com/camunda/camunda/pull/27985
-        withRetry(
-            () -> {
-              final URI deleteIndexTemplatesEndpoint =
-                  URI.create(String.format("%s/_index_template/%s-*", DEFAULT_ES_URL, testPrefix));
-              return sendHttpDeleteRequest(httpClient, deleteIndexTemplatesEndpoint);
-            },
-            5);
-      }
-    }
     CloseHelper.quietCloseAll(closeables);
-  }
-
-  @NotNull
-  private Boolean sendHttpDeleteRequest(final HttpClient httpClient, final URI deleteEndpoint)
-      throws IOException, InterruptedException {
-    final var httpRequest = HttpRequest.newBuilder().DELETE().uri(deleteEndpoint).build();
-    final var response = httpClient.send(httpRequest, BodyHandlers.ofString());
-    final var statusCode = response.statusCode();
-    if (statusCode / 100 == 2) {
-      LOGGER.info("Deletion on {} was successful", deleteEndpoint.toString());
-      return true;
-    } else {
-      LOGGER.warn(
-          "Failure on deletion at {}. Status code: {} [{}]",
-          deleteEndpoint.toString(),
-          statusCode,
-          response.body());
-    }
-    return false;
   }
 
   @Override
@@ -381,6 +209,24 @@ public class CamundaMultiDBExtension
     final CamundaClient camundaClient = testApplication.newClientBuilder().build();
     closeables.add(camundaClient);
     return camundaClient;
+  }
+
+  private static final class NoopDBSetupHelper implements MultiDbSetupHelper {
+    @Override
+    public boolean validateConnection() {
+      return true;
+    }
+
+    @Override
+    public boolean validateSchemaCreation(final String prefix) {
+      return true;
+    }
+
+    @Override
+    public void cleanup(final String prefix) {}
+
+    @Override
+    public void close() throws Exception {}
   }
 
   public enum DatabaseType {

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/ElasticOpenSearchSetupHelper.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/ElasticOpenSearchSetupHelper.java
@@ -132,6 +132,17 @@ public class ElasticOpenSearchSetupHelper implements MultiDbSetupHelper {
             testPrefix);
         return false;
       }
+
+      final int templateCount = getCountOfIndexTemplatesWithPrefix(endpoint, testPrefix);
+      if (templateCount <= 0) {
+        LOGGER.debug("{} templates found for prefix {}, retry...", templateCount, testPrefix);
+        return false;
+      }
+
+      LOGGER.debug(
+          "Found {} indices and {} index templates. Schema creation validated.",
+          count,
+          templateCount);
       return true;
     } catch (final IOException | InterruptedException e) {
       LOGGER.debug("Exception on retrieving schema with prefix {}", testPrefix, e);

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/ElasticOpenSearchSetupHelper.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/ElasticOpenSearchSetupHelper.java
@@ -158,8 +158,7 @@ public class ElasticOpenSearchSetupHelper implements MultiDbSetupHelper {
       // https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-delete-index.html
       withRetry(
           () -> {
-            final URI deleteIndicesEndpoint =
-                URI.create(String.format("%s/%s-*", endpoint, prefix));
+            final URI deleteIndicesEndpoint = URI.create(String.format("%s/%s*", endpoint, prefix));
             return sendHttpDeleteRequest(httpClient, deleteIndicesEndpoint);
           },
           5);
@@ -172,7 +171,7 @@ public class ElasticOpenSearchSetupHelper implements MultiDbSetupHelper {
       withRetry(
           () -> {
             final URI deleteIndexTemplatesEndpoint =
-                URI.create(String.format("%s/_index_template/%s-*", endpoint, prefix));
+                URI.create(String.format("%s/_index_template/%s*", endpoint, prefix));
             return sendHttpDeleteRequest(httpClient, deleteIndexTemplatesEndpoint);
           },
           5);

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/ElasticOpenSearchSetupHelper.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/ElasticOpenSearchSetupHelper.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Collection;
+import java.util.concurrent.Callable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ElasticOpenSearchSetupHelper implements MultiDbSetupHelper {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final Logger LOGGER = LoggerFactory.getLogger(ElasticOpenSearchSetupHelper.class);
+  private final HttpClient httpClient = HttpClient.newHttpClient();
+
+  private final Collection<IndexDescriptor> expectedDescriptors;
+  private final String endpoint;
+
+  public ElasticOpenSearchSetupHelper(
+      final String endpoint, final Collection<IndexDescriptor> expectedDescriptors) {
+    this.endpoint = endpoint;
+    this.expectedDescriptors = expectedDescriptors;
+  }
+
+  @Override
+  public void close() {
+    httpClient.close();
+  }
+
+  /**
+   * Run given callable with retry. Callable should return true, if operation succeeded, to stop
+   * retrying.
+   *
+   * @param operation operation to be executed with retry, returning true will stop communicate
+   *     success and stop retrying
+   * @param maxAttempt the maximum attempts to retry given operation
+   */
+  private void withRetry(final Callable<Boolean> operation, final int maxAttempt) {
+    int attempt = 0;
+    boolean shouldRetry = true;
+    while (shouldRetry) {
+      try {
+        // if we succeed we don't want to retry
+        shouldRetry = !operation.call();
+      } catch (final Exception ex) {
+        LOGGER.debug(
+            "Failed to execute {}. Attempts: [{}/{}]", operation, attempt + 1, maxAttempt, ex);
+      } finally {
+        // if we reached the max attempt we stop
+        if (++attempt >= maxAttempt) {
+          shouldRetry = false;
+        }
+      }
+
+      if (shouldRetry) {
+        try {
+          // wait a little between retries
+          Thread.sleep(100);
+        } catch (final InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    }
+  }
+
+  private boolean sendHttpDeleteRequest(final HttpClient httpClient, final URI deleteEndpoint)
+      throws IOException, InterruptedException {
+    final var httpRequest = HttpRequest.newBuilder().DELETE().uri(deleteEndpoint).build();
+    final var response = httpClient.send(httpRequest, BodyHandlers.ofString());
+    final var statusCode = response.statusCode();
+    if (statusCode / 100 == 2) {
+      LOGGER.info("Deletion on {} was successful", deleteEndpoint.toString());
+      return true;
+    } else {
+      LOGGER.warn(
+          "Failure on deletion at {}. Status code: {} [{}]",
+          deleteEndpoint.toString(),
+          statusCode,
+          response.body());
+    }
+    return false;
+  }
+
+  @Override
+  public boolean validateConnection() {
+    final HttpRequest httpRequest =
+        HttpRequest.newBuilder().GET().uri(URI.create(String.format("%s/", endpoint))).build();
+    try (final HttpClient httpClient = HttpClient.newHttpClient()) {
+      final HttpResponse<String> response = httpClient.send(httpRequest, BodyHandlers.ofString());
+      final int statusCode = response.statusCode();
+      return statusCode / 100 == 2;
+    } catch (final IOException | InterruptedException e) {
+      LOGGER.debug("Exception on validating exception", e);
+    }
+    return false;
+  }
+
+  /**
+   * Validate the schema creation. Expects harmonized indices to be created. Optimize indices and ES
+   * Exporter are not included.
+   *
+   * <p>ES exporter indices are only created, on first exporting, so we expect at least this amount
+   * or more (to fight race conditions).
+   *
+   * @param testPrefix the test prefix of the actual indices
+   */
+  @Override
+  public boolean validateSchemaCreation(final String testPrefix) {
+    try {
+      final int count = getCountOfIndicesWithPrefix(endpoint, testPrefix);
+      if (expectedDescriptors.size() > count) {
+        LOGGER.debug(
+            "[{}/{}] indices with prefix {} in secondary storage, retry...",
+            count,
+            expectedDescriptors.size(),
+            testPrefix);
+        return false;
+      }
+      return true;
+    } catch (final IOException | InterruptedException e) {
+      LOGGER.debug("Exception on retrieving schema with prefix {}", testPrefix, e);
+    }
+    return false;
+  }
+
+  @Override
+  public void cleanup(final String prefix) {
+    try (final HttpClient httpClient = HttpClient.newHttpClient()) {
+
+      // delete indices
+      // https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-delete-index.html
+      withRetry(
+          () -> {
+            final URI deleteIndicesEndpoint =
+                URI.create(String.format("%s/%s-*", endpoint, prefix));
+            return sendHttpDeleteRequest(httpClient, deleteIndicesEndpoint);
+          },
+          5);
+
+      // Deleting index templates are separate from deleting indices, and we need to make sure
+      // that we also get rid of the template, so we can properly recreate them
+      // https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-delete-template.html
+      //
+      // See related CI incident https://github.com/camunda/camunda/pull/27985
+      withRetry(
+          () -> {
+            final URI deleteIndexTemplatesEndpoint =
+                URI.create(String.format("%s/_index_template/%s-*", endpoint, prefix));
+            return sendHttpDeleteRequest(httpClient, deleteIndexTemplatesEndpoint);
+          },
+          5);
+    }
+  }
+
+  protected int getCountOfIndicesWithPrefix(final String url, final String testPrefix)
+      throws IOException, InterruptedException {
+    final HttpRequest httpRequest =
+        HttpRequest.newBuilder()
+            .GET()
+            .uri(URI.create(String.format("%s/%s*", url, testPrefix)))
+            .build();
+    final HttpResponse<String> response = httpClient.send(httpRequest, BodyHandlers.ofString());
+    final int statusCode = response.statusCode();
+    assertThat(statusCode).isBetween(200, 299);
+
+    // Get how many indices with given prefix we have
+    final JsonNode jsonNode = OBJECT_MAPPER.readTree(response.body());
+    return jsonNode.size();
+  }
+
+  protected int getCountOfIndexTemplatesWithPrefix(final String url, final String testPrefix)
+      throws IOException, InterruptedException {
+    final HttpRequest httpRequest =
+        HttpRequest.newBuilder()
+            .GET()
+            .uri(URI.create(String.format("%s/_index_template/%s*", url, testPrefix)))
+            .build();
+    final HttpResponse<String> response = httpClient.send(httpRequest, BodyHandlers.ofString());
+    final int statusCode = response.statusCode();
+    if (statusCode == 404) {
+      return 0;
+    }
+
+    assertThat(statusCode).isBetween(200, 299);
+
+    // Get how many indices with given prefix we have
+    final JsonNode jsonNode = OBJECT_MAPPER.readTree(response.body());
+    return jsonNode.get("index_templates").size();
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/ElasticsearchSetupHelperTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/ElasticsearchSetupHelperTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.webapps.schema.descriptors.IndexDescriptors;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+public class ElasticsearchSetupHelperTest {
+
+  private static ElasticsearchContainer elasticsearchContainer;
+  private static String elasticSearchUrl;
+  private ElasticOpenSearchSetupHelper elasticOpenSearchSetupHelper;
+  private String indexPrefix;
+
+  @BeforeAll
+  public static void setUpEs() {
+    elasticsearchContainer = TestSearchContainers.createDefeaultElasticsearchContainer();
+    elasticsearchContainer.start();
+    elasticSearchUrl = "http://" + elasticsearchContainer.getHttpHostAddress();
+  }
+
+  @AfterAll
+  public static void tearDownES() {
+    elasticsearchContainer.close();
+  }
+
+  @Nested
+  public class ConnectionCheck {
+    @Test
+    public void shouldValidateConnection() {
+      // given
+      elasticOpenSearchSetupHelper = new ElasticOpenSearchSetupHelper(elasticSearchUrl, List.of());
+
+      // when
+      final boolean connectionIsValid = elasticOpenSearchSetupHelper.validateConnection();
+
+      // then
+      assertThat(connectionIsValid).isTrue();
+    }
+
+    @Test
+    public void shouldFailValidatingConnectionOnWrongURL() {
+      // given
+      final String wrongEndpoint = "http://wrongUrl";
+      elasticOpenSearchSetupHelper = new ElasticOpenSearchSetupHelper(wrongEndpoint, List.of());
+
+      // when
+      final boolean connectionIsValid = elasticOpenSearchSetupHelper.validateConnection();
+
+      // then
+      assertThat(connectionIsValid).isFalse();
+    }
+  }
+
+  @Nested
+  public class DataCheck {
+
+    private TestStandaloneBroker testApplication;
+    private MultiDbConfigurator multiDbConfigurator;
+    private CamundaClient camundaClient;
+
+    @BeforeEach
+    public void setup() {
+      indexPrefix = UUID.randomUUID().toString().substring(0, 8);
+
+      testApplication = new TestStandaloneBroker();
+      multiDbConfigurator = new MultiDbConfigurator(testApplication);
+
+      multiDbConfigurator.configureElasticsearchSupport(elasticSearchUrl, indexPrefix);
+      final var expectedDescriptors = new IndexDescriptors(indexPrefix, true).all();
+      elasticOpenSearchSetupHelper =
+          new ElasticOpenSearchSetupHelper(elasticSearchUrl, expectedDescriptors);
+
+      testApplication.start();
+      testApplication.awaitCompleteTopology();
+
+      camundaClient = testApplication.newClientBuilder().build();
+
+      // to generate some data - especially for ES exporter
+      camundaClient
+          .newDeployResourceCommand()
+          .addProcessModel(
+              Bpmn.createExecutableProcess("test").startEvent().endEvent().done(), "process.bpmn")
+          .send()
+          .join();
+
+      camundaClient.newCreateInstanceCommand().bpmnProcessId("test").latestVersion().send().join();
+      camundaClient.newCreateInstanceCommand().bpmnProcessId("test").latestVersion().send().join();
+      camundaClient.newCreateInstanceCommand().bpmnProcessId("test").latestVersion().send().join();
+    }
+
+    @Test
+    public void shouldValidateSchema() {
+      // given
+
+      // when
+      Awaitility.await("schema should be created eventually")
+          .untilAsserted(
+              () -> {
+                final boolean schemaHasBeenCreated =
+                    elasticOpenSearchSetupHelper.validateSchemaCreation(indexPrefix);
+
+                // then
+                assertThat(schemaHasBeenCreated).isTrue();
+              });
+    }
+
+    @Test
+    public void shouldFailValidatingSchemaWithWrongIndexPrefix() {
+      // given
+
+      // when
+      final boolean schemaHasBeenCreated =
+          elasticOpenSearchSetupHelper.validateSchemaCreation("wrongPrefix");
+
+      // then
+      assertThat(schemaHasBeenCreated).isFalse();
+    }
+
+    @Test
+    public void shouldCleanupSchema() {
+      // given
+      Awaitility.await("schema should be created eventually")
+          .untilAsserted(
+              () -> {
+                final boolean schemaHasBeenCreated =
+                    elasticOpenSearchSetupHelper.validateSchemaCreation(indexPrefix);
+                assertThat(schemaHasBeenCreated).isTrue();
+
+                // We want to wait in our test whether ES Indices have been created, to validate
+                // clean up works correctly. We need to check for different indices, as ES exporter
+                // indices contain _ after prefix.
+                //
+                // We don't want to have this as part of the #validateSchemaCreation
+                // as they are only created when data is exported. This would mean we need to
+                // generate additional data, to trigger such, which we don't want for most tests
+                final String esExporterPrefix = indexPrefix + "_";
+                final int indexCount =
+                    elasticOpenSearchSetupHelper.getCountOfIndicesWithPrefix(
+                        elasticSearchUrl, esExporterPrefix);
+                assertThat(indexCount).isNotZero();
+                final int templateCount =
+                    elasticOpenSearchSetupHelper.getCountOfIndexTemplatesWithPrefix(
+                        elasticSearchUrl, esExporterPrefix);
+                assertThat(templateCount).isNotZero();
+              });
+      // we need to make sure that the application stopped, before we start deleting
+      // otherwise the test becomes flaky - as we run into race conditions
+      testApplication.close();
+
+      // when
+      elasticOpenSearchSetupHelper.cleanup(indexPrefix);
+
+      // then
+      Awaitility.await("Indices should be cleaned up")
+          .timeout(Duration.ofMinutes(1))
+          .untilAsserted(
+              () -> {
+                final boolean schemaHasBeenCreated =
+                    elasticOpenSearchSetupHelper.validateSchemaCreation(indexPrefix);
+                assertThat(schemaHasBeenCreated).isFalse();
+
+                final int countOfIndicesWithPrefix =
+                    elasticOpenSearchSetupHelper.getCountOfIndicesWithPrefix(
+                        elasticSearchUrl, indexPrefix);
+                assertThat(countOfIndicesWithPrefix).isZero();
+
+                final int countOfIndexTemplatesWithPrefix =
+                    elasticOpenSearchSetupHelper.getCountOfIndexTemplatesWithPrefix(
+                        elasticSearchUrl, indexPrefix);
+                assertThat(countOfIndexTemplatesWithPrefix).isZero();
+              });
+    }
+
+    @AfterEach
+    public void tearDown() {
+      elasticOpenSearchSetupHelper.close();
+      testApplication.close();
+    }
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfigurator.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfigurator.java
@@ -73,7 +73,11 @@ public class MultiDbConfigurator {
         "ElasticsearchExporter",
         cfg -> {
           cfg.setClassName(ElasticsearchExporter.class.getName());
-          cfg.setArgs(Map.of("url", elasticsearchUrl, "index", Map.of("prefix", indexPrefix)));
+          cfg.setArgs(
+              Map.of(
+                  "url", elasticsearchUrl,
+                  "index", Map.of("prefix", indexPrefix),
+                  "bulk", Map.of("size", 1)));
         });
 
     testApplication.withProperty(

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbSetupHelper.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbSetupHelper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.utils;
+
+/**
+ * Helper used in {@link CamundaMultiDBExtension} to manage the multi database setup.
+ *
+ * <p>Different implementations might exist related to different targets, like OpenSearch,
+ * ElasticSearch, RDBMS, etc.
+ */
+public interface MultiDbSetupHelper extends AutoCloseable {
+
+  /**
+   * Validates that the connection can be established to the secondary storage
+   *
+   * @return true if connection can be established, false otherwise
+   */
+  boolean validateConnection();
+
+  /**
+   * To validate schema creation, used to store related test data, which can be identified under
+   * given test prefix.
+   *
+   * @param prefix prefix used to identify related test data
+   * @return true if schema has been created successfully, false otherwise
+   */
+  boolean validateSchemaCreation(final String prefix);
+
+  /**
+   * Clean up test data. Can be called after all tests have been executed.
+   *
+   * <p>Implementations should make sure to clean all related test data (related to the test
+   * prefix).
+   *
+   * @param prefix prefix used to identify related test data
+   */
+  void cleanup(final String prefix);
+}


### PR DESCRIPTION
## Description

**Challenge**: Data is not cleaned up properly, and we have a growing complexity in the extension, handling setup-related code for ES/OS.

### Without this fix (main branch)

ES/OS Exporter indices and templates are not cleaned up correctly. 

![2025-02-12_10-32](https://github.com/user-attachments/assets/56cd052b-7f7b-4586-8ce6-4c6799cbc27e)

![2025-02-12_10-32_1](https://github.com/user-attachments/assets/c866234a-2e89-4ccf-9452-daa4fedfa53f)

### With this refactoring and the fixes:

![2025-02-12_10-19](https://github.com/user-attachments/assets/ccc7f71e-99e7-4ee3-ad28-d8b8d201fbc4)


Context: 

 * CI Incident: [index templates are not cleaned up, causing to fail CI jobs](https://app.slack.com/client/T0PM0P1SA/C08CAP74823) 
 * Investigation showed that ES indices are not cleaned up at all
 * @igpetrov reported that [AWS Opensearch has several indices left ](https://camunda.slack.com/archives/C05QBRGMA9F/p1739276759677299)


## PR contains

This PR tried to clean this up, to overcome the above-mentioned challenge. This is done via:

 * Introduction of a new interface to encapsulate the logic of handling with
 multi db setup like: 
   * validation of connection 
   * schema creation
   * clean up data.
 * Create new implementation for ES/OS setup handling:
   * validate connection
   * validate schema creation
   * deletion of test data
 * Add additional test to verify logic
 * Several fixes are contained here as well:
   * Configure ES exporter bulk size to 1
     * To ensure that flushing happens immediately
     * This reduces potential race conditions, such that indices are earlier created
   and data is exported
   * Validate template creation, to reduce further race conditions and validate clean-up
   * Delete all data not only from Camunda Exporter but also from ES exporter
     * Make sure that we delete all indices and templates.
     * ES Exporter uses a different pattern for prefix _ instead of -. This caused us to not clean up test data correctly.

## Related issues

related #26896 
