### PR TITLE
refactor: remove C7 engine-commons config from Optimize C8

### DIFF
--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationService.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationService.java
@@ -367,31 +367,6 @@ public class ConfigurationService {
     this.maximumBackoff = maximumBackoff;
   }
 
-  public int getEngineConnectTimeout() {
-    if (engineConnectTimeout == null) {
-      engineConnectTimeout =
-          configJsonContext.read(
-              ConfigurationServiceConstants.ENGINE_CONNECT_TIMEOUT, Integer.class);
-    }
-    return engineConnectTimeout;
-  }
-
-  public void setEngineConnectTimeout(final Integer engineConnectTimeout) {
-    this.engineConnectTimeout = engineConnectTimeout;
-  }
-
-  public int getEngineReadTimeout() {
-    if (engineReadTimeout == null) {
-      engineReadTimeout =
-          configJsonContext.read(ConfigurationServiceConstants.ENGINE_READ_TIMEOUT, Integer.class);
-    }
-    return engineReadTimeout;
-  }
-
-  public void setEngineReadTimeout(final Integer engineReadTimeout) {
-    this.engineReadTimeout = engineReadTimeout;
-  }
-
   public int getCurrentTimeBackoffMilliseconds() {
     if (currentTimeBackoffMilliseconds == null) {
       currentTimeBackoffMilliseconds =

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceConstants.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceConstants.java
@@ -130,9 +130,6 @@ public final class ConfigurationServiceConstants {
   public static final String IMPORT_INDEX_AUTO_STORAGE_INTERVAL =
       "$.import.importIndexStorageIntervalInSec";
 
-  public static final String ENGINE_CONNECT_TIMEOUT = "$.engine-commons.connection.timeout";
-  public static final String ENGINE_READ_TIMEOUT = "$.engine-commons.read.timeout";
-
   public static final String INITIAL_BACKOFF_INTERVAL = "$.import.handler.backoff.initial";
   public static final String MAXIMUM_BACK_OFF = "$.import.handler.backoff.max";
   public static final String ES_AGGREGATION_BUCKET_LIMIT = "$.es.settings.aggregationBucketLimit";

--- a/optimize/util/optimize-commons/src/main/resources/service-config.yaml
+++ b/optimize/util/optimize-commons/src/main/resources/service-config.yaml
@@ -183,18 +183,6 @@ engines:
       # Enables/disables linking to other Camunda Web Applications
       enabled: true
 
-engine-commons:
-  connection:
-    #Maximum time without connection to the engine, Optimize should wait
-    #until a timeout is triggered. A value of zero means to wait an
-    # infinite amount of time.
-    timeout: 0
-  read:
-    # Maximum time a request to the engine should last,
-    # before a timeout triggers. A value of zero means to wait an
-    # infinite amount of time.
-    timeout: 0
-
 zeebe:
   # Toggles whether Optimize should attempt to import data from the connected Zeebe instance
   enabled: ${CAMUNDA_OPTIMIZE_ZEEBE_ENABLED:false}


### PR DESCRIPTION
## Description

This is part of the "C7 config cleanup from C8". Because there's a lot of configs that need cleaning, I'm breaking this work down into multiple PRs. This one is focused on "engine-commons config" cleanup. I'm not seeing any getter/setter calls so this config should be relatively safe to remove. Most of the lines removed are setters/getters and boilerplates. For these updates I don't see any references to the engine-commons config in [C8 docs](https://docs.camunda.io/optimize/next/self-managed/optimize-deployment/configuration/system-configuration/)

Before removing a config, I checked that :

- it's not being used/referenced in camunda/camunda
- it's not expected in camunda-cloud repos
- it's not expected in camunda/camunda-platform-helm

## Related issues

related to https://github.com/camunda/camunda-optimize/issues/13375
