### PR TITLE
Add support for OTLP and Dynatrace as Micrometer backends

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -202,6 +202,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-otlp</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
     </dependency>
@@ -493,6 +498,9 @@
             <!-- Used to parse PKCS1 certificates -->
             <dependency>org.bouncycastle:bcprov-jdk18on</dependency>
             <dependency>org.bouncycastle:bcpkix-jdk18on</dependency>
+
+            <!-- OTLP Micrometer Exporter -->
+            <dependency>io.micrometer:micrometer-registry-otlp</dependency>
           </usedDependencies>
         </configuration>
       </plugin>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -405,8 +403,7 @@
           <configurationDirectory>config</configurationDirectory>
           <copyConfigurationDirectory>true</copyConfigurationDirectory>
           <extraJvmArguments>-XX:+ExitOnOutOfMemoryError
-            -Dfile.encoding=UTF-8 -Xshare:auto
-          </extraJvmArguments>
+            -Dfile.encoding=UTF-8 -Xshare:auto</extraJvmArguments>
           <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
           <platforms>
             <platform>windows</platform>
@@ -497,14 +494,10 @@
           <ignoredNonTestScopedDependencies>
             <ignoredNonTestScopedDependency>org.agrona:agrona</ignoredNonTestScopedDependency>
             <ignoredNonTestScopedDependency>io.netty:netty-handler</ignoredNonTestScopedDependency>
-            <ignoredNonTestScopedDependency>io.camunda:zeebe-protocol
-            </ignoredNonTestScopedDependency>
-            <ignoredNonTestScopedDependency>com.fasterxml.jackson.core:jackson-core
-            </ignoredNonTestScopedDependency>
-            <ignoredNonTestScopedDependency>com.fasterxml.jackson.datatype:jackson-datatype-jsr310
-            </ignoredNonTestScopedDependency>
-            <ignoredNonTestScopedDependency>com.fasterxml.jackson.core:jackson-databind
-            </ignoredNonTestScopedDependency>
+            <ignoredNonTestScopedDependency>io.camunda:zeebe-protocol</ignoredNonTestScopedDependency>
+            <ignoredNonTestScopedDependency>com.fasterxml.jackson.core:jackson-core</ignoredNonTestScopedDependency>
+            <ignoredNonTestScopedDependency>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</ignoredNonTestScopedDependency>
+            <ignoredNonTestScopedDependency>com.fasterxml.jackson.core:jackson-databind</ignoredNonTestScopedDependency>
           </ignoredNonTestScopedDependencies>
           <!-- dependencies only packaged but not explicitly used -->
           <usedDependencies>
@@ -541,8 +534,7 @@
               <goal>generate</goal>
             </goals>
             <configuration>
-              <inputSpec>${project.basedir}/src/main/resources/api/backup-management-api.yaml
-              </inputSpec>
+              <inputSpec>${project.basedir}/src/main/resources/api/backup-management-api.yaml</inputSpec>
               <modelPackage>io.camunda.zeebe.management.backups</modelPackage>
             </configuration>
           </execution>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -196,14 +198,23 @@
       <artifactId>spring-boot-starter-webflux</artifactId>
     </dependency>
 
+    <!-- Micrometer backend/implementations -->
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-prometheus</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-otlp</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-dynatrace</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -394,7 +405,8 @@
           <configurationDirectory>config</configurationDirectory>
           <copyConfigurationDirectory>true</copyConfigurationDirectory>
           <extraJvmArguments>-XX:+ExitOnOutOfMemoryError
-            -Dfile.encoding=UTF-8 -Xshare:auto</extraJvmArguments>
+            -Dfile.encoding=UTF-8 -Xshare:auto
+          </extraJvmArguments>
           <includeConfigurationDirectoryInClasspath>true</includeConfigurationDirectoryInClasspath>
           <platforms>
             <platform>windows</platform>
@@ -441,10 +453,17 @@
             <configuration>
               <target>
                 <?SORTPOM IGNORE?> <!-- ordering is important here, chmod needs to run after copying -->
-                <copy failonerror="${zbctl.force}" file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl.exe" tofile="${project.build.directory}/camunda-zeebe/bin/zbctl.exe" />
-                <copy failonerror="${zbctl.force}" file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl.darwin" tofile="${project.build.directory}/camunda-zeebe/bin/zbctl.darwin" />
-                <copy failonerror="${zbctl.force}" file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl" tofile="${project.build.directory}/camunda-zeebe/bin/zbctl" />
-                <chmod dir="${project.build.directory}/camunda-zeebe/bin" failonerror="${zbctl.force}" includes="zbctl*" perm="ugo+rx" />
+                <copy failonerror="${zbctl.force}"
+                  file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl.exe"
+                  tofile="${project.build.directory}/camunda-zeebe/bin/zbctl.exe"/>
+                <copy failonerror="${zbctl.force}"
+                  file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl.darwin"
+                  tofile="${project.build.directory}/camunda-zeebe/bin/zbctl.darwin"/>
+                <copy failonerror="${zbctl.force}"
+                  file="${zbctl.rootDir}/clients/go/cmd/zbctl/dist/zbctl"
+                  tofile="${project.build.directory}/camunda-zeebe/bin/zbctl"/>
+                <chmod dir="${project.build.directory}/camunda-zeebe/bin"
+                  failonerror="${zbctl.force}" includes="zbctl*" perm="ugo+rx"/>
                 <?SORTPOM RESUME?>
               </target>
             </configuration>
