### PR TITLE
[Backport stable/8.6] Create CODEOWNERS for OpenAPI changes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# C8 REST OpenAPI changes are owned by the API reviewers team
+/zeebe/gateway-protocol/src/main/proto/rest-api.yaml @camunda/docs-api-reviewers


### PR DESCRIPTION
# Description
Backport of #28385 to `stable/8.6`.

relates to #28384