### PR TITLE
Implement endpoint and command to activate an ad-hoc subprocess activity

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -16,6 +16,7 @@
 package io.camunda.client;
 
 import io.camunda.client.api.ExperimentalApi;
+import io.camunda.client.api.command.ActivateAdHocSubprocessActivitiesCommandStep1;
 import io.camunda.client.api.command.AssignGroupToTenantCommandStep1;
 import io.camunda.client.api.command.AssignMappingToTenantCommandStep1;
 import io.camunda.client.api.command.AssignUserTaskCommandStep1;
@@ -899,6 +900,25 @@ public interface CamundaClient extends AutoCloseable, JobClient {
   @ExperimentalApi("https://github.com/camunda/camunda/issues/27930")
   AdHocSubprocessActivityQuery newAdHocSubprocessActivityQuery(
       long processDefinitionKey, String adHocSubprocessId);
+
+  /**
+   * Command to activate activities within an activated ad-hoc subprocess.
+   *
+   * <pre>
+   *   camundaClient
+   *    .newActivateAdHocSubprocessActivitiesCommand(adHocSubprocessInstanceKey)
+   *    .activateElement("A")
+   *    .activateElements("B", "C")
+   *    .activateElements(Arrays.asList("D", "E"))
+   *    .send();
+   * </pre>
+   *
+   * @param adHocSubprocessInstanceKey the key which identifies the corresponding ad-hoc subprocess
+   *     instance
+   * @return a builder for the command
+   */
+  ActivateAdHocSubprocessActivitiesCommandStep1 newActivateAdHocSubprocessActivitiesCommand(
+      String adHocSubprocessInstanceKey);
 
   /**
    * Executes a search request to query user tasks.

--- a/clients/java/src/main/java/io/camunda/client/api/command/ActivateAdHocSubprocessActivitiesCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ActivateAdHocSubprocessActivitiesCommandStep1.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.ActivateAdHocSubprocessActivitiesResponse;
+import java.util.Arrays;
+import java.util.Collection;
+
+public interface ActivateAdHocSubprocessActivitiesCommandStep1 {
+
+  /**
+   * Create an {@link io.camunda.client.protocol.rest.AdHocSubprocessActivateActivitiesInstruction}
+   * for the given element id.
+   *
+   * @param elementId the id of the element to activate
+   * @return the builder for this command
+   */
+  ActivateAdHocSubprocessActivitiesCommandStep2 activateElement(final String elementId);
+
+  /**
+   * Create an {@link io.camunda.client.protocol.rest.AdHocSubprocessActivateActivitiesInstruction}
+   * for each of the given element ids.
+   *
+   * @param elementIds the ids of the elements to activate
+   * @return the builder for this command
+   * @throws IllegalArgumentException if elementIds is null or empty
+   */
+  default ActivateAdHocSubprocessActivitiesCommandStep2 activateElements(
+      final Collection<String> elementIds) {
+    if (elementIds == null || elementIds.isEmpty()) {
+      throw new IllegalArgumentException("elementIds must not be empty");
+    }
+
+    ActivateAdHocSubprocessActivitiesCommandStep2 builder = null;
+    for (final String elementId : elementIds) {
+      builder = activateElement(elementId);
+    }
+
+    return builder;
+  }
+
+  /**
+   * Create an {@link io.camunda.client.protocol.rest.AdHocSubprocessActivateActivitiesInstruction}
+   * for each of the given element ids.
+   *
+   * @param elementIds the ids of the elements to activate
+   * @return the builder for this command
+   * @throws IllegalArgumentException if elementIds is null or empty
+   */
+  default ActivateAdHocSubprocessActivitiesCommandStep2 activateElements(
+      final String... elementIds) {
+    return activateElements(Arrays.asList(elementIds));
+  }
+
+  interface ActivateAdHocSubprocessActivitiesCommandStep2
+      extends ActivateAdHocSubprocessActivitiesCommandStep1,
+          FinalCommandStep<ActivateAdHocSubprocessActivitiesResponse> {}
+}

