### PR TITLE
fix: use correct unspecified owner type for authorization

### DIFF
--- a/identity/client/src/utility/api/authorizations/index.ts
+++ b/identity/client/src/utility/api/authorizations/index.ts
@@ -47,7 +47,7 @@ export enum OwnerType {
   "ROLE" = "ROLE",
   "GROUP" = "GROUP",
   "MAPPING" = "MAPPING",
-  "UNSPECIFICED" = "UNSPECIFICED",
+  "UNSPECIFIED" = "UNSPECIFIED",
 }
 
 export enum ResourceType {

--- a/identity/client/src/utility/localization/en/authorizations.json
+++ b/identity/client/src/utility/localization/en/authorizations.json
@@ -33,5 +33,5 @@
   "DELETE_PROCESS_INSTANCE": "Delete Process Instance",
   "DELETE_DECISION_INSTANCE": "Delete Decision Instance",
   "MAPPING": "Mapping",
-  "UNSPECIFICED": "Unspecified"
+  "UNSPECIFIED": "Unspecified"
 }


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
This PR fixes a typo in the owner type used when creating an authorization.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

related to #26723
