### PR TITLE
Fix flaky IncidentQueryTest

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentQueryTest.java
@@ -82,7 +82,7 @@ class IncidentQueryTest {
 
     // then
     assertThat(result).isNotNull();
-    assertThat(result).isEqualTo(incident);
+    assertThat(result.getIncidentKey()).isEqualTo(incidentKey);
   }
 
   @Test


### PR DESCRIPTION
## Description

The IncidentQueryTest should test the minimal required data to avoid flakiness. It's important that the incident key matches. All other attributes of the incident are not relevant for this test case and only increase potential flakiness if we verify them, too.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #24271 
