### PR TITLE
feat: avoid log pollution with similar error messages

### DIFF
--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -261,6 +261,11 @@
       <artifactId>aws-java-sdk-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTask.java
@@ -11,4 +11,12 @@ import java.util.concurrent.CompletionStage;
 
 public interface BackgroundTask {
   CompletionStage<Integer> execute();
+
+  default String getCaption() {
+    final String simpleName = getClass().getSimpleName();
+    if (simpleName == null || simpleName.isEmpty()) {
+      return getClass().getName();
+    }
+    return simpleName;
+  }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTask.java
@@ -13,10 +13,6 @@ public interface BackgroundTask {
   CompletionStage<Integer> execute();
 
   default String getCaption() {
-    final String simpleName = getClass().getSimpleName();
-    if (simpleName == null || simpleName.isEmpty()) {
-      return getClass().getName();
-    }
-    return simpleName;
+    return getClass().getSimpleName();
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/ReschedulingTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/ReschedulingTask.java
@@ -7,31 +7,23 @@
  */
 package io.camunda.exporter.tasks;
 
+import io.camunda.exporter.tasks.util.ReschedulingTaskLogger;
 import io.camunda.zeebe.util.ExponentialBackoff;
-import java.net.ConnectException;
-import java.net.SocketException;
-import java.net.SocketTimeoutException;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 
 public final class ReschedulingTask implements Runnable {
-  private static final Set<Class<? extends Exception>> BACKGROUND_SUPPRESSED_EXCEPTIONS =
-      Set.of(SocketTimeoutException.class, ConnectException.class, SocketException.class);
-
-  private static final Integer FAILURE_LOGGING_SKIP_COUNT = 10;
   private final BackgroundTask task;
   private final int minimumWorkCount;
   private final ScheduledExecutorService executor;
   private final Logger logger;
+  private final ReschedulingTaskLogger periodicLogger;
   private final ExponentialBackoff idleStrategy;
   private final ExponentialBackoff errorStrategy;
   private long delayMs;
   private long errorDelayMs;
-  private Integer failureCount = 0;
-  private String lastErrorMessage;
 
   public ReschedulingTask(
       final BackgroundTask task,
@@ -45,6 +37,7 @@ public final class ReschedulingTask implements Runnable {
     this.executor = executor;
     this.logger = logger;
 
+    periodicLogger = new ReschedulingTaskLogger(logger);
     idleStrategy = new ExponentialBackoff(maxDelayBetweenRunsMs, delayBetweenRunsMs, 1.2, 0);
     errorStrategy = new ExponentialBackoff(10_000, delayBetweenRunsMs, 1.2, 0);
   }
@@ -86,37 +79,12 @@ public final class ReschedulingTask implements Runnable {
     return errorDelayMs;
   }
 
-  /**
-   * To avoid log pollution with similar error messages we will log on ERROR level every 10th
-   * occurrence and all others on DEBUG level. Additionally, for some exception classes like
-   * `ConnectException` we will log the on WARN level.
-   *
-   * @param error
-   */
   private void logError(final Throwable error) {
     final String errorMessage =
         String.format(
             "Error occurred while performing a background task %s; error message `%s`; operation will be retried",
             task.getCaption(), error.getCause().getMessage());
-    if (lastErrorMessage != null && lastErrorMessage.equals(errorMessage)) {
-      failureCount++;
-    } else {
-      failureCount = 1;
-      lastErrorMessage = errorMessage;
-    }
-    // only log the error message if it's different from the last one, or if it's the same, only log
-    // every n-th time
-    if (lastErrorMessage == null
-        || !lastErrorMessage.equals(errorMessage)
-        || failureCount % FAILURE_LOGGING_SKIP_COUNT == 1) {
-      if (BACKGROUND_SUPPRESSED_EXCEPTIONS.contains(error.getCause().getClass())) {
-        logger.warn(errorMessage);
-      } else {
-        logger.error(errorMessage, error);
-      }
-    } else {
-      logger.debug(errorMessage);
-    }
+    periodicLogger.logError(errorMessage, error);
   }
 
   private void reschedule(final long delay) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/ReschedulingTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/ReschedulingTask.java
@@ -80,11 +80,11 @@ public final class ReschedulingTask implements Runnable {
   }
 
   private void logError(final Throwable error) {
-    final String errorMessage =
-        String.format(
-            "Error occurred while performing a background task %s; error message `%s`; operation will be retried",
-            task.getCaption(), error.getCause().getMessage());
-    periodicLogger.logError(errorMessage, error);
+    periodicLogger.logError(
+        "Error occurred while performing a background task {}; error message {}; operation will be retried",
+        error,
+        task.getCaption(),
+        error.getCause().getMessage());
   }
 
   private void reschedule(final long delay) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
@@ -66,4 +66,9 @@ public class BatchOperationArchiverJob implements ArchiverJob {
             executor)
         .thenApplyAsync(ok -> processInstanceKeys.size(), executor);
   }
+
+  @Override
+  public String toString() {
+    return "Batch operation archiver job";
+  }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstancesArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstancesArchiverJob.java
@@ -89,4 +89,9 @@ public class ProcessInstancesArchiverJob implements ArchiverJob {
             executor)
         .thenApplyAsync(ok -> processInstanceKeys.size(), executor);
   }
+
+  @Override
+  public String getCaption() {
+    return "Process instances archiver job";
+  }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateTask.java
@@ -42,6 +42,11 @@ public class BatchOperationUpdateTask implements BackgroundTask {
         .thenComposeAsync(this::updateBatchOperations, executor);
   }
 
+  @Override
+  public String getCaption() {
+    return "Batch operation update task";
+  }
+
   private CompletionStage<Integer> updateBatchOperations(
       final Collection<String> batchOperationIds) {
     if (batchOperationIds.isEmpty()) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -76,6 +76,11 @@ public final class IncidentUpdateTask implements BackgroundTask {
     }
   }
 
+  @Override
+  public String getCaption() {
+    return "Incident update task";
+  }
+
   private int processNextBatch() {
     final var data = new AdditionalData();
     final var batch = getPendingIncidentsBatch(data);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/util/ReschedulingTaskLogger.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/util/ReschedulingTaskLogger.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.util;
+
+import java.net.ConnectException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.util.Set;
+import org.slf4j.Logger;
+
+/**
+ * To avoid log pollution with similar error messages this logger logs on ERROR level every 10th
+ * occurrence and all others on DEBUG level. Additionally, for some exception classes like
+ * `ConnectException` it logs them on WARN level.
+ */
+public class ReschedulingTaskLogger {
+  private static final Integer DEFAULT_SKIP_ENTRIES_COUNT = 10;
+  private static final Set<Class<? extends Exception>> BACKGROUND_SUPPRESSED_EXCEPTIONS =
+      Set.of(SocketTimeoutException.class, ConnectException.class, SocketException.class);
+  private Integer skipEntriesCount = DEFAULT_SKIP_ENTRIES_COUNT;
+  private final Logger logger;
+  private Integer failureCount = 0;
+  private String lastErrorMessage;
+
+  public ReschedulingTaskLogger(final Logger logger) {
+    this.logger = logger;
+  }
+
+  public ReschedulingTaskLogger(final Integer skipEntriesCount, final Logger logger) {
+    this.skipEntriesCount = skipEntriesCount;
+    this.logger = logger;
+  }
+
+  public void logError(final String errorMessage, final Throwable error) {
+    if (lastErrorMessage != null && lastErrorMessage.equals(errorMessage)) {
+      failureCount++;
+    } else {
+      failureCount = 1;
+      lastErrorMessage = errorMessage;
+    }
+    // only log the error message if it's different from the last one, or if it's the same, only log
+    // every n-th time
+    if (lastErrorMessage == null || failureCount % skipEntriesCount == 1) {
+      if (shouldBeSupressed(error)) {
+        logger.warn(errorMessage);
+      } else {
+        logger.error(errorMessage, error);
+      }
+    } else {
+      logger.debug(errorMessage);
+    }
+  }
+
+  private boolean shouldBeSupressed(final Throwable error) {
+    return BACKGROUND_SUPPRESSED_EXCEPTIONS.contains(error.getClass())
+        || (error.getCause() != null
+            && BACKGROUND_SUPPRESSED_EXCEPTIONS.contains(error.getCause().getClass()));
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/ReschedulingTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/ReschedulingTaskTest.java
@@ -7,10 +7,6 @@
  */
 package io.camunda.exporter.tasks;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.contains;
-import static org.mockito.ArgumentMatchers.eq;
-
 import io.camunda.exporter.tasks.archiver.ArchiverJob;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -18,7 +14,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,71 +38,6 @@ final class ReschedulingTaskTest {
     inOrder
         .verify(executor, Mockito.timeout(5_000).times(1))
         .schedule(task, 10L, TimeUnit.MILLISECONDS);
-  }
-
-  @Test
-  void shouldLogEvery10ThReoccurringError() {
-    // given
-    final Logger loggerMock = Mockito.spy(Logger.class);
-    final Exception exception = new RuntimeException("failure");
-    final var task =
-        new ReschedulingTask(
-            new FailingJob().setException(exception), 1, 10, 10, executor, loggerMock);
-
-    // when
-    task.run();
-
-    // then - every 10th error is logged on error level, others on debug
-    final String errorMessage =
-        "Error occurred while performing a background task FailingJob; error message `failure`; operation will be retried";
-    final ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
-    final var inOrder = Mockito.inOrder(loggerMock);
-    inOrder
-        .verify(loggerMock, Mockito.timeout(5_000).times(1))
-        .error(eq(errorMessage), exceptionCaptor.capture());
-    assertThat(exceptionCaptor.getValue().getCause()).isEqualTo(exception);
-    for (int i = 1; i <= 9; i++) {
-      inOrder.verify(loggerMock, Mockito.timeout(5_000).times(1)).debug(errorMessage);
-    }
-    inOrder
-        .verify(loggerMock, Mockito.timeout(5_000).times(1))
-        .error(eq(errorMessage), exceptionCaptor.capture());
-    assertThat(exceptionCaptor.getValue().getCause()).isEqualTo(exception);
-    for (int i = 1; i <= 9; i++) {
-      inOrder.verify(loggerMock, Mockito.timeout(5_000).times(1)).debug(errorMessage);
-    }
-  }
-
-  @Test
-  void shouldLogEveryNewError() {
-    // given
-    final Logger loggerMock = Mockito.spy(Logger.class);
-    final Exception exception = new RuntimeException("failure");
-    final var task =
-        new ReschedulingTask(
-            new FailingJob().setException(exception).setRandomExceptionMessage(true),
-            1,
-            10,
-            10,
-            executor,
-            loggerMock);
-
-    // when
-    task.run();
-
-    // then - when errors are different they are all logged on error level
-    final String errorMessageSubstring =
-        "Error occurred while performing a background task FailingJob;";
-    final ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
-    final var inOrder = Mockito.inOrder(loggerMock);
-    inOrder
-        .verify(loggerMock, Mockito.timeout(5_000).times(1))
-        .error(contains(errorMessageSubstring), exceptionCaptor.capture());
-    assertThat(exceptionCaptor.getValue().getCause().getMessage()).contains(exception.getMessage());
-    inOrder
-        .verify(loggerMock, Mockito.timeout(5_000).times(1))
-        .error(contains(errorMessageSubstring), exceptionCaptor.capture());
-    assertThat(exceptionCaptor.getValue().getCause().getMessage()).contains(exception.getMessage());
   }
 
   @Test
@@ -251,26 +181,9 @@ final class ReschedulingTaskTest {
   }
 
   private static final class FailingJob implements ArchiverJob {
-
-    private Exception exception = new RuntimeException("failure");
-    private boolean randomExceptionMessage = false;
-
     @Override
     public CompletableFuture<Integer> archiveNextBatch() {
-      if (randomExceptionMessage) {
-        exception = new RuntimeException("failure" + System.currentTimeMillis());
-      }
-      return CompletableFuture.failedFuture(exception);
-    }
-
-    public FailingJob setException(final Exception exception) {
-      this.exception = exception;
-      return this;
-    }
-
-    public FailingJob setRandomExceptionMessage(final boolean randomExceptionMessage) {
-      this.randomExceptionMessage = randomExceptionMessage;
-      return this;
+      return CompletableFuture.failedFuture(new RuntimeException("failure"));
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/utils/ReschedulingTaskLoggerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/utils/ReschedulingTaskLoggerTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.utils;
+
+import io.camunda.exporter.tasks.util.ReschedulingTaskLogger;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+
+public class ReschedulingTaskLoggerTest {
+
+  @Test
+  void shouldLogEvery10ThReoccurringError() {
+    // given
+    final Logger loggerMock = Mockito.spy(Logger.class);
+    final ReschedulingTaskLogger logger = new ReschedulingTaskLogger(loggerMock);
+    final String errorMessage = "error message";
+    final Exception exception = new RuntimeException(errorMessage);
+
+    // when
+    for (int i = 1; i <= 20; i++) {
+      logger.logError(errorMessage, exception);
+    }
+
+    // then - every 10th error is logged on error level, others on debug
+    final var inOrder = Mockito.inOrder(loggerMock);
+
+    inOrder.verify(loggerMock, Mockito.timeout(5_000).times(1)).error(errorMessage, exception);
+    inOrder.verify(loggerMock, Mockito.timeout(5_000).times(9)).debug(errorMessage);
+
+    inOrder.verify(loggerMock, Mockito.timeout(5_000).times(1)).error(errorMessage, exception);
+    inOrder.verify(loggerMock, Mockito.timeout(5_000).times(9)).debug(errorMessage);
+  }
+
+  @Test
+  void shouldLogEveryNewError() {
+    // given
+    final Logger loggerMock = Mockito.spy(Logger.class);
+    final String errorMessage1 = "failure1";
+    final String errorMessage2 = "failure2";
+    final Exception exception1 = new RuntimeException(errorMessage1);
+    final Exception exception2 = new RuntimeException(errorMessage2);
+    final ReschedulingTaskLogger logger = new ReschedulingTaskLogger(loggerMock);
+
+    // when
+    logger.logError(errorMessage1, exception1);
+    logger.logError(errorMessage2, exception2);
+
+    // then - when errors are different they are all logged on error level
+    final var inOrder = Mockito.inOrder(loggerMock);
+    inOrder.verify(loggerMock, Mockito.timeout(5_000).times(1)).error(errorMessage1, exception1);
+    inOrder.verify(loggerMock, Mockito.timeout(5_000).times(1)).error(errorMessage2, exception2);
+  }
+}


### PR DESCRIPTION
## Description

Improve logging in background tasks:
* add information about which background task has failed
* when one and the same exception is reoccurring, log only every 10th occurrence. Other are logged on DEBUG level.

## Related issues

closes #25539, #28158
