### PR TITLE
docs: add 504 to PI creation REST API

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -713,6 +713,13 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
+        "504":
+          description: |
+            The process instance creation request timed out in the gateway.
+
+            This can happen if the `awaitCompletion` request parameter is set to `true`
+            and the created process instance did not complete within the defined request timeout.
+            This often happens when the created instance is not fully automated or contains wait states.
   /process-instances/search:
     post:
       tags:
@@ -4409,7 +4416,8 @@ components:
         awaitCompletion:
           description: |
             Wait for the process instance to complete. If the process instance completion does
-            not occur within the requestTimeout, the request will be closed. Disabled by default.
+            not occur within the requestTimeout, the request will be closed. This can lead to a 504
+            response status. Disabled by default.
           type: boolean
           default: false
         fetchVariables:


### PR DESCRIPTION
# Description
Backport of #28740 to `stable/8.7`.

**Note**: I did not backport the 400 refactoring as this would become quite involved. A lot of other response code refactorings have not been backported. If we want to this, we should do this holistically once.
//cc @pepopowitz 

relates to #28467