### PR TITLE
refactor: make package.go reuse code for different os (#27964)

### DIFF
--- a/c8run/main.go
+++ b/c8run/main.go
@@ -545,20 +545,10 @@ func main() {
 	}
 
 	if baseCommand == "package" {
-		if runtime.GOOS == "windows" {
-			err := PackageWindows(camundaVersion, elasticsearchVersion, connectorsVersion, composeTag)
-			if err != nil {
-				fmt.Printf("%+v", err)
-				os.Exit(1)
-			}
-		} else if runtime.GOOS == "linux" || runtime.GOOS == "darwin" {
-			err := PackageUnix(camundaVersion, elasticsearchVersion, connectorsVersion, composeTag)
-			if err != nil {
-				fmt.Printf("%+v", err)
-				os.Exit(1)
-			}
-		} else {
-			panic("Unsupported system")
+		err := Package(camundaVersion, elasticsearchVersion, connectorsVersion, composeTag)
+		if err != nil {
+			fmt.Printf("%+v", err)
+			os.Exit(1)
 		}
 	}
 

--- a/c8run/package.go
+++ b/c8run/package.go
@@ -160,11 +160,6 @@ func Package(camundaVersion string, elasticsearchVersion string, connectorsVersi
 		return fmt.Errorf("Package "+osType+": failed to download camunda %w\n%s", err, debug.Stack())
 	}
 
-	err = downloadAndExtract(camundaFilePath, camundaUrl, "camunda-zeebe-"+camundaVersion, authToken, extractFunc)
-	if err != nil {
-		return fmt.Errorf("Package "+osType+": failed to fetch camunda: %w\n%s", err, debug.Stack())
-	}
-
 	err = downloadAndExtract(connectorsFilePath, connectorsUrl, connectorsFilePath, javaArtifactsToken, func(_, _ string) error { return nil })
 	if err != nil {
 		return fmt.Errorf("Package "+osType+": failed to fetch connectors: %w\n%s", err, debug.Stack())

--- a/c8run/package.go
+++ b/c8run/package.go
@@ -4,11 +4,12 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"github.com/camunda/camunda/c8run/internal/archive"
 	"os"
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
+
+	"github.com/camunda/camunda/c8run/internal/archive"
 )
 
 func Clean(camundaVersion string, elasticsearchVersion string) {
@@ -40,163 +41,164 @@ func downloadAndExtract(filePath, url, extractDir string, authToken string, extr
 	return nil
 }
 
-func PackageWindows(camundaVersion string, elasticsearchVersion string, connectorsVersion string, composeTag string) error {
-	elasticsearchUrl := "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-" + elasticsearchVersion + "-windows-x86_64.zip"
-	elasticsearchFilePath := "elasticsearch-" + elasticsearchVersion + ".zip"
-	camundaFilePath := "camunda-zeebe-" + camundaVersion + ".zip"
-	camundaUrl := "https://repository.nexus.camunda.cloud/content/groups/internal/io/camunda/camunda-zeebe/" + camundaVersion + "/camunda-zeebe-" + camundaVersion + ".zip"
-	connectorsFilePath := "connector-runtime-bundle-" + connectorsVersion + "-with-dependencies.jar"
-	connectorsUrl := "https://repository.nexus.camunda.cloud/content/groups/internal/io/camunda/connector/connector-runtime-bundle/" + connectorsVersion + "/" + connectorsFilePath
-	composeUrl := "https://github.com/camunda/camunda-platform/archive/refs/tags/" + composeTag + ".zip"
-	composeFilePath := composeTag + ".zip"
-	composeExtractionPath := "camunda-platform-" + composeTag
-	authToken := os.Getenv("GH_TOKEN")
+func setOsSpecificValues() (string, string, string, func(string, string) error, error) {
+	var architecture string
+	var osType string = runtime.GOOS
+	var pkgName string
+	var extractFunc func(string, string) error
 
+	switch osType {
+	case "windows":
+		architecture = "x86_64"
+		pkgName = ".zip"
+		extractFunc = archive.UnzipSource
+		return osType, architecture, pkgName, extractFunc, nil
+	case "linux", "darwin":
+		pkgName = ".tar.gz"
+		extractFunc = archive.ExtractTarGzArchive
+		if runtime.GOARCH == "amd64" {
+			architecture = "x86_64"
+		} else if runtime.GOARCH == "arm64" {
+			architecture = "aarch64"
+		} else {
+			return "", "", "", nil, fmt.Errorf("unsupported architecture: %s", runtime.GOARCH)
+		}
+		return osType, architecture, pkgName, extractFunc, nil
+	default:
+		return "", "", "", nil, fmt.Errorf("unsupported operating system: %s", osType)
+	}
+}
+
+func getJavaArtifactsToken() (string, error) {
 	javaArtifactsUser := os.Getenv("JAVA_ARTIFACTS_USER")
 	javaArtifactsPassword := os.Getenv("JAVA_ARTIFACTS_PASSWORD")
 
 	if javaArtifactsUser == "" || javaArtifactsPassword == "" {
-		return fmt.Errorf("PackageWindows: JAVA_ARTIFACTS_USER or JAVA_ARTIFACTS_PASSWORD env vars are not set")
+		return "", fmt.Errorf("JAVA_ARTIFACTS_USER or JAVA_ARTIFACTS_PASSWORD environment variables are not set")
 	}
 
-	javaArtifactsToken := "Basic " + base64.StdEncoding.EncodeToString([]byte(javaArtifactsUser+":"+javaArtifactsPassword))
+	token := base64.StdEncoding.EncodeToString([]byte(javaArtifactsUser + ":" + javaArtifactsPassword))
+	return "Basic " + token, nil
+}
 
-	Clean(camundaVersion, elasticsearchVersion)
-
-	err := downloadAndExtract(elasticsearchFilePath, elasticsearchUrl, "elasticsearch-"+elasticsearchVersion, "", archive.UnzipSource)
-	if err != nil {
-		return fmt.Errorf("PackageWindows: failed to fetch elasticsearch: %w\n%s", err, debug.Stack())
-	}
-
-	err = downloadAndExtract(camundaFilePath, camundaUrl, "camunda-zeebe-"+camundaVersion, javaArtifactsToken, archive.UnzipSource)
-	if err != nil {
-		return fmt.Errorf("PackageWindows: failed to fetch camunda: %w\n%s", err, debug.Stack())
-	}
-
-	err = downloadAndExtract(connectorsFilePath, connectorsUrl, connectorsFilePath, javaArtifactsToken, func(_, _ string) error { return nil })
-	if err != nil {
-		return fmt.Errorf("PackageWindows: failed to fetch connectors: %w\n%s", err, debug.Stack())
-	}
-
-	err = downloadAndExtract(composeFilePath, composeUrl, composeExtractionPath, authToken, archive.UnzipSource)
-	if err != nil {
-		return fmt.Errorf("PackageWindows: failed to fetch compose release %w\n%s", err, debug.Stack())
-	}
-
-	err = os.Chdir("..")
-	if err != nil {
-		return fmt.Errorf("PackageWindows: failed to chdir %w", err)
-	}
-	filesToArchive := []string{
+func getFilesToArchive(osType, elasticsearchVersion, connectorsFilePath, camundaVersion, composeExtractionPath string) []string {
+	commonFiles := []string{
 		filepath.Join("c8run", "README.md"),
 		filepath.Join("c8run", "connectors-application.properties"),
 		filepath.Join("c8run", connectorsFilePath),
 		filepath.Join("c8run", "elasticsearch-"+elasticsearchVersion),
 		filepath.Join("c8run", "custom_connectors"),
 		filepath.Join("c8run", "configuration"),
-		filepath.Join("c8run", "c8run.exe"),
 		filepath.Join("c8run", "endpoints.txt"),
 		filepath.Join("c8run", "log"),
 		filepath.Join("c8run", "camunda-zeebe-"+camundaVersion),
-		filepath.Join("c8run", "package.bat"),
 		filepath.Join("c8run", ".env"),
 		filepath.Join("c8run", composeExtractionPath),
 	}
-	err = archive.ZipSource(filesToArchive, filepath.Join("c8run", "camunda8-run-"+camundaVersion+"-windows-x86_64.zip"))
-	if err != nil {
-		return fmt.Errorf("PackageWindows: failed to create c8run package %w\n%s", err, debug.Stack())
-	}
-	err = os.Chdir("c8run")
-	if err != nil {
-		return fmt.Errorf("PackageWindows: failed to chdir %w", err)
+
+	if osType == "windows" {
+		return append(commonFiles, filepath.Join("c8run", "c8run.exe"), filepath.Join("c8run", "package.bat"))
+	} else if osType == "linux" || osType == "darwin" {
+		return append(commonFiles, filepath.Join("c8run", "c8run"), filepath.Join("c8run", "start.sh"), filepath.Join("c8run", "shutdown.sh"), filepath.Join("c8run", "package.sh"))
 	}
 	return nil
 }
 
-func PackageUnix(camundaVersion string, elasticsearchVersion string, connectorsVersion string, composeTag string) error {
-	var architecture string
-	if runtime.GOARCH == "amd64" {
-		architecture = "x86_64"
-	} else if runtime.GOARCH == "arm64" {
-		architecture = "aarch64"
+func createTarGzArchive(filesToArchive []string, outputPath string) error {
+	outputArchive, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to create empty archive file: %w\n%s", err, debug.Stack())
+	}
+	defer outputArchive.Close()
+
+	if err := archive.CreateTarGzArchive(filesToArchive, outputArchive); err != nil {
+		return fmt.Errorf("failed to fill camunda archive: %w\n%s", err, debug.Stack())
+	}
+	return nil
+}
+
+func createZipArchive(filesToArchive []string, outputPath string) error {
+	if err := archive.ZipSource(filesToArchive, outputPath); err != nil {
+		return fmt.Errorf("failed to create c8run package: %w\n%s", err, debug.Stack())
+	}
+	return nil
+}
+
+func Package(camundaVersion string, elasticsearchVersion string, connectorsVersion string, composeTag string) error {
+	var osType, architecture, pkgName, extractFunc, err = setOsSpecificValues()
+	if err != nil {
+		fmt.Printf("%+v", err)
+		os.Exit(1)
 	}
 
-	elasticsearchUrl := "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-" + elasticsearchVersion + "-" + runtime.GOOS + "-" + architecture + ".tar.gz"
-	elasticsearchFilePath := "elasticsearch-" + elasticsearchVersion + ".tar.gz"
-	camundaFilePath := "camunda-zeebe-" + camundaVersion + ".tar.gz"
-	camundaUrl := "https://repository.nexus.camunda.cloud/content/groups/internal/io/camunda/camunda-zeebe/" + camundaVersion + "/camunda-zeebe-" + camundaVersion + ".tar.gz"
+	elasticsearchUrl := "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-" + elasticsearchVersion + "-" + osType + "-" + architecture + pkgName
+	elasticsearchFilePath := "elasticsearch-" + elasticsearchVersion + pkgName
+	camundaFilePath := "camunda-zeebe-" + camundaVersion + pkgName
+	camundaUrl := "https://repository.nexus.camunda.cloud/content/groups/internal/io/camunda/camunda-zeebe/" + camundaVersion + "/camunda-zeebe-" + camundaVersion + pkgName
 	connectorsFilePath := "connector-runtime-bundle-" + connectorsVersion + "-with-dependencies.jar"
 	connectorsUrl := "https://repository.nexus.camunda.cloud/content/groups/internal/io/camunda/connector/connector-runtime-bundle/" + connectorsVersion + "/" + connectorsFilePath
-
-	composeUrl := "https://github.com/camunda/camunda-platform/archive/refs/tags/" + composeTag + ".tar.gz"
-	composeFilePath := composeTag + ".tar.gz"
+	composeUrl := "https://github.com/camunda/camunda-platform/archive/refs/tags/" + composeTag + pkgName
+	composeFilePath := composeTag + pkgName
 	composeExtractionPath := "camunda-platform-" + composeTag
 	authToken := os.Getenv("GH_TOKEN")
 
-	// set your LDAP credentials for local usage (name.surname as username, password)
-	javaArtifactsUser := os.Getenv("JAVA_ARTIFACTS_USER")
-	javaArtifactsPassword := os.Getenv("JAVA_ARTIFACTS_PASSWORD")
-
-	if javaArtifactsUser == "" || javaArtifactsPassword == "" {
-		return fmt.Errorf("PackageUnix: JAVA_ARTIFACTS_USER or JAVA_ARTIFACTS_PASSWORD env vars are not set")
+	javaArtifactsToken, err := getJavaArtifactsToken()
+	if err != nil {
+		fmt.Printf("%+v", err)
+		os.Exit(1)
 	}
-
-	javaArtifactsToken := "Basic " + base64.StdEncoding.EncodeToString([]byte(javaArtifactsUser+":"+javaArtifactsPassword))
 
 	Clean(camundaVersion, elasticsearchVersion)
 
-	err := downloadAndExtract(elasticsearchFilePath, elasticsearchUrl, "elasticsearch-"+elasticsearchVersion, "", archive.ExtractTarGzArchive)
+	err = downloadAndExtract(elasticsearchFilePath, elasticsearchUrl, "elasticsearch-"+elasticsearchVersion, "", extractFunc)
 	if err != nil {
-		return fmt.Errorf("PackageUnix: failed to fetch elasticsearch %w\n%s", err, debug.Stack())
+		return fmt.Errorf("Package "+osType+": failed to fetch elasticsearch: %w\n%s", err, debug.Stack())
 	}
 
-	err = downloadAndExtract(camundaFilePath, camundaUrl, "camunda-zeebe-"+camundaVersion, javaArtifactsToken, archive.ExtractTarGzArchive)
+	err = downloadAndExtract(camundaFilePath, camundaUrl, "camunda-zeebe-"+camundaVersion, javaArtifactsToken, extractFunc)
 	if err != nil {
-		return fmt.Errorf("PackageUnix: failed to fetch camunda %w\n%s", err, debug.Stack())
+		return fmt.Errorf("Package "+osType+": failed to download camunda %w\n%s", err, debug.Stack())
+	}
+
+	err = downloadAndExtract(camundaFilePath, camundaUrl, "camunda-zeebe-"+camundaVersion, authToken, extractFunc)
+	if err != nil {
+		return fmt.Errorf("Package "+osType+": failed to fetch camunda: %w\n%s", err, debug.Stack())
 	}
 
 	err = downloadAndExtract(connectorsFilePath, connectorsUrl, connectorsFilePath, javaArtifactsToken, func(_, _ string) error { return nil })
 	if err != nil {
-		return fmt.Errorf("PackageUnix: failed to fetch connectors %w\n%s", err, debug.Stack())
+		return fmt.Errorf("Package "+osType+": failed to fetch connectors: %w\n%s", err, debug.Stack())
 	}
 
-	err = downloadAndExtract(composeFilePath, composeUrl, composeExtractionPath, authToken, archive.ExtractTarGzArchive)
+	err = downloadAndExtract(composeFilePath, composeUrl, composeExtractionPath, authToken, extractFunc)
 	if err != nil {
-		return fmt.Errorf("PackageUnix: failed to fetch compose release %w\n%s", err, debug.Stack())
+		return fmt.Errorf("Package "+osType+": failed to fetch compose release %w\n%s", err, debug.Stack())
 	}
 
 	err = os.Chdir("..")
 	if err != nil {
-		return fmt.Errorf("PackageUnix: failed to chdir %w", err)
+		return fmt.Errorf("Package "+osType+": failed to chdir %w", err)
 	}
-	filesToArchive := []string{
-		filepath.Join("c8run", "README.md"),
-		filepath.Join("c8run", "connectors-application.properties"),
-		filepath.Join("c8run", connectorsFilePath),
-		filepath.Join("c8run", "elasticsearch-"+elasticsearchVersion),
-		filepath.Join("c8run", "custom_connectors"),
-		filepath.Join("c8run", "configuration"),
-		filepath.Join("c8run", "c8run"),
-		filepath.Join("c8run", "endpoints.txt"),
-		filepath.Join("c8run", "log"),
-		filepath.Join("c8run", "camunda-zeebe-"+camundaVersion),
-		filepath.Join("c8run", "start.sh"),
-		filepath.Join("c8run", "shutdown.sh"),
-		filepath.Join("c8run", "package.sh"),
-		filepath.Join("c8run", ".env"),
-		filepath.Join("c8run", composeExtractionPath),
+
+	filesToArchive := getFilesToArchive(osType, elasticsearchVersion, connectorsFilePath, camundaVersion, composeExtractionPath)
+	outputFileName := "camunda8-run-" + camundaVersion + "-" + osType + "-" + architecture + pkgName
+	outputPath := filepath.Join("c8run", outputFileName)
+
+	if osType == "linux" || osType == "darwin" {
+		if err := createTarGzArchive(filesToArchive, outputPath); err != nil {
+			return fmt.Errorf("Package %s: %w", osType, err)
+		}
+	} else {
+		if err := createZipArchive(filesToArchive, outputPath); err != nil {
+			return fmt.Errorf("Package %s: %w", osType, err)
+		}
 	}
-	outputArchive, err := os.Create(filepath.Join("c8run", "camunda8-run-"+camundaVersion+"-"+runtime.GOOS+"-"+architecture+".tar.gz"))
-	if err != nil {
-		return fmt.Errorf("PackageUnix: failed to create empty archive file %w\n%s", err, debug.Stack())
-	}
-	err = archive.CreateTarGzArchive(filesToArchive, outputArchive)
-	if err != nil {
-		return fmt.Errorf("PackageUnix: failed to fill camunda archive %w\n%s", err, debug.Stack())
-	}
+
 	err = os.Chdir("c8run")
 	if err != nil {
-		return fmt.Errorf("PackageUnix: failed to chdir %w", err)
+		return fmt.Errorf("Package "+osType+": failed to chdir %w", err)
 	}
+
 	return nil
+
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Refactoring the `package.go` file to reuse many of its code/ unify the package function.

related to: https://github.com/camunda/camunda/pull/27964#issuecomment-2660215922

--> automatic backporting failed: so manually back-porting refactoring of package.go

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
- [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
- [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI"
requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
- [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
