### PR TITLE
feat: include processInstanceKey to the tasklist-task-variables

### DIFF
--- a/tasklist/common/src/main/java/io/camunda/tasklist/entities/TaskVariableEntity.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/entities/TaskVariableEntity.java
@@ -17,10 +17,11 @@ public class TaskVariableEntity extends TasklistZeebeEntity<TaskVariableEntity> 
   private String value;
   private String fullValue;
   private boolean isPreview;
+  private Long processInstanceKey;
 
   public TaskVariableEntity() {}
 
-  public static String getIdBy(String taskId, String name) {
+  public static String getIdBy(final String taskId, final String name) {
     return String.format("%s-%s", taskId, name);
   }
 
@@ -69,8 +70,22 @@ public class TaskVariableEntity extends TasklistZeebeEntity<TaskVariableEntity> 
     return this;
   }
 
+  public Long getProcessInstanceKey() {
+    return processInstanceKey;
+  }
+
+  public TaskVariableEntity setProcessInstanceKey(final Long processInstanceKey) {
+    this.processInstanceKey = processInstanceKey;
+    return this;
+  }
+
   public static TaskVariableEntity createFrom(
-      String tenantId, String taskId, String name, String value, int variableSizeThreshold) {
+      final String tenantId,
+      final String taskId,
+      final String name,
+      final String value,
+      final int variableSizeThreshold,
+      final String processInstanceKey) {
     final TaskVariableEntity entity =
         new TaskVariableEntity().setId(getIdBy(taskId, name)).setTaskId(taskId).setName(name);
     if (value.length() > variableSizeThreshold) {
@@ -82,10 +97,12 @@ public class TaskVariableEntity extends TasklistZeebeEntity<TaskVariableEntity> 
     }
     entity.setFullValue(value);
     entity.setTenantId(tenantId);
+    entity.setProcessInstanceKey(Long.valueOf(processInstanceKey));
     return entity;
   }
 
-  public static TaskVariableEntity createFrom(String taskId, VariableEntity variableEntity) {
+  public static TaskVariableEntity createFrom(
+      final String taskId, final VariableEntity variableEntity, final String processInstanceKey) {
     return new TaskVariableEntity()
         .setId(getIdBy(taskId, variableEntity.getName()))
         .setTaskId(taskId)
@@ -93,11 +110,14 @@ public class TaskVariableEntity extends TasklistZeebeEntity<TaskVariableEntity> 
         .setValue(variableEntity.getValue())
         .setIsPreview(variableEntity.getIsPreview())
         .setFullValue(variableEntity.getFullValue())
+        .setProcessInstanceKey(Long.valueOf(processInstanceKey))
         .setTenantId(variableEntity.getTenantId());
   }
 
   public static TaskVariableEntity createFrom(
-      String taskId, DraftTaskVariableEntity draftTaskVariableEntity) {
+      final String taskId,
+      final DraftTaskVariableEntity draftTaskVariableEntity,
+      final String processInstanceKey) {
     return new TaskVariableEntity()
         .setId(getIdBy(taskId, draftTaskVariableEntity.getName()))
         .setTaskId(taskId)
@@ -105,7 +125,14 @@ public class TaskVariableEntity extends TasklistZeebeEntity<TaskVariableEntity> 
         .setValue(draftTaskVariableEntity.getValue())
         .setIsPreview(draftTaskVariableEntity.getIsPreview())
         .setFullValue(draftTaskVariableEntity.getFullValue())
+        .setProcessInstanceKey(Long.valueOf(processInstanceKey))
         .setTenantId(draftTaskVariableEntity.getTenantId());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        super.hashCode(), taskId, name, value, fullValue, isPreview, processInstanceKey);
   }
 
   @Override
@@ -124,11 +151,7 @@ public class TaskVariableEntity extends TasklistZeebeEntity<TaskVariableEntity> 
         && Objects.equals(taskId, that.taskId)
         && Objects.equals(name, that.name)
         && Objects.equals(value, that.value)
+        && Objects.equals(processInstanceKey, that.processInstanceKey)
         && Objects.equals(fullValue, that.fullValue);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(super.hashCode(), taskId, name, value, fullValue, isPreview);
   }
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/templates/TaskVariableTemplate.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/templates/TaskVariableTemplate.java
@@ -30,13 +30,14 @@ public class TaskVariableTemplate extends AbstractTemplateDescriptor implements 
   public static final String FULL_VALUE = "fullValue";
   public static final String IS_PREVIEW = "isPreview";
   public static final String TENANT_ID = "tenantId";
