### PR TITLE
fix: spring sdk - do not set a default region in saas mode

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/resources/modes/saas.yaml
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/resources/modes/saas.yaml
@@ -3,7 +3,6 @@ camunda:
     mode: saas
     cloud:
       base-url: zeebe.camunda.io
-      region: bru-2
       port: 443
     auth:
       token-url: https://login.cloud.camunda.io/oauth/token


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Do not set a default region.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
