### PR TITLE
Validate username, mapping id and tenant id match to a specific pattern

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/DecisionAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/DecisionAuthorizationIT.java
@@ -50,7 +50,7 @@ class DecisionAuthorizationIT {
   private static final String DECISION_DEFINITION_ID_2 = "test_qa";
   private static final String DECISION_REQUIREMENTS_ID_2 = "definitions_test";
   private static final String ADMIN = "admin";
-  private static final String RESTRICTED = "restricted-user";
+  private static final String RESTRICTED = "restrictedUser";
 
   @UserDefinition
   private static final User ADMIN_USER =

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/DecisionInstanceAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/DecisionInstanceAuthorizationIT.java
@@ -49,7 +49,7 @@ class DecisionInstanceAuthorizationIT {
   private static final String DECISION_DEFINITION_ID_1 = "decision_1";
   private static final String DECISION_DEFINITION_ID_2 = "test_qa";
   private static final String ADMIN = "admin";
-  private static final String RESTRICTED = "restricted-user";
+  private static final String RESTRICTED = "restrictedUser";
 
   @UserDefinition
   private static final User ADMIN_USER =

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/GroupSearchingAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/GroupSearchingAuthorizationIT.java
@@ -52,8 +52,8 @@ class GroupSearchingAuthorizationIT {
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   private static final String ADMIN = "admin";
-  private static final String RESTRICTED = "restricted-user";
-  private static final String RESTRICTED_WITH_READ = "restricted-user-2";
+  private static final String RESTRICTED = "restrictedUser";
+  private static final String RESTRICTED_WITH_READ = "restricteUser2";
   private static final String DEFAULT_PASSWORD = "password";
   private static final String GROUP_SEARCH_ENDPOINT = "v2/groups/search";
   private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(15);

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/ProcessAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/ProcessAuthorizationIT.java
@@ -44,7 +44,7 @@ class ProcessAuthorizationIT {
   static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(BROKER);
 
   private static final String ADMIN = "admin";
-  private static final String RESTRICTED = "restricted-user";
+  private static final String RESTRICTED = "restrictedUser";
 
   @UserDefinition
   private static final User ADMIN_USER =

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/RoleSearchingAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/RoleSearchingAuthorizationIT.java
@@ -52,8 +52,8 @@ class RoleSearchingAuthorizationIT {
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   private static final String ADMIN = "admin";
-  private static final String RESTRICTED = "restricted-user";
-  private static final String RESTRICTED_WITH_READ = "restricted-user-2";
+  private static final String RESTRICTED = "restrictedUser";
+  private static final String RESTRICTED_WITH_READ = "restrictedUser2";
   private static final String DEFAULT_PASSWORD = "password";
   private static final String ROLE_SEARCH_ENDPOINT = "v2/roles/search";
   private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(15);

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/TenantAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/TenantAuthorizationIT.java
@@ -57,8 +57,8 @@ class TenantAuthorizationIT {
   static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(BROKER);
 
   private static final String ADMIN = "admin";
-  private static final String RESTRICTED = "restricted-user";
-  private static final String UNAUTHORIZED = "unauthorized-user";
+  private static final String RESTRICTED = "restrictedUser";
+  private static final String UNAUTHORIZED = "unauthorizedUser";
 
   @UserDefinition
   private static final User ADMIN_USER =

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/UserSearchingAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/UserSearchingAuthorizationIT.java
@@ -52,8 +52,8 @@ class UserSearchingAuthorizationIT {
   static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(BROKER);
 
   private static final String ADMIN = "admin";
-  private static final String RESTRICTED = "restricted-user";
-  private static final String RESTRICTED_WITH_READ = "restricted-user-2";
+  private static final String RESTRICTED = "restrictedUser";
+  private static final String RESTRICTED_WITH_READ = "restrictedUser2";
   private static final String DEFAULT_PASSWORD = "password";
   private static final String USER_SEARCH_ENDPOINT = "v2/users/search";
   private static final Duration AWAIT_TIMEOUT = Duration.ofSeconds(15);
@@ -119,7 +119,7 @@ class UserSearchingAuthorizationIT {
     // then
     assertThat(userSearchResponse.items())
         .map(UserResponse::username)
-        .contains("demo", "admin", "user1", "user2", "restricted-user-2");
+        .contains("demo", "admin", "user1", "user2", "restrictedUser2");
   }
 
   @Test
@@ -133,7 +133,7 @@ class UserSearchingAuthorizationIT {
     assertThat(tenantSearchResponse.items())
         .hasSize(1)
         .map(UserResponse::username)
-        .containsExactlyInAnyOrder("restricted-user");
+        .containsExactlyInAnyOrder("restrictedUser");
   }
 
   private static void createUser(final CamundaClient adminClient, final String username) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ErrorMessages.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ErrorMessages.java
@@ -32,4 +32,6 @@ public final class ErrorMessages {
   public static final String ERROR_MESSAGE_ALL_REQUIRED_FIELD = "All %s are required";
   public static final String ERROR_MESSAGE_TOO_MANY_CHARACTERS =
       "The provided %s exceeds the limit of %d characters";
+  public static final String ERROR_MESSAGE_ILLEGAL_CHARACTER =
+      "The provided %s contains illegal characters. It must match the pattern '%s'";
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/IdentifierPatterns.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/IdentifierPatterns.java
@@ -11,6 +11,8 @@ import java.util.regex.Pattern;
 
 public final class IdentifierPatterns {
 
+  public static final int MAX_LENGTH = 256;
+
   /** 1 or more alphanumeric characters, '@', '.', or '_'. */
   public static final String USERNAME_REGEX = "[a-zA-Z0-9@._]+";
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/IdentifierPatterns.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/IdentifierPatterns.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.validator;
+
+import java.util.regex.Pattern;
+
+public final class IdentifierPatterns {
+
+  /** 1 or more alphanumeric characters, '@', '.', or '_'. */
+  public static final String USERNAME_REGEX = "[a-zA-Z0-9@._]+";
+
+  public static final Pattern USERNAME_PATTERN = Pattern.compile(USERNAME_REGEX);
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/IdentifierPatterns.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/IdentifierPatterns.java
@@ -14,5 +14,9 @@ public final class IdentifierPatterns {
   /** 1 or more alphanumeric characters, '@', '.', or '_'. */
   public static final String USERNAME_REGEX = "[a-zA-Z0-9@._]+";
 
+  /** 1 or more alphanumeric characters. */
+  public static final String ID_REGEX = "[a-zA-Z0-9]+";
+
   public static final Pattern USERNAME_PATTERN = Pattern.compile(USERNAME_REGEX);
+  public static final Pattern ID_PATTERN = Pattern.compile(ID_REGEX);
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/MappingValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/MappingValidator.java
@@ -9,8 +9,10 @@ package io.camunda.zeebe.gateway.rest.validator;
 
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_ILLEGAL_CHARACTER;
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS;
 import static io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns.ID_PATTERN;
 import static io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns.ID_REGEX;
+import static io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns.MAX_LENGTH;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
 
 import io.camunda.zeebe.gateway.protocol.rest.MappingRuleCreateRequest;
@@ -34,6 +36,8 @@ public class MappingValidator {
           }
           if (request.getId() == null || request.getId().isBlank()) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("id"));
+          } else if (request.getId().length() > MAX_LENGTH) {
+            violations.add(ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted("id", MAX_LENGTH));
           } else if (!ID_PATTERN.matcher(request.getId()).matches()) {
             violations.add(ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted("id", ID_REGEX));
           }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/MappingValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/MappingValidator.java
@@ -8,6 +8,9 @@
 package io.camunda.zeebe.gateway.rest.validator;
 
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_ILLEGAL_CHARACTER;
+import static io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns.ID_PATTERN;
+import static io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns.ID_REGEX;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
 
 import io.camunda.zeebe.gateway.protocol.rest.MappingRuleCreateRequest;
@@ -31,6 +34,8 @@ public class MappingValidator {
           }
           if (request.getId() == null || request.getId().isBlank()) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("id"));
+          } else if (!ID_PATTERN.matcher(request.getId()).matches()) {
+            violations.add(ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted("id", ID_REGEX));
           }
         });
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/TenantRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/TenantRequestValidator.java
@@ -8,6 +8,9 @@
 package io.camunda.zeebe.gateway.rest.validator;
 
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_ILLEGAL_CHARACTER;
+import static io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns.ID_PATTERN;
+import static io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns.ID_REGEX;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
 
 import io.camunda.zeebe.gateway.protocol.rest.TenantCreateRequest;
@@ -25,6 +28,8 @@ public final class TenantRequestValidator {
         violations -> {
           if (request.getTenantId() == null || request.getTenantId().isBlank()) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("tenantId"));
+          } else if (!ID_PATTERN.matcher(request.getTenantId()).matches()) {
+            violations.add(ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted("tenantId", ID_REGEX));
           }
           if (request.getName() == null || request.getName().isBlank()) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("name"));

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/TenantRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/TenantRequestValidator.java
@@ -9,8 +9,10 @@ package io.camunda.zeebe.gateway.rest.validator;
 
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_ILLEGAL_CHARACTER;
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS;
 import static io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns.ID_PATTERN;
 import static io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns.ID_REGEX;
+import static io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns.MAX_LENGTH;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
 
 import io.camunda.zeebe.gateway.protocol.rest.TenantCreateRequest;
@@ -28,6 +30,8 @@ public final class TenantRequestValidator {
         violations -> {
           if (request.getTenantId() == null || request.getTenantId().isBlank()) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("tenantId"));
+          } else if (request.getTenantId().length() > MAX_LENGTH) {
+            violations.add(ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted("tenantId", MAX_LENGTH));
           } else if (!ID_PATTERN.matcher(request.getTenantId()).matches()) {
             violations.add(ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted("tenantId", ID_REGEX));
           }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/UserValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/UserValidator.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.rest.validator;
 
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_ILLEGAL_CHARACTER;
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_INVALID_EMAIL;
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
@@ -17,12 +18,15 @@ import io.camunda.zeebe.gateway.protocol.rest.UserUpdateRequest;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.springframework.http.ProblemDetail;
 
 public final class UserValidator {
 
   private static final int MAX_USERNAME_LENGTH = 256;
+  private static final String USERNAME_REGEX = "[a-zA-Z0-9@._]+";
+  private static final Pattern USERNAME_PATTERN = Pattern.compile(USERNAME_REGEX);
 
   public static Optional<ProblemDetail> validateUserUpdateRequest(final UserUpdateRequest request) {
     return validate(
@@ -48,6 +52,8 @@ public final class UserValidator {
       violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("username"));
     } else if (username.length() > MAX_USERNAME_LENGTH) {
       violations.add(ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted("username", MAX_USERNAME_LENGTH));
+    } else if (!USERNAME_PATTERN.matcher(username).matches()) {
+      violations.add(ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted("username", USERNAME_REGEX));
     }
   }
 
@@ -56,11 +62,13 @@ public final class UserValidator {
     if (name == null || name.isBlank()) {
       violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("name"));
     }
+
     if (email == null || email.isBlank()) {
       violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("email"));
     } else if (!EmailValidator.getInstance().isValid(email)) {
       violations.add(ERROR_MESSAGE_INVALID_EMAIL.formatted(email));
     }
+
     return violations;
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/UserValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/UserValidator.java
@@ -11,6 +11,8 @@ import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAG
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_ILLEGAL_CHARACTER;
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_INVALID_EMAIL;
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS;
+import static io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns.USERNAME_PATTERN;
+import static io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns.USERNAME_REGEX;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
 
 import io.camunda.zeebe.gateway.protocol.rest.UserRequest;
@@ -18,15 +20,12 @@ import io.camunda.zeebe.gateway.protocol.rest.UserUpdateRequest;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.Pattern;
 import org.apache.commons.validator.routines.EmailValidator;
 import org.springframework.http.ProblemDetail;
 
 public final class UserValidator {
 
   private static final int MAX_USERNAME_LENGTH = 256;
-  private static final String USERNAME_REGEX = "[a-zA-Z0-9@._]+";
-  private static final Pattern USERNAME_PATTERN = Pattern.compile(USERNAME_REGEX);
 
   public static Optional<ProblemDetail> validateUserUpdateRequest(final UserUpdateRequest request) {
     return validate(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/UserValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/UserValidator.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAG
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_ILLEGAL_CHARACTER;
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_INVALID_EMAIL;
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS;
+import static io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns.MAX_LENGTH;
 import static io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns.USERNAME_PATTERN;
 import static io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns.USERNAME_REGEX;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
@@ -24,8 +25,6 @@ import org.apache.commons.validator.routines.EmailValidator;
 import org.springframework.http.ProblemDetail;
 
 public final class UserValidator {
-
-  private static final int MAX_USERNAME_LENGTH = 256;
 
   public static Optional<ProblemDetail> validateUserUpdateRequest(final UserUpdateRequest request) {
     return validate(
@@ -49,8 +48,8 @@ public final class UserValidator {
     final var username = request.getUsername();
     if (username == null || username.isBlank()) {
       violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("username"));
-    } else if (username.length() > MAX_USERNAME_LENGTH) {
-      violations.add(ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted("username", MAX_USERNAME_LENGTH));
+    } else if (username.length() > MAX_LENGTH) {
+      violations.add(ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted("username", MAX_LENGTH));
     } else if (!USERNAME_PATTERN.matcher(username).matches()) {
       violations.add(ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted("username", USERNAME_REGEX));
     }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
@@ -51,20 +52,20 @@ public class TenantControllerTest extends RestControllerTest {
     when(tenantServices.withAuthentication(any(Authentication.class))).thenReturn(tenantServices);
   }
 
-  @Test
-  void createTenantShouldReturnAccepted() {
+  @ParameterizedTest
+  @ValueSource(strings = {"foo", "Foo", "foo123"})
+  void createTenantShouldReturnAccepted(final String id) {
     // given
     final var tenantName = "Test Tenant";
-    final var tenantId = "tenant-test-id";
     final var tenantDescription = "Test description";
-    when(tenantServices.createTenant(new TenantDTO(null, tenantId, tenantName, tenantDescription)))
+    when(tenantServices.createTenant(new TenantDTO(null, id, tenantName, tenantDescription)))
         .thenReturn(
             CompletableFuture.completedFuture(
                 new TenantRecord()
                     .setTenantKey(100L)
                     .setName(tenantName)
                     .setDescription(tenantDescription)
-                    .setTenantId(tenantId)));
+                    .setTenantId(id)));
 
     // when
     webClient
@@ -73,24 +74,21 @@ public class TenantControllerTest extends RestControllerTest {
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(
-            new TenantCreateRequest()
-                .name(tenantName)
-                .description(tenantDescription)
-                .tenantId(tenantId))
+            new TenantCreateRequest().name(tenantName).description(tenantDescription).tenantId(id))
         .exchange()
         .expectStatus()
         .isCreated();
 
     // then
     verify(tenantServices, times(1))
-        .createTenant(new TenantDTO(null, tenantId, tenantName, tenantDescription));
+        .createTenant(new TenantDTO(null, id, tenantName, tenantDescription));
   }
 
   @Test
   void createTenantShouldReturnAllDetails() {
     // given
     final var tenantName = "Test Tenant";
-    final var tenantId = "tenant-test-id";
+    final var tenantId = "tenantId";
     final var tenantDescription = "Test description";
     final var tenantKey = 100L;
     when(tenantServices.createTenant(new TenantDTO(null, tenantId, tenantName, tenantDescription)))
@@ -156,6 +154,45 @@ public class TenantControllerTest extends RestControllerTest {
               "status": 400,
               "title": "INVALID_ARGUMENT",
               "detail": "No tenantId provided.",
+              "instance": "%s"
+            }"""
+                .formatted(TENANT_BASE_URL));
+
+    // then
+    verifyNoInteractions(tenantServices);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "foo~", "foo!", "foo#", "foo$", "foo%", "foo^", "foo&", "foo*", "foo(", "foo)", "foo=",
+        "foo+", "foo{", "foo[", "foo}", "foo]", "foo|", "foo\\", "foo:", "foo;", "foo\"", "foo'",
+        "foo<", "foo>", "foo,", "foo?", "foo/", "foo ", "foo@", "foo_", "foo.", "foo\t", "foo\n",
+        "foo\r",
+      })
+  void shouldRejectTenantCreationWithIllegalCharactersInId(final String id) {
+    // given
+    final var tenantName = "Tenant Name";
+    final var request = new TenantCreateRequest().tenantId(id).name(tenantName);
+
+    // when
+    webClient
+        .post()
+        .uri(TENANT_BASE_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "status": 400,
+              "title": "INVALID_ARGUMENT",
+              "detail": "The provided tenantId contains illegal characters. It must match the pattern '[a-zA-Z0-9]+'.",
               "instance": "%s"
             }"""
                 .formatted(TENANT_BASE_URL));

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -202,6 +202,38 @@ public class TenantControllerTest extends RestControllerTest {
   }
 
   @Test
+  void shouldRejectTenantWithTooLongId() {
+    // given
+    final var id = "x".repeat(257);
+    final var request = new TenantCreateRequest().tenantId(id).name("Tenant name");
+
+    // when
+    webClient
+        .post()
+        .uri(TENANT_BASE_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "status": 400,
+              "title": "INVALID_ARGUMENT",
+              "detail": "The provided tenantId exceeds the limit of 256 characters.",
+              "instance": "%s"
+            }"""
+                .formatted(TENANT_BASE_URL));
+
+    // then
+    verifyNoInteractions(tenantServices);
+  }
+
+  @Test
   void updateTenantShouldReturnUpdatedResponse() {
     // given
     final var tenantKey = 100L;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
@@ -254,6 +254,32 @@ public class MappingControllerTest extends RestControllerTest {
   }
 
   @Test
+  void shouldRejectMappingWithTooLongId() {
+    // given
+    final var id = "x".repeat(257);
+    final var request =
+        new MappingRuleCreateRequest()
+            .id(id)
+            .claimName("claimName")
+            .claimValue("claimValue")
+            .name("name");
+
+    // when then
+    assertRequestRejectedExceptionally(
+        request,
+        """
+            {
+              "type": "about:blank",
+              "status": 400,
+              "title": "INVALID_ARGUMENT",
+              "detail": "The provided id exceeds the limit of 256 characters.",
+              "instance": "%s"
+            }"""
+            .formatted(MAPPING_RULES_PATH));
+    verifyNoInteractions(mappingServices);
+  }
+
+  @Test
   void deleteMappingShouldReturnNoContent() {
     // given
     final long mappingKey = 100L;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
@@ -22,6 +22,8 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
@@ -38,8 +40,9 @@ public class MappingControllerTest extends RestControllerTest {
     when(mappingServices.withAuthentication(any(Authentication.class))).thenReturn(mappingServices);
   }
 
-  @Test
-  void createMappingShouldReturnCreated() {
+  @ParameterizedTest
+  @ValueSource(strings = {"foo", "Foo", "foo123"})
+  void createMappingShouldReturnCreated(final String id) {
     // given
     final var dto = validCreateMappingRequest();
     final var mappingRecord =
@@ -47,7 +50,7 @@ public class MappingControllerTest extends RestControllerTest {
             .setMappingKey(1L)
             .setClaimName(dto.claimName())
             .setClaimValue(dto.claimValue())
-            .setId(dto.id())
+            .setId(id)
             .setName(dto.name());
 
     when(mappingServices.createMapping(dto))
@@ -212,6 +215,38 @@ public class MappingControllerTest extends RestControllerTest {
               "status": 400,
               "title": "INVALID_ARGUMENT",
               "detail": "No name provided.",
+              "instance": "%s"
+            }"""
+            .formatted(MAPPING_RULES_PATH));
+    verifyNoInteractions(mappingServices);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "foo~", "foo!", "foo#", "foo$", "foo%", "foo^", "foo&", "foo*", "foo(", "foo)", "foo=",
+        "foo+", "foo{", "foo[", "foo}", "foo]", "foo|", "foo\\", "foo:", "foo;", "foo\"", "foo'",
+        "foo<", "foo>", "foo,", "foo?", "foo/", "foo ", "foo@", "foo_", "foo.", "foo\t", "foo\n",
+        "foo\r",
+      })
+  void shouldRejectMappingCreationWithIllegalCharactersInId(final String id) {
+    // given
+    final var request =
+        new MappingRuleCreateRequest()
+            .id(id)
+            .claimName("claimName")
+            .claimValue("claimValue")
+            .name("name");
+
+    // when then
+    assertRequestRejectedExceptionally(
+        request,
+        """
+            {
+              "type": "about:blank",
+              "status": 400,
+              "title": "INVALID_ARGUMENT",
+              "detail": "The provided id contains illegal characters. It must match the pattern '[a-zA-Z0-9]+'.",
               "instance": "%s"
             }"""
             .formatted(MAPPING_RULES_PATH));

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/BasicAuthOverGrpcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/BasicAuthOverGrpcIT.java
@@ -26,7 +26,6 @@ import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import java.util.List;
-import java.util.UUID;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -86,7 +85,7 @@ public class BasicAuthOverGrpcIT {
   void shouldBeAuthorizedWithUserThatIsGrantedPermissions() {
     // given
     final var processId = Strings.newRandomValidBpmnId();
-    final var username = UUID.randomUUID().toString();
+    final var username = Strings.newRandomValidUsername();
     final var password = "password";
     authUtil.createUserWithPermissions(
         username,
@@ -113,7 +112,7 @@ public class BasicAuthOverGrpcIT {
   void shouldBeUnauthorizedWithUserThatIsNotGrantedPermissions() {
     // given
     final var processId = Strings.newRandomValidBpmnId();
-    final var username = UUID.randomUUID().toString();
+    final var username = Strings.newRandomValidUsername();
     final var password = "password";
     authUtil.createUser(username, password);
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/BasicAuthOverRestIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/BasicAuthOverRestIT.java
@@ -25,7 +25,6 @@ import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import java.util.List;
-import java.util.UUID;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -83,7 +82,7 @@ final class BasicAuthOverRestIT {
   void shouldBeAuthorizedWithUserThatIsGrantedPermissions() {
     // given
     final var processId = Strings.newRandomValidBpmnId();
-    final var username = UUID.randomUUID().toString();
+    final var username = Strings.newRandomValidUsername();
     final var password = "password";
     authUtil.createUserWithPermissions(
         username,
@@ -110,7 +109,7 @@ final class BasicAuthOverRestIT {
   void shouldBeUnauthorizedWithUserThatIsNotGrantedPermissions() {
     // given
     final var processId = Strings.newRandomValidBpmnId();
-    final var username = UUID.randomUUID().toString();
+    final var username = Strings.newRandomValidUsername();
     final var password = "password";
     authUtil.createUser(username, password);
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignGroupToTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignGroupToTenantTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 @ZeebeIntegration
 class AssignGroupToTenantTest {
 
-  private static final String TENANT_ID = "tenant-id";
+  private static final String TENANT_ID = "tenantId";
 
   @TestZeebe
   private final TestStandaloneBroker zeebe =

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignMappingToTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignMappingToTenantTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 @ZeebeIntegration
 class AssignMappingToTenantTest {
 
-  private static final String TENANT_ID = "tenant-id";
+  private static final String TENANT_ID = "tenantId";
   private static final String CLAIM_NAME = "claimName";
   private static final String CLAIM_VALUE = "claimValue";
   private static final String NAME = "name";

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignUserToTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignUserToTenantTest.java
@@ -17,9 +17,9 @@ import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
-import java.util.UUID;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 @ZeebeIntegration
 class AssignUserToTenantTest {
 
-  private static final String TENANT_ID = "tenant-id";
+  private static final String TENANT_ID = "tenantId";
   private static final String USERNAME = "username";
 
   @TestZeebe
@@ -36,34 +36,29 @@ class AssignUserToTenantTest {
 
   @AutoClose private CamundaClient client;
 
-  private long tenantKey;
-  private long userKey;
-
   @BeforeEach
   void initClientAndInstances() {
     client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
 
     // Create Tenant
-    tenantKey =
-        client
-            .newCreateTenantCommand()
-            .tenantId(TENANT_ID)
-            .name("Tenant Name")
-            .send()
-            .join()
-            .getTenantKey();
+    client
+        .newCreateTenantCommand()
+        .tenantId(TENANT_ID)
+        .name("Tenant Name")
+        .send()
+        .join()
+        .getTenantKey();
 
     // Create User
-    userKey =
-        client
-            .newUserCreateCommand()
-            .username(USERNAME)
-            .name("name")
-            .email("email@example.com")
-            .password("password")
-            .send()
-            .join()
-            .getUserKey();
+    client
+        .newUserCreateCommand()
+        .username(USERNAME)
+        .name("name")
+        .email("email@example.com")
+        .password("password")
+        .send()
+        .join()
+        .getUserKey();
   }
 
   @Test
@@ -85,7 +80,7 @@ class AssignUserToTenantTest {
   @Test
   void shouldRejectAssignIfTenantDoesNotExist() {
     // Given
-    final var invalidTenantId = UUID.randomUUID().toString();
+    final var invalidTenantId = Strings.newRandomValidIdentityId();
 
     // When / Then
     assertThatThrownBy(
@@ -105,7 +100,7 @@ class AssignUserToTenantTest {
   @Test
   void shouldRejectAssignIfUserDoesNotExist() {
     // Given
-    final var invalidUserName = UUID.randomUUID().toString();
+    final var invalidUserName = Strings.newRandomValidUsername();
 
     // When / Then
     assertThatThrownBy(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateMappingTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateMappingTest.java
@@ -15,8 +15,8 @@ import io.camunda.zeebe.it.util.ZeebeAssertHelper;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.Strings;
 import java.time.Duration;
-import java.util.UUID;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,7 +27,7 @@ public class CreateMappingTest {
   public static final String CLAIM_NAME = "claimName";
   public static final String CLAIM_VALUE = "claimValue";
   public static final String NAME = "Map Name";
-  public static final String ID = "Map ID";
+  public static final String ID = "mappingId";
 
   @AutoClose CamundaClient client;
 
@@ -117,7 +117,7 @@ public class CreateMappingTest {
         .claimName(CLAIM_NAME)
         .claimValue(CLAIM_VALUE)
         .name(NAME)
-        .id(UUID.randomUUID().toString())
+        .id(Strings.newRandomValidIdentityId())
         .send()
         .join();
 
@@ -129,7 +129,7 @@ public class CreateMappingTest {
                     .claimName(CLAIM_NAME)
                     .claimValue(CLAIM_VALUE)
                     .name(NAME)
-                    .id(UUID.randomUUID().toString())
+                    .id(Strings.newRandomValidIdentityId())
                     .send()
                     .join())
         .isInstanceOf(RuntimeException.class)
@@ -164,6 +164,7 @@ public class CreateMappingTest {
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("Failed with code 409: 'Conflict'")
         .hasMessageContaining(
-            "Expected to create mapping with id 'Map ID', but a mapping with this id already exists.");
+            "Expected to create mapping with id '%s', but a mapping with this id already exists."
+                .formatted(ID));
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateTenantTest.java
@@ -41,7 +41,7 @@ class CreateTenantTest {
     final var response =
         client
             .newCreateTenantCommand()
-            .tenantId("tenant-id")
+            .tenantId("tenantId")
             .name("Tenant Name")
             .description("Tenant Description")
             .send()
@@ -50,7 +50,7 @@ class CreateTenantTest {
     // then
     assertThat(response.getTenantKey()).isGreaterThan(0);
     ZeebeAssertHelper.assertTenantCreated(
-        "tenant-id",
+        "tenantId",
         (tenant) -> {
           assertThat(tenant.getName()).isEqualTo("Tenant Name");
           assertThat(tenant.getDescription()).isEqualTo("Tenant Description");
@@ -61,12 +61,12 @@ class CreateTenantTest {
   void shouldCreateTenantWithoutDescription() {
     // when
     final var response =
-        client.newCreateTenantCommand().tenantId("tenant-id").name("Tenant Name").send().join();
+        client.newCreateTenantCommand().tenantId("tenantId").name("Tenant Name").send().join();
 
     // then
     assertThat(response.getTenantKey()).isGreaterThan(0);
     ZeebeAssertHelper.assertTenantCreated(
-        "tenant-id",
+        "tenantId",
         (tenant) -> {
           assertThat(tenant.getName()).isEqualTo("Tenant Name");
           assertThat(tenant.getDescription()).isEmpty();
@@ -76,14 +76,14 @@ class CreateTenantTest {
   @Test
   void shouldRejectIfTenantIdAlreadyExists() {
     // given
-    client.newCreateTenantCommand().tenantId("tenant-id").name("Tenant Name").send().join();
+    client.newCreateTenantCommand().tenantId("tenantId").name("Tenant Name").send().join();
 
     // when / then
     assertThatThrownBy(
             () ->
                 client
                     .newCreateTenantCommand()
-                    .tenantId("tenant-id")
+                    .tenantId("tenantId")
                     .name("Another Tenant Name")
                     .send()
                     .join())

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/DeleteTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/DeleteTenantTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 @ZeebeIntegration
 class DeleteTenantTest {
 
-  private static final String TENANT_ID = "tenant-id";
+  private static final String TENANT_ID = "tenantId";
 
   @TestZeebe
   private final TestStandaloneBroker zeebe =
@@ -53,7 +53,7 @@ class DeleteTenantTest {
 
     // then
     ZeebeAssertHelper.assertTenantDeleted(
-        "tenant-id", tenant -> assertThat(tenant.getTenantKey()).isEqualTo(tenantKey));
+        "tenantId", tenant -> assertThat(tenant.getTenantKey()).isEqualTo(tenantKey));
   }
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RemoveUserFromTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RemoveUserFromTenantTest.java
@@ -17,8 +17,8 @@ import io.camunda.zeebe.it.util.ZeebeAssertHelper;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.Strings;
 import java.time.Duration;
-import java.util.UUID;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 @ZeebeIntegration
 class RemoveUserFromTenantTest {
 
-  private static final String TENANT_ID = "tenant-id";
+  private static final String TENANT_ID = "tenantId";
   private static final String USERNAME = "username";
 
   @TestZeebe
@@ -69,7 +69,7 @@ class RemoveUserFromTenantTest {
   @Test
   void shouldRejectUnassignIfTenantDoesNotExist() {
     // Given
-    final var invalidTenantId = UUID.randomUUID().toString();
+    final var invalidTenantId = Strings.newRandomValidIdentityId();
 
     // When / Then
     assertThatThrownBy(
@@ -89,7 +89,7 @@ class RemoveUserFromTenantTest {
   @Test
   void shouldRejectUnassignIfUserDoesNotExist() {
     // Given
-    final var invalidUsername = UUID.randomUUID().toString();
+    final var invalidUsername = Strings.newRandomValidUsername();
 
     // When / Then
     assertThatThrownBy(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignGroupFromTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignGroupFromTenantTest.java
@@ -42,7 +42,7 @@ class UnassignGroupFromTenantTest {
     tenantKey =
         client
             .newCreateTenantCommand()
-            .tenantId("tenant-id")
+            .tenantId("tenantId")
             .name("Tenant Name")
             .send()
             .join()

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UpdateTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UpdateTenantTest.java
@@ -26,7 +26,7 @@ class UpdateTenantTest {
 
   private static final String UPDATED_TENANT_NAME = "Updated Tenant Name";
   private static final String UPDATED_TENANT_DESCRIPTION = "Updated Tenant Description";
-  private static final String TENANT_ID = "tenant-id";
+  private static final String TENANT_ID = "tenantId";
 
   @TestZeebe
   private final TestStandaloneBroker zeebe =

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/IdentitySetupInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/IdentitySetupInitializerIT.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotId;
+import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -56,7 +57,7 @@ final class IdentitySetupInitializerIT {
   @ValueSource(booleans = {true, false})
   void shouldInitializeIdentity(final boolean enableAuthorizations) {
     // given a broker with authorization enabled or disabled
-    final var username = UUID.randomUUID().toString();
+    final var username = Strings.newRandomValidUsername();
     final var name = UUID.randomUUID().toString();
     final var password = UUID.randomUUID().toString();
     final var email = UUID.randomUUID().toString();

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/Strings.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/Strings.java
@@ -17,4 +17,12 @@ public final class Strings {
   public static String newRandomValidBpmnId() {
     return "id-" + UUID.randomUUID().toString();
   }
+
+  public static String newRandomValidUsername() {
+    return "user" + UUID.randomUUID().toString().replace("-", "");
+  }
+
+  public static String newRandomValidIdentityId() {
+    return UUID.randomUUID().toString().replace("-", "");
+  }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Usernames should only contain alphanumeric characters, `@`, `.`, or `_`.
Mapping and tenant ids should only contain alphanumeric characters.

All should not exceed 256 characters.

-------

Roles and Groups are out of scope of this PR. These do not have an id field implemented yet. I've added an instruction to add this[ to the respective issue.](https://github.com/camunda/camunda/issues/26961)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #26341
