### PR TITLE
fix: wait for 8.7 records to be present

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FinishedImportingIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FinishedImportingIT.java
@@ -18,7 +18,6 @@ import io.camunda.operate.util.OperateZeebeAbstractIT;
 import io.camunda.operate.util.TestSupport;
 import io.camunda.operate.zeebe.ImportValueType;
 import io.camunda.operate.zeebeimport.RecordsReaderHolder;
-import io.camunda.operate.zeebeimport.ZeebeImporter;
 import io.camunda.operate.zeebeimport.elasticsearch.ElasticsearchRecordsReader;
 import io.camunda.webapps.schema.descriptors.operate.index.ImportPositionIndex;
 import io.camunda.zeebe.exporter.ElasticsearchExporter;
@@ -36,7 +35,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Map;
-import org.awaitility.Awaitility;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.search.SearchRequest;
@@ -53,8 +51,8 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
   private static final ElasticsearchExporter EXPORTER = new ElasticsearchExporter();
   private static final ElasticsearchExporterConfiguration CONFIG =
       new ElasticsearchExporterConfiguration();
+
   @Autowired public SchemaManager schemaManager;
-  @Autowired protected ZeebeImporter zeebeImporter;
   @Autowired private OperateProperties operateProperties;
   @Autowired private RecordsReaderHolder recordsReaderHolder;
   @Autowired private ImportPositionIndex importPositionIndex;
@@ -89,12 +87,12 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
 
   @Test
   public void shouldMarkRecordReadersAsCompletedIf880RecordReceived() throws IOException {
+
     // given
     final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
     EXPORTER.export(record);
     esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
-
-    zeebeImporter.performOneRoundOfImport();
+    tester.performOneRoundOfImport();
 
     // when
     final var record2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
@@ -102,24 +100,25 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
 
     // receives 8.7 record and marks partition as finished importing
-    zeebeImporter.performOneRoundOfImport();
+    tester.performOneRoundOfImport();
 
     // then
     // require multiple checks to avoid race condition. If records are written to zeebe indices and
     // before a refresh, the record reader pulls the import batch is empty so it then says that the
     // record reader is done when it is not.
     for (int i = 0; i < RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
-      zeebeImporter.performOneRoundOfImport();
+      tester.performOneRoundOfImport();
     }
 
     // the import position for
     await()
         .atMost(Duration.ofSeconds(30))
-        .until(() -> isRecordReaderIsCompleted("1-process-instance"));
+        .until(() -> isRecordReaderCompleted("1-process-instance"));
   }
 
   @Test
   public void shouldMarkMultiplePositionIndexAsCompletedIf880RecordReceived() throws IOException {
+
     final var processInstanceRecord = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
     final var decisionEvalRecord = generateRecord(ValueType.DECISION_EVALUATION, "8.7.0", 1);
     final var decisionRecord = generateRecord(ValueType.DECISION, "8.7.0", 2);
@@ -128,7 +127,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     EXPORTER.export(decisionRecord);
 
     esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
-    zeebeImporter.performOneRoundOfImport();
+    tester.performOneRoundOfImport();
 
     // when
     final var newVersionProcessInstanceRecord =
@@ -144,76 +143,66 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
       EXPORTER.export(decisionRecord2);
       esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
 
-      zeebeImporter.performOneRoundOfImport();
+      tester.performOneRoundOfImport();
     }
 
     await()
         .atMost(Duration.ofSeconds(30))
         .until(
             () ->
-                isRecordReaderIsCompleted("1-process-instance")
-                    && isRecordReaderIsCompleted("1-decision-evaluation")
-                    && !isRecordReaderIsCompleted("2-decision"));
+                isRecordReaderCompleted("1-process-instance")
+                    && isRecordReaderCompleted("1-decision-evaluation")
+                    && !isRecordReaderCompleted("2-decision"));
   }
 
   @Test
   public void shouldMarkMultiplePartitionsAsCompletedIfTheyReceiveAn880Record() throws IOException {
     // given
+
     final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
     final var partitionTwoRecord = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 2);
     EXPORTER.export(record);
     EXPORTER.export(partitionTwoRecord);
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
-        .pollInterval(Duration.ofSeconds(1))
-        .until(
-            () -> {
-              esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
-              zeebeImporter.performOneRoundOfImport();
-              return isRecordIngested("1-process-instance")
-                  && isRecordIngested("2-process-instance");
-            });
+    esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
+    tester.performOneRoundOfImport();
+
     // when
     final var record2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
     final var partitionTwoRecord2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 2);
     EXPORTER.export(record2);
     EXPORTER.export(partitionTwoRecord2);
     esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
