### PR TITLE
Ad-hoc Subprocess: Activate Activities

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -146,9 +146,16 @@ public class CamundaServicesConfiguration {
   public AdHocSubprocessActivityServices adHocSubprocessActivityServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
-      final ProcessDefinitionServices processDefinitionServices) {
+      final ProcessDefinitionServices processDefinitionServices,
+      final ProcessInstanceServices processInstanceServices,
+      final FlowNodeInstanceServices flowNodeInstanceServices) {
     return new AdHocSubprocessActivityServices(
-        brokerClient, securityContextProvider, processDefinitionServices, null);
+        brokerClient,
+        securityContextProvider,
+        processDefinitionServices,
+        processInstanceServices,
+        flowNodeInstanceServices,
+        null);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -28,6 +28,7 @@ import io.camunda.search.clients.UserTaskSearchClient;
 import io.camunda.search.clients.VariableSearchClient;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.security.impl.AuthorizationChecker;
+import io.camunda.service.AdHocSubprocessActivityServices;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.ClockServices;
 import io.camunda.service.DecisionDefinitionServices;
@@ -139,6 +140,15 @@ public class CamundaServicesConfiguration {
       final FlowNodeInstanceSearchClient flowNodeInstanceSearchClient) {
     return new FlowNodeInstanceServices(
         brokerClient, securityContextProvider, flowNodeInstanceSearchClient, null);
+  }
+
+  @Bean
+  public AdHocSubprocessActivityServices adHocSubprocessActivityServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final ProcessDefinitionServices processDefinitionServices) {
+    return new AdHocSubprocessActivityServices(
+        brokerClient, securityContextProvider, processDefinitionServices, null);
   }
 
   @Bean

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -48,6 +48,10 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-bpmn-model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>document-api</artifactId>
     </dependency>
     <dependency>
@@ -75,6 +79,10 @@
     <dependency>
       <groupId>org.camunda.bpm</groupId>
       <artifactId>camunda-license-check</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.camunda.bpm.model</groupId>
+      <artifactId>camunda-xml-model</artifactId>
     </dependency>
 
     <dependency>

--- a/service/src/main/java/io/camunda/service/AdHocSubprocessActivityServices.java
+++ b/service/src/main/java/io/camunda/service/AdHocSubprocessActivityServices.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.camunda.search.entities.ProcessDefinitionEntity;
+import io.camunda.search.exception.NotFoundException;
+import io.camunda.security.auth.Authentication;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
+import io.camunda.zeebe.model.bpmn.instance.Task;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AdHocSubprocessActivityServices extends ApiServices<AdHocSubprocessActivityServices> {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(AdHocSubprocessActivityServices.class);
+
+  private final ProcessDefinitionServices processDefinitionServices;
+
+  public AdHocSubprocessActivityServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final ProcessDefinitionServices processDefinitionServices,
+      final Authentication authentication) {
+    super(brokerClient, securityContextProvider, authentication);
+    this.processDefinitionServices = processDefinitionServices;
+  }
+
+  @Override
+  public AdHocSubprocessActivityServices withAuthentication(final Authentication authentication) {
+    return new AdHocSubprocessActivityServices(
+        brokerClient,
+        securityContextProvider,
+        processDefinitionServices.withAuthentication(authentication),
+        authentication);
+  }
+
+  public List<AdHocSubprocessActivity> findActivatableActivities(
+      final Long processDefinitionKey, final String adHocSubprocessId) {
+    final ProcessDefinitionEntity processDefinitionEntity =
+        processDefinitionServices.getByKey(processDefinitionKey);
+
+    // TODO should we cache this lookup somewhere? There are multiple ProcessCache implementations
+    // in operate, tasklist, gateway-rest, but none in this service layer. Implement caching later
+    // or introduce a process definition cache at this level?
+    final BpmnModelInstance modelInstance =
+        Bpmn.readModelFromStream(
+            new ByteArrayInputStream(
+                processDefinitionEntity.bpmnXml().getBytes(StandardCharsets.UTF_8)));
+
+    final var processElement = modelInstance.getModelElementById(adHocSubprocessId);
+    if (processElement instanceof final AdHocSubProcess adHocSubProcess) {
+      final var tasks = adHocSubProcess.getChildElementsByType(Task.class);
+      return tasks.stream()
+          .filter(task -> task.getIncoming().isEmpty())
+          .map(
+              task ->
+                  new AdHocSubprocessActivity(
+                      processDefinitionKey,
+                      adHocSubprocessId,
+                      task.getId(),
+                      task.getName(),
+                      BpmnElementType.bpmnElementTypeFor(task.getElementType().getTypeName()),
+                      extractDocumentation(task)))
+          .toList();
+    }
+
+    if (LOGGER.isWarnEnabled()) {
+      if (processElement == null) {
+        LOGGER.warn(
+            "Failed to find ad-hoc subprocess element with id '{}' in process definition with key '{}'",
+            adHocSubprocessId,
+            processDefinitionKey);
+      } else {
+        LOGGER.warn(
+            "Found element with id '{}' in process definition with key '{}' but it was of type '{}', expected 'AdHocSubProcess'",
+            adHocSubprocessId,
+            processDefinitionKey,
+            processElement.getElementType());
+      }
+    }
+
+    throw new NotFoundException(
+        "Failed to find Ad-Hoc Subprocess with ID '%s'".formatted(adHocSubprocessId));
+  }
+
+  private String extractDocumentation(final Task task) {
+    return task.getDocumentations().stream()
+        .map(ModelElementInstance::getTextContent)
+        .collect(Collectors.joining("\n"));
+  }
+
+  public record AdHocSubprocessActivity(
+      Long processDefinitionKey,
+      String adHocSubprocessId,
+      String flowNodeId,
+      String flowNodeName,
+      BpmnElementType type,
+      String documentation) {}
+}

