### PR TITLE
Fix flaky multipartition tests

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationMultipartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateAuthorizationMultipartitionTest.java
@@ -41,17 +41,20 @@ public class CreateAuthorizationMultipartitionTest {
   @Test
   public void shouldTestLifecycle() {
     // when
-    engine
-        .authorization()
-        .newAuthorization()
-        // TODO: remove with https://github.com/camunda/camunda/issues/26883
-        .withOwnerKey(1L)
-        .withOwnerId("ownerId")
-        .withOwnerType(AuthorizationOwnerType.USER)
-        .withResourceId("resourceId")
-        .withResourceType(AuthorizationResourceType.RESOURCE)
-        .withPermissions(PermissionType.CREATE)
-        .create();
+    final var authorizationKey =
+        engine
+            .authorization()
+            .newAuthorization()
+            // TODO: remove with https://github.com/camunda/camunda/issues/26883
+            .withOwnerKey(1L)
+            .withOwnerId("ownerId")
+            .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceId("resourceId")
+            .withResourceType(AuthorizationResourceType.RESOURCE)
+            .withPermissions(PermissionType.CREATE)
+            .create()
+            .getValue()
+            .getAuthorizationKey();
 
     // then
     assertThat(
@@ -91,7 +94,8 @@ public class CreateAuthorizationMultipartitionTest {
 
     for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
       assertThat(
-              RecordingExporter.records()
+              RecordingExporter.authorizationRecords()
+                  .withAuthorizationKey(authorizationKey)
                   .withPartitionId(partitionId)
                   .limit(r -> r.getIntent().equals(AuthorizationIntent.CREATED))
                   .collect(Collectors.toList()))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeMultiPartitionTest.java
@@ -52,13 +52,15 @@ public class IdentitySetupInitializeMultiPartitionTest {
     final var tenant =
         new TenantRecord().setTenantKey(3).setTenantId("tenant-id").setName("tenant-name");
 
-    engine
-        .identitySetup()
-        .initialize()
-        .withRole(role)
-        .withUser(user)
-        .withTenant(tenant)
-        .initialize();
+    final var identitySetupKey =
+        engine
+            .identitySetup()
+            .initialize()
+            .withRole(role)
+            .withUser(user)
+            .withTenant(tenant)
+            .initialize()
+            .getKey();
 
     // then
     assertThat(
@@ -92,7 +94,8 @@ public class IdentitySetupInitializeMultiPartitionTest {
 
     for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
       assertThat(
-              RecordingExporter.records()
+              RecordingExporter.identitySetupRecords()
+                  .withRecordKey(identitySetupKey)
                   .withPartitionId(partitionId)
                   .limit(r -> r.getIntent().equals(IdentitySetupIntent.INITIALIZED))
                   .collect(Collectors.toList()))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/CreateRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/CreateRoleMultiPartitionTest.java
@@ -73,6 +73,7 @@ public class CreateRoleMultiPartitionTest {
     for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
       assertThat(
               RecordingExporter.roleRecords()
+                  .withName(name)
                   .withPartitionId(partitionId)
                   .limit(record -> record.getIntent().equals(RoleIntent.CREATED))
                   .collect(Collectors.toList()))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/CreateTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/CreateTenantMultiPartitionTest.java
@@ -39,7 +39,8 @@ public class CreateTenantMultiPartitionTest {
   @Test
   public void shouldDistributeTenantCreateCommand() {
     // when
-    engine.tenant().newTenant().withTenantId("tenant-123").withName("New Tenant").create();
+    final var tenantId = "tenant-123";
+    engine.tenant().newTenant().withTenantId(tenantId).withName("New Tenant").create();
 
     // then
     assertThat(
@@ -69,7 +70,8 @@ public class CreateTenantMultiPartitionTest {
 
     for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       assertThat(
-              RecordingExporter.records()
+              RecordingExporter.tenantRecords()
+                  .withTenantId(tenantId)
                   .withPartitionId(partitionId)
                   .limit(record -> record.getIntent().equals(TenantIntent.CREATED))
                   .collect(Collectors.toList()))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateUserMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateUserMultiPartitionTest.java
@@ -82,7 +82,8 @@ public class CreateUserMultiPartitionTest {
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
     for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
       assertThat(
-              RecordingExporter.records()
+              RecordingExporter.userRecords()
+                  .withUsername(username)
                   .withPartitionId(partitionId)
                   .limit(record -> record.getIntent().equals(UserIntent.CREATED))
                   .collect(Collectors.toList()))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserMultiPartitionTest.java
@@ -97,7 +97,8 @@ public class UpdateUserMultiPartitionTest {
         .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
     for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
       assertThat(
-              RecordingExporter.records()
+              RecordingExporter.userRecords()
+                  .withUsername(username)
                   .withPartitionId(partitionId)
                   .limit(record -> record.getIntent().equals(UserIntent.UPDATED))
                   .collect(Collectors.toList()))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -488,6 +488,9 @@ public final class EngineRule extends ExternalResource {
 
   public void awaitIdentitySetup() {
     if (partitionCount > 1) {
+      RecordingExporter.identitySetupRecords(IdentitySetupIntent.INITIALIZED)
+          .skip(partitionCount - 1)
+          .await();
       RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
           .withDistributionIntent(IdentitySetupIntent.INITIALIZE)
           .await();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Fixes a number of flaky tests due to a bug in awaiting the identity setup. We were waiting for the distrinbution to be finished on partition 1. When there's multiple partitions we should also make sure we wait that the initialized events are exported.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #28129 
