### PR TITLE
[Backport stable/8.5] Fix NPE when access a null code and reusing the same metric name for different metrics

### DIFF
--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientMetricsImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClientMetricsImpl.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.client.impl;
 
+import static io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.FAILED_REQUESTS;
 import static io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.REQUEST_LATENCY;
 import static io.camunda.zeebe.broker.client.api.BrokerClientMetricsDoc.TOTAL_REQUESTS;
 
@@ -60,8 +61,8 @@ public final class BrokerClientMetricsImpl implements BrokerClientRequestMetrics
 
   private Counter registerFailedRequestCounter(
       final int partitionId, final String requestType, final Enum<?> error) {
-    return Counter.builder(TOTAL_REQUESTS.getName())
-        .description(TOTAL_REQUESTS.getDescription())
+    return Counter.builder(FAILED_REQUESTS.getName())
+        .description(FAILED_REQUESTS.getDescription())
         .tag(RequestKeyNames.REQUEST_TYPE.asString(), requestType)
         .tag(PartitionKeyNames.PARTITION.asString(), String.valueOf(partitionId))
         .tag(RequestKeyNames.ERROR.asString(), error.name())

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.transport.ClientRequest;
 import io.camunda.zeebe.transport.ClientTransport;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
@@ -166,7 +167,7 @@ final class BrokerRequestManager extends Actor {
     final Enum<?> code;
 
     if (result != null && result.getErrorCode() != ErrorCode.NULL_VAL) {
-      code = result.getErrorCode();
+      code = Objects.requireNonNullElse(result.getErrorCode(), AdditionalErrorCodes.UNKNOWN);
     } else if (error != null && error.getClass().equals(TimeoutException.class)) {
       code = AdditionalErrorCodes.TIMEOUT;
     } else {


### PR DESCRIPTION
# Description
Backport of #28480 to `stable/8.5`.

relates to 
original author: @npepinpe