--- a/clients/java/src/main/java/io/camunda/client/api/response/ActivateAdHocSubprocessActivitiesResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ActivateAdHocSubprocessActivitiesResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+public interface ActivateAdHocSubprocessActivitiesResponse {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -21,6 +21,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientConfiguration;
 import io.camunda.client.CredentialsProvider;
 import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.ActivateAdHocSubprocessActivitiesCommandStep1;
 import io.camunda.client.api.command.ActivateJobsCommandStep1;
 import io.camunda.client.api.command.AssignGroupToTenantCommandStep1;
 import io.camunda.client.api.command.AssignMappingToTenantCommandStep1;
@@ -103,6 +104,7 @@ import io.camunda.client.api.search.query.UserTaskVariableQuery;
 import io.camunda.client.api.search.query.VariableQuery;
 import io.camunda.client.api.worker.JobClient;
 import io.camunda.client.api.worker.JobWorkerBuilderStep1;
+import io.camunda.client.impl.command.ActivateAdHocSubprocessActivitiesCommandImpl;
 import io.camunda.client.impl.command.AssignGroupToTenantCommandImpl;
 import io.camunda.client.impl.command.AssignMappingToTenantCommandImpl;
 import io.camunda.client.impl.command.AssignUserTaskCommandImpl;
@@ -689,6 +691,13 @@ public final class CamundaClientImpl implements CamundaClient {
                 filter
                     .processDefinitionKey(processDefinitionKey)
                     .adHocSubprocessId(adHocSubprocessId));
+  }
+
+  @Override
+  public ActivateAdHocSubprocessActivitiesCommandStep1 newActivateAdHocSubprocessActivitiesCommand(
+      final String adHocSubprocessInstanceKey) {
+    return new ActivateAdHocSubprocessActivitiesCommandImpl(
+        httpClient, jsonMapper, adHocSubprocessInstanceKey);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ActivateAdHocSubprocessActivitiesCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ActivateAdHocSubprocessActivitiesCommandImpl.java
@@ -71,7 +71,7 @@ public final class ActivateAdHocSubprocessActivitiesCommandImpl
     final HttpCamundaFuture<ActivateAdHocSubprocessActivitiesResponse> result =
         new HttpCamundaFuture<>();
     httpClient.post(
-        "/element-instances/ad-hoc-activities/" + adHocSubprocessInstanceKey + "/activate",
+        "/element-instances/ad-hoc-activities/" + adHocSubprocessInstanceKey + "/activation",
         jsonMapper.toJson(httpRequestObject),
         httpRequestConfig.build(),
         result);

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ActivateAdHocSubprocessActivitiesCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ActivateAdHocSubprocessActivitiesCommandImpl.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.ActivateAdHocSubprocessActivitiesCommandStep1;
+import io.camunda.client.api.command.ActivateAdHocSubprocessActivitiesCommandStep1.ActivateAdHocSubprocessActivitiesCommandStep2;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.response.ActivateAdHocSubprocessActivitiesResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.protocol.rest.AdHocSubprocessActivateActivitiesInstruction;
+import io.camunda.client.protocol.rest.AdHocSubprocessActivateActivityReference;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public final class ActivateAdHocSubprocessActivitiesCommandImpl
+    implements ActivateAdHocSubprocessActivitiesCommandStep1,
+        ActivateAdHocSubprocessActivitiesCommandStep2 {
+
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  private final String adHocSubprocessInstanceKey;
+  private final AdHocSubprocessActivateActivitiesInstruction httpRequestObject;
+
+  public ActivateAdHocSubprocessActivitiesCommandImpl(
+      final HttpClient httpClient,
+      final JsonMapper jsonMapper,
+      final String adHocSubprocessInstanceKey) {
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    httpRequestConfig = httpClient.newRequestConfig();
+
+    this.adHocSubprocessInstanceKey = adHocSubprocessInstanceKey;
+    httpRequestObject = new AdHocSubprocessActivateActivitiesInstruction();
+  }
+
+  @Override
+  public ActivateAdHocSubprocessActivitiesCommandStep2 activateElement(final String elementId) {
+    httpRequestObject.addElementsItem(
+        new AdHocSubprocessActivateActivityReference().elementId(elementId));
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<ActivateAdHocSubprocessActivitiesResponse> requestTimeout(
+      final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<ActivateAdHocSubprocessActivitiesResponse> send() {
+    final HttpCamundaFuture<ActivateAdHocSubprocessActivitiesResponse> result =
+        new HttpCamundaFuture<>();
+    httpClient.post(
+        "/element-instances/ad-hoc-activities/" + adHocSubprocessInstanceKey + "/activate",
+        jsonMapper.toJson(httpRequestObject),
+        httpRequestConfig.build(),
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/ActivateAdHocSubprocessActivitiesResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/ActivateAdHocSubprocessActivitiesResponseImpl.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.ActivateAdHocSubprocessActivitiesResponse;
+
+public class ActivateAdHocSubprocessActivitiesResponseImpl
+    implements ActivateAdHocSubprocessActivitiesResponse {}

--- a/clients/java/src/test/java/io/camunda/client/adhocsubprocess/AdHocSubprocessActivityActivationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/adhocsubprocess/AdHocSubprocessActivityActivationTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.adhocsubprocess;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.api.command.ActivateAdHocSubprocessActivitiesCommandStep1;
+import io.camunda.client.api.command.ActivateAdHocSubprocessActivitiesCommandStep1.ActivateAdHocSubprocessActivitiesCommandStep2;
+import io.camunda.client.protocol.rest.AdHocSubprocessActivateActivitiesInstruction;
+import io.camunda.client.protocol.rest.AdHocSubprocessActivateActivityReference;
+import io.camunda.client.util.ClientRestTest;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+public class AdHocSubprocessActivityActivationTest extends ClientRestTest {
+
+  private static final String AD_HOC_SUBPROCESS_INSTANCE_KEY = "123456789";
+
+  @ParameterizedTest
+  @MethodSource("requestModifiers")
+  void shouldActivateAdHocSubprocessActivities(
+      final Function<
+              ActivateAdHocSubprocessActivitiesCommandStep1,
+              ActivateAdHocSubprocessActivitiesCommandStep2>
+          requestModifier) {
+    final ActivateAdHocSubprocessActivitiesCommandStep1 command =
+        client.newActivateAdHocSubprocessActivitiesCommand(AD_HOC_SUBPROCESS_INSTANCE_KEY);
+    requestModifier.apply(command).send().join();
+
+    final AdHocSubprocessActivateActivitiesInstruction request =
+        gatewayService.getLastRequest(AdHocSubprocessActivateActivitiesInstruction.class);
+    assertThat(request.getElements())
+        .extracting(AdHocSubprocessActivateActivityReference::getElementId)
+        .containsExactly("A", "B", "C");
+  }
+
+  @Test
+  void shouldActivateAdHocSubprocessActivitiesCombiningActivationMethods() {
+    client
+        .newActivateAdHocSubprocessActivitiesCommand(AD_HOC_SUBPROCESS_INSTANCE_KEY)
+        .activateElement("A")
+        .activateElements("B", "C")
+        .activateElements(Arrays.asList("D", "E"))
+        .send()
+        .join();
+
+    final AdHocSubprocessActivateActivitiesInstruction request =
+        gatewayService.getLastRequest(AdHocSubprocessActivateActivitiesInstruction.class);
+    assertThat(request.getElements())
+        .extracting(AdHocSubprocessActivateActivityReference::getElementId)
+        .containsExactly("A", "B", "C", "D", "E");
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void throwsExceptionWhenElementsCollectionIsNullOrEmpty(final Collection<String> elementIds) {
+    final ActivateAdHocSubprocessActivitiesCommandStep1 command =
+        client.newActivateAdHocSubprocessActivitiesCommand(AD_HOC_SUBPROCESS_INSTANCE_KEY);
+
+    assertThatThrownBy(() -> command.activateElements(elementIds))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("elementIds must not be empty");
+  }
+
+  @Test
+  void throwsExceptionWhenElementsArrayIsEmpty() {
+    final ActivateAdHocSubprocessActivitiesCommandStep1 command =
+        client.newActivateAdHocSubprocessActivitiesCommand(AD_HOC_SUBPROCESS_INSTANCE_KEY);
+
+    assertThatThrownBy(() -> command.activateElements(new String[] {}))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("elementIds must not be empty");
+  }
+
+  static Stream<
+          Function<
+              ActivateAdHocSubprocessActivitiesCommandStep1,
+              ActivateAdHocSubprocessActivitiesCommandStep2>>
+      requestModifiers() {
+    return Stream.of(
+        command -> command.activateElement("A").activateElement("B").activateElement("C"),
+        command -> command.activateElements("A", "B", "C"),
+        command -> command.activateElements(Arrays.asList("A", "B", "C")));
+  }
+}

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -874,6 +874,7 @@
         #     userTask: true
         #     variable: true
         #     variableDocument: true
+        #     adHocSubProcessActivityActivation: true
         #
         #   retention:
         #     enabled: false

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -788,6 +788,7 @@
         #     userTask: true
         #     variable: true
         #     variableDocument: true
+        #     adHocSubProcessActivityActivation: true
         #
         #   retention:
         #     enabled: false

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestSupport.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestSupport.java
@@ -63,6 +63,8 @@ public final class TestSupport {
       case USER_TASK -> config.userTask = value;
       case COMPENSATION_SUBSCRIPTION -> config.compensationSubscription = value;
       case MESSAGE_CORRELATION -> config.messageCorrelation = value;
+      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
+          config.adHocSubProcessActivityActivation = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);
@@ -109,6 +111,8 @@ public final class TestSupport {
       case USER_TASK -> config.userTask = value;
       case COMPENSATION_SUBSCRIPTION -> config.compensationSubscription = value;
       case MESSAGE_CORRELATION -> config.messageCorrelation = value;
+      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
+          config.adHocSubProcessActivityActivation = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);

--- a/service/src/main/java/io/camunda/service/AdHocSubprocessActivityServices.java
+++ b/service/src/main/java/io/camunda/service/AdHocSubprocessActivityServices.java
@@ -14,8 +14,10 @@ import io.camunda.search.exception.NotFoundException;
 import io.camunda.search.query.AdHocSubprocessActivityQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
+import io.camunda.service.AdHocSubprocessActivityServices.AdHocSubprocessActivateActivitiesRequest.AdHocSubprocessActivateActivityReference;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateAdHocSubprocessActivityRequest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
@@ -110,8 +112,15 @@ public class AdHocSubprocessActivityServices extends ApiServices<AdHocSubprocess
 
   public CompletableFuture<AdHocSubProcessActivityActivationRecord> activateActivities(
       final AdHocSubprocessActivateActivitiesRequest request) {
-    // TODO implement
-    return CompletableFuture.failedFuture(new UnsupportedOperationException("Not implemented yet"));
+    final var brokerRequest =
+        new BrokerActivateAdHocSubprocessActivityRequest()
+            .setAdHocSubProcessInstanceKey(request.adHocSubprocessInstanceKey());
+
+    request.elements().stream()
+        .map(AdHocSubprocessActivateActivityReference::elementId)
+        .forEach(brokerRequest::addElement);
+
+    return sendBrokerRequest(brokerRequest);
   }
 
   public record AdHocSubprocessActivateActivitiesRequest(

--- a/service/src/main/java/io/camunda/service/AdHocSubprocessActivityServices.java
+++ b/service/src/main/java/io/camunda/service/AdHocSubprocessActivityServices.java
@@ -20,8 +20,11 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
 import io.camunda.zeebe.model.bpmn.instance.FlowNode;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 
@@ -103,5 +106,16 @@ public class AdHocSubprocessActivityServices extends ApiServices<AdHocSubprocess
     }
 
     return documentation;
+  }
+
+  public CompletableFuture<AdHocSubProcessActivityActivationRecord> activateActivities(
+      final AdHocSubprocessActivateActivitiesRequest request) {
+    // TODO implement
+    return CompletableFuture.failedFuture(new UnsupportedOperationException("Not implemented yet"));
+  }
+
+  public record AdHocSubprocessActivateActivitiesRequest(
+      String adHocSubprocessInstanceKey, List<AdHocSubprocessActivateActivityReference> elements) {
+    public record AdHocSubprocessActivateActivityReference(String elementId) {}
   }
 }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestSupport.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestSupport.java
@@ -64,6 +64,8 @@ public final class TestSupport {
       case MESSAGE_CORRELATION -> config.messageCorrelation = value;
       case USER -> config.user = value;
       case AUTHORIZATION -> config.authorization = value;
+      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
+          config.adHocSubProcessActivityActivation = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);
@@ -112,6 +114,8 @@ public final class TestSupport {
       case MESSAGE_CORRELATION -> config.messageCorrelation = value;
       case USER -> config.user = value;
       case AUTHORIZATION -> config.authorization = value;
+      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
+          config.adHocSubProcessActivityActivation = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.broker.transport.RequestReaderException;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
@@ -73,6 +74,9 @@ public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequ
     RECORDS_BY_TYPE.put(ValueType.RESOURCE_DELETION, ResourceDeletionRecord::new);
     RECORDS_BY_TYPE.put(ValueType.USER_TASK, UserTaskRecord::new);
     RECORDS_BY_TYPE.put(ValueType.PROCESS_INSTANCE_MIGRATION, ProcessInstanceMigrationRecord::new);
+    RECORDS_BY_TYPE.put(
+        ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
+        AdHocSubProcessActivityActivationRecord::new);
     RECORDS_BY_TYPE.put(ValueType.COMPENSATION_SUBSCRIPTION, CompensationSubscriptionRecord::new);
     RECORDS_BY_TYPE.put(ValueType.MESSAGE_CORRELATION, MessageCorrelationRecord::new);
     RECORDS_BY_TYPE.put(ValueType.USER, UserRecord::new);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -127,7 +127,7 @@ public final class BpmnProcessors {
         keyGenerator);
     addProcessInstanceBatchStreamProcessors(typedRecordProcessors, processingState, writers);
     addAdHocSubProcessActivityStreamProcessors(
-        typedRecordProcessors, processingState, writers, keyGenerator);
+        typedRecordProcessors, processingState, writers, authCheckBehavior, keyGenerator);
 
     return bpmnStreamProcessor;
   }
@@ -331,10 +331,12 @@ public final class BpmnProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final MutableProcessingState processingState,
       final Writers writers,
+      final AuthorizationCheckBehavior authCheckBehavior,
       final KeyGenerator keyGenerator) {
     typedRecordProcessors.onCommand(
         ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
         AdHocSubProcessActivityActivationIntent.ACTIVATE,
-        new AdHocSubProcessActivityActivateProcessor(writers, processingState, keyGenerator));
+        new AdHocSubProcessActivityActivateProcessor(
+            writers, processingState, authCheckBehavior, keyGenerator));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
+import io.camunda.zeebe.engine.processing.adhocsubprocess.AdHocSubProcessActivityActivateProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnStreamProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
@@ -42,6 +43,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -124,6 +126,8 @@ public final class BpmnProcessors {
         authCheckBehavior,
         keyGenerator);
     addProcessInstanceBatchStreamProcessors(typedRecordProcessors, processingState, writers);
+    addAdHocSubProcessActivityStreamProcessors(
+        typedRecordProcessors, processingState, writers, keyGenerator);
 
     return bpmnStreamProcessor;
   }
@@ -321,5 +325,16 @@ public final class BpmnProcessors {
                 processingState.getKeyGenerator(),
                 processingState.getElementInstanceState(),
                 processingState.getProcessState()));
+  }
+
+  private static void addAdHocSubProcessActivityStreamProcessors(
+      final TypedRecordProcessors typedRecordProcessors,
+      final MutableProcessingState processingState,
+      final Writers writers,
+      final KeyGenerator keyGenerator) {
+    typedRecordProcessors.onCommand(
+        ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
+        AdHocSubProcessActivityActivationIntent.ACTIVATE,
+        new AdHocSubProcessActivityActivateProcessor(writers, processingState, keyGenerator));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessActivityActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessActivityActivateProcessor.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.adhocsubprocess;
+
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableAdHocSubProcess;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationFlowNode;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue.AdHocSubProcessActivityActivationFlowNodeValue;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import java.util.List;
+
+public class AdHocSubProcessActivityActivateProcessor
+    implements TypedRecordProcessor<AdHocSubProcessActivityActivationRecord> {
+
+  private final StateWriter stateWriter;
+  private final TypedResponseWriter responseWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final TypedCommandWriter commandWriter;
+  private final ElementInstanceState elementInstanceState;
+  private final ProcessState processState;
+  private final KeyGenerator keyGenerator;
+
+  public AdHocSubProcessActivityActivateProcessor(
+      final Writers writers,
+      final ProcessingState processingState,
+      final KeyGenerator keyGenerator) {
+    stateWriter = writers.state();
+    responseWriter = writers.response();
+    rejectionWriter = writers.rejection();
+    commandWriter = writers.command();
+    processState = processingState.getProcessState();
+    elementInstanceState = processingState.getElementInstanceState();
+    this.keyGenerator = keyGenerator;
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<AdHocSubProcessActivityActivationRecord> command) {
+    // todo: authz check
+
+    final var hasDuplicates =
+        command.getValue().getFlowNodes().stream()
+                .map(AdHocSubProcessActivityActivationFlowNodeValue::getFlowNodeId)
+                .distinct()
+                .count()
+            != command.getValue().getFlowNodes().size();
+    if (hasDuplicates) {
+      throw new DuplicateFlowNodesException(
+          command.getValue().getFlowNodes().stream()
+              .map(AdHocSubProcessActivityActivationFlowNodeValue::getFlowNodeId)
+              .toList());
+    }
+
+    final var adHocSubprocessElementInstance =
+        elementInstanceState.getInstance(
+            Long.parseLong(command.getValue().getAdHocSubProcessInstanceKey()));
+    if (adHocSubprocessElementInstance == null) {
+      throw new AdHocSubProcessInstanceIsNullException(
+          command.getValue().getAdHocSubProcessInstanceKey());
+    }
+
+    final var adHocSubprocessElementId = adHocSubprocessElementInstance.getValue().getElementId();
+    final var adHocSubprocessState = adHocSubprocessElementInstance.getState();
+    switch (adHocSubprocessState) {
+      case ELEMENT_COMPLETED, ELEMENT_TERMINATED ->
+          throw new AdHocSubProcessAlreadyDoneException(adHocSubprocessElementId);
+    }
+
+    if (adHocSubprocessState != ProcessInstanceIntent.ELEMENT_ACTIVATED) {
+      throw new AdHocSubProcessInstanceNotActivatedException(
+          command.getValue().getAdHocSubProcessInstanceKey());
+    }
+
+    final var adHocSubprocessDefinition =
+        processState
+            .getProcessByKeyAndTenant(
+                adHocSubprocessElementInstance.getValue().getProcessDefinitionKey(),
+                adHocSubprocessElementInstance.getValue().getTenantId())
+            .getProcess();
+
+    final var adHocSubprocessElement =
+        adHocSubprocessDefinition.getElementById(
+            adHocSubprocessElementInstance.getValue().getElementId());
+    final var adHocActivitiesById =
+        ((ExecutableAdHocSubProcess) adHocSubprocessElement).getAdHocActivitiesById();
+
+    // test that the given flow nodes exist within it
+    final var flowNodesNotInAdHocSubProcess =
+        command.getValue().flowNodes().stream()
+            .map(AdHocSubProcessActivityActivationFlowNode::getFlowNodeId)
+            .filter(flowNodeId -> !adHocActivitiesById.containsKey(flowNodeId))
+            .toList();
+    if (!flowNodesNotInAdHocSubProcess.isEmpty()) {
+      throw new FlowNodesNotPresentException(
+          adHocSubprocessElementId, flowNodesNotInAdHocSubProcess);
+    }
+
+    // activate the flow nodes
+    for (final var flowNode : command.getValue().getFlowNodes()) {
+      final var flowNodeToActivate =
+          adHocSubprocessDefinition.getElementById(flowNode.getFlowNodeId());
+      final var flowNodeProcessInstanceRecord = new ProcessInstanceRecord();
+      flowNodeProcessInstanceRecord.wrap(adHocSubprocessElementInstance.getValue());
+      flowNodeProcessInstanceRecord
+          // todo: should this have the same flow scope key as its parent?
+          .setFlowScopeKey(adHocSubprocessElementInstance.getKey())
+          .setElementId(flowNodeToActivate.getId())
+          // todo: are the element type and event type required?
+          .setBpmnElementType(flowNodeToActivate.getElementType())
+          .setBpmnEventType(flowNodeToActivate.getEventType());
+
+      final long elementToActivateInstanceKey = keyGenerator.nextKey();
+      commandWriter.appendFollowUpCommand(
+          elementToActivateInstanceKey,
+          ProcessInstanceIntent.ACTIVATE_ELEMENT,
+          flowNodeProcessInstanceRecord);
+    }
+
+    stateWriter.appendFollowUpEvent(
+        command.getKey(), AdHocSubProcessActivityActivationIntent.ACTIVATED, command.getValue());
+
+    responseWriter.writeEventOnCommand(
+        command.getKey(),
+        AdHocSubProcessActivityActivationIntent.ACTIVATED,
+        command.getValue(),
+        command);
+  }
+
+  @Override
+  public ProcessingError tryHandleError(
+      final TypedRecord<AdHocSubProcessActivityActivationRecord> command, final Throwable error) {
+    rejectionWriter.appendRejection(command, RejectionType.INVALID_ARGUMENT, error.getMessage());
+    responseWriter.writeRejectionOnCommand(
+        command, RejectionType.INVALID_ARGUMENT, error.getMessage());
+
+    return ProcessingError.EXPECTED_ERROR;
+  }
+
+  private static final class DuplicateFlowNodesException extends IllegalStateException {
+    private static final String ERROR_MESSAGE = "Duplicate flow nodes %s not allowed.";
+
+    private DuplicateFlowNodesException(final List<String> flowNodeIds) {
+      super(String.format(ERROR_MESSAGE, flowNodeIds));
+    }
+  }
+
+  private static final class FlowNodesNotPresentException extends IllegalStateException {
+    private static final String ERROR_MESSAGE =
+        "Flow nodes %s do not exist in ad-hoc subprocess <%s>";
+
+    private FlowNodesNotPresentException(
+        final String adHocSubprocessId, final List<String> flowNodeIds) {
+      super(String.format(ERROR_MESSAGE, flowNodeIds, adHocSubprocessId));
+    }
+  }
+
+  private static final class AdHocSubProcessAlreadyDoneException extends IllegalStateException {
+    private static final String ERROR_MESSAGE =
+        "Ad-hoc subprocess <%s> is already in a terminal state. Cannot activate any further activities.";
+
+    private AdHocSubProcessAlreadyDoneException(final String adHocSubprocessElementId) {
+      super(String.format(ERROR_MESSAGE, adHocSubprocessElementId));
+    }
+  }
+
+  private static final class AdHocSubProcessInstanceIsNullException extends IllegalStateException {
+    private static final String ERROR_MESSAGE = "Ad-hoc subprocess instance <%s> is.";
+
+    private AdHocSubProcessInstanceIsNullException(final String adHocSubprocessInstanceKey) {
+      super(String.format(ERROR_MESSAGE, adHocSubprocessInstanceKey));
+    }
+  }
+
+  private static final class AdHocSubProcessInstanceNotActivatedException
+      extends IllegalStateException {
+    private static final String ERROR_MESSAGE = "Ad-hoc subprocess instance <%s> is.";
+
+    private AdHocSubProcessInstanceNotActivatedException(final String adHocSubprocessInstanceKey) {
+      super(String.format(ERROR_MESSAGE, adHocSubprocessInstanceKey));
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessActivityActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessActivityActivateProcessor.java
@@ -20,13 +20,13 @@ import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
-import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationFlowNode;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationElement;
 import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
-import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue.AdHocSubProcessActivityActivationFlowNodeValue;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue.AdHocSubProcessActivityActivationElementValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -101,8 +101,8 @@ public class AdHocSubProcessActivityActivateProcessor
 
     // test that the given flow nodes exist within it
     final var flowNodesNotInAdHocSubProcess =
-        command.getValue().flowNodes().stream()
-            .map(AdHocSubProcessActivityActivationFlowNode::getFlowNodeId)
+        command.getValue().elements().stream()
+            .map(AdHocSubProcessActivityActivationElement::getElementId)
             .filter(flowNodeId -> !adHocActivitiesById.containsKey(flowNodeId))
             .toList();
     if (!flowNodesNotInAdHocSubProcess.isEmpty()) {
@@ -111,9 +111,9 @@ public class AdHocSubProcessActivityActivateProcessor
     }
 
     // activate the flow nodes
-    for (final var flowNode : command.getValue().getFlowNodes()) {
+    for (final var flowNode : command.getValue().getElements()) {
       final var flowNodeToActivate =
-          adHocSubprocessDefinition.getElementById(flowNode.getFlowNodeId());
+          adHocSubprocessDefinition.getElementById(flowNode.getElementId());
       final var flowNodeProcessInstanceRecord = new ProcessInstanceRecord();
       flowNodeProcessInstanceRecord.wrap(adHocSubprocessElementInstance.getValue());
       flowNodeProcessInstanceRecord
@@ -152,15 +152,15 @@ public class AdHocSubProcessActivityActivateProcessor
   private void validateDuplicateFlowNodes(
       final TypedRecord<AdHocSubProcessActivityActivationRecord> command) {
     final var hasDuplicates =
-        command.getValue().getFlowNodes().stream()
-                .map(AdHocSubProcessActivityActivationFlowNodeValue::getFlowNodeId)
+        command.getValue().getElements().stream()
+                .map(AdHocSubProcessActivityActivationElementValue::getElementId)
                 .distinct()
                 .count()
-            != command.getValue().getFlowNodes().size();
+            != command.getValue().getElements().size();
     if (hasDuplicates) {
       throw new DuplicateFlowNodesException(
-          command.getValue().getFlowNodes().stream()
-              .map(AdHocSubProcessActivityActivationFlowNodeValue::getFlowNodeId)
+          command.getValue().getElements().stream()
+              .map(AdHocSubProcessActivityActivationElementValue::getElementId)
               .toList());
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionSt
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
@@ -122,6 +123,8 @@ public final class EventAppliers implements EventApplier {
     registerCommandDistributionAppliers(state);
     registerEscalationAppliers();
     registerResourceDeletionAppliers();
+
+    registerAdHocSubProcessActivityActivationAppliers();
 
     registerUserAppliers(state);
     registerAuthorizationAppliers(state);
@@ -506,6 +509,10 @@ public final class EventAppliers implements EventApplier {
   private void registerResourceDeletionAppliers() {
     register(ResourceDeletionIntent.DELETING, NOOP_EVENT_APPLIER);
     register(ResourceDeletionIntent.DELETED, NOOP_EVENT_APPLIER);
+  }
+
+  private void registerAdHocSubProcessActivityActivationAppliers() {
+    register(AdHocSubProcessActivityActivationIntent.ACTIVATED, NOOP_EVENT_APPLIER);
   }
 
   private void registerClockAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/adhocsubprocess/ActivateAdHocSubProcessActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/adhocsubprocess/ActivateAdHocSubProcessActivityTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.adhocsubprocess;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AdHocSubProcessBuilder;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ActivateAdHocSubProcessActivityTest {
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String AD_HOC_SUB_PROCESS_ELEMENT_ID = "ad-hoc";
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  private long processInstanceKey;
+  private long adHocSubProcessInstanceKey;
+
+  @Before
+  public void setUp() {
+    final BpmnModelInstance processInstance =
+        process(
+            adHocSubProcess -> {
+              adHocSubProcess.task("A");
+              adHocSubProcess.task("B");
+              adHocSubProcess.task("C");
+            });
+    ENGINE.deployment().withXmlResource(processInstance).deploy();
+    processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    adHocSubProcessInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.AD_HOC_SUB_PROCESS)
+            .map(Record::getKey)
+            .limit(1)
+            .toList()
+            .getFirst();
+  }
+
+  private BpmnModelInstance process(final Consumer<AdHocSubProcessBuilder> modifier) {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .adHocSubProcess(AD_HOC_SUB_PROCESS_ELEMENT_ID, modifier)
+        .endEvent()
+        .done();
+  }
+
+  @Test
+  public void
+      givenRunningAdhocSubProcessInstanceWhenActivatingExistingFlowNodeThenTheFlowNodeIsActivated() {
+    final var adHocSubProcessActivityActivationRecord =
+        new AdHocSubProcessActivityActivationRecord()
+            .setAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey));
+    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("A");
+
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .adHocSubProcessActivityActivation(adHocSubProcessActivityActivationRecord)
+            .key(adHocSubProcessInstanceKey));
+
+    assertThat(
+            RecordingExporter.processInstanceRecords().withProcessInstanceKey(processInstanceKey))
+        // todo add short-circuit `limit` call?
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .contains(
+            tuple("A", ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple("A", ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .doesNotContainAnyElementsOf(
+            List.of(
+                tuple("B", ProcessInstanceIntent.ACTIVATE_ELEMENT),
+                tuple("C", ProcessInstanceIntent.ACTIVATE_ELEMENT)));
+  }
+
+  @Test
+  public void
+      givenRunningAdhocSubProcessInstanceWhenSuccessfullyActivatingAFlowNodeThenSubsequentActivatedEventIsSent() {
+    final var adHocSubProcessActivityActivationRecord =
+        new AdHocSubProcessActivityActivationRecord()
+            .setAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey));
+    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("A");
+
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .adHocSubProcessActivityActivation(adHocSubProcessActivityActivationRecord)
+            .key(adHocSubProcessInstanceKey));
+
+    assertThat(
+            RecordingExporter.adHocSubProcessActivityActivationRecords()
+                .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey)))
+        // todo add short-circuit `limit` call?
+        .extracting(r -> r.getValue().getFlowNodes().getFirst().getFlowNodeId(), Record::getIntent)
+        .contains(tuple("A", AdHocSubProcessActivityActivationIntent.ACTIVATED));
+  }
+
+  @Test
+  public void
+      givenRunningAdhocSubProcessInstanceWhenActivatingMoreThanOneFlowNodeThenAllGivenFlowNodesAreActivated() {
+    final var adHocSubProcessActivityActivationRecord =
+        new AdHocSubProcessActivityActivationRecord()
+            .setAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey));
+    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("A");
+    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("B");
+
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .adHocSubProcessActivityActivation(adHocSubProcessActivityActivationRecord)
+            .key(adHocSubProcessInstanceKey));
+
+    assertThat(
+            RecordingExporter.processInstanceRecords().withProcessInstanceKey(processInstanceKey))
+        // todo add short-circuit `limit` call?
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .contains(
+            tuple("A", ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple("A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("B", ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple("B", ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .doesNotContainAnyElementsOf(List.of(tuple("C", ProcessInstanceIntent.ACTIVATE_ELEMENT)));
+  }
+
+  @Test
+  public void
+      givenRunningAdhocSubProcessInstanceWhenActivatingFlowNodeThatDoesNotExistThenTheActivationIsRejected() {
+    final var adHocSubProcessActivityActivationRecord =
+        new AdHocSubProcessActivityActivationRecord()
+            .setAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey));
+    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("does-not-exist");
+
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .adHocSubProcessActivityActivation(adHocSubProcessActivityActivationRecord)
+            .key(adHocSubProcessInstanceKey));
+
+    assertThat(
+            RecordingExporter.adHocSubProcessActivityActivationRecords()
+                .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
+                .onlyCommandRejections()
+                .limit(1))
+        .extracting(r -> r.getValue().getFlowNodes().getFirst().getFlowNodeId(), Record::getIntent)
+        .describedAs("Expected flow node that doesn't exist to be rejected.")
+        .contains(tuple("does-not-exist", AdHocSubProcessActivityActivationIntent.ACTIVATE));
+  }
+
+  @Test
+  public void
+      givenAdhocSubProcessInATerminalStateWhenActivatingFlowNodesThenTheActivationIsRejected() {
+    final var adHocSubProcessActivityActivationRecord =
+        new AdHocSubProcessActivityActivationRecord()
+            .setAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey));
+    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("A");
+
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .adHocSubProcessActivityActivation(adHocSubProcessActivityActivationRecord)
+            .key(adHocSubProcessInstanceKey));
+
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .adHocSubProcessActivityActivation(adHocSubProcessActivityActivationRecord)
+            .key(adHocSubProcessInstanceKey));
+
+    assertThat(
+            RecordingExporter.adHocSubProcessActivityActivationRecords()
+                .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
+                .onlyCommandRejections()
+                .limit(1))
+        .describedAs(
+            "Expected activation to be rejected because the adhoc subprocess has completed.")
+        .isNotEmpty();
+  }
+
+  @Test
+  public void
+      givenRunningAdhocSubProcessWhenAttemptingToActivateDuplicateFlowNodesThenTheActivationIsRejected() {
+    final var adHocSubProcessActivityActivationRecord =
+        new AdHocSubProcessActivityActivationRecord()
+            .setAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey));
+    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("A");
+    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("A");
+
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .adHocSubProcessActivityActivation(adHocSubProcessActivityActivationRecord)
+            .key(adHocSubProcessInstanceKey));
+
+    assertThat(
+            RecordingExporter.adHocSubProcessActivityActivationRecords()
+                .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
+                .onlyCommandRejections()
+                .limit(1))
+        .describedAs(
+            "Expected activation to be rejected because duplicate flow nodes are provided.")
+        .isNotEmpty();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/adhocsubprocess/ActivateAdHocSubProcessActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/adhocsubprocess/ActivateAdHocSubProcessActivityTest.java
@@ -72,11 +72,11 @@ public class ActivateAdHocSubProcessActivityTest {
 
   @Test
   public void
-      givenRunningAdhocSubProcessInstanceWhenActivatingExistingFlowNodeThenTheFlowNodeIsActivated() {
+      givenRunningAdhocSubProcessInstanceWhenActivatingExistingElementThenTheElementIsActivated() {
     final var adHocSubProcessActivityActivationRecord =
         new AdHocSubProcessActivityActivationRecord()
             .setAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey));
-    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("A");
+    adHocSubProcessActivityActivationRecord.elements().add().setElementId("A");
 
     ENGINE.writeRecords(
         RecordToWrite.command()
@@ -98,11 +98,11 @@ public class ActivateAdHocSubProcessActivityTest {
 
   @Test
   public void
-      givenRunningAdhocSubProcessInstanceWhenSuccessfullyActivatingAFlowNodeThenSubsequentActivatedEventIsSent() {
+      givenRunningAdhocSubProcessInstanceWhenSuccessfullyActivatingAElementThenSubsequentActivatedEventIsSent() {
     final var adHocSubProcessActivityActivationRecord =
         new AdHocSubProcessActivityActivationRecord()
             .setAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey));
-    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("A");
+    adHocSubProcessActivityActivationRecord.elements().add().setElementId("A");
 
     ENGINE.writeRecords(
         RecordToWrite.command()
@@ -112,19 +112,18 @@ public class ActivateAdHocSubProcessActivityTest {
     assertThat(
             RecordingExporter.adHocSubProcessActivityActivationRecords()
                 .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey)))
-        // todo add short-circuit `limit` call?
-        .extracting(r -> r.getValue().getFlowNodes().getFirst().getFlowNodeId(), Record::getIntent)
+        .extracting(r -> r.getValue().getElements().getFirst().getElementId(), Record::getIntent)
         .contains(tuple("A", AdHocSubProcessActivityActivationIntent.ACTIVATED));
   }
 
   @Test
   public void
-      givenRunningAdhocSubProcessInstanceWhenActivatingMoreThanOneFlowNodeThenAllGivenFlowNodesAreActivated() {
+      givenRunningAdhocSubProcessInstanceWhenActivatingMoreThanOneElementThenAllGivenElementsAreActivated() {
     final var adHocSubProcessActivityActivationRecord =
         new AdHocSubProcessActivityActivationRecord()
             .setAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey));
-    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("A");
-    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("B");
+    adHocSubProcessActivityActivationRecord.elements().add().setElementId("A");
+    adHocSubProcessActivityActivationRecord.elements().add().setElementId("B");
 
     ENGINE.writeRecords(
         RecordToWrite.command()
@@ -133,7 +132,6 @@ public class ActivateAdHocSubProcessActivityTest {
 
     assertThat(
             RecordingExporter.processInstanceRecords().withProcessInstanceKey(processInstanceKey))
-        // todo add short-circuit `limit` call?
         .extracting(r -> r.getValue().getElementId(), Record::getIntent)
         .contains(
             tuple("A", ProcessInstanceIntent.ACTIVATE_ELEMENT),
@@ -145,11 +143,11 @@ public class ActivateAdHocSubProcessActivityTest {
 
   @Test
   public void
-      givenRunningAdhocSubProcessInstanceWhenActivatingFlowNodeThatDoesNotExistThenTheActivationIsRejected() {
+      givenRunningAdhocSubProcessInstanceWhenActivatingElementThatDoesNotExistThenTheActivationIsRejected() {
     final var adHocSubProcessActivityActivationRecord =
         new AdHocSubProcessActivityActivationRecord()
             .setAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey));
-    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("does-not-exist");
+    adHocSubProcessActivityActivationRecord.elements().add().setElementId("does-not-exist");
 
     ENGINE.writeRecords(
         RecordToWrite.command()
@@ -161,18 +159,18 @@ public class ActivateAdHocSubProcessActivityTest {
                 .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
                 .onlyCommandRejections()
                 .limit(1))
-        .extracting(r -> r.getValue().getFlowNodes().getFirst().getFlowNodeId(), Record::getIntent)
+        .extracting(r -> r.getValue().getElements().getFirst().getElementId(), Record::getIntent)
         .describedAs("Expected flow node that doesn't exist to be rejected.")
         .contains(tuple("does-not-exist", AdHocSubProcessActivityActivationIntent.ACTIVATE));
   }
 
   @Test
   public void
-      givenAdhocSubProcessInATerminalStateWhenActivatingFlowNodesThenTheActivationIsRejected() {
+      givenAdhocSubProcessInATerminalStateWhenActivatingElementsThenTheActivationIsRejected() {
     final var adHocSubProcessActivityActivationRecord =
         new AdHocSubProcessActivityActivationRecord()
             .setAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey));
-    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("A");
+    adHocSubProcessActivityActivationRecord.elements().add().setElementId("A");
 
     ENGINE.writeRecords(
         RecordToWrite.command()
@@ -196,12 +194,12 @@ public class ActivateAdHocSubProcessActivityTest {
 
   @Test
   public void
-      givenRunningAdhocSubProcessWhenAttemptingToActivateDuplicateFlowNodesThenTheActivationIsRejected() {
+      givenRunningAdhocSubProcessWhenAttemptingToActivateDuplicateElementsThenTheActivationIsRejected() {
     final var adHocSubProcessActivityActivationRecord =
         new AdHocSubProcessActivityActivationRecord()
             .setAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey));
-    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("A");
-    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("A");
+    adHocSubProcessActivityActivationRecord.elements().add().setElementId("A");
+    adHocSubProcessActivityActivationRecord.elements().add().setElementId("A");
 
     ENGINE.writeRecords(
         RecordToWrite.command()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordToWrite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordToWrite.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.util;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
@@ -23,6 +24,7 @@ import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
@@ -34,6 +36,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
@@ -161,6 +164,15 @@ public final class RecordToWrite implements LogAppendEntry {
   public RecordToWrite scale(final ScaleIntent intent, final ScaleRecord value) {
     recordMetadata.valueType(ValueType.SCALE).intent(intent);
     unifiedRecordValue = value;
+    return this;
+  }
+
+  public RecordToWrite adHocSubProcessActivityActivation(
+      final AdHocSubProcessActivityActivationRecordValue value) {
+    recordMetadata
+        .valueType(ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION)
+        .intent(AdHocSubProcessActivityActivationIntent.ACTIVATE);
+    unifiedRecordValue = (AdHocSubProcessActivityActivationRecord) value;
     return this;
   }
 

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -294,6 +294,9 @@ public class ElasticsearchExporter implements Exporter {
       if (index.processMessageSubscription) {
         createValueIndexTemplate(ValueType.PROCESS_MESSAGE_SUBSCRIPTION, version);
       }
+      if (index.adHocSubProcessActivityActivation) {
+        createValueIndexTemplate(ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION, version);
+      }
       if (index.decisionRequirements) {
         createValueIndexTemplate(ValueType.DECISION_REQUIREMENTS, version);
       }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -138,6 +138,8 @@ public class ElasticsearchExporterConfiguration {
         return index.compensationSubscription;
       case MESSAGE_CORRELATION:
         return index.messageCorrelation;
+      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION:
+        return index.adHocSubProcessActivityActivation;
       default:
         return false;
     }
@@ -199,6 +201,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean processMessageSubscription = true;
     public boolean variable = true;
     public boolean variableDocument = true;
+    public boolean adHocSubProcessActivityActivation = true;
 
     public boolean checkpoint = false;
     public boolean timer = true;
@@ -309,6 +312,8 @@ public class ElasticsearchExporterConfiguration {
           + signalSubscription
           + ", resourceDeletion="
           + resourceDeletion
+          + ", adHocSubProcessActivityActivation="
+          + adHocSubProcessActivityActivation
           + ", commandDistribution="
           + commandDistribution
           + ", form="

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-activity-activation-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-activity-activation-template.json
@@ -14,7 +14,7 @@
       "index.queries.cache.enabled": false
     },
     "aliases": {
-      "zeebe-record-process-instance-modification": {}
+      "zeebe-record-ad-hoc-subprocess-activity-activation": {}
     },
     "mappings": {
       "properties": {
@@ -24,9 +24,9 @@
             "adHocSubProcessInstanceKey": {
               "type": "keyword"
             },
-            "flowNodes": {
+            "elements": {
               "properties": {
-                "flowNodeId": {
+                "elementId": {
                   "type": "keyword"
                 }
               }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-activity-activation-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-activity-activation-template.json
@@ -1,0 +1,42 @@
+{
+  "index_patterns": [
+    "zeebe-record_ad-hoc-subprocess-activity-activation_*"
+  ],
+  "composed_of": [
+    "zeebe-record"
+  ],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-process-instance-modification": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "adHocSubProcessInstanceKey": {
+              "type": "keyword"
+            },
+            "flowNodes": {
+              "properties": {
+                "flowNodeId": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "tenantId": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -62,6 +62,8 @@ final class TestSupport {
       case USER_TASK -> config.userTask = value;
       case COMPENSATION_SUBSCRIPTION -> config.compensationSubscription = value;
       case MESSAGE_CORRELATION -> config.messageCorrelation = value;
+      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
+          config.adHocSubProcessActivityActivation = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -264,6 +264,9 @@ public class OpensearchExporter implements Exporter {
       if (index.processMessageSubscription) {
         createValueIndexTemplate(ValueType.PROCESS_MESSAGE_SUBSCRIPTION, version);
       }
+      if (index.adHocSubProcessActivityActivation) {
+        createValueIndexTemplate(ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION, version);
+      }
       if (index.decisionRequirements) {
         createValueIndexTemplate(ValueType.DECISION_REQUIREMENTS, version);
       }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -137,6 +137,8 @@ public class OpensearchExporterConfiguration {
         return index.compensationSubscription;
       case MESSAGE_CORRELATION:
         return index.messageCorrelation;
+      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION:
+        return index.adHocSubProcessActivityActivation;
       default:
         return false;
     }
@@ -188,6 +190,7 @@ public class OpensearchExporterConfiguration {
     public boolean processMessageSubscription = true;
     public boolean variable = true;
     public boolean variableDocument = true;
+    public boolean adHocSubProcessActivityActivation = true;
 
     public boolean checkpoint = false;
     public boolean timer = true;
@@ -297,6 +300,8 @@ public class OpensearchExporterConfiguration {
           + signalSubscription
           + ", resourceDeletion="
           + resourceDeletion
+          + ", adHocSubProcessActivityActivation="
+          + adHocSubProcessActivityActivation
           + ", recordDistribution="
           + commandDistribution
           + ", form="

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-activity-activation-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-activity-activation-template.json
@@ -14,7 +14,7 @@
       "index.queries.cache.enabled": false
     },
     "aliases": {
-      "zeebe-record-process-instance-modification": {}
+      "zeebe-record-ad-hoc-subprocess-activity-activation": {}
     },
     "mappings": {
       "properties": {
@@ -24,9 +24,9 @@
             "adHocSubProcessInstanceKey": {
               "type": "keyword"
             },
-            "flowNodes": {
+            "elements": {
               "properties": {
-                "flowNodeId": {
+                "elementId": {
                   "type": "keyword"
                 }
               }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-activity-activation-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-activity-activation-template.json
@@ -1,0 +1,42 @@
+{
+  "index_patterns": [
+    "zeebe-record_ad-hoc-subprocess-activity-activation_*"
+  ],
+  "composed_of": [
+    "zeebe-record"
+  ],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-process-instance-modification": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "adHocSubProcessInstanceKey": {
+              "type": "keyword"
+            },
+            "flowNodes": {
+              "properties": {
+                "flowNodeId": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "tenantId": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -64,6 +64,8 @@ final class TestSupport {
       case MESSAGE_CORRELATION -> config.messageCorrelation = value;
       case USER -> config.user = value;
       case AUTHORIZATION -> config.authorization = value;
+      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
+          config.adHocSubProcessActivityActivation = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3300,8 +3300,7 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
-  # TODO can we return a meaningful response?
-  /element-instances/ad-hoc-activities/{adHocSubprocessInstanceKey}/activate:
+  /element-instances/ad-hoc-activities/{adHocSubprocessInstanceKey}/activation:
     post:
       tags:
         - Ad-hoc subprocess

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3300,6 +3300,50 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  # TODO can we return a meaningful response?
+  /element-instances/ad-hoc-activities/{adHocSubprocessInstanceKey}/activate:
+    post:
+      tags:
+        - Ad-hoc subprocess
+      operationId: activateAdHocSubprocessActivities
+      summary: Activate activities within an ad-hoc subprocess
+      description: |
+        Activates selected activities within an ad-hoc subprocess identified by element ID.
+        The provided element IDs must exist within the ad-hoc subprocess instance identified by the
+        provided adHocSubprocessInstanceKey.
+      parameters:
+        - name: adHocSubprocessInstanceKey
+          in: path
+          required: true
+          description: The key of the ad-hoc subprocess instance that contains the activities.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdHocSubprocessActivateActivitiesInstruction"
+      responses:
+        "204":
+          description: The ad-hoc subprocess instance is modified.
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: |
+            The ad-hoc subprocess instance is not found or the provided key does not identify an
+            ad-hoc subprocess.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   /signals/broadcast:
     post:
       tags:
@@ -4545,6 +4589,24 @@ components:
         tenantId:
           description: The tenant ID for this activity.
           type: string
+    AdHocSubprocessActivateActivitiesInstruction:
+      type: object
+      properties:
+        elements:
+          description: Activities to activate.
+          type: array
+          items:
+            $ref: "#/components/schemas/AdHocSubprocessActivateActivityReference"
+      required:
+        - elements
+    AdHocSubprocessActivateActivityReference:
+      type: object
+      properties:
+        elementId:
+          description: The ID of the element that should be activated.
+          type: string
+      required:
+        - elementId
     DecisionDefinitionSearchQuerySortRequest:
       type: object
       properties:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -8,13 +8,13 @@
 package io.camunda.zeebe.gateway.rest;
 
 import static io.camunda.zeebe.gateway.rest.util.KeyUtil.tryParseLong;
+import static io.camunda.zeebe.gateway.rest.validator.AdHocSubprocessActivityRequestValidator.validateAdHocSubprocessSearchActivitiesRequest;
 import static io.camunda.zeebe.gateway.rest.validator.AuthorizationRequestValidator.validateAuthorizationRequest;
 import static io.camunda.zeebe.gateway.rest.validator.ClockValidator.validateClockPinRequest;
 import static io.camunda.zeebe.gateway.rest.validator.DocumentValidator.validateDocumentLinkParams;
 import static io.camunda.zeebe.gateway.rest.validator.DocumentValidator.validateDocumentMetadata;
 import static io.camunda.zeebe.gateway.rest.validator.ElementRequestValidator.validateVariableRequest;
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
-import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE;
 import static io.camunda.zeebe.gateway.rest.validator.EvaluateDecisionRequestValidator.validateEvaluateDecisionRequest;
 import static io.camunda.zeebe.gateway.rest.validator.JobRequestValidator.validateJobActivationRequest;
 import static io.camunda.zeebe.gateway.rest.validator.JobRequestValidator.validateJobErrorRequest;
@@ -28,7 +28,6 @@ import static io.camunda.zeebe.gateway.rest.validator.ProcessInstanceRequestVali
 import static io.camunda.zeebe.gateway.rest.validator.ProcessInstanceRequestValidator.validateMigrateProcessInstanceRequest;
 import static io.camunda.zeebe.gateway.rest.validator.ProcessInstanceRequestValidator.validateModifyProcessInstanceRequest;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.createProblemDetail;
-import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
 import static io.camunda.zeebe.gateway.rest.validator.ResourceRequestValidator.validateResourceDeletion;
 import static io.camunda.zeebe.gateway.rest.validator.SignalRequestValidator.validateSignalBroadcastRequest;
 import static io.camunda.zeebe.gateway.rest.validator.UserTaskRequestValidator.validateAssignmentRequest;
@@ -133,7 +132,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
@@ -801,28 +799,15 @@ public class RequestMapper {
           createProblemDetail(List.of(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("filter"))).get());
     }
 
-    final var processDefinitionKey = tryParseLong(filter.getProcessDefinitionKey());
+    final var processDefinitionKey = tryParseLong(filter.getProcessDefinitionKey()).orElse(null);
 
     return getResult(
-        validate(
-            violations -> {
-              if (processDefinitionKey.isEmpty() || processDefinitionKey.get() <= 0) {
-                violations.add(
-                    ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE.formatted(
-                        "filter.processDefinitionKey",
-                        filter.getProcessDefinitionKey(),
-                        "a non-negative numeric value"));
-              }
-
-              if (StringUtils.isBlank(filter.getAdHocSubprocessId())) {
-                violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("filter.adHocSubprocessId"));
-              }
-            }),
+        validateAdHocSubprocessSearchActivitiesRequest(filter, processDefinitionKey),
         () ->
             AdHocSubprocessActivityQuery.builder()
                 .filter(
                     AdHocSubprocessActivityFilter.builder()
-                        .processDefinitionKey(processDefinitionKey.get())
+                        .processDefinitionKey(processDefinitionKey)
                         .adHocSubprocessId(filter.getAdHocSubprocessId())
                         .build())
                 .build());

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.rest;
 
 import static io.camunda.zeebe.gateway.rest.util.KeyUtil.tryParseLong;
+import static io.camunda.zeebe.gateway.rest.validator.AdHocSubprocessActivityRequestValidator.validateAdHocSubprocessActivationRequest;
 import static io.camunda.zeebe.gateway.rest.validator.AdHocSubprocessActivityRequestValidator.validateAdHocSubprocessSearchActivitiesRequest;
 import static io.camunda.zeebe.gateway.rest.validator.AuthorizationRequestValidator.validateAuthorizationRequest;
 import static io.camunda.zeebe.gateway.rest.validator.ClockValidator.validateClockPinRequest;
@@ -45,6 +46,8 @@ import io.camunda.search.filter.AdHocSubprocessActivityFilter;
 import io.camunda.search.query.AdHocSubprocessActivityQuery;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authentication.Builder;
+import io.camunda.service.AdHocSubprocessActivityServices.AdHocSubprocessActivateActivitiesRequest;
+import io.camunda.service.AdHocSubprocessActivityServices.AdHocSubprocessActivateActivitiesRequest.AdHocSubprocessActivateActivityReference;
 import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
 import io.camunda.service.AuthorizationServices.UpdateAuthorizationRequest;
 import io.camunda.service.DocumentServices.DocumentCreateRequest;
@@ -65,6 +68,7 @@ import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.service.UserServices.UserDTO;
 import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.auth.ClaimTransformer;
+import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivateActivitiesInstruction;
 import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivitySearchQuery;
 import io.camunda.zeebe.gateway.protocol.rest.AuthorizationRequest;
 import io.camunda.zeebe.gateway.protocol.rest.CancelProcessInstanceRequest;
@@ -811,6 +815,22 @@ public class RequestMapper {
                         .adHocSubprocessId(filter.getAdHocSubprocessId())
                         .build())
                 .build());
+  }
+
+  public static Either<ProblemDetail, AdHocSubprocessActivateActivitiesRequest>
+      toAdHocSubprocessActivateActivitiesRequest(
+          final String adHocSubprocessInstanceKey,
+          final AdHocSubprocessActivateActivitiesInstruction request) {
+    return getResult(
+        validateAdHocSubprocessActivationRequest(request),
+        () ->
+            new AdHocSubprocessActivateActivitiesRequest(
+                adHocSubprocessInstanceKey,
+                request.getElements().stream()
+                    .map(
+                        element ->
+                            new AdHocSubprocessActivateActivityReference(element.getElementId()))
+                    .toList()));
   }
 
   private static List<ProcessInstanceModificationActivateInstruction>

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityController.java
@@ -11,13 +11,17 @@ import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.search.query.AdHocSubprocessActivityQuery;
 import io.camunda.service.AdHocSubprocessActivityServices;
+import io.camunda.service.AdHocSubprocessActivityServices.AdHocSubprocessActivateActivitiesRequest;
+import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivateActivitiesInstruction;
 import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivitySearchQuery;
 import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivitySearchQueryResult;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import java.util.concurrent.CompletableFuture;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -39,6 +43,15 @@ public class AdHocSubprocessActivityController {
         .fold(RestErrorMapper::mapProblemToResponse, this::searchAdHocSubprocessActivities);
   }
 
+  @CamundaPostMapping(path = "/{adHocSubprocessInstanceKey}/activate")
+  public CompletableFuture<ResponseEntity<Object>> modifyProcessInstance(
+      @PathVariable final String adHocSubprocessInstanceKey,
+      @RequestBody final AdHocSubprocessActivateActivitiesInstruction activationRequest) {
+    return RequestMapper.toAdHocSubprocessActivateActivitiesRequest(
+            adHocSubprocessInstanceKey, activationRequest)
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::activateActivities);
+  }
+
   private ResponseEntity<AdHocSubprocessActivitySearchQueryResult> searchAdHocSubprocessActivities(
       final AdHocSubprocessActivityQuery query) {
     try {
@@ -57,5 +70,14 @@ public class AdHocSubprocessActivityController {
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
+  }
+
+  private CompletableFuture<ResponseEntity<Object>> activateActivities(
+      final AdHocSubprocessActivateActivitiesRequest request) {
+    return RequestMapper.executeServiceMethodWithNoContentResult(
+        () ->
+            adHocSubprocessActivityServices
+                .withAuthentication(RequestMapper.getAuthentication())
+                .activateActivities(request));
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityController.java
@@ -43,7 +43,7 @@ public class AdHocSubprocessActivityController {
         .fold(RestErrorMapper::mapProblemToResponse, this::searchAdHocSubprocessActivities);
   }
 
-  @CamundaPostMapping(path = "/{adHocSubprocessInstanceKey}/activate")
+  @CamundaPostMapping(path = "/{adHocSubprocessInstanceKey}/activation")
   public CompletableFuture<ResponseEntity<Object>> modifyProcessInstance(
       @PathVariable final String adHocSubprocessInstanceKey,
       @RequestBody final AdHocSubprocessActivateActivitiesInstruction activationRequest) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/AdHocSubprocessActivityRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/AdHocSubprocessActivityRequestValidator.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAG
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
 
+import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivateActivitiesInstruction;
 import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivityFilter;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
@@ -32,6 +33,24 @@ public class AdHocSubprocessActivityRequestValidator {
 
           if (StringUtils.isBlank(filter.getAdHocSubprocessId())) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("filter.adHocSubprocessId"));
+          }
+        });
+  }
+
+  public static Optional<ProblemDetail> validateAdHocSubprocessActivationRequest(
+      final AdHocSubprocessActivateActivitiesInstruction request) {
+    return validate(
+        violations -> {
+          // TODO validate duplicate element IDs here?
+          if (request.getElements() == null || request.getElements().isEmpty()) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("elements"));
+          } else {
+            for (int i = 0; i < request.getElements().size(); i++) {
+              if (StringUtils.isBlank(request.getElements().get(i).getElementId())) {
+                violations.add(
+                    ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("elements[%d].elementId".formatted(i)));
+              }
+            }
           }
         });
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/AdHocSubprocessActivityRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/AdHocSubprocessActivityRequestValidator.java
@@ -41,7 +41,6 @@ public class AdHocSubprocessActivityRequestValidator {
       final AdHocSubprocessActivateActivitiesInstruction request) {
     return validate(
         violations -> {
-          // TODO validate duplicate element IDs here?
           if (request.getElements() == null || request.getElements().isEmpty()) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("elements"));
           } else {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/AdHocSubprocessActivityRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/AdHocSubprocessActivityRequestValidator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.validator;
+
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE;
+import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
+
+import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivityFilter;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.ProblemDetail;
+
+public class AdHocSubprocessActivityRequestValidator {
+
+  public static Optional<ProblemDetail> validateAdHocSubprocessSearchActivitiesRequest(
+      final AdHocSubprocessActivityFilter filter, final Long processDefinitionKey) {
+    return validate(
+        violations -> {
+          if (processDefinitionKey == null || processDefinitionKey <= 0) {
+            violations.add(
+                ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE.formatted(
+                    "filter.processDefinitionKey",
+                    processDefinitionKey,
+                    "a non-negative numeric value"));
+          }
+
+          if (StringUtils.isBlank(filter.getAdHocSubprocessId())) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("filter.adHocSubprocessId"));
+          }
+        });
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityControllerTest.java
@@ -47,7 +47,7 @@ class AdHocSubprocessActivityControllerTest extends RestControllerTest {
   private static final String AD_HOC_ACTIVITIES_URL = "/v2/element-instances/ad-hoc-activities";
   private static final String SEARCH_ACTIVITIES_URL = AD_HOC_ACTIVITIES_URL + "/search";
   private static final String ACTIVATE_ACTIVITIES_URL =
-      AD_HOC_ACTIVITIES_URL + "/{adHocSubprocessInstanceKey}/activate";
+      AD_HOC_ACTIVITIES_URL + "/{adHocSubprocessInstanceKey}/activation";
 
   @MockitoBean private AdHocSubprocessActivityServices adHocSubprocessActivityServices;
 
@@ -349,7 +349,7 @@ class AdHocSubprocessActivityControllerTest extends RestControllerTest {
                 "type": "about:blank",
                 "title": "INVALID_ARGUMENT",
                 "status": 400,
-                "instance": "/v2/element-instances/ad-hoc-activities/%s/activate"
+                "instance": "/v2/element-instances/ad-hoc-activities/%s/activation"
             }
             """
                   .formatted(AD_HOC_SUBPROCESS_INSTANCE_KEY))

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityControllerTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.entities.AdHocSubprocessActivityEntity;
@@ -21,11 +22,15 @@ import io.camunda.search.exception.NotFoundException;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.AdHocSubprocessActivityServices;
+import io.camunda.service.AdHocSubprocessActivityServices.AdHocSubprocessActivateActivitiesRequest;
+import io.camunda.service.AdHocSubprocessActivityServices.AdHocSubprocessActivateActivitiesRequest.AdHocSubprocessActivateActivityReference;
 import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivityResult;
 import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivityResult.TypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivitySearchQueryResult;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -41,6 +46,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 class AdHocSubprocessActivityControllerTest extends RestControllerTest {
   private static final String AD_HOC_ACTIVITIES_URL = "/v2/element-instances/ad-hoc-activities";
   private static final String SEARCH_ACTIVITIES_URL = AD_HOC_ACTIVITIES_URL + "/search";
+  private static final String ACTIVATE_ACTIVITIES_URL =
+      AD_HOC_ACTIVITIES_URL + "/{adHocSubprocessInstanceKey}/activate";
 
   @MockitoBean private AdHocSubprocessActivityServices adHocSubprocessActivityServices;
 
@@ -171,6 +178,8 @@ class AdHocSubprocessActivityControllerTest extends RestControllerTest {
             """)
           .jsonPath(".detail")
           .isEqualTo(expectedErrorDetail);
+
+      verifyNoInteractions(adHocSubprocessActivityServices);
     }
 
     @Test
@@ -273,6 +282,124 @@ class AdHocSubprocessActivityControllerTest extends RestControllerTest {
               }
               """,
               "No filter.adHocSubprocessId provided."));
+    }
+  }
+
+  @Nested
+  class ActivateActivities {
+
+    private static final String AD_HOC_SUBPROCESS_INSTANCE_KEY = "123456789";
+
+    @Test
+    void shouldActivateActivities() {
+      when(adHocSubprocessActivityServices.activateActivities(
+              any(AdHocSubprocessActivateActivitiesRequest.class)))
+          .thenReturn(
+              CompletableFuture.completedFuture(new AdHocSubProcessActivityActivationRecord()));
+
+      webClient
+          .post()
+          .uri(ACTIVATE_ACTIVITIES_URL, AD_HOC_SUBPROCESS_INSTANCE_KEY)
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(
+              """
+            {
+              "elements": [
+                {"elementId": "A"},
+                {"elementId": "B"},
+                {"elementId": "C"}
+              ]
+            }
+            """)
+          .exchange()
+          .expectStatus()
+          .isNoContent();
+
+      verify(adHocSubprocessActivityServices)
+          .activateActivities(
+              assertArg(
+                  request -> {
+                    assertThat(request.adHocSubprocessInstanceKey())
+                        .isEqualTo(AD_HOC_SUBPROCESS_INSTANCE_KEY);
+
+                    assertThat(request.elements())
+                        .extracting(AdHocSubprocessActivateActivityReference::elementId)
+                        .containsExactly("A", "B", "C");
+                  }));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidActivateParameters")
+    void shouldReturnBadRequestWhenValidationFails(
+        final String request, final String expectedErrorDetail) {
+      webClient
+          .post()
+          .uri(ACTIVATE_ACTIVITIES_URL, AD_HOC_SUBPROCESS_INSTANCE_KEY)
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(request)
+          .exchange()
+          .expectStatus()
+          .isBadRequest()
+          .expectBody()
+          .json(
+              """
+            {
+                "type": "about:blank",
+                "title": "INVALID_ARGUMENT",
+                "status": 400,
+                "instance": "/v2/element-instances/ad-hoc-activities/%s/activate"
+            }
+            """
+                  .formatted(AD_HOC_SUBPROCESS_INSTANCE_KEY))
+          .jsonPath(".detail")
+          .isEqualTo(expectedErrorDetail);
+
+      verifyNoInteractions(adHocSubprocessActivityServices);
+    }
+
+    static Stream<Arguments> invalidActivateParameters() {
+      return Stream.of(
+          arguments(
+              """
+              {}
+              """,
+              "No elements provided."),
+          arguments(
+              """
+              {
+                "elements": []
+              }
+              """,
+              "No elements provided."),
+          arguments(
+              """
+              {
+                "elements": [
+                  {}
+                ]
+              }
+              """,
+              "No elements[0].elementId provided."),
+          arguments(
+              """
+              {
+                "elements": [
+                  { "elementId": null }
+                ]
+              }
+              """,
+              "No elements[0].elementId provided."),
+          arguments(
+              """
+              {
+                "elements": [
+                  { "elementId": "    " }
+                ]
+              }
+              """,
+              "No elements[0].elementId provided."));
     }
   }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerActivateAdHocSubprocessActivityRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerActivateAdHocSubprocessActivityRequest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
+import org.agrona.DirectBuffer;
+
+public class BrokerActivateAdHocSubprocessActivityRequest
+    extends BrokerExecuteCommand<AdHocSubProcessActivityActivationRecord> {
+
+  private final AdHocSubProcessActivityActivationRecord requestDto =
+      new AdHocSubProcessActivityActivationRecord();
+
+  public BrokerActivateAdHocSubprocessActivityRequest() {
+    super(
+        ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
+        AdHocSubProcessActivityActivationIntent.ACTIVATE);
+  }
+
+  public BrokerActivateAdHocSubprocessActivityRequest setAdHocSubProcessInstanceKey(
+      final String adHocSubProcessInstanceKey) {
+    requestDto.setAdHocSubProcessInstanceKey(adHocSubProcessInstanceKey);
+    return this;
+  }
+
+  public BrokerActivateAdHocSubprocessActivityRequest addElement(final String elementId) {
+    requestDto.flowNodes().add().setFlowNodeId(elementId);
+    return this;
+  }
+
+  @Override
+  public AdHocSubProcessActivityActivationRecord getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected AdHocSubProcessActivityActivationRecord toResponseDto(final DirectBuffer buffer) {
+    final AdHocSubProcessActivityActivationRecord responseDto =
+        new AdHocSubProcessActivityActivationRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerActivateAdHocSubprocessActivityRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerActivateAdHocSubprocessActivityRequest.java
@@ -32,7 +32,7 @@ public class BrokerActivateAdHocSubprocessActivityRequest
   }
 
   public BrokerActivateAdHocSubprocessActivityRequest addElement(final String elementId) {
-    requestDto.flowNodes().add().setFlowNodeId(elementId);
+    requestDto.elements().add().setElementId(elementId);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivityActivationElement.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivityActivationElement.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
-import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue.AdHocSubProcessActivityActivationFlowNodeValue;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue.AdHocSubProcessActivityActivationElementValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 
 @JsonIgnoreProperties({
@@ -18,23 +18,23 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
   "encodedLength",
   "empty"
 })
-public final class AdHocSubProcessActivityActivationFlowNode extends ObjectValue
-    implements AdHocSubProcessActivityActivationFlowNodeValue {
+public final class AdHocSubProcessActivityActivationElement extends ObjectValue
+    implements AdHocSubProcessActivityActivationElementValue {
 
-  private final StringProperty flowNodeId = new StringProperty("flowNodeId");
+  private final StringProperty elementId = new StringProperty("elementId");
 
-  public AdHocSubProcessActivityActivationFlowNode() {
+  public AdHocSubProcessActivityActivationElement() {
     super(1);
-    declareProperty(flowNodeId);
+    declareProperty(elementId);
   }
 
   @Override
-  public String getFlowNodeId() {
-    return BufferUtil.bufferAsString(flowNodeId.getValue());
+  public String getElementId() {
+    return BufferUtil.bufferAsString(elementId.getValue());
   }
 
-  public AdHocSubProcessActivityActivationFlowNode setFlowNodeId(final String flowNodeId) {
-    this.flowNodeId.setValue(flowNodeId);
+  public AdHocSubProcessActivityActivationElement setElementId(final String elementId) {
+    this.elementId.setValue(elementId);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivityActivationFlowNode.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivityActivationFlowNode.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue.AdHocSubProcessActivityActivationFlowNodeValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+
+@JsonIgnoreProperties({
+  /* These fields are inherited from ObjectValue; there have no purpose in exported JSON records*/
+  "encodedLength",
+  "empty"
+})
+public final class AdHocSubProcessActivityActivationFlowNode extends ObjectValue
+    implements AdHocSubProcessActivityActivationFlowNodeValue {
+
+  private final StringProperty flowNodeId = new StringProperty("flowNodeId");
+
+  public AdHocSubProcessActivityActivationFlowNode() {
+    super(1);
+    declareProperty(flowNodeId);
+  }
+
+  @Override
+  public String getFlowNodeId() {
+    return BufferUtil.bufferAsString(flowNodeId.getValue());
+  }
+
+  public AdHocSubProcessActivityActivationFlowNode setFlowNodeId(final String flowNodeId) {
+    this.flowNodeId.setValue(flowNodeId);
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivityActivationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivityActivationRecord.java
@@ -23,15 +23,15 @@ public final class AdHocSubProcessActivityActivationRecord extends UnifiedRecord
 
   private final StringProperty adHocSubProcessInstanceKey =
       new StringProperty("adHocSubProcessInstanceKey", DEFAULT_STRING);
-  private final ArrayProperty<AdHocSubProcessActivityActivationFlowNode> flowNodes =
-      new ArrayProperty<>("flowNodes", AdHocSubProcessActivityActivationFlowNode::new);
+  private final ArrayProperty<AdHocSubProcessActivityActivationElement> elements =
+      new ArrayProperty<>("elements", AdHocSubProcessActivityActivationElement::new);
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public AdHocSubProcessActivityActivationRecord() {
     super(3);
     declareProperty(adHocSubProcessInstanceKey)
-        .declareProperty(flowNodes)
+        .declareProperty(elements)
         .declareProperty(tenantIdProp);
   }
 
@@ -47,9 +47,9 @@ public final class AdHocSubProcessActivityActivationRecord extends UnifiedRecord
   }
 
   @Override
-  public List<AdHocSubProcessActivityActivationFlowNodeValue> getFlowNodes() {
-    return flowNodes.stream()
-        .map(AdHocSubProcessActivityActivationFlowNodeValue.class::cast)
+  public List<AdHocSubProcessActivityActivationElementValue> getElements() {
+    return elements.stream()
+        .map(AdHocSubProcessActivityActivationElementValue.class::cast)
         .toList();
   }
 
@@ -58,8 +58,8 @@ public final class AdHocSubProcessActivityActivationRecord extends UnifiedRecord
    *
    * @return a {@link ValueArray} of flow nodes that can easily be added to.
    */
-  public ValueArray<AdHocSubProcessActivityActivationFlowNode> flowNodes() {
-    return flowNodes;
+  public ValueArray<AdHocSubProcessActivityActivationElement> elements() {
+    return elements;
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivityActivationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivityActivationRecord.java
@@ -29,7 +29,7 @@ public final class AdHocSubProcessActivityActivationRecord extends UnifiedRecord
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public AdHocSubProcessActivityActivationRecord() {
-    super(2);
+    super(3);
     declareProperty(adHocSubProcessInstanceKey)
         .declareProperty(flowNodes)
         .declareProperty(tenantIdProp);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivityActivationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivityActivationRecord.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess;
+
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.ValueArray;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
+
+public final class AdHocSubProcessActivityActivationRecord extends UnifiedRecordValue
+    implements AdHocSubProcessActivityActivationRecordValue {
+
+  private static final String DEFAULT_STRING = "";
+
+  private final StringProperty adHocSubProcessInstanceKey =
+      new StringProperty("adHocSubProcessInstanceKey", DEFAULT_STRING);
+  private final ArrayProperty<AdHocSubProcessActivityActivationFlowNode> flowNodes =
+      new ArrayProperty<>("flowNodes", AdHocSubProcessActivityActivationFlowNode::new);
+  private final StringProperty tenantIdProp =
+      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+  public AdHocSubProcessActivityActivationRecord() {
+    super(2);
+    declareProperty(adHocSubProcessInstanceKey)
+        .declareProperty(flowNodes)
+        .declareProperty(tenantIdProp);
+  }
+
+  @Override
+  public String getAdHocSubProcessInstanceKey() {
+    return BufferUtil.bufferAsString(adHocSubProcessInstanceKey.getValue());
+  }
+
+  public AdHocSubProcessActivityActivationRecord setAdHocSubProcessInstanceKey(
+      final String adHocSubProcessInstanceKey) {
+    this.adHocSubProcessInstanceKey.setValue(adHocSubProcessInstanceKey);
+    return this;
+  }
+
+  @Override
+  public List<AdHocSubProcessActivityActivationFlowNodeValue> getFlowNodes() {
+    return flowNodes.stream()
+        .map(AdHocSubProcessActivityActivationFlowNodeValue.class::cast)
+        .toList();
+  }
+
+  /**
+   * This function exists only to make setting up the test for the `JsonSerializableToJsonTest`.
+   *
+   * @return a {@link ValueArray} of flow nodes that can easily be added to.
+   */
+  public ValueArray<AdHocSubProcessActivityActivationFlowNode> flowNodes() {
+    return flowNodes;
+  }
+
+  @Override
+  public String getTenantId() {
+    return BufferUtil.bufferAsString(tenantIdProp.getValue());
+  }
+
+  public AdHocSubProcessActivityActivationRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.impl.record.CopiedRecord;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.VersionInfo;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
@@ -2205,6 +2206,50 @@ final class JsonSerializableToJsonTest {
         {
           "resourceKey":1,
           "tenantId": "<default>"
+        }
+        """
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ////////////////////////// AdHocSubProcessActivityActivationRecord //////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "AdHocSubProcessActivityActivationRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final var adHocSubProcessActivityActivationRecord =
+                  new AdHocSubProcessActivityActivationRecord()
+                      .setAdHocSubProcessInstanceKey("1234")
+                      .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+              adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("123");
+
+              return adHocSubProcessActivityActivationRecord;
+            },
+        """
+        {
+          "adHocSubProcessInstanceKey": "1234",
+          "tenantId": "<default>",
+          "flowNodes": [
+            {
+              "flowNodeId": "123"
+            }
+          ]
+        }
+        """
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      /////////////////////// Empty AdHocSubProcessActivityActivationRecord ///////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty AdHocSubProcessActivityActivationRecord",
+        (Supplier<UnifiedRecordValue>) AdHocSubProcessActivityActivationRecord::new,
+        """
+        {
+          "adHocSubProcessInstanceKey": "",
+          "tenantId": "<default>",
+          "flowNodes": []
         }
         """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2222,7 +2222,7 @@ final class JsonSerializableToJsonTest {
                       .setAdHocSubProcessInstanceKey("1234")
                       .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
-              adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("123");
+              adHocSubProcessActivityActivationRecord.elements().add().setElementId("123");
 
               return adHocSubProcessActivityActivationRecord;
             },
@@ -2230,9 +2230,9 @@ final class JsonSerializableToJsonTest {
         {
           "adHocSubProcessInstanceKey": "1234",
           "tenantId": "<default>",
-          "flowNodes": [
+          "elements": [
             {
-              "flowNodeId": "123"
+              "elementId": "123"
             }
           ]
         }
@@ -2249,7 +2249,7 @@ final class JsonSerializableToJsonTest {
         {
           "adHocSubProcessInstanceKey": "",
           "tenantId": "<default>",
-          "flowNodes": []
+          "elements": []
         }
         """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.protocol.record;
 
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
@@ -62,6 +63,7 @@ import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.RedistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
@@ -236,6 +238,11 @@ public final class ValueTypeMapping {
     mapping.put(
         ValueType.PROCESS_INSTANCE_BATCH,
         new Mapping<>(ProcessInstanceBatchRecordValue.class, ProcessInstanceBatchIntent.class));
+    mapping.put(
+        ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
+        new Mapping<>(
+            AdHocSubProcessActivityActivationRecordValue.class,
+            AdHocSubProcessActivityActivationIntent.class));
     mapping.put(ValueType.FORM, new Mapping<>(Form.class, FormIntent.class));
     mapping.put(ValueType.RESOURCE, new Mapping<>(Resource.class, ResourceIntent.class));
     mapping.put(

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AdHocSubProcessActivityActivationIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AdHocSubProcessActivityActivationIntent.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum AdHocSubProcessActivityActivationIntent implements Intent {
+  ACTIVATE(0),
+  ACTIVATED(1);
+
+  private static final Map<Short, Intent> LOOKUP = new HashMap<>();
+
+  static {
+    for (final AdHocSubProcessActivityActivationIntent value : values()) {
+      LOOKUP.put(value.getIntent(), value);
+    }
+  }
+
+  private final short value;
+
+  AdHocSubProcessActivityActivationIntent(final int value) {
+    this.value = (short) value;
+  }
+
+  public short getIntent() {
+    return value;
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case ACTIVATED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  public static Intent from(final short value) {
+    return LOOKUP.getOrDefault(value, Intent.UNKNOWN);
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -70,7 +70,8 @@ public interface Intent {
           RedistributionIntent.class,
           GroupIntent.class,
           MappingIntent.class,
-          IdentitySetupIntent.class);
+          IdentitySetupIntent.class,
+          AdHocSubProcessActivityActivationIntent.class);
   short NULL_VAL = 255;
   Intent UNKNOWN = UnknownIntent.UNKNOWN;
 
@@ -146,6 +147,8 @@ public interface Intent {
         return CommandDistributionIntent.from(intent);
       case PROCESS_INSTANCE_BATCH:
         return ProcessInstanceBatchIntent.from(intent);
+      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION:
+        return AdHocSubProcessActivityActivationIntent.from(intent);
       case FORM:
         return FormIntent.from(intent);
       case RESOURCE:
@@ -229,6 +232,8 @@ public interface Intent {
         return DeploymentDistributionIntent.valueOf(intent);
       case PROCESS_EVENT:
         return ProcessEventIntent.valueOf(intent);
+      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION:
+        return AdHocSubProcessActivityActivationIntent.valueOf(intent);
       case DECISION:
         return DecisionIntent.valueOf(intent);
       case DECISION_REQUIREMENTS:

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AdHocSubProcessActivityActivationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AdHocSubProcessActivityActivationRecordValue.java
@@ -38,12 +38,11 @@ public interface AdHocSubProcessActivityActivationRecordValue extends RecordValu
   /**
    * @return the list of flow node ids of the activities that need to be activated.
    */
-  List<AdHocSubProcessActivityActivationFlowNodeValue> getFlowNodes();
+  List<AdHocSubProcessActivityActivationElementValue> getElements();
 
   @Value.Immutable
-  @ImmutableProtocol(
-      builder = ImmutableAdHocSubProcessActivityActivationFlowNodeValue.Builder.class)
-  interface AdHocSubProcessActivityActivationFlowNodeValue {
-    String getFlowNodeId();
+  @ImmutableProtocol(builder = ImmutableAdHocSubProcessActivityActivationElementValue.Builder.class)
+  interface AdHocSubProcessActivityActivationElementValue {
+    String getElementId();
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AdHocSubProcessActivityActivationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AdHocSubProcessActivityActivationRecordValue.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import java.util.List;
+import org.immutables.value.Value;
+
+/**
+ * Represents a command to activate activities in a given ad-hoc subprocess.
+ *
+ * <p>See {@link io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent}
+ * for intents.
+ */
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableAdHocSubProcessActivityActivationRecordValue.Builder.class)
+public interface AdHocSubProcessActivityActivationRecordValue extends RecordValue, TenantOwned {
+
+  /**
+   * @return the instance key of the ad-hoc subprocess that will have its activities activated.
+   */
+  String getAdHocSubProcessInstanceKey();
+
+  /**
+   * @return the list of flow node ids of the activities that need to be activated.
+   */
+  List<AdHocSubProcessActivityActivationFlowNodeValue> getFlowNodes();
+
+  @Value.Immutable
+  @ImmutableProtocol(
+      builder = ImmutableAdHocSubProcessActivityActivationFlowNodeValue.Builder.class)
+  interface AdHocSubProcessActivityActivationFlowNodeValue {
+    String getFlowNodeId();
+  }
+}

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -65,6 +65,7 @@
       <validValue name="MAPPING">47</validValue>
       <validValue name="IDENTITY_SETUP">48</validValue>
       <validValue name="RESOURCE">49</validValue>
+      <validValue name="AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION">50</validValue>
 
       <!-- Management records / record not related to process automation -->
       <validValue name="REDISTRIBUTION">252</validValue>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ActivateAdHocSubprocessActivityTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ActivateAdHocSubprocessActivityTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.client.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.SignalIntent;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+@ZeebeIntegration
+public class ActivateAdHocSubprocessActivityTest {
+
+  private static final String AD_HOC_SUB_PROCESS_ELEMENT_ID = "ad-hoc";
+
+  @AutoClose CamundaClient client;
+
+  @TestZeebe
+  final TestStandaloneBroker zeebe =
+      new TestStandaloneBroker().withRecordingExporter(true).withUnauthenticatedAccess();
+
+  ZeebeResourcesHelper resourcesHelper;
+  private String processId;
+  private ProcessInstanceEvent processInstance;
+
+  @BeforeEach
+  public void init(final TestInfo testInfo) {
+    client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
+    resourcesHelper = new ZeebeResourcesHelper(client);
+
+    deploy(testInfo);
+    processInstance =
+        client.newCreateInstanceCommand().bpmnProcessId(processId).latestVersion().send().join();
+  }
+
+  @Test
+  void shouldActivateAdHocSubprocessActivities(final TestInfo testInfo) {
+    // allows us to wait for the signal to be broadcasted
+    client.newBroadcastSignalCommand().signalName("signal").send().join();
+
+    assertThat(
+            RecordingExporter.records()
+                .limit(signalBroadcasted("signal"))
+                .processInstanceRecords()
+                .withProcessInstanceKey(processInstance.getProcessInstanceKey()))
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .contains(tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .doesNotContain(
+            tuple("A", ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple("B", ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple("C", ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
+
+    final var activatedAdHocSubprocess =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstance.getProcessInstanceKey())
+            .withElementId(AD_HOC_SUB_PROCESS_ELEMENT_ID)
+            .getFirst();
+
+    // when
+    client
+        .newActivateAdHocSubprocessActivitiesCommand(
+            String.valueOf(activatedAdHocSubprocess.getKey()))
+        .activateElements("A", "C")
+        .send()
+        .join();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstance.getProcessInstanceKey())
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .contains(
+            tuple("A", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("C", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  void shouldReturnErrorOnCommandRejection(final TestInfo testInfo) {
+    final var activatedAdHocSubprocess =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstance.getProcessInstanceKey())
+            .withElementId(AD_HOC_SUB_PROCESS_ELEMENT_ID)
+            .getFirst();
+
+    assertThatThrownBy(
+            () ->
+                client
+                    .newActivateAdHocSubprocessActivitiesCommand(
+                        String.valueOf(activatedAdHocSubprocess.getKey()))
+                    .activateElements("A", "A")
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 400: 'Bad Request'")
+        .hasMessageContaining(
+            "Command 'ACTIVATE' rejected with code 'INVALID_ARGUMENT': Duplicate flow nodes [A, A] not allowed.");
+  }
+
+  private void deploy(final TestInfo testInfo) {
+    processId = "process-" + testInfo.getTestMethod().get().getName();
+
+    resourcesHelper.deployProcess(
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .adHocSubProcess(
+                AD_HOC_SUB_PROCESS_ELEMENT_ID,
+                adHocSubProcess -> {
+                  adHocSubProcess.task("A");
+                  adHocSubProcess.task("B");
+                  adHocSubProcess.task("C");
+                })
+            .endEvent()
+            .done());
+  }
+
+  private static Predicate<Record<RecordValue>> signalBroadcasted(final String signalName) {
+    return r ->
+        r.getIntent() == SignalIntent.BROADCASTED
+            && ((SignalRecord) r.getValue()).getSignalName().equals(signalName);
+  }
+}

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.stream.impl;
 
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
@@ -94,6 +95,9 @@ public final class TypedEventRegistry {
     registry.put(ValueType.DECISION_REQUIREMENTS, DecisionRequirementsRecord.class);
     registry.put(ValueType.DECISION_EVALUATION, DecisionEvaluationRecord.class);
     registry.put(ValueType.RESOURCE_DELETION, ResourceDeletionRecord.class);
+    registry.put(
+        ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
+        AdHocSubProcessActivityActivationRecord.class);
     registry.put(ValueType.COMMAND_DISTRIBUTION, CommandDistributionRecord.class);
 
     registry.put(ValueType.CHECKPOINT, CheckpointRecord.class);

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AdHocSubProcessActivityActivationRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AdHocSubProcessActivityActivationRecordStream.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue;
+import java.util.stream.Stream;
+
+public class AdHocSubProcessActivityActivationRecordStream
+    extends ExporterRecordStream<
+        AdHocSubProcessActivityActivationRecordValue,
+        AdHocSubProcessActivityActivationRecordStream> {
+
+  public AdHocSubProcessActivityActivationRecordStream(
+      final Stream<Record<AdHocSubProcessActivityActivationRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected AdHocSubProcessActivityActivationRecordStream supply(
+      final Stream<Record<AdHocSubProcessActivityActivationRecordValue>> wrappedStream) {
+    return new AdHocSubProcessActivityActivationRecordStream(wrappedStream);
+  }
+
+  public AdHocSubProcessActivityActivationRecordStream withAdHocSubProcessInstanceKey(
+      final String adHocSubProcessInstanceKey) {
+    return valueFilter(
+        record -> record.getAdHocSubProcessInstanceKey().equals(adHocSubProcessInstanceKey));
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -708,7 +708,7 @@ public class CompactRecordLogger {
 
     final var builder = new StringBuilder();
     builder
-        .append(String.format("ACTIVATE flow nodes %s", value.getFlowNodes()))
+        .append(String.format("ACTIVATE elements %s", value.getElements()))
         .append(
             String.format(
                 " in adhoc subprocess [%s]",

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
@@ -88,6 +89,7 @@ public class CompactRecordLogger {
           entry("PROCESS_INSTANCE_MODIFICATION", "MOD"),
           entry("PROCESS_INSTANCE", "PI"),
           entry("PROCESS", "PROC"),
+          entry("AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION", "ADHOC_ACT"),
           entry("TIMER", "TIME"),
           entry("MESSAGE", "MSG"),
           entry("SUBSCRIPTION", "SUB"),
@@ -143,6 +145,9 @@ public class CompactRecordLogger {
         ValueType.PROCESS_INSTANCE_MODIFICATION, this::summarizeProcessInstanceModification);
     valueLoggers.put(
         ValueType.PROCESS_MESSAGE_SUBSCRIPTION, this::summarizeProcessInstanceSubscription);
+    valueLoggers.put(
+        ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
+        this::summarizeAdHocSubProcessActivityActivation);
     valueLoggers.put(ValueType.VARIABLE, this::summarizeVariable);
     valueLoggers.put(ValueType.TIMER, this::summarizeTimer);
     valueLoggers.put(ValueType.ERROR, this::summarizeError);
@@ -696,6 +701,19 @@ public class CompactRecordLogger {
         .append(" (tenant: %s)".formatted(value.getTenantId()));
 
     return result.toString();
+  }
+
+  private String summarizeAdHocSubProcessActivityActivation(final Record<?> record) {
+    final var value = (AdHocSubProcessActivityActivationRecordValue) record.getValue();
+
+    final var builder = new StringBuilder();
+    builder
+        .append(String.format("ACTIVATE flow nodes %s", value.getFlowNodes()))
+        .append(
+            String.format(
+                " in adhoc subprocess [%s]",
+                shortenKey(Long.parseLong(value.getAdHocSubProcessInstanceKey()))));
+    return builder.toString();
   }
 
   private String summarizeVariable(final Record<?> record) {

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -45,6 +45,7 @@ import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
@@ -435,6 +436,14 @@ public final class RecordingExporter implements Exporter {
   public static ResourceDeletionRecordStream resourceDeletionRecords(
       final ResourceDeletionIntent intent) {
     return resourceDeletionRecords().withIntent(intent);
+  }
+
+  public static AdHocSubProcessActivityActivationRecordStream
+      adHocSubProcessActivityActivationRecords() {
+    return new AdHocSubProcessActivityActivationRecordStream(
+        records(
+            ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
+            AdHocSubProcessActivityActivationRecordValue.class));
   }
 
   public static FormRecordStream formRecords() {


### PR DESCRIPTION
## Description

- Adds a new `RecordValue` and `Record` called `AdHocSubProcessActivityActivationRecordValue` and `AdHocSubProcessActivityActivationRecord` respectively.
  - This is the command record that is used by the processor to activate the activity.
- Adds a new processor to process the new command.
- Adds support for the new `RecordValue` in `OpenSearch` and `ElasticSearch`.
- Adds a controller and service component in the gateway to request the broker to activate the provided flow nodes in the given ad-hoc subprocess instance.
- Adds Go and Java client implementations for the new endpoint.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #28474 
closes #28475 
