### PR TITLE
fix: add logging when client is unable to read JSON

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/http/TypedApiEntityConsumer.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/TypedApiEntityConsumer.java
@@ -99,6 +99,7 @@ public interface TypedApiEntityConsumer<T> {
         }
         return ApiEntity.of(json.readValue(buffer.asParserOnFirstToken(), ProblemDetail.class));
       } catch (final IOException ioe) {
+        LOGGER.warn("Could not read JSON content", ioe);
         // write the original JSON response into an error response
         final String jsonString = getJsonString();
         return ApiEntity.of(


### PR DESCRIPTION
## Description

This PR simply aims to provide additional context through logs, in relation to a bug that was identified in `8.8.0-alpha1`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

1st PR towards resolving https://github.com/camunda/camunda/issues/28246
