### PR TITLE
feat: post deploy event listener

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/annotation/processor/CamundaAnnotationProcessorRegistry.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/annotation/processor/CamundaAnnotationProcessorRegistry.java
@@ -18,6 +18,7 @@ package io.camunda.spring.client.annotation.processor;
 import io.camunda.client.CamundaClient;
 import io.camunda.spring.client.bean.ClassInfo;
 import io.camunda.spring.client.configuration.AnnotationProcessorConfiguration;
+import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
@@ -30,11 +31,15 @@ import org.springframework.core.Ordered;
  */
 public class CamundaAnnotationProcessorRegistry implements BeanPostProcessor, Ordered {
 
-  private final List<AbstractCamundaAnnotationProcessor> processors;
+  private final List<AbstractCamundaAnnotationProcessor> processors = new ArrayList<>();
 
-  public CamundaAnnotationProcessorRegistry(
-      final List<AbstractCamundaAnnotationProcessor> processors) {
-    this.processors = processors;
+  @Override
+  public Object postProcessBeforeInitialization(final Object bean, final String beanName)
+      throws BeansException {
+    if (bean instanceof final AbstractCamundaAnnotationProcessor processor) {
+      processors.add(processor);
+    }
+    return BeanPostProcessor.super.postProcessBeforeInitialization(bean, beanName);
   }
 
   @Override
@@ -49,6 +54,11 @@ public class CamundaAnnotationProcessorRegistry implements BeanPostProcessor, Or
     }
 
     return bean;
+  }
+
+  public List<AbstractCamundaAnnotationProcessor> getProcessors() {
+    // do not manipulate the list from outside
+    return new ArrayList<>(processors);
   }
 
   public void startAll(final CamundaClient client) {

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/annotation/processor/DeploymentAnnotationProcessor.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/annotation/processor/DeploymentAnnotationProcessor.java
@@ -23,6 +23,7 @@ import io.camunda.client.api.command.DeployResourceCommandStep1;
 import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.spring.client.annotation.value.DeploymentValue;
 import io.camunda.spring.client.bean.ClassInfo;
+import io.camunda.spring.client.event.CamundaPostDeploymentEvent;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
@@ -30,6 +31,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternResolver;
@@ -42,8 +44,11 @@ public class DeploymentAnnotationProcessor extends AbstractCamundaAnnotationProc
       new PathMatchingResourcePatternResolver();
 
   private final List<DeploymentValue> deploymentValues = new ArrayList<>();
+  private final ApplicationEventPublisher publisher;
 
-  public DeploymentAnnotationProcessor() {}
+  public DeploymentAnnotationProcessor(final ApplicationEventPublisher publisher) {
+    this.publisher = publisher;
+  }
 
   @Override
   public boolean isApplicableFor(final ClassInfo beanInfo) {
@@ -61,46 +66,61 @@ public class DeploymentAnnotationProcessor extends AbstractCamundaAnnotationProc
 
   @Override
   public void start(final CamundaClient client) {
-    deploymentValues.forEach(
-        deployment -> {
-          final DeployResourceCommandStep1 deployResourceCommand =
-              client.newDeployResourceCommand();
+    final List<Resource> resources =
+        deploymentValues.stream()
+            .flatMap(d -> d.getResources().stream())
+            .flatMap(r -> Arrays.stream(getResources(r)))
+            .distinct()
+            .toList();
 
-          final DeploymentEvent deploymentResult =
-              deployment.getResources().stream()
-                  .flatMap(resource -> Stream.of(getResources(resource)))
-                  .map(
-                      resource -> {
-                        try (final InputStream inputStream = resource.getInputStream()) {
-                          return deployResourceCommand.addResourceStream(
-                              inputStream, resource.getFilename());
-                        } catch (final IOException e) {
-                          throw new RuntimeException(e.getMessage());
-                        }
-                      })
-                  .filter(Objects::nonNull)
-                  .reduce((first, second) -> second)
-                  .orElseThrow(
-                      () ->
-                          new IllegalArgumentException("Requires at least one resource to deploy"))
-                  .send()
-                  .join();
+    final List<DeploymentEvent> list =
+        deploymentValues.stream()
+            .map(
+                deployment -> {
+                  final DeployResourceCommandStep1 deployResourceCommand =
+                      client.newDeployResourceCommand();
 
-          LOGGER.info(
-              "Deployed: {}",
-              Stream.concat(
-                      deploymentResult.getDecisionRequirements().stream()
+                  final DeploymentEvent deploymentResult =
+                      deployment.getResources().stream()
+                          .flatMap(resource -> Stream.of(getResources(resource)))
                           .map(
-                              wf ->
-                                  String.format(
-                                      "<%s:%d>",
-                                      wf.getDmnDecisionRequirementsId(), wf.getVersion())),
-                      deploymentResult.getProcesses().stream()
-                          .map(
-                              wf ->
-                                  String.format("<%s:%d>", wf.getBpmnProcessId(), wf.getVersion())))
-                  .collect(Collectors.joining(",")));
-        });
+                              resource -> {
+                                try (final InputStream inputStream = resource.getInputStream()) {
+                                  return deployResourceCommand.addResourceStream(
+                                      inputStream, resource.getFilename());
+                                } catch (final IOException e) {
+                                  throw new RuntimeException(e.getMessage());
+                                }
+                              })
+                          .filter(Objects::nonNull)
+                          .reduce((first, second) -> second)
+                          .orElseThrow(
+                              () ->
+                                  new IllegalArgumentException(
+                                      "Requires at least one resource to deploy"))
+                          .send()
+                          .join();
+
+                  LOGGER.info(
+                      "Deployed: {}",
+                      Stream.concat(
+                              deploymentResult.getDecisionRequirements().stream()
+                                  .map(
+                                      wf ->
+                                          String.format(
+                                              "<%s:%d>",
+                                              wf.getDmnDecisionRequirementsId(), wf.getVersion())),
+                              deploymentResult.getProcesses().stream()
+                                  .map(
+                                      wf ->
+                                          String.format(
+                                              "<%s:%d>", wf.getBpmnProcessId(), wf.getVersion())))
+                          .collect(Collectors.joining(",")));
+                  return deploymentResult;
+                })
+            .toList();
+
+    publisher.publishEvent(new CamundaPostDeploymentEvent(list));
   }
 
   @Override

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/annotation/processor/DeploymentAnnotationProcessor.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/annotation/processor/DeploymentAnnotationProcessor.java
@@ -105,7 +105,7 @@ public class DeploymentAnnotationProcessor extends AbstractCamundaAnnotationProc
                 deploymentEvent.getProcesses().stream()
                     .map(wf -> String.format("<%s:%d>", wf.getBpmnProcessId(), wf.getVersion())))
             .collect(Collectors.joining(",")));
