### PR TITLE
[Operate CI] Make use of current-test docker image in IT

### DIFF
--- a/.github/workflows/operate-ci-test-reusable.yml
+++ b/.github/workflows/operate-ci-test-reusable.yml
@@ -56,7 +56,15 @@ jobs:
     timeout-minutes: 40
     runs-on: ${{ inputs.runner-type }}
     if: ${{ !startsWith(inputs.branch, 'fe-') && !(startsWith(inputs.branch, 'renovate/') && contains(inputs.branch, '-fe-')) }}
-
+    env:
+      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe
+      ZEEBE_TEST_DOCKER_IMAGE_TAG: current-test
+    services:
+      # local registry is used as this job needs to push its docker image to be used by IT
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     steps:
       # Setup: checkout branch
       - name: Checkout '${{ inputs.branch }}' branch
@@ -88,16 +96,26 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-
-      # Build: all Maven artifacts
-      - name: Build Maven
-        run: |
-          ./mvnw clean install -B -T1C -P -docker,skipFrontendBuild -DskipTests -DskipChecks -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+      - uses: ./.github/actions/build-zeebe
+        id: build-camunda
+        with:
+          maven-extra-args: -PskipFrontendBuild
+      - uses: ./.github/actions/build-platform-docker
+        id: build-camunda-docker
+        with:
+          # we use a local registry for pushing
+          repository: ${{ env.ZEEBE_TEST_DOCKER_IMAGE }}
+          distball: ${{ steps.build-camunda.outputs.distball }}
+          version: ${{ env.ZEEBE_TEST_DOCKER_IMAGE_TAG }}
+          # push is needed to make accessible for integration tests
+          push: true
 
       # Run integration tests in parallel
       - name: Backend - ${{ inputs.test-type }}
         run: |
-          ${{ inputs.command }}
+          ${{ inputs.command }} \
+          -Dzeebe.currentVersion.docker.tag=${{ env.ZEEBE_TEST_DOCKER_IMAGE_TAG }} \
+          -Dzeebe.currentVersion.docker.repo=${{ env.ZEEBE_TEST_DOCKER_IMAGE }}
 
       # Reports: publish test metrics results
       - name: Upload Test Report

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/StartupIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/StartupIT.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.operate;
 
-import static io.camunda.operate.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_PROPERTY_NAME;
+import static io.camunda.operate.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.github.dockerjava.api.command.CreateContainerCmd;
@@ -49,7 +49,7 @@ public class StartupIT {
     testContainerUtil.startElasticsearch(testContext);
 
     testContainerUtil.startZeebe(
-        ContainerVersionsUtil.readProperty(ZEEBE_CURRENTVERSION_PROPERTY_NAME), testContext);
+        ContainerVersionsUtil.readProperty(ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME), testContext);
 
     operateContainer =
         testContainerUtil

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchOperateZeebeRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchOperateZeebeRuleProvider.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.operate.util;
 