--- a/service/src/main/java/io/camunda/service/AdHocSubprocessActivityServices.java
+++ b/service/src/main/java/io/camunda/service/AdHocSubprocessActivityServices.java
@@ -10,16 +10,21 @@ package io.camunda.service;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.exception.NotFoundException;
 import io.camunda.security.auth.Authentication;
+import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyRequest;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
 import io.camunda.zeebe.model.bpmn.instance.Task;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationActivateInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.slf4j.Logger;
@@ -31,14 +36,20 @@ public class AdHocSubprocessActivityServices extends ApiServices<AdHocSubprocess
       LoggerFactory.getLogger(AdHocSubprocessActivityServices.class);
 
   private final ProcessDefinitionServices processDefinitionServices;
+  private final ProcessInstanceServices processInstanceServices;
+  private final FlowNodeInstanceServices flowNodeInstanceServices;
 
   public AdHocSubprocessActivityServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ProcessDefinitionServices processDefinitionServices,
+      final ProcessInstanceServices processInstanceServices,
+      final FlowNodeInstanceServices flowNodeInstanceServices,
       final Authentication authentication) {
     super(brokerClient, securityContextProvider, authentication);
     this.processDefinitionServices = processDefinitionServices;
+    this.processInstanceServices = processInstanceServices;
+    this.flowNodeInstanceServices = flowNodeInstanceServices;
   }
 
   @Override
@@ -47,6 +58,8 @@ public class AdHocSubprocessActivityServices extends ApiServices<AdHocSubprocess
         brokerClient,
         securityContextProvider,
         processDefinitionServices.withAuthentication(authentication),
+        processInstanceServices.withAuthentication(authentication),
+        flowNodeInstanceServices.withAuthentication(authentication),
         authentication);
   }
 
@@ -97,6 +110,50 @@ public class AdHocSubprocessActivityServices extends ApiServices<AdHocSubprocess
 
     throw new NotFoundException(
         "Failed to find Ad-Hoc Subprocess with ID '%s'".formatted(adHocSubprocessId));
