### PR TITLE
[Backport stable/optimize-8.6] refactor: remove C7 tenants cache config from Optimize C8

### DIFF
--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/GlobalCacheConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/GlobalCacheConfiguration.java
@@ -11,7 +11,6 @@ import lombok.Data;
 
 @Data
 public class GlobalCacheConfiguration {
-  private CacheConfiguration tenants;
   private CacheConfiguration definitions;
   private CacheConfiguration definitionEngines;
   private CloudUserCacheConfiguration cloudUsers;

--- a/optimize/util/optimize-commons/src/main/resources/service-config.yaml
+++ b/optimize/util/optimize-commons/src/main/resources/service-config.yaml
@@ -775,11 +775,6 @@ onboarding:
 
 # Configuration of application internal in-memory caches
 caches:
-  # This cache is used to hold the list of available tenants.
-  # It helps to optimize the performance for reads on definitions, reports and collections.
-  tenants:
-    # the time a read result will be cached
-    defaultTtlMillis: 10000
   # This cache is used to cache the list of engines a particular definition is available on by definition key.
   # It helps to optimize the performance for listings of reports, collection data sources and collection roles.
   definitionEngines:


### PR DESCRIPTION
# Description
Backport of #28376 to `stable/optimize-8.6`.

relates to camunda/camunda-optimize#13375
original author: @abremard