### PR TITLE
feat: fix and enhance execution order in rdbms statement queue #28101

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
@@ -8,20 +8,30 @@
 package io.camunda.db.rdbms.write.queue;
 
 public enum ContextType {
-  AUTHORIZATION,
-  EXPORTER_POSITION,
-  DECISION_DEFINITION,
-  DECISION_INSTANCE,
-  GROUP,
-  PROCESS_DEFINITION,
-  PROCESS_INSTANCE,
-  FLOW_NODE,
-  TENANT,
-  INCIDENT,
-  VARIABLE,
-  ROLE,
-  USER,
-  USER_TASK,
-  FORM,
-  MAPPING
+  AUTHORIZATION(true),
+  EXPORTER_POSITION(false),
+  DECISION_DEFINITION(false),
+  DECISION_INSTANCE(false),
+  GROUP(false),
+  PROCESS_DEFINITION(false),
+  PROCESS_INSTANCE(false),
+  FLOW_NODE(false),
+  TENANT(false),
+  INCIDENT(false),
+  VARIABLE(false),
+  ROLE(false),
+  USER(false),
+  USER_TASK(true),
+  FORM(false),
+  MAPPING(false);
+
+  private final boolean preserveOrder;
+
+  ContextType(boolean preserveOrder) {
+    this.preserveOrder = preserveOrder;
+  }
+
+  public boolean preserveOrder() {
+    return preserveOrder;
+  }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
@@ -14,6 +14,8 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.ibatis.executor.BatchResult;
 import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.SqlSessionFactory;
@@ -136,11 +138,10 @@ public class DefaultExecutionQueue implements ExecutionQueue {
         sessionFactory.openSession(ExecutorType.BATCH, TransactionIsolationLevel.READ_UNCOMMITTED);
 
     var flushedElements = 0;
-    final var items = new ArrayList<>(queue);
-    items.sort(Comparator.comparing(QueueItem::contextType).thenComparing(QueueItem::statementId));
+    final var optimizedItems = optimizeQueueOrder(queue);
 
     try {
-      for (final var entry : items) {
+      for (final var entry : optimizedItems) {
         LOG.trace("[RDBMS ExecutionQueue, Partition {}] Executing entry: {}", partitionId, entry);
         session.update(entry.statementId(), entry.parameter());
         queue.remove();
@@ -185,6 +186,43 @@ public class DefaultExecutionQueue implements ExecutionQueue {
     } finally {
       session.close();
     }
+  }
+
+  /**
+   * Optimizes the order of the queue items to minimize the number of executed statements. Primary
+   * goal of this optimization is to batch as many statements as possible For this statements with
+   * the same MyBatis-ID have to be executed sequentially directly after each other. A second goal
+   * is to ensure that INSERT statements are always executed before UPDATE statements. <br>
+   * The optimization happens in two steps: <br>
+   * <br>
+   * First the queue is grouped by the {@link ContextType}. Here the order of the items inside this
+   * group is still preserved.<br>
+   * <br>
+   * In the second step the items inside the groups are sorted by the {@link WriteStatementType}
+   * (natural order) and {@link QueueItem#statementId()}. For some entities this step will lead to
+   * errors. Therefore, this second step can be deactivated in the {@link ContextType}.
+   *
+   * @param items queue of items
+   * @return optimized queue of items
+   */
+  private List<QueueItem> optimizeQueueOrder(final List<QueueItem> items) {
+    final Map<ContextType, List<QueueItem>> itemsByContextType =
+        items.stream().collect(Collectors.groupingBy(QueueItem::contextType));
+
+    final List<QueueItem> resultList = new ArrayList<>();
+    for (final var entry : itemsByContextType.entrySet()) {
+      final var contextType = entry.getKey();
+      if (contextType.preserveOrder()) {
+        resultList.addAll(entry.getValue());
+      } else {
+        final var contextItems = new ArrayList<>(entry.getValue());
+        contextItems.sort(
+            Comparator.comparing(QueueItem::statementType).thenComparing(QueueItem::statementId));
+        resultList.addAll(contextItems);
+      }
+    }
+
+    return resultList;
   }
 
   LinkedList<QueueItem> getQueue() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/QueueItem.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/QueueItem.java
@@ -9,13 +9,19 @@ package io.camunda.db.rdbms.write.queue;
 
 import java.util.function.Function;
 
-public record QueueItem(ContextType contextType, Object id, String statementId, Object parameter) {
+public record QueueItem(
+    ContextType contextType,
+    WriteStatementType statementType,
+    Object id,
+    String statementId,
+    Object parameter) {
 
   public QueueItem copy(final Function<QueueItemBuilder, QueueItemBuilder> builderFunction) {
     return builderFunction
         .apply(
             new QueueItemBuilder()
                 .contextType(contextType)
+                .statementType(statementType)
                 .id(id)
                 .statementId(statementId)
                 .parameter(parameter))
@@ -26,12 +32,18 @@ public record QueueItem(ContextType contextType, Object id, String statementId, 
   public static class QueueItemBuilder {
 
     private ContextType contextType;
+    private WriteStatementType statementType;
     private Object id;
     private String statementId;
     private Object parameter;
 
     public QueueItemBuilder contextType(final ContextType contextType) {
       this.contextType = contextType;
+      return this;
+    }
+
+    public QueueItemBuilder statementType(final WriteStatementType statementType) {
+      this.statementType = statementType;
       return this;
     }
 
@@ -51,7 +63,7 @@ public record QueueItem(ContextType contextType, Object id, String statementId, 
     }
 
     public QueueItem build() {
-      return new QueueItem(contextType, id, statementId, parameter);
+      return new QueueItem(contextType, statementType, id, statementId, parameter);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/WriteStatementType.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/WriteStatementType.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.queue;
+
+public enum WriteStatementType {
+
+  // do not change order
+  INSERT,
+  UPDATE,
+  DELETE
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AuthorizationWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/AuthorizationWriter.java
@@ -11,6 +11,7 @@ import io.camunda.db.rdbms.write.domain.AuthorizationDbModel;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
 
 public class AuthorizationWriter {
 
@@ -24,6 +25,7 @@ public class AuthorizationWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.AUTHORIZATION,
+            WriteStatementType.INSERT,
             authorization.authorizationKey().toString(),
             "io.camunda.db.rdbms.sql.AuthorizationMapper.insert",
             authorization));
@@ -40,6 +42,7 @@ public class AuthorizationWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.AUTHORIZATION,
+            WriteStatementType.DELETE,
             authorization.authorizationKey().toString(),
             "io.camunda.db.rdbms.sql.AuthorizationMapper.delete",
             authorization));

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/DecisionDefinitionWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/DecisionDefinitionWriter.java
@@ -11,6 +11,7 @@ import io.camunda.db.rdbms.write.domain.DecisionDefinitionDbModel;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
 
 public class DecisionDefinitionWriter {
 
@@ -24,6 +25,7 @@ public class DecisionDefinitionWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.DECISION_DEFINITION,
+            WriteStatementType.INSERT,
             decisionDefinition.decisionDefinitionKey(),
             "io.camunda.db.rdbms.sql.DecisionDefinitionMapper.insert",
             decisionDefinition));

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/DecisionInstanceWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/DecisionInstanceWriter.java
@@ -11,6 +11,7 @@ import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
 
 public class DecisionInstanceWriter {
 
@@ -24,6 +25,7 @@ public class DecisionInstanceWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.DECISION_INSTANCE,
+            WriteStatementType.INSERT,
             decisionInstance.decisionInstanceKey(),
             "io.camunda.db.rdbms.sql.DecisionInstanceMapper.insert",
             decisionInstance));
@@ -32,6 +34,7 @@ public class DecisionInstanceWriter {
       executionQueue.executeInQueue(
           new QueueItem(
               ContextType.DECISION_INSTANCE,
+              WriteStatementType.INSERT,
               decisionInstance.decisionInstanceKey(),
               "io.camunda.db.rdbms.sql.DecisionInstanceMapper.insertInput",
               decisionInstance));
@@ -41,6 +44,7 @@ public class DecisionInstanceWriter {
       executionQueue.executeInQueue(
           new QueueItem(
               ContextType.DECISION_INSTANCE,
+              WriteStatementType.INSERT,
               decisionInstance.decisionInstanceKey(),
               "io.camunda.db.rdbms.sql.DecisionInstanceMapper.insertOutput",
               decisionInstance));

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/DecisionRequirementsWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/DecisionRequirementsWriter.java
@@ -11,6 +11,7 @@ import io.camunda.db.rdbms.write.domain.DecisionRequirementsDbModel;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
 
 public class DecisionRequirementsWriter {
 
@@ -24,6 +25,7 @@ public class DecisionRequirementsWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.DECISION_DEFINITION,
+            WriteStatementType.INSERT,
             decisionRequirements.decisionRequirementsKey(),
             "io.camunda.db.rdbms.sql.DecisionRequirementsMapper.insert",
             decisionRequirements));

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ExporterPositionService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ExporterPositionService.java
@@ -12,6 +12,7 @@ import io.camunda.db.rdbms.write.domain.ExporterPositionModel;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
 
 public class ExporterPositionService {
 
@@ -28,6 +29,7 @@ public class ExporterPositionService {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.EXPORTER_POSITION,
+            WriteStatementType.INSERT,
             variable.partitionId(),
             "io.camunda.db.rdbms.sql.ExporterPositionMapper.insert",
             variable));
@@ -41,6 +43,7 @@ public class ExporterPositionService {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.EXPORTER_POSITION,
+            WriteStatementType.UPDATE,
             variable.partitionId(),
             "io.camunda.db.rdbms.sql.ExporterPositionMapper.update",
             variable));

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/FlowNodeInstanceWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/FlowNodeInstanceWriter.java
@@ -15,6 +15,7 @@ import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.UpsertMerger;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
 import java.time.OffsetDateTime;
 import java.util.function.Function;
@@ -31,6 +32,7 @@ public class FlowNodeInstanceWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.FLOW_NODE,
+            WriteStatementType.INSERT,
             flowNode.flowNodeInstanceKey(),
             "io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.insert",
             flowNode));
@@ -40,6 +42,7 @@ public class FlowNodeInstanceWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.FLOW_NODE,
+            WriteStatementType.UPDATE,
             flowNode.flowNodeInstanceKey(),
             "io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.update",
             flowNode));
@@ -53,6 +56,7 @@ public class FlowNodeInstanceWriter {
       executionQueue.executeInQueue(
           new QueueItem(
               ContextType.FLOW_NODE,
+              WriteStatementType.UPDATE,
               key,
               "io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.updateStateAndEndDate",
               dto));
@@ -76,6 +80,7 @@ public class FlowNodeInstanceWriter {
       executionQueue.executeInQueue(
           new QueueItem(
               ContextType.FLOW_NODE,
+              WriteStatementType.UPDATE,
               flowNodeInstanceKey,
               "io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.incrementSubprocessIncidentCount",
               flowNodeInstanceKey));
@@ -91,6 +96,7 @@ public class FlowNodeInstanceWriter {
       executionQueue.executeInQueue(
           new QueueItem(
               ContextType.FLOW_NODE,
+              WriteStatementType.UPDATE,
               flowNodeInstanceKey,
               "io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.decrementSubprocessIncidentCount",
               flowNodeInstanceKey));
@@ -105,6 +111,7 @@ public class FlowNodeInstanceWriter {
       executionQueue.executeInQueue(
           new QueueItem(
               ContextType.FLOW_NODE,
+              WriteStatementType.UPDATE,
               flowNodeInstanceKey,
               "io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.updateIncident",
               dto));

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/FormWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/FormWriter.java
@@ -11,6 +11,7 @@ import io.camunda.db.rdbms.write.domain.FormDbModel;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
 
 public class FormWriter {
 
@@ -23,12 +24,20 @@ public class FormWriter {
   public void create(final FormDbModel form) {
     executionQueue.executeInQueue(
         new QueueItem(
-            ContextType.FORM, form.formKey(), "io.camunda.db.rdbms.sql.FormMapper.insert", form));
+            ContextType.FORM,
+            WriteStatementType.INSERT,
+            form.formKey(),
+            "io.camunda.db.rdbms.sql.FormMapper.insert",
+            form));
   }
 
   public void update(final FormDbModel form) {
     executionQueue.executeInQueue(
         new QueueItem(
-            ContextType.FORM, form.formKey(), "io.camunda.db.rdbms.sql.FormMapper.update", form));
+            ContextType.FORM,
+            WriteStatementType.UPDATE,
+            form.formKey(),
+            "io.camunda.db.rdbms.sql.FormMapper.update",
+            form));
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/GroupWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/GroupWriter.java
@@ -13,6 +13,7 @@ import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.UpsertMerger;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import java.util.function.Function;
 
 public class GroupWriter {
@@ -27,6 +28,7 @@ public class GroupWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.GROUP,
+            WriteStatementType.INSERT,
             group.groupKey(),
             "io.camunda.db.rdbms.sql.GroupMapper.insert",
             group));
@@ -39,6 +41,7 @@ public class GroupWriter {
       executionQueue.executeInQueue(
           new QueueItem(
               ContextType.GROUP,
+              WriteStatementType.UPDATE,
               group.groupKey(),
               "io.camunda.db.rdbms.sql.GroupMapper.update",
               group));
@@ -49,6 +52,7 @@ public class GroupWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.GROUP,
+            WriteStatementType.INSERT,
             member.groupKey(),
             "io.camunda.db.rdbms.sql.GroupMapper.insertMember",
             member));
@@ -58,6 +62,7 @@ public class GroupWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.GROUP,
+            WriteStatementType.DELETE,
             member.groupKey(),
             "io.camunda.db.rdbms.sql.GroupMapper.deleteMember",
             member));
@@ -66,10 +71,15 @@ public class GroupWriter {
   public void delete(final long groupKey) {
     executionQueue.executeInQueue(
         new QueueItem(
-            ContextType.GROUP, groupKey, "io.camunda.db.rdbms.sql.GroupMapper.delete", groupKey));
+            ContextType.GROUP,
+            WriteStatementType.DELETE,
+            groupKey,
+            "io.camunda.db.rdbms.sql.GroupMapper.delete",
+            groupKey));
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.GROUP,
+            WriteStatementType.DELETE,
             groupKey,
             "io.camunda.db.rdbms.sql.GroupMapper.deleteAllMembers",
             groupKey));

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/IncidentWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/IncidentWriter.java
@@ -14,6 +14,7 @@ import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.UpsertMerger;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import io.camunda.search.entities.IncidentEntity.IncidentState;
 import java.util.function.Function;
 import org.slf4j.Logger;
