### PR TITLE
[Backport stable/8.6] fix: RaftRequestMetrics is threadsafe

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftRequestMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftRequestMetrics.java
@@ -21,8 +21,8 @@ import static io.atomix.raft.metrics.RaftRequestMetricsDoc.*;
 import io.camunda.zeebe.util.collection.Table;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class RaftRequestMetrics extends RaftMetrics {
 
@@ -32,8 +32,8 @@ public class RaftRequestMetrics extends RaftMetrics {
 
   public RaftRequestMetrics(final String partitionName, final MeterRegistry registry) {
     super(partitionName);
-    raftMessagesReceived = new HashMap<>(32);
-    raftMessagesSend = Table.simple();
+    raftMessagesReceived = new ConcurrentHashMap<>(32);
+    raftMessagesSend = Table.concurrent();
     this.registry = registry;
   }
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/metrics/RaftRequestMetricsTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/metrics/RaftRequestMetricsTest.java
@@ -50,9 +50,7 @@ public class RaftRequestMetricsTest {
           });
     }
     // when
-    for (final var task : tasks) {
-      executorService.submit(task);
-    }
+    tasks.forEach(executorService::submit);
     // shutdown the executor and wait for all tasks
     executorService.shutdown();
     // then

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/metrics/RaftRequestMetricsTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/metrics/RaftRequestMetricsTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.ArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.Test;
+
+public class RaftRequestMetricsTest {
+
+  @AutoClose private MeterRegistry meterRegistry = new SimpleMeterRegistry();
+  @AutoClose private ExecutorService executorService = Executors.newWorkStealingPool();
+  private final RaftRequestMetrics raftMetrics = new RaftRequestMetrics("1", meterRegistry);
+
+  private final AtomicBoolean failed = new AtomicBoolean(false);
+
+  @Test
+  public void shouldBeThreadSafe() {
+    // given
+    final var tasks = new ArrayList<Runnable>(20_000);
+    for (int i = 0; i < 20_000; i++) {
+      final var iFinal = i;
+      tasks.add(
+          () -> {
+            try {
+              raftMetrics.receivedMessage(String.valueOf(iFinal % 100));
+            } catch (final Exception e) {
+              failed.set(true);
+            }
+          });
+      tasks.add(
+          () -> {
+            try {
+              raftMetrics.sendMessage(String.valueOf(iFinal % 5), String.valueOf(iFinal % 100));
+            } catch (final Exception e) {
+              failed.set(true);
+            }
+          });
+    }
+    // when
+    for (final var task : tasks) {
+      executorService.submit(task);
+    }
+    // shutdown the executor and wait for all tasks
+    executorService.shutdown();
+    // then
+    assertThat(failed.get()).isFalse();
+  }
+}


### PR DESCRIPTION
# Description
Backport of #28057 to `stable/8.6`.

relates to 
original author: @entangled90