### PR TITLE
Fix flaky BackupRestoreIT

### DIFF
--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -425,6 +425,11 @@
       <artifactId>agrona</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.github.openfeign</groupId>
+      <artifactId>feign-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
@@ -47,7 +47,6 @@ public class BackupRestoreIT {
   private String dbUrl;
   private GenericContainer<?> searchContainer;
   private DataGenerator generator;
-  private BackupRestoreTestConfig config;
   private HistoryBackupClient historyBackupClient;
 
   @AfterEach
@@ -93,7 +92,6 @@ public class BackupRestoreIT {
     configurator.getOperateProperties().getBackup().setRepositoryName(REPOSITORY_NAME);
     configurator.getTasklistProperties().getBackup().setRepositoryName(REPOSITORY_NAME);
 
-    this.config = config;
     testStandaloneApplication.start().awaitCompleteTopology();
 
     camundaClient = testStandaloneApplication.newClientBuilder().build();

--- a/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
@@ -129,6 +129,7 @@ public class BackupRestoreIT {
     final var snapshots = takeResponse.getScheduledSnapshots();
 
     Awaitility.await("Backup completed")
+        .pollDelay(Duration.ofSeconds(1))
         .atMost(Duration.ofSeconds(600))
         .untilAsserted(
             () -> {

--- a/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
@@ -66,8 +66,6 @@ public class BackupRestoreIT {
                     .withStartupTimeout(Duration.ofMinutes(5))
                     // location of the repository that will be used for snapshots
                     .withEnv("path.repo", "~/");
-            // container.addFileSystemBind(
-            // repositoryDir.toString(), "~/", BindMode.READ_WRITE, SelinuxContext.SHARED);
             container.start();
             dbUrl = "http://" + container.getHttpHostAddress();
 


### PR DESCRIPTION
## Description

```
  <testcase name="shouldBackupAndRestoreToPreviousState(BackupRestoreTestConfig)[2] config=BackupRestoreTestConfig[databaseType=opensearch, bucket=bucket] (Flaky Test)" classname="io.camunda.it.backup.BackupRestoreIT" time="39.106">
    <failure type="feign.FeignException$NotFound (Flaky Test)"><![CDATA[feign.FeignException$NotFound: [404] during [GET] to [http://0.0.0.0:1431/actuator/backupHistory/1] [HistoryBackupClient#getBackup(long)]: [{"message":"No backup with id [1] found."}]
	at feign.FeignException.clientErrorStatus(FeignException.java:249)
	at feign.FeignException.errorStatus(FeignException.java:223)
	at feign.FeignException.errorStatus(FeignException.java:213)
	at feign.codec.ErrorDecoder$Default.decode(ErrorDecoder.java:103)
	at feign.InvocationContext.decodeError(InvocationContext.java:133)
	at feign.InvocationContext.proceed(InvocationContext.java:80)
	at feign.ResponseHandler.handleResponse(ResponseHandler.java:69)
	at feign.SynchronousMethodHandler.executeAndDecode(SynchronousMethodHandler.java:109)
	at feign.SynchronousMethodHandler.invoke(SynchronousMethodHandler.java:53)
	at feign.ReflectiveFeign$FeignInvocationHandler.invoke(ReflectiveFeign.java:104)
	at jdk.proxy2/jdk.proxy2.$Proxy214.getBackup(Unknown Source)
	at io.camunda.it.backup.BackupRestoreIT.lambda$shouldBackupAndRestoreToPreviousState$1(BackupRestoreIT.java:137)
	at org.awaitility.core.AssertionCondition.lambda$new$0(AssertionCondition.java:53)
	at org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:248)
	at org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:235)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
]]></failure>
```

Error happens when checking for the first time for the backup state. This might be a race condition as this is still not ready to poll even though the backup is already in progress. 

The solution might be to add one poll delay for the first check to avoid this race condition. 



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/camunda/issues/27850
