### PR TITLE
ci: snapshot uploads for 8.7 and 8.8 are independent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -727,7 +727,7 @@ jobs:
     permissions: {}  # GITHUB_TOKEN unused in this job
     if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/stable/8.7'
     concurrency:
-      group: deploy-maven-snapshot
+      group: deploy-maven-snapshot8.7
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4
@@ -799,7 +799,7 @@ jobs:
     permissions: {}  # GITHUB_TOKEN unused in this job
     if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/stable/8.7'
     concurrency:
-      group: deploy-camunda-docker-snapshot
+      group: deploy-camunda-docker-snapshot8.7
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -362,7 +362,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/stable/8.7'
     concurrency:
-      group: deploy-docker-snapshot
+      group: deploy-docker-snapshot8.7
       cancel-in-progress: false
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Currently, the snapshot uploads on `main` and `stable/8.7` (target of this PR!) use the same GHA concurrency group names. This can lead to unnecessary waiting when e.g. an upload is running for `stable/8.7` and one wants to run for `main`.

Technically, those uploads are independent because they target different artifacts (different Maven package files or Docker image tags). So there is no race condition between those 2 kinds of uploads thus different GHA concurrency groups should be used to avoid unnecessary waiting.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes) - not needed since `stable/8.7` is the only other branch with this behavior

## Related issues

Related #27193 
