### PR TITLE
[Backport stable/8.7] fix: add info to authenticate against nexus for local usage

### DIFF
--- a/c8run/package.go
+++ b/c8run/package.go
@@ -133,6 +133,7 @@ func PackageUnix(camundaVersion string, elasticsearchVersion string, connectorsV
 	composeExtractionPath := "camunda-platform-" + composeTag
 	authToken := os.Getenv("GH_TOKEN")
 
+	// set your LDAP credentials for local usage (name.surname as username, password)
 	javaArtifactsUser := os.Getenv("JAVA_ARTIFACTS_USER")
 	javaArtifactsPassword := os.Getenv("JAVA_ARTIFACTS_PASSWORD")
 


### PR DESCRIPTION
# Description
Backport of #28125 to `stable/8.7`.

relates to 
original author: @hisImminence