### PR TITLE
[Backport stable/8.5] fix: always close exporter container and distribution service

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -277,11 +277,8 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   @Override
   protected void onActorCloseRequested() {
     isOpened.set(false);
-    if (exporterMode == ExporterMode.ACTIVE) {
-      containers.forEach(ExporterContainer::close);
-    } else {
-      exporterDistributionService.close();
-    }
+    containers.forEach(ExporterContainer::close);
+    exporterDistributionService.close();
   }
 
   @Override


### PR DESCRIPTION
# Description
Backport of #28243 to `stable/8.5`.

relates to 
original author: @lenaschoenburg