### PR TITLE
[Backport stable/8.7] fix: Return document ID when storing doc locally

### DIFF
--- a/document/store/src/main/java/io/camunda/document/store/localstorage/LocalStorageDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/localstorage/LocalStorageDocumentStore.java
@@ -120,7 +120,7 @@ public class LocalStorageDocumentStore implements DocumentStore {
       return Either.left(new UnknownDocumentError(e));
     }
     return Either.right(
-        new DocumentReference(request.documentId(), hashResult.contentHash(), request.metadata()));
+        new DocumentReference(documentId, hashResult.contentHash(), request.metadata()));
   }
 
   private Either<DocumentError, DocumentContent> getDocumentInternal(final String documentId) {

--- a/document/store/src/test/java/io/camunda/document/store/localstorage/LocalStorageDocumentStoreTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/localstorage/LocalStorageDocumentStoreTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.document.store.localstorage;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -61,6 +62,28 @@ class LocalStorageDocumentStoreTest {
     // then
     assertTrue(result.isRight());
     assertEquals(documentId, result.get().documentId());
+    assertTrue(Files.exists(storagePath.resolve(documentId)));
+    assertTrue(
+        Files.exists(storagePath.resolve(documentId + LocalStorageDocumentStore.METADATA_SUFFIX)));
+  }
+
+  @Test
+  void createDocumentWithoutIdShouldReturnTheDocumentId() {
+    // given
+    final byte[] content = "test-content".getBytes();
+    final ByteArrayInputStream inputStream = new ByteArrayInputStream(content);
+    final DocumentMetadataModel metadata = givenMetadata(content);
+    final DocumentCreationRequest request =
+        new DocumentCreationRequest(null, inputStream, metadata);
+
+    // when
+    final var result = documentStore.createDocument(request).join();
+
+    // then
+    assertTrue(result.isRight());
+
+    final var documentId = result.get().documentId();
+    assertThat(documentId).isNotNull();
     assertTrue(Files.exists(storagePath.resolve(documentId)));
     assertTrue(
         Files.exists(storagePath.resolve(documentId + LocalStorageDocumentStore.METADATA_SUFFIX)));


### PR DESCRIPTION
# Description
Backport of #28419 to `stable/8.7`.

relates to camunda/camunda#28418
original author: @georgios-goulos