### PR TITLE
fix: always close exporter container and distribution service

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -407,11 +407,8 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   @Override
   protected void onActorCloseRequested() {
     isOpened.set(false);
-    if (exporterMode == ExporterMode.ACTIVE) {
-      containers.forEach(ExporterContainer::close);
-    } else {
-      exporterDistributionService.close();
-    }
+    containers.forEach(ExporterContainer::close);
+    exporterDistributionService.close();
   }
 
   @Override


### PR DESCRIPTION
Fixes two bugs:
1. `ExporterContainer`s were not closed by followers
3. `ExporterStateDistributionService` was not closed by leaders.