@@ -33,6 +34,7 @@ public class IncidentWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.INCIDENT,
+            WriteStatementType.INSERT,
             incident.incidentKey(),
             "io.camunda.db.rdbms.sql.IncidentMapper.insert",
             incident));
@@ -42,6 +44,7 @@ public class IncidentWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.INCIDENT,
+            WriteStatementType.UPDATE,
             incident.incidentKey(),
             "io.camunda.db.rdbms.sql.IncidentMapper.update",
             incident));
@@ -55,6 +58,7 @@ public class IncidentWriter {
       executionQueue.executeInQueue(
           new QueueItem(
               ContextType.INCIDENT,
+              WriteStatementType.UPDATE,
               incidentKey,
               "io.camunda.db.rdbms.sql.IncidentMapper.updateState",
               new IncidentMapper.IncidentStateDto(incidentKey, IncidentState.RESOLVED, null)));

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MappingWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MappingWriter.java
@@ -11,6 +11,7 @@ import io.camunda.db.rdbms.write.domain.MappingDbModel;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
 
 public class MappingWriter {
 
@@ -24,6 +25,7 @@ public class MappingWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.MAPPING,
+            WriteStatementType.INSERT,
             mapping.mappingKey(),
             "io.camunda.db.rdbms.sql.MappingMapper.insert",
             mapping));
