### PR TITLE
Create a stateful registry that is tied to the ZeebeDB instance lifecycle

### DIFF
--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -59,7 +59,8 @@ final class CheckpointRecordsProcessorTest {
         new ZeebeRocksDbFactory<>(
                 new RocksDbConfiguration(),
                 new ConsistencyChecksSettings(true, true),
-                new AccessMetricsConfiguration(Kind.NONE, 1))
+                new AccessMetricsConfiguration(Kind.NONE, 1),
+                new SimpleMeterRegistry())
             .createDb(database.toFile());
     final RecordProcessorContextImpl context = createContext(executor, zeebedb);
 

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbCheckpointStateTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbCheckpointStateTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.db.ConsistencyChecksSettings;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.nio.file.Path;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,7 +40,8 @@ final class DbCheckpointStateTest {
         new ZeebeRocksDbFactory<>(
                 new RocksDbConfiguration(),
                 new ConsistencyChecksSettings(true, true),
-                new AccessMetricsConfiguration(Kind.NONE, 1))
+                new AccessMetricsConfiguration(Kind.NONE, 1),
+                new SimpleMeterRegistry())
             .createDb(database.toFile());
     state = new DbCheckpointState(zeebedb, zeebedb.createContext());
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterContext.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.util.EnsureUtil;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
@@ -83,14 +84,7 @@ public final class ExporterContext implements Context, AutoCloseable {
 
   @Override
   public void close() {
-    // Clear the registry, so the metrics created are deleted:
-    // it must be done before removing the parent registry
-    meterRegistry.clear();
-    // remove the parentMeterRegistry so it's not closed when we close the composite.
-    if (underlyingMetricRegistry != null) {
-      meterRegistry.remove(underlyingMetricRegistry);
-    }
-    meterRegistry.close();
+    MicrometerUtil.discard(meterRegistry);
   }
 
   private static final class AcceptAllRecordsFilter implements RecordFilter {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/PartitionStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/PartitionStartupContext.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import java.nio.file.Path;
 
 public final class PartitionStartupContext {
@@ -36,7 +37,7 @@ public final class PartitionStartupContext {
 
   private Path partitionDirectory;
 
-  private MeterRegistry partitionMeterRegistry;
+  private CompositeMeterRegistry partitionMeterRegistry;
   private FileBasedSnapshotStore snapshotStore;
   private RaftPartition raftPartition;
   private ZeebePartition zeebePartition;
@@ -148,12 +149,12 @@ public final class PartitionStartupContext {
   }
 
   public PartitionStartupContext partitionMeterRegistry(
-      final MeterRegistry partitionMeterRegistry) {
+      final CompositeMeterRegistry partitionMeterRegistry) {
     this.partitionMeterRegistry = partitionMeterRegistry;
     return this;
   }
 
-  public MeterRegistry partitionMeterRegistry() {
+  public CompositeMeterRegistry partitionMeterRegistry() {
     return partitionMeterRegistry;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -144,7 +144,7 @@ public final class ZeebePartitionFactory {
     final var partitionId = raftPartition.id().id();
 
     final StateController stateController =
-        createStateController(raftPartition, snapshotStore, snapshotStore);
+        createStateController(raftPartition, snapshotStore, snapshotStore, partitionMeterRegistry);
 
     final var context =
         new PartitionStartupAndTransitionContextImpl(
@@ -180,7 +180,8 @@ public final class ZeebePartitionFactory {
   private StateController createStateController(
       final RaftPartition raftPartition,
       final ConstructableSnapshotStore snapshotStore,
-      final ConcurrencyControl concurrencyControl) {
+      final ConcurrencyControl concurrencyControl,
+      final MeterRegistry partitionMeterRegistry) {
     final Path runtimeDirectory;
     if (brokerCfg.getData().useSeparateRuntimeDirectory()) {
       final Path rootRuntimeDirectory = Paths.get(brokerCfg.getData().getRuntimeDirectory());
@@ -200,8 +201,8 @@ public final class ZeebePartitionFactory {
         new ZeebeRocksDbFactory<>(
             databaseCfg.createRocksDbConfiguration(),
             consistencyChecks.getSettings(),
-            new AccessMetricsConfiguration(
-                databaseCfg.getAccessMetrics(), raftPartition.id().id())),
+            new AccessMetricsConfiguration(databaseCfg.getAccessMetrics(), raftPartition.id().id()),
+            partitionMeterRegistry),
         snapshotStore,
         runtimeDirectory,
         new AtomixRecordEntrySupplierImpl(raftPartition.getServer()),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/MetricsStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/MetricsStep.java
@@ -11,8 +11,8 @@ import io.camunda.zeebe.broker.partitioning.startup.PartitionStartupContext;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.startup.StartupStep;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 
 public class MetricsStep implements StartupStep<PartitionStartupContext> {
 
@@ -24,31 +24,22 @@ public class MetricsStep implements StartupStep<PartitionStartupContext> {
   @Override
   public ActorFuture<PartitionStartupContext> startup(final PartitionStartupContext context) {
     final var brokerRegistry = context.brokerMeterRegistry();
-    final var partitionRegistry = new CompositeMeterRegistry();
+    final var partitionRegistry = MicrometerUtil.wrap(brokerRegistry);
     final Integer partitionId = context.partitionMetadata().id().id();
     partitionRegistry
         .config()
         .commonTags(PartitionKeyNames.PARTITION.asString(), partitionId.toString());
 
-    partitionRegistry.add(brokerRegistry);
     context.partitionMeterRegistry(partitionRegistry);
-
     return CompletableActorFuture.completed(context);
   }
 
   @Override
   public ActorFuture<PartitionStartupContext> shutdown(final PartitionStartupContext context) {
-    final var brokerRegistry = context.brokerMeterRegistry();
     final var partitionRegistry = context.partitionMeterRegistry();
 
     if (partitionRegistry != null) {
-      partitionRegistry.clear();
-      partitionRegistry.close();
-
-      if (brokerRegistry instanceof final CompositeMeterRegistry parent) {
-        parent.remove(partitionRegistry);
-      }
-
+      MicrometerUtil.discard(partitionRegistry);
       context.partitionMeterRegistry(null);
     }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MetricsStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MetricsStep.java
@@ -11,6 +11,7 @@ import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 
 public final class MetricsStep implements PartitionTransitionStep {
@@ -20,17 +21,8 @@ public final class MetricsStep implements PartitionTransitionStep {
       final PartitionTransitionContext context, final long term, final Role targetRole) {
     final var transitionMeterRegistry =
         (CompositeMeterRegistry) context.getPartitionTransitionMeterRegistry();
-    final var startupMeterRegistry = context.getPartitionStartupMeterRegistry();
     if (transitionMeterRegistry != null) {
-      // Clear all meters from the partition registry. Their values are invalid after the
-      // transition.
-      transitionMeterRegistry.clear();
-      // Remove the backing broker registry from the partition registry so that we can close the
-      // partition registry without closing the broker registry.
-      // This also increases reliability in case something holds on to the partition registry
-      // because any new meters will no longer be forwarded to the broker registry.
-      transitionMeterRegistry.remove(startupMeterRegistry);
-      transitionMeterRegistry.close();
+      MicrometerUtil.discard(transitionMeterRegistry);
       context.setPartitionTransitionMeterRegistry(null);
     }
     return context.getConcurrencyControl().createCompletedFuture();
@@ -40,10 +32,7 @@ public final class MetricsStep implements PartitionTransitionStep {
   public ActorFuture<Void> transitionTo(
       final PartitionTransitionContext context, final long term, final Role targetRole) {
     final var startupMeterRegistry = context.getPartitionStartupMeterRegistry();
-    final var transitionRegistry = new CompositeMeterRegistry();
-
-    // Wrap over the broker registry so that all meters are forwarded to the broker registry.
-    transitionRegistry.add(startupMeterRegistry);
+    final var transitionRegistry = MicrometerUtil.wrap(startupMeterRegistry);
 
     context.setPartitionTransitionMeterRegistry(transitionRegistry);
     return context.getConcurrencyControl().createCompletedFuture();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -43,6 +43,7 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.health.HealthMonitor;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -83,7 +84,7 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
 
   public TestPartitionTransitionContext() {
     transitionMeterRegistry = new SimpleMeterRegistry();
-    transitionMeterRegistry.config().commonTags("partitionId", "1");
+    transitionMeterRegistry.config().commonTags(PartitionKeyNames.PARTITION.asString(), "1");
 
     startupMeterRegistry.add(transitionMeterRegistry);
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/TestState.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/TestState.java
@@ -85,7 +85,8 @@ final class TestState {
     return new ZeebeRocksDbFactory<>(
         new RocksDbConfiguration(),
         new ConsistencyChecksSettings(false, false),
-        new AccessMetricsConfiguration(Kind.NONE, 1));
+        new AccessMetricsConfiguration(Kind.NONE, 1),
+        new SimpleMeterRegistry());
   }
 
   private void insertData(final List<ColumnFamily<DbString, DbString>> columns) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/DefaultZeebeDbFactory.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/DefaultZeebeDbFactory.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 public final class DefaultZeebeDbFactory {
 
@@ -23,6 +24,7 @@ public final class DefaultZeebeDbFactory {
     return new ZeebeRocksDbFactory<>(
         new RocksDbConfiguration(),
         consistencyChecks,
-        new AccessMetricsConfiguration(Kind.NONE, 1));
+        new AccessMetricsConfiguration(Kind.NONE, 1),
+        new SimpleMeterRegistry());
   }
 }

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/util/DefaultZeebeDbFactory.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/util/DefaultZeebeDbFactory.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 public final class DefaultZeebeDbFactory {
 
@@ -23,6 +24,7 @@ public final class DefaultZeebeDbFactory {
     return new ZeebeRocksDbFactory<>(
         new RocksDbConfiguration(),
         consistencyChecks,
-        new AccessMetricsConfiguration(Kind.NONE, 1));
+        new AccessMetricsConfiguration(Kind.NONE, 1),
+        new SimpleMeterRegistry());
   }
 }

--- a/zeebe/util/pom.xml
+++ b/zeebe/util/pom.xml
@@ -37,6 +37,12 @@
     </dependency>
 
     <dependency>
+      <groupId>net.jcip</groupId>
+      <artifactId>jcip-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
     </dependency>

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
@@ -144,6 +144,20 @@ public final class MicrometerUtil {
     return buckets.toArray(Duration[]::new);
   }
 
+  /**
+   * Marks this registry as discarded, clearing any metrics, closing it, and removing it from any of
+   * the wrapped registries.
+   *
+   * <p>Only use if you're sure you won't use this registry again.
+   */
+  public static void discard(final CompositeMeterRegistry registry) {
+    registry.clear();
+    // we have to remove all wrapped registries before closing, otherwise closing the composite
+    // registry will also close the wrapped registries
+    registry.getRegistries().forEach(registry::remove);
+    registry.close();
+  }
+
   private record CloseableTimer(Timer timer, Timer.Sample sample) implements CloseableSilently {
     @Override
     public void close() {

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistry.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistry.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util.micrometer;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Meter.Id;
+import io.micrometer.core.instrument.Meter.Type;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+import net.jcip.annotations.ThreadSafe;
+
+/**
+ * A {@link io.micrometer.core.instrument.composite.CompositeMeterRegistry} extension which keeps
+ * track of gauge states. This allows you to share the same gauge across boundaries without worrying
+ * about updating the wrong state.
+ *
+ * <p>NOTE: when doing this, you still need to carefully consider that updating a gauge from
+ * different contexts may lead to the wrong value being shown, so avoid using set operations unless
+ * you're really, really sure.
+ */
+@ThreadSafe
+public final class StatefulMeterRegistry extends CompositeMeterRegistry {
+  private final ConcurrentMap<Meter.Id, StatefulGauge> gauges = new ConcurrentHashMap<>();
+
+  public StatefulMeterRegistry(final MeterRegistry wrapped) {
+    super();
+    add(wrapped);
+  }
+
+  /**
+   * Registers a gauge whose will report the value of the returned {@link StatefulGauge#state()}. If
+   * a gauge with the same documentation <strong>and</strong> tags already exists <strong>in this
+   * registry</strong>, it will return the same {@link StatefulGauge} again and will not register
+   * anything.
+   *
+   * @param documentation the documentation for the gauge
+   * @param tags a set of tags to apply to the gauge
+   * @return an {@link StatefulGauge} which represents the gauge value and its state
+   */
+  public StatefulGauge newLongGauge(
+      final ExtendedMeterDocumentation documentation, final Tag... tags) {
+    return newLongGauge(documentation, Tags.of(tags));
+  }
+
+  /**
+   * Registers a gauge whose will report the value of the returned {@link AtomicLong} object. If a
+   * gauge with the same documentation <strong>and</strong> tags already exists <strong>in this
+   * registry</strong>, it will return the same {@link AtomicLong} again and will not register
+   * anything.
+   *
+   * <p>The tags are expected to be key-value pairs. So if you wanted to add {@code foo=bar} and
+   * {@code baz=buzz}, then you would pass {@code newLongGauge(doc, "foo", "bar", "baz", "buz")}.
+   *
+   * @param documentation the documentation for the gauge
+   * @param tags a set of tags as ordered key-value pairs to apply to the gauge
+   * @return an {@link AtomicLong} which represents the gauge value
+   */
+  public StatefulGauge newLongGauge(
+      final ExtendedMeterDocumentation documentation, final String... tags) {
+    return newLongGauge(documentation, Tags.of(tags));
+  }
+
+  /**
+   * Registers a gauge whose will report the value of the returned {@link StatefulGauge#state()}. If
+   * a gauge with the same documentation <strong>and</strong> tags already exists <strong>in this
+   * registry</strong>, it will return the same {@link StatefulGauge} again and will not register
+   * anything.
+   *
+   * @param documentation the documentation for the gauge
+   * @param tags a set of tags to apply to the gauge
+   * @return an {@link StatefulGauge} which represents the gauge value and its state
+   */
+  public StatefulGauge newLongGauge(
+      final ExtendedMeterDocumentation documentation, final Tags tags) {
+    final var type = documentation.getType();
+    if (type != Type.GAUGE) {
+      throw new IllegalArgumentException(
+          "Expected to register a new stateful long gauge, but it's documented as a meter of type %s"
+              .formatted(type));
+    }
+
+    final var id =
+        new Meter.Id(
+            documentation.getName(),
+            tags,
+            documentation.getBaseUnit(),
+            documentation.getDescription(),
+            type);
+
+    final var existing = gauges.get(id);
+    if (existing != null) {
+      return existing;
+    }
+
+    // NOTE: one big downside is we can't easily know if the gauge previously existed or not, so we
+    // could be return a new state that will simply do nothing. This is the same behavior as
+    // registering a gauge twice in Micrometer with a different state object anyway, but I want to
+    // highlight it here because the class may give the impression this is not possible, while it
+    // definitely is.
+    final var state = new AtomicLong();
+    final var gauge =
+        Gauge.builder(id.getName(), state, AtomicLong::get)
+            .description(id.getDescription())
+            .tags(id.getTags())
+            .strongReference(true)
+            .register(this);
+    final var statefulGauge = new StatefulGauge(gauge, state);
+    gauges.put(id, statefulGauge);
+
+    return statefulGauge;
+  }
+
+  @SuppressWarnings("NullableProblems")
+  @Override
+  public Meter remove(final Id mappedId) {
+    final var removed = super.remove(mappedId);
+    if (mappedId.getType() == Meter.Type.GAUGE) {
+      gauges.remove(mappedId);
+    }
+
+    return removed;
+  }
+
+  public record StatefulGauge(Gauge gauge, AtomicLong state) {}
+}

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistry.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistry.java
@@ -40,6 +40,18 @@ public final class StatefulMeterRegistry extends CompositeMeterRegistry {
 
   /**
    * Registers a gauge whose will report the value of the returned {@link StatefulGauge#state()}. If
+   * a gauge with the same documentation already exists <strong>in this registry</strong>, it will
+   * return the same {@link StatefulGauge} again and will not register anything.
+   *
+   * @param documentation the documentation for the gauge
+   * @return an {@link StatefulGauge} which represents the gauge value and its state
+   */
+  public StatefulGauge newLongGauge(final ExtendedMeterDocumentation documentation) {
+    return newLongGauge(documentation, Tags.empty());
+  }
+
+  /**
+   * Registers a gauge whose will report the value of the returned {@link StatefulGauge#state()}. If
    * a gauge with the same documentation <strong>and</strong> tags already exists <strong>in this
    * registry</strong>, it will return the same {@link StatefulGauge} again and will not register
    * anything.

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/MicrometerUtilTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/MicrometerUtilTest.java
@@ -9,14 +9,79 @@ package io.camunda.zeebe.util.micrometer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.temporal.ChronoUnit;
-import org.junit.Test;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
-public class MicrometerUtilTest {
+final class MicrometerUtilTest {
   @Test
-  public void shouldThrowExceptionWhenBucketsExceedLongMax() {
+  void shouldThrowExceptionWhenBucketsExceedLongMax() {
+    // given - when
     final var buckets = MicrometerUtil.exponentialBucketDuration(7, 6, 1023, ChronoUnit.MILLIS);
-    assertThat(buckets).hasSizeLessThan(1023);
-    assertThat(buckets).allMatch(d -> d.toMillis() > 0L);
+
+    // then
+    assertThat(buckets).hasSizeLessThan(1023).allMatch(d -> d.toMillis() > 0L);
+  }
+
+  @Nested
+  final class DiscardTest {
+    private final MeterRegistry wrapped = new SimpleMeterRegistry();
+    private final CompositeMeterRegistry registry = MicrometerUtil.wrap(wrapped);
+
+    @Test
+    void shouldNotCloseWrappedRegistriesOnDiscard() {
+      // given - when
+      MicrometerUtil.discard(registry);
+
+      // then
+      assertThat(wrapped.isClosed()).as("wrapped registry is not closed").isFalse();
+    }
+
+    @Test
+    void shouldRemoveWrappedRegistryOnDiscard() {
+      // given - when
+      MicrometerUtil.discard(registry);
+
+      // then
+      assertThat(registry.getRegistries()).as("has no more wrapped registries").isEmpty();
+    }
+
+    @Test
+    void shouldCloseRegistryOnDiscard() {
+      // given - when
+      MicrometerUtil.discard(registry);
+
+      // then
+      assertThat(registry.isClosed()).as("composite registry is closed").isTrue();
+    }
+
+    @Test
+    void shouldClearRegistryOnDiscard() {
+      // given
+      registry.counter("foo");
+
+      // when
+      MicrometerUtil.discard(registry);
+
+      // then
+      assertThat(registry.getMeters()).as("has no meters registered").isEmpty();
+    }
+
+    @Test
+    void shouldNotRemoveMetersFromWrappedRegistryOnDiscard() {
+      // given
+      final var counter = wrapped.counter("foo");
+
+      // when
+      MicrometerUtil.discard(registry);
+
+      // then
+      assertThat(registry.getMeters()).as("has no meters registered").isEmpty();
+      assertThat(wrapped.getMeters()).as("has some meters registered").isNotEmpty();
+      assertThat(wrapped.get(counter.getId().getName()).counter()).isSameAs(counter);
+    }
   }
 }

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistryTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistryTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util.micrometer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter.Type;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+final class StatefulMeterRegistryTest {
+
+  private final MeterRegistry wrapped = new SimpleMeterRegistry();
+  private final StatefulMeterRegistry registry = new StatefulMeterRegistry(wrapped);
+
+  @AfterEach
+  void afterEach() {
+    registry.clear();
+    registry.close();
+    registry.remove(wrapped);
+
+    wrapped.clear();
+    wrapped.close();
+  }
+
+  @Test
+  void shouldReturnSameState() {
+    // given
+    final var first = registry.newLongGauge(TestDoc.FOO, "a", "1");
+    final var second = registry.newLongGauge(TestDoc.FOO, "a", "1");
+
+    // when
+    first.state().set(1);
+    second.state().set(2);
+
+    // then
+    assertThat(second).isSameAs(first);
+    assertThat(second.state()).isSameAs(first.state()).hasValue(2);
+    assertThat(wrapped.get(TestDoc.FOO.getName()).tag("a", "1").gauge()).returns(2.0, Gauge::value);
+  }
+
+  @Test
+  void shouldRegisterDifferentGaugeBasedOnTag() {
+    // given
+    final var first = registry.newLongGauge(TestDoc.FOO, "a", "1");
+    final var second = registry.newLongGauge(TestDoc.FOO, "a", "2");
+
+    // when
+    first.state().set(1);
+    second.state().set(2);
+
+    // then
+    assertThat(first).isNotSameAs(second);
+    assertThat(first.state()).hasValue(1);
+    assertThat(second.state()).isNotSameAs(first.state()).hasValue(2);
+    assertThat(wrapped.get(TestDoc.FOO.getName()).tag("a", "1").gauge()).returns(1.0, Gauge::value);
+    assertThat(wrapped.get(TestDoc.FOO.getName()).tag("a", "2").gauge()).returns(2.0, Gauge::value);
+  }
+
+  @Test
+  void shouldRegisterDifferentGaugeBasedOnName() {
+    // given
+    final var first = registry.newLongGauge(TestDoc.FOO, "a", "1");
+    final var second = registry.newLongGauge(TestDoc.BAR, "a", "1");
+
+    // when
+    first.state().set(1);
+    second.state().set(2);
+
+    // then
+    assertThat(first).isNotSameAs(second);
+    assertThat(first.state()).hasValue(1);
+    assertThat(second.state()).isNotSameAs(first.state()).hasValue(2);
+    assertThat(wrapped.get(TestDoc.FOO.getName()).tag("a", "1").gauge()).returns(1.0, Gauge::value);
+    assertThat(wrapped.get(TestDoc.BAR.getName()).tag("a", "1").gauge()).returns(2.0, Gauge::value);
+  }
+
+  @Test
+  void shouldRemoveAllGaugesOnClear() {
+    // given
+    final var first = registry.newLongGauge(TestDoc.FOO, "a", "1");
+    final var second = registry.newLongGauge(TestDoc.BAR, "a", "1");
+    first.state().set(3);
+    second.state().set(2);
+
+    // when
+    registry.clear();
+
+    // then
+    assertThat(registry.getMeters()).isEmpty();
+    assertThat(registry.newLongGauge(TestDoc.FOO, "a", "1")).isNotSameAs(first);
+    assertThat(registry.newLongGauge(TestDoc.BAR, "a", "1")).isNotSameAs(second);
+  }
+
+  @Test
+  void shouldRemoveGaugeOnMeterRemove() {
+    // given
+    final var gauge = registry.newLongGauge(TestDoc.FOO, "a", "1");
+    gauge.state().set(3);
+
+    // when
+    registry.remove(gauge.gauge());
+
+    // then
+    assertThat(registry.getMeters()).isEmpty();
+    assertThat(registry.newLongGauge(TestDoc.FOO, "a", "1")).isNotSameAs(gauge);
+  }
+
+  @SuppressWarnings("NullableProblems")
+  private enum TestDoc implements ExtendedMeterDocumentation {
+    FOO {
+      @Override
+      public String getDescription() {
+        return "foo description";
+      }
+
+      @Override
+      public String getName() {
+        return "foo";
+      }
+
+      @Override
+      public Type getType() {
+        return Type.GAUGE;
+      }
+    },
+
+    BAR {
+      @Override
+      public String getDescription() {
+        return "bar description";
+      }
+
+      @Override
+      public String getName() {
+        return "bar";
+      }
+
+      @Override
+      public Type getType() {
+        return Type.GAUGE;
+      }
+    },
+
+    COUNTER {
+      @Override
+      public String getDescription() {
+        return "counter";
+      }
+
+      @Override
+      public String getName() {
+        return "counter";
+      }
+
+      @Override
+      public Type getType() {
+        return Type.COUNTER;
+      }
+    }
+  }
+}

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistryTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistryTest.java
@@ -23,9 +23,7 @@ final class StatefulMeterRegistryTest {
 
   @AfterEach
   void afterEach() {
-    registry.clear();
-    registry.close();
-    registry.remove(wrapped);
+    MicrometerUtil.discard(registry);
 
     wrapped.clear();
     wrapped.close();

--- a/zeebe/zb-db/pom.xml
+++ b/zeebe/zb-db/pom.xml
@@ -84,6 +84,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ZeebeDb.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ZeebeDb.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.db;
 
 import io.camunda.zeebe.protocol.EnumValue;
+import io.camunda.zeebe.util.micrometer.StatefulMeterRegistry;
 import java.io.File;
 import java.util.Optional;
 
@@ -63,4 +64,6 @@ public interface ZeebeDb<ColumnFamilyType extends Enum<? extends EnumValue> & En
    * @return {@code true} if the column is empty, otherwise {@code false}
    */
   boolean isEmpty(ColumnFamilyType column, TransactionContext context);
+
+  StatefulMeterRegistry getMeterRegistry();
 }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/SnapshotOnlyDb.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/SnapshotOnlyDb.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.ZeebeDbException;
 import io.camunda.zeebe.protocol.EnumValue;
+import io.camunda.zeebe.util.micrometer.StatefulMeterRegistry;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
@@ -70,6 +71,12 @@ final class SnapshotOnlyDb<ColumnFamilyType extends Enum<? extends EnumValue> & 
   @Override
   public boolean isEmpty(final ColumnFamilyType column, final TransactionContext context) {
     throw unsupported("isEmpty");
+  }
+
+  @Override
+  public StatefulMeterRegistry getMeterRegistry() {
+    throw new UnsupportedOperationException(
+        "No meter registry is available for a snapshot only DB, as no metrics are collected.");
   }
 
   @Override

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.db.impl.rocksdb.transaction.RocksDbOptions;
 import io.camunda.zeebe.db.impl.rocksdb.transaction.ZeebeTransactionDb;
 import io.camunda.zeebe.protocol.EnumValue;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.io.File;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -52,14 +53,17 @@ public final class ZeebeRocksDbFactory<
   private final RocksDbConfiguration rocksDbConfiguration;
   private final ConsistencyChecksSettings consistencyChecksSettings;
   private final AccessMetricsConfiguration metrics;
+  private final MeterRegistry meterRegistry;
 
   public ZeebeRocksDbFactory(
       final RocksDbConfiguration rocksDbConfiguration,
       final ConsistencyChecksSettings consistencyChecksSettings,
-      final AccessMetricsConfiguration metricsConfiguration) {
+      final AccessMetricsConfiguration metricsConfiguration,
+      final MeterRegistry meterRegistry) {
     this.rocksDbConfiguration = Objects.requireNonNull(rocksDbConfiguration);
     this.consistencyChecksSettings = Objects.requireNonNull(consistencyChecksSettings);
     metrics = metricsConfiguration;
+    this.meterRegistry = Objects.requireNonNull(meterRegistry);
   }
 
   @Override
@@ -72,7 +76,8 @@ public final class ZeebeRocksDbFactory<
           closeables,
           rocksDbConfiguration,
           consistencyChecksSettings,
-          metrics);
+          metrics,
+          meterRegistry);
     } catch (final RocksDBException e) {
       CloseHelper.quietCloseAll(closeables);
       throw new IllegalStateException("Unexpected error occurred trying to open the database", e);

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.db.impl.NoopColumnFamilyMetrics;
 import io.camunda.zeebe.db.impl.rocksdb.Loggers;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.camunda.zeebe.protocol.EnumValue;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.camunda.zeebe.util.micrometer.StatefulMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.File;
@@ -115,12 +116,7 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<? extends EnumVal
     closables.add(defaultColumnFamilyHandle);
 
     final var statefulMeterRegistry = new StatefulMeterRegistry(wrappedRegistry);
-    closables.add(
-        () -> {
-          statefulMeterRegistry.clear();
-          statefulMeterRegistry.close();
-          statefulMeterRegistry.remove(wrappedRegistry);
-        });
+    closables.add(() -> MicrometerUtil.discard(statefulMeterRegistry));
 
     return new ZeebeTransactionDb<>(
         defaultColumnFamilyHandle,

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
@@ -25,7 +25,6 @@ import io.camunda.zeebe.util.micrometer.StatefulMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -48,7 +47,7 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<? extends EnumVal
   private static final String ERROR_MESSAGE_CLOSE_RESOURCE =
       "Expected to close RocksDB resource successfully, but exception was thrown. Will continue to close remaining resources.";
   private final OptimisticTransactionDB optimisticTransactionDB;
-  private final List<AutoCloseable> closables;
+  private final List<AutoCloseable> closeables;
   private final ReadOptions prefixReadOptions;
   private final ReadOptions defaultReadOptions;
   private final WriteOptions defaultWriteOptions;
@@ -61,7 +60,7 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<? extends EnumVal
   protected ZeebeTransactionDb(
       final ColumnFamilyHandle defaultHandle,
       final OptimisticTransactionDB optimisticTransactionDB,
-      final List<AutoCloseable> closables,
+      final List<AutoCloseable> closeables,
       final RocksDbConfiguration rocksDbConfiguration,
       final ConsistencyChecksSettings consistencyChecksSettings,
       final AccessMetricsConfiguration accessMetricsConfiguration,
@@ -69,7 +68,7 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<? extends EnumVal
     this.defaultHandle = defaultHandle;
     defaultNativeHandle = getNativeHandle(defaultHandle);
     this.optimisticTransactionDB = optimisticTransactionDB;
-    this.closables = closables;
+    this.closeables = closeables;
     this.consistencyChecksSettings = consistencyChecksSettings;
     this.accessMetricsConfiguration = accessMetricsConfiguration;
     this.meterRegistry = meterRegistry;
@@ -82,11 +81,11 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<? extends EnumVal
             // high latency, at the cost of making iterators more expensive (memory and computation
             // wise)
             .setReadaheadSize(0);
-    closables.add(prefixReadOptions);
+    closeables.add(prefixReadOptions);
     defaultReadOptions = new ReadOptions();
-    closables.add(defaultReadOptions);
+    closeables.add(defaultReadOptions);
     defaultWriteOptions = new WriteOptions().setDisableWAL(rocksDbConfiguration.isWalDisabled());
-    closables.add(defaultWriteOptions);
+    closeables.add(defaultWriteOptions);
   }
 
   public static <ColumnFamilyNames extends Enum<? extends EnumValue> & EnumValue>
@@ -100,8 +99,7 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<? extends EnumVal
           final MeterRegistry wrappedRegistry)
           throws RocksDBException {
     final var cfDescriptors =
-        Arrays.asList( // todo: could consider using List.of
-            new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, options.cfOptions()));
+        List.of(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, options.cfOptions()));
     final List<ColumnFamilyHandle> cfHandles = new ArrayList<>();
     final OptimisticTransactionDB optimisticTransactionDB =
         OptimisticTransactionDB.open(options.dbOptions(), path, cfDescriptors, cfHandles);
@@ -210,7 +208,7 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<? extends EnumVal
   public TransactionContext createContext() {
     final Transaction transaction = optimisticTransactionDB.beginTransaction(defaultWriteOptions);
     final ZeebeTransaction zeebeTransaction = new ZeebeTransaction(transaction, this);
-    closables.add(zeebeTransaction);
+    closeables.add(zeebeTransaction);
     return new DefaultTransactionContext(zeebeTransaction);
   }
 
@@ -241,8 +239,8 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<? extends EnumVal
     // 5. db options
     // 6. column family options
     // https://github.com/facebook/rocksdb/wiki/RocksJava-Basics#opening-a-database-with-column-families
-    Collections.reverse(closables);
-    closables.forEach(
+    Collections.reverse(closeables);
+    closeables.forEach(
         closable -> {
           try {
             closable.close();

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/DefaultZeebeDbFactory.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/DefaultZeebeDbFactory.java
@@ -14,16 +14,24 @@ import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
 import io.camunda.zeebe.protocol.EnumValue;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 public final class DefaultZeebeDbFactory {
 
   public static <ColumnFamilyType extends Enum<? extends EnumValue> & EnumValue>
       ZeebeDbFactory<ColumnFamilyType> getDefaultFactory() {
+    return getDefaultFactory(new SimpleMeterRegistry());
+  }
+
+  public static <ColumnFamilyType extends Enum<? extends EnumValue> & EnumValue>
+      ZeebeDbFactory<ColumnFamilyType> getDefaultFactory(final MeterRegistry meterRegistry) {
     // enable consistency checks for tests
     final var consistencyChecks = new ConsistencyChecksSettings(true, true);
     return new ZeebeRocksDbFactory<>(
         new RocksDbConfiguration(),
         consistencyChecks,
-        new AccessMetricsConfiguration(Kind.NONE, 1));
+        new AccessMetricsConfiguration(Kind.NONE, 1),
+        meterRegistry);
   }
 }

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.db.impl.DefaultColumnFamily;
 import io.camunda.zeebe.db.impl.DefaultZeebeDbFactory;
 import io.camunda.zeebe.util.ByteValue;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Properties;
@@ -87,7 +88,8 @@ final class ZeebeRocksDbFactoryTest {
         new ZeebeRocksDbFactory<>(
             new RocksDbConfiguration().setColumnFamilyOptions(customProperties),
             new ConsistencyChecksSettings(),
-            new AccessMetricsConfiguration(Kind.NONE, 1));
+            new AccessMetricsConfiguration(Kind.NONE, 1),
+            new SimpleMeterRegistry());
 
     // when
     final var defaults = factoryWithDefaults.createColumnFamilyOptions(new ArrayList<>());
@@ -120,7 +122,8 @@ final class ZeebeRocksDbFactoryTest {
         new ZeebeRocksDbFactory<>(
             new RocksDbConfiguration().setColumnFamilyOptions(customProperties),
             new ConsistencyChecksSettings(),
-            new AccessMetricsConfiguration(Kind.NONE, 1));
+            new AccessMetricsConfiguration(Kind.NONE, 1),
+            new SimpleMeterRegistry());
 
     // expect
     //noinspection resource


### PR DESCRIPTION
## Description

This PR adds a new `StatefulMeterRegistry` utility which is a composite registry with a new kind of metric, a stateful gauge. This is simply a gauge which tracks its own state, much like Prometheus gauges. The idea is to later be able to use it for certain metrics in the workflow engine which are opened from different contexts.

The PR also adds that the ZeebeDb instance carries its own registry which is closed when the DB is closed. Usage of this registry should be delegated to metrics which are tied to the underlying DB only.

## Related issues

related to #27144
