### PR TITLE
Write followup events/command of `User.UPDATE` with correct user key

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -529,7 +529,7 @@ public class CommandDistributionIdempotencyTest {
                   final var user = createUser();
                   ENGINE
                       .user()
-                      .updateUser(user.getKey())
+                      .updateUser()
                       .withUsername(user.getValue().getUsername())
                       .withName(UUID.randomUUID().toString())
                       .update();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserMultiPartitionTest.java
@@ -49,7 +49,7 @@ public class UpdateUserMultiPartitionTest {
 
     ENGINE
         .user()
-        .updateUser(userRecord.getKey())
+        .updateUser()
         .withUsername(userRecord.getValue().getUsername())
         .withName("Bar Foo")
         .withEmail("bar@foo.com")
@@ -122,7 +122,7 @@ public class UpdateUserMultiPartitionTest {
 
     ENGINE
         .user()
-        .updateUser(userRecord.getKey())
+        .updateUser()
         .withUsername(userRecord.getValue().getUsername())
         .withName("Bar Foo")
         .withEmail("bar@foo.com")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserTest.java
@@ -44,7 +44,7 @@ public class UpdateUserTest {
     final var updatedUser =
         ENGINE
             .user()
-            .updateUser(userRecord.getKey())
+            .updateUser()
             .withUsername(userRecord.getValue().getUsername())
             .withName("Bar Foo")
             .withEmail("foo@bar.blah")
@@ -67,7 +67,7 @@ public class UpdateUserTest {
     final var userNotFoundRejection =
         ENGINE
             .user()
-            .updateUser(-1L)
+            .updateUser()
             .withUsername(username)
             .withName("Foo Bar")
             .withEmail("bar@foo")
@@ -98,7 +98,7 @@ public class UpdateUserTest {
 
     ENGINE
         .user()
-        .updateUser(userRecord.getKey())
+        .updateUser()
         .withUsername(userRecord.getValue().getUsername())
         .withName("Bar Foo")
         .withEmail("foo@bar.blah")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserClient.java
@@ -26,8 +26,8 @@ public final class UserClient {
     return new UserCreationClient(writer, username);
   }
 
-  public UpdateUserClient updateUser(final Long userKey) {
-    return new UpdateUserClient(writer, userKey);
+  public UpdateUserClient updateUser() {
+    return new UpdateUserClient(writer);
   }
 
   public UpdateUserClient updateUser(final long userKey, final UserRecord userRecord) {
@@ -119,10 +119,9 @@ public final class UserClient {
     private final UserRecord userRecord;
     private Function<Long, Record<UserRecordValue>> expectation = SUCCESS_SUPPLIER;
 
-    public UpdateUserClient(final CommandWriter writer, final long userKey) {
+    public UpdateUserClient(final CommandWriter writer) {
       this.writer = writer;
       userRecord = new UserRecord();
-      userRecord.setUserKey(userKey);
     }
 
     public UpdateUserClient(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

We set the user key to the key that was on the command. This will always be -1 since it's a command received from the 
gateway. As users are identified by their username there's no need to have a userkey set.

We should make sure on followup commands that we set the userkey properly. We can do this by taking it from the 
persisted user and setting it on the command. As well as ensuring that we write any followup commands/events with the 
correct user key.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #28404
