### PR TITLE
Fix NPE when access a null code and reusing the same metric name for different metrics

### DIFF
--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClientRequestMetrics.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClientRequestMetrics.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.client.api;
 
+import static io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.FAILED_REQUESTS;
 import static io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.REQUEST_LATENCY;
 import static io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.TOTAL_REQUESTS;
 
@@ -63,8 +64,8 @@ public final class BrokerClientRequestMetrics {
 
   private Counter registerFailedRequestCounter(
       final int partitionId, final String requestType, final Enum<?> error) {
-    return Counter.builder(TOTAL_REQUESTS.getName())
-        .description(TOTAL_REQUESTS.getDescription())
+    return Counter.builder(FAILED_REQUESTS.getName())
+        .description(FAILED_REQUESTS.getDescription())
         .tag(RequestKeyNames.REQUEST_TYPE.asString(), requestType)
         .tag(PartitionKeyNames.PARTITION.asString(), String.valueOf(partitionId))
         .tag(RequestKeyNames.ERROR.asString(), error.name())

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.transport.ClientRequest;
 import io.camunda.zeebe.transport.ClientTransport;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
@@ -169,10 +170,11 @@ final class BrokerRequestManager extends Actor {
     if (result != null && result.getErrorCode() == ErrorCode.RESOURCE_EXHAUSTED) {
       return;
     }
+
     final Enum<?> code;
 
     if (result != null && result.getErrorCode() != ErrorCode.NULL_VAL) {
-      code = result.getErrorCode();
+      code = Objects.requireNonNullElse(result.getErrorCode(), AdditionalErrorCodes.UNKNOWN);
     } else if (error != null && error.getClass().equals(TimeoutException.class)) {
       code = AdditionalErrorCodes.TIMEOUT;
     } else {


### PR DESCRIPTION
## Description

This PR fixes two errors reported here:

- https://console.cloud.google.com/errors/detail/CMrD3f2fpZnN8wE;service=zeebe;time=P7D;locations=global?inv=1&invt=AbqE7A&project=camunda-saas-int
- https://console.cloud.google.com/errors/detail/CKX1hunDydf0FQ;service=zeebe;time=P7D;locations=global?inv=1&invt=AbqE7A&project=camunda-saas-int
