### PR TITLE
Fix: job worker stream disabled by default

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/annotation/JobWorker.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/annotation/JobWorker.java
@@ -101,7 +101,7 @@ public @interface JobWorker {
 
   String[] tenantIds() default {};
 
-  boolean streamEnabled() default true;
+  boolean streamEnabled() default false;
 
   /** Stream timeout in ms */
   long streamTimeout() default 3600000L;


### PR DESCRIPTION
## Description

This is a fix for the the first issue mentioned [here](https://github.com/camunda/camunda/issues/27502)

This bug was fixed in the community project but have not been applied to the Spring SDK and have led to user issues.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #27502
