### PR TITLE
Assign original author to backport pull requests

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -42,8 +42,8 @@ jobs:
             Backport of #${pull_number} to `${target_branch}`.
 
             relates to ${issue_refs}
-            original author: @${pull_author}
 
+          add_author_as_assignee: true
           experimental: >
             {
               "conflict_resolution": "draft_commit_conflicts"


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

With [backport-action `v3.2.0`](https://github.com/korthout/backport-action/releases/tag/v3.2.0), we can now automatically assign the author of the original pull request to the created backport pull requests.

This means we no longer have to tag the author in the pull body (description).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [x] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

- [slack discussion](https://camunda.slack.com/archives/C03B0F6FUQG/p1740394480535249?thread_ts=1740394301.386649&cid=C03B0F6FUQG)
