### PR TITLE
fix: perform delayed flush when wait for importers is disabled

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -274,6 +274,12 @@ public class CamundaExporter implements Exporter {
   }
 
   private void checkImportersCompletedAndReschedule() {
+    if (!configuration.getIndex().shouldWaitForImporters()) {
+      LOG.debug(
+          "Waiting for importers to complete is disabled, thus scheduling delayed flush regardless of importer state.");
+      scheduleDelayedFlush();
+      return;
+    }
     if (!importersCompleted) {
       scheduleImportersCompletedCheck();
     }


### PR DESCRIPTION
## Description

Previously the delayed flush was not executed if wait for importers was disabled but actual importer indices with incomplete states existed. As the regular flush is already performed regardless of importer state, when the `shouldWaitForImporters` flag is set, this adopts the delayed flush to behave in the same way. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)
