### PR TITLE
deps: Update Netty to version 4.1.118Final

### DIFF
--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -88,6 +88,7 @@
     <elasticsearch-test-container.version>1.19.8</elasticsearch-test-container.version>
     <postgres-test-container.version>1.17.6</postgres-test-container.version>
     <wiremock.version>3.9.2</wiremock.version>
+    <netty.version>4.1.118.Final</netty.version>
     <version.docker-java-api>3.3.6</version.docker-java-api>
     <version.httpclient>4.5.14</version.httpclient>
     <version.elasticsearch7>7.17.27</version.elasticsearch7>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Updated netty version to 4.1.118Final by adding back an explicit version in the operate parent pom, since otherwise an older version included through zeebe/AWS is pulled.

Checked the operate jar lib to make sure the correct version is added:

/camunda/operate/webapp/target/operate-webapp-8.5.12-SNAPSHOT-exec/BOOT-INF/lib:
> $ printf '%s\n' netty*.jar
> netty-buffer-4.1.118.Final.jar
> netty-codec-4.1.118.Final.jar
> netty-codec-http-4.1.118.Final.jar
> netty-codec-http2-4.1.118.Final.jar
> netty-codec-socks-4.1.118.Final.jar
> netty-common-4.1.118.Final.jar
> netty-handler-4.1.118.Final.jar
> netty-handler-proxy-4.1.118.Final.jar
> netty-nio-client-2.25.70.jar
> netty-resolver-4.1.118.Final.jar
> netty-tcnative-boringssl-static-2.0.70.Final-linux-aarch_64.jar
> netty-tcnative-boringssl-static-2.0.70.Final-linux-x86_64.jar
> netty-tcnative-boringssl-static-2.0.70.Final-osx-aarch_64.jar
> netty-tcnative-boringssl-static-2.0.70.Final-osx-x86_64.jar
> netty-tcnative-boringssl-static-2.0.70.Final-windows-x86_64.jar
> netty-tcnative-boringssl-static-2.0.70.Final.jar
> netty-tcnative-classes-2.0.70.Final.jar
> netty-transport-4.1.118.Final.jar
> netty-transport-classes-epoll-4.1.118.Final.jar
> netty-transport-native-unix-common-4.1.118.Final.jar


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

relates to https://github.com/camunda/camunda/issues/27862
