### PR TITLE
[Backport stable/8.7] fix: add c8run log file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,13 @@ els-snapshots
 
 optimize/client/.node/
 .yarn
+
+c8run/*.tar.gz
+c8run/*.jar
+c8run/log/*.log
+c8run/camunda-zeebe*
+c8run/elasticsearch*
+c8run/c8run
+
+/camunda.mv.db
+/camunda.trace.db


### PR DESCRIPTION
# Description
Backport of #28182 to `stable/8.7`.

relates to 
original author: @hisImminence