### PR TITLE
Ad-Hoc Subprocess: Search activatable activities REST API

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -79,6 +79,7 @@ import io.camunda.client.api.fetch.UserTaskGetRequest;
 import io.camunda.client.api.fetch.VariableGetRequest;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.DocumentReferenceResponse;
+import io.camunda.client.api.search.query.AdHocSubprocessActivityQuery;
 import io.camunda.client.api.search.query.DecisionDefinitionQuery;
 import io.camunda.client.api.search.query.DecisionInstanceQuery;
 import io.camunda.client.api.search.query.DecisionRequirementsQuery;
@@ -850,6 +851,54 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @return a builder for the request to get a flow node instance
    */
   FlowNodeInstanceGetRequest newFlowNodeInstanceGetRequest(long flowNodeInstanceKey);
+
+  /**
+   * Executes a search request to query activities within ad-hoc subprocesses.
+   *
+   * <p>Note that this API currently requires filters for both process definition key and ad-hoc
+   * subprocess ID and does not support paging or sorting.
+   *
+   * <pre>
+   * long processDefinitionId = ...;
+   * String adHocSubprocessId = ...;
+   *
+   * camundaClient
+   *  .newAdHocSubprocessActivityQuery()
+   *  .filter((f) -> f
+   *     .processDefinitionId(processDefinitionId)
+   *     .adHocSubprocessId(adHocSubprocessId)
+   *  )
+   *  .send();
+   * </pre>
+   *
+   * @return a builder for the ad-hoc subprocess activity query
+   */
+  @ExperimentalApi("https://github.com/camunda/camunda/issues/27930")
+  AdHocSubprocessActivityQuery newAdHocSubprocessActivityQuery();
+
+  /**
+   * Executes a search request to query activities within ad-hoc subprocesses.
+   *
+   * <p>Note that this API currently requires filters for both process definition key and ad-hoc
+   * subprocess ID and does not support paging or sorting.
+   *
+   * <pre>
+   * long processDefinitionId = ...;
+   * String adHocSubprocessId = ...;
+   *
+   * camundaClient
+   *  .newAdHocSubprocessActivityQuery(
+   *    processDefinitionId,
+   *    adHocSubprocessId
+   *  )
+   *  .send();
+   * </pre>
+   *
+   * @return a builder for the ad-hoc subprocess activity query
+   */
+  @ExperimentalApi("https://github.com/camunda/camunda/issues/27930")
+  AdHocSubprocessActivityQuery newAdHocSubprocessActivityQuery(
+      long processDefinitionKey, String adHocSubprocessId);
 
   /**
    * Executes a search request to query user tasks.

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -859,13 +859,13 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * subprocess ID and does not support paging or sorting.
    *
    * <pre>
-   * long processDefinitionId = ...;
+   * long processDefinitionKey = ...;
    * String adHocSubprocessId = ...;
    *
    * camundaClient
    *  .newAdHocSubprocessActivityQuery()
    *  .filter((f) -> f
-   *     .processDefinitionId(processDefinitionId)
+   *     .processDefinitionKey(processDefinitionKey)
    *     .adHocSubprocessId(adHocSubprocessId)
    *  )
    *  .send();
@@ -883,12 +883,12 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * subprocess ID and does not support paging or sorting.
    *
    * <pre>
-   * long processDefinitionId = ...;
+   * long processDefinitionKey = ...;
    * String adHocSubprocessId = ...;
    *
    * camundaClient
    *  .newAdHocSubprocessActivityQuery(
-   *    processDefinitionId,
+   *    processDefinitionKey,
    *    adHocSubprocessId
    *  )
    *  .send();

--- a/clients/java/src/main/java/io/camunda/client/api/search/SearchRequestBuilders.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/SearchRequestBuilders.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.api.search;
 
+import io.camunda.client.api.search.filter.AdHocSubprocessActivityFilter;
 import io.camunda.client.api.search.filter.DecisionDefinitionFilter;
 import io.camunda.client.api.search.filter.DecisionInstanceFilter;
 import io.camunda.client.api.search.filter.DecisionRequirementsFilter;
@@ -35,6 +36,7 @@ import io.camunda.client.api.search.sort.ProcessInstanceSort;
 import io.camunda.client.api.search.sort.UserTaskSort;
 import io.camunda.client.api.search.sort.VariableSort;
 import io.camunda.client.impl.search.SearchRequestPageImpl;
+import io.camunda.client.impl.search.filter.AdHocSubprocessActivityFilterImpl;
 import io.camunda.client.impl.search.filter.DecisionDefinitionFilterImpl;
 import io.camunda.client.impl.search.filter.DecisionInstanceFilterImpl;
 import io.camunda.client.impl.search.filter.DecisionRequirementsFilterImpl;
@@ -253,6 +255,17 @@ public final class SearchRequestBuilders {
     final FlownodeInstanceSort sort = flowNodeInstanceSort();
     fn.accept(sort);
     return sort;
+  }
+
+  public static AdHocSubprocessActivityFilter adHocSubprocessActivityFilter() {
+    return new AdHocSubprocessActivityFilterImpl();
+  }
+
+  public static AdHocSubprocessActivityFilter adHocSubprocessActivityFilter(
+      final Consumer<AdHocSubprocessActivityFilter> fn) {
+    final AdHocSubprocessActivityFilter filter = adHocSubprocessActivityFilter();
+    fn.accept(filter);
+    return filter;
   }
 
   public static VariableFilter variableFilter() {

--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/AdHocSubprocessActivityFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/AdHocSubprocessActivityFilter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.filter;
+
+import io.camunda.client.api.search.query.TypedSearchQueryRequest.SearchRequestFilter;
+
+public interface AdHocSubprocessActivityFilter extends SearchRequestFilter {
+
+  /**
+   * Filters ad-hoc subprocess activities by process definition key.
+   *
+   * @param processDefinitionKey the process definition key of the ad-hoc subprocess
+   * @return the updated filter
+   */
+  AdHocSubprocessActivityFilter processDefinitionKey(final long processDefinitionKey);
+
+  /**
+   * Filters flow node instances by ad-hoc subprocess id.
+   *
+   * @param adHocSubprocessId the id of the ad-hoc subprocess
+   * @return the updated filter
+   */
+  AdHocSubprocessActivityFilter adHocSubprocessId(final String adHocSubprocessId);
+
+  /**
+   * Returns prepared REST API filter object.
+   *
+   * @return the API filter object
+   */
+  io.camunda.client.protocol.rest.AdHocSubprocessActivityFilter getRequestFilter();
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/query/AdHocSubprocessActivityQuery.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/query/AdHocSubprocessActivityQuery.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.query;
+
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.search.filter.AdHocSubprocessActivityFilter;
+import io.camunda.client.api.search.response.AdHocSubprocessActivityResponse;
+import java.util.function.Consumer;
+
+public interface AdHocSubprocessActivityQuery
+    extends FinalCommandStep<AdHocSubprocessActivityResponse> {
+  /**
+   * Sets the filter to be included in the search request.
+   *
+   * @param filter the filter
+   * @return the builder for the search request
+   */
+  AdHocSubprocessActivityQuery filter(final AdHocSubprocessActivityFilter filter);
+
+  /**
+   * Provides a fluent builder to create a filter to be included in the search request.
+   *
+   * @param fn consumer to create the filter
+   * @return the builder for the search request
+   */
+  AdHocSubprocessActivityQuery filter(final Consumer<AdHocSubprocessActivityFilter> fn);
+}

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/AdHocSubprocessActivityResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/AdHocSubprocessActivityResponse.java
@@ -31,9 +31,9 @@ public interface AdHocSubprocessActivityResponse {
 
     String getAdHocSubprocessId();
 
-    String getFlowNodeId();
+    String getElementId();
 
-    String getFlowNodeName();
+    String getElementName();
 
     AdHocSubprocessActivityType getType();
 

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/AdHocSubprocessActivityResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/AdHocSubprocessActivityResponse.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.search.response;
+
+import io.camunda.client.impl.util.EnumUtil;
+import io.camunda.client.protocol.rest.AdHocSubprocessActivityResult;
+import java.util.List;
+
+public interface AdHocSubprocessActivityResponse {
+
+  List<AdHocSubprocessActivity> getItems();
+
+  interface AdHocSubprocessActivity {
+
+    Long getProcessDefinitionKey();
+
+    String getProcessDefinitionId();
+
+    String getAdHocSubprocessId();
+
+    String getFlowNodeId();
+
+    String getFlowNodeName();
+
+    AdHocSubprocessActivityType getType();
+
+    String getDocumentation();
+
+    String getTenantId();
+
+    enum AdHocSubprocessActivityType {
+      UNSPECIFIED,
+      PROCESS,
+      SUB_PROCESS,
+      EVENT_SUB_PROCESS,
+      INTERMEDIATE_CATCH_EVENT,
+      INTERMEDIATE_THROW_EVENT,
+      BOUNDARY_EVENT,
+      SERVICE_TASK,
+      RECEIVE_TASK,
+      USER_TASK,
+      MANUAL_TASK,
+      TASK,
+      MULTI_INSTANCE_BODY,
+      CALL_ACTIVITY,
+      BUSINESS_RULE_TASK,
+      SCRIPT_TASK,
+      SEND_TASK,
+      UNKNOWN,
+      UNKNOWN_ENUM_VALUE;
+
+      public static AdHocSubprocessActivityType fromProtocolType(
+          final AdHocSubprocessActivityResult.TypeEnum value) {
+        if (value == null) {
+          return null;
+        }
+
+        try {
+          return AdHocSubprocessActivityType.valueOf(value.name());
+        } catch (final IllegalArgumentException e) {
+          EnumUtil.logUnknownEnumValue(value, "ad-hoc subprocess activity type", values());
+          return UNKNOWN_ENUM_VALUE;
+        }
+      }
+    }
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -90,6 +90,7 @@ import io.camunda.client.api.fetch.UserTaskGetRequest;
 import io.camunda.client.api.fetch.VariableGetRequest;
 import io.camunda.client.api.response.ActivatedJob;
 import io.camunda.client.api.response.DocumentReferenceResponse;
+import io.camunda.client.api.search.query.AdHocSubprocessActivityQuery;
 import io.camunda.client.api.search.query.DecisionDefinitionQuery;
 import io.camunda.client.api.search.query.DecisionInstanceQuery;
 import io.camunda.client.api.search.query.DecisionRequirementsQuery;
@@ -166,6 +167,7 @@ import io.camunda.client.impl.fetch.UserTaskGetRequestImpl;
 import io.camunda.client.impl.fetch.VariableGetRequestImpl;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.http.HttpClientFactory;
+import io.camunda.client.impl.search.query.AdHocSubprocessActivityQueryImpl;
 import io.camunda.client.impl.search.query.DecisionDefinitionQueryImpl;
 import io.camunda.client.impl.search.query.DecisionInstanceQueryImpl;
 import io.camunda.client.impl.search.query.DecisionRequirementsQueryImpl;
@@ -671,6 +673,22 @@ public final class CamundaClientImpl implements CamundaClient {
   @Override
   public FlowNodeInstanceGetRequest newFlowNodeInstanceGetRequest(final long flowNodeInstanceKey) {
     return new FlowNodeInstanceGetRequestImpl(httpClient, flowNodeInstanceKey);
+  }
+
+  @Override
+  public AdHocSubprocessActivityQuery newAdHocSubprocessActivityQuery() {
+    return new AdHocSubprocessActivityQueryImpl(httpClient, jsonMapper);
+  }
+
+  @Override
+  public AdHocSubprocessActivityQuery newAdHocSubprocessActivityQuery(
+      final long processDefinitionKey, final String adHocSubprocessId) {
+    return newAdHocSubprocessActivityQuery()
+        .filter(
+            filter ->
+                filter
+                    .processDefinitionKey(processDefinitionKey)
+                    .adHocSubprocessId(adHocSubprocessId));
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/AdHocSubprocessActivityFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/AdHocSubprocessActivityFilterImpl.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.filter;
+
+import io.camunda.client.api.search.filter.AdHocSubprocessActivityFilter;
+
+public class AdHocSubprocessActivityFilterImpl implements AdHocSubprocessActivityFilter {
+
+  private final io.camunda.client.protocol.rest.AdHocSubprocessActivityFilter filter;
+
+  public AdHocSubprocessActivityFilterImpl() {
+    filter = new io.camunda.client.protocol.rest.AdHocSubprocessActivityFilter();
+  }
+
+  @Override
+  public AdHocSubprocessActivityFilterImpl processDefinitionKey(final long processDefinitionKey) {
+    filter.setProcessDefinitionKey(String.valueOf(processDefinitionKey));
+    return this;
+  }
+
+  @Override
+  public AdHocSubprocessActivityFilterImpl adHocSubprocessId(final String adHocSubprocessId) {
+    filter.setAdHocSubprocessId(adHocSubprocessId);
+    return this;
+  }
+
+  @Override
+  public io.camunda.client.protocol.rest.AdHocSubprocessActivityFilter getRequestFilter() {
+    return filter;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/query/AdHocSubprocessActivityQueryImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/query/AdHocSubprocessActivityQueryImpl.java
@@ -70,7 +70,7 @@ public class AdHocSubprocessActivityQueryImpl implements AdHocSubprocessActivity
   public CamundaFuture<AdHocSubprocessActivityResponse> send() {
     final HttpCamundaFuture<AdHocSubprocessActivityResponse> result = new HttpCamundaFuture<>();
     httpClient.post(
-        "/ad-hoc-activities/search",
+        "/element-instances/ad-hoc-activities/search",
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
         AdHocSubprocessActivitySearchQueryResult.class,

--- a/clients/java/src/main/java/io/camunda/client/impl/search/query/AdHocSubprocessActivityQueryImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/query/AdHocSubprocessActivityQueryImpl.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.query;
+
+import static io.camunda.client.api.search.SearchRequestBuilders.adHocSubprocessActivityFilter;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.search.filter.AdHocSubprocessActivityFilter;
+import io.camunda.client.api.search.query.AdHocSubprocessActivityQuery;
+import io.camunda.client.api.search.response.AdHocSubprocessActivityResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.impl.search.response.AdHocSubprocessActivityResponseImpl;
+import io.camunda.client.protocol.rest.AdHocSubprocessActivitySearchQuery;
+import io.camunda.client.protocol.rest.AdHocSubprocessActivitySearchQueryResult;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class AdHocSubprocessActivityQueryImpl implements AdHocSubprocessActivityQuery {
+
+  private final AdHocSubprocessActivitySearchQuery request;
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public AdHocSubprocessActivityQueryImpl(
+      final HttpClient httpClient, final JsonMapper jsonMapper) {
+    request = new AdHocSubprocessActivitySearchQuery();
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public AdHocSubprocessActivityQuery filter(final AdHocSubprocessActivityFilter filter) {
+    request.setFilter(filter.getRequestFilter());
+    return this;
+  }
+
+  @Override
+  public AdHocSubprocessActivityQuery filter(final Consumer<AdHocSubprocessActivityFilter> fn) {
+    return filter(adHocSubprocessActivityFilter(fn));
+  }
+
+  @Override
+  public FinalCommandStep<AdHocSubprocessActivityResponse> requestTimeout(
+      final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<AdHocSubprocessActivityResponse> send() {
+    final HttpCamundaFuture<AdHocSubprocessActivityResponse> result = new HttpCamundaFuture<>();
+    httpClient.post(
+        "/ad-hoc-activities/search",
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        AdHocSubprocessActivitySearchQueryResult.class,
+        AdHocSubprocessActivityResponseImpl::new,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/AdHocSubprocessActivityResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/AdHocSubprocessActivityResponseImpl.java
@@ -42,8 +42,8 @@ public class AdHocSubprocessActivityResponseImpl implements AdHocSubprocessActiv
     private final Long processDefinitionKey;
     private final String processDefinitionId;
     private final String adHocSubprocessId;
-    private final String flowNodeId;
-    private final String flowNodeName;
+    private final String elementId;
+    private final String elementName;
     private final AdHocSubprocessActivityType type;
     private final String documentation;
     private final String tenantId;
@@ -52,8 +52,8 @@ public class AdHocSubprocessActivityResponseImpl implements AdHocSubprocessActiv
       processDefinitionKey = Long.valueOf(result.getProcessDefinitionKey());
       processDefinitionId = result.getProcessDefinitionId();
       adHocSubprocessId = result.getAdHocSubprocessId();
-      flowNodeId = result.getFlowNodeId();
-      flowNodeName = result.getFlowNodeName();
+      elementId = result.getElementId();
+      elementName = result.getElementName();
       type = AdHocSubprocessActivityType.fromProtocolType(result.getType());
       documentation = result.getDocumentation();
       tenantId = result.getTenantId();
@@ -75,13 +75,13 @@ public class AdHocSubprocessActivityResponseImpl implements AdHocSubprocessActiv
     }
 
     @Override
-    public String getFlowNodeId() {
-      return flowNodeId;
+    public String getElementId() {
+      return elementId;
     }
 
     @Override
-    public String getFlowNodeName() {
-      return flowNodeName;
+    public String getElementName() {
+      return elementName;
     }
 
     @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/AdHocSubprocessActivityResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/AdHocSubprocessActivityResponseImpl.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.search.response;
+
+import io.camunda.client.api.search.response.AdHocSubprocessActivityResponse;
+import io.camunda.client.protocol.rest.AdHocSubprocessActivityResult;
+import io.camunda.client.protocol.rest.AdHocSubprocessActivitySearchQueryResult;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AdHocSubprocessActivityResponseImpl implements AdHocSubprocessActivityResponse {
+
+  private final List<AdHocSubprocessActivity> items;
+
+  public AdHocSubprocessActivityResponseImpl(
+      final AdHocSubprocessActivitySearchQueryResult response) {
+    items =
+        response.getItems().stream()
+            .map(AdHocSubprocessActivityImpl::new)
+            .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<AdHocSubprocessActivity> getItems() {
+    return items;
+  }
+
+  public static class AdHocSubprocessActivityImpl implements AdHocSubprocessActivity {
+    private final Long processDefinitionKey;
+    private final String processDefinitionId;
+    private final String adHocSubprocessId;
+    private final String flowNodeId;
+    private final String flowNodeName;
+    private final AdHocSubprocessActivityType type;
+    private final String documentation;
+    private final String tenantId;
+
+    public AdHocSubprocessActivityImpl(final AdHocSubprocessActivityResult result) {
+      processDefinitionKey = Long.valueOf(result.getProcessDefinitionKey());
+      processDefinitionId = result.getProcessDefinitionId();
+      adHocSubprocessId = result.getAdHocSubprocessId();
+      flowNodeId = result.getFlowNodeId();
+      flowNodeName = result.getFlowNodeName();
+      type = AdHocSubprocessActivityType.fromProtocolType(result.getType());
+      documentation = result.getDocumentation();
+      tenantId = result.getTenantId();
+    }
+
+    @Override
+    public Long getProcessDefinitionKey() {
+      return processDefinitionKey;
+    }
+
+    @Override
+    public String getProcessDefinitionId() {
+      return processDefinitionId;
+    }
+
+    @Override
+    public String getAdHocSubprocessId() {
+      return adHocSubprocessId;
+    }
+
+    @Override
+    public String getFlowNodeId() {
+      return flowNodeId;
+    }
+
+    @Override
+    public String getFlowNodeName() {
+      return flowNodeName;
+    }
+
+    @Override
+    public AdHocSubprocessActivityType getType() {
+      return type;
+    }
+
+    @Override
+    public String getDocumentation() {
+      return documentation;
+    }
+
+    @Override
+    public String getTenantId() {
+      return tenantId;
+    }
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/adhocsubprocess/AdHocSubprocessActivitySearchTest.java
+++ b/clients/java/src/test/java/io/camunda/client/adhocsubprocess/AdHocSubprocessActivitySearchTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.adhocsubprocess;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.client.api.search.response.AdHocSubprocessActivityResponse;
+import io.camunda.client.api.search.response.AdHocSubprocessActivityResponse.AdHocSubprocessActivity;
+import io.camunda.client.api.search.response.AdHocSubprocessActivityResponse.AdHocSubprocessActivity.AdHocSubprocessActivityType;
+import io.camunda.client.protocol.rest.AdHocSubprocessActivityResult;
+import io.camunda.client.protocol.rest.AdHocSubprocessActivityResult.TypeEnum;
+import io.camunda.client.protocol.rest.AdHocSubprocessActivitySearchQuery;
+import io.camunda.client.protocol.rest.AdHocSubprocessActivitySearchQueryResult;
+import io.camunda.client.util.ClientRestTest;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+public class AdHocSubprocessActivitySearchTest extends ClientRestTest {
+
+  private static final Long PROCESS_DEFINITION_KEY = 2251799813685281L;
+  private static final String PROCESS_DEFINITION_ID = "TestParentAdHocSubprocess";
+  private static final String AD_HOC_SUBPROCESS_ID = "TestAdHocSubprocess";
+
+  @Test
+  void shouldSearchAdHocSubprocessActivities() {
+    // given
+    final AdHocSubprocessActivitySearchQueryResult searchQueryResult =
+        new AdHocSubprocessActivitySearchQueryResult();
+    searchQueryResult.addItemsItem(
+        adHocSubprocessActivityResult(
+            r -> {
+              r.processDefinitionKey(String.valueOf(PROCESS_DEFINITION_KEY));
+              r.processDefinitionId(PROCESS_DEFINITION_ID);
+              r.setAdHocSubprocessId(AD_HOC_SUBPROCESS_ID);
+              r.setFlowNodeId("task1");
+              r.setFlowNodeName("Task #1");
+              r.setType(TypeEnum.SERVICE_TASK);
+              r.setDocumentation("The first task in the ad-hoc subprocess");
+              r.setTenantId("<default>");
+            }));
+    searchQueryResult.addItemsItem(
+        adHocSubprocessActivityResult(
+            r -> {
+              r.processDefinitionKey(String.valueOf(PROCESS_DEFINITION_KEY));
+              r.processDefinitionId(PROCESS_DEFINITION_ID);
+              r.setAdHocSubprocessId(AD_HOC_SUBPROCESS_ID);
+              r.setFlowNodeId("task2");
+              r.setFlowNodeName("Task #2");
+              r.setType(TypeEnum.USER_TASK);
+              r.setDocumentation("The second task in the ad-hoc subprocess");
+              r.setTenantId("<default>");
+            }));
+
+    gatewayService.onAdHocSubprocessActivitySearch(searchQueryResult);
+
+    // when
+    final AdHocSubprocessActivityResponse response =
+        client
+            .newAdHocSubprocessActivityQuery(PROCESS_DEFINITION_KEY, AD_HOC_SUBPROCESS_ID)
+            .send()
+            .join();
+
+    // then
+    final AdHocSubprocessActivitySearchQuery request =
+        gatewayService.getLastRequest(AdHocSubprocessActivitySearchQuery.class);
+    assertThat(request.getFilter().getProcessDefinitionKey())
+        .isEqualTo(PROCESS_DEFINITION_KEY.toString());
+    assertThat(request.getFilter().getAdHocSubprocessId()).isEqualTo(AD_HOC_SUBPROCESS_ID);
+
+    assertThat(response.getItems())
+        .hasSize(2)
+        .extracting(
+            AdHocSubprocessActivity::getProcessDefinitionKey,
+            AdHocSubprocessActivity::getProcessDefinitionId,
+            AdHocSubprocessActivity::getAdHocSubprocessId,
+            AdHocSubprocessActivity::getFlowNodeId,
+            AdHocSubprocessActivity::getFlowNodeName,
+            AdHocSubprocessActivity::getType,
+            AdHocSubprocessActivity::getDocumentation,
+            AdHocSubprocessActivity::getTenantId)
+        .containsExactly(
+            tuple(
+                PROCESS_DEFINITION_KEY,
+                PROCESS_DEFINITION_ID,
+                AD_HOC_SUBPROCESS_ID,
+                "task1",
+                "Task #1",
+                AdHocSubprocessActivityType.SERVICE_TASK,
+                "The first task in the ad-hoc subprocess",
+                "<default>"),
+            tuple(
+                PROCESS_DEFINITION_KEY,
+                PROCESS_DEFINITION_ID,
+                AD_HOC_SUBPROCESS_ID,
+                "task2",
+                "Task #2",
+                AdHocSubprocessActivityType.USER_TASK,
+                "The second task in the ad-hoc subprocess",
+                "<default>"));
+  }
+
+  @Test
+  void shouldMapUnknownEnumValueToFallbackValueWithoutBreaking() {
+    // given
+    final String responseJson =
+        "{\n"
+            + "  \"items\": [\n"
+            + "    {\n"
+            + "      \"processDefinitionKey\": \"2251799813685281\",\n"
+            + "      \"processDefinitionId\": \"TestParentAdHocSubprocess\",\n"
+            + "      \"adHocSubprocessId\": \"TestAdHocSubprocess\",\n"
+            + "      \"flowNodeId\": \"unknownTask\",\n"
+            + "      \"flowNodeName\": \"Unknown Task\",\n"
+            + "      \"type\": \"START_EVENT\",\n"
+            + "      \"tenantId\": \"<default>\"\n"
+            + "    }\n"
+            + "  ]\n"
+            + "}";
+
+    gatewayService.onAdHocSubprocessActivitySearch(responseJson);
+
+    // when
+    final AdHocSubprocessActivityResponse response =
+        client
+            .newAdHocSubprocessActivityQuery(PROCESS_DEFINITION_KEY, AD_HOC_SUBPROCESS_ID)
+            .send()
+            .join();
+
+    // then
+    assertThat(response.getItems())
+        .hasSize(1)
+        .extracting(
+            AdHocSubprocessActivity::getProcessDefinitionKey,
+            AdHocSubprocessActivity::getProcessDefinitionId,
+            AdHocSubprocessActivity::getAdHocSubprocessId,
+            AdHocSubprocessActivity::getFlowNodeId,
+            AdHocSubprocessActivity::getFlowNodeName,
+            AdHocSubprocessActivity::getType,
+            AdHocSubprocessActivity::getDocumentation,
+            AdHocSubprocessActivity::getTenantId)
+        .containsExactly(
+            tuple(
+                PROCESS_DEFINITION_KEY,
+                PROCESS_DEFINITION_ID,
+                AD_HOC_SUBPROCESS_ID,
+                "unknownTask",
+                "Unknown Task",
+                AdHocSubprocessActivityType.UNKNOWN_ENUM_VALUE,
+                null,
+                "<default>"));
+  }
+
+  private static AdHocSubprocessActivityResult adHocSubprocessActivityResult(
+      final Consumer<AdHocSubprocessActivityResult> consumer) {
+    final AdHocSubprocessActivityResult result = new AdHocSubprocessActivityResult();
+    consumer.accept(result);
+    return result;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/adhocsubprocess/AdHocSubprocessActivitySearchTest.java
+++ b/clients/java/src/test/java/io/camunda/client/adhocsubprocess/AdHocSubprocessActivitySearchTest.java
@@ -46,8 +46,8 @@ public class AdHocSubprocessActivitySearchTest extends ClientRestTest {
               r.processDefinitionKey(String.valueOf(PROCESS_DEFINITION_KEY));
               r.processDefinitionId(PROCESS_DEFINITION_ID);
               r.setAdHocSubprocessId(AD_HOC_SUBPROCESS_ID);
-              r.setFlowNodeId("task1");
-              r.setFlowNodeName("Task #1");
+              r.setElementId("task1");
+              r.setElementName("Task #1");
               r.setType(TypeEnum.SERVICE_TASK);
               r.setDocumentation("The first task in the ad-hoc subprocess");
               r.setTenantId("<default>");
@@ -58,8 +58,8 @@ public class AdHocSubprocessActivitySearchTest extends ClientRestTest {
               r.processDefinitionKey(String.valueOf(PROCESS_DEFINITION_KEY));
               r.processDefinitionId(PROCESS_DEFINITION_ID);
               r.setAdHocSubprocessId(AD_HOC_SUBPROCESS_ID);
-              r.setFlowNodeId("task2");
-              r.setFlowNodeName("Task #2");
+              r.setElementId("task2");
+              r.setElementName("Task #2");
               r.setType(TypeEnum.USER_TASK);
               r.setDocumentation("The second task in the ad-hoc subprocess");
               r.setTenantId("<default>");
@@ -87,8 +87,8 @@ public class AdHocSubprocessActivitySearchTest extends ClientRestTest {
             AdHocSubprocessActivity::getProcessDefinitionKey,
             AdHocSubprocessActivity::getProcessDefinitionId,
             AdHocSubprocessActivity::getAdHocSubprocessId,
-            AdHocSubprocessActivity::getFlowNodeId,
-            AdHocSubprocessActivity::getFlowNodeName,
+            AdHocSubprocessActivity::getElementId,
+            AdHocSubprocessActivity::getElementName,
             AdHocSubprocessActivity::getType,
             AdHocSubprocessActivity::getDocumentation,
             AdHocSubprocessActivity::getTenantId)
@@ -123,8 +123,8 @@ public class AdHocSubprocessActivitySearchTest extends ClientRestTest {
             + "      \"processDefinitionKey\": \"2251799813685281\",\n"
             + "      \"processDefinitionId\": \"TestParentAdHocSubprocess\",\n"
             + "      \"adHocSubprocessId\": \"TestAdHocSubprocess\",\n"
-            + "      \"flowNodeId\": \"unknownTask\",\n"
-            + "      \"flowNodeName\": \"Unknown Task\",\n"
+            + "      \"elementId\": \"unknownTask\",\n"
+            + "      \"elementName\": \"Unknown Task\",\n"
             + "      \"type\": \"START_EVENT\",\n"
             + "      \"tenantId\": \"<default>\"\n"
             + "    }\n"
@@ -147,8 +147,8 @@ public class AdHocSubprocessActivitySearchTest extends ClientRestTest {
             AdHocSubprocessActivity::getProcessDefinitionKey,
             AdHocSubprocessActivity::getProcessDefinitionId,
             AdHocSubprocessActivity::getAdHocSubprocessId,
-            AdHocSubprocessActivity::getFlowNodeId,
-            AdHocSubprocessActivity::getFlowNodeName,
+            AdHocSubprocessActivity::getElementId,
+            AdHocSubprocessActivity::getElementName,
             AdHocSubprocessActivity::getType,
             AdHocSubprocessActivity::getDocumentation,
             AdHocSubprocessActivity::getTenantId)

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -39,6 +39,8 @@ public class RestGatewayPaths {
       REST_API_PATH + "/decision-definitions/evaluation";
   private static final String URL_CREATE_PROCESS_INSTANCE = REST_API_PATH + "/process-instances";
   private static final String URL_DEPLOYMENTS_URL = REST_API_PATH + "/deployments";
+  private static final String URL_AD_HOC_SUBPROCESS_ACTIVITIES_SEARCH =
+      REST_API_PATH + "/ad-hoc-activities/search";
 
   /**
    * @return the topology request URL
@@ -136,5 +138,9 @@ public class RestGatewayPaths {
 
   public static String getDeploymentsUrl() {
     return URL_DEPLOYMENTS_URL;
+  }
+
+  public static String getAdHocSubprocessActivitiesSearchUrl() {
+    return URL_AD_HOC_SUBPROCESS_ACTIVITIES_SEARCH;
   }
 }

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayPaths.java
@@ -40,7 +40,7 @@ public class RestGatewayPaths {
   private static final String URL_CREATE_PROCESS_INSTANCE = REST_API_PATH + "/process-instances";
   private static final String URL_DEPLOYMENTS_URL = REST_API_PATH + "/deployments";
   private static final String URL_AD_HOC_SUBPROCESS_ACTIVITIES_SEARCH =
-      REST_API_PATH + "/ad-hoc-activities/search";
+      REST_API_PATH + "/element-instances/ad-hoc-activities/search";
 
   /**
    * @return the topology request URL

--- a/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/client/util/RestGatewayService.java
@@ -20,6 +20,7 @@ import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.impl.CamundaObjectMapper;
+import io.camunda.client.protocol.rest.AdHocSubprocessActivitySearchQueryResult;
 import io.camunda.client.protocol.rest.DeploymentResult;
 import io.camunda.client.protocol.rest.EvaluateDecisionResult;
 import io.camunda.client.protocol.rest.JobActivationResult;
@@ -85,6 +86,19 @@ public class RestGatewayService {
         .register(
             WireMock.post(RestGatewayPaths.getDeploymentsUrl())
                 .willReturn(WireMock.okJson(JSON_MAPPER.toJson(response))));
+  }
+
+  public void onAdHocSubprocessActivitySearch(
+      final AdHocSubprocessActivitySearchQueryResult response) {
+    onAdHocSubprocessActivitySearch(JSON_MAPPER.toJson(response));
+  }
+
+  public void onAdHocSubprocessActivitySearch(final String jsonResponse) {
+    mockInfo
+        .getWireMock()
+        .register(
+            WireMock.post(RestGatewayPaths.getAdHocSubprocessActivitiesSearchUrl())
+                .willReturn(WireMock.okJson(jsonResponse)));
   }
 
   /**

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -28,6 +28,7 @@ import io.camunda.search.clients.UserTaskSearchClient;
 import io.camunda.search.clients.VariableSearchClient;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.impl.AuthorizationChecker;
+import io.camunda.service.AdHocSubprocessActivityServices;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.ClockServices;
 import io.camunda.service.DecisionDefinitionServices;
@@ -139,6 +140,15 @@ public class CamundaServicesConfiguration {
       final FlowNodeInstanceSearchClient flowNodeInstanceSearchClient) {
     return new FlowNodeInstanceServices(
         brokerClient, securityContextProvider, flowNodeInstanceSearchClient, null);
+  }
+
+  @Bean
+  public AdHocSubprocessActivityServices adHocSubprocessActivityServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final ProcessDefinitionServices processDefinitionServices) {
+    return new AdHocSubprocessActivityServices(
+        brokerClient, securityContextProvider, processDefinitionServices, null);
   }
 
   @Bean

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/AdHocSubprocessActivityQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/AdHocSubprocessActivityQueryTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static io.camunda.it.client.QueryTest.deployResource;
+import static io.camunda.it.client.QueryTest.waitForProcessesToBeDeployed;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.Process;
+import io.camunda.client.api.search.response.AdHocSubprocessActivityResponse.AdHocSubprocessActivity;
+import io.camunda.client.api.search.response.AdHocSubprocessActivityResponse.AdHocSubprocessActivity.AdHocSubprocessActivityType;
+import io.camunda.it.utils.MultiDbTest;
+import org.junit.jupiter.api.Test;
+
+@MultiDbTest
+public class AdHocSubprocessActivityQueryTest {
+
+  private static CamundaClient camundaClient;
+
+  @Test
+  void findsAdHocSubprocessActivities() {
+    final var process = deployAdHocSubprocessProcess();
+    final var response =
+        camundaClient
+            .newAdHocSubprocessActivityQuery(
+                process.getProcessDefinitionKey(), "TestAdHocSubprocess")
+            .send()
+            .join();
+
+    assertThat(response.getItems())
+        .hasSize(2)
+        // TestServiceTask is no root node (has incoming sequence flow)
+        .noneMatch(activity -> activity.getFlowNodeId().equals("TestServiceTask"))
+        .extracting(
+            AdHocSubprocessActivity::getProcessDefinitionKey,
+            AdHocSubprocessActivity::getProcessDefinitionId,
+            AdHocSubprocessActivity::getAdHocSubprocessId,
+            AdHocSubprocessActivity::getFlowNodeId,
+            AdHocSubprocessActivity::getFlowNodeName,
+            AdHocSubprocessActivity::getType,
+            AdHocSubprocessActivity::getDocumentation,
+            AdHocSubprocessActivity::getTenantId)
+        .containsExactlyInAnyOrder(
+            tuple(
+                process.getProcessDefinitionKey(),
+                process.getBpmnProcessId(),
+                "TestAdHocSubprocess",
+                "TestScriptTask",
+                "test script task",
+                AdHocSubprocessActivityType.SCRIPT_TASK,
+                "This is a test script task",
+                "<default>"),
+            tuple(
+                process.getProcessDefinitionKey(),
+                process.getBpmnProcessId(),
+                "TestAdHocSubprocess",
+                "TestUserTask",
+                "test user task",
+                AdHocSubprocessActivityType.USER_TASK,
+                null,
+                "<default>"));
+  }
+
+  private Process deployAdHocSubprocessProcess() {
+    final var deployedProcesses =
+        deployResource(camundaClient, "process/ad_hoc_subprocess_activities.bpmn").getProcesses();
+    assertThat(deployedProcesses).hasSize(1);
+
+    waitForProcessesToBeDeployed(camundaClient, 1);
+
+    return deployedProcesses.getFirst();
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/AdHocSubprocessActivityQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/AdHocSubprocessActivityQueryTest.java
@@ -37,13 +37,13 @@ public class AdHocSubprocessActivityQueryTest {
     assertThat(response.getItems())
         .hasSize(2)
         // TestServiceTask is no root node (has incoming sequence flow)
-        .noneMatch(activity -> activity.getFlowNodeId().equals("TestServiceTask"))
+        .noneMatch(activity -> activity.getElementId().equals("TestServiceTask"))
         .extracting(
             AdHocSubprocessActivity::getProcessDefinitionKey,
             AdHocSubprocessActivity::getProcessDefinitionId,
             AdHocSubprocessActivity::getAdHocSubprocessId,
-            AdHocSubprocessActivity::getFlowNodeId,
-            AdHocSubprocessActivity::getFlowNodeName,
+            AdHocSubprocessActivity::getElementId,
+            AdHocSubprocessActivity::getElementName,
             AdHocSubprocessActivity::getType,
             AdHocSubprocessActivity::getDocumentation,
             AdHocSubprocessActivity::getTenantId)

--- a/qa/integration-tests/src/test/resources/process/ad_hoc_subprocess_activities.bpmn
+++ b/qa/integration-tests/src/test/resources/process/ad_hoc_subprocess_activities.bpmn
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1kj358h" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.32.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="TestParentAdHocSubprocess" isExecutable="true">
+    <bpmn:adHocSubProcess id="TestAdHocSubprocess" name="Ad-Hoc Subprocess">
+      <bpmn:extensionElements>
+        <zeebe:adHoc />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1nmmpcw</bpmn:incoming>
+      <bpmn:outgoing>Flow_1e1ppa1</bpmn:outgoing>
+      <bpmn:sequenceFlow id="Flow_0h7ye31" sourceRef="TestUserTask" targetRef="TestServiceTask" />
+      <bpmn:scriptTask id="TestScriptTask" name="test script task">
+        <bpmn:documentation>This is a test script task</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:script expression="=2 * 2" resultVariable="fooCalculation" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+      <bpmn:serviceTask id="TestServiceTask" name="test service task">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="testType" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_0h7ye31</bpmn:incoming>
+      </bpmn:serviceTask>
+      <bpmn:userTask id="TestUserTask" name="test user task">
+        <bpmn:extensionElements>
+          <zeebe:userTask />
+          <zeebe:formDefinition formId="testForm" />
+        </bpmn:extensionElements>
+        <bpmn:outgoing>Flow_0h7ye31</bpmn:outgoing>
+      </bpmn:userTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_1e1ppa1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1e1ppa1" sourceRef="TestAdHocSubprocess" targetRef="EndEvent_1" />
+    <bpmn:sequenceFlow id="Flow_1nmmpcw" sourceRef="StartEvent_1" targetRef="TestAdHocSubprocess" />
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1nmmpcw</bpmn:outgoing>
+    </bpmn:startEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="TestParentAdHocSubprocess">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="172" y="187" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_071g6t1_di" bpmnElement="TestAdHocSubprocess" isExpanded="true">
+        <dc:Bounds x="280" y="70" width="350" height="270" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0vuyrum_di" bpmnElement="TestScriptTask">
+        <dc:Bounds x="410" y="110" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1wiygn1_di" bpmnElement="TestUserTask">
+        <dc:Bounds x="330" y="215" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_18de575_di" bpmnElement="TestServiceTask">
+        <dc:Bounds x="480" y="215" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0h7ye31_di" bpmnElement="Flow_0h7ye31">
+        <di:waypoint x="430" y="255" />
+        <di:waypoint x="480" y="255" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0nc2s10_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="702" y="187" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1nmmpcw_di" bpmnElement="Flow_1nmmpcw">
+        <di:waypoint x="208" y="205" />
+        <di:waypoint x="280" y="205" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1e1ppa1_di" bpmnElement="Flow_1e1ppa1">
+        <di:waypoint x="630" y="205" />
+        <di:waypoint x="702" y="205" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AdHocSubprocessActivityEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AdHocSubprocessActivityEntity.java
@@ -15,8 +15,8 @@ public record AdHocSubprocessActivityEntity(
     Long processDefinitionKey,
     String processDefinitionId,
     String adHocSubprocessId,
-    String flowNodeId,
-    String flowNodeName,
+    String elementId,
+    String elementName,
     ActivityType type,
     String documentation,
     String tenantId) {

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AdHocSubprocessActivityEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AdHocSubprocessActivityEntity.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record AdHocSubprocessActivityEntity(
+    Long processDefinitionKey,
+    String processDefinitionId,
+    String adHocSubprocessId,
+    String flowNodeId,
+    String flowNodeName,
+    ActivityType type,
+    String documentation,
+    String tenantId) {
+
+  public enum ActivityType {
+    UNSPECIFIED,
+    PROCESS,
+    SUB_PROCESS,
+    EVENT_SUB_PROCESS,
+    INTERMEDIATE_CATCH_EVENT,
+    INTERMEDIATE_THROW_EVENT,
+    BOUNDARY_EVENT,
+    SERVICE_TASK,
+    RECEIVE_TASK,
+    USER_TASK,
+    MANUAL_TASK,
+    TASK,
+    MULTI_INSTANCE_BODY,
+    CALL_ACTIVITY,
+    BUSINESS_RULE_TASK,
+    SCRIPT_TASK,
+    SEND_TASK,
+    UNKNOWN;
+
+    public static ActivityType fromZeebeBpmnElementTypeName(final String elementTypeName) {
+      return fromZeebeBpmnElementType(BpmnElementType.bpmnElementTypeFor(elementTypeName));
+    }
+
+    public static ActivityType fromZeebeBpmnElementType(final BpmnElementType bpmnElementType) {
+      if (bpmnElementType == null) {
+        return UNSPECIFIED;
+      }
+
+      try {
+        return ActivityType.valueOf(bpmnElementType.name());
+      } catch (final IllegalArgumentException ex) {
+        return UNKNOWN;
+      }
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/AdHocSubprocessActivityFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/AdHocSubprocessActivityFilter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.filter;
+
+import io.camunda.util.ObjectBuilder;
+
+public record AdHocSubprocessActivityFilter(Long processDefinitionKey, String adHocSubprocessId)
+    implements FilterBase {
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder implements ObjectBuilder<AdHocSubprocessActivityFilter> {
+
+    private Long processDefinitionKey;
+    private String adHocSubprocessId;
+
+    public Builder processDefinitionKey(final Long processDefinitionKey) {
+      this.processDefinitionKey = processDefinitionKey;
+      return this;
+    }
+
+    public Builder adHocSubprocessId(final String adHocSubprocessId) {
+      this.adHocSubprocessId = adHocSubprocessId;
+      return this;
+    }
+
+    @Override
+    public AdHocSubprocessActivityFilter build() {
+      return new AdHocSubprocessActivityFilter(processDefinitionKey, adHocSubprocessId);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/AdHocSubprocessActivityQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/AdHocSubprocessActivityQuery.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.query;
+
+import io.camunda.search.filter.AdHocSubprocessActivityFilter;
+import io.camunda.util.ObjectBuilder;
+
+public record AdHocSubprocessActivityQuery(AdHocSubprocessActivityFilter filter) {
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder implements ObjectBuilder<AdHocSubprocessActivityQuery> {
+
+    private AdHocSubprocessActivityFilter filter;
+
+    public Builder filter(final AdHocSubprocessActivityFilter filter) {
+      this.filter = filter;
+      return this;
+    }
+
+    @Override
+    public AdHocSubprocessActivityQuery build() {
+      return new AdHocSubprocessActivityQuery(filter);
+    }
+  }
+}

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -48,6 +48,10 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-bpmn-model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>document-api</artifactId>
     </dependency>
     <dependency>
@@ -75,6 +79,10 @@
     <dependency>
       <groupId>org.camunda.bpm</groupId>
       <artifactId>camunda-license-check</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.model</groupId>
+      <artifactId>camunda-xml-model</artifactId>
     </dependency>
 
     <dependency>
@@ -127,7 +135,7 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
+      <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -135,6 +135,11 @@
 
     <dependency>
       <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>

--- a/service/src/main/java/io/camunda/service/AdHocSubprocessActivityServices.java
+++ b/service/src/main/java/io/camunda/service/AdHocSubprocessActivityServices.java
@@ -59,25 +59,25 @@ public class AdHocSubprocessActivityServices extends ApiServices<AdHocSubprocess
 
     final var processElement =
         modelInstance.getModelElementById(query.filter().adHocSubprocessId());
-    if (processElement instanceof final AdHocSubProcess adHocSubProcess) {
-      final var flowNodes = adHocSubProcess.getChildElementsByType(FlowNode.class);
-      final var rootActivities =
-          flowNodes.stream()
-              .filter(flowNode -> flowNode.getIncoming().isEmpty())
-              .map(
-                  flowNode ->
-                      toAdHocSubprocessActivityEntity(
-                          processDefinitionEntity, adHocSubProcess, flowNode))
-              .toList();
-
-      return new SearchQueryResult.Builder<AdHocSubprocessActivityEntity>()
-          .items(rootActivities)
-          .build();
+    if (!(processElement instanceof final AdHocSubProcess adHocSubProcess)) {
+      throw new NotFoundException(
+          "Failed to find Ad-Hoc Subprocess with ID '%s'"
+              .formatted(query.filter().adHocSubprocessId()));
     }
 
-    throw new NotFoundException(
-        "Failed to find Ad-Hoc Subprocess with ID '%s'"
-            .formatted(query.filter().adHocSubprocessId()));
+    final var flowNodes = adHocSubProcess.getChildElementsByType(FlowNode.class);
+    final var rootActivities =
+        flowNodes.stream()
+            .filter(flowNode -> flowNode.getIncoming().isEmpty())
+            .map(
+                flowNode ->
+                    toAdHocSubprocessActivityEntity(
+                        processDefinitionEntity, adHocSubProcess, flowNode))
+            .toList();
+
+    return new SearchQueryResult.Builder<AdHocSubprocessActivityEntity>()
+        .items(rootActivities)
+        .build();
   }
 
   private AdHocSubprocessActivityEntity toAdHocSubprocessActivityEntity(

--- a/service/src/main/java/io/camunda/service/AdHocSubprocessActivityServices.java
+++ b/service/src/main/java/io/camunda/service/AdHocSubprocessActivityServices.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.camunda.search.entities.AdHocSubprocessActivityEntity;
+import io.camunda.search.entities.AdHocSubprocessActivityEntity.ActivityType;
+import io.camunda.search.entities.ProcessDefinitionEntity;
+import io.camunda.search.exception.NotFoundException;
+import io.camunda.search.query.AdHocSubprocessActivityQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.Authentication;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
+import io.camunda.zeebe.model.bpmn.instance.FlowNode;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
+
+public class AdHocSubprocessActivityServices extends ApiServices<AdHocSubprocessActivityServices> {
+
+  private final ProcessDefinitionServices processDefinitionServices;
+
+  public AdHocSubprocessActivityServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final ProcessDefinitionServices processDefinitionServices,
+      final Authentication authentication) {
+    super(brokerClient, securityContextProvider, authentication);
+    this.processDefinitionServices = processDefinitionServices;
+  }
+
+  @Override
+  public AdHocSubprocessActivityServices withAuthentication(final Authentication authentication) {
+    return new AdHocSubprocessActivityServices(
+        brokerClient,
+        securityContextProvider,
+        processDefinitionServices.withAuthentication(authentication),
+        authentication);
+  }
+
+  public SearchQueryResult<AdHocSubprocessActivityEntity> search(
+      final AdHocSubprocessActivityQuery query) {
+    final ProcessDefinitionEntity processDefinitionEntity =
+        processDefinitionServices.getByKey(query.filter().processDefinitionKey());
+
+    final BpmnModelInstance modelInstance =
+        Bpmn.readModelFromStream(
+            new ByteArrayInputStream(
+                processDefinitionEntity.bpmnXml().getBytes(StandardCharsets.UTF_8)));
+
+    final var processElement =
+        modelInstance.getModelElementById(query.filter().adHocSubprocessId());
+    if (processElement instanceof final AdHocSubProcess adHocSubProcess) {
+      final var flowNodes = adHocSubProcess.getChildElementsByType(FlowNode.class);
+      final var rootActivities =
+          flowNodes.stream()
+              .filter(flowNode -> flowNode.getIncoming().isEmpty())
+              .map(
+                  flowNode ->
+                      toAdHocSubprocessActivityEntity(
+                          processDefinitionEntity, adHocSubProcess, flowNode))
+              .toList();
+
+      return new SearchQueryResult.Builder<AdHocSubprocessActivityEntity>()
+          .items(rootActivities)
+          .build();
+    }
+
+    throw new NotFoundException(
+        "Failed to find Ad-Hoc Subprocess with ID '%s'"
+            .formatted(query.filter().adHocSubprocessId()));
+  }
+
+  private AdHocSubprocessActivityEntity toAdHocSubprocessActivityEntity(
+      final ProcessDefinitionEntity processDefinitionEntity,
+      final AdHocSubProcess adHocSubProcess,
+      final FlowNode flowNode) {
+    return new AdHocSubprocessActivityEntity(
+        processDefinitionEntity.processDefinitionKey(),
+        processDefinitionEntity.processDefinitionId(),
+        adHocSubProcess.getId(),
+        flowNode.getId(),
+        flowNode.getName(),
+        ActivityType.fromZeebeBpmnElementTypeName(flowNode.getElementType().getTypeName()),
+        documentationAsString(flowNode),
+        processDefinitionEntity.tenantId());
+  }
+
+  private String documentationAsString(final FlowNode flowNode) {
+    final var documentation =
+        flowNode.getDocumentations().stream()
+            .map(ModelElementInstance::getTextContent)
+            .collect(Collectors.joining("\n"));
+
+    if (documentation.isBlank()) {
+      return null;
+    }
+
+    return documentation;
+  }
+}

--- a/service/src/main/java/io/camunda/service/AdHocSubprocessActivityServices.java
+++ b/service/src/main/java/io/camunda/service/AdHocSubprocessActivityServices.java
@@ -65,39 +65,36 @@ public class AdHocSubprocessActivityServices extends ApiServices<AdHocSubprocess
               .formatted(query.filter().adHocSubprocessId()));
     }
 
-    final var flowNodes = adHocSubProcess.getChildElementsByType(FlowNode.class);
-    final var rootActivities =
-        flowNodes.stream()
-            .filter(flowNode -> flowNode.getIncoming().isEmpty())
+    final var activities =
+        adHocSubProcess.getChildElementsByType(FlowNode.class).stream()
+            .filter(element -> element.getIncoming().isEmpty())
             .map(
-                flowNode ->
+                element ->
                     toAdHocSubprocessActivityEntity(
-                        processDefinitionEntity, adHocSubProcess, flowNode))
+                        processDefinitionEntity, adHocSubProcess, element))
             .toList();
 
-    return new SearchQueryResult.Builder<AdHocSubprocessActivityEntity>()
-        .items(rootActivities)
-        .build();
+    return new SearchQueryResult.Builder<AdHocSubprocessActivityEntity>().items(activities).build();
   }
 
   private AdHocSubprocessActivityEntity toAdHocSubprocessActivityEntity(
       final ProcessDefinitionEntity processDefinitionEntity,
       final AdHocSubProcess adHocSubProcess,
-      final FlowNode flowNode) {
+      final FlowNode element) {
     return new AdHocSubprocessActivityEntity(
         processDefinitionEntity.processDefinitionKey(),
         processDefinitionEntity.processDefinitionId(),
         adHocSubProcess.getId(),
-        flowNode.getId(),
-        flowNode.getName(),
-        ActivityType.fromZeebeBpmnElementTypeName(flowNode.getElementType().getTypeName()),
-        documentationAsString(flowNode),
+        element.getId(),
+        element.getName(),
+        ActivityType.fromZeebeBpmnElementTypeName(element.getElementType().getTypeName()),
+        documentationAsString(element),
         processDefinitionEntity.tenantId());
   }
 
-  private String documentationAsString(final FlowNode flowNode) {
+  private String documentationAsString(final FlowNode element) {
     final var documentation =
-        flowNode.getDocumentations().stream()
+        element.getDocumentations().stream()
             .map(ModelElementInstance::getTextContent)
             .collect(Collectors.joining("\n"));
 

--- a/service/src/test/java/io/camunda/service/AdHocSubprocessActivityServicesTest.java
+++ b/service/src/test/java/io/camunda/service/AdHocSubprocessActivityServicesTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.entities.AdHocSubprocessActivityEntity;
+import io.camunda.search.entities.AdHocSubprocessActivityEntity.ActivityType;
+import io.camunda.search.entities.ProcessDefinitionEntity;
+import io.camunda.search.exception.NotFoundException;
+import io.camunda.search.filter.AdHocSubprocessActivityFilter;
+import io.camunda.search.filter.AdHocSubprocessActivityFilter.Builder;
+import io.camunda.search.query.AdHocSubprocessActivityQuery;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AdHocSubprocessActivityServicesTest {
+
+  @Mock private BrokerClient brokerClient;
+  @Mock private SecurityContextProvider securityContextProvider;
+  @Mock private ProcessDefinitionServices processDefinitionServices;
+
+  @InjectMocks private AdHocSubprocessActivityServices adHocSubprocessActivityServices;
+
+  @Nested
+  class SearchActivities {
+    private static final long PROCESS_DEFINITION_KEY = 2251799813685281L;
+    private static final String PROCESS_DEFINITION_ID = "TestParentAdHocSubprocess";
+    private static final String AD_HOC_SUBPROCESS_ID = "TestAdHocSubprocess";
+
+    @Mock private ProcessDefinitionEntity processDefinitionEntity;
+
+    @BeforeEach
+    void setUp() throws Exception {
+      when(processDefinitionServices.getByKey(PROCESS_DEFINITION_KEY))
+          .thenReturn(processDefinitionEntity);
+
+      when(processDefinitionEntity.bpmnXml())
+          .thenReturn(
+              Files.readString(
+                  Path.of(
+                      getClass()
+                          .getClassLoader()
+                          .getResource("ad-hoc-subprocess/test-ad-hoc-subprocess.bpmn")
+                          .toURI())));
+    }
+
+    @Test
+    void shouldSearchAdHocSubprocessActivities() {
+      when(processDefinitionEntity.processDefinitionKey()).thenReturn(PROCESS_DEFINITION_KEY);
+      when(processDefinitionEntity.processDefinitionId()).thenReturn(PROCESS_DEFINITION_ID);
+      when(processDefinitionEntity.tenantId()).thenReturn("<default>");
+
+      final var result = adHocSubprocessActivityServices.search(defaultSearchQuery());
+
+      assertThat(result.items())
+          .hasSize(2)
+          // TestServiceTask is no root node (has incoming sequence flow)
+          .noneMatch(activity -> activity.flowNodeId().equals("TestServiceTask"))
+          .extracting(
+              AdHocSubprocessActivityEntity::processDefinitionKey,
+              AdHocSubprocessActivityEntity::processDefinitionId,
+              AdHocSubprocessActivityEntity::adHocSubprocessId,
+              AdHocSubprocessActivityEntity::flowNodeId,
+              AdHocSubprocessActivityEntity::flowNodeName,
+              AdHocSubprocessActivityEntity::type,
+              AdHocSubprocessActivityEntity::documentation,
+              AdHocSubprocessActivityEntity::tenantId)
+          .containsExactlyInAnyOrder(
+              tuple(
+                  PROCESS_DEFINITION_KEY,
+                  PROCESS_DEFINITION_ID,
+                  AD_HOC_SUBPROCESS_ID,
+                  "TestScriptTask",
+                  "test script task",
+                  ActivityType.SCRIPT_TASK,
+                  "This is a test script task",
+                  "<default>"),
+              tuple(
+                  PROCESS_DEFINITION_KEY,
+                  PROCESS_DEFINITION_ID,
+                  AD_HOC_SUBPROCESS_ID,
+                  "TestUserTask",
+                  "test user task",
+                  ActivityType.USER_TASK,
+                  null,
+                  "<default>"));
+    }
+
+    @Test
+    void shouldThrowNotFoundExceptionWhenAdHocSubprocessDoesNotExist() {
+      assertThatThrownBy(
+              () ->
+                  adHocSubprocessActivityServices.search(
+                      defaultSearchQuery(filter -> filter.adHocSubprocessId("nonExistingId"))))
+          .isInstanceOf(NotFoundException.class)
+          .hasMessage("Failed to find Ad-Hoc Subprocess with ID 'nonExistingId'");
+    }
+
+    @Test
+    void shouldThrowNotFoundExceptionWhenElementWithAdHocSubprocessIdIsUnexpectedType() {
+      assertThatThrownBy(
+              () ->
+                  adHocSubprocessActivityServices.search(
+                      defaultSearchQuery(filter -> filter.adHocSubprocessId("StartEvent_1"))))
+          .isInstanceOf(NotFoundException.class)
+          .hasMessage("Failed to find Ad-Hoc Subprocess with ID 'StartEvent_1'");
+    }
+
+    private AdHocSubprocessActivityQuery defaultSearchQuery() {
+      return defaultSearchQuery(filter -> {});
+    }
+
+    private AdHocSubprocessActivityQuery defaultSearchQuery(
+        final Consumer<Builder> filterModification) {
+      final var filterBuilder =
+          AdHocSubprocessActivityFilter.builder()
+              .processDefinitionKey(PROCESS_DEFINITION_KEY)
+              .adHocSubprocessId(AD_HOC_SUBPROCESS_ID);
+
+      filterModification.accept(filterBuilder);
+
+      return AdHocSubprocessActivityQuery.builder().filter(filterBuilder.build()).build();
+    }
+  }
+}

--- a/service/src/test/java/io/camunda/service/AdHocSubprocessActivityServicesTest.java
+++ b/service/src/test/java/io/camunda/service/AdHocSubprocessActivityServicesTest.java
@@ -75,13 +75,13 @@ class AdHocSubprocessActivityServicesTest {
       assertThat(result.items())
           .hasSize(2)
           // TestServiceTask is no root node (has incoming sequence flow)
-          .noneMatch(activity -> activity.flowNodeId().equals("TestServiceTask"))
+          .noneMatch(activity -> activity.elementId().equals("TestServiceTask"))
           .extracting(
               AdHocSubprocessActivityEntity::processDefinitionKey,
               AdHocSubprocessActivityEntity::processDefinitionId,
               AdHocSubprocessActivityEntity::adHocSubprocessId,
-              AdHocSubprocessActivityEntity::flowNodeId,
-              AdHocSubprocessActivityEntity::flowNodeName,
+              AdHocSubprocessActivityEntity::elementId,
+              AdHocSubprocessActivityEntity::elementName,
               AdHocSubprocessActivityEntity::type,
               AdHocSubprocessActivityEntity::documentation,
               AdHocSubprocessActivityEntity::tenantId)

--- a/service/src/test/resources/ad-hoc-subprocess/test-ad-hoc-subprocess.bpmn
+++ b/service/src/test/resources/ad-hoc-subprocess/test-ad-hoc-subprocess.bpmn
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1kj358h" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.32.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="TestParentAdHocSubprocess" isExecutable="true">
+    <bpmn:adHocSubProcess id="TestAdHocSubprocess" name="Ad-Hoc Subprocess">
+      <bpmn:extensionElements>
+        <zeebe:adHoc />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1nmmpcw</bpmn:incoming>
+      <bpmn:outgoing>Flow_1e1ppa1</bpmn:outgoing>
+      <bpmn:sequenceFlow id="Flow_0h7ye31" sourceRef="TestUserTask" targetRef="TestServiceTask" />
+      <bpmn:scriptTask id="TestScriptTask" name="test script task">
+        <bpmn:documentation>This is a test script task</bpmn:documentation>
+        <bpmn:extensionElements>
+          <zeebe:script expression="=2 * 2" resultVariable="fooCalculation" />
+        </bpmn:extensionElements>
+      </bpmn:scriptTask>
+      <bpmn:serviceTask id="TestServiceTask" name="test service task">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="testType" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_0h7ye31</bpmn:incoming>
+      </bpmn:serviceTask>
+      <bpmn:userTask id="TestUserTask" name="test user task">
+        <bpmn:extensionElements>
+          <zeebe:userTask />
+          <zeebe:formDefinition formId="testForm" />
+        </bpmn:extensionElements>
+        <bpmn:outgoing>Flow_0h7ye31</bpmn:outgoing>
+      </bpmn:userTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_1e1ppa1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1e1ppa1" sourceRef="TestAdHocSubprocess" targetRef="EndEvent_1" />
+    <bpmn:sequenceFlow id="Flow_1nmmpcw" sourceRef="StartEvent_1" targetRef="TestAdHocSubprocess" />
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1nmmpcw</bpmn:outgoing>
+    </bpmn:startEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="TestParentAdHocSubprocess">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="172" y="187" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_071g6t1_di" bpmnElement="TestAdHocSubprocess" isExpanded="true">
+        <dc:Bounds x="280" y="70" width="350" height="270" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0vuyrum_di" bpmnElement="TestScriptTask">
+        <dc:Bounds x="410" y="110" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1wiygn1_di" bpmnElement="TestUserTask">
+        <dc:Bounds x="330" y="215" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_18de575_di" bpmnElement="TestServiceTask">
+        <dc:Bounds x="480" y="215" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0h7ye31_di" bpmnElement="Flow_0h7ye31">
+        <di:waypoint x="430" y="255" />
+        <di:waypoint x="480" y="255" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0nc2s10_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="702" y="187" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1nmmpcw_di" bpmnElement="Flow_1nmmpcw">
+        <di:waypoint x="208" y="205" />
+        <di:waypoint x="280" y="205" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1e1ppa1_di" bpmnElement="Flow_1e1ppa1">
+        <di:waypoint x="630" y="205" />
+        <di:waypoint x="702" y="205" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1644,46 +1644,6 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
-  /ad-hoc-activities/search:
-    post:
-      tags:
-        - Ad-hoc subprocess
-      operationId: findAdHocSubprocessActivities
-      summary: Query activatable activities
-      description: |
-        Search for activatable activities within ad-hoc subprocesses based on given criteria.
-
-        Note that this API currently requires filters for both process definition key and ad-hoc
-        subprocess ID and does not support paging or sorting.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/AdHocSubprocessActivitySearchQuery"
-      responses:
-        "200":
-          description: >
-            The ad-hoc subprocess activities search result.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/AdHocSubprocessActivitySearchQueryResult"
-        "400":
-          description: >
-            The ad-hoc subprocess activities search query failed.
-            More details are provided in the response body.
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ProblemDetail"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "403":
-          $ref: "#/components/responses/Forbidden"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-
   /decision-definitions/search:
     post:
       tags:
@@ -3302,6 +3262,46 @@ paths:
           description: The variables were updated.
         "400":
           $ref: "#/components/responses/InvalidData"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /element-instances/ad-hoc-activities/search:
+    post:
+      tags:
+        - Ad-hoc subprocess
+      operationId: findAdHocSubprocessActivities
+      summary: Query activatable activities
+      description: |
+        Search for activatable activities within ad-hoc subprocesses based on given criteria.
+
+        Note that this API currently requires filters for both process definition key and ad-hoc
+        subprocess ID and does not support paging or sorting.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdHocSubprocessActivitySearchQuery"
+      responses:
+        "200":
+          description: >
+            The ad-hoc subprocess activities search result.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdHocSubprocessActivitySearchQueryResult"
+        "400":
+          description: >
+            The ad-hoc subprocess activities search query failed.
+            More details are provided in the response body.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalServerError"
 

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1649,7 +1649,7 @@ paths:
       tags:
         - Ad-hoc subprocess
       operationId: findAdHocSubprocessActivities
-      summary: Query activatable activities within ad-hoc subprocesses
+      summary: Query activatable activities
       description: |
         Search for activatable activities within ad-hoc subprocesses based on given criteria.
 
@@ -4528,7 +4528,7 @@ components:
           description: The flow node name for this activity.
           type: string
         type:
-          description: Type of activity as defined set of values.
+          description: Type of activity with a defined set of values.
           type: string
           enum:
             - UNSPECIFIED

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3270,12 +3270,15 @@ paths:
       tags:
         - Ad-hoc subprocess
       operationId: findAdHocSubprocessActivities
-      summary: Query activatable activities
+      summary: Query activatable activities (alpha)
       description: |
         Search for activatable activities within ad-hoc subprocesses based on given criteria.
 
         Note that this API currently requires filters for both process definition key and ad-hoc
         subprocess ID and does not support paging or sorting.
+
+        This endpoint is an alpha feature and may be subject to change
+        in future releases.
       requestBody:
         required: true
         content:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4521,11 +4521,11 @@ components:
         adHocSubprocessId:
           description: The ad-hoc subprocess element ID.
           type: string
-        flowNodeId:
-          description: The flow node ID for this activity.
+        elementId:
+          description: The element ID for this activity.
           type: string
-        flowNodeName:
-          description: The flow node name for this activity.
+        elementName:
+          description: The element name for this activity.
           type: string
         type:
           description: Type of activity with a defined set of values.

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -24,6 +24,7 @@ servers:
         description: The schema of the Camunda 8 REST API server.
 
 tags:
+  - name: Ad-hoc subprocess
   - name: Authentication
   - name: Authorization
   - name: Clock
@@ -1640,6 +1641,46 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /ad-hoc-activities/search:
+    post:
+      tags:
+        - Ad-hoc subprocess
+      operationId: findAdHocSubprocessActivities
+      summary: Query activatable activities within ad-hoc subprocesses
+      description: |
+        Search for activatable activities within ad-hoc subprocesses based on given criteria.
+
+        Note that this API currently requires filters for both process definition key and ad-hoc
+        subprocess ID and does not support paging or sorting.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdHocSubprocessActivitySearchQuery"
+      responses:
+        "200":
+          description: >
+            The ad-hoc subprocess activities search result.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdHocSubprocessActivitySearchQueryResult"
+        "400":
+          description: >
+            The ad-hoc subprocess activities search query failed.
+            More details are provided in the response body.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalServerError"
 
@@ -4436,6 +4477,83 @@ components:
           type: string
         incidentKey:
           description: Incident key associated with this flow node instance.
+          type: string
+    AdHocSubprocessActivitySearchQuery:
+      description: Ad-hoc subprocess activities search request.
+      type: object
+      required:
+        - filter
+      properties:
+        filter:
+          description: The ad-hoc subprocess activity search filters.
+          allOf:
+            - $ref: "#/components/schemas/AdHocSubprocessActivityFilter"
+    AdHocSubprocessActivityFilter:
+      description: Flow node instance filter.
+      type: object
+      required:
+        - processDefinitionKey
+        - adHocSubprocessId
+      properties:
+        processDefinitionKey:
+          description: The process definition key.
+          type: string
+        adHocSubprocessId:
+          description: The ad-hoc subprocess process element ID.
+          type: string
+    AdHocSubprocessActivitySearchQueryResult:
+      type: object
+      properties:
+        items:
+          description: The matching ad-hoc subprocess activities.
+          type: array
+          items:
+            $ref: "#/components/schemas/AdHocSubprocessActivityResult"
+    AdHocSubprocessActivityResult:
+      type: object
+      properties:
+        processDefinitionKey:
+          description: The process definition key associated to this activity.
+          type: string
+        processDefinitionId:
+          description: The process definition ID associated to this activity.
+          type: string
+        adHocSubprocessId:
+          description: The ad-hoc subprocess process element ID.
+          type: string
+        flowNodeId:
+          description: The flow node ID for this activity.
+          type: string
+        flowNodeName:
+          description: The flow node name for this activity.
+          type: string
+        type:
+          description: Type of activity as defined set of values.
+          type: string
+          enum:
+            - UNSPECIFIED
+            - PROCESS
+            - SUB_PROCESS
+            - EVENT_SUB_PROCESS
+            - INTERMEDIATE_CATCH_EVENT
+            - INTERMEDIATE_THROW_EVENT
+            - BOUNDARY_EVENT
+            - SERVICE_TASK
+            - RECEIVE_TASK
+            - USER_TASK
+            - MANUAL_TASK
+            - TASK
+            - MULTI_INSTANCE_BODY
+            - CALL_ACTIVITY
+            - BUSINESS_RULE_TASK
+            - SCRIPT_TASK
+            - SEND_TASK
+            - UNKNOWN
+        documentation:
+          description: The documentation for this activity.
+          type: string
+        tenantId:
+          description: The tenant ID for this activity.
           type: string
     DecisionDefinitionSearchQuerySortRequest:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4499,7 +4499,7 @@ components:
           description: The process definition key.
           type: string
         adHocSubprocessId:
-          description: The ad-hoc subprocess process element ID.
+          description: The ad-hoc subprocess element ID.
           type: string
     AdHocSubprocessActivitySearchQueryResult:
       type: object
@@ -4519,7 +4519,7 @@ components:
           description: The process definition ID associated to this activity.
           type: string
         adHocSubprocessId:
-          description: The ad-hoc subprocess process element ID.
+          description: The ad-hoc subprocess element ID.
           type: string
         flowNodeId:
           description: The flow node ID for this activity.

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest;
 
+import static io.camunda.zeebe.gateway.rest.util.KeyUtil.tryParseLong;
 import static io.camunda.zeebe.gateway.rest.validator.AuthorizationRequestValidator.validateAuthorizationRequest;
 import static io.camunda.zeebe.gateway.rest.validator.ClockValidator.validateClockPinRequest;
 import static io.camunda.zeebe.gateway.rest.validator.DocumentValidator.validateDocumentLinkParams;
@@ -928,14 +929,6 @@ public class RequestMapper {
       final R request, final Function<R, Long> valueExtractor, final Long defaultValue) {
     final Long value = request == null ? null : valueExtractor.apply(request);
     return value == null ? defaultValue : value;
-  }
-
-  private static Optional<Long> tryParseLong(final String value) {
-    try {
-      return Optional.of(Long.parseLong(value));
-    } catch (final NumberFormatException e) {
-      return Optional.empty();
-    }
   }
 
   private static <R> long getKeyOrDefault(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -384,8 +384,8 @@ public final class SearchQueryResponseMapper {
         .processDefinitionKey(entity.processDefinitionKey().toString())
         .processDefinitionId(entity.processDefinitionId())
         .adHocSubprocessId(entity.adHocSubprocessId())
-        .flowNodeId(entity.flowNodeId())
-        .flowNodeName(entity.flowNodeName())
+        .elementId(entity.elementId())
+        .elementName(entity.elementName())
         .type(AdHocSubprocessActivityResult.TypeEnum.fromValue(entity.type().name()))
         .documentation(entity.documentation())
         .tenantId(entity.tenantId());

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.gateway.rest.ResponseMapper.formatDate;
 import static java.util.Collections.emptyList;
 import static java.util.Optional.ofNullable;
 
+import io.camunda.search.entities.AdHocSubprocessActivityEntity;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.entities.DecisionInstanceEntity;
@@ -33,6 +34,7 @@ import io.camunda.search.entities.UserEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivityResult;
 import io.camunda.zeebe.gateway.protocol.rest.AuthorizationResult;
 import io.camunda.zeebe.gateway.protocol.rest.AuthorizationSearchResult;
 import io.camunda.zeebe.gateway.protocol.rest.DecisionDefinitionResult;
@@ -374,6 +376,19 @@ public final class SearchQueryResponseMapper {
         .state(FlowNodeInstanceResult.StateEnum.fromValue(instance.state().name()))
         .type(FlowNodeInstanceResult.TypeEnum.fromValue(instance.type().name()))
         .tenantId(instance.tenantId());
+  }
+
+  public static AdHocSubprocessActivityResult toAdHocSubprocessActivity(
+      final AdHocSubprocessActivityEntity entity) {
+    return new AdHocSubprocessActivityResult()
+        .processDefinitionKey(entity.processDefinitionKey().toString())
+        .processDefinitionId(entity.processDefinitionId())
+        .adHocSubprocessId(entity.adHocSubprocessId())
+        .flowNodeId(entity.flowNodeId())
+        .flowNodeName(entity.flowNodeName())
+        .type(AdHocSubprocessActivityResult.TypeEnum.fromValue(entity.type().name()))
+        .documentation(entity.documentation())
+        .tenantId(entity.tenantId());
   }
 
   public static DecisionDefinitionResult toDecisionDefinition(final DecisionDefinitionEntity d) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @CamundaRestController
-@RequestMapping("/v2/ad-hoc-activities")
+@RequestMapping("/v2/element-instances/ad-hoc-activities")
 public class AdHocSubprocessActivityController {
 
   private final AdHocSubprocessActivityServices adHocSubprocessActivityServices;

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityController.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
+
+import io.camunda.search.query.AdHocSubprocessActivityQuery;
+import io.camunda.service.AdHocSubprocessActivityServices;
+import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivitySearchQuery;
+import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivitySearchQueryResult;
+import io.camunda.zeebe.gateway.rest.RequestMapper;
+import io.camunda.zeebe.gateway.rest.RestErrorMapper;
+import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@CamundaRestController
+@RequestMapping("/v2/ad-hoc-activities")
+public class AdHocSubprocessActivityController {
+
+  private final AdHocSubprocessActivityServices adHocSubprocessActivityServices;
+
+  public AdHocSubprocessActivityController(
+      final AdHocSubprocessActivityServices adHocSubprocessActivityServices) {
+    this.adHocSubprocessActivityServices = adHocSubprocessActivityServices;
+  }
+
+  @CamundaPostMapping(path = "/search")
+  public ResponseEntity<AdHocSubprocessActivitySearchQueryResult> searchAdHocSubprocessActivities(
+      @RequestBody final AdHocSubprocessActivitySearchQuery query) {
+    return RequestMapper.toAdHocSubprocessActivityQuery(query)
+        .fold(RestErrorMapper::mapProblemToResponse, this::searchAdHocSubprocessActivities);
+  }
+
+  private ResponseEntity<AdHocSubprocessActivitySearchQueryResult> searchAdHocSubprocessActivities(
+      final AdHocSubprocessActivityQuery query) {
+    try {
+      final var activities =
+          adHocSubprocessActivityServices
+              .withAuthentication(RequestMapper.getAuthentication())
+              .search(query);
+
+      final var result = new AdHocSubprocessActivitySearchQueryResult();
+      result.setItems(
+          activities.items().stream()
+              .map(SearchQueryResponseMapper::toAdHocSubprocessActivity)
+              .toList());
+
+      return ResponseEntity.ok(result);
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/util/KeyUtil.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/util/KeyUtil.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.gateway.rest.util;
 
+import java.util.Optional;
+
 public class KeyUtil {
 
   public static Long keyToLong(final String key) {
@@ -15,5 +17,13 @@ public class KeyUtil {
 
   public static String keyToString(final Long value) {
     return value != null ? String.valueOf(value) : null;
+  }
+
+  public static Optional<Long> tryParseLong(final String key) {
+    try {
+      return Optional.ofNullable(keyToLong(key));
+    } catch (final NumberFormatException e) {
+      return Optional.empty();
+    }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityControllerTest.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.assertArg;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.entities.AdHocSubprocessActivityEntity;
+import io.camunda.search.entities.AdHocSubprocessActivityEntity.ActivityType;
+import io.camunda.search.exception.NotFoundException;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.Authentication;
+import io.camunda.service.AdHocSubprocessActivityServices;
+import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivityResult;
+import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivityResult.TypeEnum;
+import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivitySearchQueryResult;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@WebMvcTest(value = AdHocSubprocessActivityController.class)
+class AdHocSubprocessActivityControllerTest extends RestControllerTest {
+  private static final String AD_HOC_ACTIVITIES_URL = "/v2/ad-hoc-activities";
+  private static final String SEARCH_ACTIVITIES_URL = AD_HOC_ACTIVITIES_URL + "/search";
+
+  @MockitoBean private AdHocSubprocessActivityServices adHocSubprocessActivityServices;
+
+  @BeforeEach
+  void setUpServices() {
+    when(adHocSubprocessActivityServices.withAuthentication(any(Authentication.class)))
+        .thenReturn(adHocSubprocessActivityServices);
+  }
+
+  @Nested
+  class SearchActivities {
+    private static final Long PROCESS_DEFINITION_KEY = 2251799813685281L;
+    private static final String PROCESS_DEFINITION_ID = "TestParentAdHocSubprocess";
+    private static final String AD_HOC_SUBPROCESS_ID = "TestAdHocSubprocess";
+
+    @Test
+    void shouldMapSearchResultToSuccessfulResponse() {
+      when(adHocSubprocessActivityServices.search(any()))
+          .thenReturn(
+              new SearchQueryResult.Builder<AdHocSubprocessActivityEntity>()
+                  .items(
+                      List.of(
+                          new AdHocSubprocessActivityEntity(
+                              PROCESS_DEFINITION_KEY,
+                              PROCESS_DEFINITION_ID,
+                              AD_HOC_SUBPROCESS_ID,
+                              "task1",
+                              "Task #1",
+                              ActivityType.SERVICE_TASK,
+                              "The first task in the ad-hoc subprocess",
+                              null),
+                          new AdHocSubprocessActivityEntity(
+                              PROCESS_DEFINITION_KEY,
+                              PROCESS_DEFINITION_ID,
+                              AD_HOC_SUBPROCESS_ID,
+                              "task2",
+                              "Task #2",
+                              ActivityType.USER_TASK,
+                              "The second task in the ad-hoc subprocess",
+                              null)))
+                  .build());
+
+      webClient
+          .post()
+          .uri(SEARCH_ACTIVITIES_URL)
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(
+              """
+            {
+              "filter": {
+                "processDefinitionKey": 2251799813685281,
+                "adHocSubprocessId": "TestAdHocSubprocess"
+              }
+            }
+            """)
+          .exchange()
+          .expectStatus()
+          .isOk()
+          .expectBody(AdHocSubprocessActivitySearchQueryResult.class)
+          .consumeWith(
+              result -> {
+                final var responseBody = result.getResponseBody();
+                assertThat(responseBody).isNotNull();
+                assertThat(responseBody.getItems())
+                    .hasSize(2)
+                    .extracting(
+                        AdHocSubprocessActivityResult::getProcessDefinitionKey,
+                        AdHocSubprocessActivityResult::getProcessDefinitionId,
+                        AdHocSubprocessActivityResult::getAdHocSubprocessId,
+                        AdHocSubprocessActivityResult::getFlowNodeId,
+                        AdHocSubprocessActivityResult::getFlowNodeName,
+                        AdHocSubprocessActivityResult::getType,
+                        AdHocSubprocessActivityResult::getDocumentation,
+                        AdHocSubprocessActivityResult::getTenantId)
+                    .containsExactly(
+                        tuple(
+                            PROCESS_DEFINITION_KEY.toString(),
+                            PROCESS_DEFINITION_ID,
+                            AD_HOC_SUBPROCESS_ID,
+                            "task1",
+                            "Task #1",
+                            TypeEnum.SERVICE_TASK,
+                            "The first task in the ad-hoc subprocess",
+                            null),
+                        tuple(
+                            PROCESS_DEFINITION_KEY.toString(),
+                            PROCESS_DEFINITION_ID,
+                            AD_HOC_SUBPROCESS_ID,
+                            "task2",
+                            "Task #2",
+                            TypeEnum.USER_TASK,
+                            "The second task in the ad-hoc subprocess",
+                            null));
+              });
+
+      verify(adHocSubprocessActivityServices)
+          .search(
+              assertArg(
+                  r -> {
+                    assertThat(r.filter().processDefinitionKey()).isEqualTo(PROCESS_DEFINITION_KEY);
+                    assertThat(r.filter().adHocSubprocessId()).isEqualTo(AD_HOC_SUBPROCESS_ID);
+                  }));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidSearchParameters")
+    void shouldRejectSearchWhenParametersAreInvalidOrMissing(
+        final String request, final String expectedErrorDetail) {
+      webClient
+          .post()
+          .uri(SEARCH_ACTIVITIES_URL)
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(request)
+          .exchange()
+          .expectStatus()
+          .isBadRequest()
+          .expectBody()
+          .json(
+              """
+            {
+                "type": "about:blank",
+                "title": "INVALID_ARGUMENT",
+                "status": 400,
+                "instance": "/v2/ad-hoc-activities/search"
+            }
+            """)
+          .jsonPath(".detail")
+          .isEqualTo(expectedErrorDetail);
+    }
+
+    @Test
+    void shouldMapServiceExceptionToErrorResponse() {
+      when(adHocSubprocessActivityServices.search(any()))
+          .thenThrow(
+              new NotFoundException(
+                  "Failed to find Ad-Hoc Subprocess with ID 'TestAdHocSubprocess'"));
+
+      webClient
+          .post()
+          .uri(SEARCH_ACTIVITIES_URL)
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(
+              """
+            {
+              "filter": {
+                "processDefinitionKey": 2251799813685281,
+                "adHocSubprocessId": "TestAdHocSubprocess"
+              }
+            }
+            """)
+          .exchange()
+          .expectStatus()
+          .isNotFound()
+          .expectBody()
+          .json(
+              """
+            {
+                "type": "about:blank",
+                "title": "NOT_FOUND",
+                "status": 404,
+                "detail": "Failed to find Ad-Hoc Subprocess with ID 'TestAdHocSubprocess'",
+                "instance": "/v2/ad-hoc-activities/search"
+            }
+            """);
+    }
+
+    static Stream<Arguments> invalidSearchParameters() {
+      return Stream.of(
+          arguments(
+              """
+              {}
+              """,
+              "No filter provided."),
+          arguments(
+              """
+              {
+                "filter": {}
+              }
+              """,
+              "The value for filter.processDefinitionKey is 'null' but must be a non-negative numeric value. No filter.adHocSubprocessId provided."),
+          arguments(
+              """
+              {
+                "filter": {
+                  "processDefinitionKey": 0,
+                  "adHocSubprocessId": "TestAdHocSubprocess"
+                }
+              }
+              """,
+              "The value for filter.processDefinitionKey is '0' but must be a non-negative numeric value."),
+          arguments(
+              """
+              {
+                "filter": {
+                  "processDefinitionKey": -1,
+                  "adHocSubprocessId": "TestAdHocSubprocess"
+                }
+              }
+              """,
+              "The value for filter.processDefinitionKey is '-1' but must be a non-negative numeric value."),
+          arguments(
+              """
+              {
+                "filter": {
+                  "processDefinitionKey": 2251799813685281
+                }
+              }
+              """,
+              "No filter.adHocSubprocessId provided."),
+          arguments(
+              """
+              {
+                "filter": {
+                  "processDefinitionKey": 2251799813685281,
+                  "adHocSubprocessId": ""
+                }
+              }
+              """,
+              "No filter.adHocSubprocessId provided."),
+          arguments(
+              """
+              {
+                "filter": {
+                  "processDefinitionKey": 2251799813685281,
+                  "adHocSubprocessId": "   "
+                }
+              }
+              """,
+              "No filter.adHocSubprocessId provided."));
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityControllerTest.java
@@ -111,8 +111,8 @@ class AdHocSubprocessActivityControllerTest extends RestControllerTest {
                         AdHocSubprocessActivityResult::getProcessDefinitionKey,
                         AdHocSubprocessActivityResult::getProcessDefinitionId,
                         AdHocSubprocessActivityResult::getAdHocSubprocessId,
-                        AdHocSubprocessActivityResult::getFlowNodeId,
-                        AdHocSubprocessActivityResult::getFlowNodeName,
+                        AdHocSubprocessActivityResult::getElementId,
+                        AdHocSubprocessActivityResult::getElementName,
                         AdHocSubprocessActivityResult::getType,
                         AdHocSubprocessActivityResult::getDocumentation,
                         AdHocSubprocessActivityResult::getTenantId)

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityControllerTest.java
@@ -39,7 +39,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(value = AdHocSubprocessActivityController.class)
 class AdHocSubprocessActivityControllerTest extends RestControllerTest {
-  private static final String AD_HOC_ACTIVITIES_URL = "/v2/ad-hoc-activities";
+  private static final String AD_HOC_ACTIVITIES_URL = "/v2/element-instances/ad-hoc-activities";
   private static final String SEARCH_ACTIVITIES_URL = AD_HOC_ACTIVITIES_URL + "/search";
 
   @MockitoBean private AdHocSubprocessActivityServices adHocSubprocessActivityServices;
@@ -166,7 +166,7 @@ class AdHocSubprocessActivityControllerTest extends RestControllerTest {
                 "type": "about:blank",
                 "title": "INVALID_ARGUMENT",
                 "status": 400,
-                "instance": "/v2/ad-hoc-activities/search"
+                "instance": "/v2/element-instances/ad-hoc-activities/search"
             }
             """)
           .jsonPath(".detail")
@@ -205,7 +205,7 @@ class AdHocSubprocessActivityControllerTest extends RestControllerTest {
                 "title": "NOT_FOUND",
                 "status": 404,
                 "detail": "Failed to find Ad-Hoc Subprocess with ID 'TestAdHocSubprocess'",
-                "instance": "/v2/ad-hoc-activities/search"
+                "instance": "/v2/element-instances/ad-hoc-activities/search"
             }
             """);
     }


### PR DESCRIPTION
## Description

Implements a REST endpoint to search for activities within an ad-hoc subprocess.

While the final implementation of this endpoint should include process instance data and list all activities within running ad-hoc subprocesses, this first iteration returns a static list of activities as resolved from a process definition.

Therefore this endpoint requires both `processDefinitionKey` and `adHocSubprocessId` on the filter object and does not allow any sorting/paging yet.

Example request:

```json5
// POST http://localhost:8080/v2/element-instances/ad-hoc-activities/search
{
  "filter": {
    "processDefinitionKey": 2251799813685269,
    "adHocSubprocessId": "MyAdHocSubProcess"
  }
}
```

Example response:

```json5
{
  "items": [
    {
      "processDefinitionKey": "2251799813685269",
      "processDefinitionId": "TestProcessId",
      "adHocSubprocessId": "MyAdHocSubProcess",
      "elementId": "fooCalculation",
      "elementName": "foo calculation",
      "documentation": "This is a foo calculation",
      "type": "SCRIPT_TASK",
      "tenantId": "<default>"
    },
    {
      "processDefinitionKey": "2251799813685269",
      "processDefinitionId": "TestProcessId",
      "adHocSubprocessId": "AdHocSubProcess",
      "elementId": "barCalculation",
      "elementName": "bar calculation",
      "documentation": "",
      "type": "SCRIPT_TASK",
      "tenantId": "<default>"
    }
  ]
}
```

## Related issues

closes #27930
