### PR TITLE
fix: add info to authenticate against nexus for local usage

### DIFF
--- a/c8run/package.go
+++ b/c8run/package.go
@@ -133,6 +133,7 @@ func PackageUnix(camundaVersion string, elasticsearchVersion string, connectorsV
 	composeExtractionPath := "camunda-platform-" + composeTag
 	authToken := os.Getenv("GH_TOKEN")
 
+	// set your LDAP credentials for local usage (name.surname as username, password)
 	javaArtifactsUser := os.Getenv("JAVA_ARTIFACTS_USER")
 	javaArtifactsPassword := os.Getenv("JAVA_ARTIFACTS_PASSWORD")
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Add information on how to authenticate for local downloads from nexus.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
