### PR TITLE
fix: remove duplicate camunda-zeebe download

### DIFF
--- a/c8run/package.go
+++ b/c8run/package.go
@@ -160,11 +160,6 @@ func Package(camundaVersion string, elasticsearchVersion string, connectorsVersi
 		return fmt.Errorf("Package "+osType+": failed to download camunda %w\n%s", err, debug.Stack())
 	}
 
-	err = downloadAndExtract(camundaFilePath, camundaUrl, "camunda-zeebe-"+camundaVersion, authToken, extractFunc)
-	if err != nil {
-		return fmt.Errorf("Package "+osType+": failed to fetch camunda: %w\n%s", err, debug.Stack())
-	}
-
 	err = downloadAndExtract(connectorsFilePath, connectorsUrl, connectorsFilePath, javaArtifactsToken, func(_, _ string) error { return nil })
 	if err != nil {
 		return fmt.Errorf("Package "+osType+": failed to fetch connectors: %w\n%s", err, debug.Stack())


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Remove duplicate camunda-zeebe download. Introduced in refactoring of package.go: https://github.com/camunda/camunda/pull/27964/files#diff-afb2a8c2c2ee118ead621806fa9222edf3300e82428251d2da46fb3264fbb198R163

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
