### PR TITLE
feat: rdbms - add partitionId for history cleanup relevant tables #28101

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -60,6 +60,7 @@
       <column name="NUM_INCIDENTS" type="SMALLINT" />
       <column name="ELEMENT_ID" type="VARCHAR(255)"/>
       <column name="VERSION" type="SMALLINT" />
+      <column name="PARTITION_ID" type="NUMBER"/>
     </createTable>
 
     <modifySql dbms="mariadb">
@@ -84,6 +85,7 @@
       <column name="VAR_FULL_VALUE" type="CLOB"/>
       <column name="TENANT_ID" type="VARCHAR(255)"/>
       <column name="IS_PREVIEW" type="BOOLEAN"/>
+      <column name="PARTITION_ID" type="NUMBER"/>
     </createTable>
 
     <createIndex tableName="${prefix}VARIABLE" indexName="${prefix}IDX_VARIABLE_PROCESS_INSTANCE_KEY">
@@ -117,6 +119,7 @@
       <column name="TENANT_ID" type="VARCHAR(255)"/>
       <column name="INCIDENT_KEY" type="BIGINT" />
       <column name="NUM_SUBPROCESS_INCIDENTS" type="SMALLINT" />
+      <column name="PARTITION_ID" type="NUMBER"/>
     </createTable>
 
     <modifySql dbms="mariadb">
@@ -147,6 +150,7 @@
       <column name="PROCESS_DEFINITION_VERSION" type="SMALLINT"/>
       <column name="CUSTOM_HEADERS" type="CLOB"/>
       <column name="PRIORITY" type="INT"/>
+      <column name="PARTITION_ID" type="NUMBER"/>
     </createTable>
 
     <createTable tableName="${prefix}CANDIDATE_USER">
@@ -195,6 +199,7 @@
       <column name="TENANT_ID" type="VARCHAR(255)"/>
       <column name="JOB_KEY" type="BIGINT" />
       <column name="SCOPE_KEY" type="BIGINT" />
+      <column name="PARTITION_ID" type="NUMBER"/>
     </createTable>
 
     <modifySql dbms="mariadb">
@@ -232,6 +237,7 @@
       <column name="VERSION" type="SMALLINT" />
       <column name="RESOURCE_NAME" type="VARCHAR(4000)" />
       <column name="XML" type="CLOB" />
+      <column name="PARTITION_ID" type="NUMBER"/>
     </createTable>
 
     <createIndex tableName="${prefix}DECISION_REQUIREMENTS" indexName="${prefix}IDX_DECISION_REQUIREMENTS_ID">
@@ -261,6 +267,7 @@
       <column name="RESULT" type="VARCHAR(255)" />
       <column name="EVALUATION_FAILURE" type="VARCHAR(255)"/>
       <column name="TENANT_ID" type="VARCHAR(255)"/>
+      <column name="PARTITION_ID" type="NUMBER"/>
     </createTable>
 
     <modifySql dbms="mariadb">

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -237,7 +237,6 @@
       <column name="VERSION" type="SMALLINT" />
       <column name="RESOURCE_NAME" type="VARCHAR(4000)" />
       <column name="XML" type="CLOB" />
