### PR TITLE
test: add Zeebe to BackupRestoreIT to simulate the whole procedure

### DIFF
--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -435,6 +435,10 @@
       <artifactId>feign-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -114,12 +114,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
@@ -438,7 +432,14 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
+      <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-backup-store-azure</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
   <repositories>
     <repository>

--- a/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupDBClient.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupDBClient.java
@@ -8,9 +8,12 @@
 package io.camunda.it.backup;
 
 import io.camunda.search.connect.configuration.DatabaseType;
+import io.camunda.webapps.backup.BackupRepository;
+import io.camunda.webapps.backup.repository.SnapshotNameProvider;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.Executor;
 
 /**
  * interface to abstract Elasticsearch/Opensearch clients for testing purposes. Methods defined here
@@ -22,10 +25,11 @@ public interface BackupDBClient extends AutoCloseable {
 
   void createRepository(String repositoryName) throws IOException;
 
-  static BackupDBClient create(final String url, final DatabaseType databaseType)
+  static BackupDBClient create(
+      final String url, final DatabaseType databaseType, final Executor executor)
       throws IOException {
     return switch (databaseType) {
-      case ELASTICSEARCH -> new ESDBClientBackup(url);
+      case ELASTICSEARCH -> new ESDBClientBackup(url, executor);
       case OPENSEARCH -> new OSDBClientBackup(url);
       default -> throw new IllegalStateException("Unsupported database type: " + databaseType);
     };
@@ -33,6 +37,9 @@ public interface BackupDBClient extends AutoCloseable {
 
   // TODO remove this when purge functionality is available
   void deleteAllIndices(final String indexPrefix) throws IOException;
+
+  BackupRepository zeebeBackupRepository(
+      String repositoryName, SnapshotNameProvider snapshotNameProvider);
 
   List<String> cat() throws IOException;
 }

--- a/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
@@ -8,45 +8,75 @@
 package io.camunda.it.backup;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import feign.FeignException.NotFound;
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.search.response.ProcessInstanceState;
 import io.camunda.it.utils.MultiDbConfigurator;
+import io.camunda.management.backups.StateCode;
 import io.camunda.management.backups.TakeBackupHistoryResponse;
 import io.camunda.qa.util.cluster.HistoryBackupClient;
 import io.camunda.qa.util.cluster.TestSimpleCamundaApplication;
 import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.webapps.backup.BackupStateDto;
+import io.camunda.zeebe.backup.azure.AzureBackupStore;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
+import io.camunda.zeebe.qa.util.actuator.BackupActuator;
+import io.camunda.zeebe.qa.util.actuator.ExportingActuator;
+import io.camunda.zeebe.qa.util.cluster.TestRestoreApp;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.testcontainers.AzuriteContainer;
+import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.agrona.CloseHelper;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
+@Testcontainers
 @ZeebeIntegration
 public class BackupRestoreIT {
   private static final String REPOSITORY_NAME = "test-repository";
   private static final String INDEX_PREFIX = "backup-restore";
   private static final String PROCESS_ID = "backup-process";
+  private static final long BACKUP_ID = 3L;
   private static final int PROCESS_INSTANCE_NUMBER = 10;
+  @Container private static final AzuriteContainer AZURITE_CONTAINER = new AzuriteContainer();
   protected CamundaClient camundaClient;
+  protected ExportingActuator exportingActuator;
+  protected BackupActuator backupActuator;
 
   @TestZeebe(autoStart = false)
   protected TestStandaloneApplication<?> testStandaloneApplication;
 
   protected BackupDBClient backupDbClient;
-  private String dbUrl;
+
+  @RegisterExtension
+  @SuppressWarnings("unused")
+  final ContainerLogsDumper logsWatcher =
+      new ContainerLogsDumper(() -> Map.of("azurite", AZURITE_CONTAINER));
+
+  private AzureBackupStore store;
+  private final String containerName =
+      RandomStringUtils.insecure().nextAlphabetic(10).toLowerCase();
+  // cannot be a @Container because it's initialized in setup()
   private GenericContainer<?> searchContainer;
   private DataGenerator generator;
   private HistoryBackupClient historyBackupClient;
@@ -60,6 +90,8 @@ public class BackupRestoreIT {
     testStandaloneApplication =
         new TestSimpleCamundaApplication().withAuthenticationMethod(AuthenticationMethod.BASIC);
     final var configurator = new MultiDbConfigurator(testStandaloneApplication);
+    testStandaloneApplication.withBrokerConfig(this::configureZeebeBackupStore);
+    final String dbUrl;
     searchContainer =
         switch (config.databaseType) {
           case ELASTICSEARCH -> {
@@ -101,11 +133,13 @@ public class BackupRestoreIT {
     testStandaloneApplication.start().awaitCompleteTopology();
 
     camundaClient = testStandaloneApplication.newClientBuilder().build();
+    exportingActuator = ExportingActuator.of(testStandaloneApplication);
+    backupActuator = BackupActuator.of(testStandaloneApplication);
 
     historyBackupClient = HistoryBackupClient.of(testStandaloneApplication);
     backupDbClient = BackupDBClient.create(dbUrl, config.databaseType);
     backupDbClient.createRepository(REPOSITORY_NAME);
-    generator = new DataGenerator(camundaClient, PROCESS_ID);
+    generator = new DataGenerator(camundaClient, PROCESS_ID, Duration.ofSeconds(50));
   }
 
   public static Stream<BackupRestoreTestConfig> sources() {
@@ -118,33 +152,26 @@ public class BackupRestoreIT {
 
   @ParameterizedTest
   @MethodSource(value = {"sources"})
-  public void shouldBackupAndRestoreToPreviousState(final BackupRestoreTestConfig config)
+  public void shonldBackupAndRestoreToPreviousState(final BackupRestoreTestConfig config)
       throws Exception {
     // given
     setup(config);
-    camundaClient.newTopologyRequest().send().join();
-    generator.generate(PROCESS_INSTANCE_NUMBER);
 
-    final var takeResponse = historyBackupClient.takeBackup(1L);
-    assertThat(takeResponse)
-        .extracting(TakeBackupHistoryResponse::getScheduledSnapshots)
-        .asInstanceOf(InstanceOfAssertFactories.LIST)
-        .isNotEmpty();
-    final var snapshots = takeResponse.getScheduledSnapshots();
+    testStandaloneApplication.awaitCompleteTopology();
+    // generate completed processes
+    generator.generateCompletedProcesses(PROCESS_INSTANCE_NUMBER);
 
-    Awaitility.await("Backup completed")
-        .atMost(Duration.ofSeconds(600))
-        .untilAsserted(
-            () -> {
-              try {
-                final var backupResponse = historyBackupClient.getBackup(1L);
-                assertThat(backupResponse.getState()).isEqualTo(BackupStateDto.COMPLETED);
-                assertThat(backupResponse.getDetails())
-                    .allMatch(d -> d.getState().equals("SUCCESS"));
-              } catch (final NotFound e) {
-                throw new AssertionError("Backup not found:", e);
-              }
-            });
+    // generate some processes, but do not complete them,
+    // we will complete them after the restore
+    //    generator.generateUncompletedProcesses(PROCESS_INSTANCE_NUMBER);
+
+    // BACKUP PROCEDURE
+    // Zeebe is soft-paused
+    exportingActuator.softPause();
+
+    final var snapshots = takeHistoryBackup();
+    takeZeebeBackup();
+    exportingActuator.resume();
 
     // when
     // if we stop all apps and restart elasticsearch
@@ -153,13 +180,76 @@ public class BackupRestoreIT {
     backupDbClient.deleteAllIndices(INDEX_PREFIX);
     Awaitility.await().untilAsserted(() -> assertThat(backupDbClient.cat()).isEmpty());
 
-    // restore with a new client is successful
+    // RESTORE PROCEDURE
     backupDbClient.restore(REPOSITORY_NAME, snapshots);
+    restoreZeebe();
 
     testStandaloneApplication.start();
 
+    //    generator.verifyAllExported(ProcessInstanceState.ACTIVE);
+    // complete the processes that were not terminated before stopping the apps
+    //    generator.completeProcesses(PROCESS_INSTANCE_NUMBER);
+
     // then
-    generator.verifyAllExported();
+    generator.verifyAllExported(ProcessInstanceState.COMPLETED);
+  }
+
+  private void configureZeebeBackupStore(final BrokerCfg cfg) {
+    final var backup = cfg.getData().getBackup();
+    final var azure = backup.getAzure();
+
+    backup.setStore(BackupStoreType.AZURE);
+    azure.setBasePath(containerName);
+    azure.setConnectionString(AZURITE_CONTAINER.getConnectString());
+  }
+
+  private void restoreZeebe() {
+    try (final var restoreApp =
+        new TestRestoreApp(testStandaloneApplication.brokerConfig()).withBackupId(BACKUP_ID)) {
+
+      assertThatNoException().isThrownBy(restoreApp::start);
+    }
+  }
+
+  private List<String> takeHistoryBackup() {
+    final var takeResponse = historyBackupClient.takeBackup(BACKUP_ID);
+    assertThat(takeResponse)
+        .extracting(TakeBackupHistoryResponse::getScheduledSnapshots)
+        .asInstanceOf(InstanceOfAssertFactories.LIST)
+        .isNotEmpty();
+    System.out.println("ciao");
+    final var snapshots = takeResponse.getScheduledSnapshots();
+
+    Awaitility.await("Webapps Backup completed")
+        .atMost(Duration.ofSeconds(60))
+        .untilAsserted(
+            () -> {
+              try {
+                final var backupResponse = historyBackupClient.getBackup(BACKUP_ID);
+                assertThat(backupResponse.getState()).isEqualTo(BackupStateDto.COMPLETED);
+                assertThat(backupResponse.getDetails())
+                    .allMatch(d -> d.getState().equals("SUCCESS"));
+              } catch (final NotFound e) {
+                throw new AssertionError("Backup not found:", e);
+              }
+            });
+    return snapshots;
+  }
+
+  private void takeZeebeBackup() {
+    backupActuator.take(BACKUP_ID);
+    Awaitility.await("Zeebe backup completed")
+        .untilAsserted(
+            () -> {
+              try {
+                final var status = backupActuator.status(BACKUP_ID);
+                assertThat(status.getState()).isEqualTo(StateCode.COMPLETED);
+                assertThat(status.getDetails())
+                    .allSatisfy(d -> assertThat(d.getState()).isEqualTo(StateCode.COMPLETED));
+              } catch (final Exception e) {
+                throw new AssertionError("Backup not found", e);
+              }
+            });
   }
 
   public record BackupRestoreTestConfig(DatabaseType databaseType, String bucket) {}

--- a/qa/integration-tests/src/test/java/io/camunda/it/backup/ZeebeSnapshotNameProvider.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/backup/ZeebeSnapshotNameProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.backup;
+
+import io.camunda.webapps.backup.BackupException;
+import io.camunda.webapps.backup.Metadata;
+import io.camunda.webapps.backup.repository.SnapshotNameProvider;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ZeebeSnapshotNameProvider implements SnapshotNameProvider {
+  public static final String SNAPSHOT_NAME_PREFIX = "camunda_zeebe_";
+  private static final String SNAPSHOT_NAME_PATTERN = "{prefix}{version}_part_{index}_of_{count}";
+  private static final String SNAPSHOT_NAME_PREFIX_PATTERN = SNAPSHOT_NAME_PREFIX + "{backupId}_";
+  private static final Pattern BACKUPID_PATTERN =
+      Pattern.compile(SNAPSHOT_NAME_PREFIX + "(\\d*)_.*");
+
+  @Override
+  public String getSnapshotNamePrefix(final long backupId) {
+    return SNAPSHOT_NAME_PREFIX_PATTERN.replace("{backupId}", String.valueOf(backupId));
+  }
+
+  @Override
+  public String getSnapshotName(final Metadata metadata) {
+    return SNAPSHOT_NAME_PATTERN
+        .replace("{prefix}", getSnapshotNamePrefix(metadata.backupId()))
+        .replace("{version}", metadata.version())
+        .replace("{index}", metadata.partNo() + "")
+        .replace("{count}", metadata.partCount() + "");
+  }
+
+  @Override
+  public Long extractBackupId(final String snapshotName) {
+    final Matcher matcher = BACKUPID_PATTERN.matcher(snapshotName);
+    if (matcher.matches()) {
+      return Long.valueOf(matcher.group(1));
+    } else {
+      throw new BackupException("Unable to extract backupId. Snapshot name: " + snapshotName);
+    }
+  }
+
+  @Override
+  public String snapshotNamePrefix() {
+    return SNAPSHOT_NAME_PREFIX;
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/ElasticsearchSetupHelperTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/ElasticsearchSetupHelperTest.java
@@ -155,7 +155,7 @@ public class ElasticsearchSetupHelperTest {
                 // We don't want to have this as part of the #validateSchemaCreation
                 // as they are only created when data is exported. This would mean we need to
                 // generate additional data, to trigger such, which we don't want for most tests
-                final String esExporterPrefix = indexPrefix + "_";
+                final String esExporterPrefix = multiDbConfigurator.zeebeIndexPrefix() + "_";
                 final int indexCount =
                     elasticOpenSearchSetupHelper.getCountOfIndicesWithPrefix(
                         elasticSearchUrl, esExporterPrefix);

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfigurator.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfigurator.java
@@ -20,8 +20,10 @@ import java.util.UUID;
  * Helper class to configure any {@link TestStandaloneApplication}, with specific secondary storage.
  */
 public class MultiDbConfigurator {
+  public static String zeebePrefix = "-zeebe-records";
 
   private final TestStandaloneApplication<?> testApplication;
+  private String indexPrefix;
 
   public MultiDbConfigurator(final TestStandaloneApplication<?> testApplication) {
     this.testApplication = testApplication;
@@ -29,20 +31,20 @@ public class MultiDbConfigurator {
 
   public void configureElasticsearchSupport(
       final String elasticsearchUrl, final String indexPrefix) {
-
+    this.indexPrefix = indexPrefix;
     final Map<String, Object> elasticsearchProperties = new HashMap<>();
 
     /* Tasklist */
     elasticsearchProperties.put("camunda.tasklist.elasticsearch.url", elasticsearchUrl);
     elasticsearchProperties.put("camunda.tasklist.zeebeElasticsearch.url", elasticsearchUrl);
     elasticsearchProperties.put("camunda.tasklist.elasticsearch.indexPrefix", indexPrefix);
-    elasticsearchProperties.put("camunda.tasklist.zeebeElasticsearch.prefix", indexPrefix);
+    elasticsearchProperties.put("camunda.tasklist.zeebeElasticsearch.prefix", zeebeIndexPrefix());
 
     /* Operate */
     elasticsearchProperties.put("camunda.operate.elasticsearch.url", elasticsearchUrl);
     elasticsearchProperties.put("camunda.operate.zeebeElasticsearch.url", elasticsearchUrl);
     elasticsearchProperties.put("camunda.operate.elasticsearch.indexPrefix", indexPrefix);
-    elasticsearchProperties.put("camunda.operate.zeebeElasticsearch.prefix", indexPrefix);
+    elasticsearchProperties.put("camunda.operate.zeebeElasticsearch.prefix", zeebeIndexPrefix());
 
     /* Camunda */
     elasticsearchProperties.put(
@@ -80,7 +82,7 @@ public class MultiDbConfigurator {
           cfg.setArgs(
               Map.of(
                   "url", elasticsearchUrl,
-                  "index", Map.of("prefix", indexPrefix),
+                  "index", Map.of("prefix", zeebeIndexPrefix()),
                   "bulk", Map.of("size", 1)));
         });
   }
@@ -90,6 +92,7 @@ public class MultiDbConfigurator {
       final String indexPrefix,
       final String userName,
       final String userPassword) {
+    this.indexPrefix = indexPrefix;
 
     final Map<String, Object> opensearchProperties = new HashMap<>();
 
@@ -97,7 +100,7 @@ public class MultiDbConfigurator {
     opensearchProperties.put("camunda.tasklist.opensearch.url", opensearchUrl);
     opensearchProperties.put("camunda.tasklist.zeebeOpensearch.url", opensearchUrl);
     opensearchProperties.put("camunda.tasklist.opensearch.indexPrefix", indexPrefix);
-    opensearchProperties.put("camunda.tasklist.zeebeOpensearch.prefix", indexPrefix);
+    opensearchProperties.put("camunda.tasklist.zeebeOpensearch.prefix", zeebeIndexPrefix());
     opensearchProperties.put("camunda.tasklist.opensearch.username", userName);
     opensearchProperties.put("camunda.tasklist.opensearch.password", userPassword);
 
@@ -105,7 +108,7 @@ public class MultiDbConfigurator {
     opensearchProperties.put("camunda.operate.opensearch.url", opensearchUrl);
     opensearchProperties.put("camunda.operate.zeebeOpensearch.url", opensearchUrl);
     opensearchProperties.put("camunda.operate.opensearch.indexPrefix", indexPrefix);
-    opensearchProperties.put("camunda.operate.zeebeOpensearch.prefix", indexPrefix);
+    opensearchProperties.put("camunda.operate.zeebeOpensearch.prefix", zeebeIndexPrefix());
     opensearchProperties.put("camunda.operate.opensearch.username", userName);
     opensearchProperties.put("camunda.operate.opensearch.password", userPassword);
 
@@ -154,7 +157,7 @@ public class MultiDbConfigurator {
                   "url",
                   opensearchUrl,
                   "index",
-                  Map.of("prefix", indexPrefix),
+                  Map.of("prefix", zeebeIndexPrefix()),
                   "bulk",
                   Map.of("size", 1),
                   "authentication",
@@ -178,5 +181,13 @@ public class MultiDbConfigurator {
           cfg.setClassName("-");
           cfg.setArgs(Map.of("flushInterval", "0"));
         });
+  }
+
+  public String getIndexPrefix() {
+    return indexPrefix;
+  }
+
+  public String zeebeIndexPrefix() {
+    return indexPrefix != null ? indexPrefix + zeebePrefix : indexPrefix;
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfiguratorTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfiguratorTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.it.utils;
 
+import static io.camunda.it.utils.MultiDbConfigurator.zeebePrefix;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.application.commons.configuration.BrokerBasedConfiguration.BrokerBasedProperties;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.Test;
 public class MultiDbConfiguratorTest {
 
   public static final String EXPECTED_PREFIX = "custom";
+  public static final String EXPECTED_ZEEBE_PREFIX = "custom" + zeebePrefix;
   public static final String EXPECTED_URL = "localhost";
   public static final String EXPECTED_USER = "user";
   public static final String EXPECTED_PW = "pw";
@@ -65,7 +67,7 @@ public class MultiDbConfiguratorTest {
     assertProperty(
         testSimpleCamundaApplication,
         "camunda.tasklist.zeebeElasticsearch.prefix",
-        EXPECTED_PREFIX);
+        EXPECTED_ZEEBE_PREFIX);
 
     /* Operate Config Assertions */
     assertProperty(
@@ -76,7 +78,9 @@ public class MultiDbConfiguratorTest {
     assertProperty(
         testSimpleCamundaApplication, "camunda.operate.elasticsearch.indexPrefix", EXPECTED_PREFIX);
     assertProperty(
-        testSimpleCamundaApplication, "camunda.operate.zeebeElasticsearch.prefix", EXPECTED_PREFIX);
+        testSimpleCamundaApplication,
+        "camunda.operate.zeebeElasticsearch.prefix",
+        EXPECTED_ZEEBE_PREFIX);
 
     /* Camunda Config Assertions */
 
@@ -126,7 +130,9 @@ public class MultiDbConfiguratorTest {
     assertProperty(
         testSimpleCamundaApplication, "camunda.tasklist.opensearch.indexPrefix", EXPECTED_PREFIX);
     assertProperty(
-        testSimpleCamundaApplication, "camunda.tasklist.zeebeOpensearch.prefix", EXPECTED_PREFIX);
+        testSimpleCamundaApplication,
+        "camunda.tasklist.zeebeOpensearch.prefix",
+        EXPECTED_ZEEBE_PREFIX);
     assertProperty(
         testSimpleCamundaApplication, "camunda.tasklist.opensearch.username", EXPECTED_USER);
     assertProperty(
@@ -141,7 +147,9 @@ public class MultiDbConfiguratorTest {
     assertProperty(
         testSimpleCamundaApplication, "camunda.operate.opensearch.indexPrefix", EXPECTED_PREFIX);
     assertProperty(
-        testSimpleCamundaApplication, "camunda.operate.zeebeOpensearch.prefix", EXPECTED_PREFIX);
+        testSimpleCamundaApplication,
+        "camunda.operate.zeebeOpensearch.prefix",
+        EXPECTED_ZEEBE_PREFIX);
     assertProperty(
         testSimpleCamundaApplication, "camunda.operate.opensearch.username", EXPECTED_USER);
     assertProperty(

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestSimpleCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestSimpleCamundaApplication.java
@@ -236,4 +236,9 @@ public final class TestSimpleCamundaApplication
     modifier.accept(brokerProperties);
     return this;
   }
+
+  @Override
+  public BrokerBasedProperties brokerConfig() {
+    return brokerProperties;
+  }
 }

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneCamunda.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneCamunda.java
@@ -256,6 +256,7 @@ public final class TestStandaloneCamunda extends TestSpringApplication<TestStand
   }
 
   /** Returns the broker configuration */
+  @Override
   public BrokerBasedProperties brokerConfig() {
     return brokerProperties;
   }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneApplication.java
@@ -34,4 +34,6 @@ public interface TestStandaloneApplication<T extends TestStandaloneApplication<T
    * started, but likely has no effect until it's restarted.
    */
   T withBrokerConfig(final Consumer<BrokerBasedProperties> modifier);
+
+  BrokerBasedProperties brokerConfig();
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -166,6 +166,7 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
   }
 
   /** Returns the broker configuration */
+  @Override
   public BrokerBasedProperties brokerConfig() {
     return config;
   }


### PR DESCRIPTION
## Description

Added backup & restore of zeebe state to BackupRestoreIT to simulate the whole procedure.
The store configured for zeebe is azure (they are all tested anyway in zeebe/qa IT so no need to duplicate the tests here).
Moreover, some process instances are started and are not completed before the backup procedure starts.
After the backup is completed, the restore procedure is started and those process instances are completed after the restore. 
## Related issues

relates #25935 
