### PR TITLE
ci: fetch depth of 0 for deploy workflow

### DIFF
--- a/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
+++ b/.github/workflows/camunda-platform-docker-deploy-saas-image.yml
@@ -30,6 +30,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
+          fetch-depth: 0
       - name: Authenticate for saas image registry
         id: auth-saas
         uses: google-github-actions/auth@v2


### PR DESCRIPTION
## Description

Workaround for https://github.com/yarnpkg/berry/issues/4014 .

Caused builds of the workflow to fail with `[INFO] Usage Error: No ancestor could be found between any of HEAD and master, origin/master, upstream/master, main, origin/main, upstream/main`, see e.g. https://github.com/camunda/camunda/actions/runs/13411100239