+    // Import 8.8 records to trigger importer's counting of empty batches
+    tester.performOneRoundOfImport();
 
-    for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
-      zeebeImporter.performOneRoundOfImport();
+    // Import empty batches
+    for (int i = 0; i < RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+      tester.performOneRoundOfImport();
     }
 
     // the import position for
     await()
         .atMost(Duration.ofSeconds(30))
-        .until(() -> isRecordReaderIsCompleted("1-process-instance"));
+        .until(() -> isRecordReaderCompleted("1-process-instance"));
     await()
         .atMost(Duration.ofSeconds(30))
-        .until(() -> isRecordReaderIsCompleted("2-process-instance"));
+        .until(() -> isRecordReaderCompleted("2-process-instance"));
   }
 
   @Test
   public void shouldNotMarkedAsCompletedViaMetricsWhenImportingIsNotDone() throws IOException {
     // given
+
     final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
     final var partitionTwoRecord = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 2);
     EXPORTER.export(record);
     EXPORTER.export(partitionTwoRecord);
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
-        .pollInterval(Duration.ofSeconds(1))
-        .until(
-            () -> {
-              esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
-              zeebeImporter.performOneRoundOfImport();
-              return isRecordIngested("1-process-instance")
-                  && isRecordIngested("2-process-instance");
-            });
+    esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
+    tester.performOneRoundOfImport();
 
     // when
     for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
-      zeebeImporter.performOneRoundOfImport();
+      tester.performOneRoundOfImport();
     }
 
     // then
@@ -231,22 +220,16 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
   }
 
   @Test
