### PR TITLE
Root-cause flaky IncidentQueryTest

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/IncidentImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/IncidentImpl.java
@@ -151,4 +151,39 @@ public class IncidentImpl implements Incident {
         && Objects.equals(jobKey, incident.jobKey)
         && Objects.equals(tenantId, incident.tenantId);
   }
+
+  @Override
+  public String toString() {
+    return "IncidentImpl{"
+        + "incidentKey="
+        + incidentKey
+        + ", processDefinitionKey="
+        + processDefinitionKey
+        + ", processDefinitionId='"
+        + processDefinitionId
+        + '\''
+        + ", processInstanceKey="
+        + processInstanceKey
+        + ", errorType="
+        + errorType
+        + ", errorMessage='"
+        + errorMessage
+        + '\''
+        + ", flowNodeId='"
+        + flowNodeId
+        + '\''
+        + ", flowNodeInstanceKey="
+        + flowNodeInstanceKey
+        + ", creationTime='"
+        + creationTime
+        + '\''
+        + ", state="
+        + state
+        + ", jobKey="
+        + jobKey
+        + ", tenantId='"
+        + tenantId
+        + '\''
+        + '}';
+  }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentQueryTest.java
@@ -82,7 +82,7 @@ class IncidentQueryTest {
 
     // then
     assertThat(result).isNotNull();
-    assertThat(result).isEqualTo(incident);
+    assertThat(result.getIncidentKey()).isEqualTo(incidentKey);
   }
 
   @Test

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentQueryTest.java
@@ -82,7 +82,7 @@ class IncidentQueryTest {
 
     // then
     assertThat(result).isNotNull();
-    assertThat(result.getIncidentKey()).isEqualTo(incidentKey);
+    assertThat(result).isEqualTo(incident);
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR adds `toString` to the `IncidentImpl` to find out how the incident differs when the test fails from time to time.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

related to #24271 
