### PR TITLE
Camunda exporter startup bug

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -987,8 +987,8 @@
         #
         #   index:
         #     prefix:
-        #     zeebeIndexPrefix: zeebe-record
-        #     The 'zeebeIndexPrefix' must be the same value as the Elasticsearch exporter 'elasticsearch.args.index.prefix'
+        #     zeebeExporterIndexPrefix: zeebe-record
+        #     The 'zeebeIndexPrefix' must be the same value as the Elasticsearch/OpenSearch exporter 'elasticsearch.args.index.prefix'
         #     otherwise the exporter may never start.
         #     numberOfShards: 3
         #     numberOfReplicas: 0

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -987,6 +987,9 @@
         #
         #   index:
         #     prefix:
+        #     zeebeIndexPrefix: zeebe-record
+        #     The 'zeebeIndexPrefix' must be the same value as the Elasticsearch exporter 'elasticsearch.args.index.prefix'
+        #     otherwise the exporter may never start.
         #     numberOfShards: 3
         #     numberOfReplicas: 0
         #     variableSizeThreshold: 8191

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -901,6 +901,9 @@
         #
         #   index:
         #     prefix:
+        #     zeebeIndexPrefix: zeebe-record
+        #     The 'zeebeIndexPrefix' must be the same value as the Elasticsearch exporter 'elasticsearch.args.index.prefix'
+        #     otherwise the exporter may never start.
         #     numberOfShards: 3
         #     numberOfReplicas: 0
         #     variableSizeThreshold: 8191

--- a/qa/integration-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Base64;
-import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
@@ -94,8 +93,6 @@ public class PrefixMigrationIT {
                 "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME",
                 "io.camunda.exporter.CamundaExporter")
             .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_PREFIX", newPrefix);
