### PR TITLE
refactor: adjust optimize start-backend script to use dist

### DIFF
--- a/optimize/client/docker-compose.yml
+++ b/optimize/client/docker-compose.yml
@@ -68,6 +68,7 @@ services:
       - 'JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m'
     ports:
       - '26500:26500'
+      - '9600:9600'
     healthcheck:
       test: ['CMD-SHELL', "timeout 10s bash -c ':> /dev/tcp/127.0.0.1/9600' || exit 1"]
       interval: 30s
@@ -90,6 +91,7 @@ services:
       - DATABASE_PORT=9200
     ports:
       - 26500:26500
+      - 9600:9600
     healthcheck:
       test: ['CMD-SHELL', "timeout 10s bash -c ':> /dev/tcp/127.0.0.1/9600' || exit 1"]
       interval: 30s

--- a/optimize/client/scripts/start-backend.js
+++ b/optimize/client/scripts/start-backend.js
@@ -8,7 +8,6 @@
 
 import {spawn} from 'child_process';
 import {resolve as _resolve, dirname} from 'path';
-import {platform} from 'os';
 import {readFile} from 'fs';
 import {parseString} from 'xml2js';
 import {fileURLToPath} from 'url';
@@ -100,24 +99,21 @@ setVersionInfo().then(setupEnvironment).then(startBackend);
 
 function startBackend() {
   return new Promise((resolve, reject) => {
-  const engineEnv = {
-        cloud: cloudEnv,
-        'self-managed': selfManagedEnv,
-      };
+    const engineEnv = {
+      cloud: cloudEnv,
+      'self-managed': selfManagedEnv,
+    };
 
-    backendProcess = spawnWithArgs(
-      `dist/target/camunda-zeebe/bin/optimize`,
-      {
-        cwd: _resolve(__dirname, '..', '..', '..'),
-        shell: true,
-        env: {
-          ...process.env,
-          ...commonEnv,
-          ...engineEnv[mode],
-          CLASSPATH_PREFIX: 'optimize/client/demo-data'
-        },
-      }
-    );
+    backendProcess = spawnWithArgs(`dist/target/camunda-zeebe/bin/optimize`, {
+      cwd: _resolve(__dirname, '..', '..', '..'),
+      shell: true,
+      env: {
+        ...process.env,
+        ...commonEnv,
+        ...engineEnv[mode],
+        CLASSPATH_PREFIX: 'optimize/client/demo-data',
+      },
+    });
 
     backendProcess.stdout.on('data', (data) => server.addLog(data, 'backend'));
     backendProcess.stderr.on('data', (data) => server.addLog(data, 'backend', true));
@@ -161,7 +157,7 @@ async function setupEnvironment() {
 function buildBackend() {
   return new Promise((resolve, reject) => {
     buildBackendProcess = spawnWithArgs(
-      'mvn clean install -DskipTests -Dskip.docker -Dskip.fe.build -pl optimize/backend -am -T1C',
+      'mvn clean install -DskipTests -Dskip.docker -Dskip.fe.build -pl dist -am -T1C',
       {
         cwd: _resolve(__dirname, '..', '..', '..'),
         shell: true,


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
The start-backend script we use in the front-end setup of Optimize does not work anymore. This happened after adjusting Optimize to be part of the single Application. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

