### PR TITLE
[Backport stable/8.5] Update dependency org.apache.httpcomponents.core5:httpcore5 to v5.3

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -60,7 +60,7 @@
     <version.httpasyncclient>4.1.5</version.httpasyncclient>
     <version.httpclient>4.5.14</version.httpclient>
     <version.httpclient5>5.3.1</version.httpclient5>
-    <version.httpcore5>5.2.5</version.httpcore5>
+    <version.httpcore5>5.3</version.httpcore5>
     <version.httpcomponents>4.4.16</version.httpcomponents>
     <version.identity>8.5.13</version.identity>
     <version.jackson>2.17.2</version.jackson>

--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
@@ -489,6 +489,15 @@ public class ZeebeClientConfigurationProperties {
     }
 
     public void setGrpcAddress(final URI grpcAddress) {
+      /*
+       * Validates that the provided gRPC address is an absolute URI.
+       *
+       * <p>We use {@code URI.getHost() == null} to check for absolute URIs because:
+       * <ul>
+       *   <li>For absolute URIs (with a scheme) (e.g., "https://example.com"), {@code URI.getHost()} returns the hostname (e.g., "example.com").</li>
+       *   <li>For relative URIs (without a scheme) (e.g., "example.com"), {@code URI.getHost()} returns {@code null}.</li>
+       * </ul>
+       */
       if (grpcAddress != null && grpcAddress.getHost() == null) {
         throw new IllegalArgumentException("grpcAddress must be an absolute URI");
       }
@@ -504,6 +513,15 @@ public class ZeebeClientConfigurationProperties {
     }
 
     public void setRestAddress(final URI restAddress) {
+      /*
+       * Validates that the provided gRPC address is an absolute URI.
+       *
+       * <p>We use {@code URI.getHost() == null} to check for absolute URIs because:
+       * <ul>
+       *   <li>For absolute URIs (with a scheme) (e.g., "https://example.com"), {@code URI.getHost()} returns the hostname (e.g., "example.com").</li>
+       *   <li>For relative URIs (without a scheme) (e.g., "example.com"), {@code URI.getHost()} returns {@code null}.</li>
+       * </ul>
+       */
       if (restAddress != null && restAddress.getHost() == null) {
         throw new IllegalArgumentException("restAddress must be an absolute URI");
       }

--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
@@ -489,6 +489,9 @@ public class ZeebeClientConfigurationProperties {
     }
 
     public void setGrpcAddress(final URI grpcAddress) {
+      if (grpcAddress != null && grpcAddress.getHost() == null) {
+        throw new IllegalArgumentException("grpcAddress must be an absolute URI");
+      }
       this.grpcAddress = grpcAddress;
     }
 
@@ -501,6 +504,9 @@ public class ZeebeClientConfigurationProperties {
     }
 
     public void setRestAddress(final URI restAddress) {
+      if (restAddress != null && restAddress.getHost() == null) {
+        throw new IllegalArgumentException("restAddress must be an absolute URI");
+      }
       this.restAddress = restAddress;
     }
 

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -57,13 +57,15 @@ public interface ZeebeClientBuilder {
 
   /**
    * @param restAddress the REST API address of a gateway that the client can connect to. The
-   *     default value is {@code 0.0.0.0:8080}.
+   *     address must be an absolute URL, including the scheme.
+   *     <p>The default value is {@code https://0.0.0.0:8080}.
    */
   ZeebeClientBuilder restAddress(URI restAddress);
 
   /**
-   * @param grpcAddress the gRPC address of a gateway that the client can connect to. The default
-   *     value is {@code 0.0.0.0:26500}.
+   * @param grpcAddress the gRPC address of a gateway that the client can connect to. The address
+   *     must be an absolute URL, including the scheme.
+   *     <p>The default value is {@code https://0.0.0.0:26500}.
    */
   ZeebeClientBuilder grpcAddress(URI grpcAddress);
 

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -348,12 +348,18 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
 
   @Override
   public ZeebeClientBuilder restAddress(final URI restAddress) {
+    if (restAddress != null && restAddress.getHost() == null) {
+      throw new IllegalArgumentException("restAddress must be an absolute URI");
+    }
     this.restAddress = restAddress;
     return this;
   }
 
   @Override
   public ZeebeClientBuilder grpcAddress(final URI grpcAddress) {
+    if (grpcAddress != null && grpcAddress.getHost() == null) {
+      throw new IllegalArgumentException("grpcAddress must be an absolute URI");
+    }
     this.grpcAddress = grpcAddress;
     grpcAddressUsed = true;
     return this;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -348,6 +348,15 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
 
   @Override
   public ZeebeClientBuilder restAddress(final URI restAddress) {
+    /*
+     * Validates that the provided rest address is an absolute URI.
+     *
+     * <p>We use {@code URI.getHost() == null} to check for absolute URIs because:
+     * <ul>
+     *   <li>For absolute URIs (with a scheme) (e.g., "https://example.com"), {@code URI.getHost()} returns the hostname (e.g., "example.com").</li>
+     *   <li>For relative URIs (without a scheme) (e.g., "example.com"), {@code URI.getHost()} returns {@code null}.</li>
+     * </ul>
+     */
     if (restAddress != null && restAddress.getHost() == null) {
       throw new IllegalArgumentException("restAddress must be an absolute URI");
     }
@@ -357,6 +366,15 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
 
   @Override
   public ZeebeClientBuilder grpcAddress(final URI grpcAddress) {
+    /*
+     * Validates that the provided gRPC address is an absolute URI.
+     *
+     * <p>We use {@code URI.getHost() == null} to check for absolute URIs because:
+     * <ul>
+     *   <li>For absolute URIs (with a scheme) (e.g., "https://example.com"), {@code URI.getHost()} returns the hostname (e.g., "example.com").</li>
+     *   <li>For relative URIs (without a scheme) (e.g., "example.com"), {@code URI.getHost()} returns {@code null}.</li>
+     * </ul>
+     */
     if (grpcAddress != null && grpcAddress.getHost() == null) {
       throw new IllegalArgumentException("grpcAddress must be an absolute URI");
     }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.client.impl.http;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.client.CredentialsProvider;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
+import io.camunda.zeebe.client.api.command.InternalClientException;
 import io.camunda.zeebe.client.impl.NoopCredentialsProvider;
 import io.camunda.zeebe.client.impl.util.VersionUtil;
 import java.io.File;
@@ -105,8 +106,8 @@ public class HttpClientFactory {
       builder.setScheme(config.isPlaintextConnectionEnabled() ? "http" : "https");
 
       return builder.build();
-    } catch (final URISyntaxException e) {
-      throw new RuntimeException(e);
+    } catch (final URISyntaxException | UnsupportedOperationException e) {
+      throw new InternalClientException("Issues with REST API URI.", e);
     }
   }
 

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
@@ -106,7 +106,7 @@ public class HttpClientFactory {
       builder.setScheme(config.isPlaintextConnectionEnabled() ? "http" : "https");
 
       return builder.build();
-    } catch (final URISyntaxException | UnsupportedOperationException e) {
+    } catch (final URISyntaxException e) {
       throw new InternalClientException("Issues with REST API URI.", e);
     }
   }

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -564,7 +564,7 @@ public final class ZeebeClientTest extends ClientTest {
   @Test
   public void shouldSetRestAddressFromSetterWithClientBuilder() throws URISyntaxException {
     // given
-    final URI restAddress = new URI("localhost:9090");
+    final URI restAddress = new URI("http://localhost:9090");
     final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
     builder.restAddress(restAddress);
 
@@ -578,7 +578,7 @@ public final class ZeebeClientTest extends ClientTest {
   @Test
   public void shouldSetRestAddressPortFromPropertyWithClientBuilder() throws URISyntaxException {
     // given
-    final URI restAddress = new URI("localhost:9090");
+    final URI restAddress = new URI("http://localhost:9090");
     final Properties properties = new Properties();
     properties.setProperty(ClientProperties.REST_ADDRESS, restAddress.toString());
     final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
@@ -594,7 +594,7 @@ public final class ZeebeClientTest extends ClientTest {
   @Test
   public void shouldSetRestAddressPortFromEnvVarWithClientBuilder() throws URISyntaxException {
     // given
-    final URI restAddress = new URI("localhost:9090");
+    final URI restAddress = new URI("http://localhost:9090");
     Environment.system().put(REST_ADDRESS_VAR, restAddress.toString());
 
     // when


### PR DESCRIPTION
# Description
Backport of #28723 to `stable/8.5`.

relates to camunda/camunda#28554 #27764 https://github.com/camunda/camunda/issues/28698