@@ -33,6 +35,7 @@ public class MappingWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.MAPPING,
+            WriteStatementType.DELETE,
             mappingKey,
             "io.camunda.db.rdbms.sql.MappingMapper.delete",
             mappingKey));

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessDefinitionWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessDefinitionWriter.java
@@ -11,6 +11,7 @@ import io.camunda.db.rdbms.write.domain.ProcessDefinitionDbModel;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
 
 public class ProcessDefinitionWriter {
 
@@ -24,6 +25,7 @@ public class ProcessDefinitionWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.PROCESS_DEFINITION,
+            WriteStatementType.INSERT,
             processDefinition.processDefinitionKey(),
             "io.camunda.db.rdbms.sql.ProcessDefinitionMapper.insert",
             processDefinition));

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessInstanceWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/ProcessInstanceWriter.java
@@ -14,6 +14,7 @@ import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.UpsertMerger;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import java.time.OffsetDateTime;
 import java.util.function.Function;
@@ -30,6 +31,7 @@ public class ProcessInstanceWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.PROCESS_INSTANCE,
+            WriteStatementType.INSERT,
             processInstance.processInstanceKey(),
             "io.camunda.db.rdbms.sql.ProcessInstanceMapper.insert",
             processInstance));
@@ -39,6 +41,7 @@ public class ProcessInstanceWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.PROCESS_INSTANCE,
+            WriteStatementType.UPDATE,
             processInstance.processInstanceKey(),
             "io.camunda.db.rdbms.sql.ProcessInstanceMapper.update",
             processInstance));
