### PR TITLE
feat: showing updating task listeners correctly in operate

### DIFF
--- a/operate/client/src/modules/types/operate.d.ts
+++ b/operate/client/src/modules/types/operate.d.ts
@@ -111,6 +111,7 @@ interface ListenerEntity {
     | 'END'
     | 'COMPLETING'
     | 'ASSIGNING'
+    | 'UPDATING'
     | 'UNKNOWN'
     | 'UNSPECIFIED';
   time: string;

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ListenerReaderIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ListenerReaderIT.java
@@ -74,7 +74,7 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
     final ListenerDto actual3 = resultListeners.get(1);
     assertEquals("21", actual3.getListenerKey());
     assertEquals(ListenerType.TASK_LISTENER, actual3.getListenerType());
-    assertEquals(ListenerEventType.UNKNOWN, actual3.getEvent());
+    assertEquals(ListenerEventType.UPDATING, actual3.getEvent());
     assertEquals(ListenerState.ACTIVE, actual3.getState());
     assertNull(actual3.getTime());
 
@@ -116,7 +116,7 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
     final ListenerDto actual0 = resultListeners.get(0);
     assertEquals("21", actual0.getListenerKey());
     assertEquals(ListenerType.TASK_LISTENER, actual0.getListenerType());
-    assertEquals(ListenerEventType.UNKNOWN, actual0.getEvent());
+    assertEquals(ListenerEventType.UPDATING, actual0.getEvent());
     assertEquals(ListenerState.ACTIVE, actual0.getState());
     assertNull(actual0.getTime());
 

--- a/operate/schema/src/test/java/io/camunda/operate/enties/ListenerEventTypeTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/enties/ListenerEventTypeTest.java
@@ -28,5 +28,7 @@ public class ListenerEventTypeTest {
     assertEquals(actual5, ListenerEventType.UNKNOWN);
     final ListenerEventType actual6 = ListenerEventType.fromZeebeListenerEventType(null);
     assertEquals(actual6, ListenerEventType.UNSPECIFIED);
+    final ListenerEventType actual7 = ListenerEventType.fromZeebeListenerEventType("UPDATING");
+    assertEquals(actual7, ListenerEventType.UPDATING);
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/ListenerEventType.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/ListenerEventType.java
@@ -15,6 +15,7 @@ public enum ListenerEventType {
   END,
   COMPLETING,
   ASSIGNING,
+  UPDATING,
   UNKNOWN,
   UNSPECIFIED;
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Added support for showing updating task listeners with the correct listener type, similar to here: https://github.com/camunda/camunda/pull/25557

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/camunda/issues/28228
