### PR TITLE
fix: fixed FK relations and fix rdbmsPurger FK handling

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -155,14 +155,24 @@
 
     <createTable tableName="${prefix}CANDIDATE_USER">
       <column name="USER_TASK_KEY" type="BIGINT">
-        <constraints foreignKeyName="FK_CANDIDATE_USER_USER_TASK"/>
+        <constraints
+          foreignKeyName="${prefix}FK_CANDIDATE_USER_USER_TASK"
+          referencedTableName="${prefix}USER_TASK"
+          referencedColumnNames="USER_TASK_KEY"
+          deleteCascade="true"/>
+        />
       </column>
       <column name="CANDIDATE_USER" type="VARCHAR(255)"/>
     </createTable>
 
     <createTable tableName="${prefix}CANDIDATE_GROUP">
       <column name="USER_TASK_KEY" type="BIGINT">
-        <constraints foreignKeyName="FK_CANDIDATE_GROUP_USER_TASK"/>
+        <constraints
+          foreignKeyName="${prefix}FK_CANDIDATE_GROUP_USER_TASK"
+          referencedTableName="${prefix}USER_TASK"
+          referencedColumnNames="USER_TASK_KEY"
+          deleteCascade="true"/>
+        />
       </column>
       <column name="CANDIDATE_GROUP" type="VARCHAR(255)"/>
     </createTable>
@@ -278,7 +288,13 @@
   <changeSet id="create_decision_instance_input_table" author="cthiel">
     <createTable tableName="${prefix}DECISION_INSTANCE_INPUT">
       <column name="DECISION_INSTANCE_ID" type="VARCHAR(255)">
-        <constraints primaryKey="true"/>
+        <constraints
+          primaryKey="true"
+          foreignKeyName="${prefix}FK_DEC_INST_INPUT_DEC_INST"
+          referencedTableName="${prefix}DECISION_INSTANCE"
+          referencedColumnNames="DECISION_INSTANCE_ID"
+          deleteCascade="true"/>
+        />
       </column>
       <column name="INPUT_ID" type="VARCHAR(255)">
         <constraints primaryKey="true"/>
@@ -292,7 +308,13 @@
   <changeSet id="create_decision_instance_output_table" author="cthiel">
     <createTable tableName="${prefix}DECISION_INSTANCE_OUTPUT">
       <column name="DECISION_INSTANCE_ID" type="VARCHAR(255)">
-        <constraints primaryKey="true"/>
+        <constraints
+          primaryKey="true"
+          foreignKeyName="${prefix}FK_DEC_INST_OUTPUT_DEC_INST"
+          referencedTableName="${prefix}DECISION_INSTANCE"
+          referencedColumnNames="DECISION_INSTANCE_ID"
+          deleteCascade="true"/>
+        />
       </column>
       <column name="OUTPUT_ID" type="VARCHAR(255)">
         <constraints primaryKey="true"/>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/config/VendorDatabaseProperties.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/config/VendorDatabaseProperties.java