@@ -53,6 +56,7 @@ public class ProcessInstanceWriter {
       executionQueue.executeInQueue(
           new QueueItem(
               ContextType.PROCESS_INSTANCE,
+              WriteStatementType.UPDATE,
               key,
               "io.camunda.db.rdbms.sql.ProcessInstanceMapper.updateStateAndEndDate",
               dto));
@@ -66,6 +70,7 @@ public class ProcessInstanceWriter {
       executionQueue.executeInQueue(
           new QueueItem(
               ContextType.PROCESS_INSTANCE,
+              WriteStatementType.UPDATE,
               key,
               "io.camunda.db.rdbms.sql.ProcessInstanceMapper.incrementIncidentCount",
               key));
@@ -79,6 +84,7 @@ public class ProcessInstanceWriter {
       executionQueue.executeInQueue(
           new QueueItem(
               ContextType.PROCESS_INSTANCE,
+              WriteStatementType.UPDATE,
               key,
               "io.camunda.db.rdbms.sql.ProcessInstanceMapper.decrementIncidentCount",
               key));

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RoleWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RoleWriter.java
@@ -13,6 +13,7 @@ import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.UpsertMerger;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import java.util.function.Function;
 
 public class RoleWriter {
@@ -26,7 +27,11 @@ public class RoleWriter {
   public void create(final RoleDbModel role) {
     executionQueue.executeInQueue(
         new QueueItem(
-            ContextType.ROLE, role.roleKey(), "io.camunda.db.rdbms.sql.RoleMapper.insert", role));
+            ContextType.ROLE,
+            WriteStatementType.INSERT,
+            role.roleKey(),
+            "io.camunda.db.rdbms.sql.RoleMapper.insert",
+            role));
   }
 
   public void update(final RoleDbModel role) {
@@ -35,7 +40,11 @@ public class RoleWriter {
     if (!wasMerged) {
       executionQueue.executeInQueue(
           new QueueItem(
-              ContextType.ROLE, role.roleKey(), "io.camunda.db.rdbms.sql.RoleMapper.update", role));
+              ContextType.ROLE,
+              WriteStatementType.UPDATE,
+              role.roleKey(),
+              "io.camunda.db.rdbms.sql.RoleMapper.update",
+              role));
     }
   }
 
@@ -43,6 +52,7 @@ public class RoleWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.ROLE,
+            WriteStatementType.INSERT,
             member.roleKey(),
             "io.camunda.db.rdbms.sql.RoleMapper.insertMember",
             member));