-  public void shouldMarkImporterCompletedViaMetricsAsWell() throws IOException {
+  public void shouldMarkImporterCompletedViaMetricsAsWell()
+      throws IOException, InterruptedException {
     // given
+
     final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
     final var partitionTwoRecord = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 2);
     EXPORTER.export(record);
     EXPORTER.export(partitionTwoRecord);
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
-        .pollInterval(Duration.ofSeconds(1))
-        .until(
-            () -> {
-              esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
-              zeebeImporter.performOneRoundOfImport();
-              return isRecordIngested("1-process-instance")
-                  && isRecordIngested("2-process-instance");
-            });
+    esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
+    tester.performOneRoundOfImport();
 
     // when
     final var record2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
@@ -255,16 +238,20 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     EXPORTER.export(partitionTwoRecord2);
     esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
 
-    for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
-      zeebeImporter.performOneRoundOfImport();
+    // Import 8.8 records to trigger importer's counting of empty batches
+    tester.performOneRoundOfImport();
+
+    // Import empty batches
+    for (int i = 0; i < RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+      tester.performOneRoundOfImport();
     }
 
     await()
         .atMost(Duration.ofSeconds(30))
-        .until(() -> isRecordReaderIsCompleted("1-process-instance"));
+        .until(() -> isRecordReaderCompleted("1-process-instance"));
     await()
         .atMost(Duration.ofSeconds(30))
-        .until(() -> isRecordReaderIsCompleted("2-process-instance"));
+        .until(() -> isRecordReaderCompleted("2-process-instance"));
 
     // then
 
@@ -294,11 +281,11 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
   @Test
   public void shouldNotSetCompletedToFalseForSubsequentRecordsAfterImportingDone()
       throws IOException {
+
     final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
     EXPORTER.export(record);
     esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
-
-    zeebeImporter.performOneRoundOfImport();
+    tester.performOneRoundOfImport();
 
     // when
     final var record2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
@@ -306,7 +293,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
 
     // receives 8.7 record and marks partition as finished importing
-    zeebeImporter.performOneRoundOfImport();
+    tester.performOneRoundOfImport();
 
     // then
     // Require multiple checks to avoid race condition.
@@ -314,32 +301,32 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     // pulls an empty import batch, then it might assume falsely
     // that it is done, while it is not.
     for (int i = 0; i < RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
-      zeebeImporter.performOneRoundOfImport();
+      tester.performOneRoundOfImport();
     }
 
     await()
         .atMost(Duration.ofSeconds(30))
-        .until(() -> isRecordReaderIsCompleted("1-process-instance"));
+        .until(() -> isRecordReaderCompleted("1-process-instance"));
 
     final var record3 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
     EXPORTER.export(record3);
     esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
 
-    zeebeImporter.performOneRoundOfImport();
+    tester.performOneRoundOfImport();
 
     await()
         .during(Duration.ofSeconds(10))
         .atMost(Duration.ofSeconds(12))
-        .until(() -> isRecordReaderIsCompleted("1-process-instance"));
+        .until(() -> isRecordReaderCompleted("1-process-instance"));
   }
 
   @Test
   public void shouldNotOverwriteImportPositionDocumentWithDefaultValue() throws IOException {
+
     final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
     EXPORTER.export(record);
     esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
-
-    zeebeImporter.performOneRoundOfImport();
+    tester.performOneRoundOfImport();
 
     assertImportPositionMatchesRecord(record, ImportValueType.PROCESS_INSTANCE, 1);
 
@@ -361,6 +348,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
 
   @Test
   public void shouldWriteDefaultEmptyDefaultImportPositionDocumentsOnRecordReaderStart() {
+
     recordsReaderHolder.getAllRecordsReaders().stream()
         .map(ElasticsearchRecordsReader.class::cast)
         .forEach(ElasticsearchRecordsReader::postConstruct);
@@ -384,20 +372,21 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
   @Test
   public void shouldMarkRecordReadersCompletedEvenIfZeebeIndicesDontExist() throws IOException {
     // given
+
     final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
     EXPORTER.export(record);
     esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
 
     // when
     for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
-      zeebeImporter.performOneRoundOfImport();
+      tester.performOneRoundOfImport();
     }
 
     // then
     for (final var type : ImportValueType.IMPORT_VALUE_TYPES) {
       await()
           .atMost(Duration.ofSeconds(30))
-          .until(() -> isRecordReaderIsCompleted("1-" + type.getAliasTemplate()));
+          .until(() -> isRecordReaderCompleted("1-" + type.getAliasTemplate()));
     }
   }
 
@@ -422,7 +411,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
             });
   }
 
-  private boolean isRecordReaderIsCompleted(final String partitionIdFieldValue) throws IOException {
+  private boolean isRecordReaderCompleted(final String partitionIdFieldValue) throws IOException {
     final var hits =
         Arrays.stream(
                 esClient
@@ -453,30 +442,5 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
             r.withBrokerVersion(brokerVersion)
                 .withPartitionId(partitionId)
                 .withTimestamp(System.currentTimeMillis()));
-  }
-
-  private boolean isRecordIngested(final String partitionIdFieldValue) throws IOException {
-    final var hits =
-        Arrays.stream(
-                esClient
-                    .search(
-                        new SearchRequest(importPositionIndex.getFullQualifiedName())
-                            .source(new SearchSourceBuilder().size(100)),
-                        RequestOptions.DEFAULT)
-                    .getHits()
-                    .getHits())
-            .map(SearchHit::getSourceAsMap)
-            .toList();
-    if (hits.isEmpty()) {
-      return false;
-    }
-    return (Boolean)
-        hits.stream()
-            .filter(
-                hit ->
-                    hit.get(ImportPositionIndex.ID).equals(partitionIdFieldValue)
-                        && ((Long) hit.get(ImportPositionIndex.SEQUENCE)) > 0)
-            .findFirst()
-            .isPresent();
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FinishedImportingIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FinishedImportingIT.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Map;
+import org.awaitility.Awaitility;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.search.SearchRequest;
@@ -162,10 +163,16 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     final var partitionTwoRecord = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 2);
     EXPORTER.export(record);
     EXPORTER.export(partitionTwoRecord);
-    esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
-
-    zeebeImporter.performOneRoundOfImport();
-
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(
+            () -> {
+              esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
+              zeebeImporter.performOneRoundOfImport();
+              return isRecordIngested("1-process-instance")
+                  && isRecordIngested("2-process-instance");
+            });
     // when
     final var record2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
     final var partitionTwoRecord2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 2);
