### PR TITLE
SchemaManager: Parallelize index creation

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SchemaManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SchemaManager.java
@@ -14,6 +14,7 @@ import io.camunda.exporter.config.ExporterConfiguration.RetentionConfiguration;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -124,13 +125,14 @@ public class SchemaManager {
     }
 
     final var existingIndexNames =
-        searchEngineClient.getMappings(allIndexNames(), MappingSource.INDEX).keySet();
+        Collections.synchronizedSet(
+            searchEngineClient.getMappings(allIndexNames(), MappingSource.INDEX).keySet());
 
     LOG.info(
         "Found '{}' existing indices. Create missing index templates based on '{}' descriptors.",
         existingIndexNames.size(),
         indexTemplateDescriptors.size());
-    indexDescriptors.stream()
+    indexDescriptors.parallelStream()
         .filter(descriptor -> !existingIndexNames.contains(descriptor.getFullQualifiedName()))
         .forEach(
             descriptor -> {
@@ -147,15 +149,16 @@ public class SchemaManager {
     }
 
     final var existingTemplateNames =
-        searchEngineClient
-            .getMappings(config.getIndex().getPrefix() + "*", MappingSource.INDEX_TEMPLATE)
-            .keySet();
+        Collections.synchronizedSet(
+            searchEngineClient
+                .getMappings(config.getIndex().getPrefix() + "*", MappingSource.INDEX_TEMPLATE)
+                .keySet());
 
     LOG.info(
         "Found '{}' existing index templates. Create missing index templates based on '{}' descriptors.",
         existingTemplateNames.size(),
         indexTemplateDescriptors.size());
-    indexTemplateDescriptors.stream()
+    indexTemplateDescriptors.parallelStream()
         .filter(descriptor -> !existingTemplateNames.contains(descriptor.getTemplateName()))
         .forEach(
             descriptor -> {


### PR DESCRIPTION
## Description

To make index and template creation quicker, as suggested by @entangled90.

For that we use virtual threads for the creation of indices and templates. This is to make bootstrapping quicker, especially for tests quite useful. We can see a test reduction (will post results tomorrow).


> [!Note]
>
> @npepinpe mentioned it might make more sense, to use ES async client, but for index creations I did find any async method. Open for any hints.


## Related issues

closes #
