### PR TITLE
Schema manager updates settings

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SchemaManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SchemaManager.java
@@ -55,11 +55,11 @@ public class SchemaManager {
 
     //  used to update existing indices/templates
     LOG.info("Update index schema. '{}' indices need to be updated", newIndexProperties.size());
-    updateSchema(newIndexProperties);
+    updateSchemaMappings(newIndexProperties);
     LOG.info(
         "Update index template schema. '{}' index templates need to be updated",
         newIndexProperties.size());
-    updateSchema(newIndexTemplateProperties);
+    updateSchemaMappings(newIndexTemplateProperties);
 
     final RetentionConfiguration retention = config.getArchiver().getRetention();
     if (retention.isEnabled()) {
@@ -132,7 +132,8 @@ public class SchemaManager {
             });
   }
 
-  public void updateSchema(final Map<IndexDescriptor, Collection<IndexMappingProperty>> newFields) {
+  public void updateSchemaMappings(
+      final Map<IndexDescriptor, Collection<IndexMappingProperty>> newFields) {
     for (final var newFieldEntry : newFields.entrySet()) {
       final var descriptor = newFieldEntry.getKey();
       final var newProperties = newFieldEntry.getValue();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SchemaManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SchemaManager.java
@@ -16,6 +16,7 @@ import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,7 +83,9 @@ public class SchemaManager {
             .keySet();
 
     final var existingIndexNames =
-        searchEngineClient.getMappings(allIndexNames(), MappingSource.INDEX).keySet();
+        allIndexNames().isBlank()
+            ? Set.of()
+            : searchEngineClient.getMappings(allIndexNames(), MappingSource.INDEX).keySet();
 
     indexTemplateDescriptors.stream()
         .filter(desc -> existingTemplateNames.contains(desc.getTemplateName()))

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SearchEngineClient.java
@@ -44,4 +44,7 @@ public interface SearchEngineClient {
 
   boolean importersCompleted(
       final int partitionId, final List<IndexDescriptor> importPositionIndices);
+
+  void updateIndexTemplateSettings(
+      final IndexTemplateDescriptor indexTemplateDescriptor, final IndexSettings currentSettings);
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -364,8 +364,10 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
       final var templateFields =
           deserializeJson(
               IndexTemplateMapping._DESERIALIZER,
-              utils.appendToFileSchemaSettings(templateFile, settings));
-
+              utils.new SchemaSettingsAppender(templateFile)
+                  .withNumberOfReplicas(settings.getNumberOfReplicas())
+                  .withNumberOfShards(settings.getNumberOfShards())
+                  .build());
       return new PutIndexTemplateRequest.Builder()
           .name(indexTemplateDescriptor.getTemplateName())
           .indexPatterns(indexTemplateDescriptor.getIndexPattern())
@@ -394,7 +396,10 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
       final var templateFields =
           deserializeJson(
               IndexTemplateMapping._DESERIALIZER,
-              utils.appendToFileSchemaSettings(templateFile, settings));
+              utils.new SchemaSettingsAppender(templateFile)
+                  .withNumberOfReplicas(settings.getNumberOfReplicas())
+                  .withNumberOfShards(settings.getNumberOfShards())
+                  .build());
 
       return new CreateIndexRequest.Builder()
           .index(indexDescriptor.getFullQualifiedName())

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/opensearch/OpensearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/opensearch/OpensearchEngineClient.java
@@ -7,12 +7,14 @@
  */
 package io.camunda.exporter.schema.opensearch;
 
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.camunda.exporter.SchemaResourceSerializer;
 import io.camunda.exporter.config.ExporterConfiguration.IndexSettings;
+import io.camunda.exporter.exceptions.ElasticsearchExporterException;
 import io.camunda.exporter.exceptions.IndexSchemaValidationException;
 import io.camunda.exporter.exceptions.OpensearchExporterException;
 import io.camunda.exporter.schema.IndexMapping;
@@ -48,6 +50,7 @@ import org.opensearch.client.opensearch.indices.PutIndexTemplateRequest;
 import org.opensearch.client.opensearch.indices.PutIndicesSettingsRequest;
 import org.opensearch.client.opensearch.indices.PutMappingRequest;
 import org.opensearch.client.opensearch.indices.get_index_template.IndexTemplateItem;
+import org.opensearch.client.opensearch.indices.get_index_template.IndexTemplateSummary;
 import org.opensearch.client.opensearch.indices.put_index_template.IndexTemplateMapping;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -241,9 +244,28 @@ public class OpensearchEngineClient implements SearchEngineClient {
     }
   }
 
+  /**
+   * Overwrites the settings of the existing index template with the settings block in the
+   * descriptor schema json file.
+   *
+   * @param indexTemplateDescriptor of the index template to have its settings overwritten.
+   */
   @Override
   public void updateIndexTemplateSettings(
-      final IndexTemplateDescriptor indexDescriptor, final IndexSettings currentSettings) {}
+      final IndexTemplateDescriptor indexTemplateDescriptor, final IndexSettings currentSettings) {
+    final var updateIndexTemplateSettingsRequest =
+        updateTemplateSettings(indexTemplateDescriptor, currentSettings);
+
+    try {
+      client.indices().putIndexTemplate(updateIndexTemplateSettingsRequest);
+    } catch (final IOException | ElasticsearchException e) {
+      throw new ElasticsearchExporterException(
+          String.format(
+              "Expected to update index template settings '%s' with '%s', but failed ",
+              indexTemplateDescriptor.getTemplateName(), updateIndexTemplateSettingsRequest),
+          e);
+    }
+  }
 
   private SearchRequest allImportPositionDocuments(
       final int partitionId, final List<IndexDescriptor> importPositionIndices) {
@@ -407,6 +429,58 @@ public class OpensearchEngineClient implements SearchEngineClient {
           "Failed to load file "
               + indexTemplateDescriptor.getMappingsClasspathFilename()
               + " from classpath.",
+          e);
+    }
+  }
+
+  private PutIndexTemplateRequest updateTemplateSettings(
+      final IndexTemplateDescriptor indexTemplateDescriptor, final IndexSettings currentSettings) {
+    try (final var templateFile =
+        getClass().getResourceAsStream(indexTemplateDescriptor.getMappingsClasspathFilename())) {
+      final var updatedTemplateSettings =
+          deserializeJson(
+                  IndexTemplateMapping._DESERIALIZER,
+                  utils.new SchemaSettingsAppender(templateFile)
+                      .withNumberOfShards(currentSettings.getNumberOfShards())
+                      .withNumberOfReplicas(currentSettings.getNumberOfReplicas())
+                      .build())
+              .settings();
+
+      final var currentIndexTemplateState = getIndexTemplateState(indexTemplateDescriptor);
+
+      return new PutIndexTemplateRequest.Builder()
+          .name(indexTemplateDescriptor.getTemplateName())
+          .indexPatterns(indexTemplateDescriptor.getIndexPattern())
+          .template(
+              t ->
+                  t.settings(updatedTemplateSettings)
+                      .mappings(currentIndexTemplateState.mappings())
+                      .aliases(currentIndexTemplateState.aliases()))
+          .build();
+
+    } catch (final IOException e) {
+      throw new OpensearchExporterException(
+          "Failed to load file "
+              + indexTemplateDescriptor.getMappingsClasspathFilename()
+              + " from classpath.",
+          e);
+    }
+  }
+
+  private IndexTemplateSummary getIndexTemplateState(
+      final IndexTemplateDescriptor indexTemplateDescriptor) {
+    try {
+      return client
+          .indices()
+          .getIndexTemplate(r -> r.name(indexTemplateDescriptor.getTemplateName()))
+          .indexTemplates()
+          .getFirst()
+          .indexTemplate()
+          .template();
+    } catch (final IOException e) {
+      throw new OpensearchExporterException(
+          String.format(
+              "Failed to retrieve index template '%s'", indexTemplateDescriptor.getTemplateName()),
           e);
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/opensearch/OpensearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/opensearch/OpensearchEngineClient.java
@@ -241,6 +241,10 @@ public class OpensearchEngineClient implements SearchEngineClient {
     }
   }
 
+  @Override
+  public void updateIndexTemplateSettings(
+      final IndexTemplateDescriptor indexDescriptor, final IndexSettings currentSettings) {}
+
   private SearchRequest allImportPositionDocuments(
       final int partitionId, final List<IndexDescriptor> importPositionIndices) {
     final var importPositionIndicesNames =
@@ -383,7 +387,10 @@ public class OpensearchEngineClient implements SearchEngineClient {
       final var templateFields =
           deserializeJson(
               IndexTemplateMapping._DESERIALIZER,
-              utils.appendToFileSchemaSettings(templateFile, settings));
+              utils.new SchemaSettingsAppender(templateFile)
+                  .withNumberOfShards(settings.getNumberOfShards())
+                  .withNumberOfReplicas(settings.getNumberOfReplicas())
+                  .build());
 
       return new PutIndexTemplateRequest.Builder()
           .name(indexTemplateDescriptor.getTemplateName())
@@ -413,7 +420,10 @@ public class OpensearchEngineClient implements SearchEngineClient {
       final var templateFields =
           deserializeJson(
               IndexTemplateMapping._DESERIALIZER,
-              utils.appendToFileSchemaSettings(templateFile, settings));
+              utils.new SchemaSettingsAppender(templateFile)
+                  .withNumberOfShards(settings.getNumberOfShards())
+                  .withNumberOfReplicas(settings.getNumberOfReplicas())
+                  .build());
 
       return new CreateIndexRequest.Builder()
           .index(indexDescriptor.getFullQualifiedName())

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/SearchEngineClientUtils.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/SearchEngineClientUtils.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.config.ExporterConfiguration.IndexSettings;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
-import io.camunda.webapps.schema.entities.operate.ImportPositionEntity;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -65,28 +64,5 @@ public class SearchEngineClientUtils {
               "Failed to serialise settings in PutSettingsRequest [%s]", settingsMap.toString()),
           e);
     }
