### PR TITLE
deps: update json smart to 2.5.2 [Backport stable/8.7]

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1855,7 +1855,7 @@
       <dependency>
         <groupId>net.minidev</groupId>
         <artifactId>json-smart</artifactId>
-        <version>2.4.11</version>
+        <version>2.5.2</version>
       </dependency>
 
       <!-- needed for tests in elasticsearch-exporter -->


### PR DESCRIPTION
## Description

[CVE-2024-57699](https://github.com/advisories/GHSA-pq2g-wx69-c263) has been resolved in net.minidev:json-smart:2.5.2