+  }
+
+  public CompletableFuture<ProcessInstanceModificationRecord> activateActivities(
+      final Long adHocSubprocessInstanceKey, final List<String> flowNodeIds) {
+    final var flowNode = flowNodeInstanceServices.getByKey(adHocSubprocessInstanceKey);
+
+    // TODO type returns as UNKNOWN - something to fix in exporter?
+    /*
+    if (flowNode.type() != FlowNodeType.AD_HOC_SUB_PROCESS) {
+      throw new IllegalArgumentException(
+          "Flow node instance with key '%s' is not an Ad-Hoc Subprocess"
+              .formatted(adHocSubprocessInstanceKey));
+    }
+    */
+
+    final var activatable =
+        findActivatableActivities(flowNode.processDefinitionKey(), flowNode.flowNodeId()).stream()
+            .map(AdHocSubprocessActivity::flowNodeId)
+            .toList();
+
+    final var unsupported =
+        flowNodeIds.stream().filter(flowNodeId -> !activatable.contains(flowNodeId)).toList();
+    if (!unsupported.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Flow node IDs '%s' are not activatable in Ad-Hoc Subprocess with ID '%s'"
+              .formatted(unsupported, flowNode.flowNodeId()));
+    }
+
+    final var activateInstructions =
+        flowNodeIds.stream()
+            .map(
+                flowNodeId -> {
+                  final var instruction = new ProcessInstanceModificationActivateInstruction();
+                  instruction.setAncestorScopeKey(-1);
+                  instruction.setElementId(flowNodeId);
+                  return instruction;
+                })
+            .toList();
+
+    final var modifyRequest =
+        new ProcessInstanceModifyRequest(
+            flowNode.processInstanceKey(), activateInstructions, Collections.emptyList(), null);
+
+    return processInstanceServices.modifyProcessInstance(modifyRequest);
   }
 
   private String extractDocumentation(final Task task) {

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -24,6 +24,7 @@ servers:
         description: The schema of the Camunda 8 REST API server.
 
 tags:
+  - name: Ad-hoc subprocess
   - name: Authentication
   - name: Authorization
   - name: Clock
@@ -1819,6 +1820,43 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /ad-hoc-activities/activatable:
+    post:
+      tags:
+        - Ad-hoc subprocess
+      operationId: findAdHocSubprocessActivities
+      summary: Query activatable activities within an ad-hoc subprocess
+      description: |
+        Search for activities which can be activated within an ad-hoc subprocess.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdHocSubprocessActivitySearchQuery"
+      responses:
+        "200":
+          description: >
+            The ad-hoc subprocess activities search result.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdHocSubprocessActivitySearchQueryResult"
+        "400":
+          description: >
+            The ad-hoc subprocess activities search query failed.
+            More details are provided in the response body.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalServerError"
 
@@ -4796,6 +4834,60 @@ components:
         incidentKey:
           description: Incident key associated with this flow node instance.
           type: string
+    AdHocSubprocessActivitySearchQuery:
+      description: Ad-hoc subprocess activities search request.
+      type: object
+      required:
+        - processDefinitionKey
+        - adHocSubprocessId
+      properties:
+        processDefinitionKey:
+          description: The process definition key.
+          type: string
+        adHocSubprocessId:
+          description: The ad-hoc subprocess process element ID.
+          type: string
+    AdHocSubprocessActivitySearchQueryResult:
+      type: object
+      properties:
+        items:
+          description: The matching ad-hoc subprocess activities.
+          type: array
+          items:
+            $ref: "#/components/schemas/AdHocSubprocessActivityResult"
+    AdHocSubprocessActivityResult:
+      type: object
+      properties:
+        processDefinitionKey:
+          description: The process definition key associated to this activity within the ad-hoc subprocess.
+          type: string
+        adHocSubprocessId:
+          description: The ad-hoc subprocess process element ID.
+          type: string
+        flowNodeId:
+          description: The flow node ID for this activity within the ad-hoc subprocess.
+          type: string
+        flowNodeName:
+          description: The flow node name for this activity within the ad-hoc subprocess.
+          type: string
+        documentation:
+          description: The documentation for this activity within the ad-hoc subprocess.
+          type: string
+        # TODO which types do we need to support here? e.g. (sub-)process?
+        type:
+          description: Type of activity as defined set of values.
+          type: string
+          enum:
+            - BUSINESS_RULE_TASK
+            - MANUAL_TASK
+            - RECEIVE_TASK
+            - SCRIPT_TASK
+            - SEND_TASK
+            - SERVICE_TASK
+            - TASK
+            - UNKNOWN
+            - UNSPECIFIED
+            - USER_TASK
     DecisionDefinitionSearchQuerySortRequest:
       type: object
       properties:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1860,6 +1860,54 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /ad-hoc-activities/{adHocSubprocessInstanceKey}/activate:
+    post:
+      tags:
+        - Ad-hoc subprocess
+      operationId: activateAdHocSubprocessActivities
+      summary: Activate activities within an ad-hoc subprocess
+      description: |
+        Activates selected activities within an ad-hoc subprocess identified by flowNodeId.
+
+        The provided flowNodeIds must be within the ad-hoc subprocess instance identified by the
+        provider adHocSubprocessInstanceKey.
+      parameters:
+        - name: adHocSubprocessInstanceKey
+          in: path
+          required: true
+          description: The key of the ad-hoc subprocess instance that contains the activities.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdHocSubprocessActivateActivitiesInstruction"
+      responses:
+        "204":
+          description: The ad-hoc subprocess instance is modified.
+        "400":
+          description: The provided data is not valid.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: |
+            The ad-hoc subprocess instance is not found or the provided key does not identify an
+            ad-hoc subprocess.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   /decision-definitions/search:
     post:
       tags:
@@ -4888,6 +4936,24 @@ components:
             - UNKNOWN
             - UNSPECIFIED
             - USER_TASK
+    AdHocSubprocessActivateActivitiesInstruction:
+      type: object
+      properties:
+        flowNodes:
+          description: Flow nodes to activate.
+          type: array
+          items:
+            $ref: "#/components/schemas/AdHocSubprocessActivateActivityReference"
+      required:
+        - flowNodes
+    AdHocSubprocessActivateActivityReference:
+      type: object
+      properties:
+        flowNodeId:
+          description: ID of the activity to activate
+          type: string
+      required:
+        - flowNodeId
     DecisionDefinitionSearchQuerySortRequest:
       type: object
       properties:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityController.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
+
+import io.camunda.search.entities.ProcessDefinitionEntity;
+import io.camunda.search.exception.NotFoundException;
+import io.camunda.service.ProcessDefinitionServices;
+import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivityResult;
+import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivitySearchQuery;
+import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivitySearchQueryResult;
+import io.camunda.zeebe.gateway.rest.RequestMapper;
+import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
+import io.camunda.zeebe.model.bpmn.instance.Task;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@CamundaRestController
+@RequestMapping("/v2/ad-hoc-activities")
+public class AdHocSubprocessActivityController {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(AdHocSubprocessActivityController.class);
+
+  private final ProcessDefinitionServices processDefinitionServices;
+
+  public AdHocSubprocessActivityController(
+      final ProcessDefinitionServices processDefinitionServices) {
+    this.processDefinitionServices = processDefinitionServices;
+  }
+
+  @CamundaPostMapping(path = "/activatable")
+  public ResponseEntity<AdHocSubprocessActivitySearchQueryResult> getActivities(
+      @RequestBody final AdHocSubprocessActivitySearchQuery request) {
+    try {
+      final var activities = findActivatableActivities(request);
+
+      final var result = new AdHocSubprocessActivitySearchQueryResult();
+      result.setItems(activities);
+
+      return ResponseEntity.ok(result);
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+  }
+
+  private List<AdHocSubprocessActivityResult> findActivatableActivities(
+      final AdHocSubprocessActivitySearchQuery request) {
+    final ProcessDefinitionEntity processDefinitionEntity =
+        processDefinitionServices
+            .withAuthentication(RequestMapper.getAuthentication())
+            .getByKey(Long.valueOf(request.getProcessDefinitionKey()));
+
+    final BpmnModelInstance modelInstance =
+        Bpmn.readModelFromStream(
+            new ByteArrayInputStream(
+                processDefinitionEntity.bpmnXml().getBytes(StandardCharsets.UTF_8)));
+
+    final var processElement = modelInstance.getModelElementById(request.getAdHocSubprocessId());
+    if (processElement instanceof final AdHocSubProcess adHocSubProcess) {
+      final var tasks = adHocSubProcess.getChildElementsByType(Task.class);
+      return tasks.stream()
+          .filter(task -> task.getIncoming().isEmpty())
+          .map(task -> toAdHocActivity(request, task))
+          .toList();
+    }
+
+    if (LOGGER.isWarnEnabled()) {
+      if (processElement == null) {
+        LOGGER.warn(
+            "Failed to find ad-hoc subprocess element with id '{}' in process definition with key '{}'",
+            request.getAdHocSubprocessId(),
+            request.getProcessDefinitionKey());
+      } else {
+        LOGGER.warn(
+            "Found element with id '{}' in process definition with key '{}' but it was of type '{}', expected 'AdHocSubProcess'",
+            request.getAdHocSubprocessId(),
+            request.getProcessDefinitionKey(),
+            processElement.getElementType());
+      }
+    }
+
+    throw new NotFoundException(
+        "Failed to find Ad-Hoc Subprocess with ID %s".formatted(request.getAdHocSubprocessId()));
+  }
+
+  private AdHocSubprocessActivityResult toAdHocActivity(
+      final AdHocSubprocessActivitySearchQuery query, final Task task) {
+    final var result = new AdHocSubprocessActivityResult();
+    result.setProcessDefinitionKey(query.getProcessDefinitionKey());
+    result.setAdHocSubprocessId(query.getAdHocSubprocessId());
+    result.setFlowNodeId(task.getId());
+    result.setFlowNodeName(task.getName());
+
+    // TODO how to map type to enum (scriptTask vs SCRIPT_TASK)?
+    // result.setType(task.getElementType());
+
+    // TODO documentation vs description?
+    result.setDocumentation(
+        task.getDocumentations().stream()
+            .map(ModelElementInstance::getTextContent)
+            .collect(Collectors.joining("\n")));
+
+    return result;
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityController.java
@@ -9,25 +9,13 @@ package io.camunda.zeebe.gateway.rest.controller;
 
 import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 
-import io.camunda.search.entities.ProcessDefinitionEntity;
-import io.camunda.search.exception.NotFoundException;
-import io.camunda.service.ProcessDefinitionServices;
+import io.camunda.service.AdHocSubprocessActivityServices;
+import io.camunda.service.AdHocSubprocessActivityServices.AdHocSubprocessActivity;
 import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivityResult;
 import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivitySearchQuery;
 import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivitySearchQueryResult;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
-import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
-import io.camunda.zeebe.model.bpmn.instance.Task;
-import java.io.ByteArrayInputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.stream.Collectors;
-import org.camunda.bpm.model.xml.instance.ModelElementInstance;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,24 +24,25 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping("/v2/ad-hoc-activities")
 public class AdHocSubprocessActivityController {
 
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(AdHocSubprocessActivityController.class);
-
-  private final ProcessDefinitionServices processDefinitionServices;
+  private final AdHocSubprocessActivityServices adHocSubprocessActivityServices;
 
   public AdHocSubprocessActivityController(
-      final ProcessDefinitionServices processDefinitionServices) {
-    this.processDefinitionServices = processDefinitionServices;
+      final AdHocSubprocessActivityServices adHocSubprocessActivityServices) {
+    this.adHocSubprocessActivityServices = adHocSubprocessActivityServices;
   }
 
   @CamundaPostMapping(path = "/activatable")
-  public ResponseEntity<AdHocSubprocessActivitySearchQueryResult> getActivities(
+  public ResponseEntity<AdHocSubprocessActivitySearchQueryResult> findActivatableActivities(
       @RequestBody final AdHocSubprocessActivitySearchQuery request) {
     try {
-      final var activities = findActivatableActivities(request);
+      final var activities =
+          adHocSubprocessActivityServices
+              .withAuthentication(RequestMapper.getAuthentication())
+              .findActivatableActivities(
+                  Long.valueOf(request.getProcessDefinitionKey()), request.getAdHocSubprocessId());
 
       final var result = new AdHocSubprocessActivitySearchQueryResult();
-      result.setItems(activities);
+      result.setItems(activities.stream().map(this::toAdHocActivity).toList());
 
       return ResponseEntity.ok(result);
     } catch (final Exception e) {
@@ -61,63 +50,14 @@ public class AdHocSubprocessActivityController {
     }
   }
 
-  private List<AdHocSubprocessActivityResult> findActivatableActivities(
-      final AdHocSubprocessActivitySearchQuery request) {
-    final ProcessDefinitionEntity processDefinitionEntity =
-        processDefinitionServices
-            .withAuthentication(RequestMapper.getAuthentication())
-            .getByKey(Long.valueOf(request.getProcessDefinitionKey()));
-
-    final BpmnModelInstance modelInstance =
-        Bpmn.readModelFromStream(
-            new ByteArrayInputStream(
-                processDefinitionEntity.bpmnXml().getBytes(StandardCharsets.UTF_8)));
-
-    final var processElement = modelInstance.getModelElementById(request.getAdHocSubprocessId());
-    if (processElement instanceof final AdHocSubProcess adHocSubProcess) {
-      final var tasks = adHocSubProcess.getChildElementsByType(Task.class);
-      return tasks.stream()
-          .filter(task -> task.getIncoming().isEmpty())
-          .map(task -> toAdHocActivity(request, task))
-          .toList();
-    }
-
-    if (LOGGER.isWarnEnabled()) {
-      if (processElement == null) {
-        LOGGER.warn(
-            "Failed to find ad-hoc subprocess element with id '{}' in process definition with key '{}'",
-            request.getAdHocSubprocessId(),
-            request.getProcessDefinitionKey());
-      } else {
-        LOGGER.warn(
-            "Found element with id '{}' in process definition with key '{}' but it was of type '{}', expected 'AdHocSubProcess'",
-            request.getAdHocSubprocessId(),
-            request.getProcessDefinitionKey(),
-            processElement.getElementType());
-      }
-    }
-
-    throw new NotFoundException(
-        "Failed to find Ad-Hoc Subprocess with ID %s".formatted(request.getAdHocSubprocessId()));
-  }
-
-  private AdHocSubprocessActivityResult toAdHocActivity(
-      final AdHocSubprocessActivitySearchQuery query, final Task task) {
+  private AdHocSubprocessActivityResult toAdHocActivity(final AdHocSubprocessActivity activity) {
     final var result = new AdHocSubprocessActivityResult();
-    result.setProcessDefinitionKey(query.getProcessDefinitionKey());
-    result.setAdHocSubprocessId(query.getAdHocSubprocessId());
-    result.setFlowNodeId(task.getId());
-    result.setFlowNodeName(task.getName());
-
-    // TODO how to map type to enum (scriptTask vs SCRIPT_TASK)?
-    // result.setType(task.getElementType());
-
-    // TODO documentation vs description?
-    result.setDocumentation(
-        task.getDocumentations().stream()
-            .map(ModelElementInstance::getTextContent)
-            .collect(Collectors.joining("\n")));
-
+    result.setProcessDefinitionKey(activity.processDefinitionKey().toString());
+    result.setAdHocSubprocessId(activity.adHocSubprocessId());
+    result.setFlowNodeId(activity.flowNodeId());
+    result.setFlowNodeName(activity.flowNodeName());
+    result.setType(AdHocSubprocessActivityResult.TypeEnum.fromValue(activity.type().name()));
+    result.setDocumentation(activity.documentation());
     return result;
   }
 }


### PR DESCRIPTION
## Description

Implements a REST API endpoint to activate activities within a running ad-hoc subprocess instance. 

Example request (`2251799813685279` being the flow node ID of a running ad-hoc subprocess):

```
// POST http://localhost:8080/v2/ad-hoc-activities/2251799813685279/activate
{
    "flowNodes": [
        {
            "flowNodeId": "fooCalculation"
        },
        {
            "flowNodeId": "barCalculation"
        }
    ]
}
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #28219
