### PR TITLE
feat: Validate doc handling setup on startup

### DIFF
--- a/document/api/src/main/java/io/camunda/document/api/DocumentStore.java
+++ b/document/api/src/main/java/io/camunda/document/api/DocumentStore.java
@@ -12,6 +12,10 @@ import java.util.concurrent.CompletableFuture;
 
 public interface DocumentStore {
 
+  String SETUP_VALIDATION_FAILURE_MESSAGE =
+      "The application will continue to operate, "
+          + "but document handling features may be unavailable or limited.";
+
   CompletableFuture<Either<DocumentError, DocumentReference>> createDocument(
       DocumentCreationRequest request);
 
@@ -24,4 +28,6 @@ public interface DocumentStore {
 
   CompletableFuture<Either<DocumentError, Void>> verifyContentHash(
       String documentId, String contentHash);
+
+  default void validateSetup() {}
 }

--- a/document/store/src/main/java/io/camunda/document/store/SimpleDocumentStoreRegistry.java
+++ b/document/store/src/main/java/io/camunda/document/store/SimpleDocumentStoreRegistry.java
@@ -87,6 +87,7 @@ public class SimpleDocumentStoreRegistry implements DocumentStoreRegistry {
     for (final DocumentStoreConfigurationRecord configuration : configurations) {
       final DocumentStoreProvider provider = findProvider(loader, configuration);
       final DocumentStore store = provider.createDocumentStore(configuration, executor);
+      store.validateSetup();
       stores.put(configuration.id(), store);
     }
   }

--- a/document/store/src/main/java/io/camunda/document/store/localstorage/LocalStorageDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/localstorage/LocalStorageDocumentStore.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.util.Either;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -35,7 +36,7 @@ import org.slf4j.Logger;
 public class LocalStorageDocumentStore implements DocumentStore {
 
   public static final String METADATA_SUFFIX = "-metadata";
-  private static final Logger LOG =
+  private static final Logger LOGGER =
       org.slf4j.LoggerFactory.getLogger(LocalStorageDocumentStore.class);
   private final Path storagePath;
   private final FileHandler fileHandler;
@@ -86,6 +87,24 @@ public class LocalStorageDocumentStore implements DocumentStore {
         () -> verifyContentHashInternal(documentId, contentHash), executor);
   }
 
+  @Override
+  public void validateSetup() {
+    try {
+      if (Files.exists(storagePath)) {
+        LOGGER.info("Successfully accessed storage path '{}'", storagePath);
+      } else {
+        LOGGER.warn(
+            "Storage path '{}' does not exist. {}", storagePath, SETUP_VALIDATION_FAILURE_MESSAGE);
+      }
+    } catch (final Exception e) {
+      LOGGER.warn(
+          "Could not verify the existence of the storage path '{}'. {}",
+          storagePath,
+          SETUP_VALIDATION_FAILURE_MESSAGE,
+          e);
+    }
+  }
+
   private Either<DocumentError, DocumentReference> createDocumentInternal(
       final DocumentCreationRequest request) {
     final String documentId = getDocumentId(request);
@@ -99,7 +118,7 @@ public class LocalStorageDocumentStore implements DocumentStore {
         fileHandler.delete(documentFilePath);
         fileHandler.delete(documentMetaDataFilePath);
       } catch (final IOException e) {
-        LOG.warn("Error deleting document or metadata with document ID {}", documentId);
+        LOGGER.warn("Error deleting document or metadata with document ID {}", documentId);
         return Either.left(new UnknownDocumentError(e));
       }
     }

--- a/document/store/src/main/java/io/camunda/document/store/localstorage/LocalStorageDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/localstorage/LocalStorageDocumentStoreProvider.java
@@ -46,7 +46,7 @@ public class LocalStorageDocumentStoreProvider implements DocumentStoreProvider 
           "Failed to configure document store with id '"
               + configuration.id()
               + "': '"
-              + STORAGE_PATH
+              + pathString
               + " must be a valid path'");
     }
   }

--- a/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreTest.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.document.store.aws;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -421,5 +423,22 @@ class AwsDocumentStoreTest {
     // then
     assertTrue(result.isLeft());
     assertInstanceOf(UnknownDocumentError.class, result.getLeft());
+  }
+
+  @Test
+  void validateSetupShouldHandleExceptionIfExceptionIsThrown() {
+    // given
+    when(s3Client.headBucket(any(HeadBucketRequest.class)))
+        .thenThrow(new RuntimeException("Unexpected error"));
+    final var requestCaptor = ArgumentCaptor.forClass(HeadBucketRequest.class);
+
+    // when
+    assertThatNoException().isThrownBy(() -> documentStore.validateSetup());
+
+    // then
+    verify(s3Client).headBucket(requestCaptor.capture());
+    verifyNoMoreInteractions(s3Client);
+    final var request = requestCaptor.getValue();
+    assertThat(request.bucket()).isEqualTo(BUCKET_NAME);
   }
 }

