### PR TITLE
fix: TreePath properties not populated in some cases

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -158,7 +158,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             processingState.getKeyGenerator(),
             writers,
             catchEventBehavior,
-            processingState.getElementInstanceState());
+            processingState.getElementInstanceState(),
+            stateBehavior);
 
     signalBehavior =
         new BpmnSignalBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -87,11 +87,15 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             clock,
             transientProcessMessageSubscriptionState);
 
+    stateBehavior = new BpmnStateBehavior(processingState, variableBehavior);
+
     eventTriggerBehavior =
         new EventTriggerBehavior(
-            processingState.getKeyGenerator(), catchEventBehavior, writers, processingState);
-
-    stateBehavior = new BpmnStateBehavior(processingState, variableBehavior);
+            processingState.getKeyGenerator(),
+            catchEventBehavior,
+            writers,
+            processingState,
+            stateBehavior);
 
     bpmnDecisionBehavior =
         new BpmnDecisionBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
@@ -291,6 +291,14 @@ public class BpmnCompensationSubscriptionBehaviour {
         .setBpmnElementType(boundaryEvent.getElementType())
         .setBpmnEventType(boundaryEvent.getEventType());
 
+    final var elementTreePath =
+        stateBehavior.getElementTreePath(
+            boundaryEventKey, context.getFlowScopeKey(), boundaryEventRecord);
+    boundaryEventRecord
+        .setElementInstancePath(elementTreePath.elementInstancePath())
+        .setProcessDefinitionPath(elementTreePath.processDefinitionPath())
+        .setCallingElementPath(elementTreePath.callingElementPath());
+
     stateWriter.appendFollowUpEvent(
         boundaryEventKey, ProcessInstanceIntent.ELEMENT_ACTIVATING, boundaryEventRecord);
     stateWriter.appendFollowUpEvent(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
@@ -429,14 +429,17 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
         .isEqualTo(ProcessInstanceState.CANCELED);
   }
 
-  @Test
-  void shouldUpdateStateForMigrateRecord() {
+  @ParameterizedTest
+  @EnumSource(
+      value = ProcessInstanceIntent.class,
+      names = {"ELEMENT_MIGRATED", "ANCESTOR_MIGRATED"},
+      mode = Mode.INCLUDE)
+  void shouldUpdateStateAfterMigration(final ProcessInstanceIntent intent) {
     // given
     final long timestamp = new Date().getTime();
     final Record<ProcessInstanceRecordValue> processInstanceRecord =
         factory.generateRecord(
-            ValueType.PROCESS_INSTANCE,
-            r -> r.withIntent(ProcessInstanceIntent.ELEMENT_MIGRATED).withTimestamp(timestamp));
+            ValueType.PROCESS_INSTANCE, r -> r.withIntent(intent).withTimestamp(timestamp));
 
     final String treePath =
         new TreePath()


### PR DESCRIPTION
## Description
- Populate tree-path for activating compensation boundary events
- Populate tree-path properties for `ACTIVATING` triggered events
- Populate tree-path properties for `ACTIVATING` ancestral subprocesses for elements triggered by events
- Added a test cases to verify:
   - re-activating element by modification recalculates the tree-path
   - tree-path is populated for sub-process body element instance on activation
   - tree-path is populated for compensation event elements
   - tree-path is populated for all activating elements in RandomizedPropertyTest
## Related issues

closes #26048 
