### PR TITLE
fix: (main) bean post processor produced warn logs

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/pom.xml
+++ b/clients/spring-boot-starter-camunda-sdk/pom.xml
@@ -217,6 +217,11 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -237,6 +242,7 @@
             <dependency>io.camunda:zeebe-protocol-jackson</dependency>
             <dependency>org.springframework.boot:spring-boot-configuration-processor</dependency>
             <dependency>commons-collections:commons-collections</dependency>
+            <dependency>ch.qos.logback:logback-classic</dependency>
           </usedDependencies>
         </configuration>
       </plugin>

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/annotation/processor/CamundaAnnotationProcessorRegistry.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/annotation/processor/CamundaAnnotationProcessorRegistry.java
@@ -19,7 +19,13 @@ import io.camunda.client.CamundaClient;
 import io.camunda.spring.client.bean.ClassInfo;
 import io.camunda.spring.client.configuration.AnnotationProcessorConfiguration;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.core.Ordered;
@@ -30,8 +36,10 @@ import org.springframework.core.Ordered;
  * <p>Keeps a list of all annotations and reads them after all Spring beans are initialized
  */
 public class CamundaAnnotationProcessorRegistry implements BeanPostProcessor, Ordered {
-
-  private final List<AbstractCamundaAnnotationProcessor> processors = new ArrayList<>();
+  private static final Logger LOG =
+      LoggerFactory.getLogger(CamundaAnnotationProcessorRegistry.class);
+  private final Set<AbstractCamundaAnnotationProcessor> processors = new HashSet<>();
+  private final Map<String, Object> beans = new HashMap<>();
 
   @Override
   public Object postProcessBeforeInitialization(final Object bean, final String beanName)
@@ -45,14 +53,12 @@ public class CamundaAnnotationProcessorRegistry implements BeanPostProcessor, Or
   @Override
   public Object postProcessAfterInitialization(final Object bean, final String beanName)
       throws BeansException {
-    final ClassInfo beanInfo = ClassInfo.builder().bean(bean).beanName(beanName).build();
-
-    for (final AbstractCamundaAnnotationProcessor camundaPostProcessor : processors) {
-      if (camundaPostProcessor.isApplicableFor(beanInfo)) {
-        camundaPostProcessor.configureFor(beanInfo);
-      }
+    if (bean instanceof final AbstractCamundaAnnotationProcessor processor) {
+      LOG.debug("Found processor: {}", beanName);
+      processors.add(processor);
+    } else {
+      beans.put(beanName, bean);
     }
-
     return bean;
   }
 
@@ -62,11 +68,29 @@ public class CamundaAnnotationProcessorRegistry implements BeanPostProcessor, Or
   }
 
   public void startAll(final CamundaClient client) {
+    processBeans();
     processors.forEach(camundaPostProcessor -> camundaPostProcessor.start(client));
   }
 
   public void stopAll(final CamundaClient client) {
     processors.forEach(camundaPostProcessor -> camundaPostProcessor.stop(client));
+  }
+
+  private void processBeans() {
+    beans.forEach(
+        (beanName, bean) -> {
+          final ClassInfo classInfo = ClassInfo.builder().bean(bean).beanName(beanName).build();
+          for (final AbstractCamundaAnnotationProcessor zeebePostProcessor : processors) {
+            if (zeebePostProcessor.isApplicableFor(classInfo)) {
+              LOG.debug(
+                  "Configuring bean {} with post processor {}",
+                  beanName,
+                  zeebePostProcessor.getBeanName());
+              zeebePostProcessor.configureFor(classInfo);
+            }
+          }
+        });
+    beans.clear();
   }
 
   @Override

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/annotation/processor/CamundaAnnotationProcessorRegistry.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/annotation/processor/CamundaAnnotationProcessorRegistry.java
@@ -81,12 +81,12 @@ public class CamundaAnnotationProcessorRegistry implements BeanPostProcessor, Or
         (beanName, bean) -> {
           final ClassInfo classInfo = ClassInfo.builder().bean(bean).beanName(beanName).build();
           for (final AbstractCamundaAnnotationProcessor camundaProcessor : processors) {
-            if (zeebePostProcessor.isApplicableFor(classInfo)) {
+            if (camundaProcessor.isApplicableFor(classInfo)) {
               LOG.debug(
                   "Configuring bean {} with post processor {}",
                   beanName,
-                  zeebePostProcessor.getBeanName());
-              zeebePostProcessor.configureFor(classInfo);
+                  camundaProcessor.getBeanName());
+              camundaProcessor.configureFor(classInfo);
             }
           }
         });

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/annotation/processor/CamundaAnnotationProcessorRegistry.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/annotation/processor/CamundaAnnotationProcessorRegistry.java
@@ -80,7 +80,7 @@ public class CamundaAnnotationProcessorRegistry implements BeanPostProcessor, Or
     beans.forEach(
         (beanName, bean) -> {
           final ClassInfo classInfo = ClassInfo.builder().bean(bean).beanName(beanName).build();
-          for (final AbstractCamundaAnnotationProcessor zeebePostProcessor : processors) {
+          for (final AbstractCamundaAnnotationProcessor camundaProcessor : processors) {
             if (zeebePostProcessor.isApplicableFor(classInfo)) {
               LOG.debug(
                   "Configuring bean {} with post processor {}",

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/AnnotationProcessorConfigurationTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/AnnotationProcessorConfigurationTest.java
@@ -19,8 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.spring.client.annotation.processor.AbstractCamundaAnnotationProcessor;
 import io.camunda.spring.client.annotation.processor.CamundaAnnotationProcessorRegistry;
-import io.camunda.spring.client.annotation.processor.DeploymentAnnotationProcessor;
-import io.camunda.spring.client.annotation.processor.JobWorkerAnnotationProcessor;
 import io.camunda.spring.client.configuration.AnnotationProcessorConfiguration;
 import io.camunda.spring.client.jobhandling.JobWorkerManager;
 import java.util.List;
@@ -40,7 +38,5 @@ public class AnnotationProcessorConfigurationTest {
   void shouldRun() {
     final List<AbstractCamundaAnnotationProcessor> processors = registry.getProcessors();
     assertThat(processors).hasSize(2);
-    assertThat(processors.get(0)).isInstanceOf(DeploymentAnnotationProcessor.class);
-    assertThat(processors.get(1)).isInstanceOf(JobWorkerAnnotationProcessor.class);
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/AnnotationProcessorConfigurationTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/AnnotationProcessorConfigurationTest.java
@@ -19,6 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.spring.client.annotation.processor.AbstractCamundaAnnotationProcessor;
 import io.camunda.spring.client.annotation.processor.CamundaAnnotationProcessorRegistry;
+import io.camunda.spring.client.annotation.processor.DeploymentAnnotationProcessor;
+import io.camunda.spring.client.annotation.processor.JobWorkerAnnotationProcessor;
 import io.camunda.spring.client.configuration.AnnotationProcessorConfiguration;
 import io.camunda.spring.client.jobhandling.JobWorkerManager;
 import java.util.List;
@@ -38,5 +40,9 @@ public class AnnotationProcessorConfigurationTest {
   void shouldRun() {
     final List<AbstractCamundaAnnotationProcessor> processors = registry.getProcessors();
     assertThat(processors).hasSize(2);
+    assertThat(processors)
+        .anySatisfy(p -> assertThat(p).isInstanceOf(JobWorkerAnnotationProcessor.class));
+    assertThat(processors)
+        .anySatisfy(p -> assertThat(p).isInstanceOf(DeploymentAnnotationProcessor.class));
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/AnnotationProcessorConfigurationTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/AnnotationProcessorConfigurationTest.java
@@ -17,32 +17,99 @@ package io.camunda.spring.client.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.client.CamundaClient;
 import io.camunda.spring.client.annotation.processor.AbstractCamundaAnnotationProcessor;
 import io.camunda.spring.client.annotation.processor.CamundaAnnotationProcessorRegistry;
-import io.camunda.spring.client.annotation.processor.DeploymentAnnotationProcessor;
-import io.camunda.spring.client.annotation.processor.JobWorkerAnnotationProcessor;
+import io.camunda.spring.client.bean.ClassInfo;
 import io.camunda.spring.client.configuration.AnnotationProcessorConfiguration;
 import io.camunda.spring.client.jobhandling.JobWorkerManager;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-@SpringBootTest(classes = AnnotationProcessorConfiguration.class)
+@SpringBootTest(
+    classes = {
+      AnnotationProcessorConfiguration.class,
+      AnnotationProcessorConfigurationTest.TestConfig.class
+    })
 public class AnnotationProcessorConfigurationTest {
   // required to auto-wire with the job worker annotation processor configuration
   @MockitoBean JobWorkerManager jobWorkerManager;
-
+  @MockitoBean CamundaClient camundaClient;
   @Autowired CamundaAnnotationProcessorRegistry registry;
+  @Autowired MockedBean mockedBean;
 
   @Test
   void shouldRun() {
+    // when - we mock the creation of the camunda client
+    registry.startAll(camundaClient);
+    // then
     final List<AbstractCamundaAnnotationProcessor> processors = registry.getProcessors();
-    assertThat(processors).hasSize(2);
     assertThat(processors)
-        .anySatisfy(p -> assertThat(p).isInstanceOf(JobWorkerAnnotationProcessor.class));
-    assertThat(processors)
-        .anySatisfy(p -> assertThat(p).isInstanceOf(DeploymentAnnotationProcessor.class));
+        .anySatisfy(p -> assertThat(p).isInstanceOf(MockCamundaAnnotationProcessor.class));
+    assertThat(mockedBean.isConfigured()).isTrue();
+    assertThat(mockedBean.isStarted()).isTrue();
+  }
+
+  @Configuration
+  static class TestConfig {
+    @Bean
+    public MockCamundaAnnotationProcessor mockCamundaAnnotationProcessor() {
+      return new MockCamundaAnnotationProcessor();
+    }
+
+    @Bean
+    public MockedBean mockedBean() {
+      return new MockedBean();
+    }
+  }
+
+  private static class MockCamundaAnnotationProcessor extends AbstractCamundaAnnotationProcessor {
+    private MockedBean mockedBean;
+
+    @Override
+    public boolean isApplicableFor(final ClassInfo beanInfo) {
+      return beanInfo.getBean() instanceof MockedBean;
+    }
+
+    @Override
+    public void configureFor(final ClassInfo beanInfo) {
+      final MockedBean bean = (MockedBean) beanInfo.getBean();
+      bean.setConfigured(true);
+      mockedBean = bean;
+    }
+
+    @Override
+    public void start(final CamundaClient client) {
+      mockedBean.setStarted(true);
+    }
+
+    @Override
+    public void stop(final CamundaClient client) {}
+  }
+
+  private static class MockedBean {
+    private boolean configured;
+    private boolean started;
+
+    public boolean isConfigured() {
+      return configured;
+    }
+
+    public void setConfigured(final boolean configured) {
+      this.configured = configured;
+    }
+
+    public boolean isStarted() {
+      return started;
+    }
+
+    public void setStarted(final boolean started) {
+      this.started = started;
+    }
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/AnnotationProcessorConfigurationTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/AnnotationProcessorConfigurationTest.java
@@ -68,7 +68,8 @@ public class AnnotationProcessorConfigurationTest {
     }
   }
 
-  private static class MockCamundaAnnotationProcessor extends AbstractCamundaAnnotationProcessor {
+  private static final class MockCamundaAnnotationProcessor
+      extends AbstractCamundaAnnotationProcessor {
     private MockedBean mockedBean;
 
     @Override
@@ -92,7 +93,7 @@ public class AnnotationProcessorConfigurationTest {
     public void stop(final CamundaClient client) {}
   }
 
-  private static class MockedBean {
+  private static final class MockedBean {
     private boolean configured;
     private boolean started;
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR fixes the bean post processing that I recently broke...

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
