### PR TITLE
Handle multi instance body correctly during migration

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableProcess.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableProcess.java
@@ -38,7 +38,18 @@ public class ExecutableProcess extends ExecutableFlowElementContainer {
     return flowElements.get(wrapString(id));
   }
 
-  /** convenience function for transformation */
+  /**
+   * Retrieve the executable element by its id and expected type.
+   *
+   * <p>To retrieve the multi-instance activity element itself, the {@link
+   * ExecutableMultiInstanceBody} class type should be passed as the expected type.
+   *
+   * <p>To retrieve the inner element of a multi-instance activity, the expected type should be the
+   * element type of the inner activity.
+   *
+   * @param id the id of the element
+   * @param expectedType the expected type of the element
+   */
   public <T extends ExecutableFlowElement> T getElementById(
       final String id, final Class<T> expectedType) {
     return getElementById(wrapString(id), expectedType);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationCatchEventBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationCatchEventBehaviour.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableAct
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableBoundaryEvent;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventSupplier;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMultiInstanceBody;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceMigrationPreconditions.ProcessInstanceMigrationPreconditionFailedException;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -115,10 +116,14 @@ public class ProcessInstanceMigrationCatchEventBehaviour {
       final String elementId) {
     final var context = new BpmnElementContextImpl();
     context.init(elementInstance.getKey(), elementInstanceRecord, elementInstance.getState());
-    final var targetElement =
-        targetProcessDefinition
-            .getProcess()
-            .getElementById(targetElementId, ExecutableCatchEventSupplier.class);
+
+    // set type explicitly for multi-instance body because inner activities has the same element id
+    final var expectedType =
+        elementInstanceRecord.getBpmnElementType() == BpmnElementType.MULTI_INSTANCE_BODY
+            ? ExecutableMultiInstanceBody.class
+            : ExecutableCatchEventSupplier.class;
+    final ExecutableCatchEventSupplier targetElement =
+        targetProcessDefinition.getProcess().getElementById(targetElementId, expectedType);
 
     if (elementInstanceRecord.getBpmnElementType() == BpmnElementType.PROCESS) {
       handleCompensationCatchEvents(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Multi-instance body events are migrated wrong due to a bug in catch event behaviour of process instance migration. Since inner activities of the multi instance body has the same element id as the multi instance body, if we do not set the expected element type, the inner activity of the multi instance body is returned. As a result, event subscriptions are handled for wrong target element.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #26623 
