### PR TITLE
[Backport stable/8.7] fix: make MessagingMetricsImpl ThreadSafe

### DIFF
--- a/zeebe/atomix/cluster/pom.xml
+++ b/zeebe/atomix/cluster/pom.xml
@@ -276,6 +276,11 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-resolver</artifactId>
     </dependency>
+    <dependency>
+      <groupId>net.jcip</groupId>
+      <artifactId>jcip-annotations</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
   </dependencies>
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/MessagingMetricsImpl.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/MessagingMetricsImpl.java
@@ -17,9 +17,11 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import net.jcip.annotations.ThreadSafe;
 
+@ThreadSafe
 final class MessagingMetricsImpl implements MessagingMetrics {
 
   private final Map<String, Timer> requestResponseLatency;
@@ -40,12 +42,12 @@ final class MessagingMetricsImpl implements MessagingMetrics {
 
   MessagingMetricsImpl(final MeterRegistry registry) {
     this.registry = registry;
-    requestResponseLatency = new HashMap<>();
-    requestSize = Table.simple();
-    requestMessageCounter = Table.simple();
-    requestRespCounter = Table.simple();
-    responseCounter = Map3D.simple();
-    inFlightCounter = Table.simple();
+    requestResponseLatency = new ConcurrentHashMap<>();
+    requestSize = Table.concurrent();
+    requestMessageCounter = Table.concurrent();
+    requestRespCounter = Table.concurrent();
+    responseCounter = Map3D.concurrent();
+    inFlightCounter = Table.concurrent();
   }
 
   @Override

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyDnsMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyDnsMetrics.java
@@ -25,7 +25,7 @@ final class NettyDnsMetrics implements DnsQueryLifecycleObserver {
 
   private final Counter error;
   private final Counter written;
-  private final Counter succeded;
+  private final Counter succeeded;
 
   /** indexed by {@link DnsResponseCode#intValue()} */
   private final MeterProvider<Counter> failed;
@@ -34,7 +34,7 @@ final class NettyDnsMetrics implements DnsQueryLifecycleObserver {
     error = Counter.builder(ERROR.getName()).description(ERROR.getDescription()).register(registry);
     written =
         Counter.builder(WRITTEN.getName()).description(WRITTEN.getDescription()).register(registry);
-    succeded =
+    succeeded =
         Counter.builder(SUCCESS.getName()).description(SUCCESS.getDescription()).register(registry);
     failed =
         Counter.builder(FAILED.getName())
@@ -73,6 +73,6 @@ final class NettyDnsMetrics implements DnsQueryLifecycleObserver {
 
   @Override
   public void querySucceed() {
-    succeded.increment();
+    succeeded.increment();
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyDnsMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyDnsMetrics.java
@@ -18,7 +18,9 @@ import io.netty.handler.codec.dns.DnsResponseCode;
 import io.netty.resolver.dns.DnsQueryLifecycleObserver;
 import java.net.InetSocketAddress;
 import java.util.List;
+import net.jcip.annotations.ThreadSafe;
 
+@ThreadSafe
 final class NettyDnsMetrics implements DnsQueryLifecycleObserver {
 
   private final Counter error;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocolMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocolMetrics.java
@@ -13,7 +13,9 @@ import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+import net.jcip.annotations.ThreadSafe;
 
+@ThreadSafe
 final class SwimMembershipProtocolMetrics {
 
   private final Map<String, AtomicLong> incarnationNumbers = new ConcurrentHashMap<>();


### PR DESCRIPTION
# Description
Backport of #28108 to `stable/8.7`.

relates to #28109
original author: @entangled90