-      <column name="PARTITION_ID" type="NUMBER"/>
     </createTable>
 
     <createIndex tableName="${prefix}DECISION_REQUIREMENTS" indexName="${prefix}IDX_DECISION_REQUIREMENTS_ID">

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ExporterPositionMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ExporterPositionMapper.java
@@ -15,5 +15,5 @@ public interface ExporterPositionMapper {
 
   void update(ExporterPositionModel variable);
 
-  ExporterPositionModel findOne(Long key);
+  ExporterPositionModel findOne(int key);
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/DecisionInstanceDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/DecisionInstanceDbModel.java
@@ -33,6 +33,7 @@ public record DecisionInstanceDbModel(
     Long rootDecisionDefinitionKey,
     DecisionDefinitionType decisionType,
     String tenantId,
+    Long partitionId,
     List<EvaluatedInput> evaluatedInputs,
     List<EvaluatedOutput> evaluatedOutputs) {
 
@@ -61,6 +62,7 @@ public record DecisionInstanceDbModel(
     private Long rootDecisionDefinitionKey;
     private DecisionDefinitionType decisionType;
     private String tenantId;
+    private int partitionId;
     private List<EvaluatedInput> evaluatedInputs;
     private List<EvaluatedOutput> evaluatedOutputs;
 
@@ -154,6 +156,11 @@ public record DecisionInstanceDbModel(
       return this;
     }
 
+    public Builder partitionId(final int value) {
+      partitionId = value;
+      return this;
+    }
+
     public Builder evaluatedInputs(final List<EvaluatedInput> value) {
       evaluatedInputs = value;
       return this;
@@ -185,6 +192,7 @@ public record DecisionInstanceDbModel(
           rootDecisionDefinitionKey,
           decisionType,
           tenantId,
+          Long.valueOf(partitionId),
           evaluatedInputs,
           evaluatedOutputs);
     }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/DecisionInstanceDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/DecisionInstanceDbModel.java
@@ -33,7 +33,7 @@ public record DecisionInstanceDbModel(
     Long rootDecisionDefinitionKey,
     DecisionDefinitionType decisionType,
     String tenantId,
-    Long partitionId,
+    int partitionId,
     List<EvaluatedInput> evaluatedInputs,
     List<EvaluatedOutput> evaluatedOutputs) {
 
@@ -192,7 +192,7 @@ public record DecisionInstanceDbModel(
           rootDecisionDefinitionKey,
           decisionType,
           tenantId,
-          Long.valueOf(partitionId),
+          partitionId,
           evaluatedInputs,
           evaluatedOutputs);
     }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/DecisionRequirementsDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/DecisionRequirementsDbModel.java
@@ -16,8 +16,7 @@ public record DecisionRequirementsDbModel(
     String resourceName,
     Integer version,
     String xml,
-    String tenantId,
-    int partitionId) {
+    String tenantId) {
 
   public static final class Builder implements ObjectBuilder<DecisionRequirementsDbModel> {
 
@@ -28,7 +27,6 @@ public record DecisionRequirementsDbModel(
     private Integer version;
     private String xml;
     private String tenantId;
-    private int partitionId;
 
     public DecisionRequirementsDbModel.Builder decisionRequirementsKey(final Long value) {
       decisionRequirementsKey = value;
@@ -65,11 +63,6 @@ public record DecisionRequirementsDbModel(
       return this;
     }
 
-    public DecisionRequirementsDbModel.Builder partitionId(final int value) {
-      partitionId = value;
-      return this;
-    }
-
     @Override
     public DecisionRequirementsDbModel build() {
       return new DecisionRequirementsDbModel(
@@ -79,8 +72,7 @@ public record DecisionRequirementsDbModel(
           resourceName,
           version,
           xml,
-          tenantId,
-          partitionId);
+          tenantId);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/DecisionRequirementsDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/DecisionRequirementsDbModel.java
@@ -16,7 +16,8 @@ public record DecisionRequirementsDbModel(
     String resourceName,
     Integer version,
     String xml,
-    String tenantId) {
+    String tenantId,
+    int partitionId) {
 
   public static final class Builder implements ObjectBuilder<DecisionRequirementsDbModel> {
 
@@ -27,6 +28,7 @@ public record DecisionRequirementsDbModel(
     private Integer version;
     private String xml;
     private String tenantId;
+    private int partitionId;
 
     public DecisionRequirementsDbModel.Builder decisionRequirementsKey(final Long value) {
       decisionRequirementsKey = value;
@@ -63,6 +65,11 @@ public record DecisionRequirementsDbModel(
       return this;
     }
 
+    public DecisionRequirementsDbModel.Builder partitionId(final int value) {
+      partitionId = value;
+      return this;
+    }
+
     @Override
     public DecisionRequirementsDbModel build() {
       return new DecisionRequirementsDbModel(
@@ -72,7 +79,8 @@ public record DecisionRequirementsDbModel(
           resourceName,
           version,
           xml,
-          tenantId);
+          tenantId,
+          partitionId);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ExporterPositionModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ExporterPositionModel.java
@@ -10,7 +10,7 @@ package io.camunda.db.rdbms.write.domain;
 import java.time.LocalDateTime;
 
 public record ExporterPositionModel(
-    Long partitionId,
+    int partitionId,
     String exporter,
     Long lastExportedPosition,
     LocalDateTime created,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/FlowNodeInstanceDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/FlowNodeInstanceDbModel.java
@@ -26,7 +26,8 @@ public record FlowNodeInstanceDbModel(
     FlowNodeState state,
     Long incidentKey,
     Long numSubprocessIncidents,
-    String tenantId)
+    String tenantId,
+    int partitionId)
     implements Copyable<FlowNodeInstanceDbModel> {
 
   @Override
@@ -48,7 +49,8 @@ public record FlowNodeInstanceDbModel(
                 .state(state)
                 .incidentKey(incidentKey)
                 .numSubprocessIncidents(numSubprocessIncidents)
-                .tenantId(tenantId))
+                .tenantId(tenantId)
+                .partitionId(partitionId))
         .build();
   }
 
@@ -68,6 +70,7 @@ public record FlowNodeInstanceDbModel(
     private Long incidentKey;
     private Long numSubprocessIncidents = 0L;
     private String tenantId;
+    private int partitionId;
 
     // Public constructor to initialize the builder
     public FlowNodeInstanceDbModelBuilder() {}
@@ -143,6 +146,11 @@ public record FlowNodeInstanceDbModel(
       return this;
     }
 
+    public FlowNodeInstanceDbModelBuilder partitionId(final int partitionId) {
+      this.partitionId = partitionId;
+      return this;
+    }
+
     @Override
     public FlowNodeInstanceDbModel build() {
       return new FlowNodeInstanceDbModel(
@@ -158,7 +166,8 @@ public record FlowNodeInstanceDbModel(
           state,
           incidentKey,
           numSubprocessIncidents,
-          tenantId);
+          tenantId,
+          partitionId);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/IncidentDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/IncidentDbModel.java
@@ -26,7 +26,8 @@ public record IncidentDbModel(
     OffsetDateTime creationDate,
     IncidentState state,
     String treePath,
-    String tenantId)
+    String tenantId,
+    int partitionId)
     implements DbModel<IncidentDbModel> {
 
   @Override
@@ -48,7 +49,8 @@ public record IncidentDbModel(
                 .creationDate(creationDate)
                 .state(state)
                 .treePath(treePath)
-                .tenantId(tenantId))
+                .tenantId(tenantId)
+                .partitionId(partitionId))
         .build();
   }
 
@@ -67,6 +69,7 @@ public record IncidentDbModel(
     private IncidentState state;
     private String treePath;
     private String tenantId;
+    private int partitionId;
 
     public Builder incidentKey(final Long incidentKey) {
       this.incidentKey = incidentKey;
@@ -133,6 +136,11 @@ public record IncidentDbModel(
       return this;
     }
 
+    public Builder partitionId(final int partitionId) {
+      this.partitionId = partitionId;
+      return this;
+    }
+
     @Override
     public IncidentDbModel build() {
       return new IncidentDbModel(
@@ -148,7 +156,8 @@ public record IncidentDbModel(
           creationDate,
           state,
           treePath,
-          tenantId);
+          tenantId,
+          partitionId);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ProcessInstanceDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ProcessInstanceDbModel.java
@@ -24,7 +24,8 @@ public record ProcessInstanceDbModel(
     Long parentElementInstanceKey,
     Integer numIncidents,
     String elementId,
-    int version)
+    int version,
+    int partitionId)
     implements DbModel<ProcessInstanceDbModel> {
 
   @Override
@@ -45,7 +46,8 @@ public record ProcessInstanceDbModel(
                 .state(state)
                 .numIncidents(numIncidents)
                 .tenantId(tenantId)
-                .version(version))
+                .version(version)
+                .partitionId(partitionId))
         .build();
   }
 
@@ -64,6 +66,7 @@ public record ProcessInstanceDbModel(
     private String elementId;
     private int numIncidents = 0;
     private int version;
+    private int partitionId;
 
     // Public constructor to initialize the builder
     public ProcessInstanceDbModelBuilder() {}
@@ -135,6 +138,11 @@ public record ProcessInstanceDbModel(
       return this;
     }
 
+    public ProcessInstanceDbModelBuilder partitionId(final int partitionId) {
+      this.partitionId = partitionId;
+      return this;
+    }
+
     @Override
     public ProcessInstanceDbModel build() {
       return new ProcessInstanceDbModel(
@@ -149,7 +157,8 @@ public record ProcessInstanceDbModel(
           parentElementInstanceKey,
           numIncidents,
           elementId,
-          version);
+          version,
+          partitionId);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ProcessInstanceDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/ProcessInstanceDbModel.java
@@ -59,11 +59,11 @@ public record ProcessInstanceDbModel(
     private Long processDefinitionKey;
     private ProcessInstanceState state;
     private OffsetDateTime startDate;
-    private OffsetDateTime endDate;
+    private OffsetDateTime endDate = null;
     private String tenantId;
     private Long parentProcessInstanceKey;
     private Long parentElementInstanceKey;
-    private String elementId;
+    private String elementId = null;
     private int numIncidents = 0;
     private int version;
     private int partitionId;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/UserTaskDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/UserTaskDbModel.java
@@ -37,6 +37,7 @@ public class UserTaskDbModel {
   private String serializedCustomHeaders;
   private Map<String, String> customHeaders;
   private Integer priority;
+  private int partitionId;
 
   public UserTaskDbModel(final Long userTaskKey) {
     this.userTaskKey = userTaskKey;
@@ -60,7 +61,8 @@ public class UserTaskDbModel {
       final String externalFormReference,
       final Integer processDefinitionVersion,
       final Map<String, String> customHeaders,
-      final Integer priority) {
+      final Integer priority,
+      final int partitionId) {
     this.userTaskKey = userTaskKey;
     this.elementId = elementId;
     this.processDefinitionId = processDefinitionId;
@@ -80,6 +82,7 @@ public class UserTaskDbModel {
     this.customHeaders = customHeaders;
     serializedCustomHeaders = CustomHeaderSerializer.serialize(customHeaders);
     this.priority = priority;
+    this.partitionId = partitionId;
   }
 
   // Methods without get/set prefix
@@ -253,6 +256,10 @@ public class UserTaskDbModel {
     this.priority = priority;
   }
 
+  public int partitionId() {
+    return partitionId;
+  }
+
   public Builder toBuilder() {
     return new Builder()
         .userTaskKey(userTaskKey)
@@ -274,7 +281,8 @@ public class UserTaskDbModel {
         .externalFormReference(externalFormReference)
         .processDefinitionVersion(processDefinitionVersion)
         .customHeaders(customHeaders)
-        .priority(priority);
+        .priority(priority)
+        .partitionId(partitionId);
   }
 
   public static class Builder implements ObjectBuilder<UserTaskDbModel> {
@@ -299,6 +307,7 @@ public class UserTaskDbModel {
     private Integer processDefinitionVersion;
     private Map<String, String> customHeaders;
     private Integer priority;
+    private int partitionId;
 
     // Public constructor to initialize the builder
     public Builder() {}
@@ -409,6 +418,11 @@ public class UserTaskDbModel {
       return this;
     }
 
+    public Builder partitionId(final int partitionId) {
+      this.partitionId = partitionId;
+      return this;
+    }
+
     // Build method to create the record
     @Override
     public UserTaskDbModel build() {
@@ -431,7 +445,8 @@ public class UserTaskDbModel {
               externalFormReference,
               processDefinitionVersion,
               customHeaders,
-              priority);
+              priority,
+              partitionId);
 
       model.candidateUsers(candidateUsers);
       model.candidateGroups(candidateGroups);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/VariableDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/VariableDbModel.java
@@ -28,7 +28,8 @@ public record VariableDbModel(
     Long scopeKey,
     Long processInstanceKey,
     String processDefinitionId,
-    String tenantId) {
+    String tenantId,
+    int partitionId) {
 
   public VariableDbModel copy(
       final Function<ObjectBuilder<VariableDbModel>, ObjectBuilder<VariableDbModel>>
@@ -42,7 +43,8 @@ public record VariableDbModel(
                 .scopeKey(scopeKey)
                 .processInstanceKey(processInstanceKey)
                 .processDefinitionId(processDefinitionId)
-                .tenantId(tenantId))
+                .tenantId(tenantId)
+                .partitionId(partitionId))
         .build();
   }
 
@@ -60,7 +62,8 @@ public record VariableDbModel(
           scopeKey,
           processInstanceKey,
           processDefinitionId,
-          tenantId);
+          tenantId,
+          partitionId);
     } else {
       return this;
     }
@@ -75,6 +78,7 @@ public record VariableDbModel(
     private Long processInstanceKey;
     private String processDefinitionId;
     private String tenantId;
+    private int partitionId;
 
     public VariableDbModelBuilder() {}
 
@@ -113,6 +117,11 @@ public record VariableDbModel(
       return this;
     }
 
+    public VariableDbModelBuilder partitionId(final int partitionId) {
+      this.partitionId = partitionId;
+      return this;
+    }
+
     // Build method to create the record
     @Override
     public VariableDbModel build() {
@@ -138,7 +147,8 @@ public record VariableDbModel(
           scopeKey,
           processInstanceKey,
           processDefinitionId,
-          tenantId);
+          tenantId,
+          partitionId);
     }
 
     private VariableDbModel getLongModel() {
@@ -154,7 +164,8 @@ public record VariableDbModel(
           scopeKey,
           processInstanceKey,
           processDefinitionId,
-          tenantId);
+          tenantId,
+          partitionId);
     }
 
     private VariableDbModel getDoubleModel() {
@@ -170,7 +181,8 @@ public record VariableDbModel(
           scopeKey,
           processInstanceKey,
           processDefinitionId,
-          tenantId);
+          tenantId,
+          partitionId);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ExporterPositionService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ExporterPositionService.java
@@ -46,7 +46,7 @@ public class ExporterPositionService {
             variable));
   }
 
-  public ExporterPositionModel findOne(final Long key) {
+  public ExporterPositionModel findOne(final int key) {
     return exporterPositionMapper.findOne(key);
   }
 }

--- a/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
@@ -183,7 +183,9 @@
                                    STATE,
                                    EVALUATION_DATE,
                                    RESULT,
-                                   EVALUATION_FAILURE)
+                                            EVALUATION_FAILURE,
+                                            TENANT_ID,
+                                            PARTITION_ID)
     VALUES (#{decisionInstanceId}, #{decisionInstanceKey}, #{processInstanceKey},
             #{processDefinitionKey}, #{processDefinitionId},
             #{decisionDefinitionKey}, #{decisionDefinitionId},
@@ -191,7 +193,8 @@
             #{flowNodeInstanceKey}, #{flowNodeId},
             #{rootDecisionDefinitionKey},
             #{decisionType}, #{state},
-            #{evaluationDate, jdbcType=TIMESTAMP}, #{result}, #{evaluationFailure})
+            #{evaluationDate, jdbcType=TIMESTAMP}, #{result}, #{evaluationFailure},
+            #{tenantId}, #{partitionId})
   </insert>
 
   <insert

--- a/db/rdbms/src/main/resources/mapper/DecisionRequirementsMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionRequirementsMapper.xml
@@ -86,9 +86,8 @@
     parameterType="io.camunda.db.rdbms.write.domain.DecisionRequirementsDbModel"
     flushCache="true">
     INSERT INTO ${prefix}DECISION_REQUIREMENTS (DECISION_REQUIREMENTS_KEY, DECISION_REQUIREMENTS_ID,
-                                                NAME, TENANT_ID, VERSION, RESOURCE_NAME, XML,
-                                                PARTITION_ID)
+                                                NAME, TENANT_ID, VERSION, RESOURCE_NAME, XML)
     VALUES (#{decisionRequirementsKey}, #{decisionRequirementsId}, #{name},
-            #{tenantId}, #{version}, #{resourceName}, #{xml}, #{partitionId})
+            #{tenantId}, #{version}, #{resourceName}, #{xml})
   </insert>
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/DecisionRequirementsMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionRequirementsMapper.xml
@@ -85,8 +85,10 @@
     id="insert"
     parameterType="io.camunda.db.rdbms.write.domain.DecisionRequirementsDbModel"
     flushCache="true">
-    INSERT INTO ${prefix}DECISION_REQUIREMENTS (DECISION_REQUIREMENTS_KEY, DECISION_REQUIREMENTS_ID, NAME, TENANT_ID, VERSION, RESOURCE_NAME, XML)
+    INSERT INTO ${prefix}DECISION_REQUIREMENTS (DECISION_REQUIREMENTS_KEY, DECISION_REQUIREMENTS_ID,
+                                                NAME, TENANT_ID, VERSION, RESOURCE_NAME, XML,
+                                                PARTITION_ID)
     VALUES (#{decisionRequirementsKey}, #{decisionRequirementsId}, #{name},
-            #{tenantId}, #{version}, #{resourceName}, #{xml})
+            #{tenantId}, #{version}, #{resourceName}, #{xml}, #{partitionId})
   </insert>
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/ExporterPositionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ExporterPositionMapper.xml
@@ -11,7 +11,7 @@
 
   <select id="findOne"
     statementType="PREPARED"
-    parameterType="java.lang.Long"
+    parameterType="java.lang.Integer"
     resultType="io.camunda.db.rdbms.write.domain.ExporterPositionModel">
       SELECT
         PARTITION_ID,

--- a/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
@@ -120,11 +120,12 @@
     flushCache="true">
     INSERT INTO ${prefix}FLOW_NODE_INSTANCE (FLOW_NODE_INSTANCE_KEY, FLOW_NODE_ID, PROCESS_INSTANCE_KEY,
                                     PROCESS_DEFINITION_ID, PROCESS_DEFINITION_KEY, TYPE, STATE,
-                                    START_DATE, END_DATE, TENANT_ID, TREE_PATH, INCIDENT_KEY, NUM_SUBPROCESS_INCIDENTS)
+                                             START_DATE, END_DATE, TENANT_ID, TREE_PATH,
+                                             INCIDENT_KEY, NUM_SUBPROCESS_INCIDENTS, PARTITION_ID)
     VALUES (#{flowNodeInstanceKey}, #{flowNodeId}, #{processInstanceKey}, #{processDefinitionId},
             #{processDefinitionKey}, #{type}, #{state},
             #{startDate, jdbcType=TIMESTAMP}, #{endDate, jdbcType=TIMESTAMP}, #{tenantId},
-            #{treePath}, #{incidentKey}, #{numSubprocessIncidents})
+            #{treePath}, #{incidentKey}, #{numSubprocessIncidents}, #{partitionId})
   </insert>
 
   <update

--- a/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/IncidentMapper.xml
@@ -131,10 +131,11 @@
                           STATE,
                           CREATION_DATE,
                           JOB_KEY,
-                          TENANT_ID)
+                                   TENANT_ID,
+                                   PARTITION_ID)
     VALUES (#{incidentKey}, #{flowNodeInstanceKey}, #{flowNodeId}, #{processInstanceKey},
             #{processDefinitionId}, #{processDefinitionKey}, #{errorMessage}, #{errorType},
-            #{state},             #{creationDate, jdbcType=TIMESTAMP}, #{jobKey}, #{tenantId})
+            #{state}, #{creationDate, jdbcType=TIMESTAMP}, #{jobKey}, #{tenantId}, #{partitionId})
   </insert>
 
   <update

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -192,9 +192,9 @@
     parameterType="io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel"
     flushCache="true">
     INSERT INTO ${prefix}PROCESS_INSTANCE (PROCESS_INSTANCE_KEY, PROCESS_DEFINITION_ID, PROCESS_DEFINITION_KEY, STATE, START_DATE, END_DATE, TENANT_ID, PARENT_PROCESS_INSTANCE_KEY, PARENT_ELEMENT_INSTANCE_KEY,
-                                  NUM_INCIDENTS, VERSION)
+                                           NUM_INCIDENTS, VERSION, PARTITION_ID)
     VALUES (#{processInstanceKey}, #{processDefinitionId}, #{processDefinitionKey}, #{state}, #{startDate, jdbcType=TIMESTAMP}, #{endDate, jdbcType=TIMESTAMP}, #{tenantId}, #{parentProcessInstanceKey},
-            #{parentElementInstanceKey}, #{numIncidents}, #{version})
+            #{parentElementInstanceKey}, #{numIncidents}, #{version}, #{partitionId})
   </insert>
 
   <update

--- a/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
@@ -21,14 +21,14 @@
                            PROCESS_DEFINITION_KEY, PROCESS_INSTANCE_KEY,
                            ELEMENT_INSTANCE_KEY, TENANT_ID, DUE_DATE, FOLLOW_UP_DATE,
                            EXTERNAL_FORM_REFERENCE, PROCESS_DEFINITION_VERSION, CUSTOM_HEADERS,
-                           PRIORITY)
+                                    PRIORITY, PARTITION_ID)
     VALUES (#{userTaskKey}, #{elementId}, #{processDefinitionId}, #{creationDate},
             #{completionDate},
             #{assignee}, #{state}, #{formKey},
             #{processDefinitionKey}, #{processInstanceKey}, #{elementInstanceKey}, #{tenantId},
             #{dueDate}, #{followUpDate},
             #{externalFormReference}, #{processDefinitionVersion}, #{serializedCustomHeaders},
-            #{priority})
+            #{priority}, #{partitionId})
   </insert>
 
   <insert flushCache="true"

--- a/db/rdbms/src/main/resources/mapper/VariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/VariableMapper.xml
@@ -125,11 +125,10 @@
     parameterType="io.camunda.db.rdbms.write.domain.VariableDbModel"
     flushCache="true">
     INSERT INTO ${prefix}VARIABLE (VAR_KEY, PROCESS_INSTANCE_KEY, PROCESS_DEFINITION_ID, SCOPE_KEY, TYPE, VAR_NAME, DOUBLE_VALUE,
-                          LONG_VALUE,
-                          VAR_VALUE, VAR_FULL_VALUE, TENANT_ID, IS_PREVIEW)
+                                   LONG_VALUE, VAR_VALUE, VAR_FULL_VALUE, TENANT_ID, IS_PREVIEW,
+                                   PARTITION_ID)
     VALUES (#{variableKey}, #{processInstanceKey}, #{processDefinitionId}, #{scopeKey}, #{type}, #{name}, #{doubleValue},
-            #{longValue},
-            #{value}, #{fullValue}, #{tenantId}, #{isPreview})
+            #{longValue}, #{value}, #{fullValue}, #{tenantId}, #{isPreview}, #{partitionId})
   </insert>
 
   <update

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
@@ -29,7 +29,7 @@ public class RdbmsExporter {
   private final Map<ValueType, List<RdbmsExportHandler>> registeredHandlers;
   private Controller controller;
 
-  private final long partitionId;
+  private final int partitionId;
   private final RdbmsWriter rdbmsWriter;
 
   // configuration

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterConfig.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterConfig.java
@@ -17,26 +17,26 @@ import java.util.Map;
 import java.util.function.Function;
 
 public record RdbmsExporterConfig(
-    long partitionId,
+    int partitionId,
     Duration flushInterval,
     int maxQueueSize,
     RdbmsWriter rdbmsWriter,
     Map<ValueType, List<RdbmsExportHandler>> handlers) {
 
-  public static RdbmsExporterConfig of(Function<Builder, Builder> builderFunction) {
+  public static RdbmsExporterConfig of(final Function<Builder, Builder> builderFunction) {
     return builderFunction.apply(new Builder()).build();
   }
 
   // create a static builder for this record. Also create methods to add handlers to the map
   public static final class Builder {
 
-    private long partitionId;
+    private int partitionId;
     private Duration flushInterval;
     private int maxQueueSize;
     private RdbmsWriter rdbmsWriter;
     private Map<ValueType, List<RdbmsExportHandler>> handlers = new HashMap<>();
 
-    public Builder partitionId(final long value) {
+    public Builder partitionId(final int value) {
       partitionId = value;
       return this;
     }
@@ -61,7 +61,7 @@ public record RdbmsExporterConfig(
       return this;
     }
 
-    public Builder withHandler(final ValueType valueType, RdbmsExportHandler handler) {
+    public Builder withHandler(final ValueType valueType, final RdbmsExportHandler handler) {
       if (!handlers.containsKey(valueType)) {
         handlers.put(valueType, new ArrayList<>());
       }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -29,8 +29,6 @@ import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import java.time.Duration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** https://docs.camunda.io/docs/next/components/zeebe/technical-concepts/process-lifecycles/ */
 public class RdbmsExporterWrapper implements Exporter {
@@ -40,11 +38,8 @@ public class RdbmsExporterWrapper implements Exporter {
 
   private static final int DEFAULT_FLUSH_INTERVAL = 500;
   private static final int DEFAULT_MAX_QUEUE_SIZE = 1000;
-  private static final Logger LOG = LoggerFactory.getLogger(RdbmsExporterWrapper.class);
 
-  private long partitionId;
   private final RdbmsService rdbmsService;
-  private RdbmsWriter rdbmsWriter;
 
   private RdbmsExporter exporter;
 
@@ -55,10 +50,8 @@ public class RdbmsExporterWrapper implements Exporter {
   @Override
   public void configure(final Context context) {
     final var maxQueueSize = readMaxQueueSize(context);
-
-    partitionId = context.getPartitionId();
-
-    rdbmsWriter = rdbmsService.createWriter(partitionId, maxQueueSize);
+    final int partitionId = context.getPartitionId();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(partitionId, maxQueueSize);
 
     final var builder =
         new RdbmsExporterConfig.Builder()

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/DecisionInstanceExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/DecisionInstanceExportHandler.java
@@ -97,6 +97,7 @@ public class DecisionInstanceExportHandler
         .decisionType(DecisionDefinitionType.fromValue(evaluatedDecision.getDecisionType()))
         .evaluationFailure(
             state == DecisionInstanceState.FAILED ? value.getEvaluationFailureMessage() : null)
+        .partitionId(record.getPartitionId())
         .build();
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/DecisionRequirementsExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/DecisionRequirementsExportHandler.java
@@ -35,11 +35,11 @@ public class DecisionRequirementsExportHandler
 
   @Override
   public void export(final Record<DecisionRequirementsRecordValue> record) {
-    final DecisionRequirementsRecordValue value = record.getValue();
-    decisionRequirementsWriter.create(map(value));
+    decisionRequirementsWriter.create(map(record));
   }
 
-  private DecisionRequirementsDbModel map(final DecisionRequirementsRecordValue value) {
+  private DecisionRequirementsDbModel map(final Record<DecisionRequirementsRecordValue> record) {
+    final DecisionRequirementsRecordValue value = record.getValue();
     return new DecisionRequirementsDbModel.Builder()
         .decisionRequirementsKey(value.getDecisionRequirementsKey())
         .decisionRequirementsId(value.getDecisionRequirementsId())
@@ -48,6 +48,7 @@ public class DecisionRequirementsExportHandler
         .resourceName(value.getResourceName())
         .xml(new String(value.getResource(), StandardCharsets.UTF_8))
         .tenantId(value.getTenantId())
+        .partitionId(record.getPartitionId())
         .build();
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/DecisionRequirementsExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/DecisionRequirementsExportHandler.java
@@ -48,7 +48,6 @@ public class DecisionRequirementsExportHandler
         .resourceName(value.getResourceName())
         .xml(new String(value.getResource(), StandardCharsets.UTF_8))
         .tenantId(value.getTenantId())
-        .partitionId(record.getPartitionId())
         .build();
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/FlowNodeExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/FlowNodeExportHandler.java
@@ -79,6 +79,7 @@ public class FlowNodeExportHandler implements RdbmsExportHandler<ProcessInstance
         .state(FlowNodeState.ACTIVE)
         .startDate(DateUtil.toOffsetDateTime(record.getTimestamp()))
         .type(mapFlowNodeType(value))
+        .partitionId(record.getPartitionId())
         .build();
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandler.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.rdbms.handlers;
 
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel;
+import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel.ProcessInstanceDbModelBuilder;
 import io.camunda.db.rdbms.write.service.ProcessInstanceWriter;
 import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
@@ -55,18 +56,20 @@ public class ProcessInstanceExportHandler
 
   private ProcessInstanceDbModel map(final Record<ProcessInstanceRecordValue> record) {
     final var value = record.getValue();
-    return new ProcessInstanceDbModel(
-        value.getProcessInstanceKey(),
-        value.getBpmnProcessId(),
-        value.getProcessDefinitionKey(),
-        ProcessInstanceState.ACTIVE,
-        DateUtil.toOffsetDateTime(record.getTimestamp()),
-        null,
-        value.getTenantId(),
-        value.getParentProcessInstanceKey(),
-        value.getParentElementInstanceKey(),
-        0,
-        null,
-        value.getVersion());
+    return new ProcessInstanceDbModelBuilder()
+        .processInstanceKey(value.getProcessInstanceKey())
+        .processDefinitionId(value.getBpmnProcessId())
+        .processDefinitionKey(value.getProcessDefinitionKey())
+        .state(ProcessInstanceState.ACTIVE)
+        .startDate(DateUtil.toOffsetDateTime(record.getTimestamp()))
+        .endDate(null)
+        .tenantId(value.getTenantId())
+        .parentProcessInstanceKey(value.getParentProcessInstanceKey())
+        .parentElementInstanceKey(value.getParentElementInstanceKey())
+        .numIncidents(0)
+        .elementId(null)
+        .version(value.getVersion())
+        .partitionId(record.getPartitionId())
+        .build();
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandler.java
@@ -62,12 +62,9 @@ public class ProcessInstanceExportHandler
         .processDefinitionKey(value.getProcessDefinitionKey())
         .state(ProcessInstanceState.ACTIVE)
         .startDate(DateUtil.toOffsetDateTime(record.getTimestamp()))
-        .endDate(null)
         .tenantId(value.getTenantId())
         .parentProcessInstanceKey(value.getParentProcessInstanceKey())
         .parentElementInstanceKey(value.getParentElementInstanceKey())
-        .numIncidents(0)
-        .elementId(null)
         .version(value.getVersion())
         .partitionId(record.getPartitionId())
         .build();

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/UserTaskExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/UserTaskExportHandler.java
@@ -56,14 +56,17 @@ public class UserTaskExportHandler implements RdbmsExportHandler<UserTaskRecordV
   public void export(final Record<UserTaskRecordValue> record) {
     final UserTaskRecordValue value = record.getValue();
     switch (record.getIntent()) {
-      case CREATED -> userTaskWriter.create(map(value, UserTaskState.CREATED, null));
+      case CREATED -> userTaskWriter.create(map(record, UserTaskState.CREATED, null));
       case CANCELED ->
           userTaskWriter.update(
-              map(value, UserTaskState.CANCELED, DateUtil.toOffsetDateTime(record.getTimestamp())));
+              map(
+                  record,
+                  UserTaskState.CANCELED,
+                  DateUtil.toOffsetDateTime(record.getTimestamp())));
       case COMPLETED ->
           userTaskWriter.update(
               map(
-                  value,
+                  record,
                   UserTaskState.COMPLETED,
                   DateUtil.toOffsetDateTime(record.getTimestamp())));
       case MIGRATED ->
@@ -75,38 +78,40 @@ public class UserTaskExportHandler implements RdbmsExportHandler<UserTaskRecordV
                   .elementId(value.getElementId())
                   .processDefinitionVersion(value.getProcessDefinitionVersion())
                   .build());
-      default -> userTaskWriter.update(map(value, null, null));
+      default -> userTaskWriter.update(map(record, null, null));
     }
   }
 
   private UserTaskDbModel map(
-      final UserTaskRecordValue record,
+      final Record<UserTaskRecordValue> record,
       final UserTaskState state,
       final OffsetDateTime completionTime) {
+    final UserTaskRecordValue value = record.getValue();
     return new UserTaskDbModel.Builder()
-        .userTaskKey(record.getUserTaskKey())
-        .elementId(record.getElementId())
-        .processDefinitionId(record.getBpmnProcessId())
-        .creationDate(DateUtil.toOffsetDateTime(record.getCreationTimestamp()))
+        .userTaskKey(value.getUserTaskKey())
+        .elementId(value.getElementId())
+        .processDefinitionId(value.getBpmnProcessId())
+        .creationDate(DateUtil.toOffsetDateTime(value.getCreationTimestamp()))
         .completionDate(completionTime)
-        .assignee(StringUtils.isNotEmpty(record.getAssignee()) ? record.getAssignee() : null)
+        .assignee(StringUtils.isNotEmpty(value.getAssignee()) ? value.getAssignee() : null)
         .state(state)
-        .formKey(record.getFormKey() > 0 ? record.getFormKey() : null)
-        .processDefinitionKey(record.getProcessDefinitionKey())
-        .processInstanceKey(record.getProcessInstanceKey())
-        .elementInstanceKey(record.getElementInstanceKey())
-        .tenantId(record.getTenantId())
-        .dueDate(DateUtil.toOffsetDateTime(record.getDueDate()))
-        .followUpDate(DateUtil.toOffsetDateTime(record.getFollowUpDate()))
-        .candidateGroups(record.getCandidateGroupsList())
-        .candidateUsers(record.getCandidateUsersList())
+        .formKey(value.getFormKey() > 0 ? value.getFormKey() : null)
+        .processDefinitionKey(value.getProcessDefinitionKey())
+        .processInstanceKey(value.getProcessInstanceKey())
+        .elementInstanceKey(value.getElementInstanceKey())
+        .tenantId(value.getTenantId())
+        .dueDate(DateUtil.toOffsetDateTime(value.getDueDate()))
+        .followUpDate(DateUtil.toOffsetDateTime(value.getFollowUpDate()))
+        .candidateGroups(value.getCandidateGroupsList())
+        .candidateUsers(value.getCandidateUsersList())
         .externalFormReference(
-            StringUtils.isNotEmpty(record.getExternalFormReference())
-                ? record.getExternalFormReference()
+            StringUtils.isNotEmpty(value.getExternalFormReference())
+                ? value.getExternalFormReference()
                 : null)
-        .processDefinitionVersion(record.getProcessDefinitionVersion())
-        .customHeaders(record.getCustomHeaders())
-        .priority(record.getPriority())
+        .processDefinitionVersion(value.getProcessDefinitionVersion())
+        .customHeaders(value.getCustomHeaders())
+        .priority(value.getPriority())
+        .partitionId(record.getPartitionId())
         .build();
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/VariableExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/VariableExportHandler.java
@@ -33,15 +33,16 @@ public class VariableExportHandler implements RdbmsExportHandler<VariableRecordV
   public void export(final Record<VariableRecordValue> record) {
     final VariableRecordValue value = record.getValue();
     if (record.getIntent() == VariableIntent.CREATED) {
-      variableWriter.create(map(record.getKey(), value));
+      variableWriter.create(map(record.getKey(), record));
     } else if (record.getIntent() == VariableIntent.UPDATED) {
-      variableWriter.update(map(record.getKey(), value));
+      variableWriter.update(map(record.getKey(), record));
     } else if (record.getIntent() == VariableIntent.MIGRATED) {
       variableWriter.migrateToProcess(record.getKey(), value.getBpmnProcessId());
     }
   }
 
-  private VariableDbModel map(final Long key, final VariableRecordValue value) {
+  private VariableDbModel map(final Long key, final Record<VariableRecordValue> record) {
+    final VariableRecordValue value = record.getValue();
     return new VariableDbModel.VariableDbModelBuilder()
         .variableKey(key)
         .name(value.getName())
@@ -50,6 +51,7 @@ public class VariableExportHandler implements RdbmsExportHandler<VariableRecordV
         .processInstanceKey(value.getProcessInstanceKey())
         .processDefinitionId(value.getBpmnProcessId())
         .tenantId(value.getTenantId())
+        .partitionId(record.getPartitionId())
         .build();
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
@@ -9,7 +9,7 @@ package io.camunda.exporter.rdbms;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -252,7 +252,7 @@ class RdbmsExporterTest {
     rdbmsWriter = mock(RdbmsWriter.class);
     executionQueue = new StubExecutionQueue();
     positionService = mock(ExporterPositionService.class);
-    when(positionService.findOne(anyLong())).thenReturn(null);
+    when(positionService.findOne(anyInt())).thenReturn(null);
     rdbmsPurger = mock(RdbmsPurger.class);
 
     when(rdbmsWriter.getExporterPositionService()).thenReturn(positionService);


### PR DESCRIPTION
## Description

Add partitionId for history cleanup relevant tables. This is needed to do cleanup per partition, so that multiple exporters (one per partition) can cleanup there "own" data. 
