### PR TITLE
test: only run AdHocSubProcess test with compatible version of zeebe

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeProcessInstanceImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeProcessInstanceImportIT.java
@@ -766,6 +766,7 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
             });
   }
 
+  @EnabledIf("isZeebeVersion87_OrLater")
   @Test
   public void importZeebeProcessInstanceData_processContainsAdHocSubProcess() {
     // given


### PR DESCRIPTION
## Description

The Zeebe integration tests are failing on versions pre 8.7 
This is a follow-up PR to [this one](https://github.com/camunda/camunda/pull/28406) to fix the other AdHocSubProcess test that was introduced
https://github.com/camunda/camunda/actions/runs/13424048952

Do not run the test on the failing versions of zeebe as AdHocSubProcess are not supported for them