### PR TITLE
Fix flaky PrefixMigrationIT

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
@@ -237,8 +237,6 @@ public class PrefixMigrationIT {
         new MultiDbConfigurator(testSimpleCamundaApplication);
     final var esUrl = String.format("http://localhost:%d", esContainer.getMappedPort(9200));
     multiDbConfigurator.configureElasticsearchSupport(esUrl, NEW_PREFIX);
-    testSimpleCamundaApplication.withProperty("camunda.tasklist.zeebeElasticsearch.prefix", null);
-    testSimpleCamundaApplication.withProperty("camunda.operate.zeebeElasticsearch.prefix", null);
     testSimpleCamundaApplication.start();
     testSimpleCamundaApplication.awaitCompleteTopology();
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
@@ -20,10 +20,14 @@ import java.io.IOException;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Base64;
-import org.assertj.core.api.Assertions;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -33,6 +37,7 @@ import org.testcontainers.utility.DockerImageName;
 @Testcontainers
 public class PrefixMigrationIT {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(PrefixMigrationIT.class);
   private static final int SERVER_PORT = 8080;
   private static final int MANAGEMENT_PORT = 9600;
   private static final int GATEWAY_GRPC_PORT = 26500;
@@ -48,6 +53,11 @@ public class PrefixMigrationIT {
           .withNetwork(NETWORK)
           .withNetworkAliases(ELASTIC_ALIAS)
           .withStartupTimeout(Duration.ofMinutes(5)); // can be slow in CI
+
+  @BeforeEach
+  public void setup() {
+    esContainer.followOutput(new Slf4jLogConsumer(LOGGER));
+  }
 
   private GenericContainer<?> createCamundaContainer(
       final String image, final String operatePrefix, final String tasklistPrefix) {


### PR DESCRIPTION
## Description

The PrefixMigrationIT used thread sleep to delay test execution, so we somewhat make sure importers see data before migration.

Problem with this was that first thread sleep is not reliable and we have no guarantee that we have seen data. Secondly, with using the MultiDbConfigurator we are configure the ES Exporter with a prefix, this can cause that data is written to a different index as read by Operate importers (as here we don't set the prefix).

These combinations caused flakiness. \cc @EuroLew 

### What this PR does

Replacing the `Thread.sleep` with a more reliable method, querying the v1 API to make sure Importers have seen data before doing the migration.

## Related

Slack thread https://camunda.slack.com/archives/C06F0GLJNFM/p1740163747867229
