### PR TITLE
feat: update treepath for migrated element instances

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -508,7 +508,7 @@ public class ProcessInstanceMigrationMigrateProcessor
         .setCallingElementPath(elementTreePath.callingElementPath());
 
     stateWriter.appendFollowUpEvent(
-        instance.getKey(), ProcessInstanceIntent.ELEMENT_MIGRATED, elementInstanceRecord);
+        instance.getKey(), ProcessInstanceIntent.ANCESTOR_MIGRATED, elementInstanceRecord);
 
     if (elementInstanceRecord.getBpmnElementType() == BpmnElementType.CALL_ACTIVITY) {
       // found more call activities? add the called child instance to the queue to continue going

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -359,13 +359,13 @@ public class ProcessInstanceMigrationMigrateProcessor
         incidentState.getProcessInstanceIncidentKey(elementInstance.getKey());
     if (processIncidentKey != MISSING_INCIDENT) {
       appendIncidentMigratedEvent(
-          processIncidentKey, targetProcessDefinition, targetElementId, processInstanceKey);
+          processIncidentKey, targetProcessDefinition, targetElementId, elementInstanceRecord);
     }
 
     final var jobIncidentKey = incidentState.getJobIncidentKey(elementInstance.getJobKey());
     if (jobIncidentKey != MISSING_INCIDENT) {
       appendIncidentMigratedEvent(
-          jobIncidentKey, targetProcessDefinition, targetElementId, processInstanceKey);
+          jobIncidentKey, targetProcessDefinition, targetElementId, elementInstanceRecord);
     }
 
     if (elementInstance.getUserTaskKey() > 0) {
@@ -523,7 +523,7 @@ public class ProcessInstanceMigrationMigrateProcessor
       final long incidentKey,
       final DeployedProcess targetProcessDefinition,
       final String targetElementId,
-      final long processInstanceKey) {
+      final ProcessInstanceRecord elementInstanceRecord) {
     final var incidentRecord = incidentState.getIncidentRecord(incidentKey);
     if (incidentRecord == null) {
       throw new SafetyCheckFailedException(
@@ -532,7 +532,7 @@ public class ProcessInstanceMigrationMigrateProcessor
               Expected to migrate a user task for process instance with key '%d', \
               but could not find incident with key '%d'. \
               Please report this as a bug""",
-              processInstanceKey, incidentKey));
+              elementInstanceRecord.getProcessInstanceKey(), incidentKey));
     }
     stateWriter.appendFollowUpEvent(
         incidentKey,
@@ -540,7 +540,10 @@ public class ProcessInstanceMigrationMigrateProcessor
         incidentRecord
             .setProcessDefinitionKey(targetProcessDefinition.getKey())
             .setBpmnProcessId(targetProcessDefinition.getBpmnProcessId())
-            .setElementId(BufferUtil.wrapString(targetElementId)));
+            .setElementId(BufferUtil.wrapString(targetElementId))
+            .setElementInstancePath(elementInstanceRecord.getElementInstancePath())
+            .setProcessDefinitionPath(elementInstanceRecord.getProcessDefinitionPath())
+            .setCallingElementPath(elementInstanceRecord.getCallingElementPath()));
   }
 
   private Set<ExecutableSequenceFlow> getSequenceFlowsToMigrate(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -220,6 +220,9 @@ public final class EventAppliers implements EventApplier {
     register(
         ProcessInstanceIntent.ELEMENT_MIGRATED,
         new ProcessInstanceElementMigratedApplier(elementInstanceState, processState));
+    register(
+        ProcessInstanceIntent.ANCESTOR_MIGRATED,
+        new ProcessInstanceAncestorMigratedApplier(elementInstanceState));
   }
 
   private void registerProcessInstanceCreationAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceAncestorMigratedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceAncestorMigratedApplier.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+
+final class ProcessInstanceAncestorMigratedApplier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  private final MutableElementInstanceState elementInstanceState;
+
+  public ProcessInstanceAncestorMigratedApplier(
+      final MutableElementInstanceState elementInstanceState) {
+    this.elementInstanceState = elementInstanceState;
+  }
+
+  @Override
+  public void applyState(final long elementInstanceKey, final ProcessInstanceRecord value) {
+    elementInstanceState.updateInstance(
+        elementInstanceKey,
+        elementInstance -> {
+          elementInstance
+              .getValue()
+              .setElementInstancePath(value.getElementInstancePath())
+              .setProcessDefinitionPath(value.getProcessDefinitionPath())
+              .setCallingElementPath(value.getCallingElementPath());
+        });
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplier.java
@@ -55,7 +55,8 @@ final class ProcessInstanceElementMigratedApplier
               .setCallingElementPath(value.getCallingElementPath());
         });
 
-    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS
+        && previousProcessDefinitionKey.get() != value.getProcessDefinitionKey()) {
       elementInstanceState.deleteProcessInstanceKeyByDefinitionKey(
           value.getProcessInstanceKey(), previousProcessDefinitionKey.get());
       elementInstanceState.insertProcessInstanceKeyByDefinitionKey(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplier.java
@@ -49,7 +49,10 @@ final class ProcessInstanceElementMigratedApplier
               .setBpmnProcessId(value.getBpmnProcessId())
               .setVersion(value.getVersion())
               .setElementId(value.getElementId())
-              .setFlowScopeKey(value.getFlowScopeKey());
+              .setFlowScopeKey(value.getFlowScopeKey())
+              .setElementInstancePath(value.getElementInstancePath())
+              .setProcessDefinitionPath(value.getProcessDefinitionPath())
+              .setCallingElementPath(value.getCallingElementPath());
         });
 
     if (value.getBpmnElementType() == BpmnElementType.PROCESS) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplier.java
@@ -55,8 +55,7 @@ final class ProcessInstanceElementMigratedApplier
               .setCallingElementPath(value.getCallingElementPath());
         });
 
-    if (value.getBpmnElementType() == BpmnElementType.PROCESS
-        && previousProcessDefinitionKey.get() != value.getProcessDefinitionKey()) {
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
       elementInstanceState.deleteProcessInstanceKeyByDefinitionKey(
           value.getProcessInstanceKey(), previousProcessDefinitionKey.get());
       elementInstanceState.insertProcessInstanceKeyByDefinitionKey(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateCallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateCallActivityTest.java
@@ -565,7 +565,7 @@ public class MigrateCallActivityTest {
 
     // then
     assertThat(
-            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ANCESTOR_MIGRATED)
                 .withProcessInstanceKey(level2ChildProcessInstanceKey)
                 .withElementType(BpmnElementType.USER_TASK)
                 .withElementId("A")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateIncidentTest.java
@@ -97,7 +97,9 @@ public class MigrateIncidentTest {
         .hasElementInstanceKey(incident.getValue().getElementInstanceKey())
         .hasJobKey(incident.getValue().getJobKey())
         .hasVariableScopeKey(incident.getValue().getVariableScopeKey())
-        .hasTenantId(incident.getValue().getTenantId());
+        .hasTenantId(incident.getValue().getTenantId())
+        .describedAs("Expect that the process definition path is updated")
+        .hasOnlyProcessDefinitionPath(targetProcessDefinitionKey);
 
     // after resolving the incident, job can be completed and the process should continue
     ENGINE.job().ofInstance(processInstanceKey).withType("jobTypeA").withRetries(1).updateRetries();
@@ -187,7 +189,9 @@ public class MigrateIncidentTest {
         .hasElementInstanceKey(incident.getValue().getElementInstanceKey())
         .hasJobKey(incident.getValue().getJobKey())
         .hasVariableScopeKey(incident.getValue().getVariableScopeKey())
-        .hasTenantId(incident.getValue().getTenantId());
+        .hasTenantId(incident.getValue().getTenantId())
+        .describedAs("Expect that the process definition path is updated")
+        .hasOnlyProcessDefinitionPath(targetProcessDefinitionKey);
 
     // after resolving the incident, the process should continue as expected
     final Record<IncidentRecordValue> incidentRecord =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -133,7 +134,12 @@ public class MigrateProcessInstanceTest {
         .hasBpmnProcessId(otherProcessId)
         .hasElementId(otherProcessId)
         .describedAs("Expect that version number did not change")
-        .hasVersion(1);
+        .hasVersion(1)
+        .hasElementInstancePath(List.of(processInstanceKey))
+        .describedAs(
+            "Expect that process definition path changed to contain new process definition key")
+        .hasProcessDefinitionPath(List.of(otherProcessDefinitionKey))
+        .hasCallingElementPath(List.of());
   }
 
   @Test
@@ -192,6 +198,10 @@ public class MigrateProcessInstanceTest {
         .hasVersion(2)
         .describedAs("Expect that bpmn process id and element id did not change")
         .hasBpmnProcessId(processId)
-        .hasElementId(processId);
+        .hasElementInstancePath(List.of(processInstanceKey))
+        .describedAs(
+            "Expect that process definition path changed to contain new process definition key")
+        .hasProcessDefinitionPath(List.of(v2ProcessDefinitionKey))
+        .hasCallingElementPath(List.of());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.handlers;
 
 import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ANCESTOR_MIGRATED;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATING;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_COMPLETED;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_MIGRATED;
@@ -65,7 +66,8 @@ public class FlowNodeInstanceFromProcessInstanceHandler
     return !isOfTypes(processInstanceRecordValue, UNHANDLED_TYPES)
         && (AI_START_STATES.contains(intent)
             || AI_FINISH_STATES.contains(intent)
-            || ELEMENT_MIGRATED.equals(intent));
+            || ELEMENT_MIGRATED.equals(intent)
+            || ANCESTOR_MIGRATED.equals(intent));
   }
 
   @Override
@@ -94,7 +96,9 @@ public class FlowNodeInstanceFromProcessInstanceHandler
     entity.setTenantId(tenantOrDefault(recordValue.getTenantId()));
     entity.setScopeKey(recordValue.getFlowScopeKey());
 
-    if (intent.equals(ELEMENT_ACTIVATING) || intent.equals(ELEMENT_MIGRATED)) {
+    if (intent.equals(ELEMENT_ACTIVATING)
+        || intent.equals(ELEMENT_MIGRATED)
+        || intent.equals(ANCESTOR_MIGRATED)) {
       setTreePath(record, entity);
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
@@ -94,31 +94,8 @@ public class FlowNodeInstanceFromProcessInstanceHandler
     entity.setTenantId(tenantOrDefault(recordValue.getTenantId()));
     entity.setScopeKey(recordValue.getFlowScopeKey());
 
-    if (intent.equals(ELEMENT_ACTIVATING)) {
-      final ProcessInstanceRecordValue value = record.getValue();
-      if (value.getElementInstancePath() != null && !value.getElementInstancePath().isEmpty()) {
-        // Build the intra treePath in the format:
-        // <pre>
-        //   <processInstanceKey>/<flowNodeInstanceKey>/.../<flowNodeInstanceKey>
-        // </pre>
-        //
-        // Where upper level flowNodeInstanceKeys are normally subprocess(es) or multi-instance
-        // bodies.
-        // This is an intra tree path that shows position of flow node instance inside one process
-        // instance.
-        // We take last entry, as in intra path we're not interested in upper level process instance
-        // scope hierarchies.
-        final List<String> treePathEntries =
-            value.getElementInstancePath().getLast().stream().map(String::valueOf).toList();
-        entity.setTreePath(String.join("/", treePathEntries));
-        entity.setLevel(treePathEntries.size() - 1);
-      } else {
-        LOGGER.warn(
-            "No elementInstancePath is provided for flow node instance id: {}. TreePath will be set to default value.",
-            entity.getId());
-        entity.setTreePath(recordValue.getProcessInstanceKey() + "/" + record.getKey());
-        entity.setLevel(1);
-      }
+    if (intent.equals(ELEMENT_ACTIVATING) || intent.equals(ELEMENT_MIGRATED)) {
+      setTreePath(record, entity);
     }
 
     final OffsetDateTime recordTime =
@@ -175,6 +152,37 @@ public class FlowNodeInstanceFromProcessInstanceHandler
   @Override
   public String getIndexName() {
     return indexName;
+  }
+
+  /**
+   * Sets the tree path and level of the flow node instance.
+   *
+   * <pre>
+   *   <processInstanceKey>/<flowNodeInstanceKey>/.../<flowNodeInstanceKey>
+   * </pre>
+   *
+   * Upper level flowNodeInstanceKeys are typically subprocesses or multi-instance bodies. This
+   * intra tree path shows the position of a flow node instance within a single process instance.
+   * The last entry is used, as we are not interested in upper-level process instance scope
+   * hierarchies.
+   */
+  private static void setTreePath(
+      final Record<ProcessInstanceRecordValue> record, final FlowNodeInstanceEntity entity) {
+    final var recordValue = record.getValue();
+    if (recordValue.getElementInstancePath() != null
+        && !recordValue.getElementInstancePath().isEmpty()) {
+
+      final List<String> treePathEntries =
+          recordValue.getElementInstancePath().getLast().stream().map(String::valueOf).toList();
+      entity.setTreePath(String.join("/", treePathEntries));
+      entity.setLevel(treePathEntries.size() - 1);
+    } else {
+      LOGGER.warn(
+          "No elementInstancePath is provided for flow node instance id: {}. TreePath will be set to default value.",
+          entity.getId());
+      entity.setTreePath(recordValue.getProcessInstanceKey() + "/" + record.getKey());
+      entity.setLevel(1);
+    }
   }
 
   private boolean isOfTypes(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
@@ -129,6 +129,7 @@ public class IncidentHandler implements ExportHandler<IncidentEntity, IncidentRe
     updateFields.put(PROCESS_DEFINITION_KEY, entity.getProcessDefinitionKey());
     updateFields.put(FLOW_NODE_ID, entity.getFlowNodeId());
     updateFields.put(POSITION, entity.getPosition());
+    updateFields.put(TREE_PATH, entity.getTreePath());
     batchRequest.upsert(indexName, String.valueOf(entity.getKey()), entity, updateFields);
   }
 
@@ -144,7 +145,7 @@ public class IncidentHandler implements ExportHandler<IncidentEntity, IncidentRe
     final List<Integer> callingElementPath = value.getCallingElementPath();
     final List<Long> processDefinitionPath = value.getProcessDefinitionPath();
 
-    final Long processInstanceKey = Long.valueOf(value.getProcessInstanceKey());
+    final Long processInstanceKey = value.getProcessInstanceKey();
 
     // example of how the tree path is built when current instance is on the third level of calling
     // hierarchy:

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
@@ -123,24 +123,14 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
       }
     } else if (intent.equals(ELEMENT_ACTIVATING)) {
 
-      final ProcessInstanceRecordValue value = record.getValue();
-      final List<List<Long>> elementInstancePath = value.getElementInstancePath();
-      final List<Integer> callingElementPath = value.getCallingElementPath();
-      final List<Long> processDefinitionPath = value.getProcessDefinitionPath();
-      final Long processInstanceKey = value.getProcessInstanceKey();
-
-      final TreePath treePath =
-          createTreePath(
-              processCache,
-              record.getKey(),
-              processInstanceKey,
-              elementInstancePath,
-              processDefinitionPath,
-              callingElementPath);
+      final TreePath treePath = createTreePath(record);
       piEntity
           .setTreePath(treePath.toString())
           .setStartDate(timestamp)
           .setState(ProcessInstanceState.ACTIVE);
+    } else if (intent.equals(ELEMENT_MIGRATED)) {
+      final TreePath treePath = createTreePath(record);
+      piEntity.setTreePath(treePath.toString()).setState(ProcessInstanceState.ACTIVE);
     } else {
       piEntity.setState(ProcessInstanceState.ACTIVE);
     }
@@ -227,13 +217,12 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
     return processCache.get(processDefinitionJey).map(CachedProcessEntity::versionTag).orElse(null);
   }
 
-  public static TreePath createTreePath(
-      final ExporterEntityCache<Long, CachedProcessEntity> processCache,
-      final long key,
-      final Long processInstanceKey,
-      final List<List<Long>> elementInstancePath,
-      final List<Long> processDefinitionPath,
-      final List<Integer> callingElementPath) {
+  public TreePath createTreePath(final Record<ProcessInstanceRecordValue> record) {
+    final var value = record.getValue();
+    final var elementInstancePath = value.getElementInstancePath();
+    final var callingElementPath = value.getCallingElementPath();
+    final var processDefinitionPath = value.getProcessDefinitionPath();
+    final Long processInstanceKey = value.getProcessInstanceKey();
     if (elementInstancePath == null || elementInstancePath.isEmpty()) {
       LOGGER.warn(
           "No elementInstancePath is provided for process instance key: {}. TreePath will be set to default value (PI key).",
@@ -265,7 +254,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
             "Expected to find process in cache. TreePath won't contain proper callActivityId, will use the lexicographic index instead {}. [processInstanceKey: {}, processDefinitionKey: {}, incidentKey: {}]",
             processInstanceKey,
             processDefinitionPath.get(i),
-            key,
+            record.getKey(),
             index);
         treePath.appendFlowNode(String.valueOf(index));
       }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
@@ -72,7 +72,8 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
       final var intent = record.getIntent();
       return PI_AND_AI_START_STATES.contains(intent)
           || PI_AND_AI_FINISH_STATES.contains(intent)
-          || ELEMENT_MIGRATED.equals(intent);
+          || ELEMENT_MIGRATED.equals(intent)
+          || ANCESTOR_MIGRATED.equals(intent);
     }
     return false;
   }
@@ -128,7 +129,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
           .setTreePath(treePath.toString())
           .setStartDate(timestamp)
           .setState(ProcessInstanceState.ACTIVE);
-    } else if (intent.equals(ELEMENT_MIGRATED)) {
+    } else if (intent.equals(ELEMENT_MIGRATED) || intent.equals(ANCESTOR_MIGRATED)) {
       final TreePath treePath = createTreePath(record);
       piEntity.setTreePath(treePath.toString()).setState(ProcessInstanceState.ACTIVE);
     } else {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
@@ -27,14 +27,14 @@ import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
 
 public class FlowNodeInstanceFromProcessInstanceHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
@@ -52,24 +52,23 @@ public class FlowNodeInstanceFromProcessInstanceHandlerTest {
     assertThat(underTest.getEntityType()).isEqualTo(FlowNodeInstanceEntity.class);
   }
 
-  @Test
-  public void shouldHandleRecord() {
-    final Set<ProcessInstanceIntent> intents2Handle =
-        Set.of(
-            ProcessInstanceIntent.ELEMENT_ACTIVATING,
-            ProcessInstanceIntent.ELEMENT_COMPLETED,
-            ProcessInstanceIntent.ELEMENT_TERMINATED,
-            ProcessInstanceIntent.ELEMENT_MIGRATED);
-
-    intents2Handle.stream()
-        .forEach(
-            intent -> {
-              final Record<ProcessInstanceRecordValue> processInstanceRecord = createRecord(intent);
-              // when - then
-              assertThat(underTest.handlesRecord(processInstanceRecord))
-                  .as("Handles intent %s", intent)
-                  .isTrue();
-            });
+  @ParameterizedTest
+  @EnumSource(
+      value = ProcessInstanceIntent.class,
+      names = {
+        "ELEMENT_ACTIVATING",
+        "ELEMENT_COMPLETED",
+        "ELEMENT_TERMINATED",
+        "ELEMENT_MIGRATED",
+        "ANCESTOR_MIGRATED"
+      },
+      mode = Mode.INCLUDE)
+  public void shouldHandleRecord(final ProcessInstanceIntent intent) {
+    final Record<ProcessInstanceRecordValue> processInstanceRecord = createRecord(intent);
+    // when - then
+    assertThat(underTest.handlesRecord(processInstanceRecord))
+        .as("Handles intent %s", intent)
+        .isTrue();
   }
 
   private Record<ProcessInstanceRecordValue> createRecord(final ProcessInstanceIntent intent) {
@@ -85,28 +84,23 @@ public class FlowNodeInstanceFromProcessInstanceHandlerTest {
     return processInstanceRecord;
   }
 
-  @Test
-  public void shouldNotHandleRecord() {
-    final Set<ProcessInstanceIntent> intents2Handle =
-        Set.of(
-            ProcessInstanceIntent.ELEMENT_ACTIVATING,
-            ProcessInstanceIntent.ELEMENT_COMPLETED,
-            ProcessInstanceIntent.ELEMENT_TERMINATED,
-            ProcessInstanceIntent.ELEMENT_MIGRATED);
-    final Set<ProcessInstanceIntent> intents2Ignore =
-        Arrays.stream(ProcessInstanceIntent.values())
-            .filter(intent -> !intents2Handle.contains(intent))
-            .collect(Collectors.toSet());
-
-    intents2Ignore.stream()
-        .forEach(
-            intent -> {
-              final Record<ProcessInstanceRecordValue> processInstanceRecord = createRecord(intent);
-              // when - then
-              assertThat(underTest.handlesRecord(processInstanceRecord))
-                  .as("Does not handle intent %s", intent)
-                  .isFalse();
-            });
+  @ParameterizedTest
+  @EnumSource(
+      value = ProcessInstanceIntent.class,
+      names = {
+        "ELEMENT_ACTIVATING",
+        "ELEMENT_COMPLETED",
+        "ELEMENT_TERMINATED",
+        "ELEMENT_MIGRATED",
+        "ANCESTOR_MIGRATED"
+      },
+      mode = Mode.EXCLUDE)
+  public void shouldNotHandleRecord(final ProcessInstanceIntent intent) {
+    final Record<ProcessInstanceRecordValue> processInstanceRecord = createRecord(intent);
+    // when - then
+    assertThat(underTest.handlesRecord(processInstanceRecord))
+        .as("Does not handle intent %s", intent)
+        .isFalse();
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
@@ -399,6 +399,8 @@ public class FlowNodeInstanceFromProcessInstanceHandlerTest {
             r ->
                 r.withIntent(ProcessInstanceIntent.ELEMENT_MIGRATED)
                     .withValue(processInstanceRecordValue));
+    final String defaultTreePath =
+        processInstanceRecordValue.getProcessInstanceKey() + "/" + processInstanceRecord.getKey();
 
     // when
     final FlowNodeInstanceEntity flowNodeInstanceEntity = new FlowNodeInstanceEntity();
@@ -409,5 +411,6 @@ public class FlowNodeInstanceFromProcessInstanceHandlerTest {
     assertThat(flowNodeInstanceEntity.getStartDate()).isNull();
     assertThat(flowNodeInstanceEntity.getEndDate()).isNull();
     assertThat(flowNodeInstanceEntity.getPosition()).isNull();
+    assertThat(flowNodeInstanceEntity.getTreePath()).isEqualTo(defaultTreePath);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
@@ -151,7 +151,9 @@ public class IncidentHandlerTest {
                 "bpmnProcessId",
                 incidentRecordValue.getBpmnProcessId(),
                 "processDefinitionKey",
-                incidentRecordValue.getProcessDefinitionKey()));
+                incidentRecordValue.getProcessDefinitionKey(),
+                "treePath",
+                incidentEntity.getTreePath()));
     verify(incidentNotifier).notifyAsync(List.of(incidentEntity));
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
@@ -34,14 +34,14 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
 
 public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
 
@@ -61,61 +61,43 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
     assertThat(underTest.getEntityType()).isEqualTo(ProcessInstanceForListViewEntity.class);
   }
 
-  @Test
-  public void shouldHandleRecord() {
-    final Set<ProcessInstanceIntent> intents2Handle =
-        Set.of(
-            ELEMENT_ACTIVATING,
-            ProcessInstanceIntent.ELEMENT_COMPLETED,
-            ProcessInstanceIntent.ELEMENT_TERMINATED,
-            ProcessInstanceIntent.ELEMENT_MIGRATED);
-
-    intents2Handle.stream()
-        .forEach(
-            intent -> {
-              final Record<ProcessInstanceRecordValue> processInstanceRecord = createRecord(intent);
-              // when - then
-              assertThat(underTest.handlesRecord(processInstanceRecord))
-                  .as("Handles intent %s", intent)
-                  .isTrue();
-            });
+  @ParameterizedTest
+  @EnumSource(
+      value = ProcessInstanceIntent.class,
+      names = {
+        "ELEMENT_ACTIVATING",
+        "ELEMENT_COMPLETED",
+        "ELEMENT_TERMINATED",
+        "ELEMENT_MIGRATED",
+        "ANCESTOR_MIGRATED"
+      },
+      mode = Mode.INCLUDE)
+  public void shouldHandleRecord(final ProcessInstanceIntent intent) {
+    final Record<ProcessInstanceRecordValue> processInstanceRecord = createRecord(intent);
+    // when - then
+    assertThat(underTest.handlesRecord(processInstanceRecord))
+        .as("Handles intent %s", intent)
+        .isTrue();
   }
 
-  private Record<ProcessInstanceRecordValue> createRecord(final ProcessInstanceIntent intent) {
-    final ProcessInstanceRecordValue processInstanceRecordValue =
-        ImmutableProcessInstanceRecordValue.builder()
-            .from(factory.generateObject(ProcessInstanceRecordValue.class))
-            .withBpmnElementType(BpmnElementType.PROCESS)
-            .build();
-    final Record<ProcessInstanceRecordValue> processInstanceRecord =
-        factory.generateRecord(
-            ValueType.PROCESS_INSTANCE,
-            r -> r.withIntent(intent).withValue(processInstanceRecordValue));
-    return processInstanceRecord;
-  }
+  @ParameterizedTest
+  @EnumSource(
+      value = ProcessInstanceIntent.class,
+      names = {
+        "ELEMENT_ACTIVATING",
+        "ELEMENT_COMPLETED",
+        "ELEMENT_TERMINATED",
+        "ELEMENT_MIGRATED",
+        "ANCESTOR_MIGRATED"
+      },
+      mode = Mode.EXCLUDE)
+  public void shouldNotHandleRecord(final ProcessInstanceIntent intent) {
 
-  @Test
-  public void shouldNotHandleRecord() {
-    final Set<ProcessInstanceIntent> intents2Handle =
-        Set.of(
-            ELEMENT_ACTIVATING,
-            ProcessInstanceIntent.ELEMENT_COMPLETED,
-            ProcessInstanceIntent.ELEMENT_TERMINATED,
-            ProcessInstanceIntent.ELEMENT_MIGRATED);
-    final Set<ProcessInstanceIntent> intents2Ignore =
-        Arrays.stream(ProcessInstanceIntent.values())
-            .filter(intent -> !intents2Handle.contains(intent))
-            .collect(Collectors.toSet());
-
-    intents2Ignore.stream()
-        .forEach(
-            intent -> {
-              final Record<ProcessInstanceRecordValue> processInstanceRecord = createRecord(intent);
-              // when - then
-              assertThat(underTest.handlesRecord(processInstanceRecord))
-                  .as("Does not handle intent %s", intent)
-                  .isFalse();
-            });
+    final Record<ProcessInstanceRecordValue> processInstanceRecord = createRecord(intent);
+    // when - then
+    assertThat(underTest.handlesRecord(processInstanceRecord))
+        .as("Does not handle intent %s", intent)
+        .isFalse();
   }
 
   @Test
@@ -471,5 +453,18 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
     assertThat(processInstanceForListViewEntity.getStartDate()).isNull();
     assertThat(processInstanceForListViewEntity.getState()).isEqualTo(ProcessInstanceState.ACTIVE);
     assertThat(processInstanceForListViewEntity.getTreePath()).isEqualTo(treePath);
+  }
+
+  private Record<ProcessInstanceRecordValue> createRecord(final ProcessInstanceIntent intent) {
+    final ProcessInstanceRecordValue processInstanceRecordValue =
+        ImmutableProcessInstanceRecordValue.builder()
+            .from(factory.generateObject(ProcessInstanceRecordValue.class))
+            .withBpmnElementType(BpmnElementType.PROCESS)
+            .build();
+    final Record<ProcessInstanceRecordValue> processInstanceRecord =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            r -> r.withIntent(intent).withValue(processInstanceRecordValue));
+    return processInstanceRecord;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.verify;
 import io.camunda.exporter.cache.TestProcessCache;
 import io.camunda.exporter.cache.process.CachedProcessEntity;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.operate.TreePath;
 import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.operate.listview.ListViewJoinRelation;
 import io.camunda.webapps.schema.entities.operate.listview.ProcessInstanceForListViewEntity;
@@ -455,13 +456,20 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
             ValueType.PROCESS_INSTANCE,
             r -> r.withIntent(ProcessInstanceIntent.ELEMENT_MIGRATED).withTimestamp(timestamp));
 
-    // when then
+    final String treePath =
+        new TreePath()
+            .startTreePath(processInstanceRecord.getValue().getProcessInstanceKey())
+            .toString();
+
+    // when
     final ProcessInstanceForListViewEntity processInstanceForListViewEntity =
         new ProcessInstanceForListViewEntity();
     underTest.updateEntity(processInstanceRecord, processInstanceForListViewEntity);
 
+    // then
     assertThat(processInstanceForListViewEntity.getEndDate()).isNull();
     assertThat(processInstanceForListViewEntity.getStartDate()).isNull();
     assertThat(processInstanceForListViewEntity.getState()).isEqualTo(ProcessInstanceState.ACTIVE);
+    assertThat(processInstanceForListViewEntity.getTreePath()).isEqualTo(treePath);
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
@@ -45,7 +45,9 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
    * all operations defined by the listener are fully executed before proceeding with the element's
    * activation or completion.
    */
-  COMPLETE_EXECUTION_LISTENER((short) 12);
+  COMPLETE_EXECUTION_LISTENER((short) 12),
+  /** Represents the intent signaling the migration of an ancestor element instance. */
+  ANCESTOR_MIGRATED((short) 13);
 
   private static final Set<ProcessInstanceIntent> PROCESS_INSTANCE_COMMANDS = EnumSet.of(CANCEL);
   private static final Set<ProcessInstanceIntent> BPMN_ELEMENT_COMMANDS =
@@ -96,6 +98,8 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
         return ELEMENT_MIGRATED;
       case 12:
         return COMPLETE_EXECUTION_LISTENER;
+      case 13:
+        return ANCESTOR_MIGRATED;
       default:
         return Intent.UNKNOWN;
     }
@@ -117,6 +121,7 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
       case ELEMENT_TERMINATING:
       case ELEMENT_TERMINATED:
       case ELEMENT_MIGRATED:
+      case ANCESTOR_MIGRATED:
         return true;
       default:
         return false;

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -572,7 +572,33 @@ public class CompactRecordLogger {
         .append(formatId(value.getElementId()))
         .append(
             summarizeProcessInformation(value.getBpmnProcessId(), value.getProcessInstanceKey()))
+        .append(summarizeTreePath(value))
         .toString();
+  }
+
+  private String summarizeTreePath(final ProcessInstanceRecordValue value) {
+    final StringBuilder result = new StringBuilder();
+    if (!value.getElementInstancePath().isEmpty()) {
+      result
+          .append(" ElementInstancePath: ")
+          .append(
+              value.getElementInstancePath().stream()
+                  .map(p -> p.stream().map(this::shortenKey).collect(Collectors.joining(" -> ")))
+                  .toList());
+    }
+    if (!value.getProcessDefinitionPath().isEmpty()) {
+      result
+          .append(" ProcessDefinitionPath: [")
+          .append(
+              value.getProcessDefinitionPath().stream()
+                  .map(this::shortenKey)
+                  .collect(Collectors.joining(" -> ")))
+          .append("]");
+    }
+    if (!value.getCallingElementPath().isEmpty()) {
+      result.append(" CallingElementPath: ").append(value.getCallingElementPath());
+    }
+    return result.toString();
   }
 
   private String summarizeProcessInstanceCreation(final Record<?> record) {


### PR DESCRIPTION
## Description

- Recalculates the tree-path properties for migrated process instances 
- Adjusts the migrated event appliers to update the treepath in state. No need for a new applier version because treepath fields already existed in the record, and will stay the same unless altered during migration
- ~~Migrate the elements of a called subprocess (@berkaycanbc , @korthout please review)~~
- Introduced a new intent `ANCESTOR_MIGRATED` to mark elements of a called sub-process when it has an ancestor that has been migrated. 
   - When migrating the parent process instance, new call activities might be included. Therefore, we need to adjust the tree path of the called subprocess elements accordingly.
- Update the tree-path when exporting a migrated process instances and incidents
- Updated CompactRecordLogger to include a summary for tree-path information when found. To help with debugging

## Related issues

closes #26094