-import static io.camunda.operate.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_PROPERTY_NAME;
+import static io.camunda.operate.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
@@ -141,7 +141,7 @@ public class ElasticsearchOperateZeebeRuleProvider implements OperateZeebeRulePr
   public void startZeebe() {
 
     final String zeebeVersion =
-        ContainerVersionsUtil.readProperty(ZEEBE_CURRENTVERSION_PROPERTY_NAME);
+        ContainerVersionsUtil.readProperty(ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME);
     zeebeContainer =
         testContainerUtil.startZeebe(
             zeebeVersion,

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchOperateZeebeRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchOperateZeebeRuleProvider.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.operate.util;
 
-import static io.camunda.operate.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_PROPERTY_NAME;
+import static io.camunda.operate.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME;
 import static io.camunda.operate.store.opensearch.dsl.RequestDSL.componentTemplateRequestBuilder;
 import static org.junit.Assert.assertTrue;
 
@@ -116,7 +116,7 @@ public class OpensearchOperateZeebeRuleProvider implements OperateZeebeRuleProvi
   public void startZeebe() {
 
     final String zeebeVersion =
-        ContainerVersionsUtil.readProperty(ZEEBE_CURRENTVERSION_PROPERTY_NAME);
+        ContainerVersionsUtil.readProperty(ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME);
     zeebeContainer =
         testContainerUtil.startZeebe(
             zeebeVersion,

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/ZeebeContainerManager.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/ZeebeContainerManager.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.operate.util.j5templates;
 
-import static io.camunda.operate.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_PROPERTY_NAME;
+import static io.camunda.operate.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.ClientException;
@@ -50,7 +50,7 @@ public abstract class ZeebeContainerManager {
 
     // Start zeebe
     final String zeebeVersion =
-        ContainerVersionsUtil.readProperty(ZEEBE_CURRENTVERSION_PROPERTY_NAME);
+        ContainerVersionsUtil.readProperty(ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME);
     zeebeContainer =
         testContainerUtil.startZeebe(
             zeebeVersion,

--- a/operate/qa/integration-tests/src/test/resources/container-versions.properties
+++ b/operate/qa/integration-tests/src/test/resources/container-versions.properties
@@ -1,3 +1,4 @@
 zeebe.versions=@version.zeebe.old@,@version.zeebe.docker.current@
-zeebe.currentVersion=@version.zeebe.docker.current@
+zeebe.currentVersion.docker.tag=@version.zeebe.docker.current@
+zeebe.currentVersion.docker.repo=@version.zeebe.docker.repo@
 identity.currentVersion=@version.identity.docker.current@

--- a/operate/qa/pom.xml
+++ b/operate/qa/pom.xml
@@ -25,6 +25,7 @@
     <!-- properties for ImportSeveralVersionsTest and import-old-zeebe-tests module -->
     <version.zeebe.old>8.1.0</version.zeebe.old>
     <version.zeebe.docker.current>SNAPSHOT</version.zeebe.docker.current>
+    <version.zeebe.docker.repo>camunda/zeebe</version.zeebe.docker.repo>
     <version.identity.docker.current>8.5.0</version.identity.docker.current>
 
   </properties>

--- a/operate/qa/util/src/main/java/io/camunda/operate/qa/util/ContainerVersionsUtil.java
+++ b/operate/qa/util/src/main/java/io/camunda/operate/qa/util/ContainerVersionsUtil.java
@@ -15,18 +15,30 @@ import java.util.Properties;
 public class ContainerVersionsUtil {
 
   public static final String ZEEBE_VERSIONS_PROPERTY_NAME = "zeebe.versions";
-  public static final String ZEEBE_CURRENTVERSION_PROPERTY_NAME = "zeebe.currentVersion";
+
+  public static final String ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME =
+      "zeebe.currentVersion.docker.tag";
+  public static final String ZEEBE_CURRENTVERSION_DOCKER_REPO_PROPERTY_NAME =
+      "zeebe.currentVersion.docker.repo";
   public static final String IDENTITY_CURRENTVERSION_DOCKER_PROPERTY_NAME =
       "identity.currentVersion";
   public static final String VERSIONS_DELIMITER = ",";
   private static final String VERSIONS_FILE = "/container-versions.properties";
 
-  public static String readProperty(String propertyName) {
-    try (InputStream propsFile = ContainerVersionsUtil.class.getResourceAsStream(VERSIONS_FILE)) {
+  public static String readProperty(final String propertyName) {
+    // Read first System properties, to make sure we can override it in CI
+    // If not available we default to spring/maven properties
+    final String value = System.getProperty(propertyName);
+    if (value != null) {
+      return value;
+    }
+
+    try (final InputStream propsFile =
+        ContainerVersionsUtil.class.getResourceAsStream(VERSIONS_FILE)) {
       final Properties props = new Properties();
       props.load(propsFile);
       return props.getProperty(propertyName);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new OperateRuntimeException(
           "Unable to read the list of supported Zeebe zeebeVersions.", e);
     }

--- a/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContainerUtil.java
+++ b/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContainerUtil.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.operate.qa.util;
 
+import static io.camunda.operate.qa.util.ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_REPO_PROPERTY_NAME;
 import static io.camunda.operate.util.ThreadUtil.sleepFor;
 import static org.testcontainers.images.PullPolicy.alwaysPull;
 
@@ -463,19 +464,6 @@ public class TestContainerUtil {
   }
 
   public ZeebeContainer startZeebe(
-      final String dataFolderPath,
-      final String version,
-      final String prefix,
-      final Integer partitionCount) {
-    final TestContext testContext =
-        new TestContext()
-            .setZeebeDataFolder(new File(dataFolderPath))
-            .setZeebeIndexPrefix(prefix)
-            .setPartitionCount(partitionCount);
-    return startZeebe(version, testContext);
-  }
-
-  public ZeebeContainer startZeebe(
       final String version,
       final String prefix,
       final Integer partitionCount,
@@ -492,10 +480,13 @@ public class TestContainerUtil {
 
   public ZeebeContainer startZeebe(final String version, final TestContext testContext) {
     if (broker == null) {
-      LOGGER.info("************ Starting Zeebe {} ************", version);
+      final String dockerRepo =
+          ContainerVersionsUtil.readProperty(ZEEBE_CURRENTVERSION_DOCKER_REPO_PROPERTY_NAME);
+      LOGGER.info("************ Starting Zeebe {}:{} ************", dockerRepo, version);
       final long startTime = System.currentTimeMillis();
       Testcontainers.exposeHostPorts(ELS_PORT);
-      broker = new ZeebeContainer(DockerImageName.parse("camunda/zeebe:" + version));
+      broker =
+          new ZeebeContainer(DockerImageName.parse(String.format("%s:%s", dockerRepo, version)));
       broker.withLogConsumer(new Slf4jLogConsumer(LOGGER));
       if (testContext.getNetwork() != null) {
         broker.withNetwork(testContext.getNetwork());
@@ -512,7 +503,9 @@ public class TestContainerUtil {
       // this user cannot access a mounted volume that is owned by root
       broker.withCreateContainerCmdModifier(cmd -> cmd.withUser("root"));
 
-      if ("SNAPSHOT".equals(version) || SemanticVersion.fromVersion(version).isAtLeast("8.8.0")) {
+      if ("SNAPSHOT".equals(version)
+          || "current-test".equals(version)
+          || SemanticVersion.fromVersion(version).isAtLeast("8.8.0")) {
         configureCamundaExporter(testContext);
       } else {
         configureElasticsearchExporter(testContext);


### PR DESCRIPTION
## Description

For Operate CI:

- Build a branch corresponding docker image for Zeebe (introduce separate step)
- Make use of current-test docker image for Zeebe test container
   * Introduce separate property to override the docker repo/registry
   * Make use of property, this allows to use local registry
   * Make sure that current-test tag is accepted by IT infrastructure
   * Read system properties - and default to previous logic if necessary
     Otherwise properties were not accepted somehow
- Current solution also allows to run test locally still with SNAPSHOT


## Related issues

closes https://github.com/camunda/camunda/issues/28070

See for context: https://camunda.slack.com/archives/C06F0GLJNFM/p1739174602278719?thread_ts=1739172753.912819&cid=C06F0GLJNFM

This is to at least make sure that we better test changes, but limit our efforts/work in refactoring the Tasklist CI/IT, as this covered in a follow up PDP