@@ -193,7 +200,16 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     final var partitionTwoRecord = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 2);
     EXPORTER.export(record);
     EXPORTER.export(partitionTwoRecord);
-    esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(
+            () -> {
+              esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
+              zeebeImporter.performOneRoundOfImport();
+              return isRecordIngested("1-process-instance")
+                  && isRecordIngested("2-process-instance");
+            });
 
     // when
     for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
@@ -221,9 +237,16 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     final var partitionTwoRecord = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 2);
     EXPORTER.export(record);
     EXPORTER.export(partitionTwoRecord);
-    esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
-
-    zeebeImporter.performOneRoundOfImport();
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(30))
+        .pollInterval(Duration.ofSeconds(1))
+        .until(
+            () -> {
+              esClient.indices().refresh(new RefreshRequest("*"), RequestOptions.DEFAULT);
+              zeebeImporter.performOneRoundOfImport();
+              return isRecordIngested("1-process-instance")
+                  && isRecordIngested("2-process-instance");
+            });
 
     // when
     final var record2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
@@ -430,5 +453,30 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
             r.withBrokerVersion(brokerVersion)
                 .withPartitionId(partitionId)
                 .withTimestamp(System.currentTimeMillis()));
+  }
+
+  private boolean isRecordIngested(final String partitionIdFieldValue) throws IOException {
+    final var hits =
+        Arrays.stream(
+                esClient
+                    .search(
+                        new SearchRequest(importPositionIndex.getFullQualifiedName())
+                            .source(new SearchSourceBuilder().size(100)),
+                        RequestOptions.DEFAULT)
+                    .getHits()
+                    .getHits())
+            .map(SearchHit::getSourceAsMap)
+            .toList();
+    if (hits.isEmpty()) {
+      return false;
+    }
+    return (Boolean)
+        hits.stream()
+            .filter(
+                hit ->
+                    hit.get(ImportPositionIndex.ID).equals(partitionIdFieldValue)
+                        && ((Long) hit.get(ImportPositionIndex.SEQUENCE)) > 0)
+            .findFirst()
+            .isPresent();
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchFinishedImportingIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/opensearch/OpensearchFinishedImportingIT.java
@@ -8,7 +8,6 @@
 package io.camunda.operate.opensearch;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.awaitility.Awaitility.await;
 
 import io.camunda.operate.conditions.DatabaseCondition;
 import io.camunda.operate.property.OperateProperties;
@@ -18,7 +17,6 @@ import io.camunda.operate.util.OperateZeebeAbstractIT;
 import io.camunda.operate.util.TestSupport;
 import io.camunda.operate.zeebe.ImportValueType;
 import io.camunda.operate.zeebeimport.RecordsReaderHolder;
-import io.camunda.operate.zeebeimport.ZeebeImporter;
 import io.camunda.operate.zeebeimport.opensearch.OpensearchRecordsReader;
 import io.camunda.webapps.schema.descriptors.operate.index.ImportPositionIndex;
 import io.camunda.webapps.schema.entities.operate.ImportPositionEntity;
@@ -56,7 +54,6 @@ public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
       new OpensearchExporterConfiguration();
 
   @Autowired public SchemaManager schemaManager;
-  @Autowired protected ZeebeImporter zeebeImporter;
   @Autowired private OperateProperties operateProperties;
   @Autowired private RecordsReaderHolder recordsReaderHolder;
   @Autowired private ImportPositionIndex importPositionIndex;
@@ -94,8 +91,7 @@ public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
     final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
     EXPORTER.export(record);
     osClient.index().refresh("*");
-
-    zeebeImporter.performOneRoundOfImport();
+    tester.performOneRoundOfImport();
 
     // when
     final var record2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
@@ -103,19 +99,19 @@ public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
     osClient.index().refresh("*");
 
     // receives 8.7 record and marks partition as finished importing
-    zeebeImporter.performOneRoundOfImport();
+    tester.performOneRoundOfImport();
 
     // then
     // require multiple checks to avoid race condition. If records are written to zeebe indices and
     // before a refresh, the record reader pulls the import batch is empty so it then says that the
     // record reader is done when it is not.
     for (int i = 0; i < RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
-      zeebeImporter.performOneRoundOfImport();
+      tester.performOneRoundOfImport();
     }
 
     Awaitility.await()
         .atMost(Duration.ofSeconds(30))
-        .until(() -> isRecordReaderIsCompleted("1-process-instance"));
+        .until(() -> isRecordReaderCompleted("1-process-instance"));
   }
 
   @Test
