### PR TITLE
fix: set  operate.client.profile to simple in c8run

### DIFF
--- a/c8run/connectors-application.properties
+++ b/c8run/connectors-application.properties
@@ -3,4 +3,6 @@ zeebe.client.security.plaintext=true
 camunda.operate.client.url=http://localhost:8080
 camunda.operate.client.username=demo
 camunda.operate.client.password=demo
+operate.client.profile=simple
+operate.client.base-url=http://localhost:8080
 server.port=8085

--- a/c8run/connectors-application.properties
+++ b/c8run/connectors-application.properties
@@ -1,8 +1,5 @@
 zeebe.client.broker.gateway-address=127.0.0.1:26500
 zeebe.client.security.plaintext=true
-camunda.operate.client.url=http://localhost:8080
-camunda.operate.client.username=demo
-camunda.operate.client.password=demo
 operate.client.profile=simple
 operate.client.base-url=http://localhost:8080
 server.port=8085


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
