### PR TITLE
add gha to release c8run for 8.7

### DIFF
--- a/.github/workflows/c8run-release.yaml
+++ b/.github/workflows/c8run-release.yaml
@@ -1,0 +1,126 @@
+name: "C8Run: release"
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "release branch of c8run to release (stable/8.7, main, etc.)"
+        type: string
+        required: true
+        default: ""
+      camundaRelease:
+        description: "name of release in camunda"
+        type: string
+        required: true
+        default: ""
+
+permissions:
+  actions: read
+  attestations: none
+  checks: read
+  contents: write
+  deployments: none
+  id-token: none
+  issues: none
+  discussions: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: write
+
+jobs:
+  release:
+    name: C8Run Release ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        # macos-latest is ARM, mac os 13 will execute on x86 runner.
+        os: [ubuntu-latest, macos-latest, macos-13]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c # v3.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/distribution/ci NEXUS_USERNAME;
+            secret/data/products/distribution/ci NEXUS_PASSWORD;
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.23.1'
+          cache: false  # disabling since not working anyways without a cache-dependency-path specified
+
+      - name: Build c8run
+        run: go build
+        working-directory: ./c8run
+
+      - name: make a package
+        run: ./c8run package
+        shell: bash
+        working-directory: ./c8run
+        env:
+          JAVA_ARTIFACTS_USER: ${{ steps.secrets.outputs.NEXUS_USERNAME }}
+          JAVA_ARTIFACTS_PASSWORD: ${{ steps.secrets.outputs.NEXUS_PASSWORD }}
+
+      - name: upload asset
+        working-directory: ./c8run
+        run: gh release upload "${{ env.CAMUNDA_RELEASE }}" camunda8-run-*
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CAMUNDA_RELEASE: ${{ inputs.camundaRelease }}
+
+  release_windows:
+    name: C8Run Release windows
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c # v3.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/distribution/ci NEXUS_USERNAME;
+            secret/data/products/distribution/ci NEXUS_PASSWORD;
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '>=1.23.1'
+          cache: false  # disabling since not working anyways without a cache-dependency-path specified
+
+      - name: Build c8run
+        run: go build
+        working-directory: .\c8run
+
+      - name: make a package
+        run: .\c8run.exe package
+        working-directory: .\c8run
+        env:
+          GH_TOKEN: ${{ github.token }}
+          JAVA_ARTIFACTS_USER: ${{ steps.secrets.outputs.NEXUS_USERNAME }}
+          JAVA_ARTIFACTS_PASSWORD: ${{ steps.secrets.outputs.NEXUS_PASSWORD }}
+
+      - name: upload asset
+        working-directory: .\c8run
+        run: |
+          gh release upload "${{ env.CAMUNDA_RELEASE }}" camunda8-run-${{ env.CAMUNDA_RELEASE }}-windows-x86_64.zip
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CAMUNDA_RELEASE: ${{ inputs.camundaRelease }}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

add GHA to reelase C8run for 8.7, as I get the following error when trying to release C8Run for 8.7, [here](https://github.com/camunda/camunda/actions/workflows/c8run-release.yaml):

<img width="948" alt="image" src="https://github.com/user-attachments/assets/fba827c0-7ecc-4108-8777-d52d135611d3" />


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
