### PR TITLE
[Backport stable/8.6] Fix: job worker stream disabled by default

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/annotation/JobWorker.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/annotation/JobWorker.java
@@ -101,7 +101,7 @@ public @interface JobWorker {
 
   String[] tenantIds() default {};
 
-  boolean streamEnabled() default true;
+  boolean streamEnabled() default false;
 
   /** Stream timeout in ms */
   long streamTimeout() default 3600000L;


### PR DESCRIPTION
# Description
Backport of #28239 to `stable/8.6`.

relates to #27502
original author: @ana-vinogradova-camunda