### PR TITLE
[Backport stable/8.6] fix: add info to authenticate against nexus for local usage

### DIFF
--- a/c8run/package.go
+++ b/c8run/package.go
@@ -112,6 +112,7 @@ func PackageUnix(camundaVersion string, elasticsearchVersion string, connectorsV
 	connectorsFilePath := "connector-runtime-bundle-" + connectorsVersion + "-with-dependencies.jar"
 	connectorsUrl := "https://repository.nexus.camunda.cloud/content/groups/internal/io/camunda/connector/connector-runtime-bundle/" + connectorsVersion + "/" + connectorsFilePath
 
+	// set your LDAP credentials for local usage (name.surname as username, password)
 	javaArtifactsUser := os.Getenv("JAVA_ARTIFACTS_USER")
 	javaArtifactsPassword := os.Getenv("JAVA_ARTIFACTS_PASSWORD")
 


### PR DESCRIPTION
# Description
Backport of #28125 to `stable/8.6`.

relates to 
original author: @hisImminence