### PR TITLE
feat: updating settings should happen first to avoid errors with deserialisation

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SchemaManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SchemaManager.java
@@ -56,13 +56,13 @@ public class SchemaManager {
     initialiseResources();
 
     //  used to update existing indices/templates
+    updateSchemaSettings();
     LOG.info("Update index schema. '{}' indices need to be updated", newIndexProperties.size());
     updateSchemaMappings(newIndexProperties);
     LOG.info(
         "Update index template schema. '{}' index templates need to be updated",
         newIndexTemplateProperties.size());
     updateSchemaMappings(newIndexTemplateProperties);
-    updateSchemaSettings();
 
     final RetentionConfiguration retention = config.getArchiver().getRetention();
     if (retention.isEnabled()) {


### PR DESCRIPTION
## Description

Settings should get updated before mappings, this is because there are some settings which will cause errors with deserialisation when retrieving index templates https://github.com/elastic/elasticsearch-java/issues/696.
