### PR TITLE
fix: delete zeebe-record indices to fix flakiness

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -129,8 +129,10 @@ final class CamundaExporterIT {
         Optional.ofNullable(System.getProperty(IT_OPENSEARCH_AWS_INSTANCE_URL_PROPERTY)).orElse("");
     if (openSearchAwsInstanceUrl.isEmpty()) {
       searchDB.esClient().indices().delete(req -> req.index(CUSTOM_PREFIX + "*"));
+      searchDB.esClient().indices().delete(req -> req.index("zeebe-record*"));
     }
     searchDB.osClient().indices().delete(req -> req.index(CUSTOM_PREFIX + "*"));
+    searchDB.osClient().indices().delete(req -> req.index("zeebe-record*"));
   }
 
   @TestTemplate

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -129,10 +129,8 @@ final class CamundaExporterIT {
         Optional.ofNullable(System.getProperty(IT_OPENSEARCH_AWS_INSTANCE_URL_PROPERTY)).orElse("");
     if (openSearchAwsInstanceUrl.isEmpty()) {
       searchDB.esClient().indices().delete(req -> req.index(CUSTOM_PREFIX + "*"));
-      searchDB.esClient().indices().delete(req -> req.index("zeebe-record*"));
     }
     searchDB.osClient().indices().delete(req -> req.index(CUSTOM_PREFIX + "*"));
-    searchDB.osClient().indices().delete(req -> req.index("zeebe-record*"));
   }
 
   @TestTemplate
@@ -729,8 +727,11 @@ final class CamundaExporterIT {
         final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
         throws IOException {
       // given
+      final String zeebeIndexPrefix = CUSTOM_PREFIX + "-zeebe-record";
+      config.getIndex().setZeebeIndexPrefix(zeebeIndexPrefix);
       createSchemas(config, clientAdapter);
-      clientAdapter.index("1", "zeebe-record-decision", Map.of("key", "12345"));
+      clientAdapter.index("1", zeebeIndexPrefix + "-decision", Map.of("key", "12345"));
+
       // adds a not complete position index document so exporter sees importing as not yet completed
       indexImportPositionEntity("decision", false, clientAdapter);
       clientAdapter.refresh();
@@ -870,14 +871,15 @@ final class CamundaExporterIT {
         throws IOException {
       // given
       assertThat(config.getBulk().getSize()).isEqualTo(1);
+      final String zeebeIndexPrefix = CUSTOM_PREFIX + "-zeebe-record";
+      config.getIndex().setZeebeIndexPrefix(zeebeIndexPrefix);
 
       // Simulate existing zeebe index so it will not skip the wait for importers
-      clientAdapter.index("1", "zeebe-record-decision", Map.of("key", "12345"));
+      clientAdapter.index("1", zeebeIndexPrefix + "-decision", Map.of("key", "12345"));
 
       // if schemas are never created then import position indices do not exist and all checks about
       // whether the importers are completed will return false.
       config.setCreateSchema(false);
-      config.getIndex().setPrefix(RandomStringUtils.randomAlphabetic(10).toLowerCase());
       final var context = getContextFromConfig(config);
       camundaExporter.configure(context);
       camundaExporter.open(controller);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

CamundaExporterIT was flaky because the `zeebe-record` created indices for the Importers finished checks were not being cleaned up after test cases, causing the `shouldFlushIfImporterNotCompletedButNoZeebeIndices` case to fail

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
