### PR TITLE
Follow up on fixing Tasklist IT

### DIFF
--- a/.github/workflows/tasklist-ci-test-reusable.yml
+++ b/.github/workflows/tasklist-ci-test-reusable.yml
@@ -90,7 +90,6 @@ jobs:
           repository: ${{ env.ZEEBE_TEST_DOCKER_IMAGE }}
           distball: ${{ steps.build-camunda.outputs.distball }}
           version: ${{ env.ZEEBE_TEST_DOCKER_IMAGE_TAG }}
-          dockerfile: camunda.Dockerfile
           # push is needed to make accessible for integration tests
           push: true
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/it/ZeebeConnectorSecureIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/it/ZeebeConnectorSecureIT.java
@@ -45,7 +45,9 @@ public class ZeebeConnectorSecureIT {
   private static final String CERTIFICATE_FILE = "zeebe-test-chain.cert.pem";
   private static final String PRIVATE_KEY_FILE = "zeebe-test-server.key.pem";
   private static final DockerImageName ZEEBE_DOCKER_IMAGE =
-      DockerImageName.parse("camunda/zeebe")
+      DockerImageName.parse(
+              ContainerVersionsUtil.readProperty(
+                  ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_REPO_PROPERTY_NAME))
           .withTag(
               ContainerVersionsUtil.readProperty(
                   ContainerVersionsUtil.ZEEBE_CURRENTVERSION_DOCKER_PROPERTY_NAME));

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/ContainerVersionsUtil.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/ContainerVersionsUtil.java
@@ -23,6 +23,13 @@ public class ContainerVersionsUtil {
   private static final String VERSIONS_FILE = "container-versions.properties";
 
   public static String readProperty(final String propertyName) {
+    // Read first System properties, to make sure we can override it in CI
+    // If not available we default to spring/maven properties
+    final String value = System.getProperty(propertyName);
+    if (value != null) {
+      return value;
+    }
+
     try (final InputStream propsFile =
         ContainerVersionsUtil.class.getClassLoader().getResourceAsStream(VERSIONS_FILE)) {
       final Properties props = new Properties();


### PR DESCRIPTION
## Description

1. Use system properties to resolve the container tag and repo name
2. Previously we were not able to correctly resolve the values, and defaulted to the camunda/zeebe:snapshot.
    3. I was able to reproduce it in https://github.com/camunda/camunda/pull/28096
    4. Where in https://github.com/camunda/camunda/pull/28096/commits/4f5caf31008254d9674fb34134b2b8ee166ada5d I simply used a wrong repo name, and it was still working.
5. Build Zeebe docker image instead of Camunda (which failed on startup? - likely because of importers waiting?)



<!-- Describe the goal and purpose of this PR. -->

I fixed the similar issue in https://github.com/camunda/camunda/pull/28071 and validated in the logs

## Related issues

closes https://github.com/camunda/camunda/pull/28096
related to https://github.com/camunda/camunda/pull/28071
related to https://github.com/camunda/camunda/issues/27906
