### PR TITLE
[Backport stable/optimize-8.6] refactor: remove C7 engine-commons config from Optimize C8

### DIFF
--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationService.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationService.java
@@ -320,23 +320,6 @@ public class ConfigurationService {
     return maximumBackoff;
   }
 
-  public int getEngineConnectTimeout() {
-    if (engineConnectTimeout == null) {
-      engineConnectTimeout =
-          configJsonContext.read(
-              ConfigurationServiceConstants.ENGINE_CONNECT_TIMEOUT, Integer.class);
-    }
-    return engineConnectTimeout;
-  }
-
-  public int getEngineReadTimeout() {
-    if (engineReadTimeout == null) {
-      engineReadTimeout =
-          configJsonContext.read(ConfigurationServiceConstants.ENGINE_READ_TIMEOUT, Integer.class);
-    }
-    return engineReadTimeout;
-  }
-
   public int getCurrentTimeBackoffMilliseconds() {
     if (currentTimeBackoffMilliseconds == null) {
       currentTimeBackoffMilliseconds =

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceConstants.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceConstants.java
@@ -133,9 +133,6 @@ public class ConfigurationServiceConstants {
   public static final String IMPORT_INDEX_AUTO_STORAGE_INTERVAL =
       "$.import.importIndexStorageIntervalInSec";
 
-  public static final String ENGINE_CONNECT_TIMEOUT = "$.engine-commons.connection.timeout";
-  public static final String ENGINE_READ_TIMEOUT = "$.engine-commons.read.timeout";
-
   public static final String INITIAL_BACKOFF_INTERVAL = "$.import.handler.backoff.initial";
   public static final String MAXIMUM_BACK_OFF = "$.import.handler.backoff.max";
   public static final String ES_AGGREGATION_BUCKET_LIMIT = "$.es.settings.aggregationBucketLimit";

--- a/optimize/util/optimize-commons/src/main/resources/service-config.yaml
+++ b/optimize/util/optimize-commons/src/main/resources/service-config.yaml
@@ -183,18 +183,6 @@ engines:
       # Enables/disables linking to other Camunda Web Applications
       enabled: true
 
-engine-commons:
-  connection:
-    #Maximum time without connection to the engine, Optimize should wait
-    #until a timeout is triggered. A value of zero means to wait an
-    # infinite amount of time.
-    timeout: 0
-  read:
-    # Maximum time a request to the engine should last,
-    # before a timeout triggers. A value of zero means to wait an
-    # infinite amount of time.
-    timeout: 0
-
 zeebe:
   # Toggles whether Optimize should attempt to import data from the connected Zeebe instance
   enabled: ${CAMUNDA_OPTIMIZE_ZEEBE_ENABLED:false}


### PR DESCRIPTION
# Description
Backport of #28283 to `stable/optimize-8.6`.

relates to camunda/camunda-optimize#13375
original author: @abremard