@@ -478,10 +497,14 @@
           <ignoredNonTestScopedDependencies>
             <ignoredNonTestScopedDependency>org.agrona:agrona</ignoredNonTestScopedDependency>
             <ignoredNonTestScopedDependency>io.netty:netty-handler</ignoredNonTestScopedDependency>
-            <ignoredNonTestScopedDependency>io.camunda:zeebe-protocol</ignoredNonTestScopedDependency>
-            <ignoredNonTestScopedDependency>com.fasterxml.jackson.core:jackson-core</ignoredNonTestScopedDependency>
-            <ignoredNonTestScopedDependency>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</ignoredNonTestScopedDependency>
-            <ignoredNonTestScopedDependency>com.fasterxml.jackson.core:jackson-databind</ignoredNonTestScopedDependency>
+            <ignoredNonTestScopedDependency>io.camunda:zeebe-protocol
+            </ignoredNonTestScopedDependency>
+            <ignoredNonTestScopedDependency>com.fasterxml.jackson.core:jackson-core
+            </ignoredNonTestScopedDependency>
+            <ignoredNonTestScopedDependency>com.fasterxml.jackson.datatype:jackson-datatype-jsr310
+            </ignoredNonTestScopedDependency>
+            <ignoredNonTestScopedDependency>com.fasterxml.jackson.core:jackson-databind
+            </ignoredNonTestScopedDependency>
           </ignoredNonTestScopedDependencies>
           <!-- dependencies only packaged but not explicitly used -->
           <usedDependencies>
@@ -499,8 +522,10 @@
             <dependency>org.bouncycastle:bcprov-jdk18on</dependency>
             <dependency>org.bouncycastle:bcpkix-jdk18on</dependency>
 
-            <!-- OTLP Micrometer Exporter -->
+            <!-- Micrometer Exporters/Registries -->
+            <dependency>io.micrometer:micrometer-registry-prometheus</dependency>
             <dependency>io.micrometer:micrometer-registry-otlp</dependency>
+            <dependency>io.micrometer:micrometer-registry-dynatrace</dependency>
           </usedDependencies>
         </configuration>
       </plugin>
@@ -516,7 +541,8 @@
               <goal>generate</goal>
             </goals>
             <configuration>
-              <inputSpec>${project.basedir}/src/main/resources/api/backup-management-api.yaml</inputSpec>
+              <inputSpec>${project.basedir}/src/main/resources/api/backup-management-api.yaml
+              </inputSpec>
               <modelPackage>io.camunda.zeebe.management.backups</modelPackage>
             </configuration>
           </execution>

--- a/dist/src/main/java/io/camunda/zeebe/broker/StandaloneBroker.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/StandaloneBroker.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.shared.MainSupport;
 import io.camunda.zeebe.shared.Profile;
 import io.camunda.zeebe.util.FileUtil;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,7 +62,7 @@ public class StandaloneBroker
       final ActorScheduler actorScheduler,
       final AtomixCluster cluster,
       final BrokerClient brokerClient,