--- a/document/store/src/test/java/io/camunda/document/store/localstorage/LocalStorageDocumentStoreTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/localstorage/LocalStorageDocumentStoreTest.java
@@ -8,7 +8,9 @@
 package io.camunda.document.store.localstorage;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mockStatic;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.document.api.*;
@@ -26,6 +28,7 @@ import java.util.concurrent.Executors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 
 class LocalStorageDocumentStoreTest {
 
@@ -210,6 +213,20 @@ class LocalStorageDocumentStoreTest {
     // then
     assertTrue(result.isLeft());
     assertInstanceOf(DocumentNotFound.class, result.getLeft());
+  }
+
+  @Test
+  void validateSetupShouldHandleExceptionIfSecurityExceptionIsThrown() {
+    try (final MockedStatic<Files> mockedFiles = mockStatic(Files.class)) {
+      // given
+      mockedFiles.when(() -> Files.exists(storagePath)).thenThrow(SecurityException.class);
+
+      // when
+      assertThatNoException().isThrownBy(() -> documentStore.validateSetup());
+
+      // then
+      mockedFiles.verify(() -> Files.exists(storagePath));
+    }
   }
 
   private void deleteDirectoryRecursively(final Path directory) throws IOException {


### PR DESCRIPTION
## Description

The new code simply tries to ensure the app has access to the document stores (AWS, GCP, local storage) during startup. Nothing is done for in-memory storage as we assume documents can always be stored that way.

If something goes wrong during this step (bucket not found, invalid credentials, etc) warnings will be logged, but will not prevent the application from starting.

## AWS

### Happy path log

```
2025-02-19 15:26:48.528 [] [main] [] INFO 
      io.camunda.document.store.aws.AwsDocumentStore - Successfully accessed bucket 'document-handling-test-bucket'
```

### Bucket does not exist

```
2025-02-19 15:30:43.914 [] [main] [] WARN 
      io.camunda.document.store.aws.AwsDocumentStore - Could not access bucket 'invalid-bucket'. The application will continue to operate, but document handling features may be unavailable or limited.
software.amazon.awssdk.services.s3.model.S3Exception: Moved Permanently (Service: S3, Status Code: 301, Request ID: YR5QNTHY308YP8AX, Extended Request ID: IB80HWQNzCN5m3mpgQq9CAsUWxMr1wQSpN0JFulVmAFLLU7iJmVUOjz3k2gR2r8thYcCsldw2UFDX5EP2JhE1WR6wcY2Kes3FylRrtaZiNI=)
	at software.amazon.awssdk.services.s3.model.S3Exception$BuilderImpl.build(S3Exception.java:104) ~[s3-2.29.50.jar:?]
...
```

## GCP

Note: the app could not access the GCP bucket due to Insufficient permissions for accessing bucket information. However, as this is just a warning and not an exiting error, the application can be used normally and document operations will work fine.

```
2025-02-19 15:35:24.544 [] [main] [] WARN 
      io.camunda.document.store.gcp.GcpDocumentStore - Could not access bucket 'camunda-saas-dev-test-document-storage' with the given credentials. The application will continue to operate, but document handling features may be unavailable or limited.
com.google.cloud.storage.StorageException: document-storage@camunda-saas-dev.iam.gserviceaccount.com does not have storage.buckets.get access to the Google Cloud Storage bucket. Permission 'storage.buckets.get' denied on resource (or it may not exist).
	at com.google.cloud.storage.StorageException.translate(StorageException.java:179) ~[google-cloud-storage-2.47.0.jar:2.47.0]
...
```

## Local storage

### Happy path

```
2025-02-19 15:54:12.061 [] [main] [] INFO 
      io.camunda.document.store.localstorage.LocalStorageDocumentStore - Successfully accessed storage path '/Users/georgios.goulos/repositories/camunda'
```

### Path does not exist
```
2025-02-19 15:55:13.728 [] [main] [] WARN 
      io.camunda.document.store.localstorage.LocalStorageDocumentStore - Storage path '/Users/georgios.goulos/sfdsfdsfgg/dfdsf' does not exist. The application will continue to operate, but document handling features may be unavailable or limited.
```

<!-- Describe the goal and purpose of this PR. -->

## Related issues

1st PR towards closing https://github.com/camunda/camunda/issues/27792?reload=1
