### PR TITLE
refactor: remove combined and reportType from report payload

### DIFF
--- a/optimize/client/scripts/start-backend.js
+++ b/optimize/client/scripts/start-backend.js
@@ -8,7 +8,6 @@
 
 import {spawn} from 'child_process';
 import {resolve as _resolve, dirname} from 'path';
-import {platform} from 'os';
 import {readFile} from 'fs';
 import {parseString} from 'xml2js';
 import {fileURLToPath} from 'url';
@@ -100,24 +99,21 @@ setVersionInfo().then(setupEnvironment).then(startBackend);
 
 function startBackend() {
   return new Promise((resolve, reject) => {
-  const engineEnv = {
-        cloud: cloudEnv,
-        'self-managed': selfManagedEnv,
-      };
+    const engineEnv = {
+      cloud: cloudEnv,
+      'self-managed': selfManagedEnv,
+    };
 
-    backendProcess = spawnWithArgs(
-      `dist/target/camunda-zeebe/bin/optimize`,
-      {
-        cwd: _resolve(__dirname, '..', '..', '..'),
-        shell: true,
-        env: {
-          ...process.env,
-          ...commonEnv,
-          ...engineEnv[mode],
-          CLASSPATH_PREFIX: 'optimize/client/demo-data'
-        },
-      }
-    );
+    backendProcess = spawnWithArgs(`dist/target/camunda-zeebe/bin/optimize`, {
+      cwd: _resolve(__dirname, '..', '..', '..'),
+      shell: true,
+      env: {
+        ...process.env,
+        ...commonEnv,
+        ...engineEnv[mode],
+        CLASSPATH_PREFIX: 'optimize/client/demo-data',
+      },
+    });
 
     backendProcess.stdout.on('data', (data) => server.addLog(data, 'backend'));
     backendProcess.stderr.on('data', (data) => server.addLog(data, 'backend', true));

--- a/optimize/client/src/components/Analysis/BranchAnalysis/service.js
+++ b/optimize/client/src/components/Analysis/BranchAnalysis/service.js
@@ -32,7 +32,6 @@ export async function loadFrequencyData(
 
 function createFlowNodeFrequencyReport(key, versions, tenantIds, identifier, filter) {
   return {
-    reportType: 'process',
     data: {
       definitions: [{key, versions, tenantIds, identifier}],
       filter,

--- a/optimize/client/src/components/Analysis/BranchAnalysis/service.js
+++ b/optimize/client/src/components/Analysis/BranchAnalysis/service.js
@@ -7,7 +7,7 @@
  */
 
 import {post} from 'request';
-import { getFullURL } from '../../../modules/api';
+import {getFullURL} from '../../../modules/api';
 
 export async function loadFrequencyData(
   processDefinitionKey,

--- a/optimize/client/src/components/Analysis/TaskAnalysis/service.js
+++ b/optimize/client/src/components/Analysis/TaskAnalysis/service.js
@@ -7,7 +7,7 @@
  */
 
 import {post} from 'request';
-import { getFullURL } from '../../../modules/api.ts';
+import {getFullURL} from '../../../modules/api.ts';
 
 export async function loadNodesOutliers(config) {
   const response = await post(getFullURL('api/analysis/flowNodeOutliers'), config);

--- a/optimize/client/src/components/Analysis/TaskAnalysis/service.ts
+++ b/optimize/client/src/components/Analysis/TaskAnalysis/service.ts
@@ -9,7 +9,7 @@
 import {t} from 'translation';
 import {post} from 'request';
 import {AnalysisDurationChartEntry} from 'types';
-import { getFullURL } from '../../../modules/api';
+import {getFullURL} from '../../../modules/api';
 
 export interface OutliersVariable {
   variableName: string;

--- a/optimize/client/src/components/Dashboards/filters/service.js
+++ b/optimize/client/src/components/Dashboards/filters/service.js
@@ -7,7 +7,7 @@
  */
 
 import {post, get} from 'request';
-import { getFullURL } from '../../../modules/api';
+import {getFullURL} from '../../../modules/api';
 
 export async function getVariableNames(reportIds) {
   const response = await post(getFullURL('api/variables/reports'), {reportIds});

--- a/optimize/client/src/components/Dashboards/service.js
+++ b/optimize/client/src/components/Dashboards/service.js
@@ -7,7 +7,7 @@
  */
 
 import {get, del, post} from 'request';
-import { getFullURL } from '../../modules/api';
+import {getFullURL} from '../../modules/api';
 
 export async function shareDashboard(dashboardId) {
   const body = {
@@ -36,7 +36,9 @@ export async function revokeDashboardSharing(id) {
 
 export async function isAuthorizedToShareDashboard(dashboardId) {
   try {
-    const response = await get(getFullURL(`api/share/dashboard/${dashboardId}/isAuthorizedToShare`));
+    const response = await get(
+      getFullURL(`api/share/dashboard/${dashboardId}/isAuthorizedToShare`)
+    );
     return response.status === 200;
   } catch (_error) {
     return false;

--- a/optimize/client/src/components/Home/Collection.test.js
+++ b/optimize/client/src/components/Home/Collection.test.js
@@ -81,7 +81,6 @@ jest.mock('./service', () => ({
       created: '2017-11-11T11:11:11.1111+0200',
       owner: 'user_id',
       lastModifier: 'user_id',
-      reportType: 'process',
       entityType: 'report',
       data: {
         subEntityCounts: {},

--- a/optimize/client/src/components/Home/CollectionEnitiesList.js
+++ b/optimize/client/src/components/Home/CollectionEnitiesList.js
@@ -32,7 +32,7 @@ import {checkConflicts, importEntity, removeEntities} from './service';
 import {formatLink, formatSubEntities, formatType} from './formatters';
 
 import './CollectionEnitiesList.scss';
-import { getFullURL } from '../../modules/api';
+import {getFullURL} from '../../modules/api';
 
 export default function CollectionEnitiesList({
   collection,
@@ -176,9 +176,11 @@ export default function CollectionEnitiesList({
                   icon: <Save />,
                   text: t('common.export'),
                   action: () => {
-                    window.location.href = getFullURL(`api/export/${entityType}/json/${
-                      entity.id
-                    }/${encodeURIComponent(formatters.formatFileName(entity.name))}.json`);
+                    window.location.href = getFullURL(
+                      `api/export/${entityType}/json/${
+                        entity.id
+                      }/${encodeURIComponent(formatters.formatFileName(entity.name))}.json`
+                    );
                   },
                 }
               );

--- a/optimize/client/src/components/Home/CollectionEnitiesList.test.js
+++ b/optimize/client/src/components/Home/CollectionEnitiesList.test.js
@@ -57,8 +57,6 @@ const entities = [
     created: '2017-11-11T11:11:11.1111+0200',
     owner: 'user_id',
     lastModifier: 'user_id',
-    reportType: 'process', // or "decision"
-    combined: false,
     entityType: 'report',
     data: {
       subEntityCounts: {},

--- a/optimize/client/src/components/Home/Home.js
+++ b/optimize/client/src/components/Home/Home.js
@@ -43,7 +43,7 @@ import {importEntity, removeEntities, checkConflicts} from './service';
 import {formatLink, formatType, formatSubEntities} from './formatters';
 
 import './Home.scss';
-import { getFullURL } from '../../modules/api';
+import {getFullURL} from '../../modules/api';
 
 export function Home({mightFail, user}) {
   const [entities, setEntities] = useState(null);
@@ -209,9 +209,11 @@ export function Home({mightFail, user}) {
                   icon: <Save />,
                   text: t('common.export'),
                   action: () => {
-                    window.location.href = getFullURL(`api/export/${entityType}/json/${
-                      entity.id
-                    }/${encodeURIComponent(formatters.formatFileName(entity.name))}.json`);
+                    window.location.href = getFullURL(
+                      `api/export/${entityType}/json/${
+                        entity.id
+                      }/${encodeURIComponent(formatters.formatFileName(entity.name))}.json`
+                    );
                   },
                 });
               }

--- a/optimize/client/src/components/Home/Home.test.js
+++ b/optimize/client/src/components/Home/Home.test.js
@@ -28,7 +28,6 @@ jest.mock('services', () => ({
         roleCounts: {},
         subEntityCounts: {},
       },
-      reportType: 'process',
     },
   ]),
 }));

--- a/optimize/client/src/components/Home/modals/MoveCopy.test.tsx
+++ b/optimize/client/src/components/Home/modals/MoveCopy.test.tsx
@@ -62,7 +62,6 @@ jest.mock('services', () => ({
       currentUserRole: 'editor',
       data: {subEntityCounts: {}, roleCounts: {}},
       lastModifier: 'user_id',
-      reportType: 'process',
       entityType: 'report',
     },
     {

--- a/optimize/client/src/components/Home/service.js
+++ b/optimize/client/src/components/Home/service.js
@@ -7,7 +7,7 @@
  */
 
 import {get, post, put, del} from 'request';
-import { getFullURL } from '../../modules/api';
+import {getFullURL} from '../../modules/api';
 
 export async function loadCollectionEntities(id, sortBy, sortOrder) {
   const params = {};
@@ -43,7 +43,11 @@ export async function getSources(collection) {
 }
 
 export async function editSource(collection, scopeId, tenants, force = false) {
-  return await put(getFullURL(`api/collection/${collection}/scope/${scopeId}`), {tenants}, {query: {force}});
+  return await put(
+    getFullURL(`api/collection/${collection}/scope/${scopeId}`),
+    {tenants},
+    {query: {force}}
+  );
 }
 
 export async function removeSource(collection, scopeId) {
@@ -51,7 +55,9 @@ export async function removeSource(collection, scopeId) {
 }
 
 export async function checkDeleteSourceConflicts(collection, scopeId) {
-  const response = await get(getFullURL(`api/collection/${collection}/scope/${scopeId}/delete-conflicts`));
+  const response = await get(
+    getFullURL(`api/collection/${collection}/scope/${scopeId}/delete-conflicts`)
+  );
   return await response.json();
 }
 

--- a/optimize/client/src/components/Logout.js
+++ b/optimize/client/src/components/Logout.js
@@ -12,7 +12,7 @@ import {get} from 'request';
 import {withErrorHandling} from 'HOC';
 import {addNotification} from 'notifications';
 import {t} from 'translation';
-import { getFullURL } from '../modules/api';
+import {getFullURL} from '../modules/api';
 
 export function Logout({mightFail, history}) {
   useEffect(() => {

--- a/optimize/client/src/components/Processes/service.js
+++ b/optimize/client/src/components/Processes/service.js
@@ -8,7 +8,7 @@
 
 import {get, put} from 'request';
 import {formatters} from 'services';
-import { getFullURL } from '../../modules/api';
+import {getFullURL} from '../../modules/api';
 
 export async function loadProcesses(sortBy, sortOrder) {
   const params = {};

--- a/optimize/client/src/components/Reports/Report.test.js
+++ b/optimize/client/src/components/Reports/Report.test.js
@@ -44,7 +44,6 @@ const report = {
   description: 'description',
   lastModifier: 'lastModifier',
   lastModified: '2017-11-11T11:11:11.1111+0200',
-  reportType: 'process',
   data: {
     processDefinitionKey: null,
     configuration: {},

--- a/optimize/client/src/components/Reports/ReportEdit.test.js
+++ b/optimize/client/src/components/Reports/ReportEdit.test.js
@@ -64,7 +64,6 @@ const report = {
   description: 'description',
   lastModifier: 'lastModifier',
   lastModified: '2017-11-11T11:11:11.1111+0200',
-  reportType: 'process',
   data: {
     definitions: [
       {

--- a/optimize/client/src/components/Reports/ReportView.test.js
+++ b/optimize/client/src/components/Reports/ReportView.test.js
@@ -52,7 +52,6 @@ const report = {
   name: 'name',
   lastModifier: 'lastModifier',
   lastModified: '2017-11-11T11:11:11.1111+0200',
-  reportType: 'process',
   currentUserRole: 'editor',
   data: {
     processDefinitionKey: null,

--- a/optimize/client/src/components/Reports/ReportWarnings.test.js
+++ b/optimize/client/src/components/Reports/ReportWarnings.test.js
@@ -26,7 +26,6 @@ const report = {
   name: 'name',
   lastModifier: 'lastModifier',
   lastModified: '2017-11-11T11:11:11.1111+0200',
-  reportType: 'process',
   data: {
     processDefinitionKey: 'aKey',
     processDefinitionVersions: ['aVersion'],

--- a/optimize/client/src/components/Reports/controlPanels/Configuration/visualizations/HeatmapConfig.test.js
+++ b/optimize/client/src/components/Reports/controlPanels/Configuration/visualizations/HeatmapConfig.test.js
@@ -37,7 +37,6 @@ it('should pass relevant configuration to RelativeAbsoluteSelection', () => {
   expect(node.find('RelativeAbsoluteSelection').props()).toEqual({
     absolute: true,
     relative: false,
-    reportType: undefined,
     hideRelative: false,
     onChange: expect.any(Function),
   });

--- a/optimize/client/src/components/Reports/controlPanels/Configuration/visualizations/PieChartConfig.test.js
+++ b/optimize/client/src/components/Reports/controlPanels/Configuration/visualizations/PieChartConfig.test.js
@@ -25,7 +25,6 @@ it('it should display correct configuration for piechart', () => {
   expect(node.find('RelativeAbsoluteSelection').props()).toEqual({
     absolute: true,
     relative: false,
-    reportType: undefined,
     hideRelative: false,
     onChange: expect.any(Function),
   });

--- a/optimize/client/src/components/Reports/controlPanels/Configuration/visualizations/subComponents/RelativeAbsoluteSelection.test.tsx
+++ b/optimize/client/src/components/Reports/controlPanels/Configuration/visualizations/subComponents/RelativeAbsoluteSelection.test.tsx
@@ -13,7 +13,6 @@ import RelativeAbsoluteSelection from './RelativeAbsoluteSelection';
 const props = {
   absolute: true,
   relative: true,
-  reportType: 'process',
   onChange: jest.fn(),
 };
 

--- a/optimize/client/src/components/Reports/controlPanels/DefinitionList/service.js
+++ b/optimize/client/src/components/Reports/controlPanels/DefinitionList/service.js
@@ -7,7 +7,7 @@
  */
 
 import {get, post} from 'request';
-import { getFullURL } from '../../../../modules/api.ts';
+import {getFullURL} from '../../../../modules/api.ts';
 
 export async function loadTenants(type, definitions, collectionId) {
   const payload = {definitions};
@@ -15,7 +15,10 @@ export async function loadTenants(type, definitions, collectionId) {
     payload.filterByCollectionScope = collectionId;
   }
 
-  const response = await post(getFullURL(`api/definition/${type}/_resolveTenantsForVersions`), payload);
+  const response = await post(
+    getFullURL(`api/definition/${type}/_resolveTenantsForVersions`),
+    payload
+  );
 
   return await response.json();
 }

--- a/optimize/client/src/components/Reports/controlPanels/DefinitionList/service.ts
+++ b/optimize/client/src/components/Reports/controlPanels/DefinitionList/service.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { getFullURL } from '../../../../modules/api';
+import {getFullURL} from '../../../../modules/api';
 import {post} from 'request';
 
 export function updateVariables(definitionKey: string, labels: string[]) {

--- a/optimize/client/src/components/Reports/controlPanels/service.js
+++ b/optimize/client/src/components/Reports/controlPanels/service.js
@@ -7,7 +7,7 @@
  */
 
 import {post} from 'request';
-import { getFullURL } from '../../../modules/api';
+import {getFullURL} from '../../../modules/api';
 
 export function isDurationHeatmap({view, visualization, definitions}) {
   return (
@@ -30,7 +30,10 @@ export async function loadTenants(type, definitions, collectionId) {
     payload.filterByCollectionScope = collectionId;
   }
 
-  const response = await post(getFullURL(`api/definition/${type}/_resolveTenantsForVersions`), payload);
+  const response = await post(
+    getFullURL(`api/definition/${type}/_resolveTenantsForVersions`),
+    payload
+  );
 
   return await response.json();
 }

--- a/optimize/client/src/components/Reports/service.js
+++ b/optimize/client/src/components/Reports/service.js
@@ -7,7 +7,7 @@
  */
 
 import {get, del, post} from 'request';
-import { getFullURL } from '../../modules/api';
+import {getFullURL} from '../../modules/api';
 
 export async function shareReport(reportId) {
   const body = {

--- a/optimize/client/src/components/Sharing/service.js
+++ b/optimize/client/src/components/Sharing/service.js
@@ -7,7 +7,7 @@
  */
 
 import {get, post} from 'request';
-import { getFullURL } from '../../modules/api';
+import {getFullURL} from '../../modules/api';
 
 export async function evaluateEntity(id, type, query = {}) {
   const request = type === 'dashboard' ? get : post;

--- a/optimize/client/src/modules/api.test.ts
+++ b/optimize/client/src/modules/api.test.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { getFullURL } from './api';
+import {getFullURL} from './api';
 
 beforeAll(() => {
   Object.defineProperty(window, 'location', {

--- a/optimize/client/src/modules/components/CopyToClipboard/CopyToClipboard.tsx
+++ b/optimize/client/src/modules/components/CopyToClipboard/CopyToClipboard.tsx
@@ -28,7 +28,7 @@ export default function CopyToClipboard({
     <Button
       className="CopyToClipboard"
       size="sm"
-      onClick={(evt) => {
+      onClick={(evt: React.MouseEvent<HTMLButtonElement>) => {
         evt.preventDefault();
         const input = document.createElement('input');
         input.value = value;

--- a/optimize/client/src/modules/components/DefinitionSelection/service.ts
+++ b/optimize/client/src/modules/components/DefinitionSelection/service.ts
@@ -8,7 +8,7 @@
 
 import {Tenant} from 'types';
 import {get, post} from 'request';
-import { getFullURL } from '../../api';
+import {getFullURL} from '../../api';
 
 export type Version = {
   version: string;
@@ -50,7 +50,10 @@ export async function loadTenants(
     payload.filterByCollectionScope = collectionId;
   }
 
-  const response = await post(getFullURL(`api/definition/${type}/_resolveTenantsForVersions`), payload);
+  const response = await post(
+    getFullURL(`api/definition/${type}/_resolveTenantsForVersions`),
+    payload
+  );
 
   return response.json();
 }

--- a/optimize/client/src/modules/components/InstanceCount/InstanceCount.test.js
+++ b/optimize/client/src/modules/components/InstanceCount/InstanceCount.test.js
@@ -48,7 +48,6 @@ const props = {
       instanceCount: 123,
       instanceCountWithoutFilters: 500,
     },
-    reportType: 'process',
   },
 };
 

--- a/optimize/client/src/modules/components/KpiCreationModal/KpiCreationModal.tsx
+++ b/optimize/client/src/modules/components/KpiCreationModal/KpiCreationModal.tsx
@@ -57,7 +57,7 @@ export default function KpiCreationModal({onClose}: KpiCreationModalProps): JSX.
     track('openKpiWizzard');
   }, []);
 
-  const loadReport = async (reportPayload: ReportEvaluationPayload<'process'>) => {
+  const loadReport = async (reportPayload: ReportEvaluationPayload) => {
     setLoading(true);
     await mightFail(evaluateReport(reportPayload), setEvaluatedReport, showError, () =>
       setLoading(false)
@@ -158,7 +158,7 @@ export default function KpiCreationModal({onClose}: KpiCreationModalProps): JSX.
                   return;
                 }
 
-                const newReportPayload = newReport.new as ReportEvaluationPayload<'process'>;
+                const newReportPayload = newReport.new as ReportEvaluationPayload;
                 await loadReport({
                   ...newReportPayload,
                   collectionId: getCollection(pathname),

--- a/optimize/client/src/modules/components/ReportDetails/SingleReportDetails.test.js
+++ b/optimize/client/src/modules/components/ReportDetails/SingleReportDetails.test.js
@@ -49,7 +49,6 @@ const props = {
       groupBy: {type: 'startDate', value: {unit: 'automatic'}},
     },
     name: 'Report Name',
-    reportType: 'process',
     owner: 'Test Person',
     lastModified: '2020-06-23T09:32:48.938+0200',
     lastModifier: 'Test Person',

--- a/optimize/client/src/modules/components/ReportDetails/service.js
+++ b/optimize/client/src/modules/components/ReportDetails/service.js
@@ -7,11 +7,14 @@
  */
 
 import {post} from 'request';
-import { getFullURL } from '../../api';
+import {getFullURL} from '../../api';
 
 export async function loadTenants(definitions) {
   const params = {definitions};
-  const response = await post(getFullURL(`api/definition/process/_resolveTenantsForVersions`), params);
+  const response = await post(
+    getFullURL(`api/definition/process/_resolveTenantsForVersions`),
+    params
+  );
 
   return await response.json();
 }

--- a/optimize/client/src/modules/components/ReportRenderer/HyperReportRenderer.js
+++ b/optimize/client/src/modules/components/ReportRenderer/HyperReportRenderer.js
@@ -48,7 +48,6 @@ export default function HyperReportRenderer({report, ...rest}) {
     newResultData[key] = {
       id: key,
       name: label,
-      reportType: 'process',
       data: report.data,
       result: {
         ...result,

--- a/optimize/client/src/modules/components/ReportRenderer/HyperReportRenderer.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/HyperReportRenderer.test.js
@@ -31,7 +31,6 @@ jest.mock('services', () => {
 });
 
 const userTaskAssigneeReport = {
-  reportType: 'process',
   data: {
     processDefinitionKey: 'aKey',
     processDefinitionVersion: '1',

--- a/optimize/client/src/modules/components/ReportRenderer/ProcessReportRenderer.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/ProcessReportRenderer.test.js
@@ -28,7 +28,6 @@ jest.mock('services', () => {
 });
 
 const report = {
-  reportType: 'process',
   data: {
     processDefinitionKey: 'aKey',
     processDefinitionVersion: '1',
@@ -59,7 +58,6 @@ it('should provide an errorMessage property to the component', () => {
 });
 
 const exampleDurationReport = {
-  reportType: 'process',
   data: {
     processDefinitionKey: 'aKey',
     processDefinitionVersion: '1',

--- a/optimize/client/src/modules/components/ReportRenderer/ReportRenderer.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/ReportRenderer.test.js
@@ -13,7 +13,6 @@ import NoDataNotice from './NoDataNotice';
 import SetupNotice from './SetupNotice';
 
 const reportTemplate = {
-  reportType: 'process',
   data: {
     definitions: [
       {

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/defaultChart/createDefaultChartData.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Chart/defaultChart/createDefaultChartData.test.js
@@ -37,7 +37,6 @@ it('should return correct chart data object for a single report', () => {
         view: {properties: ['duration'], entity: 'flowNode'},
       },
       targetValue: false,
-      reportType: 'process',
     },
     theme: 'light',
   });
@@ -78,7 +77,6 @@ it('should return correct chart data object for multi-measure report', () => {
             },
           ],
         },
-        reportType: 'process',
       },
       theme: 'light',
     })
@@ -123,7 +121,6 @@ it('should assign line/bar visualization to dataset according to measureVisualiz
         view: {properties: ['frequency', 'duration'], entity: 'flowNode'},
       },
       targetValue: false,
-      reportType: 'process',
     },
     theme: 'light',
   });

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Heatmap/Heatmap.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Heatmap/Heatmap.test.js
@@ -45,7 +45,6 @@ jest.mock('services', () => {
 
 const report = {
   name: 'test',
-  reportType: 'process',
   data: {
     configuration: {
       xml: 'some diagram XML',

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Number.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Number.test.js
@@ -41,7 +41,6 @@ beforeEach(() => {
 });
 
 const report = {
-  reportType: 'process',
   data: {
     configuration: {
       targetValue: {active: false},
@@ -123,7 +122,6 @@ it('should show the view label underneath the number', () => {
 
   node.setProps({
     report: {
-      reportType: 'process',
       result: {
         measures: [{data: 123, aggregationType: {type: 'avg', value: null}, property: 'duration'}],
       },

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Table/DefaultTable.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Table/DefaultTable.test.js
@@ -30,7 +30,6 @@ beforeEach(() => {
 
 const testDefinition = {key: 'definitionKey', versions: ['ver1'], tenantIds: ['id1']};
 const report = {
-  reportType: 'process',
   data: {
     definitions: [testDefinition],
     groupBy: {

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Table/RawDataTable.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Table/RawDataTable.test.js
@@ -28,7 +28,6 @@ beforeEach(() => {
 
 const testDefinition = {key: 'definitionKey', versions: ['ver1'], tenantIds: ['id1']};
 const report = {
-  reportType: 'process',
   data: {
     definitions: [testDefinition],
     groupBy: {

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Table/Table.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Table/Table.test.js
@@ -35,7 +35,6 @@ beforeEach(() => {
 
 const testDefinition = {key: 'definitionKey', versions: ['ver1'], tenantIds: ['id1']};
 const report = {
-  reportType: 'process',
   data: {
     definitions: [testDefinition],
     groupBy: {

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Table/processDefaultData.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Table/processDefaultData.test.js
@@ -29,7 +29,6 @@ jest.mock('services', () => ({
 }));
 
 const report = {
-  reportType: 'process',
   data: {
     groupBy: {type: 'startDate', value: {unit: 'automatic'}},
     view: {entity: 'processInstance', properties: ['frequency']},

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Table/processHyperData.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Table/processHyperData.test.js
@@ -29,7 +29,6 @@ jest.mock('./service', () => ({
 }));
 
 const singleReport = {
-  reportType: 'process',
   data: {
     view: {properties: ['frequency']},
     groupBy: {type: 'none'},

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Table/processRawData.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Table/processRawData.js
@@ -13,12 +13,7 @@ import {format} from 'dates';
 import {formatters} from 'services';
 import {t} from 'translation';
 
-import {
-  getNoDataMessage,
-  isVisibleColumn,
-  getLabelWithType,
-  sortColumns,
-} from './service';
+import {getNoDataMessage, isVisibleColumn, getLabelWithType, sortColumns} from './service';
 
 const {duration} = formatters;
 

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Table/processRawData.test.js
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Table/processRawData.test.js
@@ -63,7 +63,7 @@ describe('Process table', () => {
   };
 
   it('should transform data to table compatible format', () => {
-    expect(processRawData({report: {reportType: 'process', data, result}})).toMatchSnapshot();
+    expect(processRawData({report: {data, result}})).toMatchSnapshot();
   });
 
   it('should not include columns that are hidden', () => {
@@ -77,7 +77,7 @@ describe('Process table', () => {
         },
       },
     };
-    expect(processRawData({report: {reportType: 'process', data, result}})).toEqual({
+    expect(processRawData({report: {data, result}})).toEqual({
       body: [['foo'], ['xyz']],
       head: [{id: 'processInstanceId', label: 'Process instance Id', title: 'Process instance Id'}],
     });
@@ -94,7 +94,7 @@ describe('Process table', () => {
         },
       },
     };
-    expect(processRawData({report: {reportType: 'process', data, result}})).toMatchSnapshot();
+    expect(processRawData({report: {data, result}})).toMatchSnapshot();
   });
 
   it('should format start and end dates', () => {
@@ -104,7 +104,6 @@ describe('Process table', () => {
 
     const cells = processRawData({
       report: {
-        reportType: 'process',
         result: {
           data: [{startDate, endDate}],
         },
@@ -124,7 +123,6 @@ describe('Process table', () => {
   it('should format duration', () => {
     const cells = processRawData({
       report: {
-        reportType: 'process',
         result: {
           data: [{duration: 123023423}],
         },
@@ -140,7 +138,6 @@ describe('Process table', () => {
   it('should display the processInstanceId as text', () => {
     const cell = processRawData({
       report: {
-        reportType: 'process',
         result: {data: [{processInstanceId: '123', engineName: '1'}]},
         data: {
           configuration: {
@@ -157,7 +154,6 @@ describe('Process table', () => {
     const spy = jest.fn();
     const {body} = processRawData({
       report: {
-        reportType: 'process',
         data,
         result,
       },
@@ -171,7 +167,7 @@ describe('Process table', () => {
   });
 
   it('should disable sorting for flow node duration columns', () => {
-    const {head} = processRawData({report: {reportType: 'process', data, result}});
+    const {head} = processRawData({report: {data, result}});
 
     const flowNodeDurationColumns = head.filter((column) => column.type === 'flowNodeDurations');
 

--- a/optimize/client/src/modules/components/ReportRenderer/visualizations/Table/service.ts
+++ b/optimize/client/src/modules/components/ReportRenderer/visualizations/Table/service.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import { getFullURL } from '../../../../api';
+import {getFullURL} from '../../../../api';
 import {post} from 'request';
 
 export async function loadObjectValues(

--- a/optimize/client/src/modules/components/TargetSelection/TargetSelection.tsx
+++ b/optimize/client/src/modules/components/TargetSelection/TargetSelection.tsx
@@ -13,7 +13,7 @@ import CountTargetInput from './CountTargetInput';
 import DurationTargetInput from './DurationTargetInput';
 
 interface TargetSelectionProps {
-  report: Report<'process'>;
+  report: Report;
   onChange: (change: Spec<SingleReportConfiguration>) => void;
   hideBaseLine?: boolean;
 }

--- a/optimize/client/src/modules/components/UserTypeahead/service.tsx
+++ b/optimize/client/src/modules/components/UserTypeahead/service.tsx
@@ -8,7 +8,7 @@
 
 import {get} from 'request';
 import {formatters} from 'services';
-import { getFullURL } from '../../api';
+import {getFullURL} from '../../api';
 
 export interface Identity {
   id: string | null;

--- a/optimize/client/src/modules/config.tsx
+++ b/optimize/client/src/modules/config.tsx
@@ -8,7 +8,7 @@
 
 import {ReactNode, createContext, useEffect, useState} from 'react';
 import {Loading} from '@carbon/react';
-import { getFullURL } from './api';
+import {getFullURL} from './api';
 
 import {get, ErrorResponse} from 'request';
 import {showError} from 'notifications';

--- a/optimize/client/src/modules/filter/modals/assignee/service.ts
+++ b/optimize/client/src/modules/filter/modals/assignee/service.ts
@@ -9,7 +9,7 @@
 import {User} from 'components';
 import {post, get} from 'request';
 import {Definition} from 'types';
-import { getFullURL } from '../../../api';
+import {getFullURL} from '../../../api';
 
 export async function loadUsersByDefinition(
   type: string,

--- a/optimize/client/src/modules/filter/service.js
+++ b/optimize/client/src/modules/filter/service.js
@@ -8,7 +8,7 @@
 
 import {post, get} from 'request';
 import equal from 'fast-deep-equal';
-import { getFullURL } from '../api';
+import {getFullURL} from '../api';
 
 export async function loadValues(
   processDefinitionKey,

--- a/optimize/client/src/modules/newReport.json
+++ b/optimize/client/src/modules/newReport.json
@@ -92,8 +92,6 @@
       "visualization": null,
       "distributedBy": {"type": "none", "value": null}
     },
-    "combined": false,
-    "reportType": "process",
     "currentUserRole": "editor"
   }
 }

--- a/optimize/client/src/modules/services/alertService.js
+++ b/optimize/client/src/modules/services/alertService.js
@@ -8,7 +8,7 @@
 
 import {del, get, post, put} from 'request';
 import {track} from 'tracking';
-import { getFullURL } from '../api';
+import {getFullURL} from '../api';
 
 export async function loadAlerts(collection) {
   const response = await get(getFullURL(`api/collection/${collection}/alerts`));

--- a/optimize/client/src/modules/services/collectionService.ts
+++ b/optimize/client/src/modules/services/collectionService.ts
@@ -8,7 +8,7 @@
 
 import {Source} from 'types';
 import {put} from 'request';
-import { getFullURL } from '../api';
+import {getFullURL} from '../api';
 
 export async function addSources(collectionId: string, sources: Source[]) {
   return await put(getFullURL(`api/collection/${collectionId}/scope`), sources);

--- a/optimize/client/src/modules/services/dataLoaders.js
+++ b/optimize/client/src/modules/services/dataLoaders.js
@@ -7,7 +7,7 @@
  */
 
 import {get, post} from 'request';
-import { getFullURL } from '../api.ts';
+import {getFullURL} from '../api.ts';
 
 export {loadProcessDefinitionXml, loadVariables} from './dataLoaders.ts';
 

--- a/optimize/client/src/modules/services/dataLoaders.ts
+++ b/optimize/client/src/modules/services/dataLoaders.ts
@@ -8,7 +8,7 @@
 
 import {ProcessFilter, Variable} from 'types';
 import {get, post} from 'request';
-import { getFullURL } from '../api';
+import {getFullURL} from '../api';
 
 export async function loadProcessDefinitionXml(
   key?: string,

--- a/optimize/client/src/modules/services/entityService.js
+++ b/optimize/client/src/modules/services/entityService.js
@@ -10,7 +10,7 @@ import {get, post, put} from 'request';
 import {track} from 'tracking';
 import {createEventName} from './entityService.tsx';
 export {deleteEntity} from './entityService.tsx';
-import { getFullURL } from '../api.ts';
+import {getFullURL} from '../api.ts';
 
 export async function loadEntity(type, id, query) {
   const response = await get(getFullURL(`api/${type}/` + id), query);

--- a/optimize/client/src/modules/services/entityService.tsx
+++ b/optimize/client/src/modules/services/entityService.tsx
@@ -11,7 +11,7 @@ import {ChartColumn, Dashboard, Folder} from '@carbon/icons-react';
 import {del, get, post} from 'request';
 import {EntityListEntity, GenericReport} from 'types';
 import {track} from 'tracking';
-import { getFullURL } from '../api';
+import {getFullURL} from '../api';
 
 export async function loadReports(collection?: string | null): Promise<GenericReport[]> {
   let url = getFullURL('api/report');

--- a/optimize/client/src/modules/services/loadDefinitions.ts
+++ b/optimize/client/src/modules/services/loadDefinitions.ts
@@ -7,7 +7,7 @@
  */
 
 import {get} from 'request';
-import { getFullURL } from '../api';
+import {getFullURL} from '../api';
 
 export type Definition = {
   key: string;

--- a/optimize/client/src/modules/services/reportConfig/reportConfig.test.js
+++ b/optimize/client/src/modules/services/reportConfig/reportConfig.test.js
@@ -398,9 +398,7 @@ describe('process exclusive updates', () => {
 
 describe('getDefaultSorting', () => {
   it('should sort raw data a descending order by the start date', () => {
-    expect(
-      getDefaultSorting({data: {...report, view: {property: 'rawData'}}})
-    ).toEqual({
+    expect(getDefaultSorting({data: {...report, view: {property: 'rawData'}}})).toEqual({
       by: 'startDate',
       order: 'desc',
     });

--- a/optimize/client/src/modules/services/reportConfig/reportConfig.test.js
+++ b/optimize/client/src/modules/services/reportConfig/reportConfig.test.js
@@ -399,7 +399,7 @@ describe('process exclusive updates', () => {
 describe('getDefaultSorting', () => {
   it('should sort raw data a descending order by the start date', () => {
     expect(
-      getDefaultSorting({reportType: 'process', data: {...report, view: {property: 'rawData'}}})
+      getDefaultSorting({data: {...report, view: {property: 'rawData'}}})
     ).toEqual({
       by: 'startDate',
       order: 'desc',
@@ -410,7 +410,6 @@ describe('getDefaultSorting', () => {
     isCategorical.mockReturnValueOnce(true);
     expect(
       getDefaultSorting({
-        reportType: 'process',
         data: {...report, visualization: 'bar'},
       })
     ).toEqual({
@@ -422,7 +421,6 @@ describe('getDefaultSorting', () => {
   it('should sort number variable by key in ascending order', () => {
     expect(
       getDefaultSorting({
-        reportType: 'process',
         data: {
           ...report,
           groupBy: {type: 'variable', value: {type: 'Double'}},
@@ -438,7 +436,6 @@ describe('getDefaultSorting', () => {
   it('should sort flow node table report by label in ascending order', () => {
     expect(
       getDefaultSorting({
-        reportType: 'process',
         data: {
           ...report,
           view: {entity: 'flowNode', properties: ['frequency']},

--- a/optimize/client/src/modules/services/reportService.ts
+++ b/optimize/client/src/modules/services/reportService.ts
@@ -7,7 +7,7 @@
  */
 
 import {post} from 'request';
-import {Report, ReportType} from 'types';
+import {Report} from 'types';
 import { getFullURL } from '../api';
 
 interface ConfigParams {
@@ -43,13 +43,13 @@ type DeepPartial<T> = T extends object
     }
   : T;
 
-export type ReportEvaluationPayload<T extends ReportType> = DeepPartial<Report<T>>;
+export type ReportEvaluationPayload = DeepPartial<Report>;
 
-export async function evaluateReport<T extends ReportType>(
-  payload: ReportEvaluationPayload<T>,
+export async function evaluateReport(
+  payload: ReportEvaluationPayload,
   filter = [],
   query = {}
-): Promise<Report<T>> {
+): Promise<Report> {
   let response;
 
   if (typeof payload !== 'object') {
@@ -59,7 +59,7 @@ export async function evaluateReport<T extends ReportType>(
     // evaluate unsaved report
     // we dont want to send report result in payload to prevent exceedeing request size limit
     const {result: _result, ...evaluationPayload} = payload;
-    response = await post(getFullURL(`api/report/evaluate`), evaluationPayload, {query});
+    response = await post(getFullURL(`api/report/evaluate`), {...evaluationPayload, combined: false, reportType: "process"}, {query});
   }
 
   return await response.json();

--- a/optimize/client/src/modules/services/reportService.ts
+++ b/optimize/client/src/modules/services/reportService.ts
@@ -8,7 +8,7 @@
 
 import {post} from 'request';
 import {Report} from 'types';
-import { getFullURL } from '../api';
+import {getFullURL} from '../api';
 
 interface ConfigParams {
   processDefinitionKey: string;
@@ -59,7 +59,11 @@ export async function evaluateReport(
     // evaluate unsaved report
     // we dont want to send report result in payload to prevent exceedeing request size limit
     const {result: _result, ...evaluationPayload} = payload;
-    response = await post(getFullURL(`api/report/evaluate`), {...evaluationPayload, combined: false, reportType: "process"}, {query});
+    response = await post(
+      getFullURL(`api/report/evaluate`),
+      {...evaluationPayload, combined: false, reportType: 'process'},
+      {query}
+    );
   }
 
   return await response.json();

--- a/optimize/client/src/modules/translation/service.ts
+++ b/optimize/client/src/modules/translation/service.ts
@@ -7,7 +7,7 @@
  */
 
 import {get} from 'request';
-import { getFullURL } from '../api';
+import {getFullURL} from '../api';
 
 export async function loadTranslation(version: string, localeCode: string) {
   const response = await get(getFullURL(`api/localization`), {

--- a/optimize/client/src/modules/types.ts
+++ b/optimize/client/src/modules/types.ts
@@ -313,10 +313,8 @@ export interface SingleProcessReportResultData {
   value: string | number;
 }
 
-export interface Report<
-  Data extends object = SingleProcessReportData,
-  Result = unknown | undefined,
-> extends GenericEntity<Data> {
+export interface Report<Data extends object = SingleProcessReportData, Result = unknown | undefined>
+  extends GenericEntity<Data> {
   id: string;
   collectionId?: string | null;
   description: string | null;

--- a/optimize/client/src/modules/types.ts
+++ b/optimize/client/src/modules/types.ts
@@ -313,22 +313,17 @@ export interface SingleProcessReportResultData {
   value: string | number;
 }
 
-export type ReportType = 'process';
-
 export interface Report<
-  Type extends ReportType = 'process',
   Data extends object = SingleProcessReportData,
   Result = unknown | undefined,
 > extends GenericEntity<Data> {
   id: string;
   collectionId?: string | null;
-  reportType: Type;
   description: string | null;
   result: Result;
 }
 
 export type SingleProcessReport = Report<
-  'process',
   SingleProcessReportData,
   {data: SingleProcessReportResultData[]}
 >;


### PR DESCRIPTION
## Description

This PR is removing the "combined" and "reportType" fields as we don't support combined reports in C8 (see [this PR](https://github.com/camunda/camunda/pull/21131) for context).

## Related issues

related to https://github.com/camunda/camunda-optimize/issues/13439
