### PR TITLE
deps: upgrade net.minidev:json-smart to 2.5.2

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,11 +33,6 @@
   },
   "packageRules": [
     {
-      "description": "Temporary rule to prevent exposure to CVE-2024-57699 in newer versions of json-smart.",
-      "matchPackageNames": ["net.minidev:json-smart"],
-      "allowedVersions": "<=2.4.11"
-    },
-    {
       "description": "Only patch updates for our maintenance branches to avoid breaking changes.",
       "matchBaseBranches": [
         "/^stable\\/8\\..*/",

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -111,6 +111,7 @@
     <version.jqwik>1.9.2</version.jqwik>
     <version.jmock>2.13.1</version.jmock>
     <version.jmh>1.37</version.jmh>
+    <version.json-smart>2.5.2</version.json-smart>
     <version.byte-buddy>1.15.11</version.byte-buddy>
     <version.revapi>0.28.1</version.revapi>
     <version.resilience4j>2.3.0</version.resilience4j>
@@ -1874,7 +1875,7 @@
       <dependency>
         <groupId>net.minidev</groupId>
         <artifactId>json-smart</artifactId>
-        <version>2.4.11</version>
+        <version>${version.json-smart}</version>
       </dependency>
 
       <!-- needed for tests in elasticsearch-exporter -->


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
[CVE-2024-57699](https://github.com/advisories/GHSA-pq2g-wx69-c263) has been resolved in `net.minidev:json-smart:2.5.2`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
