### PR TITLE
deps: use 8.6.0 for identity and zeebe

### DIFF
--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -14,8 +14,8 @@
     <camunda.maven.artifacts.version>7.21.0</camunda.maven.artifacts.version>
 
     <!-- We use this version to compile but run IT against containers with zeebe.docker.version -->
-    <zeebe.version>8.6.0-alpha5</zeebe.version>
-    <identity.version>8.6.0-alpha5</identity.version>
+    <zeebe.version>8.6.8</zeebe.version>
+    <identity.version>8.6.8</identity.version>
     <!-- We use this for the Zeebe test container version only -->
     <zeebe.docker.version>${zeebe.version}</zeebe.docker.version>
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

External contributors cannot build the repo because Optimize is using alpha versions on the `stable/8.6` branch. This is already bumped on the `stable/optimize-8.6` branch ([example](https://github.com/camunda/camunda/commit/a65a1b7eb9b008d3986e8ab593c4fb76b499fece)), which is where Optimize is released from.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
