### PR TITLE
ci: allow pushing 8.7 SNAPSHOT artifacts again

### DIFF
--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -83,7 +83,7 @@ jobs:
       - uses: ./.github/actions/setup-build
         name: Build setup
         with:
-          dockerhub: ${{ env.IS_DEFAULT_BRANCH == 'true' }}
+          dockerhub: ${{ env.SHOULD_PUSH_DOCKER_SNAPSHOT == 'true' }}
           harbor: true
           java-distribution: adopt
           maven-cache-key-modifier: operate

--- a/.github/workflows/tasklist-ci-build-reusable.yml
+++ b/.github/workflows/tasklist-ci-build-reusable.yml
@@ -69,7 +69,7 @@ jobs:
       - uses: ./.github/actions/setup-build
         name: Build setup
         with:
-          dockerhub: ${{ env.IS_DEFAULT_BRANCH == 'true' }}
+          dockerhub: ${{ env.SHOULD_PUSH_DOCKER_SNAPSHOT == 'true' }}
           harbor: true
           java-distribution: adopt
           maven-cache-key-modifier: tasklist


### PR DESCRIPTION
## Description

Fixup for https://github.com/camunda/camunda/pull/28035 for a problem that could only be discovered once merged to `stable/8.7`. The Operate and Tasklist CI jobs couldn't push the special 8.7 SNAPSHOT artifacts to DockerHub anymore because the login wasn't performed, due to a different condition:

* https://github.com/camunda/camunda/actions/runs/13307243951/job/37160964498
* https://github.com/camunda/camunda/actions/runs/13307243707/job/37160963450

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

None
