### PR TITLE
fix: renew OIDC access token when refresh token is not a JWT [Backport stable/8.6]

### DIFF
--- a/operate/qa/integration-tests/pom.xml
+++ b/operate/qa/integration-tests/pom.xml
@@ -239,6 +239,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>net.minidev</groupId>
+      <artifactId>json-smart</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/SecurityTestUtil.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/SecurityTestUtil.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.security;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import java.util.Date;
+
+public class SecurityTestUtil {
+
+  public static RSAKey getRsaJWK(final JWSAlgorithm alg) throws JOSEException {
+    return new RSAKeyGenerator(2048)
+        .keyID("123")
+        .keyUse(KeyUse.SIGNATURE)
+        .algorithm(alg)
+        .generate();
+  }
+
+  public static ECKey getEcJWK(final JWSAlgorithm alg, final Curve curve) throws JOSEException {
+    return new ECKeyGenerator(curve)
+        .algorithm(alg)
+        .keyUse(KeyUse.SIGNATURE)
+        .keyID("345")
+        .generate();
+  }
+
+  public static String signAndSerialize(
+      final RSAKey rsaKey, final JWSAlgorithm alg, final JWTClaimsSet claimsSet)
+      throws JOSEException {
+    // Create RSA-signer with the private key
+    final JWSSigner rsaSigner = new RSASSASigner(rsaKey);
+
+    final SignedJWT rsaSignedJWT =
+        new SignedJWT(
+            new JWSHeader.Builder(alg).type(JOSEObjectType.JWT).keyID(rsaKey.getKeyID()).build(),
+            claimsSet);
+
+    rsaSignedJWT.sign(rsaSigner);
+    final String serializedJwt = rsaSignedJWT.serialize();
+    System.out.println("JWT serialized=" + serializedJwt);
+    return serializedJwt;
+  }
+
+  public static String signAndSerialize(final RSAKey rsaKey, final JWSAlgorithm alg)
+      throws JOSEException {
+    return signAndSerialize(rsaKey, alg, getDefaultClaimsSet());
+  }
+
+  public static String signAndSerialize(final ECKey ecKey, final JWSAlgorithm alg)
+      throws JOSEException {
+    // Create EC-signer with the private key
+    final ECDSASigner ecSigner = new ECDSASigner(ecKey);
+
+    final SignedJWT ecSignedJWT =
+        new SignedJWT(
+            new JWSHeader.Builder(alg).type(JOSEObjectType.JWT).keyID(ecKey.getKeyID()).build(),
+            getDefaultClaimsSet());
+
+    ecSignedJWT.sign(ecSigner);
+    final String ecSerializedJwt = ecSignedJWT.serialize();
+    System.out.println("JWT serialized=" + ecSerializedJwt);
+    return ecSerializedJwt;
+  }
+
+  public static JWTClaimsSet getDefaultClaimsSet() {
+    // prepare default JWT claims set
+    return new JWTClaimsSet.Builder()
+        .subject("alice")
+        .issuer("http://localhost")
+        .expirationTime(new Date(new Date().getTime() + 60 * 1000))
+        .build();
+  }
+}

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/identity/AuthenticationRefreshTokenIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/identity/AuthenticationRefreshTokenIT.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.security.identity;
+
+import static io.camunda.operate.OperateProfileService.IDENTITY_AUTH_PROFILE;
+import static io.camunda.operate.webapp.security.SecurityTestUtil.getRsaJWK;
+import static io.camunda.operate.webapp.security.SecurityTestUtil.signAndSerialize;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import io.camunda.identity.sdk.Identity;
+import io.camunda.identity.sdk.IdentityConfiguration;
+import io.camunda.identity.sdk.IdentityConfiguration.Type;
+import io.camunda.identity.sdk.authentication.Tokens;
+import io.camunda.identity.sdk.authentication.exception.TokenExpiredException;
+import io.camunda.identity.sdk.impl.dto.AccessTokenDto;
+import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.util.SpringContextHolder;
+import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
+import java.util.Date;
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@SpringBootTest(
+    classes = {
+      TestApplicationWithNoBeans.class,
+      OperateProperties.class,
+      IdentityAuthentication.class,
+      PermissionConverter.class,
+      IdentityRetryService.class
+    },
+    properties = {
+      "camunda.identity.audience=test-client",
+      "camunda.identity.clientId=test-client",
+      "camunda.identity.clientSecret=secret",
+    },
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles({IDENTITY_AUTH_PROFILE, "test"})
+@WireMockTest
+public class AuthenticationRefreshTokenIT {
+
+  @Autowired private ApplicationContext applicationContext;
+  @Mock private Identity identity;
+  private final WireMockRuntimeInfo wireMockInfo;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  @InjectMocks private IdentityAuthentication identityAuthentication;
+
+  public AuthenticationRefreshTokenIT(final WireMockRuntimeInfo wireMockRuntimeInfo) {
+    wireMockInfo = wireMockRuntimeInfo;
+  }
+
+  @BeforeEach
+  public void setup() {
+    new SpringContextHolder().setApplicationContext(applicationContext);
+    final IdentityConfiguration identityConfiguration =
+        applicationContext.getBean(IdentityConfiguration.class);
+    // setting properties with reflection because we need the wiremock server url here
+    ReflectionTestUtils.setField(
+        identityConfiguration, "issuerBackendUrl", wireMockInfo.getHttpBaseUrl());
+    ReflectionTestUtils.setField(identityConfiguration, "issuer", wireMockInfo.getHttpBaseUrl());
+    identityAuthentication = new IdentityAuthentication();
+  }
+
+  @Test
+  public void shouldSuccessfullyRequestNewAccessTokenViaRefreshToken()
+      throws JOSEException, JsonProcessingException {
+    // given
+
+    // create expired access token and non-JWT refresh token
+    final RSAKey rsaJWK = getRsaJWK(JWSAlgorithm.RS256);
+    final String expiredToken =
+        signAndSerialize(
+            rsaJWK, JWSAlgorithm.RS256, getClaimsSet(new Date(new Date().getTime() - 60 * 1000)));
+
+    final String refreshToken = "abcdef";
+    final String tokenType = Type.MICROSOFT.name();
+    final Tokens tokens = new Tokens(expiredToken, refreshToken, 5000L, "", tokenType);
+
+    // mock public key response
+    final String publicKey = rsaJWK.toPublicJWK().toJSONString();
+    final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
+    wireMockInfo
+        .getWireMock()
+        .register(
+            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
+                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
+
+    // mock renew token via refresh token server response (new valid tokens)
+    final String validToken =
+        signAndSerialize(
+            rsaJWK, JWSAlgorithm.RS256, getClaimsSet(new Date(new Date().getTime() + 60 * 1000)));
+    final AccessTokenDto newAccessToken =
+        new AccessTokenDto(validToken, "ghijkl", "id", 50000L, null, null);
+    wireMockInfo
+        .getWireMock()
+        .register(
+            WireMock.post(WireMock.urlMatching(".*/protocol/openid-connect/token"))
+                .willReturn(
+                    WireMock.jsonResponse(
+                        objectMapper.writeValueAsString(newAccessToken), HttpStatus.OK.value())));
+
+    // when - then
+    // throws token expired exception but does not log out
+    Assertions.assertThrows(
+        TokenExpiredException.class, () -> identityAuthentication.authenticate(tokens));
+    // methode will request new access token via the refresh token successfully
+    assertTrue(identityAuthentication.isAuthenticated());
+  }
+
+  private JWTClaimsSet getClaimsSet(final Date expirationTime) {
+    final var permissionsClaim = new JSONObject();
+    final String[] permissions = new String[] {"read:*"};
+    permissionsClaim.put("test-client", permissions);
+
+    final var audClaim = new JSONArray();
+    final String aud = "test-client";
+    audClaim.add(aud);
+
+    return new JWTClaimsSet.Builder()
+        .subject("alice")
+        .audience("test-client")
+        .claim("permissions", permissionsClaim)
+        .claim("aud", audClaim)
+        .issuer("http://localhost")
+        .expirationTime(expirationTime)
+        .build();
+  }
+}

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/oauth2/JwtDecoderIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/oauth2/JwtDecoderIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.operate.webapp.security.oauth2;
 
+import static io.camunda.operate.webapp.security.SecurityTestUtil.signAndSerialize;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -15,22 +16,14 @@ import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
 import com.nimbusds.jose.JOSEException;
-import com.nimbusds.jose.JOSEObjectType;
 import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.JWSSigner;
-import com.nimbusds.jose.crypto.ECDSASigner;
-import com.nimbusds.jose.crypto.RSASSASigner;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
-import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.SignedJWT;
 import io.camunda.identity.sdk.IdentityConfiguration;
-import java.util.Date;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -216,45 +209,5 @@ public class JwtDecoderIT {
         .keyUse(KeyUse.SIGNATURE)
         .keyID("345")
         .generate();
-  }
-
-  private String signAndSerialize(final RSAKey rsaKey, final JWSAlgorithm alg)
-      throws JOSEException {
-    // Create RSA-signer with the private key
-    final JWSSigner rsaSigner = new RSASSASigner(rsaKey);
-
-    final SignedJWT rsaSignedJWT =
-        new SignedJWT(
-            new JWSHeader.Builder(alg).type(JOSEObjectType.JWT).keyID(rsaKey.getKeyID()).build(),
-            getClaimsSet());
-
-    rsaSignedJWT.sign(rsaSigner);
-    final String serializedJwt = rsaSignedJWT.serialize();
-    System.out.println("JWT serialized=" + serializedJwt);
-    return serializedJwt;
-  }
-
-  private String signAndSerialize(final ECKey ecKey, final JWSAlgorithm alg) throws JOSEException {
-    // Create EC-signer with the private key
-    final ECDSASigner ecSigner = new ECDSASigner(ecKey);
-
-    final SignedJWT ecSignedJWT =
-        new SignedJWT(
-            new JWSHeader.Builder(alg).type(JOSEObjectType.JWT).keyID(ecKey.getKeyID()).build(),
-            getClaimsSet());
-
-    ecSignedJWT.sign(ecSigner);
-    final String ecSerializedJwt = ecSignedJWT.serialize();
-    System.out.println("JWT serialized=" + ecSerializedJwt);
-    return ecSerializedJwt;
-  }
-
-  private JWTClaimsSet getClaimsSet() {
-    // prepare default JWT claims set
-    return new JWTClaimsSet.Builder()
-        .subject("alice")
-        .issuer("http://localhost")
-        .expirationTime(new Date(new Date().getTime() + 60 * 1000))
-        .build();
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/identity/IdentityAuthentication.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/identity/IdentityAuthentication.java
@@ -44,8 +44,6 @@ public class IdentityAuthentication extends AbstractAuthenticationToken
   private String subject;
   private Date expires;
 
-  private Date refreshTokenExpiresAt;
-
   private List<OperateTenant> tenants;
 
   public IdentityAuthentication() {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/identity/IdentityAuthentication.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/identity/IdentityAuthentication.java
@@ -16,7 +16,6 @@ import io.camunda.identity.sdk.impl.rest.exception.RestException;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.SpringContextHolder;
 import io.camunda.operate.webapp.security.Permission;
-import io.camunda.operate.webapp.security.SessionRepository;
 import io.camunda.operate.webapp.security.tenant.OperateTenant;
 import io.camunda.operate.webapp.security.tenant.TenantAwareAuthentication;
 import java.io.Serial;
@@ -29,8 +28,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 
 public class IdentityAuthentication extends AbstractAuthenticationToken
     implements Serializable, TenantAwareAuthentication {
@@ -216,18 +213,6 @@ public class IdentityAuthentication extends AbstractAuthenticationToken
     expires = accessToken.getToken().getExpiresAt();
     LOGGER.info("Access token will expire at {}", expires);
     setAuthenticated(!hasExpired());
-  }
-
-  private boolean isPolling() {
-    final ServletRequestAttributes requestAttributes =
-        (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-    if (requestAttributes != null) {
-      return Boolean.TRUE.equals(
-          Boolean.parseBoolean(
-              requestAttributes.getRequest().getHeader(SessionRepository.POLLING_HEADER)));
-    } else {
-      return false;
-    }
   }
 
   private void retrieveName(final UserDetails userDetails) {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/identity/IdentityRetryService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/identity/IdentityRetryService.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.operate.webapp.security.identity;
 
-import io.camunda.identity.sdk.exception.IdentityException;
+import io.camunda.identity.sdk.impl.rest.exception.RestException;
 import io.camunda.operate.util.RetryOperation;
 import java.util.concurrent.TimeUnit;
 import org.springframework.stereotype.Component;
@@ -21,7 +21,7 @@ public class IdentityRetryService {
     return RetryOperation.<T>newBuilder()
         .noOfRetry(10)
         .delayInterval(500, TimeUnit.MILLISECONDS)
-        .retryOn(IdentityException.class)
+        .retryOn(RestException.class)
         .retryConsumer(retryConsumer)
         .message(operationName)
         .build()


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Backport of https://github.com/camunda/camunda/pull/28508

Cherry-picked all the commits from 8.7 with no conflicts, so the changes are identical.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

related to https://github.com/camunda/camunda/issues/27710
