### PR TITLE
Camunda Client out of the box Basic Auth support

### DIFF
--- a/.idea/scopes/apache_license_scope.xml
+++ b/.idea/scopes/apache_license_scope.xml
@@ -1,3 +1,3 @@
 <component name="DependencyValidationManager">
-  <scope name="apache-license-scope" pattern="file[camunda-client-java]:*/||file[zeebe-exporter-api]:*/||file[zeebe-protocol]:*/||file[zeebe-gateway-protocol-impl]:*/||file[zeebe-bpmn-model]:*/" />
+  <scope name="apache-license-scope" pattern="file[camunda-client-java]:*/||file[zeebe-exporter-api]:*/||file[zeebe-protocol]:*/||file[zeebe-gateway-protocol-impl]:*/||file[zeebe-bpmn-model]:*/||file[spring-boot-starter-camunda-sdk]:*/" />
 </component>

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientEnvironmentVariables.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientEnvironmentVariables.java
@@ -52,5 +52,10 @@ public final class CamundaClientEnvironmentVariables {
   public static final String OAUTH_ENV_CONNECT_TIMEOUT = "CAMUNDA_AUTH_CONNECT_TIMEOUT";
   public static final String OAUTH_ENV_READ_TIMEOUT = "CAMUNDA_AUTH_READ_TIMEOUT";
 
+  /** Basic Auth Environment Variables */
+  public static final String BASIC_AUTH_ENV_USERNAME = "CAMUNDA_BASIC_AUTH_USERNAME";
+
+  public static final String BASIC_AUTH_ENV_PASSWORD = "CAMUNDA_BASIC_AUTH_PASSWORD";
+
   private CamundaClientEnvironmentVariables() {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/basicauth/BasicAuthCredentialsProvider.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/basicauth/BasicAuthCredentialsProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.basicauth;
+
+import io.camunda.client.CredentialsProvider;
+import java.util.Base64;
+
+public class BasicAuthCredentialsProvider implements CredentialsProvider {
+
+  public static final String AUTH_HEADER_KEY = "Authorization";
+  private final String authHeaderValue;
+
+  public BasicAuthCredentialsProvider(final String username, final String password) {
+    final String base64EncodedCredentials =
+        Base64.getEncoder().encodeToString(String.format("%s:%s", username, password).getBytes());
+    authHeaderValue = String.format("Basic %s", base64EncodedCredentials);
+  }
+
+  @Override
+  public void applyCredentials(final CredentialsApplier applier) {
+    applier.put(AUTH_HEADER_KEY, authHeaderValue);
+  }
+
+  @Override
+  public boolean shouldRetryRequest(final StatusCode statusCode) {
+    return false;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/basicauth/BasicAuthCredentialsProvider.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/basicauth/BasicAuthCredentialsProvider.java
@@ -23,7 +23,7 @@ public class BasicAuthCredentialsProvider implements CredentialsProvider {
   public static final String AUTH_HEADER_KEY = "Authorization";
   private final String authHeaderValue;
 
-  public BasicAuthCredentialsProvider(final String username, final String password) {
+  BasicAuthCredentialsProvider(final String username, final String password) {
     final String base64EncodedCredentials =
         Base64.getEncoder().encodeToString(String.format("%s:%s", username, password).getBytes());
     authHeaderValue = String.format("Basic %s", base64EncodedCredentials);

--- a/clients/java/src/main/java/io/camunda/client/impl/basicauth/BasicAuthCredentialsProviderBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/basicauth/BasicAuthCredentialsProviderBuilder.java
@@ -15,9 +15,13 @@
  */
 package io.camunda.client.impl.basicauth;
 
+import io.camunda.client.impl.BuilderUtils;
+import io.camunda.client.impl.CamundaClientEnvironmentVariables;
+
 public final class BasicAuthCredentialsProviderBuilder {
   private String username;
   private String password;
+  private boolean applyEnvironmentOverrides = true;
 
   public BasicAuthCredentialsProviderBuilder username(final String username) {
     this.username = username;
@@ -29,7 +33,37 @@ public final class BasicAuthCredentialsProviderBuilder {
     return this;
   }
 
+  public BasicAuthCredentialsProviderBuilder applyEnvironmentOverrides(
+      final boolean applyEnvironmentOverrides) {
+    this.applyEnvironmentOverrides = applyEnvironmentOverrides;
+    return this;
+  }
+
   public BasicAuthCredentialsProvider build() {
+    if (applyEnvironmentOverrides) {
+      BuilderUtils.applyEnvironmentValueIfNotNull(
+          this::username, CamundaClientEnvironmentVariables.BASIC_AUTH_ENV_USERNAME);
+      BuilderUtils.applyEnvironmentValueIfNotNull(
+          this::password, CamundaClientEnvironmentVariables.BASIC_AUTH_ENV_PASSWORD);
+    }
+
+    validate();
+
     return new BasicAuthCredentialsProvider(username, password);
+  }
+
+  private void validate() {
+    if (username == null || username.isEmpty()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Username cannot be null or empty. Ensure the username is set explicitly, or through the environment variable '%s'.",
+              CamundaClientEnvironmentVariables.BASIC_AUTH_ENV_USERNAME));
+    }
+    if (password == null || password.isEmpty()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Password cannot be null or empty. Ensure the password is set explicitly, or through the environment variable '%s'.",
+              CamundaClientEnvironmentVariables.BASIC_AUTH_ENV_PASSWORD));
+    }
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/basicauth/BasicAuthCredentialsProviderBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/basicauth/BasicAuthCredentialsProviderBuilder.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.basicauth;
+
+public final class BasicAuthCredentialsProviderBuilder {
+  private String username;
+  private String password;
+
+  public BasicAuthCredentialsProviderBuilder username(final String username) {
+    this.username = username;
+    return this;
+  }
+
+  public BasicAuthCredentialsProviderBuilder password(final String password) {
+    this.password = password;
+    return this;
+  }
+
+  public BasicAuthCredentialsProvider build() {
+    return new BasicAuthCredentialsProvider(username, password);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/basicauth/BasicAuthCredentialsProviderBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/basicauth/BasicAuthCredentialsProviderBuilder.java
@@ -23,16 +23,33 @@ public final class BasicAuthCredentialsProviderBuilder {
   private String password;
   private boolean applyEnvironmentOverrides = true;
 
+  /**
+   * Username to be used for basic authentication. This can also be set using the environment
+   * variable 'CAMUNDA_BASIC_AUTH_USERNAME'. If both are set the environment variable will take
+   * precedence unless disabling environment by setting it to false using the {@link
+   * #applyEnvironmentOverrides}' method.
+   */
   public BasicAuthCredentialsProviderBuilder username(final String username) {
     this.username = username;
     return this;
   }
 
+  /**
+   * Password to be used for basic authentication. This can also be set using the environment
+   * variable 'CAMUNDA_BASIC_AUTH_PASSWORD'. If both are set the environment variable will take
+   * precedence unless disabling environment by setting it to false using the {@link
+   * #applyEnvironmentOverrides}' method.
+   */
   public BasicAuthCredentialsProviderBuilder password(final String password) {
     this.password = password;
     return this;
   }
 
+  /**
+   * Whether to apply environment overrides to the builder. If set to true environment variables
+   * will take precedence over values explicitly set in this builder. If set to false the
+   * environment variables will not be used at all. If they do exist they will be ignored.
+   */
   public BasicAuthCredentialsProviderBuilder applyEnvironmentOverrides(
       final boolean applyEnvironmentOverrides) {
     this.applyEnvironmentOverrides = applyEnvironmentOverrides;

--- a/clients/java/src/test/java/io/camunda/client/BasicAuthCredentialsProviderBuilderTest.java
+++ b/clients/java/src/test/java/io/camunda/client/BasicAuthCredentialsProviderBuilderTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.impl.CamundaClientEnvironmentVariables;
+import io.camunda.client.impl.basicauth.BasicAuthCredentialsProvider;
+import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
+import io.camunda.client.impl.util.Environment;
+import io.camunda.client.impl.util.EnvironmentExtension;
+import io.camunda.client.util.TestCredentialsApplier;
+import io.camunda.client.util.TestCredentialsApplier.Credential;
+import java.util.Base64;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(EnvironmentExtension.class)
+public class BasicAuthCredentialsProviderBuilderTest {
+
+  @Test
+  void shouldFailWithNullUsername() {
+    // given
+    final BasicAuthCredentialsProviderBuilder builder = new BasicAuthCredentialsProviderBuilder();
+
+    // when
+    builder.password("password");
+
+    // then
+    assertThatThrownBy(builder::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageEndingWith(
+            "Username cannot be null or empty. Ensure the username is set explicitly, or through the environment variable 'CAMUNDA_BASIC_AUTH_USERNAME'.");
+  }
+
+  @Test
+  void shouldFailWithEmptyUsername() {
+    // given
+    final BasicAuthCredentialsProviderBuilder builder = new BasicAuthCredentialsProviderBuilder();
+
+    // when
+    builder.username("").password("password");
+
+    // then
+    assertThatThrownBy(builder::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageEndingWith(
+            "Username cannot be null or empty. Ensure the username is set explicitly, or through the environment variable 'CAMUNDA_BASIC_AUTH_USERNAME'.");
+  }
+
+  @Test
+  void shouldFailWithNullPassword() {
+    // given
+    final BasicAuthCredentialsProviderBuilder builder = new BasicAuthCredentialsProviderBuilder();
+
+    // when
+    builder.username("username");
+
+    // then
+    assertThatThrownBy(builder::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageEndingWith(
+            "Password cannot be null or empty. Ensure the password is set explicitly, or through the environment variable 'CAMUNDA_BASIC_AUTH_PASSWORD'.");
+  }
+
+  @Test
+  void shouldUseEnvironmentVariableByDefault() {
+    // given
+    final Environment system = Environment.system();
+    system.put(CamundaClientEnvironmentVariables.BASIC_AUTH_ENV_USERNAME, "foo");
+    system.put(CamundaClientEnvironmentVariables.BASIC_AUTH_ENV_PASSWORD, "bar");
+    final BasicAuthCredentialsProviderBuilder builder = new BasicAuthCredentialsProviderBuilder();
+    final TestCredentialsApplier applier = new TestCredentialsApplier();
+
+    // when
+    final BasicAuthCredentialsProvider provider = builder.build();
+    provider.applyCredentials(applier);
+
+    // then
+    assertThat(applier.getCredentials())
+        .containsExactly(
+            new Credential("Authorization", "Basic " + base64EncodeCredentials("foo", "bar")));
+  }
+
+  @Test
+  void shouldNotApplyEnvironmentOverrides() {
+    // given
+    final Environment system = Environment.system();
+    system.put(CamundaClientEnvironmentVariables.BASIC_AUTH_ENV_USERNAME, "foo");
+    system.put(CamundaClientEnvironmentVariables.BASIC_AUTH_ENV_PASSWORD, "bar");
+    final BasicAuthCredentialsProviderBuilder builder = new BasicAuthCredentialsProviderBuilder();
+
+    // when
+    builder.applyEnvironmentOverrides(false);
+
+    // then
+    assertThatThrownBy(builder::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageEndingWith(
+            "Username cannot be null or empty. Ensure the username is set explicitly, or through the environment variable 'CAMUNDA_BASIC_AUTH_USERNAME'.");
+  }
+
+  private String base64EncodeCredentials(final String username, final String password) {
+    return Base64.getEncoder()
+        .encodeToString(String.format("%s:%s", username, password).getBytes());
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/BasicAuthCredentialsProviderTest.java
+++ b/clients/java/src/test/java/io/camunda/client/BasicAuthCredentialsProviderTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.impl.HttpStatusCode;
+import io.camunda.client.impl.basicauth.BasicAuthCredentialsProvider;
+import io.camunda.client.util.TestCredentialsApplier;
+import io.camunda.client.util.TestCredentialsApplier.Credential;
+import java.util.Base64;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+public class BasicAuthCredentialsProviderTest {
+
+  private final TestCredentialsApplier applier = new TestCredentialsApplier();
+
+  @Test
+  void shouldEncodeCredentialsAndAddToCall() {
+    // given
+    final String username = UUID.randomUUID().toString();
+    final String password = UUID.randomUUID().toString();
+    final BasicAuthCredentialsProvider provider =
+        new BasicAuthCredentialsProvider(username, password);
+
+    // when
+    provider.applyCredentials(applier);
+
+    // then
+    assertThat(applier.getCredentials())
+        .containsExactly(
+            new Credential(
+                "Authorization", "Basic " + base64EncodeCredentials(username, password)));
+  }
+
+  @Test
+  void shouldNotRetryRequest() {
+    // given
+    final BasicAuthCredentialsProvider provider =
+        new BasicAuthCredentialsProvider("username", "password");
+
+    // when
+    final boolean shouldRetryRequest = provider.shouldRetryRequest(new HttpStatusCode(401));
+
+    // then
+    assertThat(shouldRetryRequest).isFalse();
+  }
+
+  private String base64EncodeCredentials(final String username, final String password) {
+    return Base64.getEncoder()
+        .encodeToString(String.format("%s:%s", username, password).getBytes());
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/BasicAuthCredentialsProviderTest.java
+++ b/clients/java/src/test/java/io/camunda/client/BasicAuthCredentialsProviderTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.impl.HttpStatusCode;
 import io.camunda.client.impl.basicauth.BasicAuthCredentialsProvider;
+import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
 import io.camunda.client.util.TestCredentialsApplier;
 import io.camunda.client.util.TestCredentialsApplier.Credential;
 import java.util.Base64;
@@ -35,7 +36,7 @@ public class BasicAuthCredentialsProviderTest {
     final String username = UUID.randomUUID().toString();
     final String password = UUID.randomUUID().toString();
     final BasicAuthCredentialsProvider provider =
-        new BasicAuthCredentialsProvider(username, password);
+        new BasicAuthCredentialsProviderBuilder().username(username).password(password).build();
 
     // when
     provider.applyCredentials(applier);
@@ -51,7 +52,7 @@ public class BasicAuthCredentialsProviderTest {
   void shouldNotRetryRequest() {
     // given
     final BasicAuthCredentialsProvider provider =
-        new BasicAuthCredentialsProvider("username", "password");
+        new BasicAuthCredentialsProviderBuilder().username("username").password("password").build();
 
     // when
     final boolean shouldRetryRequest = provider.shouldRetryRequest(new HttpStatusCode(401));

--- a/clients/java/src/test/java/io/camunda/client/OAuthCredentialsProviderTest.java
+++ b/clients/java/src/test/java/io/camunda/client/OAuthCredentialsProviderTest.java
@@ -30,7 +30,6 @@ import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
-import io.camunda.client.CredentialsProvider.CredentialsApplier;
 import io.camunda.client.CredentialsProvider.StatusCode;
 import io.camunda.client.api.response.Topology;
 import io.camunda.client.impl.CamundaClientCredentials;
@@ -41,6 +40,8 @@ import io.camunda.client.protocol.rest.ProblemDetail;
 import io.camunda.client.protocol.rest.TopologyResponse;
 import io.camunda.client.util.RecordingGatewayService;
 import io.camunda.client.util.RestGatewayPaths;
+import io.camunda.client.util.TestCredentialsApplier;
+import io.camunda.client.util.TestCredentialsApplier.Credential;
 import io.grpc.Metadata;
 import io.grpc.Metadata.Key;
 import io.grpc.Server;
@@ -67,10 +68,7 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -173,7 +171,7 @@ public final class OAuthCredentialsProviderTest {
     provider.applyCredentials(applier);
 
     // then
-    assertThat(applier.credentials)
+    assertThat(applier.getCredentials())
         .containsExactly(new Credential("Authorization", TOKEN_TYPE + " " + ACCESS_TOKEN));
   }
 
@@ -195,7 +193,7 @@ public final class OAuthCredentialsProviderTest {
     provider.applyCredentials(applier);
 
     // then
-    assertThat(applier.credentials)
+    assertThat(applier.getCredentials())
         .containsExactly(new Credential("Authorization", TOKEN_TYPE + " " + ACCESS_TOKEN));
   }
 
@@ -385,7 +383,7 @@ public final class OAuthCredentialsProviderTest {
         .join();
 
     // then
-    assertThat(applier.credentials)
+    assertThat(applier.getCredentials())
         .containsOnly(new Credential("Authorization", TOKEN_TYPE + " " + ACCESS_TOKEN))
         .hasSize(10);
     currentWiremockRuntimeInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
@@ -445,42 +443,6 @@ public final class OAuthCredentialsProviderTest {
 
   private String tokenHttpsUrlString() {
     return currentWiremockRuntimeInfo.getHttpsBaseUrl() + "/oauth/token";
-  }
-
-  private static final class TestCredentialsApplier implements CredentialsApplier {
-    private final List<Credential> credentials = new CopyOnWriteArrayList<>();
-
-    @Override
-    public void put(final String key, final String value) {
-      credentials.add(new Credential(key, value));
-    }
-  }
-
-  private static final class Credential {
-    private final String key;
-    private final String value;
-
-    private Credential(final String key, final String value) {
-      this.key = key;
-      this.value = value;
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(key, value);
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      final Credential that = (Credential) o;
-      return Objects.equals(key, that.key) && Objects.equals(value, that.value);
-    }
   }
 
   private static final class TestStatusCode implements StatusCode {
@@ -690,7 +652,7 @@ public final class OAuthCredentialsProviderTest {
       provider.applyCredentials(applier);
 
       // then
-      assertThat(applier.credentials)
+      assertThat(applier.getCredentials())
           .containsExactly(new Credential("Authorization", TOKEN_TYPE + " " + ACCESS_TOKEN));
     }
 

--- a/clients/java/src/test/java/io/camunda/client/util/TestCredentialsApplier.java
+++ b/clients/java/src/test/java/io/camunda/client/util/TestCredentialsApplier.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.util;
+
+import io.camunda.client.CredentialsProvider.CredentialsApplier;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public final class TestCredentialsApplier implements CredentialsApplier {
+  private final List<Credential> credentials = new CopyOnWriteArrayList<>();
+
+  @Override
+  public void put(final String key, final String value) {
+    credentials.add(new Credential(key, value));
+  }
+
+  public List<Credential> getCredentials() {
+    return credentials;
+  }
+
+  public static final class Credential {
+    private final String key;
+    private final String value;
+
+    public Credential(final String key, final String value) {
+      this.key = key;
+      this.value = value;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(key, value);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final Credential that = (Credential) o;
+      return Objects.equals(key, that.key) && Objects.equals(value, that.value);
+    }
+  }
+}

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CredentialsProviderConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CredentialsProviderConfiguration.java
@@ -39,6 +39,11 @@ public class CredentialsProviderConfiguration {
   @ConditionalOnMissingBean
   public CredentialsProvider camundaClientCredentialsProvider(
       final CamundaClientProperties camundaClientProperties) {
+    return buildOAuthCredentialsProvider(camundaClientProperties);
+  }
+
+  private CredentialsProvider buildOAuthCredentialsProvider(
+      final CamundaClientProperties camundaClientProperties) {
     final OAuthCredentialsProviderBuilder credBuilder =
         CredentialsProvider.newCredentialsProviderBuilder()
             .applyEnvironmentOverrides(false)

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CredentialsProviderConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CredentialsProviderConfiguration.java
@@ -22,7 +22,6 @@ import io.camunda.client.impl.NoopCredentialsProvider;
 import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
 import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
 import io.camunda.spring.client.properties.CamundaClientProperties;
-import io.camunda.spring.client.properties.CamundaClientProperties.ClientMode;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -41,11 +40,10 @@ public class CredentialsProviderConfiguration {
   @ConditionalOnMissingBean
   public CredentialsProvider camundaClientCredentialsProvider(
       final CamundaClientProperties camundaClientProperties) {
-    if (camundaClientProperties.getMode() == ClientMode.basic) {
-      return buildBasicAuthCredentialsProvider(camundaClientProperties);
-    } else {
-      return buildOAuthCredentialsProvider(camundaClientProperties);
-    }
+    return switch (camundaClientProperties.getMode()) {
+      case basic -> buildBasicAuthCredentialsProvider(camundaClientProperties);
+      case saas, selfManaged -> buildOAuthCredentialsProvider(camundaClientProperties);
+    };
   }
 
   private CredentialsProvider buildBasicAuthCredentialsProvider(

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CredentialsProviderConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CredentialsProviderConfiguration.java
@@ -40,10 +40,14 @@ public class CredentialsProviderConfiguration {
   @ConditionalOnMissingBean
   public CredentialsProvider camundaClientCredentialsProvider(
       final CamundaClientProperties camundaClientProperties) {
-    return switch (camundaClientProperties.getMode()) {
-      case basic -> buildBasicAuthCredentialsProvider(camundaClientProperties);
-      case saas, selfManaged -> buildOAuthCredentialsProvider(camundaClientProperties);
-    };
+    final var clientMode = camundaClientProperties.getMode();
+
+    return clientMode == null
+        ? new NoopCredentialsProvider()
+        : switch (clientMode) {
+          case basic -> buildBasicAuthCredentialsProvider(camundaClientProperties);
+          case saas, selfManaged -> buildOAuthCredentialsProvider(camundaClientProperties);
+        };
   }
 
   private CredentialsProvider buildBasicAuthCredentialsProvider(

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/properties/CamundaClientAuthProperties.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/properties/CamundaClientAuthProperties.java
@@ -21,7 +21,7 @@ import org.springframework.boot.context.properties.DeprecatedConfigurationProper
 
 public class CamundaClientAuthProperties {
 
-  // simple
+  // basic auth
   private String username;
   private String password;
 

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/properties/CamundaClientProperties.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/properties/CamundaClientProperties.java
@@ -325,6 +325,7 @@ public class CamundaClientProperties {
 
   public enum ClientMode {
     selfManaged,
-    saas
+    saas,
+    basic
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/properties/CamundaClientPropertiesPostProcessor.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/properties/CamundaClientPropertiesPostProcessor.java
@@ -151,6 +151,9 @@ public class CamundaClientPropertiesPostProcessor implements EnvironmentPostProc
       case saas -> {
         return "modes/saas.yaml";
       }
+      case basic -> {
+        return "modes/basic.yaml";
+      }
       default -> throw new IllegalStateException("Unknown client mode " + clientMode);
     }
   }

--- a/clients/spring-boot-starter-camunda-sdk/src/main/resources/modes/basic.yaml
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/resources/modes/basic.yaml
@@ -1,0 +1,9 @@
+camunda:
+  client:
+    mode: basic
+    auth:
+      username: demo
+      password: demo
+    enabled: true
+    grpc-address: http://localhost:26500
+    rest-address: http://localhost:8086

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CredentialsProviderBasicTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CredentialsProviderBasicTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.spring.client.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CredentialsProvider;
+import io.camunda.client.impl.basicauth.BasicAuthCredentialsProvider;
+import io.camunda.spring.client.configuration.CredentialsProviderConfiguration;
+import io.camunda.spring.client.properties.CamundaClientProperties;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(
+    classes = {CredentialsProviderConfiguration.class},
+    properties = {
+      "camunda.client.mode=basic",
+      "camunda.client.auth.username=foo",
+      "camunda.client.auth.password=bar"
+    })
+@EnableConfigurationProperties({CamundaClientProperties.class})
+public class CredentialsProviderBasicTest {
+  public static final String USERNAME = "foo";
+  public static final String PASSWORD = "bar";
+  @Autowired CredentialsProvider credentialsProvider;
+
+  @Test
+  void shouldCreateBasicAuthCredentialsProvider() {
+    assertThat(credentialsProvider).isExactlyInstanceOf(BasicAuthCredentialsProvider.class);
+  }
+
+  @Test
+  void shouldHaveBasicAuthHeader() throws IOException {
+    final Map<String, String> headers = new HashMap<>();
+    final var encodedCredentials =
+        Base64.getEncoder().encodeToString(String.format("%s:%s", USERNAME, PASSWORD).getBytes());
+
+    credentialsProvider.applyCredentials(headers::put);
+    assertThat(headers).isEqualTo(Map.of("Authorization", "Basic " + encodedCredentials));
+  }
+}

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CredentialsProviderBasicTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CredentialsProviderBasicTest.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.spring.client.config;
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/CamundaClientTestFactory.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/CamundaClientTestFactory.java
@@ -8,7 +8,7 @@
 package io.camunda.it.utils;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.CredentialsProvider;
+import io.camunda.client.impl.basicauth.BasicAuthCredentialsProvider;
 import io.camunda.client.protocol.rest.OwnerTypeEnum;
 import io.camunda.client.protocol.rest.PermissionTypeEnum;
 import io.camunda.client.protocol.rest.ResourceTypeEnum;
@@ -21,7 +21,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.time.Duration;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -139,23 +138,7 @@ public final class CamundaClientTestFactory implements AutoCloseable {
     return gateway
         .newClientBuilder()
         .preferRestOverGrpc(true)
-        .credentialsProvider(
-            new CredentialsProvider() {
-              @Override
-              public void applyCredentials(final CredentialsApplier applier) {
-                applier.put(
-                    "Authorization",
-                    "Basic %s"
-                        .formatted(
-                            Base64.getEncoder()
-                                .encodeToString("%s:%s".formatted(username, password).getBytes())));
-              }
-
-              @Override
-              public boolean shouldRetryRequest(final StatusCode statusCode) {
-                return false;
-              }
-            })
+        .credentialsProvider(new BasicAuthCredentialsProvider(username, password))
         .build();
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/CamundaClientTestFactory.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/CamundaClientTestFactory.java
@@ -8,7 +8,7 @@
 package io.camunda.it.utils;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.impl.basicauth.BasicAuthCredentialsProvider;
+import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
 import io.camunda.client.protocol.rest.OwnerTypeEnum;
 import io.camunda.client.protocol.rest.PermissionTypeEnum;
 import io.camunda.client.protocol.rest.ResourceTypeEnum;
@@ -138,7 +138,8 @@ public final class CamundaClientTestFactory implements AutoCloseable {
     return gateway
         .newClientBuilder()
         .preferRestOverGrpc(true)
-        .credentialsProvider(new BasicAuthCredentialsProvider(username, password))
+        .credentialsProvider(
+            new BasicAuthCredentialsProviderBuilder().username(username).password(password).build())
         .build();
   }
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/AuthorizationsUtil.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/AuthorizationsUtil.java
@@ -11,7 +11,7 @@ import static io.camunda.security.configuration.InitializationConfiguration.DEFA
 import static io.camunda.security.configuration.InitializationConfiguration.DEFAULT_USER_USERNAME;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.impl.basicauth.BasicAuthCredentialsProvider;
+import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
 import io.camunda.client.protocol.rest.OwnerTypeEnum;
 import io.camunda.client.protocol.rest.PermissionTypeEnum;
 import io.camunda.client.protocol.rest.ResourceTypeEnum;
@@ -132,7 +132,8 @@ public class AuthorizationsUtil implements CloseableSilently {
         .newClientBuilder()
         .preferRestOverGrpc(true)
         .defaultRequestTimeout(Duration.ofSeconds(15))
-        .credentialsProvider(new BasicAuthCredentialsProvider(username, password))
+        .credentialsProvider(
+            new BasicAuthCredentialsProviderBuilder().username(username).password(password).build())
         .build();
   }
 
@@ -142,7 +143,8 @@ public class AuthorizationsUtil implements CloseableSilently {
         .newClientBuilder()
         .defaultRequestTimeout(Duration.ofSeconds(15))
         .preferRestOverGrpc(false)
-        .credentialsProvider(new BasicAuthCredentialsProvider(username, password))
+        .credentialsProvider(
+            new BasicAuthCredentialsProviderBuilder().username(username).password(password).build())
         .build();
   }
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/AuthorizationsUtil.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/AuthorizationsUtil.java
@@ -11,7 +11,7 @@ import static io.camunda.security.configuration.InitializationConfiguration.DEFA
 import static io.camunda.security.configuration.InitializationConfiguration.DEFAULT_USER_USERNAME;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.client.CredentialsProvider;
+import io.camunda.client.impl.basicauth.BasicAuthCredentialsProvider;
 import io.camunda.client.protocol.rest.OwnerTypeEnum;
 import io.camunda.client.protocol.rest.PermissionTypeEnum;
 import io.camunda.client.protocol.rest.ResourceTypeEnum;
@@ -25,7 +25,6 @@ import io.camunda.zeebe.qa.util.cluster.TestGateway;
 import io.camunda.zeebe.util.CloseableSilently;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.List;
 import java.util.function.Supplier;
 import org.awaitility.Awaitility;
@@ -133,23 +132,7 @@ public class AuthorizationsUtil implements CloseableSilently {
         .newClientBuilder()
         .preferRestOverGrpc(true)
         .defaultRequestTimeout(Duration.ofSeconds(15))
-        .credentialsProvider(
-            new CredentialsProvider() {
-              @Override
-              public void applyCredentials(final CredentialsApplier applier) {
-                applier.put(
-                    "Authorization",
-                    "Basic %s"
-                        .formatted(
-                            Base64.getEncoder()
-                                .encodeToString("%s:%s".formatted(username, password).getBytes())));
-              }
-
-              @Override
-              public boolean shouldRetryRequest(final StatusCode statusCode) {
-                return false;
-              }
-            })
+        .credentialsProvider(new BasicAuthCredentialsProvider(username, password))
         .build();
   }
 
@@ -159,23 +142,7 @@ public class AuthorizationsUtil implements CloseableSilently {
         .newClientBuilder()
         .defaultRequestTimeout(Duration.ofSeconds(15))
         .preferRestOverGrpc(false)
-        .credentialsProvider(
-            new CredentialsProvider() {
-              @Override
-              public void applyCredentials(final CredentialsApplier applier) {
-                applier.put(
-                    "Authorization",
-                    "Basic %s"
-                        .formatted(
-                            Base64.getEncoder()
-                                .encodeToString("%s:%s".formatted(username, password).getBytes())));
-              }
-
-              @Override
-              public boolean shouldRetryRequest(final StatusCode statusCode) {
-                return false;
-              }
-            })
+        .credentialsProvider(new BasicAuthCredentialsProvider(username, password))
         .build();
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

If a user wants to use basic auth they'd always have to create their own credentials provider. Since with the Identity rearchitecture basic auth is valid and fully supported option, we can make this easier by providing a `BasicAuthCredentialsProvider`. This provider takes a username and password and will set these on the `Authorization` header of the request.

I've also added back basic auth support in the Spring SDK. The username and password properties were already configurable, though never used. Now they have a use again.
We used to have basic auth support in the Spring SDK before, but it was called Simple auth. I chose to rename it to basic auth, as that's what it's called 😄 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #26982 
