### PR TITLE
fix: make empty batches required to disable importer configurable

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/property/ImportProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ImportProperties.java
@@ -18,6 +18,7 @@ public class ImportProperties {
   private static final int DEFAULT_SCHEDULER_BACKOFF = 5000;
   private static final int DEFAULT_FLOW_NODE_TREE_CACHE_SIZE = 1000;
   private static final int DEFAULT_MAX_EMPTY_RUNS = 10;
+  private static final int DEFAULT_MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER = 5;
 
   private int threadsCount = DEFAULT_IMPORT_THREADS_COUNT;
 
@@ -66,6 +67,12 @@ public class ImportProperties {
   private boolean retryReadingParents = true;
 
   private int maxEmptyRuns = DEFAULT_MAX_EMPTY_RUNS;
+
+  /**
+   * When migrating from the old importers to the new CamundaExporter we need to ensure that all
+   * previous data have been imported before we start consuming data on the CamundaExporter.
+   */
+  private int completedReaderMinEmptyBatches = DEFAULT_MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER;
 
   public boolean isStartLoadingDataOnStartup() {
     return startLoadingDataOnStartup;
@@ -174,6 +181,16 @@ public class ImportProperties {
 
   public ImportProperties setMaxEmptyRuns(final int maxEmptyRuns) {
     this.maxEmptyRuns = maxEmptyRuns;
+    return this;
+  }
+
+  public int getCompletedReaderMinEmptyBatches() {
+    return completedReaderMinEmptyBatches;
+  }
+
+  public ImportProperties setCompletedReaderMinEmptyBatches(
+      final int completedReaderMinEmptyBatches) {
+    this.completedReaderMinEmptyBatches = completedReaderMinEmptyBatches;
     return this;
   }
 }

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/RecordsReaderHolder.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/RecordsReaderHolder.java
@@ -34,7 +34,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class RecordsReaderHolder {
 
-  public static final Integer MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER = 5;
   private static final Logger LOGGER = LoggerFactory.getLogger(RecordsReaderHolder.class);
 
   private Set<RecordsReader> recordsReaders = null;
@@ -89,7 +88,7 @@ public class RecordsReaderHolder {
 
       final var reader = getRecordsReader(partitionId, importValueType);
       return countEmptyBatchesAfterImportingDone.get(reader)
-          >= MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER;
+          >= operateProperties.getImporter().getCompletedReaderMinEmptyBatches();
     }
 
     return false;

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FinishedImportingIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FinishedImportingIT.java
@@ -106,7 +106,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     // require multiple checks to avoid race condition. If records are written to zeebe indices and
     // before a refresh, the record reader pulls the import batch is empty so it then says that the
     // record reader is done when it is not.
-    for (int i = 0; i < RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0; i < operateProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
       tester.performOneRoundOfImport();
     }
 
@@ -137,7 +137,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
         generateRecord(ValueType.DECISION_EVALUATION, "8.8.0", 1);
     EXPORTER.export(newVersionDecisionEvalRecord);
 
-    for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0; i <= operateProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
       // simulate existing decision records left to process so it is not marked as completed
       final var decisionRecord2 = generateRecord(ValueType.DECISION, "8.7.0", 2);
       EXPORTER.export(decisionRecord2);
@@ -176,7 +176,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     tester.performOneRoundOfImport();
 
     // Import empty batches
-    for (int i = 0; i < RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0; i <= operateProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
       tester.performOneRoundOfImport();
     }
 
@@ -201,7 +201,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     tester.performOneRoundOfImport();
 
     // when
-    for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0; i <= operateProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
       tester.performOneRoundOfImport();
     }
 
@@ -242,7 +242,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     tester.performOneRoundOfImport();
 
     // Import empty batches
-    for (int i = 0; i < RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0; i < operateProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
       tester.performOneRoundOfImport();
     }
 
@@ -300,7 +300,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     // Otherwise: If records are written to zeebe indices and before a refresh, the record reader
     // pulls an empty import batch, then it might assume falsely
     // that it is done, while it is not.
-    for (int i = 0; i < RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0; i < operateProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
       tester.performOneRoundOfImport();
     }
 
@@ -378,7 +378,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
 
     // when
-    for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0; i <= operateProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
       tester.performOneRoundOfImport();
     }
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FinishedImportingIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FinishedImportingIT.java
@@ -59,6 +59,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
   @Autowired private RestHighLevelClient esClient;
   @Autowired private MeterRegistry registry;
   private final ProtocolFactory factory = new ProtocolFactory();
+  private int emptyBatches = 0;
 
   @Before
   public void beforeEach() {
@@ -69,7 +70,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     CONFIG.index.createTemplate = true;
     CONFIG.retention.setEnabled(false);
     CONFIG.bulk.size = 1; // force flushing on the first record
-
+    emptyBatches = operateProperties.getImporter().getCompletedReaderMinEmptyBatches();
     // here enable all indexes that needed during the tests beforehand as they will be created once
     TestSupport.provideValueTypes()
         .forEach(valueType -> TestSupport.setIndexingForValueType(CONFIG.index, valueType, true));
@@ -106,7 +107,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     // require multiple checks to avoid race condition. If records are written to zeebe indices and
     // before a refresh, the record reader pulls the import batch is empty so it then says that the
     // record reader is done when it is not.
-    for (int i = 0; i < operateProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
+    for (int i = 0; i < emptyBatches; i++) {
       tester.performOneRoundOfImport();
     }
 
@@ -137,7 +138,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
         generateRecord(ValueType.DECISION_EVALUATION, "8.8.0", 1);
     EXPORTER.export(newVersionDecisionEvalRecord);
 
-    for (int i = 0; i <= operateProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
+    for (int i = 0; i <= emptyBatches; i++) {
       // simulate existing decision records left to process so it is not marked as completed
       final var decisionRecord2 = generateRecord(ValueType.DECISION, "8.7.0", 2);
       EXPORTER.export(decisionRecord2);
@@ -176,7 +177,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     tester.performOneRoundOfImport();
 
     // Import empty batches
-    for (int i = 0; i <= operateProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
+    for (int i = 0; i < emptyBatches; i++) {
       tester.performOneRoundOfImport();
     }
 
@@ -201,7 +202,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     tester.performOneRoundOfImport();
 
     // when
-    for (int i = 0; i <= operateProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
+    for (int i = 0; i <= emptyBatches; i++) {
       tester.performOneRoundOfImport();
     }
 
@@ -242,7 +243,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     tester.performOneRoundOfImport();
 
     // Import empty batches
-    for (int i = 0; i < operateProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
+    for (int i = 0; i < emptyBatches; i++) {
       tester.performOneRoundOfImport();
     }
 
@@ -300,7 +301,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     // Otherwise: If records are written to zeebe indices and before a refresh, the record reader
     // pulls an empty import batch, then it might assume falsely
     // that it is done, while it is not.
-    for (int i = 0; i < operateProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
+    for (int i = 0; i < emptyBatches; i++) {
       tester.performOneRoundOfImport();
     }
 
@@ -378,7 +379,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
 
     // when
-    for (int i = 0; i <= operateProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
+    for (int i = 0; i <= emptyBatches; i++) {
       tester.performOneRoundOfImport();
     }
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchFinishedImportingIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchFinishedImportingIT.java
@@ -105,7 +105,7 @@ public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
     // require multiple checks to avoid race condition. If records are written to zeebe indices and
     // before a refresh, the record reader pulls the import batch is empty so it then says that the
     // record reader is done when it is not.
-    for (int i = 0; i < RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0; i < operateProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
       tester.performOneRoundOfImport();
     }
 
@@ -134,7 +134,7 @@ public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
         generateRecord(ValueType.DECISION_EVALUATION, "8.8.0", 1);
     EXPORTER.export(newVersionDecisionEvalRecord);
 
-    for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0; i <= operateProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
       // simulate existing decision records left to process so it is not marked as completed
       final var decisionRecord2 = generateRecord(ValueType.DECISION, "8.7.0", 2);
       EXPORTER.export(decisionRecord2);
@@ -173,7 +173,7 @@ public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
     tester.performOneRoundOfImport();
 
     // Import empty batches
-    for (int i = 0; i < RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0; i < operateProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
       tester.performOneRoundOfImport();
     }
 
@@ -207,7 +207,7 @@ public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
     // require multiple checks to avoid race condition. If records are written to zeebe indices and
     // before a refresh, the record reader pulls the import batch is empty so it then says that the
     // record reader is done when it is not.
-    for (int i = 0; i < RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0; i < operateProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
       tester.performOneRoundOfImport();
     }
 
@@ -286,7 +286,7 @@ public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
     osClient.index().refresh("*");
 
     // when
-    for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0; i <= operateProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
       tester.performOneRoundOfImport();
     }
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/properties/PropertiesIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/properties/PropertiesIT.java
@@ -66,5 +66,6 @@ public class PropertiesIT {
     assertThat(securityConfiguration.getAuthorizations().isEnabled()).isTrue();
     // assert that it can be set from ${camunda.operate.multiTenancy.enabled}
     assertThat(securityConfiguration.getMultiTenancy().isEnabled()).isTrue();
+    assertThat(operateProperties.getImporter().getCompletedReaderMinEmptyBatches()).isEqualTo(10);
   }
 }

--- a/operate/qa/integration-tests/src/test/resources/config/application-test-properties.yml
+++ b/operate/qa/integration-tests/src/test/resources/config/application-test-properties.yml
@@ -13,6 +13,7 @@ camunda.operate:
     prefix: somePrefix
   importer:
     startLoadingDataOnStartup: false
+    completedReaderMinEmptyBatches: 10
   zeebe:
     gatewayAddress: someZeebeHost:999
   operationExecutor:

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/ImportProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/ImportProperties.java
@@ -25,6 +25,8 @@ public class ImportProperties {
 
   private static final int DEFAULT_MAX_EMPTY_RUNS = 10;
 
+  private static final int DEFAULT_MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER = 5;
+
   private int threadsCount = DEFAULT_IMPORT_THREADS_COUNT;
 
   private int queueSize = DEFAULT_IMPORT_QUEUE_SIZE;
@@ -51,6 +53,12 @@ public class ImportProperties {
   private int importPositionUpdateInterval = DEFAULT_IMPORT_POSITION_UPDATE_INTERVAL;
 
   private int maxEmptyRuns = DEFAULT_MAX_EMPTY_RUNS;
+
+  /**
+   * When migrating from the old importers to the new CamundaExporter we need to ensure that all
+   * previous data have been imported before we start consuming data on the CamundaExporter.
+   */
+  private int completedReaderMinEmptyBatches = DEFAULT_MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER;
 
   public boolean isStartLoadingDataOnStartup() {
     return startLoadingDataOnStartup;
@@ -133,6 +141,16 @@ public class ImportProperties {
 
   public ImportProperties setMaxEmptyRuns(final int maxEmptyRuns) {
     this.maxEmptyRuns = maxEmptyRuns;
+    return this;
+  }
+
+  public int getCompletedReaderMinEmptyBatches() {
+    return completedReaderMinEmptyBatches;
+  }
+
+  public ImportProperties setCompletedReaderMinEmptyBatches(
+      final int completedReaderMinEmptyBatches) {
+    this.completedReaderMinEmptyBatches = completedReaderMinEmptyBatches;
     return this;
   }
 }

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/RecordsReaderHolder.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/RecordsReaderHolder.java
@@ -33,8 +33,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class RecordsReaderHolder {
 
-  public static final Integer MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER = 5;
-
   private static final Logger LOGGER = LoggerFactory.getLogger(RecordsReaderHolder.class);
 
   private Set<RecordsReader> recordsReader = null;
@@ -93,7 +91,7 @@ public class RecordsReaderHolder {
 
       final var reader = getRecordsReader(partitionId, importValueType);
       return countEmptyBatchesAfterImportingDone.get(reader)
-          >= MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER;
+          >= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
     }
 
     return false;

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchFinishedImportingIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchFinishedImportingIT.java
@@ -116,7 +116,7 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
     // require multiple checks to avoid race condition. If records are written to zeebe indices and
     // before a refresh, the record reader pulls the import batch is empty so it then says that the
     // record reader is done when it is not.
-    for (int i = 0; i < RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0; i < tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
@@ -145,7 +145,9 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
     final var newVersionJobRecord = generateRecord(ValueType.JOB, "8.8.0", 1);
     EXPORTER.export(newVersionJobRecord);
 
-    for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0;
+        i <= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
+        i++) {
       // simulate existing variable records left to process so it is not marked as completed
       final var decisionRecord2 = generateRecord(ValueType.VARIABLE, "8.7.0", 2);
       EXPORTER.export(decisionRecord2);
@@ -181,7 +183,9 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
     EXPORTER.export(partitionTwoRecord2);
     tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
 
-    for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0;
+        i <= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
+        i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
@@ -215,7 +219,7 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
     // require multiple checks to avoid race condition. If records are written to zeebe indices and
     // before a refresh, the record reader pulls the import batch is empty so it then says that the
     // record reader is done when it is not.
-    for (int i = 0; i < RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0; i < tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
@@ -245,7 +249,9 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
     tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
 
     // when
-    for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0;
+        i <= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
+        i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
@@ -280,7 +286,9 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
     EXPORTER.export(partitionTwoRecord2);
     tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
 
-    for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0;
+        i <= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
+        i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
@@ -382,7 +390,9 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
     tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
 
     // when
-    for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0;
+        i <= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
+        i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchFinishedImportingIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchFinishedImportingIT.java
@@ -64,6 +64,7 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
   @Autowired private TasklistImportPositionIndex importPositionIndex;
   @Autowired private MeterRegistry meterRegistry;
   private final ProtocolFactory factory = new ProtocolFactory();
+  private int emptyBatches;
 
   @BeforeAll
   public static void beforeClass() {
@@ -79,7 +80,7 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
     CONFIG.index.createTemplate = true;
     CONFIG.retention.setEnabled(false);
     CONFIG.bulk.size = 1; // force flushing on the first record
-
+    emptyBatches = tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
     // here enable all indexes that needed during the tests beforehand as they will be created once
     TestSupport.provideValueTypes()
         .forEach(valueType -> TestSupport.setIndexingForValueType(CONFIG.index, valueType, true));
@@ -116,7 +117,7 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
     // require multiple checks to avoid race condition. If records are written to zeebe indices and
     // before a refresh, the record reader pulls the import batch is empty so it then says that the
     // record reader is done when it is not.
-    for (int i = 0; i < tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
+    for (int i = 0; i < emptyBatches; i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
@@ -145,9 +146,7 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
     final var newVersionJobRecord = generateRecord(ValueType.JOB, "8.8.0", 1);
     EXPORTER.export(newVersionJobRecord);
 
-    for (int i = 0;
-        i <= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
-        i++) {
+    for (int i = 0; i <= emptyBatches; i++) {
       // simulate existing variable records left to process so it is not marked as completed
       final var decisionRecord2 = generateRecord(ValueType.VARIABLE, "8.7.0", 2);
       EXPORTER.export(decisionRecord2);
@@ -183,9 +182,7 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
     EXPORTER.export(partitionTwoRecord2);
     tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
 
-    for (int i = 0;
-        i <= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
-        i++) {
+    for (int i = 0; i <= emptyBatches; i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
@@ -219,7 +216,7 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
     // require multiple checks to avoid race condition. If records are written to zeebe indices and
     // before a refresh, the record reader pulls the import batch is empty so it then says that the
     // record reader is done when it is not.
-    for (int i = 0; i < tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
+    for (int i = 0; i < emptyBatches; i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
@@ -249,9 +246,7 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
     tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
 
     // when
-    for (int i = 0;
-        i <= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
-        i++) {
+    for (int i = 0; i <= emptyBatches; i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
@@ -286,9 +281,7 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
     EXPORTER.export(partitionTwoRecord2);
     tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
 
-    for (int i = 0;
-        i <= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
-        i++) {
+    for (int i = 0; i <= emptyBatches; i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
@@ -390,9 +383,7 @@ public class ElasticsearchFinishedImportingIT extends TasklistZeebeIntegrationTe
     tasklistEsClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
 
     // when
-    for (int i = 0;
-        i <= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
-        i++) {
+    for (int i = 0; i <= emptyBatches; i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchFinishedImportingIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchFinishedImportingIT.java
@@ -122,7 +122,7 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
     // require multiple checks to avoid race condition. If records are written to zeebe indices and
     // before a refresh, the record reader pulls the import batch is empty so it then says that the
     // record reader is done when it is not.
-    for (int i = 0; i < RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0; i < tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
@@ -155,7 +155,9 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
     final var newVersionJobRecord = generateRecord(ValueType.JOB, "8.8.0", 1);
     EXPORTER.export(newVersionJobRecord);
 
-    for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0;
+        i <= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
+        i++) {
       // simulate existing variable records left to process so it is not marked as completed
       final var decisionRecord2 = generateRecord(ValueType.VARIABLE, "8.7.0", 1);
       EXPORTER.export(decisionRecord2);
@@ -191,7 +193,9 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
     EXPORTER.export(partitionTwoRecord2);
     openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
 
-    for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0;
+        i <= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
+        i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
@@ -225,7 +229,7 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
     // require multiple checks to avoid race condition. If records are written to zeebe indices and
     // before a refresh, the record reader pulls the import batch is empty so it then says that the
     // record reader is done when it is not.
-    for (int i = 0; i < RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0; i < tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
@@ -255,7 +259,9 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
     openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
 
     // when
-    for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0;
+        i <= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
+        i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
@@ -290,7 +296,9 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
     EXPORTER.export(partitionTwoRecord2);
     openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
 
-    for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0;
+        i <= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
+        i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
@@ -382,7 +390,9 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
     openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
 
     // when
-    for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+    for (int i = 0;
+        i <= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
+        i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchFinishedImportingIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpensearchFinishedImportingIT.java
@@ -68,6 +68,7 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
   @Autowired private TasklistImportPositionIndex importPositionIndex;
   @Autowired private MeterRegistry meterRegistry;
   private final ProtocolFactory factory = new ProtocolFactory();
+  private int emptyBatches;
 
   @BeforeAll
   public static void beforeClass() {
@@ -84,7 +85,7 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
     CONFIG.index.createTemplate = true;
     CONFIG.retention.setEnabled(false);
     CONFIG.bulk.size = 1; // force flushing on the first record
-
+    emptyBatches = tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
     // here enable all indexes that needed during the tests beforehand as they will be created once
     TestSupport.provideValueTypes()
         .forEach(valueType -> TestSupport.setIndexingForValueType(CONFIG.index, valueType, true));
@@ -122,7 +123,7 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
     // require multiple checks to avoid race condition. If records are written to zeebe indices and
     // before a refresh, the record reader pulls the import batch is empty so it then says that the
     // record reader is done when it is not.
-    for (int i = 0; i < tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
+    for (int i = 0; i < emptyBatches; i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
@@ -155,9 +156,7 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
     final var newVersionJobRecord = generateRecord(ValueType.JOB, "8.8.0", 1);
     EXPORTER.export(newVersionJobRecord);
 
-    for (int i = 0;
-        i <= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
-        i++) {
+    for (int i = 0; i <= emptyBatches; i++) {
       // simulate existing variable records left to process so it is not marked as completed
       final var decisionRecord2 = generateRecord(ValueType.VARIABLE, "8.7.0", 1);
       EXPORTER.export(decisionRecord2);
@@ -193,9 +192,7 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
     EXPORTER.export(partitionTwoRecord2);
     openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
 
-    for (int i = 0;
-        i <= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
-        i++) {
+    for (int i = 0; i <= emptyBatches; i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
@@ -229,7 +226,7 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
     // require multiple checks to avoid race condition. If records are written to zeebe indices and
     // before a refresh, the record reader pulls the import batch is empty so it then says that the
     // record reader is done when it is not.
-    for (int i = 0; i < tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches(); i++) {
+    for (int i = 0; i < emptyBatches; i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
@@ -259,9 +256,7 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
     openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
 
     // when
-    for (int i = 0;
-        i <= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
-        i++) {
+    for (int i = 0; i <= emptyBatches; i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
@@ -296,9 +291,7 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
     EXPORTER.export(partitionTwoRecord2);
     openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
 
-    for (int i = 0;
-        i <= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
-        i++) {
+    for (int i = 0; i <= emptyBatches; i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 
@@ -390,9 +383,7 @@ public class OpensearchFinishedImportingIT extends TasklistZeebeIntegrationTest 
     openSearchClient.indices().refresh(new RefreshRequest.Builder().index("*").build());
 
     // when
-    for (int i = 0;
-        i <= tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches();
-        i++) {
+    for (int i = 0; i <= emptyBatches; i++) {
       zeebeImporter.performOneRoundOfImport();
     }
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/properties/PropertiesTest.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/properties/PropertiesTest.java
@@ -30,6 +30,7 @@ public class PropertiesTest {
   @Test
   public void testProperties() {
     assertThat(tasklistProperties.getImporter().isStartLoadingDataOnStartup()).isFalse();
+    assertThat(tasklistProperties.getImporter().getCompletedReaderMinEmptyBatches()).isEqualTo(10);
     assertThat(tasklistProperties.getBatchOperationMaxSize()).isEqualTo(500);
     assertThat(tasklistProperties.getElasticsearch().getClusterName()).isEqualTo("clusterName");
     assertThat(tasklistProperties.getElasticsearch().getHost()).isEqualTo("someHost");

--- a/tasklist/qa/integration-tests/src/test/resources/config/application-test-properties.yml
+++ b/tasklist/qa/integration-tests/src/test/resources/config/application-test-properties.yml
@@ -14,6 +14,7 @@ camunda.tasklist:
     prefix: somePrefix
   importer:
     startLoadingDataOnStartup: false
+    completedReaderMinEmptyBatches: 10
   zeebe:
     gatewayAddress: someZeebeHost:999
   operationExecutor:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
During the migration to the CamundaExporter, we need to count the empty batches received by the old Importers to determine whether 8.7 data are finished importing. 

The property of the required batches was not configurable, moved to: `camunda.tasklist/operate.importer.completedReaderMinEmptyBatches`, by default set to 5.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
