### PR TITLE
[Backport stable/optimize-8.7] test: support ad-hoc subprocesses

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -81,6 +81,11 @@
     <!-- Zeebe dependencies -->
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-bpmn-model</artifactId>
+      <version>8.8.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol</artifactId>
       <version>${zeebe.version}</version>
     </dependency>

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeProcessInstanceImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeProcessInstanceImportIT.java
@@ -9,6 +9,8 @@ package io.camunda.optimize.service.importing;
 
 import static io.camunda.optimize.service.db.DatabaseConstants.ZEEBE_PROCESS_INSTANCE_INDEX_NAME;
 import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
+import static io.camunda.optimize.util.ZeebeBpmnModels.ACTIVATE_ELEMENTS;
+import static io.camunda.optimize.util.ZeebeBpmnModels.ADHOC_SUB_PROCESS;
 import static io.camunda.optimize.util.ZeebeBpmnModels.COMPENSATION_EVENT_TASK;
 import static io.camunda.optimize.util.ZeebeBpmnModels.CONVERGING_GATEWAY;
 import static io.camunda.optimize.util.ZeebeBpmnModels.DIVERGING_GATEWAY;
@@ -33,7 +35,9 @@ import static io.camunda.optimize.util.ZeebeBpmnModels.SIGNAL_START_INT_SUB_PROC
 import static io.camunda.optimize.util.ZeebeBpmnModels.SIGNAL_START_NON_INT_SUB_PROCESS;
 import static io.camunda.optimize.util.ZeebeBpmnModels.SIGNAL_THROW;
 import static io.camunda.optimize.util.ZeebeBpmnModels.START_EVENT;
+import static io.camunda.optimize.util.ZeebeBpmnModels.TASK;
 import static io.camunda.optimize.util.ZeebeBpmnModels.USER_TASK;
+import static io.camunda.optimize.util.ZeebeBpmnModels.createAdHocSubProcess;
 import static io.camunda.optimize.util.ZeebeBpmnModels.createCompensationEventProcess;
 import static io.camunda.optimize.util.ZeebeBpmnModels.createInclusiveGatewayProcess;
 import static io.camunda.optimize.util.ZeebeBpmnModels.createInclusiveGatewayProcessWithConverging;
@@ -757,6 +761,32 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
                   .extracting(FlowNodeInstanceDto::getFlowNodeId)
                   .contains(SERVICE_TASK_WITH_COMPENSATION_EVENT, COMPENSATION_EVENT_TASK);
             });
+  }
+
+  @Test
+  public void importZeebeProcessInstanceData_processContainsAdHocSubProcess() {
+    // given
+    final BpmnModelInstance adHocSubProcessModel =
+        createAdHocSubProcess(
+            "someProcess",
+            process ->
+                process.zeebeActiveElementsCollectionExpression(ACTIVATE_ELEMENTS).task(TASK));
+    final String processId = zeebeExtension.deployProcess(adHocSubProcessModel).getBpmnProcessId();
+    zeebeExtension.startProcessInstanceWithVariables(
+        processId, Map.of(ACTIVATE_ELEMENTS, List.of(TASK)));
+
+    // when
+    waitUntilInstanceRecordWithElementIdExported(END_EVENT);
+    importAllZeebeEntitiesFromScratch();
+
+    // then
+    assertThat(databaseIntegrationTestExtension.getAllProcessInstances())
+        .singleElement()
+        .satisfies(
+            instance ->
+                assertThat(instance.getFlowNodeInstances())
+                    .extracting(FlowNodeInstanceDto::getFlowNodeId)
+                    .contains(START_EVENT, ADHOC_SUB_PROCESS, TASK, END_EVENT));
   }
 
   // Test backwards compatibility for default tenantID applied when importing records pre multi

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/processdefinition/ZeebeProcessDefinitionImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/processdefinition/ZeebeProcessDefinitionImportIT.java
@@ -9,6 +9,8 @@ package io.camunda.optimize.service.importing.processdefinition;
 
 import static io.camunda.optimize.service.db.DatabaseConstants.ZEEBE_PROCESS_DEFINITION_INDEX_NAME;
 import static io.camunda.optimize.service.util.importing.ZeebeConstants.ZEEBE_DEFAULT_TENANT_ID;
+import static io.camunda.optimize.util.ZeebeBpmnModels.ACTIVATE_ELEMENTS;
+import static io.camunda.optimize.util.ZeebeBpmnModels.ADHOC_SUB_PROCESS;
 import static io.camunda.optimize.util.ZeebeBpmnModels.END_EVENT;
 import static io.camunda.optimize.util.ZeebeBpmnModels.SIGNAL_CATCH;
 import static io.camunda.optimize.util.ZeebeBpmnModels.SIGNAL_GATEWAY_CATCH;
@@ -20,7 +22,9 @@ import static io.camunda.optimize.util.ZeebeBpmnModels.SIGNAL_START_INT_SUB_PROC
 import static io.camunda.optimize.util.ZeebeBpmnModels.SIGNAL_START_NON_INT_SUB_PROCESS;
 import static io.camunda.optimize.util.ZeebeBpmnModels.SIGNAL_THROW;
 import static io.camunda.optimize.util.ZeebeBpmnModels.START_EVENT;
+import static io.camunda.optimize.util.ZeebeBpmnModels.TASK;
 import static io.camunda.optimize.util.ZeebeBpmnModels.USER_TASK;