@@ -128,7 +124,7 @@ public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
     EXPORTER.export(decisionRecord);
 
     osClient.index().refresh("*");
-    zeebeImporter.performOneRoundOfImport();
+    tester.performOneRoundOfImport();
 
     // when
     final var newVersionProcessInstanceRecord =
@@ -144,16 +140,16 @@ public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
       EXPORTER.export(decisionRecord2);
       osClient.index().refresh("*");
 
-      zeebeImporter.performOneRoundOfImport();
+      tester.performOneRoundOfImport();
     }
 
     Awaitility.await()
         .atMost(Duration.ofSeconds(30))
         .until(
             () ->
-                isRecordReaderIsCompleted("1-process-instance")
-                    && isRecordReaderIsCompleted("1-decision-evaluation")
-                    && !isRecordReaderIsCompleted("2-decision"));
+                isRecordReaderCompleted("1-process-instance")
+                    && isRecordReaderCompleted("1-decision-evaluation")
+                    && !isRecordReaderCompleted("2-decision"));
   }
 
   @Test
@@ -163,16 +159,8 @@ public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
     final var partitionTwoRecord = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 2);
     EXPORTER.export(record);
     EXPORTER.export(partitionTwoRecord);
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
-        .pollInterval(Duration.ofSeconds(1))
-        .until(
-            () -> {
-              osClient.index().refresh("*");
-              zeebeImporter.performOneRoundOfImport();
-              return isRecordIngested("1-process-instance")
-                  && isRecordIngested("2-process-instance");
-            });
+    osClient.index().refresh("*");
+    tester.performOneRoundOfImport();
 
     // when
     final var record2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
@@ -181,17 +169,21 @@ public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
     EXPORTER.export(partitionTwoRecord2);
     osClient.index().refresh("*");
 
-    for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
-      zeebeImporter.performOneRoundOfImport();
+    // Import 8.8 records to trigger importer's counting of empty batches
+    tester.performOneRoundOfImport();
+
+    // Import empty batches
+    for (int i = 0; i < RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
+      tester.performOneRoundOfImport();
     }
 
     // the import position for
     Awaitility.await()
         .atMost(Duration.ofSeconds(30))
-        .until(() -> isRecordReaderIsCompleted("1-process-instance"));
+        .until(() -> isRecordReaderCompleted("1-process-instance"));
     Awaitility.await()
         .atMost(Duration.ofSeconds(30))
-        .until(() -> isRecordReaderIsCompleted("2-process-instance"));
+        .until(() -> isRecordReaderCompleted("2-process-instance"));
   }
 
   @Test
@@ -201,7 +193,7 @@ public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
     EXPORTER.export(record);
     osClient.index().refresh("*");
 
-    zeebeImporter.performOneRoundOfImport();
+    tester.performOneRoundOfImport();
 
     // when
     final var record2 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
