### PR TITLE
ci: c8run build camunda from source

### DIFF
--- a/.github/actions/setup-c8run/action.yml
+++ b/.github/actions/setup-c8run/action.yml
@@ -3,6 +3,10 @@ name: Setup c8run build
 description: Sets up the required stack to build, install, and run c8run
 
 inputs:
+  checkout:
+    description: Whether to check out source
+    required: false
+    default: true
   os:
     description: The OS to run the action on
     required: false
@@ -18,6 +22,10 @@ inputs:
     required: false
   source-build:
     description: true if the camunda build should be built from source, false will build from latest camunda release
+    required: false
+    default: false
+  local-archive-build:
+    description: true if camunda platform should be taken from a local archive
     required: false
     default: false
   repository:
@@ -63,7 +71,8 @@ runs:
            sudo killall mono || true
            sudo killall xsp4 || true
 
-    - uses: actions/checkout@v4
+    - if: ${{ inputs.checkout == 'true' }}
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
         repository: ${{ inputs.repository }}
@@ -154,6 +163,12 @@ runs:
       shell: bash
       env:
         distball: ${{ steps.build-zeebe.outputs.distball }}
+
+    - name: Get version of camunda-dist
+      if: ${{ inputs.local-archive-build == 'true' }}
+      run: echo CAMUNDA_VERSION=$(ls camunda-zeebe*.tar.gz | grep -o 'camunda-zeebe-.*' | sed 's/camunda-zeebe-//' | sed 's/\.tar\.gz//') >> $GITHUB_ENV
+      shell: bash
+      working-directory: ./c8run
 
     - name: Build c8run
       run: go build

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -47,6 +47,36 @@ jobs:
         with:
           working-directory: ./c8run
 
+  camunda-dist-build:
+    name: Build camunda-dist
+    runs-on: gcp-perf-core-16-default
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-build
+        with:
+          dockerhub-readonly: true
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+
+      - name: Package camunda-dist
+        shell: bash
+        id: build-dist
+        run: |
+          ./mvnw -B -T1C -DskipTests -DskipChecks -Dflatten.skip=true package
+          export ARTIFACT=$(./mvnw -pl dist/ help:evaluate -Dexpression=project.build.finalName -q -DforceStdout)
+          echo "distball=dist/target/${ARTIFACT}.tar.gz" >> $GITHUB_OUTPUT
+
+      - name: Upload camunda-dist
+        uses: actions/upload-artifact@v4
+        with:
+          name: camunda-platform-dist
+          path: ${{ steps.build-dist.outputs.distball }}
+
   test_c8run:
     strategy:
       matrix:
@@ -55,12 +85,19 @@ jobs:
     name: C8Run Test ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+    needs: camunda-dist-build
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
           node-version: 18
+
+      - name: Download Camunda Core Dist
+        uses: actions/download-artifact@v4
+        with:
+          name: camunda-platform-dist
+          path: c8run
 
       - name: Setup C8Run
         uses: ./.github/actions/setup-c8run
@@ -70,6 +107,8 @@ jobs:
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           os: ${{ matrix.os }}
           github-token: ${{ github.token }}
+          local-archive-build: 'true'
+          checkout: 'false'
 
       - name: Install dependencies
         run: npm ci
@@ -109,6 +148,7 @@ jobs:
     name: C8Run Test Windows
     runs-on: windows-latest
     timeout-minutes: 15
+    needs: camunda-dist-build
     steps:
       - uses: actions/checkout@v4
 
@@ -128,6 +168,17 @@ jobs:
         with:
           go-version: '>=1.23.1'
           cache: false  # disabling since not working anyways without a cache-dependency-path specified
+
+      - name: Download Camunda Core Dist
+        uses: actions/download-artifact@v4
+        with:
+          name: camunda-platform-dist
+          path: c8run
+
+      - name: Get version of camunda-dist
+        run: echo CAMUNDA_VERSION=$(ls camunda-zeebe*.tar.gz | grep -o 'camunda-zeebe-.*' | sed 's/camunda-zeebe-//' | sed 's/\.tar\.gz//') >> $GITHUB_ENV
+        shell: bash
+        working-directory: .\c8run
 
       - name: Build c8run
         run: go build

