### PR TITLE
feat: make IncidentUpdateTask async

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -120,6 +120,7 @@ public final class BackgroundTaskManagerFactory {
             incidentRepository,
             postExport.isIgnoreMissingData(),
             postExport.getBatchSize(),
+            executor,
             logger),
         1,
         postExport.getDelayBetweenRuns(),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/RunnableTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/RunnableTask.java
@@ -8,15 +8,13 @@
 package io.camunda.exporter.tasks;
 
 import io.camunda.zeebe.util.CloseableSilently;
-import java.util.concurrent.CompletionStage;
 
-public interface BackgroundTask extends CloseableSilently {
-  CompletionStage<Integer> execute();
-
-  default String getCaption() {
-    return getClass().getSimpleName();
-  }
-
+/**
+ * A task that can be run and canceled via the {@link RunnableTask#close()} method. The task may be
+ * running asynchronously or synchronously.
+ */
+@FunctionalInterface
+public interface RunnableTask extends Runnable, CloseableSilently {
   @Override
   default void close() {}
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ApplyRolloverPeriodJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ApplyRolloverPeriodJob.java
@@ -7,22 +7,14 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
-import org.slf4j.Logger;
+import io.camunda.exporter.tasks.RunnableTask;
 
-public class ApplyRolloverPeriodJob implements Runnable {
+public class ApplyRolloverPeriodJob implements RunnableTask {
 
   private final ArchiverRepository repository;
-  private final CamundaExporterMetrics metrics;
-  private final Logger logger;
 
-  public ApplyRolloverPeriodJob(
-      final ArchiverRepository repository,
-      final CamundaExporterMetrics metrics,
-      final Logger logger) {
+  public ApplyRolloverPeriodJob(final ArchiverRepository repository) {
     this.repository = repository;
-    this.metrics = metrics;
-    this.logger = logger;
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/AdditionalData.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/AdditionalData.java
@@ -9,11 +9,11 @@ package io.camunda.exporter.tasks.incident;
 
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentDocument;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /** Copied from the old post-importer */
 public record AdditionalData(
@@ -27,14 +27,14 @@ public record AdditionalData(
     Map<String, Set<String>> fniIdsWithIncidentIds) {
   public AdditionalData() {
     this(
-        new HashMap<>(),
-        new HashMap<>(),
-        new HashMap<>(),
-        new HashMap<>(),
-        new HashMap<>(),
-        new HashMap<>(),
-        new HashMap<>(),
-        new HashMap<>());
+        new ConcurrentHashMap<>(),
+        new ConcurrentHashMap<>(),
+        new ConcurrentHashMap<>(),
+        new ConcurrentHashMap<>(),
+        new ConcurrentHashMap<>(),
+        new ConcurrentHashMap<>(),
+        new ConcurrentHashMap<>(),
+        new ConcurrentHashMap<>());
   }
 
   public boolean addPiIdsWithIncidentIds(final String piId, final String incidentId) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -176,8 +176,7 @@ public final class ElasticsearchIncidentUpdateRepository extends ElasticsearchRe
 
               return r.hits().hits().stream()
                   .map(h -> h.source().get(OperationTemplate.PROCESS_INSTANCE_KEY))
-                  .map(Object::toString)
-                  .map(Long::valueOf)
+                  .map(v -> ((Number) v).longValue())
                   .collect(Collectors.toSet());
             },
             executor);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
@@ -11,11 +11,11 @@ import io.camunda.webapps.schema.entities.operate.IncidentEntity;
 import io.camunda.webapps.schema.entities.operate.IncidentState;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
 /**
@@ -152,7 +152,7 @@ public interface IncidentUpdateRepository extends AutoCloseable {
       Map<String, DocumentUpdate> flowNodeInstanceRequests,
       Map<String, DocumentUpdate> incidentRequests) {
     public IncidentBulkUpdate() {
-      this(new HashMap<>(), new HashMap<>(), new HashMap<>());
+      this(new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), new ConcurrentHashMap<>());
     }
 
     public Stream<DocumentUpdate> stream() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
@@ -13,10 +13,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -82,14 +82,13 @@ public interface IncidentUpdateRepository extends AutoCloseable {
       List<String> processInstanceIds);
 
   /**
-   * Returns whether the process instances were explicitly deleted, meaning a user executed an
+   * Returns the process instances that were explicitly deleted, meaning a user executed an
    * operation to explicitly delete them from the historic data.
    *
    * @param processInstanceKeys list of process instance keys
-   * @return a map of process instance keys to whether they were deleted
+   * @return a set of process instance keys that were deleted
    */
-  CompletionStage<Map<Long, Boolean>> wereProcessInstancesDeleted(
-      final List<Long> processInstanceKeys);
+  CompletionStage<Set<Long>> deletedProcessInstances(final Set<Long> processInstanceKeys);
 
   /**
    * Executes the given bulk update against the underlying document store, waiting until the
@@ -206,10 +205,8 @@ public interface IncidentUpdateRepository extends AutoCloseable {
     }
 
     @Override
-    public CompletionStage<Map<Long, Boolean>> wereProcessInstancesDeleted(
-        final List<Long> processInstanceKeys) {
-      return CompletableFuture.completedFuture(
-          processInstanceKeys.stream().collect(Collectors.toMap(key -> key, key -> false)));
+    public CompletionStage<Set<Long>> deletedProcessInstances(final Set<Long> processInstanceKeys) {
+      return CompletableFuture.completedFuture(Set.of());
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -81,13 +82,14 @@ public interface IncidentUpdateRepository extends AutoCloseable {
       List<String> processInstanceIds);
 
   /**
-   * Returns whether the process instance was explicitly deleted, meaning a user executed an
-   * operation to explicitly delete it from the historic data.
+   * Returns whether the process instances were explicitly deleted, meaning a user executed an
+   * operation to explicitly delete them from the historic data.
    *
-   * @param processInstanceKey the key of the process instance
-   * @return true if it was deleted, false otherwise
+   * @param processInstanceKeys list of process instance keys
+   * @return a map of process instance keys to whether they were deleted
    */
-  CompletionStage<Boolean> wasProcessInstanceDeleted(final long processInstanceKey);
+  CompletionStage<Map<Long, Boolean>> wereProcessInstancesDeleted(
+      final List<Long> processInstanceKeys);
 
   /**
    * Executes the given bulk update against the underlying document store, waiting until the
@@ -204,8 +206,10 @@ public interface IncidentUpdateRepository extends AutoCloseable {
     }
 
     @Override
-    public CompletionStage<Boolean> wasProcessInstanceDeleted(final long processInstanceKey) {
-      return CompletableFuture.completedFuture(false);
+    public CompletionStage<Map<Long, Boolean>> wereProcessInstancesDeleted(
+        final List<Long> processInstanceKeys) {
+      return CompletableFuture.completedFuture(
+          processInstanceKeys.stream().collect(Collectors.toMap(key -> key, key -> false)));
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -287,6 +287,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
     return mapActiveIncidentsToAffectedInstances(data)
         .thenComposeAsync(
             ignored ->
+                // processIncident one at a time, stopping if an error is raised
                 FuturesUtil.traverseIgnoring(
                     data.incidents().values(),
                     incident -> processIncidentInBatch(data, incident, batch, bulkUpdate),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -104,7 +104,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
    *   <li>BATCH: getPendingIncidentsBatch
    *   <li>BATCH: searchForInstances
    *       <ul>
-   *         <li>PARALLEL: checkDataAndCollectParentTreePaths (modifies state adding treePath)
+   *         <li>BATCH: checkDataAndCollectParentTreePaths (modifies state adding treePath)
    *       </ul>
    *   <li>BATCH: processIncidents
    *       <ul>

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -95,6 +95,29 @@ public final class IncidentUpdateTask implements BackgroundTask {
     return "Incident update task";
   }
 
+  /**
+   * To better document which methods run in parallel and which work on the entire batch, this is a
+   * simplified call stack hierarchy for incident processing:
+   *
+   * <p>processNextBatch
+   *
+   * <ul>
+   *   <li>BATCH: getPendingIncidentsBatch
+   *   <li>BATCH: searchForInstances
+   *       <ul>
+   *         <li>PARALLEL: checkDataAndCollectParentTreePaths (modifies state adding treePath)
+   *       </ul>
+   *   <li>BATCH: processIncidents
+   *       <ul>
+   *         <li>PARALLEL: mapActiveIncidentsToAffectedInstances (modifies state w/ computeIfAbsent)
+   *         <li>PARALLEL: processIncident
+   *             <ul>
+   *               <li>PARALLEL: createProcessInstanceUpdates
+   *             </ul>
+   *         <li>BATCH: BulkUpdate
+   *       </ul>
+   * </ul>
+   */
   private CompletableFuture<Integer> processNextBatch() {
     final var data = new AdditionalData();
     return getPendingIncidentsBatch(data)

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -240,7 +240,8 @@ public final class IncidentUpdateTask implements BackgroundTask {
       throw new ExporterException(
           """
         "%d process instances are not yet imported for incident post processing; operation will \
-        be retried..."""
+        be retried...
+        """
               .formatted(countMissingInstance));
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 import javax.annotation.WillCloseWhenClosed;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
@@ -35,7 +36,6 @@ import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
 import org.opensearch.client.opensearch.core.BulkRequest;
-import org.opensearch.client.opensearch.core.CountRequest;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
@@ -165,18 +165,41 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
   }
 
   @Override
-  public CompletionStage<Boolean> wasProcessInstanceDeleted(final long processInstanceKey) {
-    final var query = createProcessInstanceDeletedQuery(processInstanceKey);
+  public CompletionStage<Map<Long, Boolean>> wereProcessInstancesDeleted(
+      final List<Long> processInstanceKeys) {
+    final var query = createProcessInstanceDeletedQuery(processInstanceKeys);
     final var request =
-        new CountRequest.Builder()
+        new SearchRequest.Builder()
             .index(operationAlias)
             .query(query)
             .allowNoIndices(true)
             .ignoreUnavailable(true)
+            .size(0)
+            .aggregations(
+                "keys",
+                a ->
+                    a.terms(
+                        t ->
+                            t.field(OperationTemplate.PROCESS_INSTANCE_KEY)
+                                .size(processInstanceKeys.size())))
             .build();
 
     try {
-      return client.count(request).thenApplyAsync(r -> r.count() > 0, executor);
+      return client
+          .search(request, Void.class)
+          .thenApplyAsync(
+              r -> {
+                final var buckets = r.aggregations().get("keys").lterms().buckets().array();
+                final Map<Long, Boolean> matchedPIs = new HashMap<>();
+                for (final var key : processInstanceKeys) {
+                  matchedPIs.put(
+                      key,
+                      buckets.stream()
+                          .anyMatch(bucket -> bucket.key().equals(String.valueOf(key))));
+                }
+                return matchedPIs;
+              },
+              executor);
     } catch (final IOException e) {
       return CompletableFuture.failedFuture(e);
     }
@@ -255,11 +278,16 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
         request, IncidentEntity.class, h -> new ActiveIncident(h.id(), h.source().getTreePath()));
   }
 
-  private Query createProcessInstanceDeletedQuery(final long processInstanceKey) {
+  private Query createProcessInstanceDeletedQuery(final List<Long> processInstanceKeys) {
     final var piKeyQ =
-        QueryBuilders.term()
+        QueryBuilders.terms()
             .field(OperationTemplate.PROCESS_INSTANCE_KEY)
-            .value(v -> v.longValue(processInstanceKey))
+            .terms(
+                t ->
+                    t.value(
+                        processInstanceKeys.stream()
+                            .map(FieldValue::of)
+                            .collect(Collectors.toList())))
             .build()
             .toQuery();
     final var typeQ =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
@@ -189,8 +189,7 @@ public final class OpenSearchIncidentUpdateRepository extends OpensearchReposito
 
                 return r.hits().hits().stream()
                     .map(h -> h.source().get(OperationTemplate.PROCESS_INSTANCE_KEY))
-                    .map(Object::toString)
-                    .map(Long::valueOf)
+                    .map(v -> ((Number) v).longValue())
                     .collect(Collectors.toSet());
               },
               executor);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
@@ -56,7 +56,7 @@ final class ElasticsearchArchiverRepositoryTest {
     // then - would normally fail if tried to access ES, since there is no backing Elastic
     assertThat(result)
         .as("did not try connecting to non existent ES")
-        .succeedsWithin(Duration.ZERO);
+        .succeedsWithin(Duration.ofSeconds(5));
   }
 
   private ElasticsearchArchiverRepository createRepository() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
@@ -55,7 +55,7 @@ final class OpenSearchArchiverRepositoryTest {
     // then - would normally fail if tried to access ES, since there is no backing Elastic
     assertThat(result)
         .as("did not try connecting to non existent ES")
-        .succeedsWithin(Duration.ZERO);
+        .succeedsWithin(Duration.ofSeconds(5));
   }
 
   private OpenSearchArchiverRepository createRepository() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -54,6 +54,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.LongStream;
@@ -671,11 +672,10 @@ abstract class IncidentUpdateRepositoryIT {
       batchRequest.executeWithRefresh();
 
       // when
-      final var wasDeleted = repository.wereProcessInstancesDeleted(List.of(1L));
+      final var wasDeleted = repository.deletedProcessInstances(Set.of(1L));
 
       // then
-      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(Map.of(1L, false));
-      // assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(false);
+      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(Set.of());
     }
 
     @Test
@@ -692,10 +692,10 @@ abstract class IncidentUpdateRepositoryIT {
       batchRequest.executeWithRefresh();
 
       // when
-      final var wasDeleted = repository.wereProcessInstancesDeleted(List.of(1L));
+      final var wasDeleted = repository.deletedProcessInstances(Set.of(1L));
 
       // then
-      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(Map.of(1L, false));
+      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(Set.of());
     }
 
     @ParameterizedTest
@@ -717,11 +717,10 @@ abstract class IncidentUpdateRepositoryIT {
       batchRequest.executeWithRefresh();
 
       // when
-      final var wasDeleted = repository.wereProcessInstancesDeleted(List.of(1L));
+      final var wasDeleted = repository.deletedProcessInstances(Set.of());
 
       // then
-      // assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(false);
-      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(Map.of(1L, false));
+      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(Set.of());
     }
 
     @ParameterizedTest
@@ -742,11 +741,10 @@ abstract class IncidentUpdateRepositoryIT {
       batchRequest.executeWithRefresh();
 
       // when
-      final var wasDeleted = repository.wereProcessInstancesDeleted(List.of(1L));
+      final var wasDeleted = repository.deletedProcessInstances(Set.of(1L));
 
       // then
-      // assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(true);
-      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(Map.of(1L, true));
+      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(Set.of(1L));
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -671,10 +671,11 @@ abstract class IncidentUpdateRepositoryIT {
       batchRequest.executeWithRefresh();
 
       // when
-      final var wasDeleted = repository.wasProcessInstanceDeleted(1L);
+      final var wasDeleted = repository.wereProcessInstancesDeleted(List.of(1L));
 
       // then
-      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(false);
+      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(Map.of(1L, false));
+      // assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(false);
     }
 
     @Test
@@ -691,10 +692,10 @@ abstract class IncidentUpdateRepositoryIT {
       batchRequest.executeWithRefresh();
 
       // when
-      final var wasDeleted = repository.wasProcessInstanceDeleted(1L);
+      final var wasDeleted = repository.wereProcessInstancesDeleted(List.of(1L));
 
       // then
-      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(false);
+      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(Map.of(1L, false));
     }
 
     @ParameterizedTest
@@ -716,10 +717,11 @@ abstract class IncidentUpdateRepositoryIT {
       batchRequest.executeWithRefresh();
 
       // when
-      final var wasDeleted = repository.wasProcessInstanceDeleted(1L);
+      final var wasDeleted = repository.wereProcessInstancesDeleted(List.of(1L));
 
       // then
-      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(false);
+      // assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(false);
+      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(Map.of(1L, false));
     }
 
     @ParameterizedTest
@@ -740,10 +742,11 @@ abstract class IncidentUpdateRepositoryIT {
       batchRequest.executeWithRefresh();
 
       // when
-      final var wasDeleted = repository.wasProcessInstanceDeleted(1L);
+      final var wasDeleted = repository.wereProcessInstancesDeleted(List.of(1L));
 
       // then
-      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(true);
+      // assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(true);
+      assertThat(wasDeleted).succeedsWithin(REQUEST_TIMEOUT).isEqualTo(Map.of(1L, true));
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -44,6 +44,7 @@ import org.slf4j.LoggerFactory;
 
 final class IncidentUpdateTaskTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(IncidentUpdateTaskTest.class);
+  private static final Duration TIMEOUT = Duration.ofSeconds(5);
 
   @AutoClose
   private static final ScheduledThreadPoolExecutor EXECUTOR = new ScheduledThreadPoolExecutor(1);
@@ -60,7 +61,7 @@ final class IncidentUpdateTaskTest {
     final var result = task.execute();
 
     // then
-    assertThat(result).succeedsWithin(Duration.ofSeconds(5)).isEqualTo(0);
+    assertThat(result).succeedsWithin(TIMEOUT).isEqualTo(0);
   }
 
   @Test
@@ -257,7 +258,7 @@ final class IncidentUpdateTaskTest {
 
       // then
       assertThat(result)
-          .succeedsWithin(Duration.ofSeconds(5))
+          .succeedsWithin(TIMEOUT)
           .asInstanceOf(InstanceOfAssertFactories.INTEGER)
           .isEqualTo(7);
     }
@@ -274,7 +275,7 @@ final class IncidentUpdateTaskTest {
 
       // then
       assertThat(result)
-          .failsWithin(Duration.ofSeconds(5))
+          .failsWithin(TIMEOUT)
           .withThrowableThat()
           .withRootCauseExactlyInstanceOf(ExporterException.class)
           .withMessageContaining("Failed to fetch incidents");
@@ -292,7 +293,7 @@ final class IncidentUpdateTaskTest {
 
       // then
       assertThat(result)
-          .failsWithin(Duration.ofSeconds(5))
+          .failsWithin(TIMEOUT)
           .withThrowableThat()
           .withRootCauseExactlyInstanceOf(ExporterException.class)
           .withMessageContaining("Process instance 3 is not yet imported for incident 5");
@@ -310,7 +311,7 @@ final class IncidentUpdateTaskTest {
 
       // then
       assertThat(result)
-          .failsWithin(Duration.ofSeconds(5))
+          .failsWithin(TIMEOUT)
           .withThrowableThat()
           .withRootCauseExactlyInstanceOf(ExporterException.class)
           .withMessageContaining("Flow node instance 2 affected by incident 5");
@@ -328,7 +329,7 @@ final class IncidentUpdateTaskTest {
 
       // then
       assertThat(result)
-          .failsWithin(Duration.ofSeconds(5))
+          .failsWithin(TIMEOUT)
           .withThrowableThat()
           .withRootCauseExactlyInstanceOf(ExporterException.class)
           .withMessageContaining("Flow node instance 2 affected by incident 5");
@@ -344,7 +345,7 @@ final class IncidentUpdateTaskTest {
       final var result = task.execute();
 
       // then
-      assertThat(result).succeedsWithin(Duration.ofSeconds(5));
+      assertThat(result).succeedsWithin(TIMEOUT);
       assertThat(repository.updated.incidentRequests())
           .hasSize(1)
           .containsEntry(
@@ -370,7 +371,7 @@ final class IncidentUpdateTaskTest {
       final var result = task.execute();
 
       // then
-      assertThat(result).succeedsWithin(Duration.ofSeconds(5));
+      assertThat(result).succeedsWithin(TIMEOUT);
       assertThat(repository.updated.listViewRequests())
           .hasSize(4)
           .containsEntry(
@@ -397,7 +398,7 @@ final class IncidentUpdateTaskTest {
       final var result = task.execute();
 
       // then
-      assertThat(result).succeedsWithin(Duration.ofSeconds(5));
+      assertThat(result).succeedsWithin(TIMEOUT);
       assertThat(repository.updated.flowNodeInstanceRequests())
           .hasSize(2)
           .containsEntry(
@@ -428,7 +429,7 @@ final class IncidentUpdateTaskTest {
       final var result = task.execute();
 
       // then
-      assertThat(result).succeedsWithin(Duration.ofSeconds(5));
+      assertThat(result).succeedsWithin(TIMEOUT);
       assertThat(repository.updated.incidentRequests())
           .hasSize(1)
           .containsEntry(
@@ -483,7 +484,7 @@ final class IncidentUpdateTaskTest {
 
       // then - we should mark the child process instance, the call activity, and the task as
       // incident free, but NOT the parent process instance as it still has an active incident
-      assertThat(result).succeedsWithin(Duration.ofSeconds(5));
+      assertThat(result).succeedsWithin(TIMEOUT);
       assertThat(repository.updated.incidentRequests())
           .hasSize(1)
           .containsEntry(
@@ -526,7 +527,7 @@ final class IncidentUpdateTaskTest {
       final var result = task.execute();
 
       // then
-      assertThat(result).succeedsWithin(Duration.ofSeconds(5));
+      assertThat(result).succeedsWithin(TIMEOUT);
       assertThat(repository.updated.listViewRequests()).isEmpty();
       assertThat(repository.updated.incidentRequests()).isEmpty();
       assertThat(repository.updated.flowNodeInstanceRequests()).isEmpty();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -48,19 +48,19 @@ final class IncidentUpdateTaskTest {
   @Test
   void shouldReturnNothingDoneOnEmptyPendingBatch() {
     // given
-    final var task = new IncidentUpdateTask(metadata, repository, false, 10, LOGGER);
+    final var task = new IncidentUpdateTask(metadata, repository, false, 10, Runnable::run, LOGGER);
 
     // when
     final var result = task.execute();
 
     // then
-    assertThat(result).succeedsWithin(Duration.ZERO).isEqualTo(0);
+    assertThat(result).succeedsWithin(Duration.ofSeconds(5)).isEqualTo(0);
   }
 
   @Test
   void shouldUseMetadataPositionToFetchPendingBatch() {
     // given
-    final var task = new IncidentUpdateTask(metadata, repository, false, 10, LOGGER);
+    final var task = new IncidentUpdateTask(metadata, repository, false, 10, Runnable::run, LOGGER);
     metadata.setLastIncidentUpdatePosition(5);
 
     // when
@@ -73,7 +73,7 @@ final class IncidentUpdateTaskTest {
   @Test
   void shouldUseBatchSizeToFetchPendingBatch() {
     // given
-    final var task = new IncidentUpdateTask(metadata, repository, false, 10, LOGGER);
+    final var task = new IncidentUpdateTask(metadata, repository, false, 10, Runnable::run, LOGGER);
 
     // when
     task.execute().toCompletableFuture().join();
@@ -232,7 +232,8 @@ final class IncidentUpdateTaskTest {
     @Test
     void shouldUpdateMetadataOnSuccess() {
       // given
-      final var task = new IncidentUpdateTask(metadata, repository, false, 10, LOGGER);
+      final var task =
+          new IncidentUpdateTask(metadata, repository, false, 10, Runnable::run, LOGGER);
 
       // when
       task.execute().toCompletableFuture().join();
@@ -244,14 +245,15 @@ final class IncidentUpdateTaskTest {
     @Test
     void shouldReturnNumberOfDocumentsUpdated() {
       // given
-      final var task = new IncidentUpdateTask(metadata, repository, false, 10, LOGGER);
+      final var task =
+          new IncidentUpdateTask(metadata, repository, false, 10, Runnable::run, LOGGER);
 
       // when
       final var result = task.execute();
 
       // then
       assertThat(result)
-          .succeedsWithin(Duration.ZERO)
+          .succeedsWithin(Duration.ofSeconds(5))
           .asInstanceOf(InstanceOfAssertFactories.INTEGER)
           .isEqualTo(7);
     }
@@ -260,7 +262,8 @@ final class IncidentUpdateTaskTest {
     void shouldFailOnMissingIncident() {
       // given
       final var task =
-          new IncidentUpdateTask(metadata, repository, false, 10, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(
+              metadata, repository, false, 10, Runnable::run, LOGGER, Duration.ZERO);
       repository.incidents = CompletableFuture.completedFuture(Map.of());
 
       // when
@@ -268,7 +271,7 @@ final class IncidentUpdateTaskTest {
 
       // then
       assertThat(result)
-          .failsWithin(Duration.ZERO)
+          .failsWithin(Duration.ofSeconds(5))
           .withThrowableThat()
           .withRootCauseExactlyInstanceOf(ExporterException.class)
           .withMessageContaining("Failed to fetch incidents");
@@ -278,7 +281,8 @@ final class IncidentUpdateTaskTest {
     void shouldFailOnMissingProcessInstance() {
       // given
       final var task =
-          new IncidentUpdateTask(metadata, repository, false, 10, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(
+              metadata, repository, false, 10, Runnable::run, LOGGER, Duration.ZERO);
       repository.processInstances = CompletableFuture.completedFuture(List.of());
 
       // when
@@ -286,7 +290,7 @@ final class IncidentUpdateTaskTest {
 
       // then
       assertThat(result)
-          .failsWithin(Duration.ZERO)
+          .failsWithin(Duration.ofSeconds(5))
           .withThrowableThat()
           .withRootCauseExactlyInstanceOf(ExporterException.class)
           .withMessageContaining("Process instance 3 is not yet imported for incident 5");
@@ -296,7 +300,8 @@ final class IncidentUpdateTaskTest {
     void shouldFailOnMissingFlowNodeInstance() {
       // given
       final var task =
-          new IncidentUpdateTask(metadata, repository, false, 10, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(
+              metadata, repository, false, 10, Runnable::run, LOGGER, Duration.ZERO);
       repository.flowNodesInListView = CompletableFuture.completedFuture(List.of());
 
       // when
@@ -304,7 +309,7 @@ final class IncidentUpdateTaskTest {
 
       // then
       assertThat(result)
-          .failsWithin(Duration.ZERO)
+          .failsWithin(Duration.ofSeconds(5))
           .withThrowableThat()
           .withRootCauseExactlyInstanceOf(ExporterException.class)
           .withMessageContaining("Flow node instance 2 affected by incident 5");
@@ -314,7 +319,8 @@ final class IncidentUpdateTaskTest {
     void shouldFailOnMissingFlowNode() {
       // given
       final var task =
-          new IncidentUpdateTask(metadata, repository, false, 10, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(
+              metadata, repository, false, 10, Runnable::run, LOGGER, Duration.ZERO);
       repository.flowNodeInstances = CompletableFuture.completedFuture(List.of());
 
       // when
@@ -322,7 +328,7 @@ final class IncidentUpdateTaskTest {
 
       // then
       assertThat(result)
-          .failsWithin(Duration.ZERO)
+          .failsWithin(Duration.ofSeconds(5))
           .withThrowableThat()
           .withRootCauseExactlyInstanceOf(ExporterException.class)
           .withMessageContaining("Flow node instance 2 affected by incident 5");
@@ -332,13 +338,14 @@ final class IncidentUpdateTaskTest {
     void shouldUpdateIncidents() {
       // given
       final var task =
-          new IncidentUpdateTask(metadata, repository, false, 10, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(
+              metadata, repository, false, 10, Runnable::run, LOGGER, Duration.ZERO);
 
       // when
       final var result = task.execute();
 
       // then
-      assertThat(result).succeedsWithin(Duration.ZERO);
+      assertThat(result).succeedsWithin(Duration.ofSeconds(5));
       assertThat(repository.updated.incidentRequests())
           .hasSize(1)
           .containsEntry(
@@ -358,13 +365,14 @@ final class IncidentUpdateTaskTest {
     void shouldUpdateListView() {
       // given
       final var task =
-          new IncidentUpdateTask(metadata, repository, false, 10, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(
+              metadata, repository, false, 10, Runnable::run, LOGGER, Duration.ZERO);
 
       // when
       final var result = task.execute();
 
       // then
-      assertThat(result).succeedsWithin(Duration.ZERO);
+      assertThat(result).succeedsWithin(Duration.ofSeconds(5));
       assertThat(repository.updated.listViewRequests())
           .hasSize(4)
           .containsEntry(
@@ -385,13 +393,14 @@ final class IncidentUpdateTaskTest {
     void shouldUpdateFlowNode() {
       // given
       final var task =
-          new IncidentUpdateTask(metadata, repository, false, 10, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(
+              metadata, repository, false, 10, Runnable::run, LOGGER, Duration.ZERO);
 
       // when
       final var result = task.execute();
 
       // then
-      assertThat(result).succeedsWithin(Duration.ZERO);
+      assertThat(result).succeedsWithin(Duration.ofSeconds(5));
       assertThat(repository.updated.flowNodeInstanceRequests())
           .hasSize(2)
           .containsEntry(
@@ -408,7 +417,8 @@ final class IncidentUpdateTaskTest {
     void shouldResolveIncident() {
       // given
       final var task =
-          new IncidentUpdateTask(metadata, repository, false, 10, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(
+              metadata, repository, false, 10, Runnable::run, LOGGER, Duration.ZERO);
       incidentEntity.setState(IncidentState.ACTIVE);
       repository.activeIncidentsByTreePaths =
           CompletableFuture.completedFuture(
@@ -422,7 +432,7 @@ final class IncidentUpdateTaskTest {
       final var result = task.execute();
 
       // then
-      assertThat(result).succeedsWithin(Duration.ZERO);
+      assertThat(result).succeedsWithin(Duration.ofSeconds(5));
       assertThat(repository.updated.incidentRequests())
           .hasSize(1)
           .containsEntry(
@@ -460,7 +470,8 @@ final class IncidentUpdateTaskTest {
       // given - we have another active incident with an overlapping tree path, but only covering
       // process instance
       final var task =
-          new IncidentUpdateTask(metadata, repository, false, 10, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(
+              metadata, repository, false, 10, Runnable::run, LOGGER, Duration.ZERO);
       incidentEntity.setState(IncidentState.ACTIVE);
       repository.activeIncidentsByTreePaths =
           CompletableFuture.completedFuture(
@@ -477,7 +488,7 @@ final class IncidentUpdateTaskTest {
 
       // then - we should mark the child process instance, the call activity, and the task as
       // incident free, but NOT the parent process instance as it still has an active incident
-      assertThat(result).succeedsWithin(Duration.ZERO);
+      assertThat(result).succeedsWithin(Duration.ofSeconds(5));
       assertThat(repository.updated.incidentRequests())
           .hasSize(1)
           .containsEntry(
@@ -511,7 +522,8 @@ final class IncidentUpdateTaskTest {
     void shouldIgnoreDeletedProcessInstance() {
       // given
       final var task =
-          new IncidentUpdateTask(metadata, repository, false, 10, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(
+              metadata, repository, false, 10, Runnable::run, LOGGER, Duration.ZERO);
       repository.processInstances =
           CompletableFuture.completedFuture(List.of(parentProcessInstance));
       repository.wasProcessInstanceDeleted = CompletableFuture.completedFuture(true);
@@ -520,7 +532,7 @@ final class IncidentUpdateTaskTest {
       final var result = task.execute();
 
       // then
-      assertThat(result).succeedsWithin(Duration.ZERO);
+      assertThat(result).succeedsWithin(Duration.ofSeconds(5));
       assertThat(repository.updated.listViewRequests()).isEmpty();
       assertThat(repository.updated.incidentRequests()).isEmpty();
       assertThat(repository.updated.flowNodeInstanceRequests()).isEmpty();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -32,7 +32,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -42,13 +44,14 @@ import org.slf4j.LoggerFactory;
 
 final class IncidentUpdateTaskTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(IncidentUpdateTaskTest.class);
+  @AutoClose  private static final ScheduledThreadPoolExecutor EXECUTOR = new ScheduledThreadPoolExecutor(1);
   private final ExporterMetadata metadata = new ExporterMetadata(TestObjectMapper.objectMapper());
   private final TestRepository repository = Mockito.spy(new TestRepository());
 
   @Test
   void shouldReturnNothingDoneOnEmptyPendingBatch() {
     // given
-    final var task = new IncidentUpdateTask(metadata, repository, false, 10, Runnable::run, LOGGER);
+    final var task = new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER);
 
     // when
     final var result = task.execute();
@@ -60,7 +63,7 @@ final class IncidentUpdateTaskTest {
   @Test
   void shouldUseMetadataPositionToFetchPendingBatch() {
     // given
-    final var task = new IncidentUpdateTask(metadata, repository, false, 10, Runnable::run, LOGGER);
+    final var task = new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER);
     metadata.setLastIncidentUpdatePosition(5);
 
     // when
@@ -73,7 +76,7 @@ final class IncidentUpdateTaskTest {
   @Test
   void shouldUseBatchSizeToFetchPendingBatch() {
     // given
-    final var task = new IncidentUpdateTask(metadata, repository, false, 10, Runnable::run, LOGGER);
+    final var task = new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER);
 
     // when
     task.execute().toCompletableFuture().join();
@@ -233,7 +236,7 @@ final class IncidentUpdateTaskTest {
     void shouldUpdateMetadataOnSuccess() {
       // given
       final var task =
-          new IncidentUpdateTask(metadata, repository, false, 10, Runnable::run, LOGGER);
+          new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER);
 
       // when
       task.execute().toCompletableFuture().join();
@@ -246,7 +249,7 @@ final class IncidentUpdateTaskTest {
     void shouldReturnNumberOfDocumentsUpdated() {
       // given
       final var task =
-          new IncidentUpdateTask(metadata, repository, false, 10, Runnable::run, LOGGER);
+          new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER);
 
       // when
       final var result = task.execute();
@@ -263,7 +266,7 @@ final class IncidentUpdateTaskTest {
       // given
       final var task =
           new IncidentUpdateTask(
-              metadata, repository, false, 10, Runnable::run, LOGGER, Duration.ZERO);
+              metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
       repository.incidents = CompletableFuture.completedFuture(Map.of());
 
       // when
@@ -282,7 +285,7 @@ final class IncidentUpdateTaskTest {
       // given
       final var task =
           new IncidentUpdateTask(
-              metadata, repository, false, 10, Runnable::run, LOGGER, Duration.ZERO);
+              metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
       repository.processInstances = CompletableFuture.completedFuture(List.of());
 
       // when
@@ -301,7 +304,7 @@ final class IncidentUpdateTaskTest {
       // given
       final var task =
           new IncidentUpdateTask(
-              metadata, repository, false, 10, Runnable::run, LOGGER, Duration.ZERO);
+              metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
       repository.flowNodesInListView = CompletableFuture.completedFuture(List.of());
 
       // when
@@ -320,7 +323,7 @@ final class IncidentUpdateTaskTest {
       // given
       final var task =
           new IncidentUpdateTask(
-              metadata, repository, false, 10, Runnable::run, LOGGER, Duration.ZERO);
+              metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
       repository.flowNodeInstances = CompletableFuture.completedFuture(List.of());
 
       // when
@@ -339,7 +342,7 @@ final class IncidentUpdateTaskTest {
       // given
       final var task =
           new IncidentUpdateTask(
-              metadata, repository, false, 10, Runnable::run, LOGGER, Duration.ZERO);
+              metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
 
       // when
       final var result = task.execute();
@@ -366,7 +369,7 @@ final class IncidentUpdateTaskTest {
       // given
       final var task =
           new IncidentUpdateTask(
-              metadata, repository, false, 10, Runnable::run, LOGGER, Duration.ZERO);
+              metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
 
       // when
       final var result = task.execute();
@@ -394,7 +397,7 @@ final class IncidentUpdateTaskTest {
       // given
       final var task =
           new IncidentUpdateTask(
-              metadata, repository, false, 10, Runnable::run, LOGGER, Duration.ZERO);
+              metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
 
       // when
       final var result = task.execute();
@@ -418,7 +421,7 @@ final class IncidentUpdateTaskTest {
       // given
       final var task =
           new IncidentUpdateTask(
-              metadata, repository, false, 10, Runnable::run, LOGGER, Duration.ZERO);
+              metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
       incidentEntity.setState(IncidentState.ACTIVE);
       repository.activeIncidentsByTreePaths =
           CompletableFuture.completedFuture(
@@ -471,7 +474,7 @@ final class IncidentUpdateTaskTest {
       // process instance
       final var task =
           new IncidentUpdateTask(
-              metadata, repository, false, 10, Runnable::run, LOGGER, Duration.ZERO);
+              metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
       incidentEntity.setState(IncidentState.ACTIVE);
       repository.activeIncidentsByTreePaths =
           CompletableFuture.completedFuture(
@@ -523,7 +526,7 @@ final class IncidentUpdateTaskTest {
       // given
       final var task =
           new IncidentUpdateTask(
-              metadata, repository, false, 10, Runnable::run, LOGGER, Duration.ZERO);
+              metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
       repository.processInstances =
           CompletableFuture.completedFuture(List.of(parentProcessInstance));
       repository.wasProcessInstanceDeleted = CompletableFuture.completedFuture(true);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -44,7 +44,10 @@ import org.slf4j.LoggerFactory;
 
 final class IncidentUpdateTaskTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(IncidentUpdateTaskTest.class);
-  @AutoClose  private static final ScheduledThreadPoolExecutor EXECUTOR = new ScheduledThreadPoolExecutor(1);
+
+  @AutoClose
+  private static final ScheduledThreadPoolExecutor EXECUTOR = new ScheduledThreadPoolExecutor(1);
+
   private final ExporterMetadata metadata = new ExporterMetadata(TestObjectMapper.objectMapper());
   private final TestRepository repository = Mockito.spy(new TestRepository());
 
@@ -235,8 +238,7 @@ final class IncidentUpdateTaskTest {
     @Test
     void shouldUpdateMetadataOnSuccess() {
       // given
-      final var task =
-          new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER);
+      final var task = new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER);
 
       // when
       task.execute().toCompletableFuture().join();
@@ -248,8 +250,7 @@ final class IncidentUpdateTaskTest {
     @Test
     void shouldReturnNumberOfDocumentsUpdated() {
       // given
-      final var task =
-          new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER);
+      final var task = new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER);
 
       // when
       final var result = task.execute();
@@ -265,8 +266,7 @@ final class IncidentUpdateTaskTest {
     void shouldFailOnMissingIncident() {
       // given
       final var task =
-          new IncidentUpdateTask(
-              metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
       repository.incidents = CompletableFuture.completedFuture(Map.of());
 
       // when
@@ -284,8 +284,7 @@ final class IncidentUpdateTaskTest {
     void shouldFailOnMissingProcessInstance() {
       // given
       final var task =
-          new IncidentUpdateTask(
-              metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
       repository.processInstances = CompletableFuture.completedFuture(List.of());
 
       // when
@@ -303,8 +302,7 @@ final class IncidentUpdateTaskTest {
     void shouldFailOnMissingFlowNodeInstance() {
       // given
       final var task =
-          new IncidentUpdateTask(
-              metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
       repository.flowNodesInListView = CompletableFuture.completedFuture(List.of());
 
       // when
@@ -322,8 +320,7 @@ final class IncidentUpdateTaskTest {
     void shouldFailOnMissingFlowNode() {
       // given
       final var task =
-          new IncidentUpdateTask(
-              metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
       repository.flowNodeInstances = CompletableFuture.completedFuture(List.of());
 
       // when
@@ -341,8 +338,7 @@ final class IncidentUpdateTaskTest {
     void shouldUpdateIncidents() {
       // given
       final var task =
-          new IncidentUpdateTask(
-              metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
 
       // when
       final var result = task.execute();
@@ -368,8 +364,7 @@ final class IncidentUpdateTaskTest {
     void shouldUpdateListView() {
       // given
       final var task =
-          new IncidentUpdateTask(
-              metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
 
       // when
       final var result = task.execute();
@@ -396,8 +391,7 @@ final class IncidentUpdateTaskTest {
     void shouldUpdateFlowNode() {
       // given
       final var task =
-          new IncidentUpdateTask(
-              metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
 
       // when
       final var result = task.execute();
@@ -420,8 +414,7 @@ final class IncidentUpdateTaskTest {
     void shouldResolveIncident() {
       // given
       final var task =
-          new IncidentUpdateTask(
-              metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
       incidentEntity.setState(IncidentState.ACTIVE);
       repository.activeIncidentsByTreePaths =
           CompletableFuture.completedFuture(
@@ -473,8 +466,7 @@ final class IncidentUpdateTaskTest {
       // given - we have another active incident with an overlapping tree path, but only covering
       // process instance
       final var task =
-          new IncidentUpdateTask(
-              metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
       incidentEntity.setState(IncidentState.ACTIVE);
       repository.activeIncidentsByTreePaths =
           CompletableFuture.completedFuture(
@@ -525,8 +517,7 @@ final class IncidentUpdateTaskTest {
     void shouldIgnoreDeletedProcessInstance() {
       // given
       final var task =
-          new IncidentUpdateTask(
-              metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
+          new IncidentUpdateTask(metadata, repository, false, 10, EXECUTOR, LOGGER, Duration.ZERO);
       repository.processInstances =
           CompletableFuture.completedFuture(List.of(parentProcessInstance));
       repository.wasProcessInstanceDeleted = CompletableFuture.completedFuture(true);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.stream.Collectors;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
@@ -138,10 +139,14 @@ final class IncidentUpdateTaskTest {
     }
 
     @Override
-    public CompletionStage<Boolean> wasProcessInstanceDeleted(final long processInstanceKey) {
+    public CompletionStage<Map<Long, Boolean>> wereProcessInstancesDeleted(
+        final List<Long> processInstanceKeys) {
       return wasProcessInstanceDeleted != null
-          ? wasProcessInstanceDeleted
-          : super.wasProcessInstanceDeleted(processInstanceKey);
+          ? CompletableFuture.completedFuture(
+              processInstanceKeys.stream()
+                  .collect(
+                      Collectors.toMap(key -> key, key -> wasProcessInstanceDeleted.getNow(false))))
+          : super.wereProcessInstancesDeleted(processInstanceKeys);
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -30,10 +30,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.stream.Collectors;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
@@ -139,14 +139,10 @@ final class IncidentUpdateTaskTest {
     }
 
     @Override
-    public CompletionStage<Map<Long, Boolean>> wereProcessInstancesDeleted(
-        final List<Long> processInstanceKeys) {
+    public CompletionStage<Set<Long>> deletedProcessInstances(final Set<Long> processInstanceKeys) {
       return wasProcessInstanceDeleted != null
-          ? CompletableFuture.completedFuture(
-              processInstanceKeys.stream()
-                  .collect(
-                      Collectors.toMap(key -> key, key -> wasProcessInstanceDeleted.getNow(false))))
-          : super.wereProcessInstancesDeleted(processInstanceKeys);
+          ? CompletableFuture.completedFuture(processInstanceKeys)
+          : super.deletedProcessInstances(processInstanceKeys);
     }
 
     @Override

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/stream/JobStreamConsumerTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/stream/JobStreamConsumerTest.java
@@ -95,7 +95,7 @@ final class JobStreamConsumerTest {
     final var result = consumer.push(BufferUtil.createCopy(job));
 
     // then
-    assertThat(result).succeedsWithin(Duration.ZERO);
+    assertThat(result).succeedsWithin(Duration.ofSeconds(5));
     assertThat(clientObserver.error).isNull();
     assertThat(clientObserver.pushed).extracting(ActivatedJob::getKey).containsExactly(1L);
   }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/concurrency/FuturesUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/concurrency/FuturesUtil.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util.concurrency;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+
+public class FuturesUtil {
+
+  /**
+   * Traverse the provided collection sequentially, applying the provided function making sure that
+   * the futures are started sequentially: When one computation completes, the next starts after it.
+   *
+   * @param collection to traverse to use as input for the function
+   * @param function the computation to execute for each element of the collection
+   * @return a Void future that will complete successfully if all Futures started complete
+   *     successfully. if one future returns an error, the computation is stopped (the rest of the
+   *     Future will not be started) and the error is returned
+   */
+  public static <A> CompletableFuture<Void> traverseIgnoring(
+      final Collection<A> collection,
+      final Function<A, CompletableFuture<Void>> function,
+      final Executor executor) {
+    var future = CompletableFuture.<Void>completedFuture(null);
+    for (final A a : collection) {
+      future = future.thenComposeAsync(unused -> function.apply(a), executor);
+    }
+    return future;
+  }
+
+  /**
+   * Traverse the collection and starts all futures immediately without waiting for completion, then
+   * wait for all tasks to be completed and then return a List containing all results. If any error
+   * is encountered, the returned future fails, but it will spawn one CompletableFuture for each
+   * element in the collection.
+   *
+   * @param collection the collection containing the element to traverse
+   * @param function the task that will be spawned
+   * @return a CompletableFuture with all the results combined
+   */
+  @SuppressWarnings("unchecked")
+  public static <A, B> CompletableFuture<List<B>> parTraverse(
+      final Collection<A> collection, final Function<A, CompletableFuture<B>> function) {
+    final CompletableFuture<B>[] futures =
+        collection.stream().map(function).toArray(CompletableFuture[]::new);
+    return CompletableFuture.allOf(futures)
+        .thenApply(unused -> Arrays.stream(futures).map(CompletableFuture::join).toList());
+  }
+}

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/concurrent/FuturesUtilTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/concurrent/FuturesUtilTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util.concurrent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.util.concurrency.FuturesUtil;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class FuturesUtilTest {
+  @AutoClose private static final ExecutorService EXECUTOR = Executors.newWorkStealingPool();
+
+  @Nested
+  class TraverseIgnoring {
+    @Test
+    public void shouldReturnCompletedFutureWhenCollectionIsEmpty() {
+      assertThat(
+              FuturesUtil.traverseIgnoring(
+                  List.of(), a -> CompletableFuture.supplyAsync(() -> null), EXECUTOR))
+          .isCompleted();
+    }
+
+    @Test
+    public void shouldRunAllFuturesSequentially() {
+      // given
+      final var count = 1000;
+      final var map = new CopyOnWriteArrayList<>();
+      final var elements = new ArrayList<Integer>(count);
+      for (int i = 0; i < count; i++) {
+        elements.add(i);
+      }
+      // when
+      FuturesUtil.traverseIgnoring(
+              elements, i -> CompletableFuture.runAsync(() -> map.add(i)), EXECUTOR)
+          .join();
+      // then
+      assertThat(map).containsExactlyElementsOf(elements);
+    }
+
+    @Test
+    public void shouldStopAndReturnErrorIfAFutureFails() {
+      // given
+      final var map = new ConcurrentHashMap<>();
+      // when
+      final var future =
+          FuturesUtil.traverseIgnoring(
+              List.of(1, 2, 3),
+              i ->
+                  i % 2 == 0
+                      ? CompletableFuture.failedFuture(new RuntimeException("Expected"))
+                      : CompletableFuture.runAsync(() -> map.put(i, i)),
+              EXECUTOR);
+      // then
+      assertThat(future)
+          .failsWithin(Duration.ofSeconds(5))
+          .withThrowableThat()
+          .withMessageContaining("Expected");
+      // does not contain 3 as the computation is not spawned
+      assertThat(map.keySet()).containsExactly(1);
+    }
+  }
+
+  @Nested
+  class ParTraversse {
+
+    @Test
+    public void shouldReturnCompletedFutureWhenCollectionIsEmpty() {
+      assertThat(FuturesUtil.parTraverse(List.of(), a -> CompletableFuture.supplyAsync(() -> null)))
+          .isCompleted();
+    }
+
+    @Test
+    public void shouldRunAllFuturesSequentially() {
+      // given
+      final var count = 1000;
+      final var map = new CopyOnWriteArrayList<>();
+      final var elements = new ArrayList<Integer>(count);
+      for (int i = 0; i < count; i++) {
+        elements.add(i);
+      }
+      // when
+      FuturesUtil.parTraverse(elements, i -> CompletableFuture.runAsync(() -> map.add(i))).join();
+      // then
+      assertThat(map).containsExactlyInAnyOrderElementsOf(elements);
+    }
+
+    @Test
+    public void shouldStopAndReturnErrorIfAFutureFails() {
+      // given
+      final var map = new ConcurrentHashMap<>();
+      // when
+      final var future =
+          FuturesUtil.parTraverse(
+              List.of(1, 2, 3, 4, 5),
+              i ->
+                  i % 2 == 0
+                      ? CompletableFuture.failedFuture(new RuntimeException("Expected"))
+                      : CompletableFuture.runAsync(() -> map.put(i, i)));
+      // then
+      assertThat(future)
+          .failsWithin(Duration.ofSeconds(5))
+          .withThrowableThat()
+          .withMessageContaining("Expected");
+      // contains all odd numbers, because the all computation have been spawned immediately
+      assertThat(map.keySet()).containsExactly(1, 3, 5);
+    }
+  }
+}


### PR DESCRIPTION
## Description
The purpose of this PR is refactor the IncidentUpdateTask in a way that it does not block any threads with `.join()` calls and try to parallelize as much as possible.
In order to perform causal ordering when processing incidents, only one incident is processed at a given time.
A couple of tasks have been parallelized and are mostly about fetching necessary data before processing the incidents:
- `searchForInstances > checkDataAndCollectParentTreePaths` : data is collected in parallel 
- `processIncident > createFlowNodeInstanceUpdates`: flow node instances are fetched in parallel if necessary

All async operation like `thenComposeAsync` are done in the provided executor, which is the executor created in `BackgroundManager`. The size of the executor has been kept the same even if the task is not blocking anymore, to avoid starving other threads.
Considering that some tasks may be spawned in parallel, this task could use more than 1 thread, but in general it should be non-blocking so it should not use 1 thread in average.

A simple mechanism for trying to gracefully shutdown this tasks have been added:
before rescheduling any task check if it's been cancelled and it if it, it will not reschedule itself.
The executor is then terminated "gracefully" with `shutdown` first, giving some time for the tasks to stop gracefully before running `shutdownNow`, if they are not yet terminated.
This mechanism can be removed if not deemed necessary

### Comments
The code is much more hard to follow and understand after this change and the parallelism that we gain is really just limited to a couple of places. 
So I think it would be ok if we decide to keep using a synchronous style except  for those two places, where we can actually gain some performance.

## Related issues
closes #27894
