### PR TITLE
fix: resolve serialization issue with persistent web session

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/entity/AuthenticationContext.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/AuthenticationContext.java
@@ -9,10 +9,12 @@ package io.camunda.authentication.entity;
 
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.service.TenantServices.TenantDTO;
+import java.io.Serializable;
 import java.util.List;
 
 public record AuthenticationContext(
     List<RoleEntity> roles,
     List<String> authorizedApplications,
     List<TenantDTO> tenants,
-    List<String> groups) {}
+    List<String> groups)
+    implements Serializable {}

--- a/authentication/src/test/java/io/camunda/authentication/session/WebSessionMapperTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/session/WebSessionMapperTest.java
@@ -37,7 +37,7 @@ public class WebSessionMapperTest {
   }
 
   @Test
-  void toPersistentSessionWithCamundaPrinciple() {
+  void toPersistentSessionWithCamundaPrincipal() {
     // given
     final var securityContext = new SecurityContextImpl();
     final UsernamePasswordAuthenticationToken authenticationToken =
@@ -127,7 +127,7 @@ public class WebSessionMapperTest {
   }
 
   @Test
-  void fromPersistentSessionWithCamundaPrinciple() {
+  void fromPersistentSessionWithCamundaPrincipal() {
     // given
     final var now = Instant.now();
     final var maxInactiveInterval = Duration.ofSeconds(1800);

--- a/authentication/src/test/java/io/camunda/authentication/session/WebSessionMapperTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/session/WebSessionMapperTest.java
@@ -9,15 +9,20 @@ package io.camunda.authentication.session;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.authentication.entity.CamundaUser.CamundaUserBuilder;
 import io.camunda.authentication.session.WebSessionMapper.SpringBasedWebSessionAttributeConverter;
 import io.camunda.search.entities.PersistentWebSessionEntity;
+import io.camunda.search.entities.RoleEntity;
 import java.io.Serializable;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.convert.support.GenericConversionService;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextImpl;
 
 public class WebSessionMapperTest {
 
@@ -29,6 +34,34 @@ public class WebSessionMapperTest {
     final var conversionService = new GenericConversionService();
     webSessionAttributeConverter = new SpringBasedWebSessionAttributeConverter(conversionService);
     webSessionMapper = new WebSessionMapper(webSessionAttributeConverter);
+  }
+
+  @Test
+  void toPersistentSessionWithCamundaPrinciple() {
+    // given
+    final var securityContext = new SecurityContextImpl();
+    final UsernamePasswordAuthenticationToken authenticationToken =
+        new UsernamePasswordAuthenticationToken(
+            CamundaUserBuilder.aCamundaUser()
+                .withUsername("test")
+                .withPassword("admin")
+                .withUserKey(1L)
+                .withRoles(List.of(new RoleEntity(1L, "testRole")))
+                .build(),
+            null);
+    securityContext.setAuthentication(authenticationToken);
+
+    final WebSession webSession = new WebSession("sessionId");
+    webSession.setAttribute("securityContext", securityContext);
+
+    // when
+    final var persistentWebSession = webSessionMapper.toPersistentWebSession(webSession);
+
+    assertThat(persistentWebSession).isNotNull();
+    assertThat(persistentWebSession.id()).isEqualTo("sessionId");
+    assertThat(persistentWebSession.attributes()).hasSize(1);
+    assertThat(persistentWebSession.attributes().get("securityContext"))
+        .isEqualTo(webSessionAttributeConverter.serialize(securityContext));
   }
 
   @Test
@@ -91,6 +124,44 @@ public class WebSessionMapperTest {
     assertThat(webSession.getAttributeNames()).hasSize(2);
     assertThat((String) webSession.getAttribute("attribute1")).isEqualTo("value1");
     assertThat((TestAttribute) webSession.getAttribute("attribute2")).isEqualTo(testAttribute);
+  }
+
+  @Test
+  void fromPersistentSessionWithCamundaPrinciple() {
+    // given
+    final var now = Instant.now();
+    final var maxInactiveInterval = Duration.ofSeconds(1800);
+    final var securityContext = new SecurityContextImpl();
+    final UsernamePasswordAuthenticationToken authenticationToken =
+        new UsernamePasswordAuthenticationToken(
+            CamundaUserBuilder.aCamundaUser()
+                .withUsername("test")
+                .withPassword("admin")
+                .withUserKey(1L)
+                .withRoles(List.of(new RoleEntity(1L, "testRole")))
+                .build(),
+            null);
+    securityContext.setAuthentication(authenticationToken);
+
+    final var persistentSession =
+        new PersistentWebSessionEntity(
+            "sessionId",
+            now.toEpochMilli(),
+            now.toEpochMilli(),
+            maxInactiveInterval.toSeconds(),
+            Map.of("securityContext", webSessionAttributeConverter.serialize(securityContext)));
+
+    // when
+    final var webSession = webSessionMapper.fromPersistentWebSession(persistentSession);
+
+    assertThat(webSession).isNotNull();
+    assertThat(webSession.getId()).isEqualTo("sessionId");
+    assertThat(webSession.getCreationTime().toEpochMilli()).isEqualTo(now.toEpochMilli());
+    assertThat(webSession.getLastAccessedTime().toEpochMilli()).isEqualTo(now.toEpochMilli());
+    assertThat(webSession.getMaxInactiveInterval()).isEqualTo(maxInactiveInterval);
+    assertThat(webSession.getAttributeNames()).hasSize(1);
+    assertThat((SecurityContextImpl) webSession.getAttribute("securityContext"))
+        .isEqualTo(securityContext);
   }
 
   private record TestAttribute(String attribute, String value) implements Serializable {}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/RoleEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/RoleEntity.java
@@ -8,10 +8,12 @@
 package io.camunda.search.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.io.Serializable;
 import java.util.Set;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record RoleEntity(Long roleKey, String name, Set<Long> assignedMemberKeys) {
+public record RoleEntity(Long roleKey, String name, Set<Long> assignedMemberKeys)
+    implements Serializable {
   public RoleEntity(final Long roleKey, final String name) {
     this(roleKey, name, Set.of());
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

As per the related issue, when persistent sessions are enabled, there is a serialization exception thrown. This is due to two nested objects that are unable to be serialized (`RoleEntity` and `AuthenticationContext`). In this PR I:

1.  Make those two classes serializable
2. Add tests to check that moving to and from those serializations work as expected

## Related issues

closes https://github.com/camunda/camunda/issues/28367
