### PR TITLE
fix: (8.6) bean post processor produced warn logs

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/annotation/processor/ZeebeAnnotationProcessorRegistry.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/annotation/processor/ZeebeAnnotationProcessorRegistry.java
@@ -41,6 +41,7 @@ public class ZeebeAnnotationProcessorRegistry implements BeanPostProcessor, Orde
   public Object postProcessAfterInitialization(final Object bean, final String beanName)
       throws BeansException {
     if (bean instanceof final AbstractZeebeAnnotationProcessor processor) {
+      LOG.debug("Found processor: {}", beanName);
       processors.add(processor);
     } else {
       beans.add(ClassInfo.builder().bean(bean).beanName(beanName).build());
@@ -67,6 +68,10 @@ public class ZeebeAnnotationProcessorRegistry implements BeanPostProcessor, Orde
         bean -> {
           for (final AbstractZeebeAnnotationProcessor zeebePostProcessor : processors) {
             if (zeebePostProcessor.isApplicableFor(bean)) {
+              LOG.debug(
+                  "Configuring bean {} with post processor {}",
+                  bean,
+                  zeebePostProcessor.getBeanName());
               zeebePostProcessor.configureFor(bean);
             }
           }

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/AnnotationProcessorConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/AnnotationProcessorConfiguration.java
@@ -16,7 +16,6 @@
 package io.camunda.zeebe.spring.client.configuration;
 
 import io.camunda.zeebe.spring.client.annotation.customizer.ZeebeWorkerValueCustomizer;
-import io.camunda.zeebe.spring.client.annotation.processor.AbstractZeebeAnnotationProcessor;
 import io.camunda.zeebe.spring.client.annotation.processor.ZeebeAnnotationProcessorRegistry;
 import io.camunda.zeebe.spring.client.annotation.processor.ZeebeDeploymentAnnotationProcessor;
 import io.camunda.zeebe.spring.client.annotation.processor.ZeebeWorkerAnnotationProcessor;
@@ -28,9 +27,8 @@ import org.springframework.context.annotation.Bean;
 public class AnnotationProcessorConfiguration {
 
   @Bean
-  public ZeebeAnnotationProcessorRegistry zeebeAnnotationProcessorRegistry(
-      final List<AbstractZeebeAnnotationProcessor> processors) {
-    return new ZeebeAnnotationProcessorRegistry(processors);
+  public static ZeebeAnnotationProcessorRegistry zeebeAnnotationProcessorRegistry() {
+    return new ZeebeAnnotationProcessorRegistry();
   }
 
   @Bean

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ExecutorServiceConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ExecutorServiceConfiguration.java
@@ -36,19 +36,11 @@ import org.springframework.context.annotation.Bean;
 @ConditionalOnMissingBean(ZeebeClientExecutorService.class)
 public class ExecutorServiceConfiguration {
 
-  private final ZeebeClientConfigurationProperties configurationProperties;
-  private final CamundaClientProperties camundaClientProperties;
-
-  public ExecutorServiceConfiguration(
-      final ZeebeClientConfigurationProperties configurationProperties,
-      final CamundaClientProperties camundaClientProperties) {
-    this.configurationProperties = configurationProperties;
-    this.camundaClientProperties = camundaClientProperties;
-  }
-
   @Bean
   public ZeebeClientExecutorService zeebeClientThreadPool(
-      @Autowired(required = false) final MeterRegistry meterRegistry) {
+      @Autowired(required = false) final MeterRegistry meterRegistry,
+      final ZeebeClientConfigurationProperties configurationProperties,
+      final CamundaClientProperties camundaClientProperties) {
     final ScheduledExecutorService threadPool =
         Executors.newScheduledThreadPool(
             getOrLegacyOrDefault(

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientAllAutoConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientAllAutoConfiguration.java
@@ -52,19 +52,11 @@ import org.springframework.context.annotation.Import;
 })
 public class ZeebeClientAllAutoConfiguration {
 
-  private final ZeebeClientConfigurationProperties configurationProperties;
-  private final CamundaClientProperties camundaClientProperties;
-
-  public ZeebeClientAllAutoConfiguration(
-      final ZeebeClientConfigurationProperties configurationProperties,
-      final CamundaClientProperties camundaClientProperties) {
-    this.configurationProperties = configurationProperties;
-    this.camundaClientProperties = camundaClientProperties;
-  }
-
   @Bean
   @ConditionalOnMissingBean
-  public ZeebeClientExecutorService zeebeClientExecutorService() {
+  public ZeebeClientExecutorService zeebeClientExecutorService(
+      final ZeebeClientConfigurationProperties configurationProperties,
+      final CamundaClientProperties camundaClientProperties) {
     return ZeebeClientExecutorService.createDefault(
         getOrLegacyOrDefault(
             "NumJobWorkerExecutionThreads",
@@ -119,7 +111,9 @@ public class ZeebeClientAllAutoConfiguration {
 
   @Bean("propertyBasedZeebeWorkerValueCustomizer")
   @ConditionalOnMissingBean(name = "propertyBasedZeebeWorkerValueCustomizer")
-  public ZeebeWorkerValueCustomizer propertyBasedZeebeWorkerValueCustomizer() {
+  public ZeebeWorkerValueCustomizer propertyBasedZeebeWorkerValueCustomizer(
+      final ZeebeClientConfigurationProperties configurationProperties,
+      final CamundaClientProperties camundaClientProperties) {
     return new PropertyBasedZeebeWorkerValueCustomizer(
         configurationProperties, camundaClientProperties);
   }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/AnnotationProcessorConfigurationTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/AnnotationProcessorConfigurationTest.java
@@ -40,7 +40,5 @@ public class AnnotationProcessorConfigurationTest {
   void shouldRun() {
     final List<AbstractZeebeAnnotationProcessor> processors = registry.getProcessors();
     assertThat(processors).hasSize(2);
-    assertThat(processors.get(0)).isInstanceOf(ZeebeDeploymentAnnotationProcessor.class);
-    assertThat(processors.get(1)).isInstanceOf(ZeebeWorkerAnnotationProcessor.class);
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/AnnotationProcessorConfigurationTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/AnnotationProcessorConfigurationTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.spring.client.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.spring.client.annotation.processor.AbstractZeebeAnnotationProcessor;
+import io.camunda.zeebe.spring.client.annotation.processor.ZeebeAnnotationProcessorRegistry;
+import io.camunda.zeebe.spring.client.annotation.processor.ZeebeDeploymentAnnotationProcessor;
+import io.camunda.zeebe.spring.client.annotation.processor.ZeebeWorkerAnnotationProcessor;
+import io.camunda.zeebe.spring.client.configuration.AnnotationProcessorConfiguration;
+import io.camunda.zeebe.spring.client.jobhandling.JobWorkerManager;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest(classes = AnnotationProcessorConfiguration.class)
+public class AnnotationProcessorConfigurationTest {
+  // required to auto-wire with the job worker annotation processor configuration
+  @MockBean JobWorkerManager jobWorkerManager;
+
+  @Autowired ZeebeAnnotationProcessorRegistry registry;
+
+  @Test
+  void shouldRun() {
+    final List<AbstractZeebeAnnotationProcessor> processors = registry.getProcessors();
+    assertThat(processors).hasSize(2);
+    assertThat(processors.get(0)).isInstanceOf(ZeebeDeploymentAnnotationProcessor.class);
+    assertThat(processors.get(1)).isInstanceOf(ZeebeWorkerAnnotationProcessor.class);
+  }
+}

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/AnnotationProcessorConfigurationTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/AnnotationProcessorConfigurationTest.java
@@ -40,5 +40,9 @@ public class AnnotationProcessorConfigurationTest {
   void shouldRun() {
     final List<AbstractZeebeAnnotationProcessor> processors = registry.getProcessors();
     assertThat(processors).hasSize(2);
+    assertThat(processors)
+        .anySatisfy(p -> assertThat(p).isInstanceOf(ZeebeWorkerAnnotationProcessor.class));
+    assertThat(processors)
+        .anySatisfy(p -> assertThat(p).isInstanceOf(ZeebeDeploymentAnnotationProcessor.class));
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/CredentialsProviderSelfManagedTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/CredentialsProviderSelfManagedTest.java
@@ -66,8 +66,6 @@ public class CredentialsProviderSelfManagedTest {
   static WireMockExtension wm =
       WireMockExtension.newInstance().options(new WireMockConfiguration().dynamicPort()).build();
 
-  private static final String ACCESS_TOKEN =
-      JWT.create().withExpiresAt(Instant.now().plusSeconds(300)).sign(Algorithm.none());
   @MockBean ZeebeClientExecutorService zeebeClientExecutorService;
   @Autowired ZeebeClientConfigurationImpl configuration;
 
@@ -97,7 +95,8 @@ public class CredentialsProviderSelfManagedTest {
     final CredentialsProvider credentialsProvider = configuration.getCredentialsProvider();
     final Map<String, String> headers = new HashMap<>();
 
-    final String accessToken = ACCESS_TOKEN;
+    final String accessToken =
+        JWT.create().withExpiresAt(Instant.now().plusSeconds(300)).sign(Algorithm.none());
     wm.stubFor(
         post("/auth-server")
             .willReturn(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This fix resolves the issue that the sdk produces logs about a misconfigured post processor.

Instead of injecting the post processor beans, it picks them up after init and processes the rest of the beans on opening the zeebe client. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