--- a/c8run/README.md
+++ b/c8run/README.md
@@ -19,7 +19,6 @@ Once extracted, go to the extracted folder and run one of the following commands
 ```
 Usage: start.sh
 Options:
-  --config     - Applies the specified configuration file
   --detached   - Starts Camunda Run as a detached process
 ```
 

--- a/c8run/e2e_tests/api_tests.sh
+++ b/c8run/e2e_tests/api_tests.sh
@@ -1,20 +1,8 @@
 #!/bin/bash
 
-printf "\nTest: Authenticate\n"
-curl -udemo:demo -f --request POST 'http://localhost:8080/api/login?username=demo&password=demo' \
-   --cookie-jar cookie.txt
-
-returnCode=$?
-
-if [[ "$returnCode" != 0 ]]; then
-   echo "test failed"
-   exit 1
-fi
-
-
 printf "\nTest: Operate process instance api\n"
 
-curl -f -L -X POST 'http://localhost:8080/v2/process-instances/search' --cookie cookie.txt \
+curl -f -L -X POST 'http://localhost:8080/v2/process-instances/search' \
 -H 'Content-Type: application/json' \
 -H 'Accept: application/json' \
 --data-raw '{
@@ -31,9 +19,9 @@ if [[ "$returnCode" != 0 ]]; then
    exit 1
 fi
 
-
+fic
 printf "\nTest: Tasklist user task\n"
-curl -udemo:demo -f -L -X POST 'http://localhost:8080/v2/user-tasks/search' --cookie cookie.txt \
+curl -f -L -X POST 'http://localhost:8080/v2/user-tasks/search' \
 -H 'Content-Type: application/json' \
 -H 'Accept: application/json' \
 --data-raw '{}'
@@ -47,7 +35,7 @@ fi
 
 
 printf "\nTest: Zeebe topology endpoint\n"
-curl -udemo:demo -f --cookie  cookie.txt  localhost:8080/v2/topology
+curl localhost:8080/v2/topology
 
 returnCode=$?
 if [[ "$returnCode" != 0 ]]; then

--- a/c8run/e2e_tests/api_tests.sh
+++ b/c8run/e2e_tests/api_tests.sh
@@ -19,7 +19,6 @@ if [[ "$returnCode" != 0 ]]; then
    exit 1
 fi
 
-fic
 printf "\nTest: Tasklist user task\n"
 curl -f -L -X POST 'http://localhost:8080/v2/user-tasks/search' \
 -H 'Content-Type: application/json' \

