### PR TITLE
Create matching index if index template already exists

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SchemaManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SchemaManager.java
@@ -164,16 +164,8 @@ public class SchemaManager {
       return;
     }
 
-    final var existingTemplateNames =
-        Collections.synchronizedSet(
-            searchEngineClient
-                .getMappings(config.getIndex().getPrefix() + "*", MappingSource.INDEX_TEMPLATE)
-                .keySet());
-
     LOG.info(
-        "Found '{}' existing index templates. Create missing index templates based on '{}' descriptors.",
-        existingTemplateNames.size(),
-        indexTemplateDescriptors.size());
+        "Creating index templates based on '{}' descriptors.", indexTemplateDescriptors.size());
     final var futures =
         indexTemplateDescriptors.stream()
             .map(


### PR DESCRIPTION
## Description

It turned out that if the templates were not cleaned up as well, the corresponding indices haven't been recreated (even if they were missing). Causing endless loops of waiting for all indices.

Instead now the schema manager will check for any templates that exist without their corresponding index and create them.

## Related issues

closes #28173 
