### PR TITLE
ci: fix percentage calc in in daily flaky test stats

### DIFF
--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -51,7 +51,7 @@ jobs:
 
           {
             echo "MESSAGE<<EOF"
-            echo "📈 ~$(expr $NUMBER_OF_FLAKYTESTS_JOBS / $NUMBER_OF_ALL_JOBS)% of jobs had flaky tests yesterday ($NUMBER_OF_FLAKYTESTS_JOBS from total of $NUMBER_OF_ALL_JOBS jobs)."
+            echo "📈 ~$(echo "scale=1; 100 * $NUMBER_OF_FLAKYTESTS_JOBS / $NUMBER_OF_ALL_JOBS" | bc)% of jobs had flaky tests yesterday ($NUMBER_OF_FLAKYTESTS_JOBS from total of $NUMBER_OF_ALL_JOBS jobs)."
             echo ""
             echo "🥇 Top 5 flakiest tests yesterday:"
             echo ""
@@ -62,7 +62,7 @@ jobs:
               echo "• ${NUMBER_OF_FLAKES}x \`${TEST_CLASS_NAME##*.}.$TEST_NAME\`\n"
             done
             echo ""
-            echo "<https://dashboard.int.camunda.com/d/ae2j69npxh3b4f/flaky-tests-camunda-camunda-monorepo?orgId=1&from=now-1d%2Fd&to=now-1d%2Fd&timezone=browser&var-branch=main|Check out Grafana for links and more details.>"
+            echo "📊 Check out <https://dashboard.int.camunda.com/d/ae2j69npxh3b4f/flaky-tests-camunda-camunda-monorepo?orgId=1&from=now-1d%2Fd&to=now-1d%2Fd&timezone=browser&var-branch=main|Grafana for links and more details.>"
             echo "EOF"
           } >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Description

`expr` command does not handle floating point results and I forgot to convert from 0-1 to 0-100% range 😬 Now this yields:

```
📈 ~3.5% of jobs had flaky tests yesterday (256 from total of 7248 jobs).

🥇 Top 5 flakiest tests yesterday:

• 44x `CommandDistributionIdempotencyTest.test[Authorization.DELETE is idempotent]`\n
• 29x `CommandDistributionIdempotencyTest.test[User.DELETE is idempotent]`\n
• 22x `RaftCorruptedDataTest.upToDateFollowerShouldNotLoseDataWhenQuorumExperienceCorruption`\n
• 21x `PrefixMigrationIT.shouldReindexDocumentsDuringPrefixMigration`\n
• 16x `PartitionJoinTest.canLeavePartitionAfterJoining(Scenario)[1] scenario=Scenario[initialClusterState=InitialClusterState[clusterSize=3, partitionCount=3, replicationFactor=1], operation=Operation[brokerId=1, partitionId=1, priority=2]]`\n

📊 Check out <https://dashboard.int.camunda.com/d/ae2j69npxh3b4f/flaky-tests-camunda-camunda-monorepo?orgId=1&from=now-1d%2Fd&to=now-1d%2Fd&timezone=browser&var-branch=main|Grafana for links and more details.>
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