@@ -52,6 +62,7 @@ public class RoleWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.ROLE,
+            WriteStatementType.DELETE,
             member.roleKey(),
             "io.camunda.db.rdbms.sql.RoleMapper.deleteMember",
             member));
@@ -60,10 +71,15 @@ public class RoleWriter {
   public void delete(final long roleKey) {
     executionQueue.executeInQueue(
         new QueueItem(
-            ContextType.ROLE, roleKey, "io.camunda.db.rdbms.sql.RoleMapper.delete", roleKey));
+            ContextType.ROLE,
+            WriteStatementType.DELETE,
+            roleKey,
+            "io.camunda.db.rdbms.sql.RoleMapper.delete",
+            roleKey));
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.ROLE,
+            WriteStatementType.DELETE,
             roleKey,
             "io.camunda.db.rdbms.sql.RoleMapper.deleteAllMembers",
             roleKey));

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/TenantWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/TenantWriter.java
@@ -13,6 +13,7 @@ import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.UpsertMerger;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import java.util.function.Function;
 
 public class TenantWriter {
@@ -27,6 +28,7 @@ public class TenantWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.TENANT,
+            WriteStatementType.INSERT,
             tenant.tenantId(),
             "io.camunda.db.rdbms.sql.TenantMapper.insert",
             tenant));