-    publisher.publishEvent(new CamundaPostDeploymentEvent(deploymentEvent));
+    publisher.publishEvent(new CamundaPostDeploymentEvent(this, deploymentEvent));
   }
 
   @Override

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/annotation/processor/DeploymentAnnotationProcessor.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/annotation/processor/DeploymentAnnotationProcessor.java
@@ -80,20 +80,20 @@ public class DeploymentAnnotationProcessor extends AbstractCamundaAnnotationProc
       throw new IllegalArgumentException("No resources found to deploy");
     }
 
-final DeployResourceCommandStep1 command = client.newDeployResourceCommand();
-DeployResourceCommandStep2 commandStep2 = null;
-for (Resource resource : resources) {
-    try (InputStream inputStream = resource.getInputStream()) {
+    final DeployResourceCommandStep1 command = client.newDeployResourceCommand();
+    DeployResourceCommandStep2 commandStep2 = null;
+    for (Resource resource : resources) {
+      try (InputStream inputStream = resource.getInputStream()) {
         if (commandStep2 == null) {
-            commandStep2 = command.addResourceStream(inputStream, resource.getFilename());
+          commandStep2 = command.addResourceStream(inputStream, resource.getFilename());
         } else {
-            commandStep2 = commandStep2.addResourceStream(inputStream, resource.getFilename());
+          commandStep2 = commandStep2.addResourceStream(inputStream, resource.getFilename());
         }
-    } catch (IOException e) {
+      } catch (IOException e) {
         throw new RuntimeException("Error reading resource: " + e.getMessage(), e);
+      }
     }
-}
-final DeploymentEvent deploymentEvent = commandStep2.send().join();
+    final DeploymentEvent deploymentEvent = commandStep2.send().join();
     LOGGER.info(
         "Deployed: {}",
         Stream.concat(

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/AnnotationProcessorConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/AnnotationProcessorConfiguration.java
@@ -16,7 +16,6 @@
 package io.camunda.spring.client.configuration;
 
 import io.camunda.spring.client.annotation.customizer.JobWorkerValueCustomizer;
-import io.camunda.spring.client.annotation.processor.AbstractCamundaAnnotationProcessor;
 import io.camunda.spring.client.annotation.processor.CamundaAnnotationProcessorRegistry;
 import io.camunda.spring.client.annotation.processor.DeploymentAnnotationProcessor;
 import io.camunda.spring.client.annotation.processor.JobWorkerAnnotationProcessor;
@@ -24,14 +23,14 @@ import io.camunda.spring.client.event.CamundaClientEventListener;
 import io.camunda.spring.client.jobhandling.JobWorkerManager;
 import java.util.List;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 
 public class AnnotationProcessorConfiguration {
 
   @Bean
-  public CamundaAnnotationProcessorRegistry camundaAnnotationProcessorRegistry(
-      final List<AbstractCamundaAnnotationProcessor> processors) {
-    return new CamundaAnnotationProcessorRegistry(processors);
+  public static CamundaAnnotationProcessorRegistry camundaAnnotationProcessorRegistry() {
+    return new CamundaAnnotationProcessorRegistry();
   }
 
   @Bean
@@ -42,8 +41,9 @@ public class AnnotationProcessorConfiguration {
 
   @Bean
   @ConditionalOnProperty(value = "camunda.client.deployment.enabled", matchIfMissing = true)
-  public DeploymentAnnotationProcessor deploymentPostProcessor() {
-    return new DeploymentAnnotationProcessor();
+  public DeploymentAnnotationProcessor deploymentPostProcessor(
+      final ApplicationEventPublisher publisher) {
+    return new DeploymentAnnotationProcessor(publisher);
   }
 
   @Bean

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/event/CamundaPostDeploymentEvent.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/event/CamundaPostDeploymentEvent.java
@@ -16,11 +16,13 @@
 package io.camunda.spring.client.event;
 
 import io.camunda.client.api.response.DeploymentEvent;
+import org.springframework.context.ApplicationEvent;
 
-public class CamundaPostDeploymentEvent {
+public class CamundaPostDeploymentEvent extends ApplicationEvent {
   private final DeploymentEvent deployment;
 
-  public CamundaPostDeploymentEvent(final DeploymentEvent deployment) {
+  public CamundaPostDeploymentEvent(final Object source, final DeploymentEvent deployment) {
+    super(source);
     this.deployment = deployment;
   }
 

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/event/CamundaPostDeploymentEvent.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/event/CamundaPostDeploymentEvent.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.spring.client.event;
+
+import io.camunda.client.api.response.DeploymentEvent;
+import java.util.List;
+
+public class CamundaPostDeploymentEvent {
+  private final List<DeploymentEvent> deployments;
+
+  public CamundaPostDeploymentEvent(final List<DeploymentEvent> deployments) {
+    this.deployments = deployments;
+  }
+
+  public List<DeploymentEvent> getDeployments() {
+    return deployments;
+  }
+}

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/event/CamundaPostDeploymentEvent.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/event/CamundaPostDeploymentEvent.java
@@ -16,16 +16,15 @@
 package io.camunda.spring.client.event;
 
 import io.camunda.client.api.response.DeploymentEvent;
-import java.util.List;
 
 public class CamundaPostDeploymentEvent {
-  private final List<DeploymentEvent> deployments;
+  private final DeploymentEvent deployment;
 
-  public CamundaPostDeploymentEvent(final List<DeploymentEvent> deployments) {
-    this.deployments = deployments;
+  public CamundaPostDeploymentEvent(final DeploymentEvent deployment) {
+    this.deployment = deployment;
   }
 
-  public List<DeploymentEvent> getDeployments() {
-    return deployments;
+  public DeploymentEvent getDeployment() {
+    return deployment;
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/AnnotationProcessorConfigurationTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/AnnotationProcessorConfigurationTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.spring.client.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.spring.client.annotation.processor.AbstractCamundaAnnotationProcessor;
+import io.camunda.spring.client.annotation.processor.CamundaAnnotationProcessorRegistry;
+import io.camunda.spring.client.annotation.processor.DeploymentAnnotationProcessor;
+import io.camunda.spring.client.annotation.processor.JobWorkerAnnotationProcessor;
+import io.camunda.spring.client.configuration.AnnotationProcessorConfiguration;
+import io.camunda.spring.client.jobhandling.JobWorkerManager;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBootTest(classes = AnnotationProcessorConfiguration.class)
+public class AnnotationProcessorConfigurationTest {
+  // required to auto-wire with the job worker annotation processor configuration
+  @MockitoBean JobWorkerManager jobWorkerManager;
+
+  @Autowired CamundaAnnotationProcessorRegistry registry;
+
+  @Test
+  void shouldRun() {
+    final List<AbstractCamundaAnnotationProcessor> processors = registry.getProcessors();
+    assertThat(processors).hasSize(2);
+    assertThat(processors.get(0)).isInstanceOf(DeploymentAnnotationProcessor.class);
+    assertThat(processors.get(1)).isInstanceOf(JobWorkerAnnotationProcessor.class);
+  }
+}

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/processor/DeploymentPostProcessorTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/processor/DeploymentPostProcessorTest.java
@@ -175,8 +175,6 @@ public class DeploymentPostProcessorTest {
           final ClassInfo classInfo =
               ClassInfo.builder().bean(new WithNoClassPathResource()).build();
 
-          // when(client.newDeployResourceCommand()).thenReturn(deployStep1);
-
           // when
           deploymentPostProcessor.configureFor(classInfo);
           deploymentPostProcessor.start(client);

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/processor/DeploymentPostProcessorTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/processor/DeploymentPostProcessorTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 
@@ -50,11 +51,13 @@ public class DeploymentPostProcessorTest {
 
   @Mock private DeploymentEvent deploymentEvent;
 
+  @Mock private ApplicationEventPublisher applicationEventPublisher;
+
   @InjectMocks private DeploymentAnnotationProcessor deploymentPostProcessor;
 
   @BeforeEach
   public void init() {
-    deploymentPostProcessor = spy(new DeploymentAnnotationProcessor());
+    deploymentPostProcessor = spy(new DeploymentAnnotationProcessor(applicationEventPublisher));
   }
 
   @Test

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/processor/DeploymentPostProcessorTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/processor/DeploymentPostProcessorTest.java
@@ -110,6 +110,7 @@ public class DeploymentPostProcessorTest {
         .thenReturn(new Resource[] {resources[1]});
 
     when(deployStep1.addResourceStream(any(), anyString())).thenReturn(deployStep2);
+    when(deployStep2.addResourceStream(any(), anyString())).thenReturn(deployStep2);
 
     when(deployStep2.send()).thenReturn(camundaFuture);
 
@@ -123,7 +124,7 @@ public class DeploymentPostProcessorTest {
 
     // then
     verify(deployStep1).addResourceStream(any(), eq("1.bpmn"));
-    verify(deployStep1).addResourceStream(any(), eq("2.bpmn"));
+    verify(deployStep2).addResourceStream(any(), eq("2.bpmn"));
 
     verify(deployStep2).send();
     verify(camundaFuture).join();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This adds a new event that you can subscribe to to the spring events: post deploy (which contains information about the deployments being done by the annotation)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #

## Open points

- [ ] find a way to get all resources bundled in one deployment event

## Optional

- [ ] backport this to 8.7?
