### PR TITLE
refactor: remove explicit dynatrace support; we will document it instead

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -210,12 +210,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-registry-dynatrace</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
     </dependency>
@@ -518,7 +512,6 @@
             <!-- Micrometer Exporters/Registries -->
             <dependency>io.micrometer:micrometer-registry-prometheus-simpleclient</dependency>
             <dependency>io.micrometer:micrometer-registry-otlp</dependency>
-            <dependency>io.micrometer:micrometer-registry-dynatrace</dependency>
           </usedDependencies>
         </configuration>
       </plugin>

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -36,14 +36,6 @@ management.endpoint.prometheus.enabled=true
 management.prometheus.metrics.export.enabled=true
 # Disable the OTEL backend by default; can be enabled on demand
 management.otlp.metrics.export.enabled=false
-# Disable the Dynatrace backend by default; can be enabled on demand
-management.dynatrace.metrics.export.enabled=false
-# In case Dynatrace is used, there is a pretty bad warning logged everytime you set some SLOs on a
-# timer or distribution summary, as Dynatrace doesn't yet natively supports buckets. We disable
-# these logs by default, as they're simply not actionable for the user. The limitation is documented
-# on our docs website, with appropriate workarounds.
-logging.level.io.micrometer.dynatrace.types.Timer=ERROR
-logging.level.io.micrometer.dynatrace.types.DistributionSummary=ERROR
 # Allow runtime configuration of log levels
 management.endpoint.loggers.enabled=true
 # Allow viewing the config properties, but sanitize their outputs

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -464,12 +464,6 @@
 
     <dependency>
       <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-registry-dynatrace</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-otlp</artifactId>
       <scope>test</scope>
     </dependency>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/observability/MetricsConfigurationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/observability/MetricsConfigurationIT.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
-import io.micrometer.dynatrace.DynatraceMeterRegistry;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.micrometer.registry.otlp.OtlpMeterRegistry;
 import java.time.Duration;
@@ -102,30 +101,6 @@ final class MetricsConfigurationIT {
               () ->
                   assertThat(logLines)
                       .anyMatch(s -> s.contains("Name: zeebe.gateway.topology.partition.roles")));
-    }
-  }
-
-  @Nested
-  final class DynatraceIT {
-    @TestZeebe
-    private final TestStandaloneBroker broker =
-        new TestStandaloneBroker()
-            .withProperty("management.dynatrace.metrics.export.enabled", "true")
-            .withProperty("management.endpoint.prometheus.enabled", "false")
-            .withProperty("management.prometheus.metrics.export.enabled", "false");
-
-    @Test
-    void shouldUseDynatraceRegistryIfEnabled() {
-      // given / when
-      final var registry = broker.bean(MeterRegistry.class);
-
-      // then
-      assertThat(registry)
-          .as(
-              "should be directly a %s, otherwise it means multiple backends are enabled",
-              DynatraceMeterRegistry.class)
-          .isNotInstanceOf(CompositeMeterRegistry.class)
-          .isInstanceOf(DynatraceMeterRegistry.class);
     }
   }
 }


### PR DESCRIPTION
## Description

This PR removes explicit Dynatrace support. We would recommend usage of the OTLP exporter instead, but if not possible, Dynatrace can still be used by mounting the registry JAR and configuring the application, so the it's also not too terrible.

If there's enough demand, we can always add it back.
