### PR TITLE
test: only run AdHocSubProcess test with compatible version of zeebe

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/AbstractCCSMIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/AbstractCCSMIT.java
@@ -95,6 +95,19 @@ public abstract class AbstractCCSMIT extends AbstractIT {
         .matches();
   }
 
+  protected static boolean isZeebeVersion87_OrLater() {
+    final Pattern zeebeVersionPattern = Pattern.compile("8.([7-9]|\\d{2,})");
+    return zeebeVersionPattern
+            .matcher(IntegrationTestConfigurationUtil.getZeebeDockerVersion())
+            .matches()
+        || isZeebeVersionSnapshot();
+  }
+
+  protected static boolean isZeebeVersionSnapshot() {
+    final String dockerVersion = IntegrationTestConfigurationUtil.getZeebeDockerVersion();
+    return dockerVersion.equalsIgnoreCase("snapshot");
+  }
+
   protected static boolean isZeebeVersionWithMultiTenancy() {
     return !isZeebeVersionPre83();
   }

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeProcessInstanceImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeProcessInstanceImportIT.java
@@ -763,6 +763,7 @@ public class ZeebeProcessInstanceImportIT extends AbstractCCSMIT {
             });
   }
 
+  @EnabledIf("isZeebeVersion87_OrLater")
   @Test
   public void importZeebeProcessInstanceData_processContainsAdHocSubProcess() {
     // given

--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/processdefinition/ZeebeProcessDefinitionImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/processdefinition/ZeebeProcessDefinitionImportIT.java
@@ -298,6 +298,7 @@ public class ZeebeProcessDefinitionImportIT extends AbstractCCSMIT {
                         SIGNAL_PROCESS_END));
   }
 
+  @EnabledIf("isZeebeVersion87_OrLater")
   @Test
   public void importZeebeProcess_processContainsAdHocSubProcess() {
     // given


### PR DESCRIPTION
## Description

The Zeebe integration tests are failing on versions pre 8.7 https://github.com/camunda/camunda/actions/runs/13401708589/job/37433814467

Do not run the test on the failing versions of zeebe as AdHocSubProcess are not supported for them
