### PR TITLE
[Backport stable/8.7] fix: c8run add cmd line params to unix

### DIFF
--- a/c8run/start.sh
+++ b/c8run/start.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-./c8run start
+./c8run start $@


### PR DESCRIPTION
# Description
Backport of #28346 to `stable/8.7`.

relates to camunda/product-hub#2459
original author: @hisImminence