### PR TITLE
IdentitySetupInitializeProcessor: don't write commands on distributed partitions

### DIFF
--- a/security/security-core/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationResourceType.java
+++ b/security/security-core/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationResourceType.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.protocol.record.value;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public enum AuthorizationResourceType {
   AUTHORIZATION(
@@ -54,5 +55,16 @@ public enum AuthorizationResourceType {
 
   public Set<PermissionType> getSupportedPermissionTypes() {
     return supportedPermissionTypes;
+  }
+
+  /**
+   * Returns all the resource types that are user provided. This is everything in this enum, except
+   * for UNSPECIFIED. UNSPECIFIED is only used as a default internally. By having this we prevent
+   * accidentally creating a wrong permission because the resource type wasn't set properly.
+   *
+   * @return a set of all user provided resource types
+   */
+  public static Set<AuthorizationResourceType> getUserProvidedResourceTypes() {
+    return Arrays.stream(values()).filter(type -> type != UNSPECIFIED).collect(Collectors.toSet());
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
@@ -38,6 +38,7 @@ public final class FeatureFlagsCfg {
   private boolean enableStraightThroughProcessingLoopDetector =
       DEFAULT_SETTINGS.enableStraightThroughProcessingLoopDetector();
   private boolean enablePartitionScaling = DEFAULT_SETTINGS.enablePartitionScaling();
+  private boolean enableIdentitySetup = DEFAULT_SETTINGS.enableIdentitySetup();
 
   public boolean isEnableYieldingDueDateChecker() {
     return enableYieldingDueDateChecker;
@@ -88,6 +89,14 @@ public final class FeatureFlagsCfg {
     this.enablePartitionScaling = enablePartitionScaling;
   }
 
+  public boolean isEnableIdentitySetup() {
+    return enableIdentitySetup;
+  }
+
+  public void setEnableIdentitySetup(final boolean enableIdentitySetup) {
+    this.enableIdentitySetup = enableIdentitySetup;
+  }
+
   public FeatureFlags toFeatureFlags() {
     return new FeatureFlags(
         enableYieldingDueDateChecker,
@@ -95,7 +104,8 @@ public final class FeatureFlagsCfg {
         enableMessageTtlCheckerAsync,
         enableTimerDueDateCheckerAsync,
         enableStraightThroughProcessingLoopDetector,
-        enablePartitionScaling
+        enablePartitionScaling,
+        enableIdentitySetup
         /*, enableFoo*/ );
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -304,7 +304,8 @@ public final class EngineProcessors {
         processingState,
         writers,
         commandDistributionBehavior,
-        securityConfig);
+        securityConfig,
+        featureFlags);
 
     return typedRecordProcessors;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupProcessors.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.FeatureFlags;
 
 public final class IdentitySetupProcessors {
   public static void addIdentitySetupProcessors(
@@ -24,13 +25,14 @@ public final class IdentitySetupProcessors {
       final MutableProcessingState processingState,
       final Writers writers,
       final CommandDistributionBehavior distributionBehavior,
-      final SecurityConfiguration securityConfig) {
+      final SecurityConfiguration securityConfig,
+      final FeatureFlags featureFlags) {
     typedRecordProcessors
         .onCommand(
             ValueType.IDENTITY_SETUP,
             IdentitySetupIntent.INITIALIZE,
             new IdentitySetupInitializeProcessor(
                 processingState, writers, keyGenerator, distributionBehavior))
-        .withListener(new IdentitySetupInitializer(securityConfig));
+        .withListener(new IdentitySetupInitializer(securityConfig, featureFlags));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/ContinuouslyReplayTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/ContinuouslyReplayTest.java
@@ -27,7 +27,6 @@ public class ContinuouslyReplayTest {
   @Rule
   public final EngineRule replay =
       EngineRule.withSharedStorage(sharedStorage)
-          .withoutAwaitingIdentitySetup()
           .withStreamProcessorMode(StreamProcessorMode.REPLAY);
 
   @Rule public final EngineRule processing = EngineRule.withSharedStorage(sharedStorage);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AnonymousAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AnonymousAuthorizationTest.java
@@ -53,7 +53,9 @@ public class AnonymousAuthorizationTest {
 
   @Rule
   public final EngineRule engine =
-      EngineRule.singlePartition().withSecurityConfig(c -> c.getAuthorizations().setEnabled(true));
+      EngineRule.singlePartition()
+          .withIdentitySetup()
+          .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true));
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCreateAuthorizationTest.java
@@ -38,6 +38,7 @@ public class AuthorizationCreateAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationDeleteAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationDeleteAuthorizationTest.java
@@ -38,6 +38,7 @@ public class AuthorizationDeleteAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationUpdateAuthorizationTest.java
@@ -38,6 +38,7 @@ public class AuthorizationUpdateAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clock/ClockPinAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clock/ClockPinAuthorizationTest.java
@@ -38,6 +38,7 @@ public class ClockPinAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateAuthorizationTest.java
@@ -39,6 +39,7 @@ public class DeploymentCreateAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopValidationDisabledTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopValidationDisabledTest.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
-import io.camunda.zeebe.util.FeatureFlags;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -23,7 +22,7 @@ public class StraightThroughProcessingLoopValidationDisabledTest {
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
           // Disable loop detector feature flag
-          .withFeatureFlags(new FeatureFlags(true, false, true, true, false, true));
+          .withFeatureFlags(ff -> ff.setEnableStraightThroughProcessingLoopDetector(false));
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporter = new RecordingExporterTestWatcher();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluateAuthorizationTest.java
@@ -38,6 +38,7 @@ public class DecisionEvaluationEvaluateAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveAuthorizationTest.java
@@ -42,6 +42,7 @@ public class IncidentResolveAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateAuthorizationTest.java
@@ -41,6 +41,7 @@ public class JobBatchActivateAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobCompleteAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobCompleteAuthorizationTest.java
@@ -41,6 +41,7 @@ public class JobCompleteAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobFailAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobFailAuthorizationTest.java
@@ -41,6 +41,7 @@ public class JobFailAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateAuthorizationTest.java
@@ -41,6 +41,7 @@ public class JobUpdateAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingCreateAuthorizationTest.java
@@ -37,6 +37,7 @@ public class MappingCreateAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateAuthorizationTest.java
@@ -44,6 +44,7 @@ public class MessageCorrelationCorrelateAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessagePublishAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessagePublishAuthorizationTest.java
@@ -44,6 +44,7 @@ public class MessagePublishAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelAuthorizationTest.java
@@ -41,6 +41,7 @@ public class ProcessInstanceCancelAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreateAuthorizationTest.java
@@ -41,6 +41,7 @@ public class ProcessInstanceCreateAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyAuthorizationTest.java
@@ -44,6 +44,7 @@ public class ProcessInstanceModificationModifyAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/ProcessInstanceMigrationMigrateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/ProcessInstanceMigrationMigrateAuthorizationTest.java
@@ -45,6 +45,7 @@ public class ProcessInstanceMigrationMigrateAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionAuthorizationTest.java
@@ -39,6 +39,7 @@ public class ResourceDeletionAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleCreateAuthorizationTest.java
@@ -37,6 +37,7 @@ public class RoleCreateAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastAuthorizationTest.java
@@ -41,6 +41,7 @@ public class SignalBroadcastAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UserCreateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UserCreateAuthorizationTest.java
@@ -38,6 +38,7 @@ public class UserCreateAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskAssignAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskAssignAuthorizationTest.java
@@ -41,6 +41,7 @@ public class UserTaskAssignAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimAuthorizationTest.java
@@ -42,6 +42,7 @@ public class UserTaskClaimAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCompleteAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCompleteAuthorizationTest.java
@@ -42,6 +42,7 @@ public class UserTaskCompleteAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UserTaskUpdateAuthorizationTest.java
@@ -43,6 +43,7 @@ public class UserTaskUpdateAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateAuthorizationTest.java
@@ -42,6 +42,7 @@ public class VariableDocumentUpdateAuthorizationTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withIdentitySetup()
           .withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true))
           .withSecurityConfig(cfg -> cfg.getInitialization().setUsers(List.of(DEFAULT_USER)));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ReplayStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ReplayStateTest.java
@@ -52,7 +52,6 @@ public final class ReplayStateTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
-          .withoutAwaitingIdentitySetup()
           .withOnProcessedCallback(record -> lastProcessedPosition = record.getPosition())
           .withOnSkippedCallback(record -> lastProcessedPosition = record.getPosition());
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -47,9 +47,11 @@ import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.scheduler.ActorScheduler;
@@ -492,7 +494,9 @@ public final class EngineRule extends ExternalResource {
           .skip(partitionCount - 1)
           .await();
       RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
-          .withDistributionIntent(IdentitySetupIntent.INITIALIZE)
+          .withDistributionIntent(AuthorizationIntent.CREATE)
+          // -2 as we don't create Authorizations for the UNSPECIFIED resource type.
+          .skip(AuthorizationResourceType.values().length - 2)
           .await();
     } else {
       RecordingExporter.identitySetupRecords(IdentitySetupIntent.INITIALIZED).await();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -496,8 +496,7 @@ public final class EngineRule extends ExternalResource {
           .await();
       RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
           .withDistributionIntent(AuthorizationIntent.CREATE)
-          // -2 as we don't create Authorizations for the UNSPECIFIED resource type.
-          .skip(AuthorizationResourceType.values().length - 2)
+          .skip(AuthorizationResourceType.getUserProvidedResourceTypes().size() - 1)
           .await();
     } else {
       RecordingExporter.identitySetupRecords(IdentitySetupIntent.INITIALIZED).await();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -158,8 +158,9 @@ public final class EngineRule extends ExternalResource {
     forEachPartition(environmentRule::closeStreamProcessor);
   }
 
-  public EngineRule awaitingIdentitySetup() {
+  public EngineRule withIdentitySetup() {
     awaitIdentitySetup = true;
+    withFeatureFlags(ff -> ff.setEnableIdentitySetup(true));
     return this;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -104,7 +104,7 @@ public final class EngineRule extends ExternalResource {
   private long lastProcessedPosition = -1L;
   private JobStreamer jobStreamer = JobStreamer.noop();
 
-  private FeatureFlags featureFlags = FeatureFlags.createDefaultForTests();
+  private final FeatureFlags featureFlags = FeatureFlags.createDefaultForTests();
   private ArrayList<TestInterPartitionCommandSender> interPartitionCommandSenders;
   private Consumer<SecurityConfiguration> securityConfigModifier = cfg -> {};
 
@@ -168,8 +168,8 @@ public final class EngineRule extends ExternalResource {
     return this;
   }
 
-  public EngineRule withFeatureFlags(final FeatureFlags featureFlags) {
-    this.featureFlags = featureFlags;
+  public EngineRule withFeatureFlags(final Consumer<FeatureFlags> modifier) {
+    modifier.accept(featureFlags);
     return this;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -96,7 +96,7 @@ public final class EngineRule extends ExternalResource {
   private final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
   private final int partitionCount;
-  private boolean awaitIdentitySetup = true;
+  private boolean awaitIdentitySetup = false;
 
   private Consumer<TypedRecord> onProcessedCallback = record -> {};
   private Consumer<LoggedEvent> onSkippedCallback = record -> {};
@@ -158,8 +158,8 @@ public final class EngineRule extends ExternalResource {
     forEachPartition(environmentRule::closeStreamProcessor);
   }
 
-  public EngineRule withoutAwaitingIdentitySetup() {
-    awaitIdentitySetup = false;
+  public EngineRule awaitingIdentitySetup() {
+    awaitIdentitySetup = true;
     return this;
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteredDataDeletionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteredDataDeletionTest.java
@@ -60,9 +60,9 @@ public final class ClusteredDataDeletionTest {
   private static void configureNoExporters(final BrokerCfg brokerCfg) {
     final DataCfg data = brokerCfg.getData();
     data.setSnapshotPeriod(SNAPSHOT_PERIOD);
-    data.setLogSegmentSize(DataSize.ofKilobytes(8));
+    data.setLogSegmentSize(DataSize.ofKilobytes(16));
     data.setLogIndexDensity(50);
-    brokerCfg.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(8));
+    brokerCfg.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(16));
 
     brokerCfg.setExporters(Collections.emptyMap());
   }
@@ -70,9 +70,9 @@ public final class ClusteredDataDeletionTest {
   private static void configureCustomExporter(final BrokerCfg brokerCfg) {
     final DataCfg data = brokerCfg.getData();
     data.setSnapshotPeriod(SNAPSHOT_PERIOD);
-    data.setLogSegmentSize(DataSize.ofKilobytes(8));
+    data.setLogSegmentSize(DataSize.ofKilobytes(16));
     data.setLogIndexDensity(50);
-    brokerCfg.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(8));
+    brokerCfg.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(16));
 
     final ExporterCfg exporterCfg = new ExporterCfg();
     exporterCfg.setClassName(TestExporter.class.getName());

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/InstallRequestHandlingTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/InstallRequestHandlingTest.java
@@ -29,8 +29,8 @@ public class InstallRequestHandlingTest {
           3,
           3,
           config -> {
-            config.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(8));
-            config.getData().setLogSegmentSize(DataSize.ofKilobytes(8));
+            config.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(16));
+            config.getData().setLogSegmentSize(DataSize.ofKilobytes(16));
             config.getData().setSnapshotPeriod(SNAPSHOT_PERIOD);
           });
   public final GrpcClientRule clientRule = new GrpcClientRule(clusteringRule);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ReaderCloseTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ReaderCloseTest.java
@@ -29,8 +29,8 @@ public class ReaderCloseTest {
           3,
           3,
           config -> {
-            config.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(8));
-            config.getData().setLogSegmentSize(DataSize.ofKilobytes(8));
+            config.getNetwork().setMaxMessageSize(DataSize.ofKilobytes(16));
+            config.getData().setLogSegmentSize(DataSize.ofKilobytes(16));
             // no exporters so that segments are immediately compacted after a snapshot.
             config.setExporters(Map.of());
           });

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
@@ -10,15 +10,7 @@ package io.camunda.zeebe.util;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
-public record FeatureFlags(
-    boolean yieldingDueDateChecker,
-    boolean enableActorMetrics,
-    boolean enableMessageTTLCheckerAsync,
-    boolean enableTimerDueDateCheckerAsync,
-    boolean enableStraightThroughProcessingLoopDetector,
-    boolean enablePartitionScaling,
-    boolean enableIdentitySetup
-    /*, boolean foo*/ ) {
+public final class FeatureFlags {
 
   /* To add a new feature toggle, please follow these steps:
    *
@@ -56,6 +48,32 @@ public record FeatureFlags(
   private static final boolean ENABLE_PARTITION_SCALING = false;
   private static final boolean ENABLE_IDENTITY_SETUP = true;
 
+  private boolean yieldingDueDateChecker;
+  private boolean enableActorMetrics;
+  private boolean enableMessageTTLCheckerAsync;
+  private boolean enableTimerDueDateCheckerAsync;
+  private boolean enableStraightThroughProcessingLoopDetector;
+  private boolean enablePartitionScaling;
+  private boolean enableIdentitySetup;
+
+  public FeatureFlags(
+      final boolean yieldingDueDateChecker,
+      final boolean enableActorMetrics,
+      final boolean enableMessageTTLCheckerAsync,
+      final boolean enableTimerDueDateCheckerAsync,
+      final boolean enableStraightThroughProcessingLoopDetector,
+      final boolean enablePartitionScaling,
+      final boolean enableIdentitySetup
+      /*, boolean foo*/ ) {
+    this.yieldingDueDateChecker = yieldingDueDateChecker;
+    this.enableActorMetrics = enableActorMetrics;
+    this.enableMessageTTLCheckerAsync = enableMessageTTLCheckerAsync;
+    this.enableTimerDueDateCheckerAsync = enableTimerDueDateCheckerAsync;
+    this.enableStraightThroughProcessingLoopDetector = enableStraightThroughProcessingLoopDetector;
+    this.enablePartitionScaling = enablePartitionScaling;
+    this.enableIdentitySetup = enableIdentitySetup;
+  }
+
   public static FeatureFlags createDefault() {
     return new FeatureFlags(
         YIELDING_DUE_DATE_CHECKER,
@@ -83,6 +101,63 @@ public record FeatureFlags(
         true, /* ENABLE_PARTITION_SCALING */
         false /* ENABLE_IDENTITY_SETUP */
         /*, FOO_DEFAULT*/ );
+  }
+
+  public boolean yieldingDueDateChecker() {
+    return yieldingDueDateChecker;
+  }
+
+  public boolean enableActorMetrics() {
+    return enableActorMetrics;
+  }
+
+  public boolean enableMessageTTLCheckerAsync() {
+    return enableMessageTTLCheckerAsync;
+  }
+
+  public boolean enableTimerDueDateCheckerAsync() {
+    return enableTimerDueDateCheckerAsync;
+  }
+
+  public boolean enableStraightThroughProcessingLoopDetector() {
+    return enableStraightThroughProcessingLoopDetector;
+  }
+
+  public boolean enablePartitionScaling() {
+    return enablePartitionScaling;
+  }
+
+  public boolean enableIdentitySetup() {
+    return enableIdentitySetup;
+  }
+
+  public void setYieldingDueDateChecker(final boolean yieldingDueDateChecker) {
+    this.yieldingDueDateChecker = yieldingDueDateChecker;
+  }
+
+  public void setEnableActorMetrics(final boolean enableActorMetrics) {
+    this.enableActorMetrics = enableActorMetrics;
+  }
+
+  public void setEnableMessageTTLCheckerAsync(final boolean enableMessageTTLCheckerAsync) {
+    this.enableMessageTTLCheckerAsync = enableMessageTTLCheckerAsync;
+  }
+
+  public void setEnableTimerDueDateCheckerAsync(final boolean enableTimerDueDateCheckerAsync) {
+    this.enableTimerDueDateCheckerAsync = enableTimerDueDateCheckerAsync;
+  }
+
+  public void setEnableStraightThroughProcessingLoopDetector(
+      final boolean enableStraightThroughProcessingLoopDetector) {
+    this.enableStraightThroughProcessingLoopDetector = enableStraightThroughProcessingLoopDetector;
+  }
+
+  public void setEnablePartitionScaling(final boolean enablePartitionScaling) {
+    this.enablePartitionScaling = enablePartitionScaling;
+  }
+
+  public void setEnableIdentitySetup(final boolean enableIdentitySetup) {
+    this.enableIdentitySetup = enableIdentitySetup;
   }
 
   @Override

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
@@ -16,7 +16,8 @@ public record FeatureFlags(
     boolean enableMessageTTLCheckerAsync,
     boolean enableTimerDueDateCheckerAsync,
     boolean enableStraightThroughProcessingLoopDetector,
-    boolean enablePartitionScaling
+    boolean enablePartitionScaling,
+    boolean enableIdentitySetup
     /*, boolean foo*/ ) {
 
   /* To add a new feature toggle, please follow these steps:
@@ -53,6 +54,7 @@ public record FeatureFlags(
   private static final boolean ENABLE_DUE_DATE_CHECKER_ASYNC = false;
   private static final boolean ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR = true;
   private static final boolean ENABLE_PARTITION_SCALING = false;
+  private static final boolean ENABLE_IDENTITY_SETUP = true;
 
   public static FeatureFlags createDefault() {
     return new FeatureFlags(
@@ -61,7 +63,8 @@ public record FeatureFlags(
         ENABLE_MSG_TTL_CHECKER_ASYNC,
         ENABLE_DUE_DATE_CHECKER_ASYNC,
         ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR,
-        ENABLE_PARTITION_SCALING
+        ENABLE_PARTITION_SCALING,
+        ENABLE_IDENTITY_SETUP
         /*, FOO_DEFAULT*/ );
   }
 
@@ -77,7 +80,8 @@ public record FeatureFlags(
         true, /* ENABLE_MSG_TTL_CHECKER_ASYNC */
         true, /* ENABLE_DUE_DATE_CHECKER_ASYNC */
         true, /* ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR */
-        true /* ENABLE_PARTITION_SCALING */
+        true, /* ENABLE_PARTITION_SCALING */
+        false /* ENABLE_IDENTITY_SETUP */
         /*, FOO_DEFAULT*/ );
   }
 


### PR DESCRIPTION
## Description

Since now from the IdentitySetupInitializeProcessor we send a follow up command (not an event anymore), the permissions need to be added only while processing new commands. Then the AuthorizationCreateProcessor will take care of distribute properly the authorization command

## Related issues

closes #28278
