### PR TITLE
 feat: explicitly add tags whenever a CompositeRegistry is created

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -199,7 +199,7 @@
     <!-- Micrometer backend/implementations -->
     <dependency>
       <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-registry-prometheus</artifactId>
+      <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
       <scope>runtime</scope>
     </dependency>
 
@@ -516,7 +516,7 @@
             <dependency>org.bouncycastle:bcpkix-jdk18on</dependency>
 
             <!-- Micrometer Exporters/Registries -->
-            <dependency>io.micrometer:micrometer-registry-prometheus</dependency>
+            <dependency>io.micrometer:micrometer-registry-prometheus-simpleclient</dependency>
             <dependency>io.micrometer:micrometer-registry-otlp</dependency>
             <dependency>io.micrometer:micrometer-registry-dynatrace</dependency>
           </usedDependencies>

--- a/dist/src/main/java/io/camunda/zeebe/gateway/JobStreamComponent.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/JobStreamComponent.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.gateway.impl.stream.JobStreamClientImpl;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.MeterRegistry;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 
@@ -23,7 +22,6 @@ public final class JobStreamComponent {
 
   @VisibleForTesting
   @Bean(destroyMethod = "close")
-  @Autowired
   public JobStreamClient jobStreamClient(
       final ActorScheduler scheduler,
       final AtomixCluster cluster,

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -38,6 +38,12 @@ management.prometheus.metrics.export.enabled=true
 management.otlp.metrics.export.enabled=false
 # Disable the Dynatrace backend by default; can be enabled on demand
 management.dynatrace.metrics.export.enabled=false
+# In case Dynatrace is used, there is a pretty bad warning logged everytime you set some SLOs on a
+# timer or distribution summary, as Dynatrace doesn't yet natively supports buckets. We disable
+# these logs by default, as they're simply not actionable for the user. The limitation is documented
+# on our docs website, with appropriate workarounds.
+logging.level.io.micrometer.dynatrace.types.Timer=ERROR
+logging.level.io.micrometer.dynatrace.types.DistributionSummary=ERROR
 # Allow runtime configuration of log levels
 management.endpoint.loggers.enabled=true
 # Allow viewing the config properties, but sanitize their outputs

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -76,7 +76,7 @@
     <version.objenesis>3.3</version.objenesis>
     <version.opensearch>2.5.0</version.opensearch>
     <version.opensearch.testcontainers>2.0.2</version.opensearch.testcontainers>
-    <version.prometheus>1.2.1</version.prometheus>
+    <version.prometheus>0.16.0</version.prometheus>
     <version.protobuf>3.25.6</version.protobuf>
     <version.protobuf-common>2.37.1</version.protobuf-common>
     <version.micrometer>1.13.11</version.micrometer>
@@ -921,10 +921,14 @@
 
       <dependency>
         <groupId>io.prometheus</groupId>
-        <artifactId>prometheus-metrics-bom</artifactId>
+        <artifactId>simpleclient</artifactId>
         <version>${version.prometheus}</version>
-        <type>pom</type>
-        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>io.prometheus</groupId>
+        <artifactId>simpleclient_httpserver</artifactId>
+        <version>${version.prometheus}</version>
       </dependency>
 
       <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -79,7 +79,7 @@
     <version.prometheus>0.16.0</version.prometheus>
     <version.protobuf>3.25.6</version.protobuf>
     <version.protobuf-common>2.37.1</version.protobuf-common>
-    <version.micrometer>1.12.6</version.micrometer>
+    <version.micrometer>1.13.9</version.micrometer>
     <version.rocksdbjni>8.11.4</version.rocksdbjni>
     <version.sbe>1.30.0</version.sbe>
     <version.scala>2.13.16</version.scala>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -76,10 +76,10 @@
     <version.objenesis>3.3</version.objenesis>
     <version.opensearch>2.5.0</version.opensearch>
     <version.opensearch.testcontainers>2.0.2</version.opensearch.testcontainers>
-    <version.prometheus>0.16.0</version.prometheus>
+    <version.prometheus>1.2.1</version.prometheus>
     <version.protobuf>3.25.6</version.protobuf>
     <version.protobuf-common>2.37.1</version.protobuf-common>
-    <version.micrometer>1.13.9</version.micrometer>
+    <version.micrometer>1.13.11</version.micrometer>
     <version.rocksdbjni>8.11.4</version.rocksdbjni>
     <version.sbe>1.30.0</version.sbe>
     <version.scala>2.13.16</version.scala>
@@ -921,14 +921,10 @@
 
       <dependency>
         <groupId>io.prometheus</groupId>
-        <artifactId>simpleclient</artifactId>
+        <artifactId>prometheus-metrics-bom</artifactId>
         <version>${version.prometheus}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.prometheus</groupId>
-        <artifactId>simpleclient_httpserver</artifactId>
-        <version>${version.prometheus}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <dependency>

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftMetrics.java
@@ -19,9 +19,7 @@ package io.atomix.raft.metrics;
 import org.slf4j.LoggerFactory;
 
 public class RaftMetrics {
-  protected static final String NAMESPACE = "atomix";
   protected static final String PARTITION_GROUP_NAME_LABEL = "partitionGroupName";
-  protected static final String PARTITION_LABEL = "partition";
 
   protected final String partition;
   protected final String partitionGroupName;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -25,7 +25,7 @@ import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import io.atomix.raft.cluster.impl.RaftMemberContext;
 import io.atomix.raft.impl.RaftContext;
-import io.atomix.raft.metrics.LeaderMetrics;
+import io.atomix.raft.metrics.LeaderAppenderMetrics;
 import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.ConfigureRequest;
@@ -69,7 +69,7 @@ final class LeaderAppender {
   private final RaftContext raft;
   private boolean open = true;
 
-  private final LeaderMetrics metrics;
+  private final LeaderAppenderMetrics metrics;
   private final long leaderTime;
   private final long leaderIndex;
   private final long electionTimeout;
@@ -84,7 +84,7 @@ final class LeaderAppender {
     log =
         ContextualLoggerFactory.getLogger(
             getClass(), LoggerContext.builder(RaftServer.class).addValue(raft.getName()).build());
-    metrics = new LeaderMetrics(raft.getName(), raft.getMeterRegistry());
+    metrics = new LeaderAppenderMetrics(raft.getName(), raft.getMeterRegistry());
     maxBatchSizePerAppend = raft.getMaxAppendBatchSize();
     leaderTime = System.currentTimeMillis();
     leaderIndex =
@@ -852,6 +852,7 @@ final class LeaderAppender {
 
   public void close() {
     open = false;
+    metrics.close();
     completeCommits(raft.getCommitIndex());
     appendFutures
         .values()

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -95,6 +95,8 @@ public class PassiveRole extends InactiveRole {
           "Failed to purge pending snapshots, which may result in unnecessary disk usage and should be monitored",
           e);
     }
+
+    snapshotReplicationMetrics.close();
     return super.stop();
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/metrics/BackupManagerMetrics.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/metrics/BackupManagerMetrics.java
@@ -76,6 +76,7 @@ public class BackupManagerMetrics {
     return Timer.builder(BACKUP_OPERATIONS_LATENCY.getName())
         .description(BACKUP_OPERATIONS_LATENCY.getDescription())
         .tags(MetricKeyName.OPERATION.asString(), operationType.name())
+        .serviceLevelObjectives(BACKUP_OPERATIONS_LATENCY.getTimerSLOs())
         .register(registry);
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/metrics/CheckpointMetrics.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/metrics/CheckpointMetrics.java
@@ -31,8 +31,8 @@ public class CheckpointMetrics {
         .description(CHECKPOINT_POSITION.getDescription())
         .register(meterRegistry);
 
-    Gauge.builder(CHECKPOINT_POSITION.getName(), checkpointPosition::get)
-        .description(CHECKPOINT_POSITION.getDescription())
+    Gauge.builder(CHECKPOINT_ID.getName(), checkpointId::get)
+        .description(CHECKPOINT_ID.getDescription())
         .register(meterRegistry);
   }
 

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.db.ConsistencyChecksSettings;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
+import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory.StatefulMeterRegistryProvider;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
@@ -60,7 +61,7 @@ final class CheckpointRecordsProcessorTest {
                 new RocksDbConfiguration(),
                 new ConsistencyChecksSettings(true, true),
                 new AccessMetricsConfiguration(Kind.NONE, 1),
-                new SimpleMeterRegistry())
+                StatefulMeterRegistryProvider.defaultProvider())
             .createDb(database.toFile());
     final RecordProcessorContextImpl context = createContext(executor, zeebedb);
 

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbCheckpointStateTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/state/DbCheckpointStateTest.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.db.ConsistencyChecksSettings;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory.StatefulMeterRegistryProvider;
 import java.nio.file.Path;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,7 +41,7 @@ final class DbCheckpointStateTest {
                 new RocksDbConfiguration(),
                 new ConsistencyChecksSettings(true, true),
                 new AccessMetricsConfiguration(Kind.NONE, 1),
-                new SimpleMeterRegistry())
+                StatefulMeterRegistryProvider.defaultProvider())
             .createDb(database.toFile());
     state = new DbCheckpointState(zeebedb, zeebedb.createContext());
   }

--- a/zeebe/benchmarks/project/pom.xml
+++ b/zeebe/benchmarks/project/pom.xml
@@ -67,13 +67,7 @@
 
     <dependency>
       <groupId>io.prometheus</groupId>
-      <artifactId>prometheus-metrics-exporter-httpserver</artifactId>
-      <version>${version.prometheus}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>io.prometheus</groupId>
-      <artifactId>prometheus-metrics-model</artifactId>
+      <artifactId>simpleclient_httpserver</artifactId>
     </dependency>
 
     <dependency>
@@ -98,7 +92,7 @@
 
     <dependency>
       <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-registry-prometheus</artifactId>
+      <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
     </dependency>
 
     <dependency>

--- a/zeebe/benchmarks/project/pom.xml
+++ b/zeebe/benchmarks/project/pom.xml
@@ -67,12 +67,13 @@
 
     <dependency>
       <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient_httpserver</artifactId>
+      <artifactId>prometheus-metrics-exporter-httpserver</artifactId>
+      <version>${version.prometheus}</version>
     </dependency>
 
     <dependency>
       <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient</artifactId>
+      <artifactId>prometheus-metrics-model</artifactId>
     </dependency>
 
     <dependency>

--- a/zeebe/benchmarks/project/pom.xml
+++ b/zeebe/benchmarks/project/pom.xml
@@ -96,6 +96,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.agrona</groupId>
       <artifactId>agrona</artifactId>
     </dependency>

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/App.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/App.java
@@ -30,10 +30,10 @@ import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
-import io.micrometer.prometheus.PrometheusConfig;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
-import io.micrometer.prometheus.PrometheusRenameFilter;
-import io.prometheus.client.exporter.HTTPServer;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusRenameFilter;
+import io.prometheus.metrics.exporter.httpserver.HTTPServer;
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -71,10 +71,10 @@ abstract class App implements Runnable {
     try {
       // you can set the daemon flag to false if you want the server to block
       monitoringServer =
-          new HTTPServer.Builder()
-              .withPort(appCfg.getMonitoringPort())
-              .withRegistry(registry.getPrometheusRegistry())
-              .build();
+          HTTPServer.builder()
+              .port(appCfg.getMonitoringPort())
+              .registry(registry.getPrometheusRegistry())
+              .buildAndStart();
     } catch (final IOException e) {
       LOG.error("Problem on starting monitoring server.", e);
     }

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/App.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/App.java
@@ -30,10 +30,10 @@ import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
-import io.micrometer.prometheusmetrics.PrometheusConfig;
-import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
-import io.micrometer.prometheusmetrics.PrometheusRenameFilter;
-import io.prometheus.metrics.exporter.httpserver.HTTPServer;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.micrometer.prometheus.PrometheusRenameFilter;
+import io.prometheus.client.exporter.HTTPServer;
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -71,10 +71,10 @@ abstract class App implements Runnable {
     try {
       // you can set the daemon flag to false if you want the server to block
       monitoringServer =
-          HTTPServer.builder()
-              .port(appCfg.getMonitoringPort())
-              .registry(registry.getPrometheusRegistry())
-              .buildAndStart();
+          new HTTPServer.Builder()
+              .withPort(appCfg.getMonitoringPort())
+              .withRegistry(registry.getPrometheusRegistry())
+              .build();
     } catch (final IOException e) {
       LOG.error("Problem on starting monitoring server.", e);
     }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterContext.java
@@ -44,6 +44,9 @@ public final class ExporterContext implements Context, AutoCloseable {
     if (meterRegistry != null) {
       this.meterRegistry.add(meterRegistry);
     }
+    // due to a weird behavior in Micrometer, tags are not forwarded by nested composite registries
+    // until this is solved, we need to pass them on over and over; later we should extract some
+    // utility to forward tags when nesting registries
     this.meterRegistry
         .config()
         .commonTags(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
@@ -7,96 +7,71 @@
  */
 package io.camunda.zeebe.broker.exporter.metrics;
 
+import static io.camunda.zeebe.broker.exporter.metrics.ExecutionLatencyMetricsDoc.CACHED_INSTANCES;
+import static io.camunda.zeebe.broker.exporter.metrics.ExecutionLatencyMetricsDoc.JOB_ACTIVATION_TIME;
+import static io.camunda.zeebe.broker.exporter.metrics.ExecutionLatencyMetricsDoc.JOB_LIFETIME;
+import static io.camunda.zeebe.broker.exporter.metrics.ExecutionLatencyMetricsDoc.PROCESS_INSTANCE_EXECUTION;
+
+import io.camunda.zeebe.broker.exporter.metrics.ExecutionLatencyMetricsDoc.CacheKeyNames;
+import io.camunda.zeebe.broker.exporter.metrics.ExecutionLatencyMetricsDoc.CacheType;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.time.Duration;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Stream;
 
 public class ExecutionLatencyMetrics {
 
-  private static final Duration[] JOB_LIFE_TIME_BUCKETS =
-      Stream.of(25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 10000, 15000, 30000, 45000)
-          .map(Duration::ofMillis)
-          .toArray(Duration[]::new);
+  private final AtomicInteger currentCachedInstanceJobsCount = new AtomicInteger();
+  private final AtomicInteger currentCacheInstanceProcessInstances = new AtomicInteger();
 
-  private static final Duration[] JOB_ACTIVATION_TIME_BUCKETS =
-      Stream.of(10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 10000, 15000, 30000)
-          .map(Duration::ofMillis)
-          .toArray(Duration[]::new);
-
-  private static final Duration[] PROCESS_INSTANCE_EXECUTION_BUCKETS =
-      Stream.of(50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 10000, 15000, 30000, 45000, 60000)
-          .map(Duration::ofMillis)
-          .toArray(Duration[]::new);
-
-  private final MeterRegistry meterRegistry;
-  private final Map<Integer, AtomicInteger> currentCachedInstanceJobsCount =
-      new ConcurrentHashMap<>();
-  private final Map<Integer, AtomicInteger> currentCacheInstanceProcessInstances =
-      new ConcurrentHashMap<>();
-  private final int partitionId;
+  private final Timer processInstanceExecutionTime;
+  private final Timer jobLifeTime;
+  private final Timer jobActivationTime;
 
   public ExecutionLatencyMetrics() {
-    this(new SimpleMeterRegistry(), 1);
+    this(new SimpleMeterRegistry());
   }
 
-  public ExecutionLatencyMetrics(final MeterRegistry meterRegistry, final int partitionId) {
-    this.meterRegistry = meterRegistry;
-    this.partitionId = partitionId;
+  public ExecutionLatencyMetrics(final MeterRegistry meterRegistry) {
+
+    processInstanceExecutionTime =
+        MicrometerUtil.buildTimer(PROCESS_INSTANCE_EXECUTION).register(meterRegistry);
+    jobLifeTime = MicrometerUtil.buildTimer(JOB_LIFETIME).register(meterRegistry);
+    jobActivationTime = MicrometerUtil.buildTimer(JOB_ACTIVATION_TIME).register(meterRegistry);
+    registerCacheCount(
+        currentCacheInstanceProcessInstances, CacheType.PROCESS_INSTANCES, meterRegistry);
+    registerCacheCount(currentCachedInstanceJobsCount, CacheType.JOBS, meterRegistry);
+  }
+
+  private void registerCacheCount(
+      final AtomicInteger state, final CacheType type, final MeterRegistry meterRegistry) {
+    Gauge.builder(CACHED_INSTANCES.getName(), state, AtomicInteger::get)
+        .description(CACHED_INSTANCES.getDescription())
+        .tag(CacheKeyNames.TYPE.asString(), type.getTagValue())
+        .register(meterRegistry);
   }
 
   public void observeProcessInstanceExecutionTime(
       final long creationTimeMs, final long completionTimeMs) {
-    Timer.builder("zeebe.process.instance.execution.time")
-        .description("The execution time of processing a complete process instance")
-        .sla(PROCESS_INSTANCE_EXECUTION_BUCKETS)
-        .register(meterRegistry)
-        .record(completionTimeMs - creationTimeMs, TimeUnit.MILLISECONDS);
+    processInstanceExecutionTime.record(completionTimeMs - creationTimeMs, TimeUnit.MILLISECONDS);
   }
 
   public void observeJobLifeTime(final long creationTimeMs, final long completionTimeMs) {
-    Timer.builder("zeebe.job.life.time")
-        .description("The life time of an job")
-        .sla(JOB_LIFE_TIME_BUCKETS)
-        .register(meterRegistry)
-        .record(completionTimeMs - creationTimeMs, TimeUnit.MILLISECONDS);
+    jobLifeTime.record(completionTimeMs - creationTimeMs, TimeUnit.MILLISECONDS);
   }
 
   public void observeJobActivationTime(final long creationTimeMs, final long activationTimeMs) {
-    Timer.builder("zeebe.job.activation.time")
-        .description("The time until an job was activated")
-        .sla(JOB_ACTIVATION_TIME_BUCKETS)
-        .register(meterRegistry)
-        .record(activationTimeMs - creationTimeMs, TimeUnit.MILLISECONDS);
+    jobActivationTime.record(activationTimeMs - creationTimeMs, TimeUnit.MILLISECONDS);
   }
 
   public void setCurrentJobsCount(final int count) {
-    setCurrentCachedInstanceGauge(count, "jobs");
+    currentCachedInstanceJobsCount.set(count);
   }
 
   public void setCurrentProcessInstanceCount(final int count) {
-    setCurrentCachedInstanceGauge(count, "processInstances");
-  }
-
-  private void setCurrentCachedInstanceGauge(final int count, final String type) {
-    final var collection =
-        "jobs".equals(type) ? currentCachedInstanceJobsCount : currentCacheInstanceProcessInstances;
-
-    collection.putIfAbsent(partitionId, new AtomicInteger());
-    collection.get(partitionId).set(count);
-
-    Gauge.builder(
-            "zeebe.execution.latency.current.cached.instances",
-            () -> collection.get(partitionId).get())
-        .description(
-            "The current cached instances for counting their execution latency. If only short-lived instances are handled this can be seen or observed as the current active instance count.")
-        .tags("type", type)
-        .register(meterRegistry);
+    currentCacheInstanceProcessInstances.set(count);
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetricsDoc.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetricsDoc.java
@@ -23,7 +23,8 @@ public enum ExecutionLatencyMetricsDoc implements ExtendedMeterDocumentation {
   CACHED_INSTANCES {
     @Override
     public String getDescription() {
-      return """
+      return
+      """
         The current cached entities for counting their execution latency. If only \
         short-lived instances are handled this can be seen or observed as the current active \
         instance count.""";

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetricsDoc.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetricsDoc.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.exporter.metrics;
+
+import io.camunda.zeebe.broker.exporter.stream.ExporterMetricsDoc.ExporterContainerKeyNames;
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter.Type;
+import java.time.Duration;
+
+@SuppressWarnings("NullableProblems")
+public enum ExecutionLatencyMetricsDoc implements ExtendedMeterDocumentation {
+  /**
+   * The current cached entities for counting their execution latency. If only short-lived instances
+   * are handled this can be seen or observed as the current active instance count.
+   */
+  CACHED_INSTANCES {
+    @Override
+    public String getDescription() {
+      return """
+        The current cached entities for counting their execution latency. If only \
+        short-lived instances are handled this can be seen or observed as the current active \
+        instance count.""";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.execution.latency.current.cached.instances";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return CacheKeyNames.values();
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return KeyName.merge(PartitionKeyNames.values(), ExporterContainerKeyNames.values());
+    }
+  },
+
+  /** The execution time of processing a complete process instance */
+  PROCESS_INSTANCE_EXECUTION {
+    private static final Duration[] BUCKETS = {
+      Duration.ofMillis(50),
+      Duration.ofMillis(75),
+      Duration.ofMillis(100),
+      Duration.ofMillis(250),
+      Duration.ofMillis(500),
+      Duration.ofMillis(750),
+      Duration.ofSeconds(1),
+      Duration.ofMillis(2500),
+      Duration.ofSeconds(5),
+      Duration.ofSeconds(10),
+      Duration.ofSeconds(15),
+      Duration.ofSeconds(30),
+      Duration.ofSeconds(45),
+      Duration.ofMinutes(1)
+    };
+
+    @Override
+    public String getDescription() {
+      return "The execution time of processing a complete process instance";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.process.instance.execution.time";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+  },
+
+  /** The lifetime of a job */
+  JOB_LIFETIME {
+    private static final Duration[] BUCKETS = {
+      Duration.ofMillis(50),
+      Duration.ofMillis(75),
+      Duration.ofMillis(100),
+      Duration.ofMillis(250),
+      Duration.ofMillis(500),
+      Duration.ofMillis(750),
+      Duration.ofSeconds(1),
+      Duration.ofMillis(2500),
+      Duration.ofSeconds(5),
+      Duration.ofSeconds(10),
+      Duration.ofSeconds(15),
+      Duration.ofSeconds(30),
+      Duration.ofSeconds(45)
+    };
+
+    @Override
+    public String getDescription() {
+      return "The lifetime of a job";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.job.life.time";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+  },
+
+  /** The time until a job was activated */
+  JOB_ACTIVATION_TIME {
+    private static final Duration[] BUCKETS = {
+      Duration.ofMillis(50),
+      Duration.ofMillis(75),
+      Duration.ofMillis(100),
+      Duration.ofMillis(250),
+      Duration.ofMillis(500),
+      Duration.ofMillis(750),
+      Duration.ofSeconds(1),
+      Duration.ofMillis(2500),
+      Duration.ofSeconds(5),
+      Duration.ofSeconds(10),
+      Duration.ofSeconds(15),
+      Duration.ofSeconds(30)
+    };
+
+    @Override
+    public String getDescription() {
+      return "The time until a job was activated";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.job.activation.time";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+  };
+
+  public enum CacheKeyNames implements KeyName {
+    /** The type of entities stored in the cache; see {@link CacheType} for possible values */
+    TYPE {
+      @Override
+      public String asString() {
+        return "type";
+      }
+    }
+  }
+
+  public enum CacheType {
+    JOBS("jobs"),
+    PROCESS_INSTANCES("processInstances");
+
+    private final String tagValue;
+
+    CacheType(final String tagValue) {
+      this.tagValue = tagValue;
+    }
+
+    public String getTagValue() {
+      return tagValue;
+    }
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java
@@ -51,32 +51,21 @@ public class MetricsExporter implements Exporter {
   private final TtlKeyCache jobCache;
 
   private Controller controller;
-  private MeterRegistry meterRegistry;
 
   public MetricsExporter() {
-    this(
-        new ExecutionLatencyMetrics(),
-        new TtlKeyCache(TIME_TO_LIVE.toMillis()),
-        new TtlKeyCache(TIME_TO_LIVE.toMillis()),
-        null);
+    this(new TtlKeyCache(TIME_TO_LIVE.toMillis()), new TtlKeyCache(TIME_TO_LIVE.toMillis()));
   }
 
   @VisibleForTesting
-  MetricsExporter(
-      final ExecutionLatencyMetrics executionLatencyMetrics,
-      final TtlKeyCache processInstanceCache,
-      final TtlKeyCache jobCache,
-      final MeterRegistry meterRegistry) {
-    this.executionLatencyMetrics = executionLatencyMetrics;
+  MetricsExporter(final TtlKeyCache processInstanceCache, final TtlKeyCache jobCache) {
     this.processInstanceCache = processInstanceCache;
     this.jobCache = jobCache;
-    this.meterRegistry = meterRegistry;
   }
 
   @Override
   public void configure(final Context context) throws Exception {
-    meterRegistry = context.getMeterRegistry();
-    executionLatencyMetrics = new ExecutionLatencyMetrics(meterRegistry, context.getPartitionId());
+    final MeterRegistry meterRegistry = context.getMeterRegistry();
+    executionLatencyMetrics = new ExecutionLatencyMetrics(meterRegistry);
     context.setFilter(
         new RecordFilter() {
           private static final Set<ValueType> ACCEPTED_VALUE_TYPES =

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetricsDoc.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetricsDoc.java
@@ -70,7 +70,8 @@ public enum ExporterMetricsDoc implements ExtendedMeterDocumentation {
 
     @Override
     public String getDescription() {
-      return """
+      return
+      """
         Describes the phase of the exporter, namely if it is exporting (0), paused (1), soft \
         paused (2), or closed (3)""";
     }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetricsDoc.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetricsDoc.java
@@ -70,8 +70,7 @@ public enum ExporterMetricsDoc implements ExtendedMeterDocumentation {
 
     @Override
     public String getDescription() {
-      return
-      """
+      return """
         Describes the phase of the exporter, namely if it is exporting (0), paused (1), soft \
         paused (2), or closed (3)""";
     }
@@ -135,6 +134,16 @@ public enum ExporterMetricsDoc implements ExtendedMeterDocumentation {
       return ExporterActionKeyNames.values();
     }
   };
+
+  public enum ExporterContainerKeyNames implements KeyName {
+    /** Identifies which exporter is emitting a metric */
+    EXPORTER_ID {
+      @Override
+      public String asString() {
+        return "exporterId";
+      }
+    }
+  }
 
   enum ExporterActionKeyNames implements KeyName {
     SKIPPED {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -47,6 +47,7 @@ import io.camunda.zeebe.broker.transport.commandapi.CommandApiService;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiServiceTransitionStep;
 import io.camunda.zeebe.db.AccessMetricsConfiguration;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
+import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory.StatefulMeterRegistryProvider;
 import io.camunda.zeebe.engine.processing.EngineProcessors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
@@ -203,8 +204,8 @@ public final class ZeebePartitionFactory {
             databaseCfg.createRocksDbConfiguration(),
             consistencyChecks.getSettings(),
             new AccessMetricsConfiguration(databaseCfg.getAccessMetrics(), raftPartition.id().id()),
-            partitionMeterRegistry,
-            PartitionKeyNames.tags(raftPartition.id().id())),
+            StatefulMeterRegistryProvider.wrapping(
+                partitionMeterRegistry, PartitionKeyNames.tags(raftPartition.id().id()))),
         snapshotStore,
         runtimeDirectory,
         new AtomixRecordEntrySupplierImpl(raftPartition.getServer()),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -60,6 +60,7 @@ import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.FeatureFlags;
 import io.camunda.zeebe.util.FileUtil;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -202,7 +203,8 @@ public final class ZeebePartitionFactory {
             databaseCfg.createRocksDbConfiguration(),
             consistencyChecks.getSettings(),
             new AccessMetricsConfiguration(databaseCfg.getAccessMetrics(), raftPartition.id().id()),
-            partitionMeterRegistry),
+            partitionMeterRegistry,
+            PartitionKeyNames.tags(raftPartition.id().id())),
         snapshotStore,
         runtimeDirectory,
         new AtomixRecordEntrySupplierImpl(raftPartition.getServer()),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/MetricsStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/MetricsStep.java
@@ -26,9 +26,7 @@ public class MetricsStep implements StartupStep<PartitionStartupContext> {
     final var brokerRegistry = context.brokerMeterRegistry();
     final var partitionRegistry = MicrometerUtil.wrap(brokerRegistry);
     final Integer partitionId = context.partitionMetadata().id().id();
-    partitionRegistry
-        .config()
-        .commonTags(PartitionKeyNames.PARTITION.asString(), partitionId.toString());
+    partitionRegistry.config().commonTags(PartitionKeyNames.tags(partitionId));
 
     context.partitionMeterRegistry(partitionRegistry);
     return CompletableActorFuture.completed(context);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/MetricsStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/MetricsStep.java
@@ -24,9 +24,9 @@ public class MetricsStep implements StartupStep<PartitionStartupContext> {
   @Override
   public ActorFuture<PartitionStartupContext> startup(final PartitionStartupContext context) {
     final var brokerRegistry = context.brokerMeterRegistry();
-    final var partitionRegistry = MicrometerUtil.wrap(brokerRegistry);
-    final Integer partitionId = context.partitionMetadata().id().id();
-    partitionRegistry.config().commonTags(PartitionKeyNames.tags(partitionId));
+    final var partitionId = context.partitionMetadata().id().id();
+    final var partitionRegistry =
+        MicrometerUtil.wrap(brokerRegistry, PartitionKeyNames.tags(partitionId));
 
     context.partitionMeterRegistry(partitionRegistry);
     return CompletableActorFuture.completed(context);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -46,9 +46,7 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.health.HealthMonitor;
-import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -151,11 +149,7 @@ public class PartitionStartupAndTransitionContextImpl
     this.diskSpaceUsageMonitor = diskSpaceUsageMonitor;
     this.gatewayBrokerTransport = gatewayBrokerTransport;
     this.topologyManager = topologyManager;
-    this.startupMeterRegistry = new CompositeMeterRegistry().add(startupMeterRegistry);
-    // due to a weird behavior in Micrometer, tags are not forwarded by nested composite registries
-    // until this is solved, we need to pass them on over and over; later we should extract some
-    // utility to forward tags when nesting registries
-    startupMeterRegistry.config().commonTags(PartitionKeyNames.tags(partitionId));
+    this.startupMeterRegistry = startupMeterRegistry;
   }
 
   public PartitionAdminControl getPartitionAdminControl() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -48,7 +48,6 @@ import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.health.HealthMonitor;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import java.util.Collection;
 import java.util.Collections;
@@ -153,9 +152,10 @@ public class PartitionStartupAndTransitionContextImpl
     this.gatewayBrokerTransport = gatewayBrokerTransport;
     this.topologyManager = topologyManager;
     this.startupMeterRegistry = new CompositeMeterRegistry().add(startupMeterRegistry);
-    this.startupMeterRegistry
-        .config()
-        .commonTags(Tags.of(PartitionKeyNames.PARTITION.asString(), String.valueOf(partitionId)));
+    // due to a weird behavior in Micrometer, tags are not forwarded by nested composite registries
+    // until this is solved, we need to pass them on over and over; later we should extract some
+    // utility to forward tags when nesting registries
+    startupMeterRegistry.config().commonTags(PartitionKeyNames.tags(partitionId));
   }
 
   public PartitionAdminControl getPartitionAdminControl() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MetricsStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MetricsStep.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 
 public final class MetricsStep implements PartitionTransitionStep {
@@ -33,6 +34,10 @@ public final class MetricsStep implements PartitionTransitionStep {
       final PartitionTransitionContext context, final long term, final Role targetRole) {
     final var startupMeterRegistry = context.getPartitionStartupMeterRegistry();
     final var transitionRegistry = MicrometerUtil.wrap(startupMeterRegistry);
+    // due to a weird behavior in Micrometer, tags are not forwarded by nested composite registries
+    // until this is solved, we need to pass them on over and over; later we should extract some
+    // utility to forward tags when nesting registries
+    transitionRegistry.config().commonTags(PartitionKeyNames.tags(context.getPartitionId()));
 
     context.setPartitionTransitionMeterRegistry(transitionRegistry);
     return context.getConcurrencyControl().createCompletedFuture();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MetricsStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MetricsStep.java
@@ -33,11 +33,8 @@ public final class MetricsStep implements PartitionTransitionStep {
   public ActorFuture<Void> transitionTo(
       final PartitionTransitionContext context, final long term, final Role targetRole) {
     final var startupMeterRegistry = context.getPartitionStartupMeterRegistry();
-    final var transitionRegistry = MicrometerUtil.wrap(startupMeterRegistry);
-    // due to a weird behavior in Micrometer, tags are not forwarded by nested composite registries
-    // until this is solved, we need to pass them on over and over; later we should extract some
-    // utility to forward tags when nesting registries
-    transitionRegistry.config().commonTags(PartitionKeyNames.tags(context.getPartitionId()));
+    final var transitionRegistry =
+        MicrometerUtil.wrap(startupMeterRegistry, PartitionKeyNames.tags(context.getPartitionId()));
 
     context.setPartitionTransitionMeterRegistry(transitionRegistry);
     return context.getConcurrencyControl().createCompletedFuture();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporterTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporterTest.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -33,21 +32,28 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class MetricsExporterTest {
-  private static final TtlKeyCache DEFAULT_KEY_CACHE =
-      new TtlKeyCache(MetricsExporter.TIME_TO_LIVE.toMillis());
+  private final ExporterTestContext context = new ExporterTestContext();
 
   @Test
-  void shouldObserveJobLifetime() {
+  void shouldObserveJobLifetime() throws Exception {
     // given
-    final var meterRegistry = new SimpleMeterRegistry();
-    final var partitionId = 1;
-    final var metrics = new ExecutionLatencyMetrics(meterRegistry, 1);
-    final var exporter =
-        new MetricsExporter(metrics, DEFAULT_KEY_CACHE, DEFAULT_KEY_CACHE, meterRegistry);
+    final var exporter = new MetricsExporter();
+    exporter.configure(context);
     exporter.open(new ExporterTestController());
-    assertThat(meterRegistry.getMeters().size())
-        .isEqualTo(0)
-        .describedAs("Expected no metrics to be measured at start");
+    assertThat(context.getMeterRegistry().getMeters())
+        .describedAs("Expected no metrics to be measured at start")
+        .allSatisfy(
+            meter ->
+                meter.match(
+                    g -> assertThat(g.value()).isZero(),
+                    ignored -> null,
+                    t -> assertThat(t.count()).isZero(),
+                    ignored -> null,
+                    ignored -> null,
+                    ignored -> null,
+                    ignored -> null,
+                    ignored -> null,
+                    ignored -> null));
 
     // when
     exporter.export(
@@ -56,7 +62,7 @@ class MetricsExporterTest {
             .withValueType(ValueType.JOB)
             .withIntent(JobIntent.CREATED)
             .withTimestamp(1651505728460L)
-            .withKey(Protocol.encodePartitionId(partitionId, 1))
+            .withKey(Protocol.encodePartitionId(1, 1))
             .build());
 
     // pass a job batch activated to simulate the full lifetime
@@ -77,14 +83,14 @@ class MetricsExporterTest {
             .withValueType(ValueType.JOB)
             .withIntent(JobIntent.COMPLETED)
             .withTimestamp(1651505729571L)
-            .withKey(Protocol.encodePartitionId(partitionId, 1))
+            .withKey(Protocol.encodePartitionId(1, 1))
             .build());
 
     // then
-    final var jobLifeTime = meterRegistry.timer("zeebe.job.life.time");
+    final var jobLifeTime = context.getMeterRegistry().timer("zeebe.job.life.time");
 
     assertThat(jobLifeTime.count())
-        .isEqualTo(1)
+        .isOne()
         .describedAs("Expected exactly 1 observed job_life_time sample counted");
 
     assertThat(
@@ -95,16 +101,12 @@ class MetricsExporterTest {
   }
 
   @Test
-  void shouldCleanupProcessInstancesWithSameStartTime() {
+  void shouldCleanupProcessInstancesWithSameStartTime() throws Exception {
     // given
     final var processCache = new TtlKeyCache();
-    final var exporter =
-        new MetricsExporter(
-            new ExecutionLatencyMetrics(),
-            processCache,
-            new TtlKeyCache(),
-            new SimpleMeterRegistry());
+    final var exporter = new MetricsExporter(processCache, new TtlKeyCache());
     final var controller = new ExporterTestController();
+    exporter.configure(context);
     exporter.open(controller);
     exporter.export(
         ImmutableRecord.<ProcessInstanceRecord>builder()
@@ -133,11 +135,12 @@ class MetricsExporterTest {
   }
 
   @Test
-  void shouldCleanupJobWithSameStartTime() {
+  void shouldCleanupJobWithSameStartTime() throws Exception {
     // given
     final var jobCache = new TtlKeyCache();
     final var exporter = new MetricsExporter();
     final var controller = new ExporterTestController();
+    exporter.configure(context);
     exporter.open(controller);
     exporter.export(
         ImmutableRecord.builder()

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -43,9 +43,9 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.health.HealthMonitor;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Collection;
 import java.util.List;
@@ -54,7 +54,7 @@ import java.util.function.Consumer;
 
 public class TestPartitionTransitionContext implements PartitionTransitionContext {
 
-  private final CompositeMeterRegistry startupMeterRegistry = new CompositeMeterRegistry();
+  private final MeterRegistry startupMeterRegistry = new SimpleMeterRegistry();
 
   private RaftPartition raftPartition;
   private Role currentRole;
@@ -83,10 +83,8 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   private MeterRegistry transitionMeterRegistry;
 
   public TestPartitionTransitionContext() {
-    transitionMeterRegistry = new SimpleMeterRegistry();
-    transitionMeterRegistry.config().commonTags(PartitionKeyNames.PARTITION.asString(), "1");
-
-    startupMeterRegistry.add(transitionMeterRegistry);
+    startupMeterRegistry.config().commonTags(PartitionKeyNames.tags(1));
+    transitionMeterRegistry = MicrometerUtil.wrap(startupMeterRegistry, PartitionKeyNames.tags(1));
   }
 
   @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/TestState.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/TestState.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
+import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory.StatefulMeterRegistryProvider;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
@@ -86,7 +87,7 @@ final class TestState {
         new RocksDbConfiguration(),
         new ConsistencyChecksSettings(false, false),
         new AccessMetricsConfiguration(Kind.NONE, 1),
-        new SimpleMeterRegistry());
+        StatefulMeterRegistryProvider.defaultProvider());
   }
 
   private void insertData(final List<ColumnFamily<DbString, DbString>> columns) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/DefaultZeebeDbFactory.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/DefaultZeebeDbFactory.java
@@ -13,8 +13,8 @@ import io.camunda.zeebe.db.ConsistencyChecksSettings;
 import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
+import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory.StatefulMeterRegistryProvider;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 public final class DefaultZeebeDbFactory {
 
@@ -25,6 +25,6 @@ public final class DefaultZeebeDbFactory {
         new RocksDbConfiguration(),
         consistencyChecks,
         new AccessMetricsConfiguration(Kind.NONE, 1),
-        new SimpleMeterRegistry());
+        StatefulMeterRegistryProvider.defaultProvider());
   }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobClientStreamMetrics.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobClientStreamMetrics.java
@@ -43,7 +43,7 @@ final class JobClientStreamMetrics implements ClientStreamMetrics {
     registerGauge(JobClientStreamMetricsDoc.CLIENTS, clientCount, registry);
     registerGauge(JobClientStreamMetricsDoc.AGGREGATED_STREAMS, aggregatedStreamCount, registry);
 
-    // pre-populate the map to
+    // pre-populate the map to ensure it is thread safe
     for (final var errorCode : ErrorCode.values()) {
       pushAttempts.put(errorCode, registerPushAttemptCounter(registry, errorCode));
     }
@@ -85,8 +85,8 @@ final class JobClientStreamMetrics implements ClientStreamMetrics {
   }
 
   private void registerGauge(
-      final JobClientStreamMetricsDoc doc, final Number state, final MeterRegistry registry) {
-    Gauge.builder(doc.getName(), state, Number::doubleValue)
+      final JobClientStreamMetricsDoc doc, final AtomicLong state, final MeterRegistry registry) {
+    Gauge.builder(doc.getName(), state, AtomicLong::get)
         .description(doc.getDescription())
         .register(registry);
   }

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -476,7 +476,7 @@
 
     <dependency>
       <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-registry-prometheus</artifactId>
+      <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/observability/MetricsConfigurationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/observability/MetricsConfigurationIT.java
@@ -19,8 +19,8 @@ import io.micrometer.dynatrace.DynatraceMeterRegistry;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.micrometer.registry.otlp.OtlpMeterRegistry;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -60,7 +60,7 @@ final class MetricsConfigurationIT {
   @SuppressWarnings("resource")
   @Nested
   final class OtlpIT {
-    private final List<String> logLines = new ArrayList<>();
+    private final List<String> logLines = new CopyOnWriteArrayList<>();
 
     @Container
     private final GenericContainer<?> otelCollector =

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/observability/MetricsConfigurationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/observability/MetricsConfigurationIT.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.dynatrace.DynatraceMeterRegistry;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import io.micrometer.registry.otlp.OtlpMeterRegistry;
 import java.time.Duration;
 import java.util.List;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/observability/MetricsConfigurationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/observability/MetricsConfigurationIT.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.dynatrace.DynatraceMeterRegistry;
-import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.micrometer.registry.otlp.OtlpMeterRegistry;
 import java.time.Duration;
 import java.util.List;

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -137,13 +137,9 @@ public class RestoreManager {
 
   private InstrumentedRaftPartition createRaftPartition(
       final PartitionMetadata metadata, final RaftPartitionFactory factory) {
-    final var partitionRegistry = new CompositeMeterRegistry();
-    // due to a weird behavior in Micrometer, tags are not forwarded by nested composite registries
-    // until this is solved, we need to pass them on over and over; later we should extract some
-    // utility to forward tags when nesting registries
     final var partitionId = metadata.id().id();
-    partitionRegistry.config().commonTags(PartitionKeyNames.tags(partitionId));
-    partitionRegistry.add(meterRegistry);
+    final var partitionRegistry =
+        MicrometerUtil.wrap(meterRegistry, PartitionKeyNames.tags(partitionId));
 
     return new InstrumentedRaftPartition(
         factory.createRaftPartition(metadata, partitionRegistry), partitionRegistry);

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -138,8 +138,11 @@ public class RestoreManager {
   private InstrumentedRaftPartition createRaftPartition(
       final PartitionMetadata metadata, final RaftPartitionFactory factory) {
     final var partitionRegistry = new CompositeMeterRegistry();
-    final var partitionId = metadata.id().id().toString();
-    partitionRegistry.config().commonTags(PartitionKeyNames.PARTITION.asString(), partitionId);
+    // due to a weird behavior in Micrometer, tags are not forwarded by nested composite registries
+    // until this is solved, we need to pass them on over and over; later we should extract some
+    // utility to forward tags when nesting registries
+    final var partitionId = metadata.id().id();
+    partitionRegistry.config().commonTags(PartitionKeyNames.tags(partitionId));
     partitionRegistry.add(meterRegistry);
 
     return new InstrumentedRaftPartition(

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotMetrics.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotMetrics.java
@@ -38,8 +38,9 @@ public final class SnapshotMetrics {
   public SnapshotMetrics(final MeterRegistry registry) {
     clock = registry.config().clock();
 
-    snapshotDuration = MicrometerUtil.timer(SNAPSHOT_DURATION).register(registry);
-    snapshotPersistDuration = MicrometerUtil.timer(SNAPSHOT_PERSIST_DURATION).register(registry);
+    snapshotDuration = MicrometerUtil.buildTimer(SNAPSHOT_DURATION).register(registry);
+    snapshotPersistDuration =
+        MicrometerUtil.buildTimer(SNAPSHOT_PERSIST_DURATION).register(registry);
     snapshotFileSize = MicrometerUtil.summary(SNAPSHOT_FILE_SIZE).register(registry);
     snapshotCount =
         Counter.builder(SNAPSHOT_COUNT.getName())

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/ProcessingMetrics.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/ProcessingMetrics.java
@@ -181,6 +181,7 @@ public class ProcessingMetrics {
     final var meterDoc = StreamMetricsDoc.PROCESSING_LATENCY;
     return Timer.builder(meterDoc.getName())
         .description(meterDoc.getDescription())
+        .serviceLevelObjectives(meterDoc.getTimerSLOs())
         .register(registry);
   }
 
@@ -188,6 +189,7 @@ public class ProcessingMetrics {
     final var meterDoc = StreamMetricsDoc.PROCESSING_DURATION;
     return Timer.builder(meterDoc.getName())
         .description(meterDoc.getDescription())
+        .serviceLevelObjectives(meterDoc.getTimerSLOs())
         .tag(ProcessingDurationKeys.VALUE_TYPE.asString(), valueType.name())
         .tag(ProcessingDurationKeys.INTENT.asString(), intent.name())
         .register(registry);

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/util/DefaultZeebeDbFactory.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/util/DefaultZeebeDbFactory.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 public final class DefaultZeebeDbFactory {
@@ -25,6 +26,7 @@ public final class DefaultZeebeDbFactory {
         new RocksDbConfiguration(),
         consistencyChecks,
         new AccessMetricsConfiguration(Kind.NONE, 1),
-        new SimpleMeterRegistry());
+        new SimpleMeterRegistry(),
+        Tags.empty());
   }
 }

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/util/DefaultZeebeDbFactory.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/util/DefaultZeebeDbFactory.java
@@ -13,9 +13,8 @@ import io.camunda.zeebe.db.ConsistencyChecksSettings;
 import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
+import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory.StatefulMeterRegistryProvider;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
-import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 public final class DefaultZeebeDbFactory {
 
@@ -26,7 +25,6 @@ public final class DefaultZeebeDbFactory {
         new RocksDbConfiguration(),
         consistencyChecks,
         new AccessMetricsConfiguration(Kind.NONE, 1),
-        new SimpleMeterRegistry(),
-        Tags.empty());
+        StatefulMeterRegistryProvider.defaultProvider());
   }
 }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
@@ -194,7 +194,7 @@ public final class MicrometerUtil {
     };
 
     public static Tags tags(final int partitionId) {
-      return Tags.of(PARTITION.name(), String.valueOf(partitionId));
+      return Tags.of(PARTITION.asString(), String.valueOf(partitionId));
     }
   }
 }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
@@ -109,7 +109,7 @@ public final class MicrometerUtil {
   }
 
   /** Returns a timer builder pre-configured based on the given documentation. */
-  public static Timer.Builder timer(final ExtendedMeterDocumentation documentation) {
+  public static Timer.Builder buildTimer(final ExtendedMeterDocumentation documentation) {
     return Timer.builder(documentation.getName())
         .description(documentation.getDescription())
         .serviceLevelObjectives(documentation.getTimerSLOs());

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
@@ -94,11 +94,18 @@ public final class MicrometerUtil {
 
   /**
    * Returns a {@link CompositeMeterRegistry} using the same config as the given registry, which
-   * will forward all metrics to that registry. This means if the forwardee has some common tags,
-   * they will be applied to the metrics you create on the returned registry.
+   * will forward all metrics to that registry.
+   *
+   * <p>NOTE: Micrometer does not support forwarding tags more than two levels down, so you always
+   * have to specify the tags again on every wrapped registry!
    */
-  public static CompositeMeterRegistry wrap(final MeterRegistry registry) {
-    return new CompositeMeterRegistry(registry.config().clock(), Collections.singleton(registry));
+  public static CompositeMeterRegistry wrap(final MeterRegistry wrapped, final Tags tags) {
+    final var registry =
+        wrapped != null
+            ? new CompositeMeterRegistry(wrapped.config().clock(), Collections.singleton(wrapped))
+            : new CompositeMeterRegistry();
+    registry.config().commonTags(tags);
+    return registry;
   }
 
   /** Returns a timer builder pre-configured based on the given documentation. */

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/MicrometerUtil.java
@@ -12,6 +12,7 @@ import io.micrometer.common.docs.KeyName;
 import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.Timer.Builder;
 import io.micrometer.core.instrument.Timer.Sample;
@@ -183,6 +184,10 @@ public final class MicrometerUtil {
       public String asString() {
         return "partition";
       }
+    };
+
+    public static Tags tags(final int partitionId) {
+      return Tags.of(PARTITION.name(), String.valueOf(partitionId));
     }
   }
 }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistry.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistry.java
@@ -33,8 +33,21 @@ import net.jcip.annotations.ThreadSafe;
 public final class StatefulMeterRegistry extends CompositeMeterRegistry {
   private final ConcurrentMap<Meter.Id, StatefulGauge> gauges = new ConcurrentHashMap<>();
 
-  public StatefulMeterRegistry(final MeterRegistry wrapped, final Tags tags) {
+  public StatefulMeterRegistry() {
     super();
+  }
+
+  /**
+   * Wraps a given meter registry, applying the given tags to this registry.
+   *
+   * <p>NOTE: Micrometer doesn't forward tags more than one level down when nesting composite meter
+   * registries, so make sure to always re-apply your tags.
+   *
+   * @param wrapped the registry to forward to
+   * @param tags the tags to apply on this registry
+   */
+  public StatefulMeterRegistry(final MeterRegistry wrapped, final Tags tags) {
+    this();
     add(wrapped);
     config().commonTags(tags);
   }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistry.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistry.java
@@ -33,9 +33,10 @@ import net.jcip.annotations.ThreadSafe;
 public final class StatefulMeterRegistry extends CompositeMeterRegistry {
   private final ConcurrentMap<Meter.Id, StatefulGauge> gauges = new ConcurrentHashMap<>();
 
-  public StatefulMeterRegistry(final MeterRegistry wrapped) {
+  public StatefulMeterRegistry(final MeterRegistry wrapped, final Tags tags) {
     super();
     add(wrapped);
+    config().commonTags(tags);
   }
 
   /**

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/MicrometerUtilTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/MicrometerUtilTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.util.micrometer;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.temporal.ChronoUnit;
@@ -29,7 +30,7 @@ final class MicrometerUtilTest {
   @Nested
   final class DiscardTest {
     private final MeterRegistry wrapped = new SimpleMeterRegistry();
-    private final CompositeMeterRegistry registry = MicrometerUtil.wrap(wrapped);
+    private final CompositeMeterRegistry registry = MicrometerUtil.wrap(wrapped, Tags.empty());
 
     @Test
     void shouldNotCloseWrappedRegistriesOnDiscard() {

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistryTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistryTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.util.micrometer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter.Type;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -19,7 +20,8 @@ import org.junit.jupiter.api.Test;
 final class StatefulMeterRegistryTest {
 
   private final MeterRegistry wrapped = new SimpleMeterRegistry();
-  private final StatefulMeterRegistry registry = new StatefulMeterRegistry(wrapped);
+  private final StatefulMeterRegistry registry =
+      new StatefulMeterRegistry(wrapped, PartitionKeyNames.tags(1));
 
   @AfterEach
   void afterEach() {

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistryTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistryTest.java
@@ -15,13 +15,19 @@ import io.micrometer.core.instrument.Meter.Type;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 final class StatefulMeterRegistryTest {
 
   private final MeterRegistry wrapped = new SimpleMeterRegistry();
-  private final StatefulMeterRegistry registry =
-      new StatefulMeterRegistry(wrapped, PartitionKeyNames.tags(1));
+  private final StatefulMeterRegistry registry = new StatefulMeterRegistry();
+
+  @BeforeEach
+  void beforeEach() {
+    registry.add(wrapped);
+    registry.config().commonTags(PartitionKeyNames.tags(1));
+  }
 
   @AfterEach
   void afterEach() {

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistryTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/micrometer/StatefulMeterRegistryTest.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.util.micrometer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.Meter.Type;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -26,7 +25,6 @@ final class StatefulMeterRegistryTest {
   @BeforeEach
   void beforeEach() {
     registry.add(wrapped);
-    registry.config().commonTags(PartitionKeyNames.tags(1));
   }
 
   @AfterEach

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactory.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.db.impl.rocksdb.transaction.RocksDbOptions;
 import io.camunda.zeebe.db.impl.rocksdb.transaction.ZeebeTransactionDb;
 import io.camunda.zeebe.protocol.EnumValue;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
 import java.io.File;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -54,16 +55,19 @@ public final class ZeebeRocksDbFactory<
   private final ConsistencyChecksSettings consistencyChecksSettings;
   private final AccessMetricsConfiguration metrics;
   private final MeterRegistry meterRegistry;
+  private final Tags tags;
 
   public ZeebeRocksDbFactory(
       final RocksDbConfiguration rocksDbConfiguration,
       final ConsistencyChecksSettings consistencyChecksSettings,
       final AccessMetricsConfiguration metricsConfiguration,
-      final MeterRegistry meterRegistry) {
+      final MeterRegistry meterRegistry,
+      final Tags tags) {
     this.rocksDbConfiguration = Objects.requireNonNull(rocksDbConfiguration);
     this.consistencyChecksSettings = Objects.requireNonNull(consistencyChecksSettings);
     metrics = metricsConfiguration;
     this.meterRegistry = Objects.requireNonNull(meterRegistry);
+    this.tags = tags;
   }
 
   @Override
@@ -77,7 +81,8 @@ public final class ZeebeRocksDbFactory<
           rocksDbConfiguration,
           consistencyChecksSettings,
           metrics,
-          meterRegistry);
+          meterRegistry,
+          tags);
     } catch (final RocksDBException e) {
       CloseHelper.quietCloseAll(closeables);
       throw new IllegalStateException("Unexpected error occurred trying to open the database", e);

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransactionDb.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.protocol.EnumValue;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.camunda.zeebe.util.micrometer.StatefulMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -100,7 +101,8 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<? extends EnumVal
           final RocksDbConfiguration rocksDbConfiguration,
           final ConsistencyChecksSettings consistencyChecksSettings,
           final AccessMetricsConfiguration metrics,
-          final MeterRegistry wrappedRegistry)
+          final MeterRegistry wrappedRegistry,
+          final Tags tags)
           throws RocksDBException {
     final var cfDescriptors =
         List.of(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, options.cfOptions()));
@@ -118,7 +120,7 @@ public class ZeebeTransactionDb<ColumnFamilyNames extends Enum<? extends EnumVal
     final ColumnFamilyHandle defaultColumnFamilyHandle = cfHandles.getFirst();
     closables.add(defaultColumnFamilyHandle);
 
-    final var statefulMeterRegistry = new StatefulMeterRegistry(wrappedRegistry);
+    final var statefulMeterRegistry = new StatefulMeterRegistry(wrappedRegistry, tags);
     closables.add(() -> MicrometerUtil.discard(statefulMeterRegistry));
 
     return new ZeebeTransactionDb<>(

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/DefaultZeebeDbFactory.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/DefaultZeebeDbFactory.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
 import io.camunda.zeebe.protocol.EnumValue;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 public final class DefaultZeebeDbFactory {
@@ -32,6 +33,7 @@ public final class DefaultZeebeDbFactory {
         new RocksDbConfiguration(),
         consistencyChecks,
         new AccessMetricsConfiguration(Kind.NONE, 1),
-        meterRegistry);
+        meterRegistry,
+        Tags.empty());
   }
 }

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/DefaultZeebeDbFactory.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/DefaultZeebeDbFactory.java
@@ -13,9 +13,10 @@ import io.camunda.zeebe.db.ConsistencyChecksSettings;
 import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
-import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory.StatefulMeterRegistryProvider;
 import io.camunda.zeebe.protocol.EnumValue;
+import io.camunda.zeebe.util.micrometer.StatefulMeterRegistry;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 public final class DefaultZeebeDbFactory {
@@ -33,6 +34,6 @@ public final class DefaultZeebeDbFactory {
         new RocksDbConfiguration(),
         consistencyChecks,
         new AccessMetricsConfiguration(Kind.NONE, 1),
-        StatefulMeterRegistryProvider.defaultProvider());
+        () -> new StatefulMeterRegistry(meterRegistry, Tags.empty()));
   }
 }

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/DefaultZeebeDbFactory.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/DefaultZeebeDbFactory.java
@@ -13,9 +13,9 @@ import io.camunda.zeebe.db.ConsistencyChecksSettings;
 import io.camunda.zeebe.db.ZeebeDbFactory;
 import io.camunda.zeebe.db.impl.rocksdb.RocksDbConfiguration;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
+import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory.StatefulMeterRegistryProvider;
 import io.camunda.zeebe.protocol.EnumValue;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 public final class DefaultZeebeDbFactory {
@@ -33,7 +33,6 @@ public final class DefaultZeebeDbFactory {
         new RocksDbConfiguration(),
         consistencyChecks,
         new AccessMetricsConfiguration(Kind.NONE, 1),
-        meterRegistry,
-        Tags.empty());
+        StatefulMeterRegistryProvider.defaultProvider());
   }
 }

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
@@ -23,9 +23,8 @@ import io.camunda.zeebe.db.impl.DbByte;
 import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.db.impl.DefaultColumnFamily;
 import io.camunda.zeebe.db.impl.DefaultZeebeDbFactory;
+import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory.StatefulMeterRegistryProvider;
 import io.camunda.zeebe.util.ByteValue;
-import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Properties;
@@ -90,8 +89,7 @@ final class ZeebeRocksDbFactoryTest {
             new RocksDbConfiguration().setColumnFamilyOptions(customProperties),
             new ConsistencyChecksSettings(),
             new AccessMetricsConfiguration(Kind.NONE, 1),
-            new SimpleMeterRegistry(),
-            Tags.empty());
+            StatefulMeterRegistryProvider.defaultProvider());
 
     // when
     final var defaults = factoryWithDefaults.createColumnFamilyOptions(new ArrayList<>());
@@ -125,8 +123,7 @@ final class ZeebeRocksDbFactoryTest {
             new RocksDbConfiguration().setColumnFamilyOptions(customProperties),
             new ConsistencyChecksSettings(),
             new AccessMetricsConfiguration(Kind.NONE, 1),
-            new SimpleMeterRegistry(),
-            Tags.empty());
+            StatefulMeterRegistryProvider.defaultProvider());
 
     // expect
     //noinspection resource

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/rocksdb/ZeebeRocksDbFactoryTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.db.impl.DefaultColumnFamily;
 import io.camunda.zeebe.db.impl.DefaultZeebeDbFactory;
 import io.camunda.zeebe.util.ByteValue;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.File;
 import java.util.ArrayList;
@@ -89,7 +90,8 @@ final class ZeebeRocksDbFactoryTest {
             new RocksDbConfiguration().setColumnFamilyOptions(customProperties),
             new ConsistencyChecksSettings(),
             new AccessMetricsConfiguration(Kind.NONE, 1),
-            new SimpleMeterRegistry());
+            new SimpleMeterRegistry(),
+            Tags.empty());
 
     // when
     final var defaults = factoryWithDefaults.createColumnFamilyOptions(new ArrayList<>());
@@ -123,7 +125,8 @@ final class ZeebeRocksDbFactoryTest {
             new RocksDbConfiguration().setColumnFamilyOptions(customProperties),
             new ConsistencyChecksSettings(),
             new AccessMetricsConfiguration(Kind.NONE, 1),
-            new SimpleMeterRegistry());
+            new SimpleMeterRegistry(),
+            Tags.empty());
 
     // expect
     //noinspection resource


### PR DESCRIPTION
## Description
Tags are not automatically propagated when CompositeRegister are nested more than one level, so we need to manually add them everywhere until this is implemented upstream

From my checks only 2 registries were missing the tags:
- PartitionTransition
- RocksDB (StatefulMeterRegistry)