+import static io.camunda.optimize.util.ZeebeBpmnModels.createAdHocSubProcess;
 import static io.camunda.optimize.util.ZeebeBpmnModels.createProcessWith83SignalEvents;
 import static io.camunda.optimize.util.ZeebeBpmnModels.createSimpleServiceTaskProcess;
 import static io.camunda.optimize.util.ZeebeBpmnModels.createSimpleUserTaskProcess;
@@ -292,6 +296,31 @@ public class ZeebeProcessDefinitionImportIT extends AbstractCCSMIT {
                         SIGNAL_INTERRUPTING_BOUNDARY,
                         SIGNAL_NON_INTERRUPTING_BOUNDARY,
                         SIGNAL_PROCESS_END));
+  }
+
+  @Test
+  public void importZeebeProcess_processContainsAdHocSubProcess() {
+    // given
+    final BpmnModelInstance adHocSubProcessModel =
+        createAdHocSubProcess(
+            "someProcess",
+            process ->
+                process.zeebeActiveElementsCollectionExpression(ACTIVATE_ELEMENTS).task(TASK));
+    zeebeExtension.deployProcess(adHocSubProcessModel).getBpmnProcessId();
+
+    // when
+    waitUntilNumberOfDefinitionsExported(1);
+    importAllZeebeEntitiesFromScratch();
+
+    // then
+    assertThat(databaseIntegrationTestExtension.getAllProcessDefinitions())
+        .singleElement()
+        .extracting(ProcessDefinitionOptimizeDto::getFlowNodeData)
+        .satisfies(
+            flowNodeDataDtos ->
+                assertThat(flowNodeDataDtos)
+                    .extracting(FlowNodeDataDto::getId)
+                    .contains(START_EVENT, ADHOC_SUB_PROCESS, TASK, END_EVENT));
   }
 
   // Test backwards compatibility for default tenantID applied when importing records pre multi

--- a/optimize/backend/src/it/java/io/camunda/optimize/util/ZeebeBpmnModels.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/util/ZeebeBpmnModels.java
@@ -9,15 +9,19 @@ package io.camunda.optimize.util;
 
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AdHocSubProcessBuilder;
 import io.camunda.zeebe.model.bpmn.builder.EndEventBuilder;
 import io.camunda.zeebe.model.bpmn.builder.ProcessBuilder;
 import java.time.Duration;
+import java.util.function.Consumer;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ZeebeBpmnModels {
 
+  public static final String ACTIVATE_ELEMENTS = "activateElements";
+  public static final String ADHOC_SUB_PROCESS = "adhocSubProcess";
   public static final String START_EVENT = "startEvent";
   public static final String SERVICE_TASK = "service_task";
   public static final String SEND_TASK = "send_task";
@@ -51,6 +55,7 @@ public class ZeebeBpmnModels {
   public static final String SIGNAL_PROCESS_SECOND_SIGNAL = "interruptingBoundarySignal";
   public static final String SIGNAL_PROCESS_THIRD_SIGNAL = "eventBasedGatewaySignal";
   public static final String SERVICE_TASK_WITH_COMPENSATION_EVENT = "compensationEvent";
+  public static final String TASK = "task";
   public static final String COMPENSATION_EVENT_TASK = "compensationEventTask";
   public static final String VERSION_TAG = "v1";
 
@@ -83,6 +88,16 @@ public class ZeebeBpmnModels {
         .name(SERVICE_TASK)
         .endEvent(END_EVENT)
         .name(null)
+        .done();
+  }
+
+  public static BpmnModelInstance createAdHocSubProcess(
+      final String processName, final Consumer<AdHocSubProcessBuilder> modifier) {
+    return Bpmn.createExecutableProcess(processName)
+        .name(processName)
+        .startEvent(START_EVENT)
+        .adHocSubProcess(ADHOC_SUB_PROCESS, modifier)
+        .endEvent(END_EVENT)
         .done();
   }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/util/BpmnModelUtil.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/util/BpmnModelUtil.java
@@ -9,6 +9,13 @@ package io.camunda.optimize.service.util;
 
 import io.camunda.optimize.dto.optimize.FlowNodeDataDto;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.BaseElement;
+import io.camunda.zeebe.model.bpmn.instance.FlowNode;
+import io.camunda.zeebe.model.bpmn.instance.Process;
+import io.camunda.zeebe.model.bpmn.instance.SubProcess;
+import io.camunda.zeebe.model.bpmn.instance.UserTask;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -27,13 +34,6 @@ import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.camunda.bpm.model.bpmn.Bpmn;
-import org.camunda.bpm.model.bpmn.BpmnModelInstance;
-import org.camunda.bpm.model.bpmn.instance.BaseElement;
-import org.camunda.bpm.model.bpmn.instance.FlowNode;
-import org.camunda.bpm.model.bpmn.instance.Process;
-import org.camunda.bpm.model.bpmn.instance.SubProcess;
-import org.camunda.bpm.model.bpmn.instance.UserTask;
 
 @Slf4j
 @NoArgsConstructor(access = AccessLevel.PRIVATE)


### PR DESCRIPTION
## Description

In Camunda 8.7, a new BPMN element was introduced : the [ad-hoc subprocess](https://www.omg.org/spec/BPMN/2.0/PDF#13.2.5%20Ad-Hoc%20Sub-Process). It is supported in Zeebe but hasn't been tested in Optimize yet. This PR adds integration tests for the new element, to validate that an ad-hoc subprocess definition as well as process instances can be exported to Optimize for evaluation.

See [thread](https://camunda.slack.com/archives/CUZUYDMMG/p1739181377577979) for details on the test approach.

## Related issues

related to https://github.com/camunda/camunda/issues/25639