-
-    container.setPortBindings(List.of("9600:9600", "8080:8080", "26500:26500"));
 
     return container;
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -69,6 +69,7 @@ public class CamundaExporter implements Exporter {
   private BackgroundTaskManager taskManager;
   private ExporterMetadata metadata;
   private boolean exporterCanFlush = false;
+  private boolean zeebeIndicesExist = false;
   private SearchEngineClient searchEngineClient;
   private int partitionId;
 
@@ -291,11 +292,13 @@ public class CamundaExporter implements Exporter {
                   d -> d instanceof ImportPositionIndex || d instanceof TasklistImportPositionIndex)
               .toList();
 
-      final var zeebeIndicesExist =
-          !searchEngineClient
-              .getMappings(
-                  configuration.getIndex().getZeebeIndexPrefix() + "*", MappingSource.INDEX)
-              .isEmpty();
+      if (!zeebeIndicesExist) {
+        zeebeIndicesExist =
+            !searchEngineClient
+                .getMappings(
+                    configuration.getIndex().getZeebeIndexPrefix() + "*", MappingSource.INDEX)
+                .isEmpty();
+      }
 
       exporterCanFlush =
           !zeebeIndicesExist

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -31,6 +31,7 @@ import io.camunda.exporter.config.ConfigValidator;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.schema.MappingSource;
 import io.camunda.exporter.schema.SchemaManager;
 import io.camunda.exporter.schema.SearchEngineClient;
 import io.camunda.exporter.store.BatchRequest;
@@ -67,7 +68,7 @@ public class CamundaExporter implements Exporter {
   private CamundaExporterMetrics metrics;
   private BackgroundTaskManager taskManager;
   private ExporterMetadata metadata;
-  private boolean importersCompleted = false;
+  private boolean exporterCanFlush = false;
   private SearchEngineClient searchEngineClient;
   private int partitionId;
 
@@ -180,7 +181,7 @@ public class CamundaExporter implements Exporter {
       return;
     }
 
-    if (configuration.getIndex().shouldWaitForImporters() && !importersCompleted) {
+    if (configuration.getIndex().shouldWaitForImporters() && !exporterCanFlush) {
       ensureCachedRecordsLessThanBulkSize(record);
 
       writer.addRecord(record);
@@ -280,7 +281,7 @@ public class CamundaExporter implements Exporter {
       scheduleDelayedFlush();
       return;
     }
-    if (!importersCompleted) {
+    if (!exporterCanFlush) {
       scheduleImportersCompletedCheck();
     }
     try {
@@ -290,13 +291,20 @@ public class CamundaExporter implements Exporter {
                   d -> d instanceof ImportPositionIndex || d instanceof TasklistImportPositionIndex)
               .toList();
 
-      importersCompleted =
-          searchEngineClient.importersCompleted(partitionId, importPositionIndices);
+      final var zeebeIndicesExist =
+          !searchEngineClient
+              .getMappings(
+                  configuration.getIndex().getZeebeIndexPrefix() + "*", MappingSource.INDEX)
+              .isEmpty();
+
+      exporterCanFlush =
+          !zeebeIndicesExist
+              || searchEngineClient.importersCompleted(partitionId, importPositionIndices);
     } catch (final Exception e) {
       LOG.warn("Unexpected exception occurred checking importers completed, will retry later.", e);
     }
 
-    if (importersCompleted) {
+    if (exporterCanFlush) {
       scheduleDelayedFlush();
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -131,6 +131,7 @@ public class ExporterConfiguration {
   public static final class IndexSettings {
     public static final int DEFAULT_VARIABLE_SIZE_THRESHOLD = 8191;
     private String prefix = "";
+    private String zeebeIndexPrefix = "zeebe-record";
 
     private Integer numberOfShards = 1;
     private Integer numberOfReplicas = 0;
@@ -178,6 +179,14 @@ public class ExporterConfiguration {
       return shouldWaitForImporters;
     }
 
+    public String getZeebeIndexPrefix() {
+      return zeebeIndexPrefix;
+    }
+
+    public void setZeebeIndexPrefix(final String zeebeIndexPrefix) {
+      this.zeebeIndexPrefix = zeebeIndexPrefix;
+    }
+
     public void setShouldWaitForImporters(final boolean shouldWaitForImporters) {
       this.shouldWaitForImporters = shouldWaitForImporters;
     }
@@ -198,6 +207,8 @@ public class ExporterConfiguration {
           + shardsByIndexName
           + ", variableSizeThreshold="
           + variableSizeThreshold
+          + ", zeebeIndexPrefix='"
+          + zeebeIndexPrefix
           + '}';
     }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -63,6 +63,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -678,11 +679,24 @@ final class CamundaExporterIT {
     }
 
     @TestTemplate
-    void shouldNotFlushIfImportersAreNotCompleted(
+    void shouldFlushIfImporterNotCompletedButNoZeebeIndices(
         final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
         throws IOException {
       // given
       createSchemas(config, clientAdapter);
+      indexImportPositionEntity("decision", false, clientAdapter);
+      clientAdapter.refresh();
+
+      checkExporterFlushesRecord(config, clientAdapter);
+    }
+
+    @TestTemplate
+    void shouldNotFlushIfImportersAreNotCompletedAndThereAreZeebeIndices(
+        final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
+        throws IOException {
+      // given
+      createSchemas(config, clientAdapter);
+      clientAdapter.index("1", "zeebe-record-decision", Map.of("key", "12345"));
       // adds a not complete position index document so exporter sees importing as not yet completed
       indexImportPositionEntity("decision", false, clientAdapter);
       clientAdapter.refresh();
@@ -726,39 +740,7 @@ final class CamundaExporterIT {
     void shouldFlushIfImportersAreCompleted(
         final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
         throws IOException {
-      // given
-      final var context = spy(getContextFromConfig(config));
-      doReturn(partitionId).when(context).getPartitionId();
-      camundaExporter.configure(context);
-      camundaExporter.open(controller);
-
-      controller.runScheduledTasks(Duration.ofMinutes(1));
-
-      // when
-      final var record =
-          factory.generateRecord(
-              ValueType.USER,
-              r -> r.withBrokerVersion("8.8.0").withTimestamp(System.currentTimeMillis()),
-              UserIntent.CREATED);
-
-      camundaExporter.export(record);
-
-      // then
-      assertThat(controller.getPosition()).isEqualTo(record.getPosition());
-      verify(controller, times(1))
-          .updateLastExportedRecordPosition(eq(record.getPosition()), any());
-
-      final var authHandler =
-          getHandlers(config).stream()
-              .filter(handler -> handler.getHandledValueType().equals(record.getValueType()))
-              .filter(handler -> handler.handlesRecord(record))
-              .findFirst()
-              .orElseThrow();
-      final var recordId = authHandler.generateIds(record).getFirst();
-
-      assertThat(
-              clientAdapter.get(recordId, authHandler.getIndexName(), authHandler.getEntityType()))
-          .isNotNull();
+      checkExporterFlushesRecord(config, clientAdapter);
     }
 
     @TestTemplate
@@ -879,6 +861,44 @@ final class CamundaExporterIT {
       exporter.open(new ExporterTestController());
 
       adapter.refresh();
+    }
+
+    private void checkExporterFlushesRecord(
+        final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
+        throws IOException {
+      // given
+      final var context = spy(getContextFromConfig(config));
+      doReturn(partitionId).when(context).getPartitionId();
+      camundaExporter.configure(context);
+      camundaExporter.open(controller);
+
+      controller.runScheduledTasks(Duration.ofMinutes(1));
+
+      // when
+      final var record =
+          factory.generateRecord(
+              ValueType.USER,
+              r -> r.withBrokerVersion("8.8.0").withTimestamp(System.currentTimeMillis()),
+              UserIntent.CREATED);
+
+      camundaExporter.export(record);
+
+      // then
+      assertThat(controller.getPosition()).isEqualTo(record.getPosition());
+      verify(controller, times(1))
+          .updateLastExportedRecordPosition(eq(record.getPosition()), any());
+
+      final var authHandler =
+          getHandlers(config).stream()
+              .filter(handler -> handler.getHandledValueType().equals(record.getValueType()))
+              .filter(handler -> handler.handlesRecord(record))
+              .findFirst()
+              .orElseThrow();
+      final var recordId = authHandler.generateIds(record).getFirst();
+
+      assertThat(
+              clientAdapter.get(recordId, authHandler.getIndexName(), authHandler.getEntityType()))
+          .isNotNull();
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -869,10 +869,13 @@ final class CamundaExporterIT {
       // given
       assertThat(config.getBulk().getSize()).isEqualTo(1);
 
+      // Simulate existing zeebe index so it will not skip the wait for importers
+      clientAdapter.index("1", "zeebe-record-decision", Map.of("key", "12345"));
+
       // if schemas are never created then import position indices do not exist and all checks about
       // whether the importers are completed will return false.
       config.setCreateSchema(false);
-      config.getIndex().setPrefix(RandomStringUtils.randomAlphabetic(10));
+      config.getIndex().setPrefix(RandomStringUtils.randomAlphabetic(10).toLowerCase());
       final var context = getContextFromConfig(config);
       camundaExporter.configure(context);
       camundaExporter.open(controller);


### PR DESCRIPTION
## Description

There is a bug where the camunda exporter can enter an error loop in a new cluster where it is waiting for importers to complete which never will (as importers will not do any work in 8.8). This fix will as per the slack thread referred to here https://github.com/camunda/camunda/issues/26046#issuecomment-2647813197, assume that a lack of existence of zeebe indices (which the importer reads from), means that it is a fresh cluster, thus the exporter does not need to wait and we avoid the error loop.

Questions
- There is a requirement that the new `zeebeIndexPrefix` match the zeebe index prefix defined for the ES exporter, I have documented this in the yaml but I feel like this should be explicitly stated elsewhere otherwise the 8.8 camunda exporter can enter boot loops. (Although it will work work with default configuration).
- Would this need to get backported for people running benchmarks? (to which version?)

## Related issues

relates to #26046  
