### PR TITLE
Standalone Schema Manager for 8.6 and 8.7

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -177,6 +177,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>operate-schema</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>operate-importer</artifactId>
     </dependency>
 
@@ -198,6 +203,11 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>tasklist-importer</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>tasklist-els-schema</artifactId>
     </dependency>
 
     <dependency>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -586,7 +586,7 @@
               <mainClass>io.camunda.operate.schema.migration.SchemaMigration</mainClass>
             </program>
             <program>
-              <id>schema</id>
+              <id>schemaManager</id>
               <mainClass>io.camunda.application.StandaloneSchemaManager</mainClass>
             </program>
             <program>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -586,6 +586,10 @@
               <mainClass>io.camunda.operate.schema.migration.SchemaMigration</mainClass>
             </program>
             <program>
+              <id>schema</id>
+              <mainClass>io.camunda.application.StandaloneSchemaManager</mainClass>
+            </program>
+            <program>
               <id>tasklist</id>
               <mainClass>io.camunda.application.StandaloneTasklist</mainClass>
             </program>

--- a/dist/src/main/java/io/camunda/application/StandaloneSchemaManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneSchemaManager.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application;
+
+import io.camunda.application.listeners.ApplicationErrorListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
+
+/**
+ * Create or update Schemas for ElasticSearch by running this standalone application.
+ *
+ * <p>Example properties:
+ *
+ * <pre>
+ * camunda.operate.elasticsearch.indexPrefix=operate
+ * camunda.operate.elasticsearch.clusterName=elasticsearch
+ * camunda.operate.elasticsearch.url=https://localhost:9200
+ * camunda.operate.elasticsearch.ssl.selfSigned=true
+ * camunda.operate.elasticsearch.ssl.verifyHostname=false
+ * camunda.operate.elasticsearch.ssl.certificatePath=C:/.../config/certs/http_ca.crt
+ * camunda.operate.elasticsearch.username=camunda-admin
+ * camunda.operate.elasticsearch.password=camunda123
+ *
+ * camunda.operate.zeebeElasticsearch.indexPrefix=zeebe-record
+ * camunda.operate.zeebeElasticsearch.clusterName=elasticsearch
+ * camunda.operate.zeebeElasticsearch.url=https://localhost:9200
+ * camunda.operate.zeebeElasticsearch.ssl.selfSigned=true
+ * camunda.operate.zeebeElasticsearch.ssl.verifyHostname=false
+ * camunda.operate.zeebeElasticsearch.ssl.certificatePath=C:/.../config/certs/http_ca.crt
+ * camunda.operate.zeebeElasticsearch.username=camunda-admin
+ * camunda.operate.zeebeElasticsearch.password=camunda123
+ *
+ * camunda.tasklist.elasticsearch.indexPrefix=tasklist
+ * camunda.tasklist.elasticsearch.clusterName=elasticsearch
+ * camunda.tasklist.elasticsearch.url=https://localhost:9200
+ * camunda.tasklist.elasticsearch.ssl.selfSigned=true
+ * camunda.tasklist.elasticsearch.ssl.verifyHostname=false
+ * camunda.tasklist.elasticsearch.ssl.certificatePath=C:/.../config/certs/http_ca.crt
+ * camunda.tasklist.elasticsearch.username=camunda-admin
+ * camunda.tasklist.elasticsearch.password=camunda123
+ *
+ * camunda.tasklist.zeebeElasticsearch.indexPrefix=zeebe-record
+ * camunda.tasklist.zeebeElasticsearch.clusterName=elasticsearch
+ * camunda.tasklist.zeebeElasticsearch.url=https://localhost:9200
+ * camunda.tasklist.zeebeElasticsearch.ssl.selfSigned=true
+ * camunda.tasklist.zeebeElasticsearch.ssl.verifyHostname=false
+ * camunda.tasklist.zeebeElasticsearch.ssl.certificatePath=C:/.../config/certs/http_ca.crt
+ * camunda.tasklist.zeebeElasticsearch.username=camunda-admin
+ * camunda.tasklist.zeebeElasticsearch.password=camunda123
+ * </pre>
+ *
+ * All of those properties can also be handed over via environment variables, e.g.
+ * `CAMUNDA_OPERATE_ELASTICSEARCH_INDEXPREFIX`
+ */
+@SpringBootConfiguration
+@EnableConfigurationProperties
+@ComponentScan(
+    basePackages = {
+      "io.camunda.operate.property",
+      "io.camunda.operate.schema",
+      "io.camunda.tasklist.property",
+      "io.camunda.tasklist.schema"
+    },
+    nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
+public class StandaloneSchemaManager {
+
+  private static final Logger LOG = LoggerFactory.getLogger(StandaloneSchemaManager.class);
+
+  public static void main(final String[] args) throws Exception {
+
+    // To ensure that debug logging performed using java.util.logging is routed into Log4j 2
+    MainSupport.putSystemPropertyIfAbsent(
+        "java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager");
+    // Workaround for https://github.com/spring-projects/spring-boot/issues/26627
+    MainSupport.putSystemPropertyIfAbsent(
+        "spring.config.location",
+        "optional:classpath:/,optional:classpath:/config/,optional:file:./,optional:file:./config/");
+
+    // show banner
+    MainSupport.putSystemPropertyIfAbsent(
+        "spring.banner.location", "classpath:/assets/camunda_banner.txt");
+
+    LOG.info("Creating/updating Elasticsearch schema for Camunda ...");
+
+    final SpringApplication standaloneSchemaManagerApplication =
+        new SpringApplicationBuilder()
+            .web(WebApplicationType.NONE)
+            .logStartupInfo(true)
+            .sources(StandaloneSchemaManager.class) // SchemaManagerConnectConfiguration.class)
+            .addCommandLineProperties(true)
+            .listeners(new ApplicationErrorListener())
+            .build(args);
+
+    final ConfigurableApplicationContext applicationContext =
+        standaloneSchemaManagerApplication.run(args);
+
+    final io.camunda.operate.schema.SchemaStartup schemaStartup =
+        applicationContext.getBean(io.camunda.operate.schema.SchemaStartup.class);
+    final io.camunda.tasklist.schema.SchemaStartup tasklistSchemaStartup =
+        applicationContext.getBean(io.camunda.tasklist.schema.SchemaStartup.class);
+
+    LOG.info("... finished creating/updating Elasticsearch schema for Camunda");
+    System.exit(0);
+  }
+
+  /*
+  io.camunda.operate.schema.elasticsearch.ElasticsearchSchemaManager operateSchemaManager =
+      new io.camunda.operate.schema.elasticsearch.ElasticsearchSchemaManager();
+  io.camunda.tasklist.schema.manager.ElasticsearchSchemaManager tasklistSchemaManager =
+      new io.camunda.tasklist.schema.manager.ElasticsearchSchemaManager();
+  io.camunda.exporter.schema.ElasticsearchSchemaManager exporterSchemaManager =
+      new io.camunda.exporter.schema.ElasticsearchSchemaManager(null, null, null, null);
+  io.camunda.operate.connect.ElasticsearchConnector operateEsConnector;
+  io.camunda.tasklist.es.ElasticsearchConnector tasklistEsConnector;
+  */
+
+  /*
+  operateSchemaManager.createSchema();
+  tasklistSchemaManager.createSchema();
+  exporterSchemaManager.initialiseResources();
+  */
+}

--- a/dist/src/main/java/io/camunda/application/StandaloneSchemaManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneSchemaManager.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.application;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.application.listeners.ApplicationErrorListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,8 +17,10 @@ import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
+import org.springframework.context.annotation.Primary;
 
 /**
  * Create or update Schemas for ElasticSearch by running this standalone application.
@@ -116,20 +119,11 @@ public class StandaloneSchemaManager {
     System.exit(0);
   }
 
-  /*
-  io.camunda.operate.schema.elasticsearch.ElasticsearchSchemaManager operateSchemaManager =
-      new io.camunda.operate.schema.elasticsearch.ElasticsearchSchemaManager();
-  io.camunda.tasklist.schema.manager.ElasticsearchSchemaManager tasklistSchemaManager =
-      new io.camunda.tasklist.schema.manager.ElasticsearchSchemaManager();
-  io.camunda.exporter.schema.ElasticsearchSchemaManager exporterSchemaManager =
-      new io.camunda.exporter.schema.ElasticsearchSchemaManager(null, null, null, null);
-  io.camunda.operate.connect.ElasticsearchConnector operateEsConnector;
-  io.camunda.tasklist.es.ElasticsearchConnector tasklistEsConnector;
-  */
-
-  /*
-  operateSchemaManager.createSchema();
-  tasklistSchemaManager.createSchema();
-  exporterSchemaManager.initialiseResources();
-  */
+  @Bean
+  @Primary // required for some Spring Boot auto-configuration, as we have a tasklistObjectMapper
+  // and
+  // an operateObjectMapper
+  public ObjectMapper defaultObjectMapper() {
+    return new ObjectMapper();
+  }
 }

