### PR TITLE
fix: remove variables column from outliers table

### DIFF
--- a/optimize/client/src/components/Analysis/TaskAnalysis/OutlierDetailsTable.test.tsx
+++ b/optimize/client/src/components/Analysis/TaskAnalysis/OutlierDetailsTable.test.tsx
@@ -8,6 +8,7 @@
 
 import {shallow} from 'enzyme';
 import OutlierDetailsTable from './OutlierDetailsTable';
+import {Button} from "@carbon/react";
 
 const props = {
   flowNodeNames: {
@@ -36,20 +37,25 @@ it('should render the table properly', () => {
   const tableBody = node.find('Table').prop<(string | JSX.Element)[][]>('body');
 
   expect(tableBody.length).toBe(2);
-  expect(tableBody[0]?.length).toBe(6);
+  expect(tableBody[0]?.length).toBe(5);
 
   // task 1 with name and variable
   expect(tableBody[0]?.[0]).toBe('Task 1');
   expect(tableBody[0]?.[1]).toBe('10');
   expect(tableBody[0]?.[2]).toBe('1 instance took 50% longer than average.');
-  const task1Variabes = shallow(tableBody[0]?.[3] as JSX.Element);
-  expect(task1Variabes.text()).toBe('variable1=true');
+  const task1ViewDetails = shallow(<div>{tableBody[0]?.[3]}</div>);
+  expect(task1ViewDetails.text()).toBe('View details');
+  expect(task1ViewDetails.find(Button).text()).toBe('View details');
+  expect(task1ViewDetails.find(Button)).toExist();
 
   // task 2 with no additional data
   expect(tableBody[1]?.[0]).toBe('task2');
   expect(tableBody[1]?.[1]).toBe('5');
   expect(tableBody[1]?.[2]).toBe('2 instances took 10% longer than average.');
-  expect(tableBody[1]?.[3]).toBe('-');
+  const task2ViewDetails = shallow(<div>{tableBody[1]?.[3]}</div>);
+  expect(task2ViewDetails.text()).toBe('View details');
+  expect(task2ViewDetails.find(Button).text()).toBe('View details');
+  expect(task2ViewDetails.find(Button)).toExist();
 });
 
 it('should ommit tasks without data', () => {
@@ -79,7 +85,7 @@ it('should render download instances button', () => {
   const node = shallow(<OutlierDetailsTable {...props} />);
 
   const tableBody = node.find('Table').prop<(string | JSX.Element)[][]>('body');
-  const downloadButton = tableBody[0]?.[5] as JSX.Element;
+  const downloadButton = tableBody[0]?.[4] as JSX.Element;
 
   expect(downloadButton.props).toMatchObject({
     id: 'task1',

--- a/optimize/client/src/components/Analysis/TaskAnalysis/OutlierDetailsTable.tsx
+++ b/optimize/client/src/components/Analysis/TaskAnalysis/OutlierDetailsTable.tsx
@@ -20,12 +20,9 @@ type TaskData = {
   higherOutlier?: {count: number; relation: number; boundValue: number};
 };
 
-type Variable = {variableName: string; variableTerm: string | number | boolean};
-
 interface OutlierDetailsTableProps {
   loading?: boolean;
   nodeOutliers: Record<string, TaskData | undefined>;
-  outlierVariables: Record<string, Variable[]>;
   flowNodeNames: Record<string, string>;
   onDetailsClick: (taskId: string, taskData: TaskData) => string;
   config: AnalysisProcessDefinitionParameters;
@@ -34,25 +31,10 @@ interface OutlierDetailsTableProps {
 export default function OutlierDetailsTable({
   loading,
   nodeOutliers,
-  outlierVariables,
   flowNodeNames,
   onDetailsClick,
   config,
 }: OutlierDetailsTableProps) {
-  function getVariablesList(variables?: Variable[]): string | JSX.Element {
-    if (!variables?.length) {
-      return '-';
-    }
-
-    return (
-      <ul>
-        {variables.map(({variableName, variableTerm}) => (
-          <li key={variableName}>{`${variableName}=${variableTerm}`}</li>
-        ))}
-      </ul>
-    );
-  }
-
   function parseTableBody(): TableBody[] {
     if (!nodeOutliers) {
       return [];
@@ -68,13 +50,11 @@ export default function OutlierDetailsTable({
           higherOutlier: {count, relation, boundValue},
           totalCount,
         } = nodeOutlierData;
-        const variables = outlierVariables[nodeOutlierId];
 
         tableRows.push([
           flowNodeNames[nodeOutlierId] || nodeOutlierId,
           totalCount.toString(),
           getOutlierSummary(count, relation),
-          getVariablesList(variables),
           <Button
             kind="tertiary"
             size="sm"
@@ -104,7 +84,6 @@ export default function OutlierDetailsTable({
         t('analysis.task.table.flowNodeName').toString(),
         t('analysis.task.totalInstances').toString(),
         t('analysis.task.table.outliers').toString(),
-        t('report.variables.default').toString(),
         t('common.details').toString(),
         t('common.download').toString(),
       ]}

--- a/optimize/client/src/components/Analysis/TaskAnalysis/TaskAnalysis.js
+++ b/optimize/client/src/components/Analysis/TaskAnalysis/TaskAnalysis.js
@@ -20,7 +20,7 @@ import {track} from 'tracking';
 import OutlierControlPanel from './OutlierControlPanel';
 import OutlierDetailsModal from './OutlierDetailsModal';
 import OutlierDetailsTable from './OutlierDetailsTable';
-import {loadNodesOutliers, loadDurationData, loadCommonOutliersVariables} from './service';
+import {loadNodesOutliers, loadDurationData} from './service';
 
 import './TaskAnalysis.scss';
 
@@ -38,7 +38,6 @@ export default function TaskAnalysis() {
   const [higherNodeOutliersHeatData, setHigherNodeOutliersHeatData] = useState();
   const [flowNodeNames, setFlowNodeNames] = useState({});
   const [selectedOutlierNode, setSelectedOutlierNode] = useState(null);
-  const [higherNodeOutlierVariables, setHigherNodeOutlierVariables] = useState({});
   const [isLoadingXml, setIsLoadingXml] = useState(false);
   const [isLoadingFlowNodeNames, setIsLoadingFlowNodeNames] = useState(false);
   const [isLoadingNodeOutliers, setIsLoadingNodeOutliers] = useState(false);
@@ -90,19 +89,6 @@ export default function TaskAnalysis() {
     });
   }
 
-  const loadOutlierVariables = useCallback(async (outliersHeatData, nodeOutliers, config) => {
-    return Object.keys(outliersHeatData).reduce(async (nodeOutlierVariables, nodeOutlierId) => {
-      const outlierVariables = await loadCommonOutliersVariables({
-        ...config,
-        flowNodeId: nodeOutlierId,
-        higherOutlierBound: nodeOutliers[nodeOutlierId].higherOutlier.boundValue,
-      });
-
-      nodeOutlierVariables[nodeOutlierId] = outlierVariables;
-      return nodeOutlierVariables;
-    }, {});
-  }, []);
-
   const loadOutlierData = useCallback(
     (config) => {
       setIsLoadingNodeOutliers(true);
@@ -127,22 +113,15 @@ export default function TaskAnalysis() {
             {}
           );
 
-          const higherNodeOutlierVariables = await loadOutlierVariables(
-            higherOutliersHeatData,
-            nodeOutliers,
-            config
-          );
-
           setNodeOutliers(nodeOutliers);
           nodeOutliersRef.current = nodeOutliers;
           setHigherNodeOutliersHeatData(higherOutliersHeatData);
-          setHigherNodeOutlierVariables(higherNodeOutlierVariables);
         },
         showError,
         () => setIsLoadingNodeOutliers(false)
       );
     },
-    [loadOutlierVariables, loadFlowNodeNames, mightFail]
+    [loadFlowNodeNames, mightFail]
   );
 
   function onNodeClick({element: {id}}) {
@@ -234,7 +213,6 @@ export default function TaskAnalysis() {
             flowNodeNames={flowNodeNames}
             loading={isLoadingFlowNodeNames || isLoadingNodeOutliers}
             onDetailsClick={loadChartData}
-            outlierVariables={higherNodeOutlierVariables}
             nodeOutliers={nodeOutliers}
             config={config}
           />

--- a/optimize/client/src/components/Analysis/TaskAnalysis/TaskAnalysis.test.js
+++ b/optimize/client/src/components/Analysis/TaskAnalysis/TaskAnalysis.test.js
@@ -243,8 +243,8 @@ it('should open details modal on node click', async () => {
 });
 
 it('should load variables data and display details table', async () => {
-  loadNodesOutliers.mockClear();
   getFlowNodeNames.mockClear();
+  loadNodesOutliers.mockClear();
 
   const node = shallow(<TaskAnalysis />);
 
@@ -256,9 +256,9 @@ it('should load variables data and display details table', async () => {
 
   await flushPromises();
   runAllEffects();
-  await flushPromises();
 
-  expect(loadCommonOutliersVariables).toHaveBeenCalled();
+  expect(getFlowNodeNames).toHaveBeenCalled();
+  expect(loadNodesOutliers).toHaveBeenCalled();
   expect(node.find(OutlierDetailsTable)).toExist();
 });
 


### PR DESCRIPTION
## Description

We've been seeing an overload in ES coming from Task Analysis Page calling `api/analysis/significantOutlierVariableTerms` for each flow node in a given process. This PR is removing the variables column from the outliers table so that those outliers are only fetched when users click on "view details" button.

**Old behaviour**
![Screenshot 2568-02-13 at 14 31 17](https://github.com/user-attachments/assets/bde37f1b-e75d-463d-857f-ad391a37b1a9)

**New behaviour**
![Screenshot 2568-02-13 at 14 31 42](https://github.com/user-attachments/assets/ab285f37-1a89-4600-bcc3-550fb5d80ebc)

As shown in the screenshot, we're saving a few expensive api calls and the table no longer displays the "Variables" column.

## Related issues

related to #27844 
