### PR TITLE
fix: (8.7) add hierarchy to JobActivationResponse schema, so that docs generate properly

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1162,7 +1162,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
 
-
   /decision-definitions/evaluation:
     post:
       tags:
@@ -1680,7 +1679,7 @@ paths:
             schema:
               $ref: "#/components/schemas/IncidentSearchQuery"
       responses:
-        '200':
+        "200":
           description: >
             The incident search successful response.
           content:
@@ -1693,7 +1692,7 @@ paths:
             application/vnd.camunda.api.keys.string+json:
               schema:
                 $ref: "#/components/schemas/IncidentSearchQueryResult"
-        '400':
+        "400":
           description: >
             The incident search query failed.
             More details are provided in the response body.
@@ -1870,7 +1869,6 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
-
 
   /element-instances/{elementInstanceKey}/variables:
     post:
@@ -3226,10 +3224,16 @@ components:
         - type
         - timeout
         - maxJobsToActivate
+    JobActivationResponseBase:
+      # This base schema exists to support the downstream API documentation.
+      description: Base properties for JobActivationResponse
+      type: object
     JobActivationResponse:
       description: The list of activated jobs
       deprecated: true
       type: object
+      allOf:
+        - $ref: "#/components/schemas/JobActivationResponseBase"
       properties:
         jobs:
           type: array
@@ -3238,6 +3242,8 @@ components:
     JobActivationResult:
       description: The list of activated jobs. Key attributes as string values.
       type: object
+      allOf:
+        - $ref: "#/components/schemas/JobActivationResponseBase"
       properties:
         jobs:
           type: array
@@ -4182,7 +4188,6 @@ components:
               description: Documents that failed creation.
               items:
                 $ref: "#/components/schemas/DocumentCreationFailureDetail"
-
 
     DocumentMetadata:
       description: Information about the document.

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -599,7 +599,7 @@ paths:
         To change the time, the clock must be pinned again with a new timestamp.
 
         :::note
-        This endpoint is an [alpha feature](/reference/alpha-features.md) and may be subject to change
+        This endpoint is an alpha feature and may be subject to change
         in future releases.
         :::
       requestBody:
@@ -635,7 +635,7 @@ paths:
         normal behavior after it has been pinned to a specific time.
 
         :::note
-        This endpoint is an [alpha feature](/reference/alpha-features.md) and may be subject to change
+        This endpoint is an alpha feature and may be subject to change
         in future releases.
       responses:
         "204":


### PR DESCRIPTION
## Description

Propagates the changes from https://github.com/camunda/camunda-docs/pull/5027 upstream, so that we don't recreate the issues described in https://github.com/camunda/camunda-docs/issues/4989.

Also includes some small formatting changes (which my auto-formatter made for me), and the removal of a couple hardcoded links that don't make sense outside of the documentation.

