### PR TITLE
Make use of SingleApplication instead of docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -533,18 +533,6 @@ jobs:
           version: current-test
           push: true
           distball: ${{ steps.build-zeebe.outputs.distball }}
-      - name: Build Camunda Docker Image
-        if: matrix.group == 'root'
-        uses: ./.github/actions/build-platform-docker
-        id: build-camunda-docker
-        with:
-          repository: localhost:5000/camunda/camunda
-          version: current-test
-          distball: ${{ steps.build-zeebe.outputs.distball }}
-          platforms: ${{ env.DOCKER_PLATFORMS }}
-          dockerfile: camunda.Dockerfile
-          # push is needed for multi-arch images as buildkit does not support loading them locally
-          push: true
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
       - name: Maven Test Build


### PR DESCRIPTION
## Description

Instead of making use of the docker image of the current branch version, which we have to build first in CI, we directly use the StandaloneApplication (spring app).

This allows to reduce test execution time, and CI time (no docker image build). Ci has been reduced by 5 min.
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/camunda/issues/28287
