### PR TITLE
`VariableResolver` can return `null`

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/jobhandling/parameter/VariableResolver.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/jobhandling/parameter/VariableResolver.java
@@ -34,6 +34,9 @@ public class VariableResolver implements ParameterResolver {
   @Override
   public Object resolve(final JobClient jobClient, final ActivatedJob job) {
     final Object variableValue = getVariable(job);
+    if (variableValue == null) {
+      return null;
+    }
     try {
       return mapZeebeVariable(variableValue);
     } catch (final ClassCastException | IllegalArgumentException ex) {
@@ -48,7 +51,7 @@ public class VariableResolver implements ParameterResolver {
   }
 
   protected Object getVariable(final ActivatedJob job) {
-    return job.getVariable(variableName);
+    return job.getVariablesAsMap().get(variableName);
   }
 
   protected Object mapZeebeVariable(final Object variableValue) {

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/jobhandling/parameter/VariableResolverTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/jobhandling/parameter/VariableResolverTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.spring.client.jobhandling.parameter;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.worker.JobClient;
+import io.camunda.client.impl.CamundaObjectMapper;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class VariableResolverTest {
+
+  private VariableResolver resolver;
+  @Mock private JobClient jobClient;
+  @Mock private ActivatedJob job;
+
+  @BeforeEach
+  void setUp() {
+    resolver = new VariableResolver("testVar", String.class, new CamundaObjectMapper());
+  }
+
+  @Test
+  void shouldResolveVariableNotPresent() {
+    when(job.getVariablesAsMap()).thenReturn(Map.of("anotherVar", "another value"));
+
+    final Object resolvedValue = resolver.resolve(jobClient, job);
+
+    assertNull(resolvedValue);
+  }
+
+  @Test
+  void shouldResolveVariableIsPresent() {
+    when(job.getVariablesAsMap()).thenReturn(Map.of("testVar", "test value"));
+
+    final Object resolvedValue = resolver.resolve(jobClient, job);
+
+    assertEquals("test value", resolvedValue);
+  }
+}

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/jobhandling/parameter/VariableResolverTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/jobhandling/parameter/VariableResolverTest.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.spring.client.jobhandling.parameter;
 


### PR DESCRIPTION
## Description

This is a fix for [this issue](https://github.com/camunda/camunda/issues/28116)

There is currently inconsistency in how we handle non-existing variable.

Example:
In Client: 8.5.2 -> If a variable does not exist, then @Variable uses null
In Client: 8.6.7 -> If a variable does not exist, an exception is thrown.

Expected behavior:
`null` should be returned instead of throwing a `ClientException`.

This was [fixed](https://github.com/camunda-community-hub/spring-zeebe/pull/771) in the community project but the fix wasn't applied to the Camunda Spring SDK and have led to user issues.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #28116
