### PR TITLE
Set authorization key properly on exported entity

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandler.java
@@ -60,7 +60,7 @@ public class AuthorizationCreatedUpdatedHandler
       final Record<AuthorizationRecordValue> record, final AuthorizationEntity entity) {
     final AuthorizationRecordValue value = record.getValue();
     entity
-        .setAuthorizationKey(entity.getAuthorizationKey())
+        .setAuthorizationKey(value.getAuthorizationKey())
         .setOwnerId(value.getOwnerId())
         .setOwnerType(value.getOwnerType().name())
         .setResourceType(value.getResourceType().name())

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandler.java
@@ -47,7 +47,7 @@ public class AuthorizationCreatedUpdatedHandler
 
   @Override
   public List<String> generateIds(final Record<AuthorizationRecordValue> record) {
-    return List.of(String.valueOf(record.getValue().getAuthorizationKey()));
+    return List.of(String.valueOf(record.getKey()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationCreatedUpdatedHandlerTest.java
@@ -73,8 +73,7 @@ public class AuthorizationCreatedUpdatedHandlerTest {
     final var idList = underTest.generateIds(authorizationRecord);
 
     // then
-    assertThat(idList)
-        .containsExactly(String.valueOf(authorizationRecord.getValue().getAuthorizationKey()));
+    assertThat(idList).containsExactly(String.valueOf(authorizationRecord.getKey()));
   }
 
   @Test
@@ -95,7 +94,7 @@ public class AuthorizationCreatedUpdatedHandlerTest {
     final var authorizationRecordValue =
         ImmutableAuthorizationRecordValue.builder()
             .from(factory.generateObject(AuthorizationRecordValue.class))
-            .withAuthorizationKey(recordKey)
+            .withAuthorizationKey(456L)
             .withOwnerId("foo")
             .withOwnerType(AuthorizationOwnerType.USER)
             .withResourceId("*")
@@ -113,7 +112,7 @@ public class AuthorizationCreatedUpdatedHandlerTest {
     // when
     final var authorizationEntity =
         new AuthorizationEntity()
-            .setAuthorizationKey(recordKey)
+            .setAuthorizationKey(789L)
             .setOwnerId("bar")
             .setOwnerType(AuthorizationOwnerType.GROUP.name())
             .setResourceId("resourceId")


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

We grabbed the `authorizationKey` from the entity only to set it on the entity. This would always be `null`. We need to get the key from the exported record.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

N/A