@@ -209,30 +201,30 @@ public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
     osClient.index().refresh("*");
 
     // receives 8.7 record and marks partition as finished importing
-    zeebeImporter.performOneRoundOfImport();
+    tester.performOneRoundOfImport();
 
     // then
     // require multiple checks to avoid race condition. If records are written to zeebe indices and
     // before a refresh, the record reader pulls the import batch is empty so it then says that the
     // record reader is done when it is not.
     for (int i = 0; i < RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
-      zeebeImporter.performOneRoundOfImport();
+      tester.performOneRoundOfImport();
     }
 
     Awaitility.await()
         .atMost(Duration.ofSeconds(30))
-        .until(() -> isRecordReaderIsCompleted("1-process-instance"));
+        .until(() -> isRecordReaderCompleted("1-process-instance"));
 
     final var record3 = generateRecord(ValueType.PROCESS_INSTANCE, "8.8.0", 1);
     EXPORTER.export(record3);
     osClient.index().refresh("*");
 
-    zeebeImporter.performOneRoundOfImport();
+    tester.performOneRoundOfImport();
 
     Awaitility.await()
         .during(Duration.ofSeconds(10))
         .atMost(Duration.ofSeconds(12))
-        .until(() -> isRecordReaderIsCompleted("1-process-instance"));
+        .until(() -> isRecordReaderCompleted("1-process-instance"));
   }
 
   @Test
@@ -241,8 +233,7 @@ public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
     final var record = generateRecord(ValueType.PROCESS_INSTANCE, "8.7.0", 1);
     EXPORTER.export(record);
     osClient.index().refresh("*");
-
-    zeebeImporter.performOneRoundOfImport();
+    tester.performOneRoundOfImport();
 
     assertImportPositionMatchesRecord(record, ImportValueType.PROCESS_INSTANCE, 1);
 
@@ -296,14 +287,14 @@ public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
 
     // when
     for (int i = 0; i <= RecordsReaderHolder.MINIMUM_EMPTY_BATCHES_FOR_COMPLETED_READER; i++) {
-      zeebeImporter.performOneRoundOfImport();
+      tester.performOneRoundOfImport();
     }
 
     // then
     for (final var type : ImportValueType.IMPORT_VALUE_TYPES) {
-      await()
+      Awaitility.await()
           .atMost(Duration.ofSeconds(30))
-          .until(() -> isRecordReaderIsCompleted("1-" + type.getAliasTemplate()));
+          .until(() -> isRecordReaderCompleted("1-" + type.getAliasTemplate()));
     }
   }
 
@@ -326,7 +317,7 @@ public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
             });
   }
 
-  private boolean isRecordReaderIsCompleted(final String partitionIdFieldValue) throws IOException {
+  private boolean isRecordReaderCompleted(final String partitionIdFieldValue) throws IOException {
     final var hits =
         osClient
             .doc()
@@ -344,29 +335,8 @@ public class OpensearchFinishedImportingIT extends OperateZeebeAbstractIT {
     return hits.stream()
         .filter(hit -> hit.getId().equals(partitionIdFieldValue))
         .findFirst()
-        .orElseThrow()
-        .getCompleted();
-  }
-
-  private boolean isRecordIngested(final String partitionIdFieldValue) throws IOException {
-    final var hits =
-        osClient
-            .doc()
-            .search(
-                new Builder().index(importPositionIndex.getFullQualifiedName()).size(100),
-                ImportPositionEntity.class)
-            .hits()
-            .hits()
-            .stream()
-            .map(Hit::source)
-            .toList();
-    if (hits.isEmpty()) {
-      return false;
-    }
-    return hits.stream()
-        .filter(hit -> hit.getId().equals(partitionIdFieldValue) && hit.getSequence() > 0)
-        .findFirst()
-        .isPresent();
+        .map(ImportPositionEntity::getCompleted)
+        .orElse(false);
   }
 
   private <T extends RecordValue> Record<T> generateRecord(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Add `performOneRoundOfImport` on `OperateTester` to ensure the importer thread queue does not have records to import before progressing when doing single imports.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