@@ -45,6 +47,7 @@ public class TenantWriter {
       executionQueue.executeInQueue(
           new QueueItem(
               ContextType.TENANT,
+              WriteStatementType.UPDATE,
               tenant.tenantId(),
               "io.camunda.db.rdbms.sql.TenantMapper.update",
               tenant));
@@ -55,6 +58,7 @@ public class TenantWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.TENANT,
+            WriteStatementType.INSERT,
             member.tenantId(),
             "io.camunda.db.rdbms.sql.TenantMapper.insertMember",
             member));
@@ -64,6 +68,7 @@ public class TenantWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.TENANT,
+            WriteStatementType.DELETE,
             member.tenantId(),
             "io.camunda.db.rdbms.sql.TenantMapper.deleteMember",
             member));
@@ -73,12 +78,14 @@ public class TenantWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.TENANT,
+            WriteStatementType.DELETE,
             tenant.tenantId(),
             "io.camunda.db.rdbms.sql.TenantMapper.delete",
             tenant.tenantId()));
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.TENANT,
+            WriteStatementType.DELETE,
             tenant.tenantId(),
             "io.camunda.db.rdbms.sql.TenantMapper.deleteAllMembers",
             tenant.tenantId()));

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/UserTaskWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/UserTaskWriter.java
@@ -12,6 +12,7 @@ import io.camunda.db.rdbms.write.domain.UserTaskMigrationDbModel;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
 
 public class UserTaskWriter {
 
@@ -25,6 +26,7 @@ public class UserTaskWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.USER_TASK,
+            WriteStatementType.INSERT,
             userTaskDbModel.userTaskKey(),
             "io.camunda.db.rdbms.sql.UserTaskMapper.insert",
             userTaskDbModel));
@@ -32,6 +34,7 @@ public class UserTaskWriter {
       executionQueue.executeInQueue(
           new QueueItem(
               ContextType.USER_TASK,
+              WriteStatementType.INSERT,
               userTaskDbModel.userTaskKey(),
               "io.camunda.db.rdbms.sql.UserTaskMapper.insertCandidateUsers",
               userTaskDbModel));
@@ -40,6 +43,7 @@ public class UserTaskWriter {
       executionQueue.executeInQueue(
           new QueueItem(
               ContextType.USER_TASK,
+              WriteStatementType.INSERT,
               userTaskDbModel.userTaskKey(),
               "io.camunda.db.rdbms.sql.UserTaskMapper.insertCandidateGroups",
               userTaskDbModel));
@@ -50,12 +54,14 @@ public class UserTaskWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.USER_TASK,
+            WriteStatementType.UPDATE,
             userTaskDbModel.userTaskKey(),
             "io.camunda.db.rdbms.sql.UserTaskMapper.update",
             userTaskDbModel));
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.USER_TASK,
+            WriteStatementType.DELETE,
             userTaskDbModel.userTaskKey(),
             "io.camunda.db.rdbms.sql.UserTaskMapper.deleteCandidateUsers",
             userTaskDbModel.userTaskKey()));