+  public static final String PROCESS_INSTANCE_KEY = "processInstanceKey";
 
   @Override
   public String getIndexName() {
     return INDEX_NAME;
   }
 
-  private static Optional<String> getElsFieldByGraphqlField(String fieldName) {
+  private static Optional<String> getElsFieldByGraphqlField(final String fieldName) {
     switch (fieldName) {
       case ("id"):
         return of(ID);
@@ -53,7 +54,7 @@ public class TaskVariableTemplate extends AbstractTemplateDescriptor implements 
     }
   }
 
-  public static Set<String> getElsFieldsByGraphqlFields(Set<String> fieldNames) {
+  public static Set<String> getElsFieldsByGraphqlFields(final Set<String> fieldNames) {
     return fieldNames.stream()
         .map((fn) -> getElsFieldByGraphqlField(fn))
         .flatMap(Optional::stream)

--- a/tasklist/els-schema/src/main/resources/schema/es/create/template/tasklist-task-variable.json
+++ b/tasklist/els-schema/src/main/resources/schema/es/create/template/tasklist-task-variable.json
@@ -30,6 +30,9 @@
 			},
 			"tenantId": {
 				"type": "keyword"
+			},
+			"processInstanceKey": {
+				"type": "long"
 			}
 		}
 	}

--- a/tasklist/els-schema/src/main/resources/schema/os/create/template/tasklist-task-variable.json
+++ b/tasklist/els-schema/src/main/resources/schema/os/create/template/tasklist-task-variable.json
@@ -29,6 +29,9 @@
     },
     "tenantId": {
       "type": "keyword"
+    },
+    "processInstanceKey": {
+      "type": "long"
     }
   }
 }

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/es/UserTaskZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/es/UserTaskZeebeRecordProcessorElasticSearch.java
@@ -66,7 +66,7 @@ public class UserTaskZeebeRecordProcessorElasticSearch {
         final List<TaskVariableEntity> variables =
             userTaskRecordToVariableEntityMapper.mapVariables(record);
         for (final TaskVariableEntity variable : variables) {
-          bulkRequest.add(getVariableQuery(variable));
+          bulkRequest.add(getVariableQuery(variable, record.getValue().getProcessInstanceKey()));
         }
       }
     }
@@ -97,7 +97,8 @@ public class UserTaskZeebeRecordProcessorElasticSearch {
     }
   }
 
