### PR TITLE
Test stable/8.7

### DIFF
--- a/.github/workflows/zeebe-daily-qa.yml
+++ b/.github/workflows/zeebe-daily-qa.yml
@@ -63,6 +63,8 @@ jobs:
       matrix:
         branch:
           - 'main'
+          # TODO: remove this line after 8.7 has been released
+          - 'stable/8.7'
           - ${{ format('stable/{0}', needs.get-versions.outputs.latest-version) }}
           - ${{ format('stable/{0}', needs.get-versions.outputs.second-last-version) }}
           - ${{ format('stable/{0}', needs.get-versions.outputs.third-last-version) }}
@@ -70,6 +72,8 @@ jobs:
         include:
           - branch: 'main'
             generation_template: 'Zeebe SNAPSHOT'
+          - branch: 'stable/8.7'
+            generation_template: 'Camunda 8.7.0-alpha4'
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.latest-version) }}
             generation_template: ${{ format('Camunda {0}+gen1', needs.get-versions.outputs.latest-version) }}
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.second-last-version) }}

--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -6,6 +6,18 @@ on:
     - cron: '0 2 * * 1-5'
 
 jobs:
+  dry-run-release-87:
+    name: "Release from stable/8.7"
+    uses: camunda/camunda/.github/workflows/camunda-platform-release.yml@stable/8.7
+    secrets: inherit
+    strategy:
+      fail-fast: false
+    with:
+      releaseBranch: stable/8.7
+      releaseVersion: 0.8.7
+      nextDevelopmentVersion: 0.0.0-SNAPSHOT
+      isLatest: true
+      dryRun: true
   dry-run-release-86:
     name: "Release from stable/8.6"
     uses: camunda/camunda/.github/workflows/camunda-platform-release.yml@stable/8.6

--- a/.github/workflows/zeebe-weekly-e2e.yml
+++ b/.github/workflows/zeebe-weekly-e2e.yml
@@ -58,12 +58,15 @@ jobs:
       matrix:
         branch:
           - 'main'
+          - 'stable/8.7'
           - ${{ format('stable/{0}', needs.get-versions.outputs.latest-major-minor-version) }}
           - ${{ format('stable/{0}', needs.get-versions.outputs.previous-latest-major-minor-version) }}
           - ${{ format('stable/{0}', needs.get-versions.outputs.previous-previous-latest-major-minor-version) }}
         include:
           - branch: 'main'
             generation_template: 'Zeebe SNAPSHOT'
+          - branch: 'stable/8.7'
+            generation_template: 'Camunda 8.7.0-alpha4'
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.latest-major-minor-version) }}
             generation_template: ${{ format('Camunda {0}+gen1', needs.get-versions.outputs.latest-major-minor-version) }}
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.previous-latest-major-minor-version) }}


### PR DESCRIPTION
## Description

Allow testing workflows to test on `stable/8.7`. The branch name has been hardcoded, since this is an unique scenario where we have 2 development branches. Once 8.7 is released, we should remove the hardcoded lines

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #28193 