@@ -63,6 +69,7 @@ public class UserTaskWriter {
       executionQueue.executeInQueue(
           new QueueItem(
               ContextType.USER_TASK,
+              WriteStatementType.INSERT,
               userTaskDbModel.userTaskKey(),
               "io.camunda.db.rdbms.sql.UserTaskMapper.insertCandidateUsers",
               userTaskDbModel));
@@ -70,6 +77,7 @@ public class UserTaskWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.USER_TASK,
+            WriteStatementType.DELETE,
             userTaskDbModel.userTaskKey(),
             "io.camunda.db.rdbms.sql.UserTaskMapper.deleteCandidateGroups",
             userTaskDbModel.userTaskKey()));
@@ -77,6 +85,7 @@ public class UserTaskWriter {
       executionQueue.executeInQueue(
           new QueueItem(
               ContextType.USER_TASK,
+              WriteStatementType.INSERT,
               userTaskDbModel.userTaskKey(),
               "io.camunda.db.rdbms.sql.UserTaskMapper.insertCandidateGroups",
               userTaskDbModel));
@@ -87,6 +96,7 @@ public class UserTaskWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.USER_TASK,
+            WriteStatementType.UPDATE,
             model.userTaskKey(),
             "io.camunda.db.rdbms.sql.UserTaskMapper.migrateToProcess",
             model));

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/UserWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/UserWriter.java
@@ -12,6 +12,7 @@ import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.UpsertMerger;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import java.util.function.Function;
 
 public class UserWriter {
@@ -25,7 +26,11 @@ public class UserWriter {
   public void create(final UserDbModel user) {
     executionQueue.executeInQueue(
         new QueueItem(
-            ContextType.USER, user.userKey(), "io.camunda.db.rdbms.sql.UserMapper.insert", user));
+            ContextType.USER,
+            WriteStatementType.INSERT,
+            user.userKey(),
+            "io.camunda.db.rdbms.sql.UserMapper.insert",
+            user));
   }
 
   public void update(final UserDbModel user) {
@@ -38,6 +43,7 @@ public class UserWriter {
       executionQueue.executeInQueue(
           new QueueItem(
               ContextType.USER,
+              WriteStatementType.UPDATE,
               user.username(),
               "io.camunda.db.rdbms.sql.UserMapper.update",
               user));
@@ -47,7 +53,11 @@ public class UserWriter {
   public void delete(final String username) {
     executionQueue.executeInQueue(
         new QueueItem(
-            ContextType.USER, username, "io.camunda.db.rdbms.sql.UserMapper.delete", username));
+            ContextType.USER,
+            WriteStatementType.DELETE,
+            username,
+            "io.camunda.db.rdbms.sql.UserMapper.delete",
+            username));
   }
 
   private boolean mergeToQueue(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/VariableWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/VariableWriter.java
@@ -13,6 +13,7 @@ import io.camunda.db.rdbms.write.domain.VariableDbModel;
 import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
 
 public class VariableWriter {
 
@@ -31,6 +32,7 @@ public class VariableWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.VARIABLE,
+            WriteStatementType.INSERT,
             variable.variableKey(),
             "io.camunda.db.rdbms.sql.VariableMapper.insert",
             variable.truncateValue(vendorDatabaseProperties.variableValuePreviewSize())));
@@ -40,6 +42,7 @@ public class VariableWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.VARIABLE,
+            WriteStatementType.UPDATE,
             variable.variableKey(),
             "io.camunda.db.rdbms.sql.VariableMapper.update",
             variable.truncateValue(vendorDatabaseProperties.variableValuePreviewSize())));
