### PR TITLE
Revert "test: Temporarily exclude the MigrationUserTaskUpdateIT"

### DIFF
--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -455,10 +455,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <configuration>
-          <!-- Temporarily exclude the MigrationUserTaskUpdateIT test until it is fixed -->
-          <excludes>
-            <exclude>**/MigrationUserTaskUpdateIT.java</exclude>
-          </excludes>
           <reportFormat>plain</reportFormat>
           <consoleOutputReporter>
             <disable>true</disable>


### PR DESCRIPTION
Reverts camunda/camunda#28774
Since https://github.com/camunda/camunda/issues/28778 is fixed