### PR TITLE
[Backport stable/8.5] deps: Update dependency org.apache.httpcomponents.client5:httpclient5 to v5.4.1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -59,8 +59,8 @@
     <version.hamcrest>2.2</version.hamcrest>
     <version.httpasyncclient>4.1.5</version.httpasyncclient>
     <version.httpclient>4.5.14</version.httpclient>
-    <version.httpclient5>5.3.1</version.httpclient5>
-    <version.httpcore5>5.3</version.httpcore5>
+    <version.httpclient5>5.4.1</version.httpclient5>
+    <version.httpcore5>5.3</version.httpcore5>git
     <version.httpcomponents>4.4.16</version.httpcomponents>
     <version.identity>8.5.13</version.identity>
     <version.jackson>2.17.2</version.jackson>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -60,7 +60,7 @@
     <version.httpasyncclient>4.1.5</version.httpasyncclient>
     <version.httpclient>4.5.14</version.httpclient>
     <version.httpclient5>5.4.1</version.httpclient5>
-    <version.httpcore5>5.3</version.httpcore5>git
+    <version.httpcore5>5.3</version.httpcore5>
     <version.httpcomponents>4.4.16</version.httpcomponents>
     <version.identity>8.5.13</version.identity>
     <version.jackson>2.17.2</version.jackson>


### PR DESCRIPTION
# Description
Backport of #28724 to `stable/8.5`.

relates to camunda/camunda#28554 #27807 https://github.com/camunda/camunda/issues/28698