-  }
-
-  public boolean allImportersCompleted(
-      final List<ImportPositionEntity> recordReaderStatuses, final int totalValueTypesCount) {
-    // For a fresh install where there are no import position documents
-    if (recordReaderStatuses.isEmpty()) {
-      return true;
-    }
-
-    final var partitionCompleted =
-        recordReaderStatuses.stream().anyMatch(ImportPositionEntity::getCompleted);
-
-    // If all record readers have an import position document we can check their completed values
-
-    if (recordReaderStatuses.size() == totalValueTypesCount) {
-      return recordReaderStatuses.stream().allMatch(ImportPositionEntity::getCompleted);
-    }
-
-    // If some record readers are missing their import position document we can say their status
-    // is equal to that of the partition completion status.
-
-    return recordReaderStatuses.stream().allMatch(ImportPositionEntity::getCompleted)
-        && partitionCompleted;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/SearchEngineClientUtils.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/SearchEngineClientUtils.java
@@ -9,7 +9,6 @@ package io.camunda.exporter.utils;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.exporter.config.ExporterConfiguration.IndexSettings;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -27,22 +26,6 @@ public class SearchEngineClientUtils {
 
   public SearchEngineClientUtils(final ObjectMapper objectMapper) {
     this.objectMapper = objectMapper;
-  }
-
-  public InputStream appendToFileSchemaSettings(
-      final InputStream file, final IndexSettings settingsToAppend) throws IOException {
-
-    final var map = objectMapper.readValue(file, new TypeReference<Map<String, Object>>() {});
-
-    final var settingsBlock =
-        (Map<String, Object>) map.computeIfAbsent("settings", k -> new HashMap<>());
-    final var indexBlock =
-        (Map<String, Object>) settingsBlock.computeIfAbsent("index", k -> new HashMap<>());
-
-    indexBlock.put("number_of_shards", settingsToAppend.getNumberOfShards());
-    indexBlock.put("number_of_replicas", settingsToAppend.getNumberOfReplicas());
-
-    return new ByteArrayInputStream(objectMapper.writeValueAsBytes(map));
   }
 
   public String listIndices(final List<IndexDescriptor> indexDescriptors) {
@@ -63,6 +46,40 @@ public class SearchEngineClientUtils {
           String.format(
               "Failed to serialise settings in PutSettingsRequest [%s]", settingsMap.toString()),
           e);
+    }
+  }
+
+  public class SchemaSettingsAppender {
+    private final Map<String, Object> map;
+    private final Map<String, Object> settingsBlock;
+    private final Map<String, Object> indexBlock;
+
+    /**
+     * Reads the settings block in {@code file} and writes additional settings using a builder
+     * syntax.
+     *
+     * @param file whose settings block will be read and appended.
+     * @throws IOException if unable to parse the given file into a map.
+     */
+    public SchemaSettingsAppender(final InputStream file) throws IOException {
+      map = objectMapper.readValue(file, new TypeReference<Map<String, Object>>() {});
+      settingsBlock = (Map<String, Object>) map.computeIfAbsent("settings", k -> new HashMap<>());
+      indexBlock =
+          (Map<String, Object>) settingsBlock.computeIfAbsent("index", k -> new HashMap<>());
+    }
+
+    public SchemaSettingsAppender withNumberOfShards(final int numberOfShards) {
+      indexBlock.put("number_of_shards", numberOfShards);
+      return this;
+    }
+
+    public SchemaSettingsAppender withNumberOfReplicas(final int numberOfReplicas) {
+      indexBlock.put("number_of_replicas", numberOfReplicas);
+      return this;
+    }
+
+    public InputStream build() throws IOException {
+      return new ByteArrayInputStream(objectMapper.writeValueAsBytes(map));
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/SchemaManagerIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/SchemaManagerIT.java
@@ -435,6 +435,120 @@ public class SchemaManagerIT {
     assertThat(mappingsMatch(updatedIndex.get("mappings"), newMappingsFile)).isTrue();
   }
 
+  @TestTemplate
+  void shouldUpdateSettingsForIndexTemplatesButNotUpdateIndexSettingsWhenSchemaChanges(
+      final ExporterConfiguration config, final SearchClientAdapter searchClientAdapter)
+      throws IOException {
+    // given
+    final var schemaManager =
+        new SchemaManager(
+            searchEngineClientFromConfig(config),
+            Set.of(),
+            Set.of(indexTemplate),
+            config,
+            objectMapper);
+
+    schemaManager.startup();
+
+    final var indexTemplateSettingsToBeAppended =
+        "/index_template/template/settings/index/refresh_interval";
+    final var indexSettingsToBeAppended = "/settings/index/refresh_interval";
+
+    final var initialTemplate =
+        searchClientAdapter.getIndexTemplateAsNode(indexTemplate.getTemplateName());
+    final var initialMatchingIndex =
+        searchClientAdapter.getIndexAsNode(indexTemplate.getFullQualifiedName());
+
+    assertThat(initialTemplate.at(indexTemplateSettingsToBeAppended).asText()).isEqualTo("");
+    assertThat(initialMatchingIndex.at(indexSettingsToBeAppended).asText()).isEqualTo("");
+
+    // when
+    when(indexTemplate.getMappingsClasspathFilename())
+        .thenReturn("/mappings-and-updated-settings.json");
+
+    // change index template schema to have new updated settings and trigger update
+    schemaManager.startup();
+
+    // then
+    final var updatedTemplate =
+        searchClientAdapter.getIndexTemplateAsNode(indexTemplate.getTemplateName());
+    final var updatedMatchingIndex =
+        searchClientAdapter.getIndexAsNode(indexTemplate.getFullQualifiedName());
+
+    assertThat(updatedTemplate.at(indexTemplateSettingsToBeAppended).asText()).isEqualTo("5s");
+    assertThat(updatedMatchingIndex.at(indexSettingsToBeAppended).asText()).isEqualTo("");
+  }
+
+  @TestTemplate
+  void shouldUpdateIndexTemplateWithNewReplicaAndShardCount(
+      final ExporterConfiguration config, final SearchClientAdapter searchClientAdapter)
+      throws IOException {
+    // given
+    final var schemaManager =
+        new SchemaManager(
+            searchEngineClientFromConfig(config),
+            Set.of(),
+            Set.of(indexTemplate),
+            config,
+            objectMapper);
+
+    schemaManager.startup();
+
+    final var replicaSettingPath = "/index_template/template/settings/index/number_of_replicas";
+    final var shardsSettingPath = "/index_template/template/settings/index/number_of_shards";
+
+    final var initialTemplate =
+        searchClientAdapter.getIndexTemplateAsNode(indexTemplate.getTemplateName());
+
+    assertThat(initialTemplate.at(replicaSettingPath).asInt()).isEqualTo(0);
+    assertThat(initialTemplate.at(shardsSettingPath).asInt()).isEqualTo(1);
+
+    // when
+    config.getIndex().setNumberOfReplicas(5);
+    config.getIndex().setNumberOfShards(5);
+
+    schemaManager.startup();
+
+    // then
+    final var updatedTemplate =
+        searchClientAdapter.getIndexTemplateAsNode(indexTemplate.getTemplateName());
+
+    assertThat(updatedTemplate.at(replicaSettingPath).asInt()).isEqualTo(5);
+    assertThat(updatedTemplate.at(shardsSettingPath).asInt()).isEqualTo(5);
+  }
+
+  @TestTemplate
+  void shouldUpdateIndexWithNewReplicaCountButNotNewShardCount(
+      final ExporterConfiguration config, final SearchClientAdapter searchClientAdapter)
+      throws IOException {
+    // given
+    final var schemaManager =
+        new SchemaManager(
+            searchEngineClientFromConfig(config), Set.of(index), Set.of(), config, objectMapper);
+
+    schemaManager.startup();
+
+    final var replicaSettingPath = "/settings/index/number_of_replicas";
+    final var shardsSettingPath = "/settings/index/number_of_shards";
+
+    final var initialIndex = searchClientAdapter.getIndexAsNode(index.getFullQualifiedName());
+
+    assertThat(initialIndex.at(replicaSettingPath).asInt()).isEqualTo(0);
+    assertThat(initialIndex.at(shardsSettingPath).asInt()).isEqualTo(1);
+
+    // when
+    config.getIndex().setNumberOfReplicas(5);
+    config.getIndex().setNumberOfShards(5);
+
+    schemaManager.startup();
+
+    // then
+    final var updatedIndex = searchClientAdapter.getIndexAsNode(index.getFullQualifiedName());
+
+    assertThat(updatedIndex.at(replicaSettingPath).asInt()).isEqualTo(5);
+    assertThat(updatedIndex.at(shardsSettingPath).asInt()).isEqualTo(1);
+  }
+
   @RegressionTestTemplate("https://github.com/camunda/camunda/issues/26056")
   void shouldNotHaveValidationIssuesWithTheSameIndices(
       final ExporterConfiguration config, final SearchClientAdapter searchClientAdapter) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/SchemaManagerIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/SchemaManagerIT.java
@@ -115,7 +115,7 @@ public class SchemaManagerIT {
     final Map<IndexDescriptor, Collection<IndexMappingProperty>> schemasToChange =
         Map.of(index, newProperties);
 
-    schemaManager.updateSchema(schemasToChange);
+    schemaManager.updateSchemaMappings(schemasToChange);
 
     // then
     final var updatedIndex = searchClientAdapter.getIndexAsNode(index.getFullQualifiedName());
@@ -200,7 +200,7 @@ public class SchemaManagerIT {
 
     final Map<IndexDescriptor, Collection<IndexMappingProperty>> schemasToChange =
         Map.of(indexTemplate, Set.of());
-    schemaManager.updateSchema(schemasToChange);
+    schemaManager.updateSchemaMappings(schemasToChange);
 
     // then
     final var template =
@@ -241,7 +241,7 @@ public class SchemaManagerIT {
   }
 
   @TestTemplate
-  void shouldUpdateSchemasCorrectlyIfCreateEnabled(
+  void shouldUpdateSchemaMappingsCorrectlyIfCreateEnabled(
       final ExporterConfiguration config, final SearchClientAdapter searchClientAdapter)
       throws Exception {
     // given

--- a/zeebe/exporters/camunda-exporter/src/test/resources/mappings-and-updated-settings.json
+++ b/zeebe/exporters/camunda-exporter/src/test/resources/mappings-and-updated-settings.json
@@ -1,0 +1,18 @@
+{
+  "settings": {
+    "index": {
+      "refresh_interval": "5s"
+    }
+  },
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "hello": {
+        "type": "text"
+      },
+      "world": {
+        "type": "keyword"
+      }
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/resources/mappings-settings-replica-and-shards.json
+++ b/zeebe/exporters/camunda-exporter/src/test/resources/mappings-settings-replica-and-shards.json
@@ -1,0 +1,19 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "hello": {
+        "type": "text"
+      },
+      "world": {
+        "type": "keyword"
+      }
+    }
+  },
+  "settings": {
+    "index": {
+      "number_of_shards": 10,
+      "number_of_replicas": 10
+    }
+  }
+}


### PR DESCRIPTION
## Description

This is a first draft  to confirm the approach solves the problems it needs to. Based on the requirements defined https://github.com/camunda/camunda/issues/32872

Add ability to update settings of index and index templates:

Indices:
- Only able to update the replicas of live indices

Index templates:
- Able to update all settings for the index template.

Note the configuration for replica/shards in `ExporterConfiguration` which can be templated from envs/files etc.. takes ultimate precedence.

1. If you update shards/replica through configuration it will apply fully to index templates 
2. If you update shards/replica through configuration ONLY the replica change will apply to live indices.
3. if you update the json schema file it will fully apply to index templates (with the exception of replicas and shards) with NO changes to the corresponding index.

## Related issues

closes #28111 
