### PR TITLE
fix: handle failure on first migration element

### DIFF
--- a/migration/process-migration/src/main/java/io/camunda/migration/process/adapter/es/ElasticsearchAdapter.java
+++ b/migration/process-migration/src/main/java/io/camunda/migration/process/adapter/es/ElasticsearchAdapter.java
@@ -223,9 +223,7 @@ public class ElasticsearchAdapter implements Adapter {
     final var sorted = items.stream().sorted(Comparator.comparing(BulkResponseItem::id)).toList();
     for (int i = 0; i < sorted.size(); i++) {
       if (sorted.get(i).error() != null) {
-        return i > 0
-            ? Objects.requireNonNull(sorted.get(i - 1).id())
-            : Objects.requireNonNull(sorted.get(i).id());
+        return i == 0 ? null : Objects.requireNonNull(sorted.get(i - 1).id());
       }
     }
 

--- a/migration/process-migration/src/main/java/io/camunda/migration/process/adapter/os/OpensearchAdapter.java
+++ b/migration/process-migration/src/main/java/io/camunda/migration/process/adapter/os/OpensearchAdapter.java
@@ -221,9 +221,7 @@ public class OpensearchAdapter implements Adapter {
     final var sorted = items.stream().sorted(Comparator.comparing(BulkResponseItem::id)).toList();
     for (int i = 0; i < sorted.size(); i++) {
       if (sorted.get(i).error() != null) {
-        return i > 0
-            ? Objects.requireNonNull(sorted.get(i - 1).id())
-            : Objects.requireNonNull(sorted.get(i).id());
+        return i == 0 ? null : Objects.requireNonNull(sorted.get(i - 1).id());
       }
     }
 

--- a/migration/process-migration/src/test/java/io/camunda/migration/process/TestData.java
+++ b/migration/process-migration/src/test/java/io/camunda/migration/process/TestData.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.migration.process;
 
+import io.camunda.webapps.schema.descriptors.operate.OperateIndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.index.ProcessIndex;
 import io.camunda.webapps.schema.entities.operate.ImportPositionEntity;
 import io.camunda.webapps.schema.entities.operate.ProcessEntity;
@@ -68,5 +69,31 @@ public interface TestData {
         .setAliasName(ProcessIndex.INDEX_NAME)
         .setIndexName(ProcessIndex.INDEX_NAME)
         .setCompleted(completed);
+  }
+
+  /**
+   * Fork of {@link ProcessIndex} but does not include form related fields to cause the update to
+   * fail for ES/OS to return an error.
+   */
+  class MisconfiguredProcessIndex extends OperateIndexDescriptor {
+
+    public MisconfiguredProcessIndex(final String indexPrefix, final boolean isElasticsearch) {
+      super(indexPrefix, isElasticsearch);
+    }
+
+    @Override
+    public String getMappingsClasspathFilename() {
+      return "/misconfigured-process-index.json";
+    }
+
+    @Override
+    public String getVersion() {
+      return "8.3.0";
+    }
+
+    @Override
+    public String getIndexName() {
+      return "process";
+    }
   }
 }

--- a/migration/process-migration/src/test/java/io/camunda/migration/process/it/MigrationRunnerIT.java
+++ b/migration/process-migration/src/test/java/io/camunda/migration/process/it/MigrationRunnerIT.java
@@ -391,6 +391,7 @@ public class MigrationRunnerIT extends AdapterTest {
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
   public void shouldNotFlushStepOnError(final boolean isElasticsearch) throws IOException {
+    // given
     this.isElasticsearch = isElasticsearch;
 
     if (isElasticsearch) {
@@ -405,9 +406,12 @@ public class MigrationRunnerIT extends AdapterTest {
             : new OpensearchAdapter(properties, OS_CONFIGURATION);
     final ProcessEntity entityToBeMigrated = TestData.processEntityWithPublicFormId(1L);
     writeToMisconfiguredProcessToIndex(entityToBeMigrated);
+
+    // when
     final String migratedEntityId =
         adapter.migrate(List.of(MigrationUtil.migrate(entityToBeMigrated)));
 
+    // then
     assertThat(migratedEntityId).isNull();
 
     if (isElasticsearch) {

--- a/migration/process-migration/src/test/resources/misconfigured-process-index.json
+++ b/migration/process-migration/src/test/resources/misconfigured-process-index.json
@@ -1,0 +1,50 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "bpmnProcessId": {
+        "type": "keyword",
+        "eager_global_ordinals": true
+      },
+      "bpmnXml": {
+        "type": "text",
+        "index": false
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "keyword"
+      },
+      "partitionId": {
+        "type": "integer"
+      },
+      "resourceName": {
+        "type": "keyword"
+      },
+      "version": {
+        "type": "long"
+      },
+      "versionTag": {
+        "type": "keyword"
+      },
+      "flowNodes": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "keyword"
+          }
+        }
+      },
+      "tenantId": {
+        "type": "keyword"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Identified a case where the process-migration would skip records if the first entity (Process Definition key sorted) to migrate had errors when flushing to ES/OS
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
