### PR TITLE
fix: include OpensearchExporter in MultiDbConfigurator

### DIFF
--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -361,6 +361,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-opensearch-exporter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>co.elastic.clients</groupId>
       <artifactId>elasticsearch-java</artifactId>
       <scope>test</scope>

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfigurator.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfigurator.java
@@ -14,6 +14,7 @@ import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.tasklist.property.TasklistOpenSearchProperties;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.zeebe.exporter.ElasticsearchExporter;
+import io.camunda.zeebe.exporter.opensearch.OpensearchExporter;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
 import java.util.Map;
 import java.util.UUID;
@@ -140,6 +141,18 @@ public class MultiDbConfigurator {
                   "bulk",
                   Map.of("size", 1)));
         });
+
+    testApplication.withExporter(
+        "OpensearchExporter",
+        cfg -> {
+          cfg.setClassName(OpensearchExporter.class.getName());
+          cfg.setArgs(
+              Map.of(
+                  "url", opensearchUrl,
+                  "index", Map.of("prefix", indexPrefix),
+                  "bulk", Map.of("size", 1)));
+        });
+
     testApplication.withProperty(
         "camunda.database.type", io.camunda.search.connect.configuration.DatabaseType.OPENSEARCH);
     testApplication.withProperty("camunda.operate.database", "opensearch");

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfigurator.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfigurator.java
@@ -148,9 +148,14 @@ public class MultiDbConfigurator {
           cfg.setClassName(OpensearchExporter.class.getName());
           cfg.setArgs(
               Map.of(
-                  "url", opensearchUrl,
-                  "index", Map.of("prefix", indexPrefix),
-                  "bulk", Map.of("size", 1)));
+                  "url",
+                  opensearchUrl,
+                  "index",
+                  Map.of("prefix", indexPrefix),
+                  "bulk",
+                  Map.of("size", 1),
+                  "authentication",
+                  Map.of("username", userName, "password", userPassword)));
         });
 
     testApplication.withProperty(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Include OpensearchExporter on MultiDbConfigurator

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
