### PR TITLE
Align OpenAPI spec with the actual implementation

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -568,8 +568,7 @@ paths:
           required: true
           description: The unique identifier of the user.
           schema:
-            type: integer
-            format: int64
+            type: string
       responses:
         "202":
           description: The user was successfully removed from the tenant.
@@ -594,7 +593,6 @@ paths:
     post:
       tags:
         - Tenant
-        - User
       operationId: searchUsersForTenant
       summary: Query users for tenant
       description: Retrieves a filtered and sorted list of users for a specified tenant.
@@ -616,12 +614,6 @@ paths:
           description: The search result of users for the tenant.
           content:
             application/json:
-              schema:
-                $ref: "#/components/schemas/UserSearchResult"
-            application/vnd.camunda.api.keys.number+json:
-              schema:
-                $ref: "#/components/schemas/UserSearchResult"
-            application/vnd.camunda.api.keys.string+json:
               schema:
                 $ref: "#/components/schemas/UserSearchResult"
 
@@ -5438,10 +5430,6 @@ components:
     UserResult:
       type: "object"
       properties:
-        id:
-          description: The ID of the user.
-          type: "integer"
-          format: "int64"
         username:
           description: The username of the user.
           type: "string"

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3739,11 +3739,6 @@ components:
         tenantKey:
           type: string
           description: The unique system-generated internal tenant ID.
-        assignedMemberKeys:
-          type: array
-          description: The set of keys of members assigned to the tenant.
-          items:
-            type: string
     TenantSearchQuerySortRequest:
       type: object
       properties:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

- The username is a String, not an int64
- The second tag of an endpoint messes up the docs
- We don't need the multiple content-types anymore
- Users don't have an id, only a username

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #28754 