@@ -13,9 +13,12 @@ public class VendorDatabaseProperties {
 
   private static final String VARIABLE_VALUE_PREVIEW_SIZE = "variableValue.previewSize";
 
+  private static final String DISABLE_FK_BEFORE_TRUNCATE = "disableFkBeforeTruncate";
+
   private final Properties properties;
 
   private final int variableValuePreviewSize;
+  private final boolean disableFkBeforeTruncate;
 
   public VendorDatabaseProperties(final Properties properties) {
     this.properties = properties;
@@ -26,10 +29,21 @@ public class VendorDatabaseProperties {
     }
     variableValuePreviewSize =
         Integer.parseInt(properties.getProperty(VARIABLE_VALUE_PREVIEW_SIZE));
+
+    if (!properties.containsKey(DISABLE_FK_BEFORE_TRUNCATE)) {
+      throw new IllegalArgumentException(
+          "Property '" + DISABLE_FK_BEFORE_TRUNCATE + "' is missing");
+    }
+    disableFkBeforeTruncate =
+        Boolean.parseBoolean(properties.getProperty(DISABLE_FK_BEFORE_TRUNCATE));
   }
 
   public int variableValuePreviewSize() {
     return variableValuePreviewSize;
+  }
+
+  public boolean disableFkBeforeTruncate() {
+    return disableFkBeforeTruncate;
   }
 
   public Properties properties() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/PurgeMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/PurgeMapper.java
@@ -9,5 +9,9 @@ package io.camunda.db.rdbms.sql;
 
 public interface PurgeMapper {
 
+  void disableForeignKeyChecks();
+
+  void enableForeignKeyChecks();
+
   void truncateTable(String tableName);
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
@@ -58,7 +58,7 @@ public class RdbmsWriter {
       final VendorDatabaseProperties vendorDatabaseProperties) {
     this.executionQueue = executionQueue;
     this.exporterPositionService = exporterPositionService;
-    rdbmsPurger = new RdbmsPurger(purgeMapper);
+    rdbmsPurger = new RdbmsPurger(purgeMapper, vendorDatabaseProperties);
     authorizationWriter = new AuthorizationWriter(executionQueue);
     decisionDefinitionWriter = new DecisionDefinitionWriter(executionQueue);
     decisionInstanceWriter = new DecisionInstanceWriter(executionQueue);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RdbmsPurger.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RdbmsPurger.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms.write.service;
 
+import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.sql.PurgeMapper;
 import java.util.List;
 
@@ -40,14 +41,24 @@ public class RdbmsPurger {
           "GROUPS");
 
   private final PurgeMapper purgeMapper;
+  private final VendorDatabaseProperties vendorDatabaseProperties;
 
-  public RdbmsPurger(final PurgeMapper purgeMapper) {
+  public RdbmsPurger(
+      final PurgeMapper purgeMapper, final VendorDatabaseProperties vendorDatabaseProperties) {
     this.purgeMapper = purgeMapper;
+    this.vendorDatabaseProperties = vendorDatabaseProperties;
   }
 
   public void purgeRdbms() {
+    if (vendorDatabaseProperties.disableFkBeforeTruncate()) {
+      purgeMapper.disableForeignKeyChecks();
+    }
+
     for (final String tableName : TABLE_NAMES) {
       purgeMapper.truncateTable(tableName);
+    }
+    if (vendorDatabaseProperties.disableFkBeforeTruncate()) {
+      purgeMapper.enableForeignKeyChecks();
     }
   }
 }

--- a/db/rdbms/src/main/resources/db/vendor-properties/h2.properties
+++ b/db/rdbms/src/main/resources/db/vendor-properties/h2.properties
@@ -9,3 +9,4 @@
 paging.after=LIMIT #{page.size} OFFSET #{page.from}
 keysetPaging.limit=LIMIT #{page.size}
 variableValue.previewSize=8191
+disableFkBeforeTruncate=true

--- a/db/rdbms/src/main/resources/db/vendor-properties/mariadb.properties
+++ b/db/rdbms/src/main/resources/db/vendor-properties/mariadb.properties
@@ -9,3 +9,4 @@
 paging.after=LIMIT #{page.size} OFFSET #{page.from}
 keysetPaging.limit=LIMIT #{page.size}
 variableValue.previewSize=8191
+disableFkBeforeTruncate=true

--- a/db/rdbms/src/main/resources/db/vendor-properties/oracle.properties
+++ b/db/rdbms/src/main/resources/db/vendor-properties/oracle.properties
@@ -9,3 +9,4 @@
 paging.after=OFFSET #{page.from} ROWS FETCH NEXT #{page.size} ROWS ONLY
 keysetPaging.limit=FETCH NEXT #{page.size} ROWS ONLY
 variableValue.previewSize=4000
+disableFkBeforeTruncate=false

--- a/db/rdbms/src/main/resources/db/vendor-properties/postgresql.properties
+++ b/db/rdbms/src/main/resources/db/vendor-properties/postgresql.properties
@@ -9,3 +9,4 @@
 paging.after=LIMIT #{page.size} OFFSET #{page.from}
 keysetPaging.limit=LIMIT #{page.size}
 variableValue.previewSize=8191
+disableFkBeforeTruncate=false

--- a/db/rdbms/src/main/resources/mapper/PurgeMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/PurgeMapper.xml
@@ -9,7 +9,27 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="io.camunda.db.rdbms.sql.PurgeMapper">
 
+  <update id="disableForeignKeyChecks" databaseId="mariadb">
+    SET FOREIGN_KEY_CHECKS = 0
+  </update>
+
+  <update id="enableForeignKeyChecks" databaseId="mariadb">
+    SET FOREIGN_KEY_CHECKS = 1
+  </update>
+
+  <update id="disableForeignKeyChecks" databaseId="h2">
+    SET REFERENTIAL_INTEGRITY FALSE
+    </update>
+
+  <update id="enableForeignKeyChecks" databaseId="h2">
+    SET REFERENTIAL_INTEGRITY TRUE
+  </update>
+
   <update id="truncateTable" parameterType="java.lang.String">
     TRUNCATE TABLE ${prefix}${tableName}
+  </update>
+
+  <update id="truncateTable" parameterType="java.lang.String" databaseId="postgresql">
+    TRUNCATE TABLE ${prefix}${tableName} CASCADE
   </update>
 </mapper>

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/PurgerCompletenessIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/PurgerCompletenessIT.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
+import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.sql.PurgeMapper;
 import io.camunda.db.rdbms.write.service.RdbmsPurger;
 import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
@@ -37,12 +38,13 @@ public class PurgerCompletenessIT {
   @Autowired JdbcTemplate jdbcTemplate;
 
   @Autowired private PurgeMapper purgeMapper;
+  @Autowired private VendorDatabaseProperties vendorDatabaseProperties;
 
   @Test
   public void shouldFindWithSpecificFilter() {
     final var spy = spy(purgeMapper);
 
-    final var rdbmsPurger = new RdbmsPurger(spy);
+    final var rdbmsPurger = new RdbmsPurger(spy, vendorDatabaseProperties);
 
     rdbmsPurger.purgeRdbms();
 


### PR DESCRIPTION
## Description

- fixes the wrongly defined FKs
  - child relations in the tables now cascade the deletion
- fixes missing FK handling in rdbmsPurger. Now it deactivates FK relations when necessary for the time of the truncate (depends on the vendor)

## Related issues

closes #28101
