### PR TITLE
fix: re-add the --config flag but with it being used under spring.config.additional-location

### DIFF
--- a/.github/actions/setup-c8run/action.yml
+++ b/.github/actions/setup-c8run/action.yml
@@ -196,7 +196,7 @@ runs:
 
     - if: ${{ inputs.os == 'ubuntu-latest' }}
       name: Linux - Run c8run
-      run: ./c8run start
+      run: ./c8run start --config e2e_tests/prefix-config.yaml
       shell: bash
       working-directory: ./c8run
       env:
@@ -206,7 +206,7 @@ runs:
     - if: ${{ startsWith(inputs.os, 'macos') }}
       name: Mac - Run c8run
       shell: bash
-      run: ./c8run start
+      run: ./c8run start --config e2e_tests/prefix-config.yaml
       working-directory: ./c8run
       env:
         JAVA_VERSION: 21.0.3

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -216,11 +216,19 @@ jobs:
           JAVA_VERSION: "22.0.2"
 
       - name: Run c8run
-        run: .\c8run.exe start
+        run: .\c8run.exe start --config e2e_tests/prefix-config.yaml
         working-directory: .\c8run
         shell: cmd
         env:
           JAVA_VERSION: "22.0.2"
+
+      - name: Install jq
+        run: choco install jq
+
+      - name: Run test
+        shell: bash
+        run: ./api_tests.sh
+        working-directory: .\c8run\e2e_tests
 
       - uses: actions/setup-node@v4
         with:

--- a/c8run/e2e_tests/api_tests.sh
+++ b/c8run/e2e_tests/api_tests.sh
@@ -42,4 +42,12 @@ if [[ "$returnCode" != 0 ]]; then
    exit 1
 fi
 
+printf "\nTest: test --config flag\n"
+
+PREFIX="$( curl localhost:9600/actuator/configprops | jq '.contexts.application.beans.["io.camunda.tasklist.property.TasklistProperties"].properties.zeebeElasticsearch.prefix' )"
+echo $PREFIX
+if [[ "$PREFIX" != "\"extra-prefix-zeebe-record\"" ]]; then
+   echo "test failed"
+   exit 1
+fi
 

--- a/c8run/e2e_tests/prefix-config.yaml
+++ b/c8run/e2e_tests/prefix-config.yaml
@@ -1,0 +1,7 @@
+camunda:
+  operate:
+    zeebeElasticsearch:
+      prefix: "extra-prefix-zeebe-record"
+  tasklist:
+    zeebeElasticsearch:
+      prefix: "extra-prefix-zeebe-record"


### PR DESCRIPTION
## Description

This PR adds back the --config flag.  We found that this flag was broken after an upgrade in spring, and was also taken out because of issues it caused overriding all of the internal default configuration.

This PR adds it back but under `spring.config.additional-configuration` that way all the options are appended or overridden but not entirely replaced.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/camunda/issues/28573
