### PR TITLE
fix: use zip for c8run windows build

### DIFF
--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -70,12 +70,19 @@ jobs:
           ./mvnw -B -T1C -DskipTests -DskipChecks -Dflatten.skip=true package
           export ARTIFACT=$(./mvnw -pl dist/ help:evaluate -Dexpression=project.build.finalName -q -DforceStdout)
           echo "distball=dist/target/${ARTIFACT}.tar.gz" >> $GITHUB_OUTPUT
+          echo "distzip=dist/target/${ARTIFACT}.zip" >> $GITHUB_OUTPUT
 
       - name: Upload camunda-dist
         uses: actions/upload-artifact@v4
         with:
           name: camunda-platform-dist
           path: ${{ steps.build-dist.outputs.distball }}
+
+      - name: Upload camunda-dist-zip
+        uses: actions/upload-artifact@v4
+        with:
+          name: camunda-platform-dist-zip
+          path: ${{ steps.build-dist.outputs.distzip }}
 
   test_c8run:
     strategy:
@@ -172,11 +179,11 @@ jobs:
       - name: Download Camunda Core Dist
         uses: actions/download-artifact@v4
         with:
-          name: camunda-platform-dist
+          name: camunda-platform-dist-zip
           path: c8run
 
       - name: Get version of camunda-dist
-        run: echo CAMUNDA_VERSION=$(ls camunda-zeebe*.tar.gz | grep -o 'camunda-zeebe-.*' | sed 's/camunda-zeebe-//' | sed 's/\.tar\.gz//') >> $GITHUB_ENV
+        run: echo CAMUNDA_VERSION=$(ls camunda-zeebe*.zip | grep -o 'camunda-zeebe-.*' | sed 's/camunda-zeebe-//' | sed 's/\.zip//') >> $GITHUB_ENV
         shell: bash
         working-directory: .\c8run
 


### PR DESCRIPTION
## Description

It turns out that when we introduced source builds into c8run, for windows, we would download the source build and then the package command would download a different build and extract it. 

This change uploads the .zip file, which the ./c8run package command expects to be present in the current directory when package is called. 

This change does not need backported, since this change was necessary for integration tests to pass in the backport PRs.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
