### PR TITLE
[Backport stable/8.6] fix: Tasklist OS importer logs "missing exporter index" as warning

### DIFF
--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/os/RecordsReaderOpenSearch.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/os/RecordsReaderOpenSearch.java
@@ -144,7 +144,7 @@ public class RecordsReaderOpenSearch extends RecordsReaderAbstract {
 
     } catch (final OpenSearchException ex) {
       if (ex.getMessage().contains("no such index")) {
-        LOGGER.warn("No index found for alias '{}'", aliasName);
+        LOGGER.debug("No index found for alias '{}'", aliasName);
         throw new NoSuchIndexException();
       } else {
         final String message =


### PR DESCRIPTION
# Description
Backport of #28660 to `stable/8.6`.

relates to #28591
original author: @houssain-barouni