### PR TITLE
migrate zeebeDb to micrometer

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/RockDbMetricExporterPartitionStartupStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/RockDbMetricExporterPartitionStartupStep.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
 import io.camunda.zeebe.broker.system.partitions.PartitionStartupContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionStartupStep;
-import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDBMetricExporter;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.time.Duration;
@@ -24,10 +23,6 @@ public class RockDbMetricExporterPartitionStartupStep implements PartitionStartu
   @Override
   public ActorFuture<PartitionStartupContext> startup(
       final PartitionStartupContext partitionStartupContext) {
-    final var metricExporter =
-        new ZeebeRocksDBMetricExporter<>(
-            Integer.toString(partitionStartupContext.getPartitionId()),
-            partitionStartupContext::getZeebeDb);
     final var metricsTimer =
         partitionStartupContext
             .getActorControl()
@@ -35,7 +30,7 @@ public class RockDbMetricExporterPartitionStartupStep implements PartitionStartu
                 Duration.ofSeconds(5),
                 () -> {
                   if (partitionStartupContext.getZeebeDb() != null) {
-                    metricExporter.exportMetrics();
+                    partitionStartupContext.getZeebeDb().exportMetrics();
                   }
                 });
 

--- a/zeebe/zb-db/pom.xml
+++ b/zeebe/zb-db/pom.xml
@@ -89,11 +89,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-core</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>

--- a/zeebe/zb-db/pom.xml
+++ b/zeebe/zb-db/pom.xml
@@ -79,8 +79,13 @@
     </dependency>
 
     <dependency>
-      <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient</artifactId>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-commons</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
     </dependency>
 
     <dependency>

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamilyMetrics.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamilyMetrics.java
@@ -7,14 +7,14 @@
  */
 package io.camunda.zeebe.db;
 
-import io.prometheus.client.Histogram.Timer;
+import io.camunda.zeebe.util.CloseableSilently;
 
 public interface ColumnFamilyMetrics {
-  Timer measureGetLatency();
+  CloseableSilently measureGetLatency();
 
-  Timer measurePutLatency();
+  CloseableSilently measurePutLatency();
 
-  Timer measureDeleteLatency();
+  CloseableSilently measureDeleteLatency();
 
-  Timer measureIterateLatency();
+  CloseableSilently measureIterateLatency();
 }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamilyMetricsDoc.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamilyMetricsDoc.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.db;
+
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter.Type;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
+@SuppressWarnings("NullableProblems")
+public enum ColumnFamilyMetricsDoc implements ExtendedMeterDocumentation {
+  /** Latency of RocksDB operations per column family */
+  LATENCY {
+    private static final KeyName[] KEYS =
+        new KeyName[] {
+          PartitionKeyNames.PARTITION,
+          ColumnFamilyMetricsKeyName.COLUMN_FAMILY,
+          ColumnFamilyMetricsKeyName.OPERATION
+        };
+    private static final Duration[] BUCKETS =
+        MicrometerUtil.exponentialBucketDuration(10, 2, 15, ChronoUnit.MICROS);
+
+    @Override
+    public String getName() {
+      return "zeebe.rocksdb.latency";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public String getDescription() {
+      return "Latency of RocksDB operations per column family";
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return KEYS;
+    }
+  };
+
+  @SuppressWarnings("NullableProblems")
+  public enum ColumnFamilyMetricsKeyName implements KeyName {
+    /** The name of the column family */
+    COLUMN_FAMILY {
+      @Override
+      public String asString() {
+        return "columnFamily";
+      }
+    },
+    /**
+     * The type of operation with value {@link
+     * io.camunda.zeebe.db.ColumnFamilyMetricsDoc.OperationType}
+     */
+    OPERATION {
+      @Override
+      public String asString() {
+        return "operation";
+      }
+    }
+  }
+
+  /**
+   * Type of the operation performend on RocksDB.
+   *
+   * <p>When adding a new case, remember to add a timer to {@link
+   * io.camunda.zeebe.db.impl.FineGrainedColumnFamilyMetrics}
+   */
+  public enum OperationType {
+    GET("get"),
+    PUT("put"),
+    DELETE("delete"),
+    ITERATE("iterate");
+    private final String name;
+
+    OperationType(final String name) {
+      this.name = name;
+    }
+
+    public String getName() {
+      return name;
+    }
+  }
+}

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ZeebeDb.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ZeebeDb.java
@@ -65,7 +65,14 @@ public interface ZeebeDb<ColumnFamilyType extends Enum<? extends EnumValue> & En
    */
   boolean isEmpty(ColumnFamilyType column, TransactionContext context);
 
+  /**
+   * @return the StatefulMeterRegister instance that is tied to this ZeebeDb instance. When ZeebeDb
+   *     is closed, all metrics registered through this instances will be removed from the
+   *     underlying registry.
+   *     <p>Do not register metrics that must outlive the scope of this ZeebeDb instance
+   */
   StatefulMeterRegistry getMeterRegistry();
 
+  /** Export the metrics from RocksDB into micrometer */
   default void exportMetrics() {}
 }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ZeebeDb.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/ZeebeDb.java
