### PR TITLE
[Backport stable/8.6] Update dependency org.apache.httpcomponents.core5:httpcore5 to v5.3

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -60,13 +60,15 @@ public interface ZeebeClientBuilder {
 
   /**
    * @param restAddress the REST API address of a gateway that the client can connect to. The
-   *     default value is {@code 0.0.0.0:8080}.
+   *     address must be an absolute URL, including the scheme.
+   *     <p>The default value is {@code https://0.0.0.0:8080}.
    */
   ZeebeClientBuilder restAddress(URI restAddress);
 
   /**
-   * @param grpcAddress the gRPC address of a gateway that the client can connect to. The default
-   *     value is {@code 0.0.0.0:26500}.
+   * @param grpcAddress the gRPC address of a gateway that the client can connect to. The address
+   *     must be an absolute URL, including the scheme.
+   *     <p>The default value is {@code https://0.0.0.0:26500}.
    */
   ZeebeClientBuilder grpcAddress(URI grpcAddress);
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -370,6 +370,15 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
 
   @Override
   public ZeebeClientBuilder restAddress(final URI restAddress) {
+    /*
+     * Validates that the provided rest address is an absolute URI.
+     *
+     * <p>We use {@code URI.getHost() == null} to check for absolute URIs because:
+     * <ul>
+     *   <li>For absolute URIs (with a scheme) (e.g., "https://example.com"), {@code URI.getHost()} returns the hostname (e.g., "example.com").</li>
+     *   <li>For relative URIs (without a scheme) (e.g., "example.com"), {@code URI.getHost()} returns {@code null}.</li>
+     * </ul>
+     */
     if (restAddress != null && restAddress.getHost() == null) {
       throw new IllegalArgumentException("restAddress must be an absolute URI");
     }
@@ -379,6 +388,15 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
 
   @Override
   public ZeebeClientBuilder grpcAddress(final URI grpcAddress) {
+    /*
+     * Validates that the provided gRPC address is an absolute URI.
+     *
+     * <p>We use {@code URI.getHost() == null} to check for absolute URIs because:
+     * <ul>
+     *   <li>For absolute URIs (with a scheme) (e.g., "https://example.com"), {@code URI.getHost()} returns the hostname (e.g., "example.com").</li>
+     *   <li>For relative URIs (without a scheme) (e.g., "example.com"), {@code URI.getHost()} returns {@code null}.</li>
+     * </ul>
+     */
     if (grpcAddress != null && grpcAddress.getHost() == null) {
       throw new IllegalArgumentException("grpcAddress must be an absolute URI");
     }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -370,12 +370,18 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
 
   @Override
   public ZeebeClientBuilder restAddress(final URI restAddress) {
+    if (restAddress != null && restAddress.getHost() == null) {
+      throw new IllegalArgumentException("restAddress must be an absolute URI");
+    }
     this.restAddress = restAddress;
     return this;
   }
 
   @Override
   public ZeebeClientBuilder grpcAddress(final URI grpcAddress) {
+    if (grpcAddress != null && grpcAddress.getHost() == null) {
+      throw new IllegalArgumentException("grpcAddress must be an absolute URI");
+    }
     this.grpcAddress = grpcAddress;
     grpcAddressUsed = true;
     return this;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.client.impl.http;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.client.CredentialsProvider;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
+import io.camunda.zeebe.client.api.command.InternalClientException;
 import io.camunda.zeebe.client.impl.NoopCredentialsProvider;
 import io.camunda.zeebe.client.impl.util.VersionUtil;
 import java.io.File;
@@ -110,8 +111,8 @@ public class HttpClientFactory {
       builder.setScheme(config.isPlaintextConnectionEnabled() ? "http" : "https");
 
       return builder.build();
-    } catch (final URISyntaxException e) {
-      throw new RuntimeException(e);
+    } catch (final URISyntaxException | UnsupportedOperationException e) {
+      throw new InternalClientException("Issues with REST API URI.", e);
     }
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
@@ -111,7 +111,7 @@ public class HttpClientFactory {
       builder.setScheme(config.isPlaintextConnectionEnabled() ? "http" : "https");
 
       return builder.build();
-    } catch (final URISyntaxException | UnsupportedOperationException e) {
+    } catch (final URISyntaxException e) {
       throw new InternalClientException("Issues with REST API URI.", e);
     }
   }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -538,7 +538,7 @@ public final class ZeebeClientTest extends ClientTest {
   @Test
   public void shouldSetRestAddressFromSetterWithClientBuilder() throws URISyntaxException {
     // given
-    final URI restAddress = new URI("localhost:9090");
+    final URI restAddress = new URI("http://localhost:9090");
     final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
     builder.restAddress(restAddress);
 
@@ -552,7 +552,7 @@ public final class ZeebeClientTest extends ClientTest {
   @Test
   public void shouldSetRestAddressPortFromPropertyWithClientBuilder() throws URISyntaxException {
     // given
-    final URI restAddress = new URI("localhost:9090");
+    final URI restAddress = new URI("http://localhost:9090");
     final Properties properties = new Properties();
     properties.setProperty(REST_ADDRESS, restAddress.toString());
     final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
@@ -568,7 +568,7 @@ public final class ZeebeClientTest extends ClientTest {
   @Test
   public void shouldSetRestAddressPortFromEnvVarWithClientBuilder() throws URISyntaxException {
     // given
-    final URI restAddress = new URI("localhost:9090");
+    final URI restAddress = new URI("http://localhost:9090");
     Environment.system().put(REST_ADDRESS_VAR, restAddress.toString());
 
     // when

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
@@ -544,6 +544,15 @@ public class ZeebeClientConfigurationProperties {
 
     @Deprecated
     public void setGrpcAddress(final URI grpcAddress) {
+      /*
+       * Validates that the provided gRPC address is an absolute URI.
+       *
+       * <p>We use {@code URI.getHost() == null} to check for absolute URIs because:
+       * <ul>
+       *   <li>For absolute URIs (with a scheme) (e.g., "https://example.com"), {@code URI.getHost()} returns the hostname (e.g., "example.com").</li>
+       *   <li>For relative URIs (without a scheme) (e.g., "example.com"), {@code URI.getHost()} returns {@code null}.</li>
+       * </ul>
+       */
       if (grpcAddress != null && grpcAddress.getHost() == null) {
         throw new IllegalArgumentException("grpcAddress must be an absolute URI");
       }
@@ -558,6 +567,15 @@ public class ZeebeClientConfigurationProperties {
 
     @Deprecated
     public void setRestAddress(final URI restAddress) {
+      /*
+       * Validates that the provided gRPC address is an absolute URI.
+       *
+       * <p>We use {@code URI.getHost() == null} to check for absolute URIs because:
+       * <ul>
+       *   <li>For absolute URIs (with a scheme) (e.g., "https://example.com"), {@code URI.getHost()} returns the hostname (e.g., "example.com").</li>
+       *   <li>For relative URIs (without a scheme) (e.g., "example.com"), {@code URI.getHost()} returns {@code null}.</li>
+       * </ul>
+       */
       if (restAddress != null && restAddress.getHost() == null) {
         throw new IllegalArgumentException("restAddress must be an absolute URI");
       }

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
@@ -544,6 +544,9 @@ public class ZeebeClientConfigurationProperties {
 
     @Deprecated
     public void setGrpcAddress(final URI grpcAddress) {
+      if (grpcAddress != null && grpcAddress.getHost() == null) {
+        throw new IllegalArgumentException("grpcAddress must be an absolute URI");
+      }
       this.grpcAddress = grpcAddress;
     }
 
@@ -555,6 +558,9 @@ public class ZeebeClientConfigurationProperties {
 
     @Deprecated
     public void setRestAddress(final URI restAddress) {
+      if (restAddress != null && restAddress.getHost() == null) {
+        throw new IllegalArgumentException("restAddress must be an absolute URI");
+      }
       this.restAddress = restAddress;
     }
 

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/common/ZeebeClientProperties.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/common/ZeebeClientProperties.java
@@ -129,6 +129,9 @@ public class ZeebeClientProperties extends ApiProperties {
   }
 
   public void setGrpcAddress(final URI grpcAddress) {
+    if (grpcAddress != null && grpcAddress.getHost() == null) {
+      throw new IllegalArgumentException("grpcAddress must be an absolute URI");
+    }
     this.grpcAddress = grpcAddress;
   }
 
@@ -137,6 +140,9 @@ public class ZeebeClientProperties extends ApiProperties {
   }
 
   public void setRestAddress(final URI restAddress) {
+    if (restAddress != null && restAddress.getHost() == null) {
+      throw new IllegalArgumentException("restAddress must be an absolute URI");
+    }
     this.restAddress = restAddress;
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/common/ZeebeClientProperties.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/common/ZeebeClientProperties.java
@@ -129,6 +129,15 @@ public class ZeebeClientProperties extends ApiProperties {
   }
 
   public void setGrpcAddress(final URI grpcAddress) {
+    /*
+     * Validates that the provided gRPC address is an absolute URI.
+     *
+     * <p>We use {@code URI.getHost() == null} to check for absolute URIs because:
+     * <ul>
+     *   <li>For absolute URIs (with a scheme) (e.g., "https://example.com"), {@code URI.getHost()} returns the hostname (e.g., "example.com").</li>
+     *   <li>For relative URIs (without a scheme) (e.g., "example.com"), {@code URI.getHost()} returns {@code null}.</li>
+     * </ul>
+     */
     if (grpcAddress != null && grpcAddress.getHost() == null) {
       throw new IllegalArgumentException("grpcAddress must be an absolute URI");
     }
@@ -140,6 +149,15 @@ public class ZeebeClientProperties extends ApiProperties {
   }
 
   public void setRestAddress(final URI restAddress) {
+    /*
+     * Validates that the provided rest address is an absolute URI.
+     *
+     * <p>We use {@code URI.getHost() == null} to check for absolute URIs because:
+     * <ul>
+     *   <li>For absolute URIs (with a scheme) (e.g., "https://example.com"), {@code URI.getHost()} returns the hostname (e.g., "example.com").</li>
+     *   <li>For relative URIs (without a scheme) (e.g., "example.com"), {@code URI.getHost()} returns {@code null}.</li>
+     * </ul>
+     */
     if (restAddress != null && restAddress.getHost() == null) {
       throw new IllegalArgumentException("restAddress must be an absolute URI");
     }

--- a/operate/common/src/test/java/io/camunda/operate/connect/OpensearchConnectorTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/connect/OpensearchConnectorTest.java
@@ -30,9 +30,9 @@ import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.message.BasicHttpRequest;
-import org.apache.hc.core5.http.protocol.BasicHttpContext;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -129,7 +129,8 @@ public class OpensearchConnectorTest {
     final OperateProperties operateProperties = new OperateProperties();
     final OperateOpensearchProperties osProperties = new OperateOpensearchProperties();
     operateProperties.setOpensearch(osProperties);
-    final OpensearchConnector connector = spy(new OpensearchConnector(operateProperties, mock()));
+    final OpensearchConnector connector =
+        spy(new OpensearchConnector(operateProperties, objectMapper));
     doReturn(true).when(connector).checkHealth(any(OpenSearchClient.class));
     doReturn(true).when(connector).checkHealth(any(OpenSearchAsyncClient.class));
     doReturn(mock(HttpAsyncClientBuilder.class))
@@ -177,7 +178,7 @@ public class OpensearchConnectorTest {
 
   @Test
   void shouldApplyRequestInterceptorsForOSOperateClient() throws Exception {
-    final var context = new BasicHttpContext();
+    final var context = HttpClientContext.create();
     final var operateProps = new OperateProperties();
     final PluginRepository pluginRepository = new PluginRepository();
     pluginRepository.load(
@@ -213,7 +214,7 @@ public class OpensearchConnectorTest {
 
   @Test
   void shouldApplyRequestInterceptorsForOSAsyncOperateClient() throws Exception {
-    final var context = new BasicHttpContext();
+    final var context = HttpClientContext.create();
     final var operateProperties = new OperateProperties();
     final PluginRepository pluginRepository = new PluginRepository();
     pluginRepository.load(

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -62,7 +62,7 @@
     <version.httpasyncclient>4.1.5</version.httpasyncclient>
     <version.httpclient>4.5.14</version.httpclient>
     <version.httpclient5>5.3.1</version.httpclient5>
-    <version.httpcore5>5.2.5</version.httpcore5>
+    <version.httpcore5>5.3</version.httpcore5>
     <version.httpcomponents>4.4.16</version.httpcomponents>
     <version.identity>8.6.8</version.identity>
     <version.surefire>3.5.2</version.surefire>

--- a/tasklist/common/src/test/java/io/camunda/tasklist/os/OpensearchConnectorTest.java
+++ b/tasklist/common/src/test/java/io/camunda/tasklist/os/OpensearchConnectorTest.java
@@ -21,9 +21,9 @@ import java.util.List;
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.message.BasicHttpRequest;
-import org.apache.hc.core5.http.protocol.BasicHttpContext;
 import org.apache.http.HttpHost;
 import org.apache.http.client.methods.HttpGet;
 import org.junit.jupiter.api.Test;
@@ -46,7 +46,7 @@ class OpensearchConnectorTest {
 
   @Test
   void shouldApplyRequestInterceptorsForOSTasklistClient() throws Exception {
-    final var context = new BasicHttpContext();
+    final var context = HttpClientContext.create();
     final var taskListProperties = new TasklistProperties();
     final PluginRepository pluginRepository = new PluginRepository();
     pluginRepository.load(
@@ -84,7 +84,7 @@ class OpensearchConnectorTest {
 
   @Test
   void shouldApplyRequestInterceptorsForOSTasklistZeebeClient() throws Exception {
-    final var context = new BasicHttpContext();
+    final var context = HttpClientContext.create();
     final var taskListProperties = new TasklistProperties();
     final PluginRepository pluginRepository = new PluginRepository();
     pluginRepository.load(
@@ -122,7 +122,7 @@ class OpensearchConnectorTest {
 
   @Test
   void shouldApplyRequestInterceptorsForOSAsyncTasklistClient() throws Exception {
-    final var context = new BasicHttpContext();
+    final var context = HttpClientContext.create();
     final var taskListProperties = new TasklistProperties();
     final PluginRepository pluginRepository = new PluginRepository();
     pluginRepository.load(


### PR DESCRIPTION
# Description
Backport of #27764 to `stable/8.6`.

relates to https://github.com/camunda/camunda/issues/28554