### PR TITLE
ci: test ubuntu-24.04-arm for Zeebe smoke test

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -32,7 +32,7 @@ jobs:
           - os: linux
             runner: gcp-perf-core-8-default
           - os: linux
-            runner: "aws-arm-core-4-longrunning"
+            runner: ubuntu-24.04-arm
             arch: arm64
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Check if https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/ is usable in the monorepo:

* https://github.com/camunda/camunda/actions/runs/13310191740/job/37170566765?pr=28135

CI for Zeebe smoke tests on Linux on ARM are 🟢 but wouldn't replace self-hosted to runner to avoid making https://github.com/camunda/camunda/issues/26001 worse.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
