### PR TITLE
ci: run release-relevant CI workflows of Operate+Tasklist

### DIFF
--- a/.github/workflows/operate-ci.yml
+++ b/.github/workflows/operate-ci.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - 'main'
       - 'stable/**'
-      - 'release/**'
+      - 'release**'
     paths:
       - '.ci/**'
       - '.github/actions/**'

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - "main"
       - "stable/**"
-      - "release/**"
+      - "release**"
     paths:
       - ".ci/**"
       - ".github/actions/**"

--- a/.github/workflows/operate-frontend.yml
+++ b/.github/workflows/operate-frontend.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - 'main'
       - 'stable/**'
-      - 'release/**'
+      - 'release**'
     paths:
       - '.github/workflows/operate-frontend.yml'
       - 'operate/client/**'

--- a/.github/workflows/tasklist-ci.yml
+++ b/.github/workflows/tasklist-ci.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - "main"
       - "stable/**"
+      - "release**"
   pull_request:
 
 # Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs

--- a/.github/workflows/tasklist-docker-tests.yml
+++ b/.github/workflows/tasklist-docker-tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'main'
       - 'stable/**'
+      - 'release**'
   pull_request:
 
 # Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs

--- a/.github/workflows/tasklist-e2e-tests.yml
+++ b/.github/workflows/tasklist-e2e-tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "main"
       - "stable/**"
+      - "release**"
   pull_request:
 
 # Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs


### PR DESCRIPTION
## Description

The `Check QA results` [user task](https://bru-2.tasklist.camunda.io/689a796f-7efa-487f-9e44-76ca3a98c77b/tasklist/4503599741306020) of the release process assumes that certain GHA workflows of Operate and Tasklist are run on `release*` branches, which this PR aims to add. Also, release branches don't necessarily include a `/` anymore so we have to relax the name matching pattern.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [x] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

https://camunda.slack.com/archives/C06UWQNCU7M/p1740502956908899