### PR TITLE
refactor: remove C7 plugin config from Optimize C8

### DIFF
--- a/optimize-distro/src/config/environment-config.yaml
+++ b/optimize-distro/src/config/environment-config.yaml
@@ -163,24 +163,6 @@ serialization:
   # fetching date data from the engine(should be the same as in the engine)
   engineDateFormat: yyyy-MM-dd'T'HH:mm:ss.SSSZ
 
-plugin:
-  variableImport:
-    #Look in the given base package list for variable import adaption plugins.
-    #If empty, the import is not influenced.
-    basePackages: []
-  engineRestFilter:
-    #Look in the given base package list for engine rest filter plugins.
-    #If empty, the REST calls are not influenced.
-    basePackages: []
-  authenticationExtractor:
-    # Looks in the given base package list for authentication extractor plugins.
-    # If empty, the standard Optimize authentication mechanism is used.
-    basePackages: []
-  elasticsearchCustomHeader:
-    # Look in the given base package list for Elasticsearch custom header fetching plugins.
-    # If empty, ES requests are not influenced.
-    basePackages: []
-
 email:
   # A switch to control email sending process.
   enabled: false

--- a/optimize/util/optimize-commons/src/main/resources/service-config.yaml
+++ b/optimize/util/optimize-commons/src/main/resources/service-config.yaml
@@ -546,38 +546,6 @@ es:
       className: ${CAMUNDA_OPTIMIZE_ELASTICSEARCH_INTERCEPTORPLUGINS_4_CLASSNAME:}
       jarPath: ${CAMUNDA_OPTIMIZE_ELASTICSEARCH_INTERCEPTORPLUGINS_4_JARPATH:}
 
-plugin:
-  # Defines the directory path in the local Optimize file system which should be checked for plugins
-  directory: ${PLUGIN_DIR:./plugin}
-  variableImport:
-    # Look in the given base package list for variable import adaption plugins.
-    # If empty, the import is not influenced.
-    basePackages: [ ]
-  engineRestFilter:
-    # Look in the given base package list for engine rest filter plugins.
-    # If empty, the REST calls are not influenced.
-    basePackages: [ ]
-  authenticationExtractor:
-    # Looks in the given base package list for authentication extractor plugins.
-    # If empty, the standard Optimize authentication mechanism is used.
-    basePackages: [ ]
-  decisionInputImport:
-    # Look in the given base package list for Decision input import adaption plugins.
-    # If empty, the import is not influenced.
-    basePackages: [ ]
-  decisionOutputImport:
-    # Look in the given base package list for Decision output import adaption plugins.
-    # If empty, the import is not influenced.
-    basePackages: [ ]
-  businessKeyImport:
-    # Look in the given base package list for business key import adaption plugins.
-    # If empty, the import is not influenced.
-    basePackages: [ ]
-  elasticsearchCustomHeader:
-    # Look in the given base package list for Elasticsearch custom header fetching plugins.
-    # If empty, ES requests are not influenced.
-    basePackages: [ ]
-
 serialization:
   # Define a custom date format that should be used for
   # fetching date data from the engine(should be the same as in the engine)

--- a/optimize/util/optimize-commons/src/test/resources/environment-variable-default-value-test-config.yaml
+++ b/optimize/util/optimize-commons/src/test/resources/environment-variable-default-value-test-config.yaml
@@ -41,9 +41,5 @@ es:
       - host: ${ES_HOST_2:default2}
         httpPort: ${ES_PORT_2:9200}
 
-plugin:
-  variableImport:
-    basePackages: ['1', '${PACKAGE_2:package:2}', '${PACKAGE_3:}']
-
 container:
   accessUrl: ${ACCESS_URL:null}


### PR DESCRIPTION
## Description

This is part of the "C7 config cleanup from C8". Because there's a lot of configs that need cleaning, I'm breaking this work down into multiple PRs. This one is focused on "plugins config" cleanup. I'm not seeing any usage of these plugin configs so this change should be relatively safe. For this update there is a reference in [C8 docs](https://docs.camunda.io/optimize/next/self-managed/optimize-deployment/configuration/system-configuration/#other) which needs cleaning up. I will do this once this PR is approved and merged.

Before removing a config, I checked that :

- it's not being used/referenced in camunda/camunda
- it's not expected in camunda-cloud repos
- it's not expected in camunda/camunda-platform-helm

## Related issues

related to https://github.com/camunda/camunda-optimize/issues/13375
