### PR TITLE
[Backport stable/8.6] `VariableResolver` can return `null`

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/jobhandling/parameter/VariableResolver.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/jobhandling/parameter/VariableResolver.java
@@ -34,6 +34,9 @@ public class VariableResolver implements ParameterResolver {
   @Override
   public Object resolve(final JobClient jobClient, final ActivatedJob job) {
     final Object variableValue = getVariable(job);
+    if (variableValue == null) {
+      return null;
+    }
     try {
       return mapZeebeVariable(variableValue);
     } catch (final ClassCastException | IllegalArgumentException ex) {
@@ -48,7 +51,7 @@ public class VariableResolver implements ParameterResolver {
   }
 
   protected Object getVariable(final ActivatedJob job) {
-    return job.getVariable(variableName);
+    return job.getVariablesAsMap().get(variableName);
   }
 
   protected Object mapZeebeVariable(final Object variableValue) {

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/jobhandling/parameter/VariableResolverTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/jobhandling/parameter/VariableResolverTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.spring.client.jobhandling.parameter;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.worker.JobClient;
+import io.camunda.client.impl.CamundaObjectMapper;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class VariableResolverTest {
+
+  private VariableResolver resolver;
+  @Mock private JobClient jobClient;
+  @Mock private ActivatedJob job;
+
+  @BeforeEach
+  void setUp() {
+    resolver = new VariableResolver("testVar", String.class, new CamundaObjectMapper());
+  }
+
+  @Test
+  void shouldResolveVariableNotPresent() {
+    when(job.getVariablesAsMap()).thenReturn(Map.of("anotherVar", "another value"));
+
+    final Object resolvedValue = resolver.resolve(jobClient, job);
+
+    assertNull(resolvedValue);
+  }
+
+  @Test
+  void shouldResolveVariableIsPresent() {
+    when(job.getVariablesAsMap()).thenReturn(Map.of("testVar", "test value"));
+
+    final Object resolvedValue = resolver.resolve(jobClient, job);
+
+    assertEquals("test value", resolvedValue);
+  }
+}

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/jobhandling/parameter/VariableResolverTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/jobhandling/parameter/VariableResolverTest.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.spring.client.jobhandling.parameter;
 

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/jobhandling/parameter/VariableResolverTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/jobhandling/parameter/VariableResolverTest.java
@@ -18,9 +18,10 @@ package io.camunda.spring.client.jobhandling.parameter;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
-import io.camunda.client.api.response.ActivatedJob;
-import io.camunda.client.api.worker.JobClient;
-import io.camunda.client.impl.CamundaObjectMapper;
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.worker.JobClient;
+import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
+import io.camunda.zeebe.spring.client.jobhandling.parameter.VariableResolver;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,7 +38,7 @@ class VariableResolverTest {
 
   @BeforeEach
   void setUp() {
-    resolver = new VariableResolver("testVar", String.class, new CamundaObjectMapper());
+    resolver = new VariableResolver("testVar", String.class, new ZeebeObjectMapper());
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #28225 to `stable/8.6`.

relates to #28116
original author: @ana-vinogradova-camunda