### PR TITLE
fix: disable schema updates from tasklist's schema manager

### DIFF
--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/SchemaStartup.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/SchemaStartup.java
@@ -8,13 +8,9 @@
 package io.camunda.tasklist.schema;
 
 import io.camunda.tasklist.property.TasklistProperties;
-import io.camunda.tasklist.schema.IndexMapping.IndexMappingProperty;
 import io.camunda.tasklist.schema.manager.SchemaManager;
-import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import jakarta.annotation.PostConstruct;
 import java.io.IOException;
-import java.util.Map;
-import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,9 +35,7 @@ public class SchemaStartup {
       LOGGER.info("SchemaStartup started.");
       LOGGER.info("SchemaStartup: validate index versions.");
       schemaValidator.validateIndexVersions();
-      LOGGER.info("SchemaStartup: validate index mappings.");
-      final Map<IndexDescriptor, Set<IndexMappingProperty>> newFields =
-          schemaValidator.validateIndexMappings();
+
       final boolean createSchema =
           TasklistProperties.OPEN_SEARCH.equalsIgnoreCase(tasklistProperties.getDatabase())
               ? tasklistProperties.getOpenSearch().isCreateSchema()
@@ -55,14 +49,6 @@ public class SchemaStartup {
             "SchemaStartup: schema won't be created, it either already exist, or schema creation is disabled in configuration.");
       }
 
-      if (!newFields.isEmpty()) {
-        if (createSchema) {
-          schemaManager.updateSchema(newFields);
-        } else {
-          LOGGER.info(
-              "SchemaStartup: schema won't be updated as schema creation is disabled in configuration.");
-        }
-      }
       LOGGER.info("SchemaStartup finished.");
     } catch (final Exception ex) {
       LOGGER.error("Schema startup failed: " + ex.getMessage(), ex);

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/SchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/SchemaManager.java
@@ -24,6 +24,9 @@ public interface SchemaManager {
 
   String getIndexPrefix();
 
+  /**
+   * @deprecated schema updates should only be done via the CamundaExporter onwards
+   */
   void updateSchema(Map<IndexDescriptor, Set<IndexMappingProperty>> newFields);
 
   void createIndex(IndexDescriptor testIndex);


### PR DESCRIPTION
## Description
Tasklist's SchemaManager should not update indices anymore, this is managed by the CamundaExporter's SchemaManager

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
