### PR TITLE
fix: improve test case for process definition deploys

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessDefinitionQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessDefinitionQueryTest.java
@@ -584,7 +584,7 @@ public class ProcessDefinitionQueryTest {
                       .join();
 
               assertThat(resultForm.getFormId().equals("test"));
-              assertEquals(2L,resultForm.getVersion());
+              assertEquals(2L, resultForm.getVersion());
             });
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessDefinitionQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessDefinitionQueryTest.java
@@ -8,6 +8,7 @@
 package io.camunda.it.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 import io.camunda.client.CamundaClient;
@@ -38,25 +39,18 @@ public class ProcessDefinitionQueryTest {
 
   @BeforeAll
   public static void beforeAll() throws InterruptedException {
-
-    // Deploy form
-    deployResource(String.format("form/%s", "form.form"));
-    deployResource(String.format("form/%s", "form_v2.form"));
+    final List<String> forms = List.of("form.form", "form_v2.form");
+    forms.forEach(form -> deployResource("form/" + form));
 
     final List<String> processes =
         List.of(
             "service_tasks_v1.bpmn",
             "service_tasks_v2.bpmn",
-            "incident_process_v1.bpmn",
-            "manual_process.bpmn",
-            "parent_process_v1.bpmn",
-            "child_process_v1.bpmn",
             "process_start_form.bpmn",
             "processWithVersionTag.bpmn");
+
     processes.forEach(
-        process ->
-            DEPLOYED_PROCESSES.addAll(
-                deployResource(String.format("process/%s", process)).getProcesses()));
+        process -> DEPLOYED_PROCESSES.addAll(deployResource("process/" + process).getProcesses()));
 
     waitForProcessesToBeDeployed();
   }
@@ -283,7 +277,7 @@ public class ProcessDefinitionQueryTest {
         camundaClient.newProcessDefinitionQuery().filter(f -> f.version(version)).send().join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(8);
+    assertThat(result.items().size()).isEqualTo(4);
     assertThat(result.items().getFirst().getVersion()).isEqualTo(version);
   }
 
@@ -315,7 +309,7 @@ public class ProcessDefinitionQueryTest {
         camundaClient.newProcessDefinitionQuery().filter(f -> f.tenantId(tenantId)).send().join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(8);
+    assertThat(result.items().size()).isEqualTo(4);
     assertThat(result.items().getFirst().getTenantId()).isEqualTo(tenantId);
   }
 
@@ -333,7 +327,7 @@ public class ProcessDefinitionQueryTest {
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(8);
+    assertThat(result.items().size()).isEqualTo(4);
     assertThat(result.items().getFirst().getVersionTag()).isEqualTo(versionTag);
   }
 
@@ -373,7 +367,7 @@ public class ProcessDefinitionQueryTest {
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(8);
+    assertThat(result.items().size()).isEqualTo(4);
     assertThat(result.items().stream().map(ProcessDefinition::getProcessDefinitionId).toList())
         .containsExactlyElementsOf(expectedProcessDefinitionIds);
   }
@@ -524,7 +518,7 @@ public class ProcessDefinitionQueryTest {
             .send()
             .join();
 
-    assertThat(resultAfter.items().size()).isEqualTo(7);
+    assertThat(resultAfter.items().size()).isEqualTo(3);
     final var keyAfter = resultAfter.items().getFirst().getProcessDefinitionKey();
     // apply searchBefore
     final var resultBefore =
@@ -566,7 +560,7 @@ public class ProcessDefinitionQueryTest {
 
   private static void waitForProcessesToBeDeployed() throws InterruptedException {
     Awaitility.await("should deploy processes and import in Operate")
-        .atMost(Duration.ofMinutes(3))
+        .atMost(Duration.ofMinutes(5))
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {
@@ -590,6 +584,7 @@ public class ProcessDefinitionQueryTest {
                       .join();
 
               assertThat(resultForm.getFormId().equals("test"));
+              assertEquals(2L,resultForm.getVersion());
             });
   }
 }


### PR DESCRIPTION
## Description

The process query test is flaky because it is not deploying the processes in 3 minutes: (As it i deploying 8 processes + 2 forms)

Error:
Condition with alias 'should deploy processes and import in Operate' didn't complete within 3 minutes because assertion condition defined as a Lambda expression in io.camunda.it.client.ProcessDefinitionQueryTest 

This PR covers: 
- Going to reduce the number of processes deployed (there are process deployed that are not really used in test case)
- Increase the time to check if the process are deployed

## Related issues

closes #https://github.com/camunda/camunda/issues/24551