-      final PrometheusMeterRegistry meterRegistry) {
+      final MeterRegistry meterRegistry) {
     this.configuration = configuration;
     this.identityConfiguration = identityConfiguration;
     this.springBrokerBridge = springBrokerBridge;

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -34,8 +34,10 @@ management.endpoint.health.show-details=always
 # Configure Prometheus as the default enabled backend, for scraping
 management.endpoint.prometheus.enabled=true
 management.prometheus.metrics.export.enabled=true
-# Disable the OTEL backend by default; can be enabled on demand by users
+# Disable the OTEL backend by default; can be enabled on demand
 management.otlp.metrics.export.enabled=false
+# Disable the Dynatrace backend by default; can be enabled on demand
+management.dynatrace.metrics.export.enabled=false
 # Allow runtime configuration of log levels
 management.endpoint.loggers.enabled=true
 # Allow viewing the config properties, but sanitize their outputs

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -2,6 +2,8 @@
 server.shutdown=graceful
 spring.lifecycle.timeout-per-shutdown-phase=30s
 logging.register-shutdown-hook=true
+# The application name is the default name used by various services like OpenTelemetry
+spring.application.name=Camunda
 # REST server configuration
 # This sever is enabled even for a standalone broker without any embedded gateway, in which case
 # there will simply be no endpoints available.
@@ -29,8 +31,11 @@ management.endpoints.web.exposure.include=*
 management.endpoint.health.enabled=true
 management.endpoint.health.show-details=always
 # Metrics related configurations
+# Configure Prometheus as the default enabled backend, for scraping
 management.endpoint.prometheus.enabled=true
 management.prometheus.metrics.export.enabled=true
+# Disable the OTEL backend by default; can be enabled on demand by users
+management.otlp.metrics.export.enabled=false
 # Allow runtime configuration of log levels
 management.endpoint.loggers.enabled=true
 # Allow viewing the config properties, but sanitize their outputs

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -461,6 +461,24 @@
       <artifactId>micrometer-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-dynatrace</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-otlp</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/observability/MetricsConfigurationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/observability/MetricsConfigurationIT.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.observability;
+
+public class DefaultMicrometerBackendIT {}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/observability/MetricsConfigurationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/observability/MetricsConfigurationIT.java
@@ -7,4 +7,125 @@
  */
 package io.camunda.zeebe.it.observability;
 
-public class DefaultMicrometerBackendIT {}
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.qa.util.actuator.PrometheusActuator;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import io.micrometer.dynatrace.DynatraceMeterRegistry;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.micrometer.registry.otlp.OtlpMeterRegistry;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+@ZeebeIntegration
+final class MetricsConfigurationIT {
+
+  @Nested
+  final class PrometheusIT {
+    @TestZeebe private final TestStandaloneBroker broker = new TestStandaloneBroker();
+
+    @Test
+    void shouldEnablePrometheusScrapingByDefault() {
+      // given
+      final var actuator = PrometheusActuator.of(broker);
+      final var registry = broker.bean(MeterRegistry.class);
+
+      // when
+      final var scraped = actuator.metrics();
+
+      // then
+      assertThat(scraped).contains("jvm_info");
+      assertThat(registry)
+          .as(
+              "should be directly a %s, otherwise it means multiple backends are enabled",
+              PrometheusMeterRegistry.class)
+          .isNotInstanceOf(CompositeMeterRegistry.class)
+          .isInstanceOf(PrometheusMeterRegistry.class);
+    }
+  }
+
+  @SuppressWarnings("resource")
+  @Nested
+  final class OtlpIT {
+    private final List<String> logLines = new ArrayList<>();
+
+    @Container
+    private final GenericContainer<?> otelCollector =
+        new GenericContainer<>(
+                DockerImageName.parse("otel/opentelemetry-collector-contrib").withTag("0.119.0"))
+            .withLogConsumer(frame -> logLines.add(frame.getUtf8String()))
+            .withExposedPorts(4318, 8888, 8889, 55679);
+
+    @TestZeebe(autoStart = false) // need to configure it once the container is started
+    private final TestStandaloneBroker broker =
+        new TestStandaloneBroker()
+            .withProperty("management.otlp.metrics.export.enabled", "true")
+            .withProperty("management.otlp.metrics.export.step", "1s")
+            .withProperty("management.otlp.metrics.export.batch-size", "10")
+            .withProperty("management.endpoint.prometheus.enabled", "false")
+            .withProperty("management.prometheus.metrics.export.enabled", "false");
+
+    @Test
+    void shouldExportViaOtlp() {
+      // given
+      broker
+          .withProperty(
+              "management.otlp.metrics.export.url",
+              "http://localhost:%d/v1/metrics".formatted(otelCollector.getMappedPort(4318)))
+          .start()
+          .awaitCompleteTopology();
+      final var registry = broker.bean(MeterRegistry.class);
+
+      // when - then
+      assertThat(registry)
+          .as(
+              "should be directly a %s, otherwise it means multiple backends are enabled",
+              OtlpMeterRegistry.class)
+          .isNotInstanceOf(CompositeMeterRegistry.class)
+          .isInstanceOf(OtlpMeterRegistry.class);
+      Awaitility.await("until we get some zeebe specific metrics logged by the collector")
+          .atMost(Duration.ofSeconds(30))
+          .untilAsserted(
+              () ->
+                  assertThat(logLines)
+                      .anyMatch(s -> s.contains("Name: zeebe.gateway.topology.partition.roles")));
+    }
+  }
+
+  @Nested
+  final class DynatraceIT {
+    @TestZeebe
+    private final TestStandaloneBroker broker =
+        new TestStandaloneBroker()
+            .withProperty("management.dynatrace.metrics.export.enabled", "true")
+            .withProperty("management.endpoint.prometheus.enabled", "false")
+            .withProperty("management.prometheus.metrics.export.enabled", "false");
+
+    @Test
+    void shouldUseDynatraceRegistryIfEnabled() {
+      // given / when
+      final var registry = broker.bean(MeterRegistry.class);
+
+      // then
+      assertThat(registry)
+          .as(
+              "should be directly a %s, otherwise it means multiple backends are enabled",
+              DynatraceMeterRegistry.class)
+          .isNotInstanceOf(CompositeMeterRegistry.class)
+          .isInstanceOf(DynatraceMeterRegistry.class);
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds support for the OTLP (aka OpenTelemetry Protocol) and Dynatrace registries for Micrometer. This will let users easily use one or the other.

For Dynatrace usage, we recommend you use the OTLP backend regardless, as it has better support in terms of the kind of meters supported.

## Related issues

closes #26950
closes #26901 
closes #26897 
closes #26906 