--- a/c8run/main.go
+++ b/c8run/main.go
@@ -281,7 +281,6 @@ func getBaseCommandSettings(baseCommand string) (C8RunSettings, error) {
 
 func createStartFlagSet(settings *C8RunSettings) *flag.FlagSet {
 	startFlagSet := flag.NewFlagSet("start", flag.ExitOnError)
-	startFlagSet.StringVar(&settings.config, "config", "", "Applies the specified configuration file.")
 	startFlagSet.BoolVar(&settings.detached, "detached", false, "Starts Camunda Run as a detached process")
 	startFlagSet.IntVar(&settings.port, "port", 8080, "Port to run Camunda on")
 	startFlagSet.StringVar(&settings.keystore, "keystore", "", "Provide a JKS filepath to enable TLS")
@@ -327,8 +326,6 @@ func main() {
 	if err != nil {
 		fmt.Println("Failed to set envVars:", err)
 	}
-
-	// classPath := filepath.Join(parentDir, "configuration", "userlib") + "," + filepath.Join(parentDir, "configuration", "keystore")
 
 	baseCommand, err := getBaseCommand()
 	if err != nil {

--- a/c8run/main.go
+++ b/c8run/main.go
@@ -134,7 +134,7 @@ func adjustJavaOpts(javaOpts string, settings C8RunSettings) string {
 	if settings.password != "" {
 		javaOpts = javaOpts + " -Dcamunda.security.initialization.users[0].password=" + settings.password
 	}
-	javaOpts = javaOpts + " -Dspring.profiles.active=operate,tasklist,broker,identity,auth-basic"
+	javaOpts = javaOpts + " -Dspring.profiles.active=operate,tasklist,broker,identity,consolidated-auth"
 	os.Setenv("CAMUNDA_OPERATE_ZEEBE_RESTADDRESS", protocol+"://localhost:"+strconv.Itoa(settings.port))
 	fmt.Println("Java opts: " + javaOpts)
 	return javaOpts

--- a/c8run/main.go
+++ b/c8run/main.go
@@ -502,13 +502,7 @@ func main() {
 		if err != nil {
 			fmt.Print("Failed to write to file: " + connectorsPidPath + " continuing...")
 		}
-		var extraArgs string
-		if settings.config != "" {
-			extraArgs = "--spring.config.location=" + filepath.Join(parentDir, settings.config)
-		} else {
-			extraArgs = "--spring.config.location=" + filepath.Join(parentDir, "configuration")
-		}
-		camundaCmd := c8.CamundaCmd(camundaVersion, parentDir, extraArgs, javaOpts)
+		camundaCmd := c8.CamundaCmd(camundaVersion, parentDir, "", javaOpts)
 		camundaLogPath := filepath.Join(parentDir, "log", "camunda.log")
 		camundaLogFile, err := os.OpenFile(camundaLogPath, os.O_RDWR|os.O_CREATE, 0644)
 		if err != nil {

--- a/c8run/main_test.go
+++ b/c8run/main_test.go
@@ -22,7 +22,7 @@ func TestCamundaCmdWithKeystoreSettings(t *testing.T) {
 		keystore:         "/tmp/camundatest/certs/secret.jks",
 		keystorePassword: "changeme",
 	}
-	expectedJavaOpts := "JAVA_OPTS= -Dserver.ssl.keystore=file:" + settings.keystore + " -Dserver.ssl.enabled=true" + " -Dserver.ssl.key-password=" + settings.keystorePassword + " -Dspring.profiles.active=operate,tasklist,broker,identity,auth-basic"
+	expectedJavaOpts := "JAVA_OPTS= -Dserver.ssl.keystore=file:" + settings.keystore + " -Dserver.ssl.enabled=true" + " -Dserver.ssl.key-password=" + settings.keystorePassword + " -Dspring.profiles.active=operate,tasklist,broker,identity,consolidated-auth"
 
 	javaOpts := adjustJavaOpts("", settings)
 	c8runPlatform := getC8RunPlatform()

--- a/c8run/package.go
+++ b/c8run/package.go
@@ -88,7 +88,6 @@ func getFilesToArchive(osType, elasticsearchVersion, connectorsFilePath, camunda
 		filepath.Join("c8run", connectorsFilePath),
 		filepath.Join("c8run", "elasticsearch-"+elasticsearchVersion),
 		filepath.Join("c8run", "custom_connectors"),
-		filepath.Join("c8run", "configuration"),
 		filepath.Join("c8run", "endpoints.txt"),
 		filepath.Join("c8run", "log"),
 		filepath.Join("c8run", "camunda-zeebe-"+camundaVersion),


### PR DESCRIPTION
## Description

Builds c8run based of the current revision of camunda 8, building the distribution once to be used further down in the actual c8run jobs of the c8run build workflow - the price is 5 minutes overhead which I consider worth having actual accurate feedback on the integration state of c8run and the rest of the mono-repo.

This way we ensure integration of c8run development state with the current development state of camunda 8, enabling us to adapt to potential breaking changes asap.

This already contains two fixes that were needed to get the c8run CI working with the current state of camunda 8:
* fa5a9cfb4c8582a63774adbb2a227f5e34b01d33 which removes the setting`spring.config.location`  - It actually breaks the single app, as it leads to internal defaults not being loaded.
See https://docs.spring.io/spring-boot/reference/features/external-config.html#features.external-config.files. - I suspect this issue should already be present in the last alpha release, I wonder why it didn't surface during release already
* 4247d376f22c3f61e73cf98de185e35c7bf425ec adopts to the new auth setup including test adaptation superseding https://github.com/camunda/camunda/pull/27391

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #28187
