### PR TITLE
feat: create a CompositeMeterRegister that keep tracks of the tags registered

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/MetricsStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/MetricsStep.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.startup.StartupStep;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
+import io.micrometer.core.instrument.Tags;
 
 public class MetricsStep implements StartupStep<PartitionStartupContext> {
 
@@ -24,11 +25,10 @@ public class MetricsStep implements StartupStep<PartitionStartupContext> {
   @Override
   public ActorFuture<PartitionStartupContext> startup(final PartitionStartupContext context) {
     final var brokerRegistry = context.brokerMeterRegistry();
-    final var partitionRegistry = MicrometerUtil.wrap(brokerRegistry);
     final Integer partitionId = context.partitionMetadata().id().id();
-    partitionRegistry
-        .config()
-        .commonTags(PartitionKeyNames.PARTITION.asString(), partitionId.toString());
+    final var partitionRegistry =
+        MicrometerUtil.wrap(brokerRegistry)
+            .addTags(Tags.of(PartitionKeyNames.PARTITION.asString(), partitionId.toString()));
 
     context.partitionMeterRegistry(partitionRegistry);
     return CompletableActorFuture.completed(context);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -46,10 +46,9 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.health.HealthMonitor;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -152,10 +151,9 @@ public class PartitionStartupAndTransitionContextImpl
     this.diskSpaceUsageMonitor = diskSpaceUsageMonitor;
     this.gatewayBrokerTransport = gatewayBrokerTransport;
     this.topologyManager = topologyManager;
-    this.startupMeterRegistry = new CompositeMeterRegistry().add(startupMeterRegistry);
-    this.startupMeterRegistry
-        .config()
-        .commonTags(Tags.of(PartitionKeyNames.PARTITION.asString(), String.valueOf(partitionId)));
+    this.startupMeterRegistry =
+        MicrometerUtil.wrap(startupMeterRegistry)
+            .addTags(PartitionKeyNames.PARTITION.asString(), String.valueOf(partitionId));
   }
 
   public PartitionAdminControl getPartitionAdminControl() {

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -137,10 +137,10 @@ public class RestoreManager {
 
   private InstrumentedRaftPartition createRaftPartition(
       final PartitionMetadata metadata, final RaftPartitionFactory factory) {
-    final var partitionRegistry = new CompositeMeterRegistry();
     final var partitionId = metadata.id().id().toString();
-    partitionRegistry.config().commonTags(PartitionKeyNames.PARTITION.asString(), partitionId);
-    partitionRegistry.add(meterRegistry);
+    final var partitionRegistry =
+        MicrometerUtil.wrap(meterRegistry)
+            .addTags(PartitionKeyNames.PARTITION.asString(), partitionId);
 
     return new InstrumentedRaftPartition(
         factory.createRaftPartition(metadata, partitionRegistry), partitionRegistry);

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
@@ -96,8 +96,9 @@ public final class MicrometerUtil {
    * will forward all metrics to that registry. This means if the forwardee has some common tags,
    * they will be applied to the metrics you create on the returned registry.
    */
-  public static CompositeMeterRegistry wrap(final MeterRegistry registry) {
-    return new CompositeMeterRegistry(registry.config().clock(), Collections.singleton(registry));
+  public static WrappedCompositeMeterRegistry wrap(final MeterRegistry registry) {
+    return new WrappedCompositeMeterRegistry(
+        registry.config().clock(), Collections.singleton(registry));
   }
 
   /** Returns a timer builder pre-configured based on the given documentation. */

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistry.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistry.java
@@ -14,7 +14,6 @@ import io.micrometer.core.instrument.Meter.Type;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -30,12 +29,11 @@ import net.jcip.annotations.ThreadSafe;
  * you're really, really sure.
  */
 @ThreadSafe
-public final class StatefulMeterRegistry extends CompositeMeterRegistry {
+public final class StatefulMeterRegistry extends WrappedCompositeMeterRegistry {
   private final ConcurrentMap<Meter.Id, StatefulGauge> gauges = new ConcurrentHashMap<>();
 
   public StatefulMeterRegistry(final MeterRegistry wrapped) {
-    super();
-    add(wrapped);
+    super(wrapped);
   }
 
   /**

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/WrappedCompositeMeterRegistry.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/WrappedCompositeMeterRegistry.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util.micrometer;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+import java.util.List;
+
+public class WrappedCompositeMeterRegistry extends CompositeMeterRegistry {
+  private Tags tags = Tags.empty();
+
+  public WrappedCompositeMeterRegistry(final MeterRegistry registry) {
+    this(registry, Tags.empty());
+  }
+
+  public WrappedCompositeMeterRegistry(final MeterRegistry registry, final Tags tags) {
+    this(Clock.SYSTEM, registry != null ? List.of(registry) : List.of());
+    addTags(tags);
+  }
+
+  public WrappedCompositeMeterRegistry(
+      final Clock clock, final Iterable<MeterRegistry> registries) {
+    super(clock, registries);
+    for (final MeterRegistry meterRegistry : registries) {
+      if (meterRegistry instanceof final WrappedCompositeMeterRegistry wrapped) {
+        addTags(wrapped.tags);
+      }
+    }
+  }
+
+  public WrappedCompositeMeterRegistry addTags(final String... tags) {
+    return addTags(Tags.of(tags));
+  }
+
+  public WrappedCompositeMeterRegistry addTags(final Tags tags) {
+    this.tags = this.tags.and(tags);
+    config().commonTags(tags);
+    return this;
+  }
+}

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/CompositeMeterTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/CompositeMeterTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util.micrometer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class CompositeMeterTest {
+  @Test
+  public void testCompositeMeter() {
+    final var registry = new SimpleMeterRegistry();
+    final var firstLevel = new WrappedCompositeMeterRegistry(registry, Tags.of("foo", "bar"));
+    final var secondLevel = new WrappedCompositeMeterRegistry(firstLevel, Tags.of("qux", "baz"));
+    final var counter1 = firstLevel.counter("test1");
+    counter1.increment();
+    counter1.increment();
+    final var counter2 = secondLevel.counter("test2");
+    counter2.increment();
+
+    assertThat(registry.getMetersAsString().lines().toList())
+        .isEqualTo(
+            List.of(
+                "test1(COUNTER)[foo='bar']; count=2.0",
+                "test2(COUNTER)[foo='bar', qux='baz']; count=1.0"));
+    secondLevel.remove(counter2);
+
+    assertThat(registry.getMetersAsString().lines().toList())
+        .isEqualTo(List.of("test1(COUNTER)[foo='bar']; count=2.0"));
+  }
+}


### PR DESCRIPTION
## Description
Nested `CompositeMeterRegistry` do not forward tags associated to them, as they are implemented as `MeterFilter`  see: https://github.com/micrometer-metrics/micrometer/issues/3020

A hacky way of bypassing this limitation is to wrap the `CompositeRegister` and keep track of the tags we register. 
This is a bit brittle, as if tags are added to a `CompositeRegister` then they will be lost when nesting.



## Related issues

closes #
