### PR TITLE
[Backport stable/optimize-8.7] fix: Unable to import a report in Optimize

### DIFF
--- a/optimize/client/src/components/Home/CollectionEnitiesList.js
+++ b/optimize/client/src/components/Home/CollectionEnitiesList.js
@@ -46,7 +46,8 @@ export default function CollectionEnitiesList({
   const [creating, setCreating] = useState(null);
   const fileInput = useRef(null);
   const {mightFail} = useErrorHandling();
-  const {1: id} = useParams();
+  const {1: rawId} = useParams();
+  const id = rawId.replace(/\/$/, '');
 
   function closeCreationModal() {
     setCreating(null);


### PR DESCRIPTION
## Description

Users are unable to import reports that they have exported. The URL used by the FE contains an errant / at the end of the URL. This PR is backporting the fixes from https://github.com/camunda/camunda/pull/27787

## Related issues

related to https://github.com/camunda/camunda/issues/26353