@@ -66,4 +66,6 @@ public interface ZeebeDb<ColumnFamilyType extends Enum<? extends EnumValue> & En
   boolean isEmpty(ColumnFamilyType column, TransactionContext context);
 
   StatefulMeterRegistry getMeterRegistry();
+
+  default void exportMetrics() {}
 }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/NoopColumnFamilyMetrics.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/NoopColumnFamilyMetrics.java
@@ -8,27 +8,27 @@
 package io.camunda.zeebe.db.impl;
 
 import io.camunda.zeebe.db.ColumnFamilyMetrics;
-import io.prometheus.client.Histogram.Timer;
+import io.camunda.zeebe.util.CloseableSilently;
 
 public class NoopColumnFamilyMetrics implements ColumnFamilyMetrics {
 
   @Override
-  public Timer measureGetLatency() {
-    return null;
+  public CloseableSilently measureGetLatency() {
+    return () -> {};
   }
 
   @Override
-  public Timer measurePutLatency() {
-    return null;
+  public CloseableSilently measurePutLatency() {
+    return () -> {};
   }
 
   @Override
-  public Timer measureDeleteLatency() {
-    return null;
+  public CloseableSilently measureDeleteLatency() {
+    return () -> {};
   }
 
   @Override
-  public Timer measureIterateLatency() {
-    return null;
+  public CloseableSilently measureIterateLatency() {
+    return () -> {};
   }
 }

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDBMetricExporter.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDBMetricExporter.java
@@ -9,7 +9,8 @@ package io.camunda.zeebe.db.impl.rocksdb;
 
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.protocol.EnumValue;
-import io.prometheus.client.Gauge;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Objects;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
@@ -22,71 +23,128 @@ public final class ZeebeRocksDBMetricExporter<
   private static final Logger LOG =
       LoggerFactory.getLogger(ZeebeRocksDBMetricExporter.class.getName());
 
-  private static final String PARTITION = "partition";
   private static final String ZEEBE_NAMESPACE = "zeebe";
 
   private static final String MEMORY_METRICS_HELP =
       "Everything which might be related to current memory consumption of RocksDB per column family and partition";
-  private static final String MEMORY_METRICS_PREFIX = "rocksdb_memory";
-  private static final RocksDBMetric[] MEMORY_METRICS = {
-    new RocksDBMetric(
-        "rocksdb.cur-size-all-mem-tables", MEMORY_METRICS_PREFIX, MEMORY_METRICS_HELP),
-    new RocksDBMetric(
-        "rocksdb.cur-size-active-mem-table", MEMORY_METRICS_PREFIX, MEMORY_METRICS_HELP),
-    new RocksDBMetric("rocksdb.size-all-mem-tables", MEMORY_METRICS_PREFIX, MEMORY_METRICS_HELP),
-    new RocksDBMetric("rocksdb.block-cache-usage", MEMORY_METRICS_PREFIX, MEMORY_METRICS_HELP),
-    new RocksDBMetric("rocksdb.block-cache-capacity", MEMORY_METRICS_PREFIX, MEMORY_METRICS_HELP),
-    new RocksDBMetric(
-        "rocksdb.block-cache-pinned-usage", MEMORY_METRICS_PREFIX, MEMORY_METRICS_HELP),
-    new RocksDBMetric(
-        "rocksdb.estimate-table-readers-mem", MEMORY_METRICS_PREFIX, MEMORY_METRICS_HELP),
-  };
-
+  private static final String MEMORY_METRICS_PREFIX = "rocksdb.memory";
   private static final String SST_METRICS_HELP =
       "Everything which is related to SST files in RocksDB per column family and partition";
-  private static final String SST_METRICS_PREFIX = "rocksdb_sst";
-  private static final RocksDBMetric[] SST_METRICS = {
-    new RocksDBMetric("rocksdb.total-sst-files-size", SST_METRICS_PREFIX, SST_METRICS_HELP),
-    new RocksDBMetric("rocksdb.live-sst-files-size", SST_METRICS_PREFIX, SST_METRICS_HELP),
-  };
-
+  private static final String SST_METRICS_PREFIX = "rocksdb.sst";
   private static final String LIVE_METRICS_HELP =
       "Other estimated properties based on entries in RocksDb per column family and partition";
-  private static final String LIVE_METRICS_PREFIX = "rocksdb_live";
-  private static final RocksDBMetric[] LIVE_METRICS = {
-    new RocksDBMetric("rocksdb.num-entries-imm-mem-tables", LIVE_METRICS_PREFIX, LIVE_METRICS_HELP),
-    new RocksDBMetric("rocksdb.estimate-num-keys", LIVE_METRICS_PREFIX, LIVE_METRICS_HELP),
-    new RocksDBMetric("rocksdb.estimate-live-data-size", LIVE_METRICS_PREFIX, LIVE_METRICS_HELP),
-  };
-
+  private static final String LIVE_METRICS_PREFIX = "rocksdb.live";
   private static final String WRITE_METRICS_HELP =
       "Properties related to writes, flushes and compactions for RocksDb per column family and partition";
-  private static final String WRITE_METRICS_PREFIX = "rocksdb_writes";
-
-  private static final RocksDBMetric[] WRITE_METRICS = {
-    new RocksDBMetric("rocksdb.is-write-stopped", WRITE_METRICS_PREFIX, WRITE_METRICS_HELP),
-    new RocksDBMetric(
-        "rocksdb.actual-delayed-write-rate", WRITE_METRICS_PREFIX, WRITE_METRICS_HELP),
-    new RocksDBMetric("rocksdb.mem-table-flush-pending", WRITE_METRICS_PREFIX, WRITE_METRICS_HELP),
-    new RocksDBMetric("rocksdb.num-running-flushes", WRITE_METRICS_PREFIX, WRITE_METRICS_HELP),
-    new RocksDBMetric("rocksdb.num-running-compactions", WRITE_METRICS_PREFIX, WRITE_METRICS_HELP),
-  };
-
+  private static final String WRITE_METRICS_PREFIX = "rocksdb.writes";
   private final String partition;
   private final Supplier<ZeebeDb<ColumnFamilyType>> databaseSupplier;
+  private final RocksDBMetric[] memoryMetrics;
+  private final RocksDBMetric[] liveMetrics;
+  private final RocksDBMetric[] writeMetrics;
+  private final RocksDBMetric[] sstMetrics;
 
   public ZeebeRocksDBMetricExporter(
-      final String partition, final Supplier<ZeebeDb<ColumnFamilyType>> databaseSupplier) {
+      final String partition,
+      final Supplier<ZeebeDb<ColumnFamilyType>> databaseSupplier,
+      final MeterRegistry meterRegistry) {
     this.partition = Objects.requireNonNull(partition);
     this.databaseSupplier = databaseSupplier;
+    memoryMetrics =
+        new RocksDBMetric[] {
+          new RocksDBMetric(
+              "rocksdb.cur-size-all-mem-tables",
+              MEMORY_METRICS_PREFIX,
+              MEMORY_METRICS_HELP,
+              meterRegistry),
+          new RocksDBMetric(
+              "rocksdb.cur-size-active-mem-table",
+              MEMORY_METRICS_PREFIX,
+              MEMORY_METRICS_HELP,
+              meterRegistry),
+          new RocksDBMetric(
+              "rocksdb.size-all-mem-tables",
+              MEMORY_METRICS_PREFIX,
+              MEMORY_METRICS_HELP,
+              meterRegistry),
+          new RocksDBMetric(
+              "rocksdb.block-cache-usage",
+              MEMORY_METRICS_PREFIX,
+              MEMORY_METRICS_HELP,
+              meterRegistry),
+          new RocksDBMetric(
+              "rocksdb.block-cache-capacity",
+              MEMORY_METRICS_PREFIX,
+              MEMORY_METRICS_HELP,
+              meterRegistry),
+          new RocksDBMetric(
+              "rocksdb.block-cache-pinned-usage",
+              MEMORY_METRICS_PREFIX,
+              MEMORY_METRICS_HELP,
+              meterRegistry),
+          new RocksDBMetric(
+              "rocksdb.estimate-table-readers-mem",
+              MEMORY_METRICS_PREFIX,
+              MEMORY_METRICS_HELP,
+              meterRegistry),
+        };
+
+    liveMetrics =
+        new RocksDBMetric[] {
+          new RocksDBMetric(
+              "rocksdb.num-entries-imm-mem-tables",
+              LIVE_METRICS_PREFIX,
+              LIVE_METRICS_HELP,
+              meterRegistry),
+          new RocksDBMetric(
+              "rocksdb.estimate-num-keys", LIVE_METRICS_PREFIX, LIVE_METRICS_HELP, meterRegistry),
+          new RocksDBMetric(
+              "rocksdb.estimate-live-data-size",
+              LIVE_METRICS_PREFIX,
+              LIVE_METRICS_HELP,
+              meterRegistry),
+        };
+    writeMetrics =
+        new RocksDBMetric[] {
+          new RocksDBMetric(
+              "rocksdb.is-write-stopped", WRITE_METRICS_PREFIX, WRITE_METRICS_HELP, meterRegistry),
+          new RocksDBMetric(
+              "rocksdb.actual-delayed-write-rate",
+              WRITE_METRICS_PREFIX,
+              WRITE_METRICS_HELP,
+              meterRegistry),
+          new RocksDBMetric(
+              "rocksdb.mem-table-flush-pending",
+              WRITE_METRICS_PREFIX,
+              WRITE_METRICS_HELP,
+              meterRegistry),
+          new RocksDBMetric(
+              "rocksdb.num-running-flushes",
+              WRITE_METRICS_PREFIX,
+              WRITE_METRICS_HELP,
+              meterRegistry),
+          new RocksDBMetric(
+              "rocksdb.num-running-compactions",
+              WRITE_METRICS_PREFIX,
+              WRITE_METRICS_HELP,
+              meterRegistry),
+        };
+
+    sstMetrics =
+        new RocksDBMetric[] {
+          new RocksDBMetric(
+              "rocksdb.total-sst-files-size", SST_METRICS_PREFIX, SST_METRICS_HELP, meterRegistry),
+          new RocksDBMetric(
+              "rocksdb.live-sst-files-size", SST_METRICS_PREFIX, SST_METRICS_HELP, meterRegistry),
+        };
   }
 
   public void exportMetrics() {
     final long startTime = System.currentTimeMillis();
-    exportMetrics(MEMORY_METRICS);
-    exportMetrics(LIVE_METRICS);
-    exportMetrics(SST_METRICS);
-    exportMetrics(WRITE_METRICS);
+    exportMetrics(memoryMetrics);
+    exportMetrics(liveMetrics);
+    exportMetrics(sstMetrics);
+    exportMetrics(writeMetrics);
 
     final long elapsedTime = System.currentTimeMillis() - startTime;
     LOG.trace("Exporting RocksDBMetrics took + {} ms", elapsedTime);
@@ -112,18 +170,18 @@ public final class ZeebeRocksDBMetricExporter<
   private static final class RocksDBMetric {
 
     private final String propertyName;
-    private final Gauge gauge;
+    private volatile double value;
 
-    private RocksDBMetric(final String propertyName, final String namePrefix, final String help) {
+    private RocksDBMetric(
+        final String propertyName,
+        final String namePrefix,
+        final String help,
+        final MeterRegistry registry) {
       this.propertyName = Objects.requireNonNull(propertyName);
 
-      gauge =
-          Gauge.build()
-              .namespace(ZEEBE_NAMESPACE)
-              .name(namePrefix + gaugeSuffix())
-              .help(help)
-              .labelNames(PARTITION)
-              .register();
+      Gauge.builder(ZEEBE_NAMESPACE + ". " + namePrefix + gaugeSuffix(), () -> value)
+          .description(help)
+          .register(registry);
     }
 
     private String gaugeSuffix() {
@@ -133,7 +191,7 @@ public final class ZeebeRocksDBMetricExporter<
     }
 
     public void exportValue(final String partitionID, final Double value) {
-      gauge.labels(partitionID).set(value);
+      this.value = value;
     }
 
     public String getPropertyName() {

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.db.impl.FineGrainedColumnFamilyMetrics;
 import io.camunda.zeebe.db.impl.NoopColumnFamilyMetrics;
 import io.camunda.zeebe.db.impl.rocksdb.Loggers;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
+import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDBMetricExporter;
 import io.camunda.zeebe.protocol.EnumValue;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.camunda.zeebe.util.micrometer.StatefulMeterRegistry;
@@ -57,6 +58,7 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<? extends EnumVal
   private final ConsistencyChecksSettings consistencyChecksSettings;
   private final AccessMetricsConfiguration accessMetricsConfiguration;
   private final StatefulMeterRegistry meterRegistry;
+  private final ZeebeRocksDBMetricExporter<ColumnFamilyNames> metricExporter;
 
   protected ZeebeTransactionDb(
       final ColumnFamilyHandle defaultHandle,
@@ -73,6 +75,7 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<? extends EnumVal
     this.consistencyChecksSettings = consistencyChecksSettings;
     this.accessMetricsConfiguration = accessMetricsConfiguration;
     this.meterRegistry = meterRegistry;
+    metricExporter = new ZeebeRocksDBMetricExporter<>(this, meterRegistry);
 
     prefixReadOptions =
         new ReadOptions()
@@ -216,6 +219,11 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<? extends EnumVal
   @Override
   public StatefulMeterRegistry getMeterRegistry() {
     return meterRegistry;
+  }
+
+  @Override
+  public void exportMetrics() {
+    metricExporter.exportMetrics();
   }
 
   @Override

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
@@ -163,9 +163,7 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<? extends EnumVal
     final var metrics =
         switch (accessMetricsConfiguration.kind()) {
           case NONE -> new NoopColumnFamilyMetrics();
-          case FINE ->
-              new FineGrainedColumnFamilyMetrics(
-                  accessMetricsConfiguration.partitionId(), columnFamily);
+          case FINE -> new FineGrainedColumnFamilyMetrics(columnFamily, meterRegistry);
         };
     return new TransactionalColumnFamily<>(
         this,


### PR DESCRIPTION
## Description
The metrics in ZeebeDb are a bit different compared to the rest as well directly rocksDB for them.

Now that the meterRegistry is created inside ZeebeDb is better to have the ZeebeDbMetricsExporter couple to the lifecycle of ZeebeDb directly, so it has been moved inside it and a new default method defined in the interface, so that the timer can be scheduled at startup as it was done before.

The MeterDocumentation for the rocksDB metrics are available using the static method:
```
ZeebeRocksDBMetricExporter.allMeterDocumentations()
```
## Related issues

closes #27153
