### PR TITLE
Create CODEOWNERS for OpenAPI changes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# C8 REST OpenAPI changes are owned by the API reviewers team
+/zeebe/gateway-protocol/src/main/proto/rest-api.yaml @camunda/docs-api-reviewers


### PR DESCRIPTION
## Description

Creates a code owners file, assigning ownership of the C8 REST OpenAPI file to the @camunda/docs-api-reviewers team.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #28384 