-  private UpdateRequest getVariableQuery(final TaskVariableEntity variable)
+  private UpdateRequest getVariableQuery(
+      final TaskVariableEntity variable, final Long processInstanceKey)
       throws PersistenceException {
     try {
       LOGGER.debug("Variable instance for list view: id {}", variable.getId());
@@ -105,6 +106,7 @@ public class UserTaskZeebeRecordProcessorElasticSearch {
       updateFields.put(TaskVariableTemplate.VALUE, variable.getValue());
       updateFields.put(TaskVariableTemplate.FULL_VALUE, variable.getFullValue());
       updateFields.put(TaskVariableTemplate.IS_PREVIEW, variable.getIsPreview());
+      updateFields.put(TaskVariableTemplate.PROCESS_INSTANCE_KEY, processInstanceKey);
 
       return new UpdateRequest()
           .index(variableIndex.getFullQualifiedName())

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/os/UserTaskZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/os/UserTaskZeebeRecordProcessorOpenSearch.java
@@ -66,7 +66,7 @@ public class UserTaskZeebeRecordProcessorOpenSearch {
       final List<TaskVariableEntity> variables =
           userTaskRecordToVariableEntityMapper.mapVariables(record);
       for (final TaskVariableEntity variable : variables) {
-        operations.add(getVariableQuery(variable));
+        operations.add(getVariableQuery(variable, record.getValue().getProcessInstanceKey()));
       }
     }
     // else skip task
@@ -87,12 +87,14 @@ public class UserTaskZeebeRecordProcessorOpenSearch {
         .build();
   }
 
-  private BulkOperation getVariableQuery(final TaskVariableEntity variable) {
+  private BulkOperation getVariableQuery(
+      final TaskVariableEntity variable, final Long processInstanceKey) {
     LOGGER.debug("Variable instance for list view: id {}", variable.getId());
     final Map<String, Object> updateFields = new HashMap<>();
     updateFields.put(TaskVariableTemplate.VALUE, variable.getValue());
     updateFields.put(TaskVariableTemplate.FULL_VALUE, variable.getFullValue());
     updateFields.put(TaskVariableTemplate.IS_PREVIEW, variable.getIsPreview());
+    updateFields.put(TaskVariableTemplate.PROCESS_INSTANCE_KEY, processInstanceKey);
 
     return new BulkOperation.Builder()
         .update(

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
@@ -1311,22 +1311,19 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
                 assertThat(task.getCompletionDate()).isNotNull();
               });
 
-      // Validate variables has processInstanceKey in ES/OS
-      // Fetch variables via variableStore
+      // when
       final var taskVariablesMap =
           variableStore.getTaskVariablesPerTaskId(
               List.of(new GetVariablesRequest().setTaskId(taskId)));
       assertThat(taskVariablesMap).containsKey(taskId);
       final List<TaskVariableEntity> variables = taskVariablesMap.get(taskId);
 
+      // then
       assertThat(variables).isNotNull().isNotEmpty();
 
-      // Validate that each variable has a non-null processInstanceKey
       variables.forEach(
           variable -> {
-            assertThat(variable.getProcessInstanceKey())
-                .isNotNull()
-                .isEqualTo(processInstanceId); // Replace with the expected value
+            assertThat(variable.getProcessInstanceKey()).isNotNull().isEqualTo(processInstanceId);
           });
 
       assertThat(taskVariables)
@@ -1406,22 +1403,19 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
                 assertThat(task.getImplementation()).isEqualTo(TaskImplementation.ZEEBE_USER_TASK);
               });
 
-      // Validate variables has processInstanceKey in ES/OS
-      // Fetch variables via variableStore
+      // when
       final var taskVariablesMap =
           variableStore.getTaskVariablesPerTaskId(
               List.of(new GetVariablesRequest().setTaskId(taskId)));
       assertThat(taskVariablesMap).containsKey(taskId);
       final List<TaskVariableEntity> variables = taskVariablesMap.get(taskId);
 
+      // then
       assertThat(variables).isNotNull().isNotEmpty();
 
-      // Validate that each variable has a non-null processInstanceKey
       variables.forEach(
           variable -> {
-            assertThat(variable.getProcessInstanceKey())
-                .isNotNull()
-                .isEqualTo(processInstanceId); // Replace with the expected value
+            assertThat(variable.getProcessInstanceKey()).isNotNull().isEqualTo(processInstanceId);
           });
 
       assertThat(taskVariables)

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.JsonPath;
 import io.camunda.tasklist.entities.TaskImplementation;
 import io.camunda.tasklist.entities.TaskState;
+import io.camunda.tasklist.entities.TaskVariableEntity;
 import io.camunda.tasklist.property.IdentityProperties;
 import io.camunda.tasklist.queries.RangeValueFilter;
 import io.camunda.tasklist.queries.RangeValueFilter.RangeValueFilterBuilder;
@@ -28,6 +29,8 @@ import io.camunda.tasklist.queries.Sort;
 import io.camunda.tasklist.queries.TaskByVariables;
 import io.camunda.tasklist.queries.TaskOrderBy;
 import io.camunda.tasklist.queries.TaskSortFields;
+import io.camunda.tasklist.store.VariableStore;
+import io.camunda.tasklist.store.VariableStore.GetVariablesRequest;
 import io.camunda.tasklist.util.MockMvcHelper;
 import io.camunda.tasklist.util.TasklistTester;
 import io.camunda.tasklist.util.TasklistZeebeIntegrationTest;
@@ -65,6 +68,8 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
   @InjectMocks private IdentityProperties identityProperties;
 
   @MockBean private IdentityAuthorizationService identityAuthorizationService;
+
+  @Autowired private VariableStore variableStore;
 
   @Autowired private WebApplicationContext context;
 
@@ -1290,6 +1295,7 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
               patch(TasklistURIs.TASKS_URL_V1.concat("/{taskId}/complete"), taskId),
               completeRequest);
       final var taskVariables = tester.getTaskVariables();
+      final var processInstanceId = Long.valueOf(tester.getProcessInstanceId());
 
       // then
       assertThat(result)
@@ -1304,6 +1310,24 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
                 assertThat(task.getCreationDate()).isNotNull();
                 assertThat(task.getCompletionDate()).isNotNull();
               });
+
+      // Validate variables has processInstanceKey in ES/OS
+      // Fetch variables via variableStore
+      final var taskVariablesMap =
+          variableStore.getTaskVariablesPerTaskId(
+              List.of(new GetVariablesRequest().setTaskId(taskId)));
+      assertThat(taskVariablesMap).containsKey(taskId);
+      final List<TaskVariableEntity> variables = taskVariablesMap.get(taskId);
+
+      assertThat(variables).isNotNull().isNotEmpty();
+
+      // Validate that each variable has a non-null processInstanceKey
+      variables.forEach(
+          variable -> {
+            assertThat(variable.getProcessInstanceKey())
+                .isNotNull()
+                .isEqualTo(processInstanceId); // Replace with the expected value
+          });
 
       assertThat(taskVariables)
           .extracting("name", "value", "previewValue", "isValueTruncated")
