### PR TITLE
fix: Improve title of API client response in case of failures

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/http/TypedApiEntityConsumer.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/http/TypedApiEntityConsumer.java
@@ -103,7 +103,14 @@ public interface TypedApiEntityConsumer<T> {
         // write the original JSON response into an error response
         final String jsonString = getJsonString();
         return ApiEntity.of(
-            new ProblemDetail().title("Unexpected server response").status(500).detail(jsonString));
+            new ProblemDetail()
+                .title("Cannot parse the server JSON response")
+                .status(500)
+                .detail(
+                    "The client failed to parse the JSON response: "
+                        + ioe.getMessage()
+                        + ". The received JSON payload is: "
+                        + jsonString));
       }
     }
 

--- a/clients/java/src/test/java/io/camunda/client/impl/http/ApiEntityConsumerTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/http/ApiEntityConsumerTest.java
@@ -75,8 +75,11 @@ class ApiEntityConsumerTest {
     assertThat(entity).isInstanceOf(Error.class);
     final ProblemDetail response = entity.problem();
     assertThat(response).isNotNull();
-    assertThat(response.getTitle()).isEqualTo("Unexpected server response");
-    assertThat(response.getDetail()).isEqualTo(jsonResponse);
+    assertThat(response.getTitle()).isEqualTo("Cannot parse the server JSON response");
+    assertThat(response.getDetail())
+        .contains(jsonResponse)
+        .contains("The client failed to parse the JSON response")
+        .contains("Unrecognized field \"foo\"");
   }
 
   @Test
@@ -99,8 +102,11 @@ class ApiEntityConsumerTest {
     assertThat(entity).isInstanceOf(Error.class);
     final ProblemDetail response = entity.problem();
     assertThat(response).isNotNull();
-    assertThat(response.getTitle()).isEqualTo("Unexpected server response");
-    assertThat(response.getDetail()).isEqualTo(jsonResponse);
+    assertThat(response.getTitle()).isEqualTo("Cannot parse the server JSON response");
+    assertThat(response.getDetail())
+        .contains(jsonResponse)
+        .contains("The client failed to parse the JSON response")
+        .contains("Unrecognized field \"foo\"");
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR aims to improve the title of the `ProblemDetail` instance returned by the Camunda API client when it fails to parse the JSON response appropriately.

