### PR TITLE
refactor: remove C7 tenants cache config from Optimize C8

### DIFF
--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/GlobalCacheConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/GlobalCacheConfiguration.java
@@ -9,7 +9,6 @@ package io.camunda.optimize.service.util.configuration;
 
 public class GlobalCacheConfiguration {
 
-  private CacheConfiguration tenants;
   private CacheConfiguration definitions;
   private CacheConfiguration definitionEngines;
   private CloudUserCacheConfiguration cloudUsers;
@@ -17,14 +16,6 @@ public class GlobalCacheConfiguration {
   private CacheConfiguration users;
 
   public GlobalCacheConfiguration() {}
-
-  public CacheConfiguration getTenants() {
-    return tenants;
-  }
-
-  public void setTenants(final CacheConfiguration tenants) {
-    this.tenants = tenants;
-  }
 
   public CacheConfiguration getDefinitions() {
     return definitions;
@@ -82,9 +73,7 @@ public class GlobalCacheConfiguration {
 
   @Override
   public String toString() {
-    return "GlobalCacheConfiguration(tenants="
-        + getTenants()
-        + ", definitions="
+    return "GlobalCacheConfiguration(definitions="
         + getDefinitions()
         + ", definitionEngines="
         + getDefinitionEngines()

--- a/optimize/util/optimize-commons/src/main/resources/service-config.yaml
+++ b/optimize/util/optimize-commons/src/main/resources/service-config.yaml
@@ -775,11 +775,6 @@ onboarding:
 
 # Configuration of application internal in-memory caches
 caches:
-  # This cache is used to hold the list of available tenants.
-  # It helps to optimize the performance for reads on definitions, reports and collections.
-  tenants:
-    # the time a read result will be cached
-    defaultTtlMillis: 10000
   # This cache is used to cache the list of engines a particular definition is available on by definition key.
   # It helps to optimize the performance for listings of reports, collection data sources and collection roles.
   definitionEngines:


### PR DESCRIPTION
## Description

This is part of the "C7 config cleanup from C8". Because there's a lot of configs that need cleaning, I'm breaking this work down into multiple PRs. This one is focused on "tenants cache config" cleanup. Most of the lines removed are setters/getters and boilerplates. For this update I don't see any references to the `tenants cache config` in [C8 docs](https://docs.camunda.io/optimize/next/self-managed/optimize-deployment/configuration/system-configuration/)

Before removing a config, I checked that :

- it's not being used/referenced in camunda/camunda
- it's not expected in camunda-cloud repos
- it's not expected in camunda/camunda-platform-helm

## Related issues

related to https://github.com/camunda/camunda-optimize/issues/13375
