### PR TITLE
fix: add c8run log file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ c8run/*.jar
 c8run/log/*.log
 c8run/camunda-zeebe*
 c8run/elasticsearch*
+c8run/c8run
 
 /camunda.mv.db
 /camunda.trace.db


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds the c8run log file to .gitignore

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