@@ -49,6 +52,7 @@ public class VariableWriter {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.VARIABLE,
+            WriteStatementType.UPDATE,
             variableKey,
             "io.camunda.db.rdbms.sql.VariableMapper.migrateToProcess",
             new VariableMapper.MigrateToProcessDto.Builder()

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/UpsertMergerTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/UpsertMergerTest.java
@@ -42,7 +42,12 @@ class UpsertMergerTest {
                     .endDate(NOW.minusDays(1))
                     .state(ProcessInstanceState.ACTIVE));
     final var queueItem =
-        new QueueItem(ContextType.PROCESS_INSTANCE, 1L, "statement", insertParameter);
+        new QueueItem(
+            ContextType.PROCESS_INSTANCE,
+            WriteStatementType.INSERT,
+            1L,
+            "statement",
+            insertParameter);
     final var newQueueItem = merger.merge(queueItem);
 
     assertThat(queueItem)
@@ -73,12 +78,27 @@ class UpsertMergerTest {
     return Stream.of(
         Arguments.of(
             new QueueItem(
-                ContextType.PROCESS_INSTANCE, 1L, "statement1", mock(ProcessInstanceDbModel.class)),
+                ContextType.PROCESS_INSTANCE,
+                WriteStatementType.INSERT,
+                1L,
+                "statement1",
+                mock(ProcessInstanceDbModel.class)),
             true),
-        Arguments.of(new QueueItem(ContextType.PROCESS_INSTANCE, 1L, "statement1", "bla"), false),
-        Arguments.of(new QueueItem(ContextType.PROCESS_INSTANCE, 1L, "statement1", null), false),
-        Arguments.of(new QueueItem(ContextType.PROCESS_INSTANCE, 2L, "statement1", null), false),
-        Arguments.of(new QueueItem(ContextType.FLOW_NODE, 1L, "statement1", null), false));
+        Arguments.of(
+            new QueueItem(
+                ContextType.PROCESS_INSTANCE, WriteStatementType.INSERT, 1L, "statement1", "bla"),
+            false),
+        Arguments.of(
+            new QueueItem(
+                ContextType.PROCESS_INSTANCE, WriteStatementType.INSERT, 1L, "statement1", null),
+            false),
+        Arguments.of(
+            new QueueItem(
+                ContextType.PROCESS_INSTANCE, WriteStatementType.INSERT, 2L, "statement1", null),
+            false),
+        Arguments.of(
+            new QueueItem(ContextType.FLOW_NODE, WriteStatementType.INSERT, 1L, "statement1", null),
+            false));
   }
 
   public static ProcessInstanceDbModel createRandomized(

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/FlowNodeInstanceWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/FlowNodeInstanceWriterTest.java
@@ -20,6 +20,7 @@ import io.camunda.db.rdbms.write.queue.DefaultExecutionQueue;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.UpsertMerger;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,6 +59,7 @@ class FlowNodeInstanceWriterTest {
             eq(
                 new QueueItem(
                     ContextType.FLOW_NODE,
+                    WriteStatementType.UPDATE,
                     1L,
                     "io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.updateStateAndEndDate",
                     new FlowNodeInstanceMapper.EndFlowNodeDto(1L, FlowNodeState.COMPLETED, NOW))));

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/ProcessInstanceWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/ProcessInstanceWriterTest.java
@@ -19,6 +19,7 @@ import io.camunda.db.rdbms.write.queue.ContextType;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.UpsertMerger;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,6 +58,7 @@ class ProcessInstanceWriterTest {
             eq(
                 new QueueItem(
                     ContextType.PROCESS_INSTANCE,
+                    WriteStatementType.UPDATE,
                     1L,
                     "io.camunda.db.rdbms.sql.ProcessInstanceMapper.updateStateAndEndDate",
                     new EndProcessInstanceDto(1L, ProcessInstanceState.COMPLETED, NOW))));


### PR DESCRIPTION
## Description

While working on #28101 a problem with the execution order of rdbms writer statements was discovered. It could lead to a situation where a record is updated before the insert was executed. The new implementation now executes INSERT statements first.
For a few entities (authorization, userTask) it is configurable because there an UPDATE is executed as DELETE + INSERT. There the order is left untouched.

## Related issues

relates to #28101 