--- a/dist/src/main/java/io/camunda/application/StandaloneSchemaManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneSchemaManager.java
@@ -9,6 +9,7 @@ package io.camunda.application;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.application.listeners.ApplicationErrorListener;
+import io.camunda.zeebe.exporter.ElasticsearchExporterConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
@@ -114,7 +115,8 @@ public class StandaloneSchemaManager {
         applicationContext.getBean(io.camunda.operate.schema.SchemaStartup.class);
     final io.camunda.tasklist.schema.SchemaStartup tasklistSchemaStartup =
         applicationContext.getBean(io.camunda.tasklist.schema.SchemaStartup.class);
-
+    new io.camunda.zeebe.exporter.SchemaManager(new ElasticsearchExporterConfiguration())
+        .createSchema();
     LOG.info("... finished creating/updating Elasticsearch schema for Camunda");
     System.exit(0);
   }

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -14,8 +14,8 @@
     <camunda.maven.artifacts.version>7.21.0</camunda.maven.artifacts.version>
 
     <!-- We use this version to compile but run IT against containers with zeebe.docker.version -->
-    <zeebe.version>8.6.0-alpha5</zeebe.version>
-    <identity.version>8.6.0-alpha5</identity.version>
+    <zeebe.version>8.6.8</zeebe.version>
+    <identity.version>8.6.8</identity.version>
     <!-- We use this for the Zeebe test container version only -->
     <zeebe.docker.version>${zeebe.version}</zeebe.docker.version>
 

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/SchemaManager.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/SchemaManager.java
@@ -2,6 +2,8 @@ package io.camunda.zeebe.exporter;
 
 import io.camunda.zeebe.exporter.ElasticsearchExporterConfiguration.IndexConfiguration;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,6 +24,17 @@ public class SchemaManager {
       final ElasticsearchClient client, final ElasticsearchExporterConfiguration configuration) {
     this.client = client;
     this.configuration = configuration;
+  }
+
+  /**
+   * Creates a new schema manager, and is only used by the StandaloneSchemaManager.
+   *
+   * @param configuration the exporter configuration
+   */
+  public SchemaManager(final ElasticsearchExporterConfiguration configuration) {
+    this.configuration = configuration;
+    final MeterRegistry registry = new SimpleMeterRegistry();
+    client = new ElasticsearchClient(configuration, registry);
   }
 
   public void createSchema() {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/SchemaManager.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/SchemaManager.java
@@ -1,0 +1,191 @@
+package io.camunda.zeebe.exporter;
+
+import io.camunda.zeebe.exporter.ElasticsearchExporterConfiguration.IndexConfiguration;
+import io.camunda.zeebe.protocol.record.ValueType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SchemaManager {
+  private static final Logger LOG = LoggerFactory.getLogger(SchemaManager.class.getPackageName());
+  private final ElasticsearchClient client;
+  private final ElasticsearchExporterConfiguration configuration;
+  private boolean indexTemplatesCreated = false;
+
+  /**
+   * Creates a new schema manager, and it is to be used by the exporter to manage the Elasticsearch
+   * schema.
+   *
+   * @param client the Elasticsearch client
+   * @param configuration the exporter configuration
+   */
+  public SchemaManager(
+      final ElasticsearchClient client, final ElasticsearchExporterConfiguration configuration) {
+    this.client = client;
+    this.configuration = configuration;
+  }
+
+  public void createSchema() {
+    if (!indexTemplatesCreated) {
+      createIndexTemplates();
+      updateRetentionPolicyForExistingIndices();
+    }
+  }
+
+  private void updateRetentionPolicyForExistingIndices() {
+    final boolean acknowledged;
+    if (configuration.retention.isEnabled()) {
+      acknowledged = client.bulkPutIndexLifecycleSettings(configuration.retention.getPolicyName());
+    } else {
+      acknowledged = client.bulkPutIndexLifecycleSettings(null);
+    }
+
+    if (!acknowledged) {
+      LOG.warn("Failed to acknowledge the the update of retention policy for existing indices");
+    }
+  }
+
+  private void createIndexTemplates() {
+    if (configuration.retention.isEnabled()) {
+      createIndexLifecycleManagementPolicy();
+    }
+
+    final IndexConfiguration index = configuration.index;
+
+    if (index.createTemplate) {
+      createComponentTemplate();
+
+      if (index.deployment) {
+        createValueIndexTemplate(ValueType.DEPLOYMENT);
+      }
+      if (index.process) {
+        createValueIndexTemplate(ValueType.PROCESS);
+      }
+      if (index.error) {
+        createValueIndexTemplate(ValueType.ERROR);
+      }
+      if (index.incident) {
+        createValueIndexTemplate(ValueType.INCIDENT);
+      }
+      if (index.job) {
+        createValueIndexTemplate(ValueType.JOB);
+      }
+      if (index.jobBatch) {
+        createValueIndexTemplate(ValueType.JOB_BATCH);
+      }
+      if (index.message) {
+        createValueIndexTemplate(ValueType.MESSAGE);
+      }
+      if (index.messageBatch) {
+        createValueIndexTemplate(ValueType.MESSAGE_BATCH);
+      }
+      if (index.messageSubscription) {
+        createValueIndexTemplate(ValueType.MESSAGE_SUBSCRIPTION);
+      }
+      if (index.variable) {
+        createValueIndexTemplate(ValueType.VARIABLE);
+      }
+      if (index.variableDocument) {
+        createValueIndexTemplate(ValueType.VARIABLE_DOCUMENT);
+      }
+      if (index.processInstance) {
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE);
+      }
+      if (index.processInstanceBatch) {
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_BATCH);
+      }
+      if (index.processInstanceCreation) {
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_CREATION);
+      }
+      if (index.processInstanceModification) {
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_MODIFICATION);
+      }
+      if (index.processMessageSubscription) {
+        createValueIndexTemplate(ValueType.PROCESS_MESSAGE_SUBSCRIPTION);
+      }
+      if (index.decisionRequirements) {
+        createValueIndexTemplate(ValueType.DECISION_REQUIREMENTS);
+      }
+      if (index.decision) {
+        createValueIndexTemplate(ValueType.DECISION);
+      }
+      if (index.decisionEvaluation) {
+        createValueIndexTemplate(ValueType.DECISION_EVALUATION);
+      }
+      if (index.checkpoint) {
+        createValueIndexTemplate(ValueType.CHECKPOINT);
+      }
+      if (index.timer) {
+        createValueIndexTemplate(ValueType.TIMER);
+      }
+      if (index.messageStartEventSubscription) {
+        createValueIndexTemplate(ValueType.MESSAGE_START_EVENT_SUBSCRIPTION);
+      }
+      if (index.processEvent) {
+        createValueIndexTemplate(ValueType.PROCESS_EVENT);
+      }
+      if (index.deploymentDistribution) {
+        createValueIndexTemplate(ValueType.DEPLOYMENT_DISTRIBUTION);
+      }
+      if (index.escalation) {
+        createValueIndexTemplate(ValueType.ESCALATION);
+      }
+      if (index.signal) {
+        createValueIndexTemplate(ValueType.SIGNAL);
+      }
+      if (index.signalSubscription) {
+        createValueIndexTemplate(ValueType.SIGNAL_SUBSCRIPTION);
+      }
+      if (index.resourceDeletion) {
+        createValueIndexTemplate(ValueType.RESOURCE_DELETION);
+      }
+      if (index.commandDistribution) {
+        createValueIndexTemplate(ValueType.COMMAND_DISTRIBUTION);
+      }
+      if (index.form) {
+        createValueIndexTemplate(ValueType.FORM);
+      }
+      if (index.userTask) {
+        createValueIndexTemplate(ValueType.USER_TASK);
+      }
+      if (index.processInstanceMigration) {
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_MIGRATION);
+      }
+      if (index.compensationSubscription) {
+        createValueIndexTemplate(ValueType.COMPENSATION_SUBSCRIPTION);
+      }
+      if (index.messageCorrelation) {
+        createValueIndexTemplate(ValueType.MESSAGE_CORRELATION);
+      }
+      if (index.user) {
+        createValueIndexTemplate(ValueType.USER);
+      }
+
+      if (index.authorization) {
+        createValueIndexTemplate(ValueType.AUTHORIZATION);
+      }
+    }
+
+    indexTemplatesCreated = true;
+  }
+
+  private void createIndexLifecycleManagementPolicy() {
+    if (!client.putIndexLifecycleManagementPolicy()) {
+      LOG.warn(
+          "Failed to acknowledge the creation or update of the Index Lifecycle Management Policy");
+    }
+  }
+
+  private void createComponentTemplate() {
+    if (!client.putComponentTemplate()) {
+      LOG.warn("Failed to acknowledge the creation or update of the component template");
+    }
+  }
+
+  private void createValueIndexTemplate(final ValueType valueType) {
+    if (!client.putIndexTemplate(valueType)) {
+      LOG.warn(
+          "Failed to acknowledge the creation or update of the index template for value type {}",
+          valueType);
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR is still a POC to add the `StandaloneSchemaManager` to 8.6 and 8.7 versions. This requires isolating the schema initializer in the zeebe exporter so that it can be called from the `StandaloneSchemaManager`.

**TODO:**

- [ ] In `StandaloneSchemaManager` the exporter configuration should be fetched from the application instead of creating a new object. 
- [ ] validate the templates generated:

This current POC is initializing the following templates:

Zeebe: 
```
zeebe-record_deployment-distribution_8.7.0-snapshot
zeebe-record_user-task_8.7.0-snapshot
zeebe-record_process_8.7.0-snapshot
zeebe-record_error_8.7.0-snapshot
zeebe-record_signal-subscription_8.7.0-snapshot
zeebe-record_variable-document_8.7.0-snapshot
zeebe-record_authorization_8.7.0-snapshot
zeebe-record_decision_8.7.0-snapshot
zeebe-record_process-instance-modification_8.7.0-snapshot
zeebe-record_signal_8.7.0-snapshot
zeebe-record_decision-requirements_8.7.0-snapshot
zeebe-record_command-distribution_8.7.0-snapshot
zeebe-record_process-instance-creation_8.7.0-snapshot
zeebe-record_decision-evaluation_8.7.0-snapshot
zeebe-record_message-correlation_8.7.0-snapshot
zeebe-record_user_8.7.0-snapshot
zeebe-record_deployment_8.7.0-snapshot
zeebe-record_process-instance-migration_8.7.0-snapshot
zeebe-record_process-instance_8.7.0-snapshot
zeebe-record_incident_8.7.0-snapshot
zeebe-record_message-subscription_8.7.0-snapshot
zeebe-record_form_8.7.0-snapshot
zeebe-record_escalation_8.7.0-snapshot
zeebe-record_message_8.7.0-snapshot
zeebe-record_job_8.7.0-snapshot
zeebe-record_variable_8.7.0-snapshot
zeebe-record_resource-deletion_8.7.0-snapshot
zeebe-record_process-message-subscription_8.7.0-snapshot
zeebe-record_timer_8.7.0-snapshot
zeebe-record_message-start-event-subscription_8.7.0-snapshot
zeebe-record_compensation-subscription_8.7.0-snapshot
```

tasklist:
```
tasklist-task-variable-8.3.0_template
tasklist-task-8.5.0_template
tasklist-draft-task-variable-8.3.0_template
```

operate: 
```
operate-job-8.6.0_template
operate-flownode-instance-8.3.1_template
operate-incident-8.3.1_template
operate-operation-8.4.1_template
operate-sequence-flow-8.3.0_template
operate-post-importer-queue-8.3.0_template
operate-variable-8.3.0_template
operate-message-8.5.0_template
operate-event-8.3.0_template
operate-decision-instance-8.3.0_template
operate-batch-operation-1.0.0_template
operate-user-task-8.5.0_template
operate-list-view-8.3.0_template
```

- [ ] Define behaviour
Currently the `StandaloneSchemaManager` generates indexes for operate and tasklist, should we also generate for zeebe?

# Acceptance criteria
- [x] There is a `StandaloneSchemaManager` application added to the dist module for 8.6 and 8.7
- [x] There is a shell script `schemaManager.bat` and `schemaManager` in the official distribution to start this application
- [x] The new application does:
  - [x] Sets up the Tasklist schema for Elasticsearch
  - [x] Sets up the Operate schema for Elasticsearch
  - [x] Sets up the Zeebe Elasticsearch exporter schema for Elasticsearch
- [ ] On error, the application shuts down with a non-zero code, and prints out the error.
- [x] On success, it exits with code 0.
- [ ] After running the standalone schema manager successfully, I can start Zeebe with the Elasticsearch exporter configured to not create index templates, and exporting works
- [ ] After running the standalone schema manager successfully, I can start Operate with schema creation disabled, the application works, and importing works.
- [ ] After running the standalone schema manager successfully, I can start Tasklist with schema creation disabled, the application works, and importing works.

## Related issues

closes https://github.com/camunda/camunda/issues/27883
