### PR TITLE
test: add IT tests for Mapping, Authorization searching

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/AuthorizationSearchIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/AuthorizationSearchIT.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static io.camunda.client.protocol.rest.ResourceTypeEnum.AUTHORIZATION;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.it.utils.BrokerITInvocationProvider;
+import io.camunda.it.utils.CamundaClientTestFactory.Authenticated;
+import io.camunda.it.utils.CamundaClientTestFactory.Permissions;
+import io.camunda.it.utils.CamundaClientTestFactory.User;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Base64;
+import java.util.List;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AuthorizationSearchIT {
+
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  private static final String ADMIN = "admin";
+  private static final String RESTRICTED = "restricted-user";
+  private static final String DEFAULT_PASSWORD = "password";
+  private static final String AUTH_SEARCH_ENDPOINT = "v2/authorizations/search";
+
+  private static final User ADMIN_USER =
+      new User(
+          ADMIN,
+          DEFAULT_PASSWORD,
+          List.of(
+              new Permissions(
+                  AUTHORIZATION,
+                  io.camunda.client.protocol.rest.PermissionTypeEnum.READ,
+                  List.of("*"))));
+
+  private static final User RESTRICTED_USER = new User(RESTRICTED, DEFAULT_PASSWORD, List.of());
+
+  @RegisterExtension
+  static final BrokerITInvocationProvider PROVIDER =
+      new BrokerITInvocationProvider()
+          .withoutRdbmsExporter()
+          .withBasicAuth()
+          .withAuthorizationsEnabled()
+          .withUsers(ADMIN_USER, RESTRICTED_USER);
+
+  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+
+  @TestTemplate
+  void searchShouldReturnAuthorizations(@Authenticated(ADMIN) final CamundaClient adminClient)
+      throws Exception {
+    final var response =
+        searchAuthorizations(adminClient.getConfiguration().getRestAddress().toString(), ADMIN);
+    assertThat(response.items()).isNotEmpty();
+  }
+
+  @TestTemplate
+  void searchShouldReturnEmptyListForRestrictedUser(
+      @Authenticated(RESTRICTED) final CamundaClient client) throws Exception {
+    final var response =
+        searchAuthorizations(client.getConfiguration().getRestAddress().toString(), RESTRICTED);
+    assertThat(response.items()).isEmpty();
+  }
+
+  // TODO once available, this test should use the client to make the request
+  private static AuthorizationSearchResponse searchAuthorizations(
+      final String restAddress, final String username)
+      throws URISyntaxException, IOException, InterruptedException {
+    final var encodedCredentials =
+        Base64.getEncoder()
+            .encodeToString("%s:%s".formatted(username, DEFAULT_PASSWORD).getBytes());
+    final HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(new URI("%s%s".formatted(restAddress, AUTH_SEARCH_ENDPOINT)))
+            .POST(HttpRequest.BodyPublishers.ofString(""))
+            .header("Authorization", "Basic %s".formatted(encodedCredentials))
+            .build();
+
+    final HttpResponse<String> response =
+        HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+    return OBJECT_MAPPER.readValue(response.body(), AuthorizationSearchResponse.class);
+  }
+
+  private record AuthorizationSearchResponse(List<AuthorizationResponse> items) {}
+
+  private record AuthorizationResponse(String resourceId) {}
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/AuthorizationSearchIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/AuthorizationSearchIT.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
+import io.camunda.client.protocol.rest.PermissionTypeEnum;
 import io.camunda.it.utils.BrokerITInvocationProvider;
 import io.camunda.it.utils.CamundaClientTestFactory.Authenticated;
 import io.camunda.it.utils.CamundaClientTestFactory.Permissions;
@@ -37,7 +38,7 @@ class AuthorizationSearchIT {
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   private static final String ADMIN = "admin";
-  private static final String RESTRICTED = "restricted-user";
+  private static final String RESTRICTED = "restrictedUser";
   private static final String DEFAULT_PASSWORD = "password";
   private static final String AUTH_SEARCH_ENDPOINT = "v2/authorizations/search";
 
@@ -45,11 +46,7 @@ class AuthorizationSearchIT {
       new User(
           ADMIN,
           DEFAULT_PASSWORD,
-          List.of(
-              new Permissions(
-                  AUTHORIZATION,
-                  io.camunda.client.protocol.rest.PermissionTypeEnum.READ,
-                  List.of("*"))));
+          List.of(new Permissions(AUTHORIZATION, PermissionTypeEnum.READ, List.of("*"))));
 
   private static final User RESTRICTED_USER = new User(RESTRICTED, DEFAULT_PASSWORD, List.of());
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/MappingAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/MappingAuthorizationIT.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static io.camunda.client.protocol.rest.PermissionTypeEnum.CREATE;
+import static io.camunda.client.protocol.rest.PermissionTypeEnum.READ;
+import static io.camunda.client.protocol.rest.ResourceTypeEnum.MAPPING_RULE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.client.CamundaClient;
+import io.camunda.it.utils.BrokerITInvocationProvider;
+import io.camunda.it.utils.CamundaClientTestFactory.Authenticated;
+import io.camunda.it.utils.CamundaClientTestFactory.Permissions;
+import io.camunda.it.utils.CamundaClientTestFactory.User;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+@TestInstance(Lifecycle.PER_CLASS)
+class MappingAuthorizationIT {
+
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+  private static final String ADMIN = "admin";
+  private static final String RESTRICTED = "restricted-user";
+  private static final String UNAUTHORIZED = "unauthorized-user";
+  private static final String DEFAULT_PASSWORD = "password";
+  private static final String MAPPING_SEARCH_ENDPOINT = "v2/mapping-rules/search";
+  private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(15);
+
+  private static final User ADMIN_USER =
+      new User(
+          ADMIN,
+          DEFAULT_PASSWORD,
+          List.of(
+              new Permissions(MAPPING_RULE, CREATE, List.of("*")),
+              new Permissions(MAPPING_RULE, READ, List.of("*"))));
+
+  private static final User RESTRICTED_USER =
+      new User(
+          RESTRICTED, DEFAULT_PASSWORD, List.of(new Permissions(MAPPING_RULE, READ, List.of("*"))));
+
+  private static final User UNAUTHORIZED_USER = new User(UNAUTHORIZED, DEFAULT_PASSWORD, List.of());
+
+  @RegisterExtension
+  static final BrokerITInvocationProvider PROVIDER =
+      new BrokerITInvocationProvider()
+          .withoutRdbmsExporter()
+          .withBasicAuth()
+          .withAuthorizationsEnabled()
+          .withUsers(ADMIN_USER, RESTRICTED_USER, UNAUTHORIZED_USER);
+
+  @AutoClose private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
+  private boolean initialized;
+
+  @BeforeEach
+  void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
+    if (!initialized) {
+      createMapping(adminClient, "test-name", "test-value", "mapping1");
+      createMapping(adminClient, "test-name2", "test-value2", "mapping2");
+      final int expectedCount = 2;
+      waitForMappingsToBeCreated(
+          adminClient.getConfiguration().getRestAddress().toString(), ADMIN, expectedCount);
+      initialized = true;
+    }
+  }
+
+  @TestTemplate
+  void searchShouldReturnAuthorizedMappings(
+      @Authenticated(RESTRICTED) final CamundaClient userClient) throws Exception {
+    final var mappingSearchResponse =
+        searchMappings(userClient.getConfiguration().getRestAddress().toString(), RESTRICTED);
+
+    assertThat(mappingSearchResponse.items())
+        .hasSize(2)
+        .map(MappingResponse::name)
+        .containsExactlyInAnyOrder("mapping1", "mapping2");
+  }
+
+  @TestTemplate
+  void searchShouldReturnEmptyListWhenUnauthorized(
+      @Authenticated(UNAUTHORIZED) final CamundaClient userClient) throws Exception {
+    final var mappingSearchResponse =
+        searchMappings(userClient.getConfiguration().getRestAddress().toString(), UNAUTHORIZED);
+
+    assertThat(mappingSearchResponse.items()).isEmpty();
+  }
+
+  private static void createMapping(
+      final CamundaClient adminClient,
+      final String name,
+      final String value,
+      final String mappingId) {
+    adminClient
+        .newCreateMappingCommand()
+        .claimName(name)
+        .claimValue(value)
+        .id(mappingId)
+        .name(mappingId)
+        .send()
+        .join();
+  }
+
+  private void waitForMappingsToBeCreated(
+      final String restAddress, final String username, final int expectedCount) {
+    Awaitility.await("should create mappings and import in ES")
+        .atMost(AWAIT_TIMEOUT)
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var mappingSearchResponse = searchMappings(restAddress, username);
+              assertThat(mappingSearchResponse.items()).hasSize(expectedCount);
+            });
+  }
+
+  // TODO once available, this test should use the client to make the request
+  private static MappingSearchResponse searchMappings(
+      final String restAddress, final String username)
+      throws URISyntaxException, IOException, InterruptedException {
+    final var encodedCredentials =
+        Base64.getEncoder()
+            .encodeToString("%s:%s".formatted(username, DEFAULT_PASSWORD).getBytes());
+    final HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(new URI("%s%s".formatted(restAddress, MAPPING_SEARCH_ENDPOINT)))
+            .POST(HttpRequest.BodyPublishers.ofString(""))
+            .header("Authorization", "Basic %s".formatted(encodedCredentials))
+            .build();
+
+    final HttpResponse<String> response =
+        HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+    return OBJECT_MAPPER.readValue(response.body(), MappingSearchResponse.class);
+  }
+
+  private record MappingSearchResponse(List<MappingResponse> items) {}
+
+  private record MappingResponse(String name) {}
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/MappingAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/MappingAuthorizationIT.java
@@ -42,8 +42,8 @@ class MappingAuthorizationIT {
   private static final ObjectMapper OBJECT_MAPPER =
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
   private static final String ADMIN = "admin";
-  private static final String RESTRICTED = "restricted-user";
-  private static final String UNAUTHORIZED = "unauthorized-user";
+  private static final String RESTRICTED = "restrictedUser";
+  private static final String UNAUTHORIZED = "unauthorizedUser";
   private static final String DEFAULT_PASSWORD = "password";
   private static final String MAPPING_SEARCH_ENDPOINT = "v2/mapping-rules/search";
   private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(15);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingCreatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingCreatedHandler.java
@@ -55,7 +55,8 @@ public class MappingCreatedHandler implements ExportHandler<MappingEntity, Mappi
     entity
         .setKey(value.getMappingKey())
         .setClaimName(value.getClaimName())
-        .setClaimValue(value.getClaimValue());
+        .setClaimValue(value.getClaimValue())
+        .setName(value.getName());
   }
 
   @Override

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -518,7 +518,8 @@ public final class ResponseMapper {
         new MappingRuleCreateResult()
             .mappingKey(KeyUtil.keyToString(record.getMappingKey()))
             .claimName(record.getClaimName())
-            .claimValue(record.getClaimValue());
+            .claimValue(record.getClaimValue())
+            .name(record.getName());
     return new ResponseEntity<>(response, HttpStatus.CREATED);
   }
 


### PR DESCRIPTION
## Description

  - added authorization tests for Mapping searching
 - fixed mapping response -> now its return name of mapping
  - added authorization tests for Mapping searching

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #27074
closes #27075
