### PR TITLE
fix: add c8run to autolabeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -90,3 +90,11 @@ deprecated-client:
               - 'clients/java/src/main/java/io/camunda/zeebe/**'
               - 'clients/java/src/test/java/io/camunda/zeebe/**'
       - base-branch: 'main' # TODO replace with 'backport stable/8.8' in https://github.com/camunda/camunda/issues/26820
+component/c8run:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'c8run/**'
+          - '.github/workflows/c8run-build.yaml'
+          - '.github/workflows/c8run-release.yaml'
+          - '.github/actions/setup-c8run/action.yml'
+


### PR DESCRIPTION
## Description

A new age is upon us. This PR introduces auto-labeling whenever c8run files are touched. Gone are the days of manually tagging PRs with the c8run label.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
