### PR TITLE
Fix bug blocking migration

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SchemaManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SchemaManager.java
@@ -56,13 +56,13 @@ public class SchemaManager {
     initialiseResources();
 
     //  used to update existing indices/templates
+    updateSchemaSettings();
     LOG.info("Update index schema. '{}' indices need to be updated", newIndexProperties.size());
     updateSchemaMappings(newIndexProperties);
     LOG.info(
         "Update index template schema. '{}' index templates need to be updated",
         newIndexTemplateProperties.size());
     updateSchemaMappings(newIndexTemplateProperties);
-    updateSchemaSettings();
 
     final RetentionConfiguration retention = config.getArchiver().getRetention();
     if (retention.isEnabled()) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SearchEngineClient.java
@@ -47,4 +47,6 @@ public interface SearchEngineClient {
 
   void updateIndexTemplateSettings(
       final IndexTemplateDescriptor indexTemplateDescriptor, final IndexSettings currentSettings);
+
+  void removeBreakingIndexTemplates(Collection<IndexTemplateDescriptor> indexTemplateDescriptors);
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -263,7 +263,7 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
     try {
       for (final var templateName : breakingIndexTemplates) {
         if (client.indices().existsIndexTemplate(r -> r.name(templateName)).value()) {
-          client.indices().deleteIndexTemplate(r -> r.name(breakingIndexTemplates));
+          client.indices().deleteIndexTemplate(r -> r.name(templateName));
         }
       }
     } catch (final IOException e) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -251,6 +251,29 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
     }
   }
 
+  @Override
+  public void removeBreakingIndexTemplates(
+      final Collection<IndexTemplateDescriptor> indexTemplateDescriptors) {
+    final var breakingIndexTemplates =
+        indexTemplateDescriptors.stream()
+            .map(IndexTemplateDescriptor::getTemplateName)
+            .filter(templateName -> templateName.contains("list-view"))
+            .toList();
+
+    try {
+      for (final var templateName : breakingIndexTemplates) {
+        if (client.indices().existsIndexTemplate(r -> r.name(templateName)).value()) {
+          client.indices().deleteIndexTemplate(r -> r.name(breakingIndexTemplates));
+        }
+      }
+    } catch (final IOException e) {
+      throw new ElasticsearchExporterException(
+          String.format(
+              "Failed to delete breaking legacy index templates %s", breakingIndexTemplates),
+          e);
+    }
+  }
+
   private SearchRequest allImportPositionDocuments(
       final int partitionId, final List<IndexDescriptor> importPositionIndices) {
     final var importPositionIndicesNames =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/opensearch/OpensearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/opensearch/OpensearchEngineClient.java
@@ -7,14 +7,12 @@
  */
 package io.camunda.exporter.schema.opensearch;
 
-import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.camunda.exporter.SchemaResourceSerializer;
 import io.camunda.exporter.config.ExporterConfiguration.IndexSettings;
-import io.camunda.exporter.exceptions.ElasticsearchExporterException;
 import io.camunda.exporter.exceptions.IndexSchemaValidationException;
 import io.camunda.exporter.exceptions.OpensearchExporterException;
 import io.camunda.exporter.schema.IndexMapping;
@@ -258,13 +256,19 @@ public class OpensearchEngineClient implements SearchEngineClient {
 
     try {
       client.indices().putIndexTemplate(updateIndexTemplateSettingsRequest);
-    } catch (final IOException | ElasticsearchException e) {
-      throw new ElasticsearchExporterException(
+    } catch (final IOException | OpenSearchException e) {
+      throw new OpensearchExporterException(
           String.format(
               "Expected to update index template settings '%s' with '%s', but failed ",
               indexTemplateDescriptor.getTemplateName(), updateIndexTemplateSettingsRequest),
           e);
     }
+  }
+
+  @Override
+  public void removeBreakingIndexTemplates(
+      final Collection<IndexTemplateDescriptor> indexTemplateDescriptors) {
+    // Opensearch client does not have breaking index templates.
   }
 
   private SearchRequest allImportPositionDocuments(

--- a/zeebe/exporters/camunda-exporter/src/test/resources/error-causing-settings.json
+++ b/zeebe/exporters/camunda-exporter/src/test/resources/error-causing-settings.json
@@ -1,0 +1,26 @@
+{
+  "index_patterns": ["my-index-*"],
+  "template": {
+    "mappings": {
+      "properties": {
+        "hello": {
+          "type": "text"
+        },
+        "world": {
+          "type": "keyword"
+        }
+      }
+    },
+    "settings": {
+      "index": {
+        "analysis": {
+          "normalizer": {
+            "case_insensitive": {
+              "filter": "lowercase"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

the operate-list-view index template is blocking migration as the one created by previous versions of the schema manager are not compatible with the client used by the current camunda exporter schema manager.

The issue is manifold
1. we must get the index template mappings to validate them.
2. we cannot retrieve just the mappings (indices have a getMapping which does not exist of index templates), this means we must also retrieve index template settings and deserialise them, this causes issues with our client hence blocking migration.
3. we cannot just update the settings of the index template, as the java client is limited in that a put index template request will OVERWRITE everything there is no append functionality. therefore if we wanted to just update the breaking settings we would also need to retrieve the current mappings of the index template, hence we are back at step 2.

Unfortunately this is the simplest fix I can think of, this shouldn't break anything as after deleting the list view index template that breaks migration, we will immediately after recreate it.

If the solution is not ideal, there is still the test which creates a copy of the breaking index template which can be used to check if another solution would work.


