### PR TITLE
[Backport stable/8.6] deps: Update dependency org.apache.httpcomponents.client5:httpclient5 to v5.4.1

### DIFF
--- a/operate/common/src/test/java/io/camunda/operate/connect/OpensearchConnectorTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/connect/OpensearchConnectorTest.java
@@ -32,7 +32,6 @@ import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.concurrent.FutureCallback;
-import org.apache.hc.core5.http.message.BasicHttpRequest;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -207,7 +206,7 @@ public class OpensearchConnectorTest {
     }
 
     // then
-    final var reqWrapper = (BasicHttpRequest) context.getAttribute("http.request");
+    final var reqWrapper = context.getRequest();
 
     Assertions.assertThat(reqWrapper.getFirstHeader("foo").getValue()).isEqualTo("bar");
   }
@@ -244,7 +243,7 @@ public class OpensearchConnectorTest {
     }
 
     // then
-    final var reqWrapper = (BasicHttpRequest) context.getAttribute("http.request");
+    final var reqWrapper = context.getRequest();
 
     Assertions.assertThat(reqWrapper.getFirstHeader("foo").getValue()).isEqualTo("bar");
   }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -62,7 +62,7 @@
     <version.httpasyncclient>4.1.5</version.httpasyncclient>
     <version.httpclient>4.5.14</version.httpclient>
     <version.httpclient5>5.4.1</version.httpclient5>
-    <version.httpcore5>5.3</version.httpcore5>git
+    <version.httpcore5>5.3</version.httpcore5>
     <version.httpcomponents>4.4.16</version.httpcomponents>
     <version.identity>8.6.8</version.identity>
     <version.surefire>3.5.2</version.surefire>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -61,8 +61,8 @@
     <version.hamcrest>3.0</version.hamcrest>
     <version.httpasyncclient>4.1.5</version.httpasyncclient>
     <version.httpclient>4.5.14</version.httpclient>
-    <version.httpclient5>5.3.1</version.httpclient5>
-    <version.httpcore5>5.3</version.httpcore5>
+    <version.httpclient5>5.4.1</version.httpclient5>
+    <version.httpcore5>5.3</version.httpcore5>git
     <version.httpcomponents>4.4.16</version.httpcomponents>
     <version.identity>8.6.8</version.identity>
     <version.surefire>3.5.2</version.surefire>

--- a/tasklist/common/src/test/java/io/camunda/tasklist/os/OpensearchConnectorTest.java
+++ b/tasklist/common/src/test/java/io/camunda/tasklist/os/OpensearchConnectorTest.java
@@ -23,7 +23,6 @@ import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.core5.concurrent.FutureCallback;
-import org.apache.hc.core5.http.message.BasicHttpRequest;
 import org.apache.http.HttpHost;
 import org.apache.http.client.methods.HttpGet;
 import org.junit.jupiter.api.Test;
@@ -77,7 +76,7 @@ class OpensearchConnectorTest {
     }
 
     // then
-    final var reqWrapper = (BasicHttpRequest) context.getAttribute("http.request");
+    final var reqWrapper = context.getRequest();
 
     assertThat(reqWrapper.getFirstHeader("foo").getValue()).isEqualTo("bar");
   }
@@ -115,7 +114,7 @@ class OpensearchConnectorTest {
     }
 
     // then
-    final var reqWrapper = (BasicHttpRequest) context.getAttribute("http.request");
+    final var reqWrapper = context.getRequest();
 
     assertThat(reqWrapper.getFirstHeader("foo").getValue()).isEqualTo("bar");
   }
@@ -153,7 +152,7 @@ class OpensearchConnectorTest {
     }
 
     // then
-    final var reqWrapper = (BasicHttpRequest) context.getAttribute("http.request");
+    final var reqWrapper = context.getRequest();
 
     assertThat(reqWrapper.getFirstHeader("foo").getValue()).isEqualTo("bar");
   }


### PR DESCRIPTION
# Description
Backport of #27807 to `stable/8.6`.

relates to https://github.com/camunda/camunda/issues/28554