### PR TITLE
fix: rdbms - use rule index as additional PK for decision outputs

### DIFF
--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -319,10 +319,12 @@
       <column name="OUTPUT_ID" type="VARCHAR(255)">
         <constraints primaryKey="true"/>
       </column>
+      <column name="RULE_INDEX" type="SMALLINT">
+        <constraints primaryKey="true"/>
+      </column>
       <column name="OUTPUT_NAME" type="VARCHAR(255)"/>
       <column name="OUTPUT_VALUE" type="VARCHAR(4000)" />
       <column name="RULE_ID" type="VARCHAR(255)"/>
-      <column name="RULE_INDEX" type="SMALLINT" />
     </createTable>
     <!-- No additional index for DECISION_INSTANCE_KEY needed -->
   </changeSet>


### PR DESCRIPTION
## Description

Fixes the "Unique index or primary key violation: `PUBLIC.PRIMARY_KEY_F ON PUBLIC.DECISION_INSTANCE_OUTPUT(DECISION_INSTANCE_ID, OUTPUT_ID) VALUES ( /* key:3 */ '2251799813685275-2', 'OutputClause_1cthd0w')` problem in rdbms module. 

Since DECISION_INSTANCE_ID and OUTPUT_ID ist not unique as PK, I extended the PK to also use the RULE_INDEX. 