### PR TITLE
pg-overridable-multi-db-configurator

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
@@ -92,8 +92,11 @@ public class BackupRestoreIT {
               throw new IllegalArgumentException(
                   "Unsupported database type: " + config.databaseType);
         };
-    configurator.getOperateProperties().getBackup().setRepositoryName(REPOSITORY_NAME);
-    configurator.getTasklistProperties().getBackup().setRepositoryName(REPOSITORY_NAME);
+
+    testStandaloneApplication.withProperty(
+        "camunda.tasklist.backup.repositoryName", REPOSITORY_NAME);
+    testStandaloneApplication.withProperty(
+        "camunda.operate.backup.repositoryName", REPOSITORY_NAME);
 
     testStandaloneApplication.start().awaitCompleteTopology();
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
@@ -50,10 +50,7 @@ public class PrefixMigrationIT {
           .withStartupTimeout(Duration.ofMinutes(5)); // can be slow in CI
 
   private GenericContainer<?> createCamundaContainer(
-      final String image,
-      final String operatePrefix,
-      final String tasklistPrefix,
-      final String newPrefix) {
+      final String image, final String operatePrefix, final String tasklistPrefix) {
     final var esUrl = String.format("http://%s:%d", ELASTIC_ALIAS, 9200);
 
     final var container =
@@ -129,7 +126,7 @@ public class PrefixMigrationIT {
     // given
     final var camunda87 =
         createCamundaContainer(
-            "camunda/camunda:8.7.0-SNAPSHOT", OLD_OPERATE_PREFIX, OLD_TASKLIST_PREFIX, NEW_PREFIX);
+            "camunda/camunda:8.7.0-SNAPSHOT", OLD_OPERATE_PREFIX, OLD_TASKLIST_PREFIX);
     camunda87.start();
 
     final var camunda87Client = createCamundaClient(camunda87);

--- a/qa/integration-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
@@ -80,21 +80,7 @@ public class PrefixMigrationIT {
             .withEnv("CAMUNDA_OPERATE_ZEEBEELASTICSEARCH_URL", esUrl)
             .withEnv("CAMUNDA_TASKLIST_ELASTICSEARCH_URL", esUrl)
             .withEnv("CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_URL", esUrl)
-            .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL", esUrl)
-            .withEnv("CAMUNDA_DATABASE_INDEXPREFIX", newPrefix)
-            .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_URL", esUrl)
-            .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_SIZE", "1")
-            .withEnv(
-                "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME",
-                "io.camunda.exporter.CamundaExporter")
-            .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_PREFIX", newPrefix)
-            .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_ELASTICSEARCH_URL", esUrl)
-            .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_URL", esUrl)
-            .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_SIZE", "1")
-            .withEnv(
-                "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME",
-                "io.camunda.exporter.CamundaExporter")
-            .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_PREFIX", newPrefix);
+            .withEnv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL", esUrl);
 
     return container;
   }
@@ -143,7 +129,7 @@ public class PrefixMigrationIT {
     // given
     final var camunda87 =
         createCamundaContainer(
-            "camunda/camunda:8.7.0-alpha4", OLD_OPERATE_PREFIX, OLD_TASKLIST_PREFIX, NEW_PREFIX);
+            "camunda/camunda:8.7.0-SNAPSHOT", OLD_OPERATE_PREFIX, OLD_TASKLIST_PREFIX, NEW_PREFIX);
     camunda87.start();
 
     final var camunda87Client = createCamundaClient(camunda87);
@@ -179,6 +165,8 @@ public class PrefixMigrationIT {
         new MultiDbConfigurator(testSimpleCamundaApplication);
     final var esUrl = String.format("http://localhost:%d", esContainer.getMappedPort(9200));
     multiDbConfigurator.configureElasticsearchSupport(esUrl, NEW_PREFIX);
+    testSimpleCamundaApplication.withProperty("camunda.tasklist.zeebeElasticsearch.prefix", null);
+    testSimpleCamundaApplication.withProperty("camunda.operate.zeebeElasticsearch.prefix", null);
     testSimpleCamundaApplication.start();
     testSimpleCamundaApplication.awaitCompleteTopology();
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfigurator.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfigurator.java
@@ -8,14 +8,11 @@
 package io.camunda.it.utils;
 
 import io.camunda.exporter.CamundaExporter;
-import io.camunda.operate.property.OperateOpensearchProperties;
-import io.camunda.operate.property.OperateProperties;
 import io.camunda.search.connect.configuration.DatabaseType;
-import io.camunda.tasklist.property.TasklistOpenSearchProperties;
-import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.zeebe.exporter.ElasticsearchExporter;
 import io.camunda.zeebe.exporter.opensearch.OpensearchExporter;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
@@ -26,30 +23,36 @@ public class MultiDbConfigurator {
 
   private final TestStandaloneApplication<?> testApplication;
 
-  private final OperateProperties operateProperties;
-  private final TasklistProperties tasklistProperties;
-
   public MultiDbConfigurator(final TestStandaloneApplication<?> testApplication) {
     this.testApplication = testApplication;
-    // we are configuring this always, even if we might not use the applications
-    operateProperties = new OperateProperties();
-    tasklistProperties = new TasklistProperties();
-
-    testApplication
-        .withBean("operate-config", operateProperties, OperateProperties.class)
-        .withBean("tasklist-config", tasklistProperties, TasklistProperties.class);
   }
 
   public void configureElasticsearchSupport(
       final String elasticsearchUrl, final String indexPrefix) {
-    operateProperties.getElasticsearch().setUrl(elasticsearchUrl);
-    operateProperties.getElasticsearch().setIndexPrefix(indexPrefix);
-    operateProperties.getZeebeElasticsearch().setUrl(elasticsearchUrl);
-    operateProperties.getZeebeElasticsearch().setPrefix(indexPrefix);
-    tasklistProperties.getElasticsearch().setUrl(elasticsearchUrl);
-    tasklistProperties.getElasticsearch().setIndexPrefix(indexPrefix);
-    tasklistProperties.getZeebeElasticsearch().setUrl(elasticsearchUrl);
-    tasklistProperties.getZeebeElasticsearch().setPrefix(indexPrefix);
+
+    final Map<String, Object> elasticsearchProperties = new HashMap<>();
+
+    /* Tasklist */
+    elasticsearchProperties.put("camunda.tasklist.elasticsearch.url", elasticsearchUrl);
+    elasticsearchProperties.put("camunda.tasklist.zeebeElasticsearch.url", elasticsearchUrl);
+    elasticsearchProperties.put("camunda.tasklist.elasticsearch.index-prefix", indexPrefix);
+    elasticsearchProperties.put("camunda.tasklist.zeebeElasticsearch.prefix", indexPrefix);
+
+    /* Operate */
+    elasticsearchProperties.put("camunda.operate.elasticsearch.url", elasticsearchUrl);
+    elasticsearchProperties.put("camunda.operate.zeebeElasticsearch.url", elasticsearchUrl);
+    elasticsearchProperties.put("camunda.operate.elasticsearch.index-prefix", indexPrefix);
+    elasticsearchProperties.put("camunda.operate.zeebeElasticsearch.prefix", indexPrefix);
+
+    /* Camunda */
+    elasticsearchProperties.put(
+        "camunda.database.type",
+        io.camunda.search.connect.configuration.DatabaseType.ELASTICSEARCH);
+    elasticsearchProperties.put("camunda.database.indexPrefix", indexPrefix);
+    elasticsearchProperties.put("camunda.database.url", elasticsearchUrl);
+
+    testApplication.withAdditionalProperties(elasticsearchProperties);
+
     testApplication.withExporter(
         "CamundaExporter",
         cfg -> {
@@ -80,12 +83,6 @@ public class MultiDbConfigurator {
                   "index", Map.of("prefix", indexPrefix),
                   "bulk", Map.of("size", 1)));
         });
-
-    testApplication.withProperty(
-        "camunda.database.type",
-        io.camunda.search.connect.configuration.DatabaseType.ELASTICSEARCH);
-    testApplication.withProperty("camunda.database.indexPrefix", indexPrefix);
-    testApplication.withProperty("camunda.database.url", elasticsearchUrl);
   }
 
   public void configureOpenSearchSupport(
@@ -93,30 +90,36 @@ public class MultiDbConfigurator {
       final String indexPrefix,
       final String userName,
       final String userPassword) {
-    final OperateOpensearchProperties operateOpensearch = operateProperties.getOpensearch();
-    operateOpensearch.setUrl(opensearchUrl);
-    operateOpensearch.setIndexPrefix(indexPrefix);
-    operateOpensearch.setPassword(userPassword);
-    operateOpensearch.setUsername(userName);
 
-    final var zeebeOS = operateProperties.getZeebeOpensearch();
-    zeebeOS.setUrl(opensearchUrl);
-    zeebeOS.setPassword(userPassword);
-    zeebeOS.setUsername(userName);
-    zeebeOS.setPrefix(indexPrefix);
+    final Map<String, Object> opensearchProperties = new HashMap<>();
 
-    tasklistProperties.setDatabase("opensearch");
-    final TasklistOpenSearchProperties tasklistOpensearch = tasklistProperties.getOpenSearch();
-    tasklistOpensearch.setUrl(opensearchUrl);
-    tasklistOpensearch.setIndexPrefix(indexPrefix);
-    tasklistOpensearch.setPassword(userPassword);
-    tasklistOpensearch.setUsername(userName);
+    /* Tasklist */
+    opensearchProperties.put("camunda.tasklist.opensearch.url", opensearchUrl);
+    opensearchProperties.put("camunda.tasklist.zeebeOpensearch.url", opensearchUrl);
+    opensearchProperties.put("camunda.tasklist.opensearch.index-prefix", indexPrefix);
+    opensearchProperties.put("camunda.tasklist.zeebeOpensearch.prefix", indexPrefix);
+    opensearchProperties.put("camunda.tasklist.opensearch.username", userName);
+    opensearchProperties.put("camunda.tasklist.opensearch.password", userPassword);
 
-    final var zeebeTasklistOS = tasklistProperties.getZeebeOpenSearch();
-    zeebeTasklistOS.setUrl(opensearchUrl);
-    zeebeTasklistOS.setPassword(userPassword);
-    zeebeTasklistOS.setUsername(userName);
-    zeebeTasklistOS.setPrefix(indexPrefix);
+    /* Operate */
+    opensearchProperties.put("camunda.operate.opensearch.url", opensearchUrl);
+    opensearchProperties.put("camunda.operate.zeebeOpensearch.url", opensearchUrl);
+    opensearchProperties.put("camunda.operate.opensearch.index-prefix", indexPrefix);
+    opensearchProperties.put("camunda.operate.zeebeOpensearch.prefix", indexPrefix);
+    opensearchProperties.put("camunda.operate.opensearch.username", userName);
+    opensearchProperties.put("camunda.operate.opensearch.password", userPassword);
+
+    /* Camunda */
+    opensearchProperties.put(
+        "camunda.database.type", io.camunda.search.connect.configuration.DatabaseType.OPENSEARCH);
+    opensearchProperties.put("camunda.operate.database", "opensearch");
+    opensearchProperties.put("camunda.tasklist.database", "opensearch");
+    opensearchProperties.put("camunda.database.indexPrefix", indexPrefix);
+    opensearchProperties.put("camunda.database.username", userName);
+    opensearchProperties.put("camunda.database.password", userPassword);
+    opensearchProperties.put("camunda.database.url", opensearchUrl);
+
+    testApplication.withAdditionalProperties(opensearchProperties);
 
     testApplication.withExporter(
         "CamundaExporter",
@@ -157,15 +160,6 @@ public class MultiDbConfigurator {
                   "authentication",
                   Map.of("username", userName, "password", userPassword)));
         });
-
-    testApplication.withProperty(
-        "camunda.database.type", io.camunda.search.connect.configuration.DatabaseType.OPENSEARCH);
-    testApplication.withProperty("camunda.operate.database", "opensearch");
-    testApplication.withProperty("camunda.tasklist.database", "opensearch");
-    testApplication.withProperty("camunda.database.indexPrefix", indexPrefix);
-    testApplication.withProperty("camunda.database.username", userName);
-    testApplication.withProperty("camunda.database.password", userPassword);
-    testApplication.withProperty("camunda.database.url", opensearchUrl);
   }
 
   public void configureRDBMSSupport() {
@@ -184,13 +178,5 @@ public class MultiDbConfigurator {
           cfg.setClassName("-");
           cfg.setArgs(Map.of("flushInterval", "0"));
         });
-  }
-
-  public OperateProperties getOperateProperties() {
-    return operateProperties;
-  }
-
-  public TasklistProperties getTasklistProperties() {
-    return tasklistProperties;
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfigurator.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfigurator.java
@@ -35,13 +35,13 @@ public class MultiDbConfigurator {
     /* Tasklist */
     elasticsearchProperties.put("camunda.tasklist.elasticsearch.url", elasticsearchUrl);
     elasticsearchProperties.put("camunda.tasklist.zeebeElasticsearch.url", elasticsearchUrl);
-    elasticsearchProperties.put("camunda.tasklist.elasticsearch.index-prefix", indexPrefix);
+    elasticsearchProperties.put("camunda.tasklist.elasticsearch.indexPrefix", indexPrefix);
     elasticsearchProperties.put("camunda.tasklist.zeebeElasticsearch.prefix", indexPrefix);
 
     /* Operate */
     elasticsearchProperties.put("camunda.operate.elasticsearch.url", elasticsearchUrl);
     elasticsearchProperties.put("camunda.operate.zeebeElasticsearch.url", elasticsearchUrl);
-    elasticsearchProperties.put("camunda.operate.elasticsearch.index-prefix", indexPrefix);
+    elasticsearchProperties.put("camunda.operate.elasticsearch.indexPrefix", indexPrefix);
     elasticsearchProperties.put("camunda.operate.zeebeElasticsearch.prefix", indexPrefix);
 
     /* Camunda */
@@ -96,7 +96,7 @@ public class MultiDbConfigurator {
     /* Tasklist */
     opensearchProperties.put("camunda.tasklist.opensearch.url", opensearchUrl);
     opensearchProperties.put("camunda.tasklist.zeebeOpensearch.url", opensearchUrl);
-    opensearchProperties.put("camunda.tasklist.opensearch.index-prefix", indexPrefix);
+    opensearchProperties.put("camunda.tasklist.opensearch.indexPrefix", indexPrefix);
     opensearchProperties.put("camunda.tasklist.zeebeOpensearch.prefix", indexPrefix);
     opensearchProperties.put("camunda.tasklist.opensearch.username", userName);
     opensearchProperties.put("camunda.tasklist.opensearch.password", userPassword);
@@ -104,7 +104,7 @@ public class MultiDbConfigurator {
     /* Operate */
     opensearchProperties.put("camunda.operate.opensearch.url", opensearchUrl);
     opensearchProperties.put("camunda.operate.zeebeOpensearch.url", opensearchUrl);
-    opensearchProperties.put("camunda.operate.opensearch.index-prefix", indexPrefix);
+    opensearchProperties.put("camunda.operate.opensearch.indexPrefix", indexPrefix);
     opensearchProperties.put("camunda.operate.zeebeOpensearch.prefix", indexPrefix);
     opensearchProperties.put("camunda.operate.opensearch.username", userName);
     opensearchProperties.put("camunda.operate.opensearch.password", userPassword);

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfiguratorTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/MultiDbConfiguratorTest.java
@@ -10,9 +10,7 @@ package io.camunda.it.utils;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.application.commons.configuration.BrokerBasedConfiguration.BrokerBasedProperties;
-import io.camunda.operate.property.OperateProperties;
 import io.camunda.qa.util.cluster.TestSimpleCamundaApplication;
-import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -33,8 +31,6 @@ public class MultiDbConfiguratorTest {
     new MultiDbConfigurator(testSimpleCamundaApplication);
 
     // then
-    assertThat(testSimpleCamundaApplication.bean(OperateProperties.class)).isNotNull();
-    assertThat(testSimpleCamundaApplication.bean(TasklistProperties.class)).isNotNull();
 
     final BrokerBasedProperties brokerBasedProperties =
         testSimpleCamundaApplication.bean(BrokerBasedProperties.class);
@@ -52,25 +48,40 @@ public class MultiDbConfiguratorTest {
     multiDbConfigurator.configureElasticsearchSupport(EXPECTED_URL, EXPECTED_PREFIX);
 
     // then
-    final String configuredPrefix =
-        testSimpleCamundaApplication.property("camunda.database.indexPrefix", String.class, "");
-    assertThat(configuredPrefix).isEqualTo(EXPECTED_PREFIX);
-    final String configuredUrl =
-        testSimpleCamundaApplication.property("camunda.database.url", String.class, "");
-    assertThat(configuredUrl).isEqualTo(EXPECTED_URL);
 
-    final OperateProperties operateProperties =
-        testSimpleCamundaApplication.bean(OperateProperties.class);
-    assertThat(operateProperties).isNotNull();
+    /* Tasklist Config Assertions */
+    assertProperty(
+        testSimpleCamundaApplication,
+        "camunda.tasklist.elasticsearch.indexPrefix",
+        EXPECTED_PREFIX);
+    assertProperty(
+        testSimpleCamundaApplication, "camunda.tasklist.elasticsearch.url", EXPECTED_URL);
+    assertProperty(
+        testSimpleCamundaApplication, "camunda.tasklist.zeebeElasticsearch.url", EXPECTED_URL);
+    assertProperty(
+        testSimpleCamundaApplication,
+        "camunda.tasklist.elasticsearch.indexPrefix",
+        EXPECTED_PREFIX);
+    assertProperty(
+        testSimpleCamundaApplication,
+        "camunda.tasklist.zeebeElasticsearch.prefix",
+        EXPECTED_PREFIX);
 
-    assertThat(operateProperties.getElasticsearch().getIndexPrefix()).isEqualTo(EXPECTED_PREFIX);
-    assertThat(operateProperties.getElasticsearch().getUrl()).isEqualTo(EXPECTED_URL);
+    /* Operate Config Assertions */
+    assertProperty(
+        testSimpleCamundaApplication, "camunda.operate.elasticsearch.indexPrefix", EXPECTED_PREFIX);
+    assertProperty(testSimpleCamundaApplication, "camunda.operate.elasticsearch.url", EXPECTED_URL);
+    assertProperty(
+        testSimpleCamundaApplication, "camunda.operate.zeebeElasticsearch.url", EXPECTED_URL);
+    assertProperty(
+        testSimpleCamundaApplication, "camunda.operate.elasticsearch.indexPrefix", EXPECTED_PREFIX);
+    assertProperty(
+        testSimpleCamundaApplication, "camunda.operate.zeebeElasticsearch.prefix", EXPECTED_PREFIX);
 
-    final TasklistProperties tasklistProperties =
-        testSimpleCamundaApplication.bean(TasklistProperties.class);
-    assertThat(tasklistProperties).isNotNull();
-    assertThat(tasklistProperties.getElasticsearch().getIndexPrefix()).isEqualTo(EXPECTED_PREFIX);
-    assertThat(tasklistProperties.getElasticsearch().getUrl()).isEqualTo(EXPECTED_URL);
+    /* Camunda Config Assertions */
+
+    assertProperty(testSimpleCamundaApplication, "camunda.database.indexPrefix", EXPECTED_PREFIX);
+    assertProperty(testSimpleCamundaApplication, "camunda.database.url", EXPECTED_URL);
 
     final BrokerBasedProperties brokerBasedProperties =
         testSimpleCamundaApplication.bean(BrokerBasedProperties.class);
@@ -105,35 +116,43 @@ public class MultiDbConfiguratorTest {
         EXPECTED_URL, EXPECTED_PREFIX, EXPECTED_USER, EXPECTED_PW);
 
     // then
-    final String configuredPrefix =
-        testSimpleCamundaApplication.property("camunda.database.indexPrefix", String.class, "");
-    assertThat(configuredPrefix).isEqualTo(EXPECTED_PREFIX);
-    final String configuredUser =
-        testSimpleCamundaApplication.property("camunda.database.username", String.class, "");
-    assertThat(configuredUser).isEqualTo(EXPECTED_USER);
-    final String configuredPassword =
-        testSimpleCamundaApplication.property("camunda.database.password", String.class, "");
-    assertThat(configuredPassword).isEqualTo(EXPECTED_PW);
-    final String configuredUrl =
-        testSimpleCamundaApplication.property("camunda.database.url", String.class, "");
-    assertThat(configuredUrl).isEqualTo(EXPECTED_URL);
 
-    final OperateProperties operateProperties =
-        testSimpleCamundaApplication.bean(OperateProperties.class);
-    assertThat(operateProperties).isNotNull();
+    /* Tasklist Config Assertions */
+    assertProperty(
+        testSimpleCamundaApplication, "camunda.tasklist.opensearch.indexPrefix", EXPECTED_PREFIX);
+    assertProperty(testSimpleCamundaApplication, "camunda.tasklist.opensearch.url", EXPECTED_URL);
+    assertProperty(
+        testSimpleCamundaApplication, "camunda.tasklist.zeebeOpensearch.url", EXPECTED_URL);
+    assertProperty(
+        testSimpleCamundaApplication, "camunda.tasklist.opensearch.indexPrefix", EXPECTED_PREFIX);
+    assertProperty(
+        testSimpleCamundaApplication, "camunda.tasklist.zeebeOpensearch.prefix", EXPECTED_PREFIX);
+    assertProperty(
+        testSimpleCamundaApplication, "camunda.tasklist.opensearch.username", EXPECTED_USER);
+    assertProperty(
+        testSimpleCamundaApplication, "camunda.tasklist.opensearch.password", EXPECTED_PW);
 
-    assertThat(operateProperties.getOpensearch().getIndexPrefix()).isEqualTo(EXPECTED_PREFIX);
-    assertThat(operateProperties.getOpensearch().getUrl()).isEqualTo(EXPECTED_URL);
-    assertThat(operateProperties.getOpensearch().getPassword()).isEqualTo(EXPECTED_PW);
-    assertThat(operateProperties.getOpensearch().getUsername()).isEqualTo(EXPECTED_USER);
+    /* Operate Config Assertions */
+    assertProperty(
+        testSimpleCamundaApplication, "camunda.operate.opensearch.indexPrefix", EXPECTED_PREFIX);
+    assertProperty(testSimpleCamundaApplication, "camunda.operate.opensearch.url", EXPECTED_URL);
+    assertProperty(
+        testSimpleCamundaApplication, "camunda.operate.zeebeOpensearch.url", EXPECTED_URL);
+    assertProperty(
+        testSimpleCamundaApplication, "camunda.operate.opensearch.indexPrefix", EXPECTED_PREFIX);
+    assertProperty(
+        testSimpleCamundaApplication, "camunda.operate.zeebeOpensearch.prefix", EXPECTED_PREFIX);
+    assertProperty(
+        testSimpleCamundaApplication, "camunda.operate.opensearch.username", EXPECTED_USER);
+    assertProperty(
+        testSimpleCamundaApplication, "camunda.operate.opensearch.password", EXPECTED_PW);
 
-    final TasklistProperties tasklistProperties =
-        testSimpleCamundaApplication.bean(TasklistProperties.class);
-    assertThat(tasklistProperties).isNotNull();
-    assertThat(tasklistProperties.getOpenSearch().getIndexPrefix()).isEqualTo(EXPECTED_PREFIX);
-    assertThat(tasklistProperties.getOpenSearch().getUrl()).isEqualTo(EXPECTED_URL);
-    assertThat(tasklistProperties.getOpenSearch().getPassword()).isEqualTo(EXPECTED_PW);
-    assertThat(tasklistProperties.getOpenSearch().getUsername()).isEqualTo(EXPECTED_USER);
+    /* Camunda Config Assertions */
+
+    assertProperty(testSimpleCamundaApplication, "camunda.database.indexPrefix", EXPECTED_PREFIX);
+    assertProperty(testSimpleCamundaApplication, "camunda.database.url", EXPECTED_URL);
+    assertProperty(testSimpleCamundaApplication, "camunda.database.username", EXPECTED_USER);
+    assertProperty(testSimpleCamundaApplication, "camunda.database.password", EXPECTED_PW);
 
     final BrokerBasedProperties brokerBasedProperties =
         testSimpleCamundaApplication.bean(BrokerBasedProperties.class);
@@ -158,5 +177,14 @@ public class MultiDbConfiguratorTest {
                 EXPECTED_USER,
                 "password",
                 EXPECTED_PW));
+  }
+
+  private <T> void assertProperty(
+      final TestSimpleCamundaApplication applicationContext,
+      final String propertyKey,
+      final T expectedValue) {
+    final T propertyValue =
+        applicationContext.property(propertyKey, (Class<T>) expectedValue.getClass(), null);
+    assertThat(propertyValue).isEqualTo(expectedValue);
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- Make MultiDbConfigurator setup be written in env parameters so that they can be overriden before the application is being started.
- Align PrefixMigrationIT to not make use of the `indexPrefix` on Zeebe indices
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
