### PR TITLE
fix: migrations should not block spring's context from being initialized

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/migration/MigrationsRunner.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/MigrationsRunner.java
@@ -17,6 +17,7 @@ import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -42,13 +43,16 @@ public class MigrationsRunner implements ApplicationRunner {
               } catch (final Exception e) {
                 throw new RuntimeException(e);
               }
-            })
+            },
+            "migration-parent")
         .start();
   }
 
   private void startMigrators(final ApplicationArguments args) throws Exception {
     final Exception migrationsExceptions = new Exception("migration failed");
-    try (final var executor = Executors.newFixedThreadPool(migrators.size())) {
+    try (final var executor =
+        Executors.newFixedThreadPool(
+            migrators.size(), new CustomizableThreadFactory("migration-"))) {
       final var results = executor.invokeAll(migrators);
       for (final var result : results) {
         try {

--- a/migration/migration-api/src/main/java/io/camunda/migration/api/MigrationException.java
+++ b/migration/migration-api/src/main/java/io/camunda/migration/api/MigrationException.java
@@ -13,6 +13,10 @@ public class MigrationException extends RuntimeException {
 
   @Serial private static final long serialVersionUID = 845931450938L;
 
+  public MigrationException(final Throwable cause) {
+    super(cause);
+  }
+
   public MigrationException(final String message) {
     super(message);
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Make MigrationsRunner execute the migrations without blocking Spring's context from being initialized, as the migrations are also dependent on other components of the single-app.
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

ref: https://camunda.slack.com/archives/C06F0GLJNFM/p1740134490554779?thread_ts=1740121225.157419&cid=C06F0GLJNFM