@@ -1365,6 +1389,7 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
               patch(TasklistURIs.TASKS_URL_V1.concat("/{taskId}/complete"), taskId),
               completeRequest);
       final var taskVariables = tester.getTaskVariables();
+      final var processInstanceId = Long.valueOf(tester.getProcessInstanceId());
 
       // then
       assertThat(result)
@@ -1380,6 +1405,24 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
                 assertThat(task.getCompletionDate()).isNotNull();
                 assertThat(task.getImplementation()).isEqualTo(TaskImplementation.ZEEBE_USER_TASK);
               });
+
+      // Validate variables has processInstanceKey in ES/OS
+      // Fetch variables via variableStore
+      final var taskVariablesMap =
+          variableStore.getTaskVariablesPerTaskId(
+              List.of(new GetVariablesRequest().setTaskId(taskId)));
+      assertThat(taskVariablesMap).containsKey(taskId);
+      final List<TaskVariableEntity> variables = taskVariablesMap.get(taskId);
+
+      assertThat(variables).isNotNull().isNotEmpty();
+
+      // Validate that each variable has a non-null processInstanceKey
+      variables.forEach(
+          variable -> {
+            assertThat(variable.getProcessInstanceKey())
+                .isNotNull()
+                .isEqualTo(processInstanceId); // Replace with the expected value
+          });
 
       assertThat(taskVariables)
           .extracting("name", "value", "previewValue", "isValueTruncated")

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TaskService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TaskService.java
@@ -197,7 +197,8 @@ public class TaskService {
       final TaskEntity completedTaskEntity = taskStore.persistTaskCompletion(task);
       try {
         LOGGER.info("Start variable persistence: {}", taskId);
-        variableService.persistTaskVariables(taskId, variables, withDraftVariableValues);
+        variableService.persistTaskVariables(
+            taskId, variables, withDraftVariableValues, task.getProcessInstanceId());
         deleteDraftTaskVariablesSafely(taskId);
         updateCompletedMetric(completedTaskEntity);
         LOGGER.info("Task with ID {} completed successfully.", taskId);

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/VariableService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/VariableService.java
@@ -145,7 +145,8 @@ public class VariableService {
   public void persistTaskVariables(
       final String taskId,
       final List<VariableInputDTO> changedVariables,
-      final boolean withDraftVariableValues) {
+      final boolean withDraftVariableValues,
+      final String processInstanceKey) {
     // take current runtime variables values and
     final TaskEntity task = taskStore.getTask(taskId);
     final String taskFlowNodeInstanceId = task.getFlowNodeInstanceId();
@@ -157,7 +158,8 @@ public class VariableService {
     taskVariables.forEach(
         variable ->
             finalVariablesMap.put(
-                variable.getName(), TaskVariableEntity.createFrom(taskId, variable)));
+                variable.getName(),
+                TaskVariableEntity.createFrom(taskId, variable, processInstanceKey)));
 
     if (withDraftVariableValues) {
       // update/append with draft variables
@@ -167,7 +169,8 @@ public class VariableService {
               draftTaskVariable ->
                   finalVariablesMap.put(
                       draftTaskVariable.getName(),
-                      TaskVariableEntity.createFrom(taskId, draftTaskVariable)));
+                      TaskVariableEntity.createFrom(
+                          taskId, draftTaskVariable, task.getProcessInstanceId())));
     }
 
     // update/append with variables passed for task completion
@@ -179,7 +182,8 @@ public class VariableService {
               taskId,
               var.getName(),
               var.getValue(),
-              tasklistProperties.getImporter().getVariableSizeThreshold()));
+              tasklistProperties.getImporter().getVariableSizeThreshold(),
+              task.getProcessInstanceId()));
     }
     variableStore.persistTaskVariables(finalVariablesMap.values());
   }

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/TaskServiceTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/TaskServiceTest.java
@@ -406,10 +406,12 @@ class TaskServiceTest {
     when(userReader.getCurrentUser()).thenReturn(mockedUser);
     final var taskBefore = mock(TaskEntity.class);
     when(taskStore.getTask(taskId)).thenReturn(taskBefore);
+    taskBefore.setProcessInstanceId("1234567");
     final var completedTask =
         new TaskEntity()
             .setId(taskId)
             .setState(TaskState.COMPLETED)
+            .setProcessInstanceId("1234567")
             .setAssignee("demo")
             .setCompletionTime(OffsetDateTime.now());
     when(taskStore.persistTaskCompletion(taskBefore)).thenReturn(completedTask);
@@ -420,7 +422,8 @@ class TaskServiceTest {
     // Then
     verify(taskValidator).validateCanComplete(taskBefore);
     verify(tasklistServicesAdapter).completeUserTask(eq(taskBefore), any());
-    verify(variableService).persistTaskVariables(taskId, variables, true);
+    verify(variableService)
+        .persistTaskVariables(taskId, variables, true, taskBefore.getProcessInstanceId());
     verify(variableService).deleteDraftTaskVariables(taskId);
     assertThat(result).isEqualTo(TaskDTO.createFrom(completedTask, objectMapper));
   }
@@ -436,11 +439,13 @@ class TaskServiceTest {
     when(userReader.getCurrentUser()).thenReturn(mockedUser);
     final var taskBefore = mock(TaskEntity.class);
     when(taskStore.getTask(taskId)).thenReturn(taskBefore);
+    taskBefore.setProcessDefinitionId("1234");
     final var completedTask =
         new TaskEntity()
             .setId(taskId)
             .setState(TaskState.COMPLETED)
             .setAssignee("demo")
+            .setProcessInstanceId("1234")
             .setCompletionTime(OffsetDateTime.now());
     when(taskStore.persistTaskCompletion(taskBefore)).thenReturn(completedTask);
 
@@ -450,7 +455,8 @@ class TaskServiceTest {
     // Then
     verify(taskValidator).validateCanComplete(taskBefore);
     verify(tasklistServicesAdapter).completeUserTask(eq(taskBefore), any());
-    verify(variableService).persistTaskVariables(taskId, variables, true);
+    verify(variableService)
+        .persistTaskVariables(taskId, variables, true, taskBefore.getProcessInstanceId());
     verify(variableService).deleteDraftTaskVariables(taskId);
     assertThat(result).isEqualTo(TaskDTO.createFrom(completedTask, objectMapper));
   }

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/VariableServiceTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/VariableServiceTest.java
@@ -482,6 +482,7 @@ class VariableServiceTest {
         new TaskEntity()
             .setId(taskId)
             .setFlowNodeInstanceId(flowNodeInstanceId)
+            .setProcessInstanceId("123456")
             .setTenantId("tenant_b");
     when(taskStore.getTask(taskId)).thenReturn(task);
     final ImportProperties importProperties = mock(ImportProperties.class);
@@ -502,7 +503,8 @@ class VariableServiceTest {
         List.of(
             new VariableInputDTO().setName("varB").setValue("\"changedB\""),
             new VariableInputDTO().setName("varC").setValue("\"changedC\"")),
-        false);
+        false,
+        task.getProcessInstanceId());
 
     // then
     verify(draftVariableStore, never()).getVariablesByTaskIdAndVariableNames(any(), any());
@@ -525,6 +527,7 @@ class VariableServiceTest {
         new TaskEntity()
             .setId(taskId)
             .setFlowNodeInstanceId(flowNodeInstanceId)
+            .setProcessInstanceId("123456")
             .setTenantId("tenant_c");
     when(taskStore.getTask(taskId)).thenReturn(task);
     final ImportProperties importProperties = mock(ImportProperties.class);
@@ -566,7 +569,8 @@ class VariableServiceTest {
                 .setName("varD")
                 .setValue("\"changedD_longValueThatExceedLimit\""),
             new VariableInputDTO().setName("varE").setValue("\"changedE\"")),
-        true);
+        true,
+        task.getProcessInstanceId());
 
     // then
     verify(variableStore).persistTaskVariables(taskVariableCaptor.capture());


### PR DESCRIPTION
## Description

With the return of importers, we can add that the processInstanceKey field to the task-variables template, and update the importers. This would mitigate the problem in the exporter, as the current Tasklist Archiving process would already be responsible for archiving the data and the new data indexed via the importer would already contain the processInstanceKey, meaning we wouldn’t need to worry about this during migration or develop additional jobs for the exporter (coming on version 8.8).

On this PR we are covering:
- Add the processInstanceKey to the task-variables template.
- Add this field to the importer for both Elasticsearch and Opensearch.
- Adjust variables to include the processInstanceKey once task is concluded
- Integration tests

## Related issues

closes #https://github.com/camunda/camunda/issues/26065
