### PR TITLE
Refactor `DbTenantState` to work with ids instead of keys

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -1636,15 +1636,15 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * <pre>
    * camundaClient
-   *   .newUnassignGroupFromTenantCommand(tenantKey)
+   *   .newUnassignGroupFromTenantCommand(tenantId)
    *   .groupKey(groupKey)
    *   .send();
    * </pre>
    *
-   * @param tenantKey the unique identifier of the tenant
+   * @param tenantId the unique identifier of the tenant
    * @return a builder to configure and send the unassign group from tenant command
    */
-  UnassignGroupFromTenantCommandStep1 newUnassignGroupFromTenantCommand(long tenantKey);
+  UnassignGroupFromTenantCommandStep1 newUnassignGroupFromTenantCommand(String tenantId);
 
   /**
    * Command to create an authorization

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -1544,7 +1544,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * <pre>
    * camundaClient
-   *  .newDeleteTenantCommand(tenantKey)
+   *  .newDeleteTenantCommand(tenantId)
    *  .send();
    * </pre>
    *
@@ -1560,7 +1560,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * <pre>
    * camundaClient
-   *   .newAssignMappingToTenantCommand(tenantKey)
+   *   .newAssignMappingToTenantCommand(tenantId)
    *   .mappingKey(mappingKey)
    *   .send();
    * </pre>
@@ -1568,10 +1568,10 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * <p>This command sends an HTTP PUT request to assign the specified mapping rule to the given
    * tenant.
    *
-   * @param tenantKey the unique identifier of the tenant
+   * @param tenantId the unique identifier of the tenant
    * @return a builder for the assign mapping rule to tenant command
    */
-  AssignMappingToTenantCommandStep1 newAssignMappingToTenantCommand(long tenantKey);
+  AssignMappingToTenantCommandStep1 newAssignMappingToTenantCommand(String tenantId);
 
   /**
    * Command to assign a user to a tenant.
@@ -1619,7 +1619,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * <pre>
    * camundaClient
-   *   .newAssignGroupToTenantCommand(tenantKey)
+   *   .newAssignGroupToTenantCommand(tenantId)
    *   .groupKey(groupKey)
    *   .send();
    * </pre>

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -1599,7 +1599,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *
    * <pre>
    * camundaClient
-   *   .newRemoveUserFromTenantCommand(tenantId)
+   *   .newUnassignUserFromTenantCommand(tenantId)
    *   .username(username)
    *   .send();
    * </pre>
@@ -1610,7 +1610,7 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    * @param tenantId the unique identifier of the tenant
    * @return a builder for the remove user from tenant command
    */
-  RemoveUserFromTenantCommandStep1 newRemoveUserFromTenantCommand(String tenantId);
+  RemoveUserFromTenantCommandStep1 newUnassignUserFromTenantCommand(String tenantId);
 
   /**
    * Command to assign a group to a tenant.

--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -1624,10 +1624,10 @@ public interface CamundaClient extends AutoCloseable, JobClient {
    *   .send();
    * </pre>
    *
-   * @param tenantKey the unique identifier of the tenant
+   * @param tenantId the unique identifier of the tenant
    * @return a builder to configure and send the assign group to tenant command
    */
-  AssignGroupToTenantCommandStep1 newAssignGroupToTenantCommand(long tenantKey);
+  AssignGroupToTenantCommandStep1 newAssignGroupToTenantCommand(String tenantId);
 
   /**
    * Command to unassign a group from a tenant.

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -897,8 +897,13 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public AssignGroupToTenantCommandStep1 newAssignGroupToTenantCommand(final long tenantKey) {
-    return new AssignGroupToTenantCommandImpl(httpClient, tenantKey);
+  public RemoveUserFromTenantCommandStep1 newRemoveUserFromTenantCommand(final String tenantId) {
+    return new RemoveUserFromTenantCommandImpl(httpClient, tenantId);
+  }
+
+  @Override
+  public AssignGroupToTenantCommandStep1 newAssignGroupToTenantCommand(final String tenantId) {
+    return new AssignGroupToTenantCommandImpl(httpClient, tenantId);
   }
 
   @Override
@@ -922,11 +927,6 @@ public final class CamundaClientImpl implements CamundaClient {
   public UpdateAuthorizationCommandStep1 newUpdateAuthorizationCommand(
       final long authorizationKey) {
     return new UpdateAuthorizationCommandImpl(httpClient, jsonMapper, authorizationKey);
-  }
-
-  @Override
-  public RemoveUserFromTenantCommandStep1 newRemoveUserFromTenantCommand(final String tenantId) {
-    return new RemoveUserFromTenantCommandImpl(httpClient, tenantId);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -887,8 +887,8 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public AssignMappingToTenantCommandStep1 newAssignMappingToTenantCommand(final long tenantKey) {
-    return new AssignMappingToTenantCommandImpl(httpClient, tenantKey);
+  public AssignMappingToTenantCommandStep1 newAssignMappingToTenantCommand(final String tenantId) {
+    return new AssignMappingToTenantCommandImpl(httpClient, tenantId);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -897,7 +897,7 @@ public final class CamundaClientImpl implements CamundaClient {
   }
 
   @Override
-  public RemoveUserFromTenantCommandStep1 newRemoveUserFromTenantCommand(final String tenantId) {
+  public RemoveUserFromTenantCommandStep1 newUnassignUserFromTenantCommand(final String tenantId) {
     return new RemoveUserFromTenantCommandImpl(httpClient, tenantId);
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -908,8 +908,8 @@ public final class CamundaClientImpl implements CamundaClient {
 
   @Override
   public UnassignGroupFromTenantCommandStep1 newUnassignGroupFromTenantCommand(
-      final long tenantKey) {
-    return new UnassignGroupFromTenantCommandImpl(httpClient, tenantKey);
+      final String tenantId) {
+    return new UnassignGroupFromTenantCommandImpl(httpClient, tenantId);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignGroupToTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignGroupToTenantCommandImpl.java
@@ -27,13 +27,13 @@ import org.apache.hc.client5.http.config.RequestConfig;
 public final class AssignGroupToTenantCommandImpl implements AssignGroupToTenantCommandStep1 {
 
   private final HttpClient httpClient;
-  private final long tenantKey;
+  private final String tenantId;
   private final RequestConfig.Builder httpRequestConfig;
   private long groupKey;
 
-  public AssignGroupToTenantCommandImpl(final HttpClient httpClient, final long tenantKey) {
+  public AssignGroupToTenantCommandImpl(final HttpClient httpClient, final String tenantId) {
     this.httpClient = httpClient;
-    this.tenantKey = tenantKey;
+    this.tenantId = tenantId;
     httpRequestConfig = httpClient.newRequestConfig();
   }
 
@@ -55,7 +55,7 @@ public final class AssignGroupToTenantCommandImpl implements AssignGroupToTenant
     ArgumentUtil.ensureNotNull("groupKey", groupKey);
     final HttpCamundaFuture<AssignGroupToTenantResponse> result = new HttpCamundaFuture<>();
     httpClient.put(
-        "/tenants/" + tenantKey + "/groups/" + groupKey,
+        "/tenants/" + tenantId + "/groups/" + groupKey,
         null, // No request body needed
         httpRequestConfig.build(),
         result);

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignMappingToTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignMappingToTenantCommandImpl.java
@@ -54,7 +54,7 @@ public final class AssignMappingToTenantCommandImpl implements AssignMappingToTe
   @Override
   public CamundaFuture<AssignMappingToTenantResponse> send() {
     final HttpCamundaFuture<AssignMappingToTenantResponse> result = new HttpCamundaFuture<>();
-    final String endpoint = String.format("/tenants/%d/mapping-rules/%d", tenantId, mappingKey);
+    final String endpoint = String.format("/tenants/%s/mapping-rules/%d", tenantId, mappingKey);
     httpClient.put(endpoint, null, httpRequestConfig.build(), result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/AssignMappingToTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/AssignMappingToTenantCommandImpl.java
@@ -27,14 +27,14 @@ import org.apache.hc.client5.http.config.RequestConfig;
 
 public final class AssignMappingToTenantCommandImpl implements AssignMappingToTenantCommandStep1 {
 
-  private final long tenantKey;
+  private final String tenantId;
   private long mappingKey;
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
 
-  public AssignMappingToTenantCommandImpl(final HttpClient httpClient, final long tenantKey) {
+  public AssignMappingToTenantCommandImpl(final HttpClient httpClient, final String tenantId) {
     this.httpClient = httpClient;
-    this.tenantKey = tenantKey;
+    this.tenantId = tenantId;
     httpRequestConfig = httpClient.newRequestConfig();
   }
 
@@ -54,7 +54,7 @@ public final class AssignMappingToTenantCommandImpl implements AssignMappingToTe
   @Override
   public CamundaFuture<AssignMappingToTenantResponse> send() {
     final HttpCamundaFuture<AssignMappingToTenantResponse> result = new HttpCamundaFuture<>();
-    final String endpoint = String.format("/tenants/%d/mapping-rules/%d", tenantKey, mappingKey);
+    final String endpoint = String.format("/tenants/%d/mapping-rules/%d", tenantId, mappingKey);
     httpClient.put(endpoint, null, httpRequestConfig.build(), result);
     return result;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/UnassignGroupFromTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/UnassignGroupFromTenantCommandImpl.java
@@ -29,13 +29,13 @@ public final class UnassignGroupFromTenantCommandImpl
     implements UnassignGroupFromTenantCommandStep1 {
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
-  private final long tenantKey;
+  private final String tenantId;
   private long groupKey;
 
-  public UnassignGroupFromTenantCommandImpl(final HttpClient httpClient, final long tenantKey) {
+  public UnassignGroupFromTenantCommandImpl(final HttpClient httpClient, final String tenantId) {
     this.httpClient = httpClient;
     httpRequestConfig = httpClient.newRequestConfig();
-    this.tenantKey = tenantKey;
+    this.tenantId = tenantId;
   }
 
   @Override
@@ -56,7 +56,7 @@ public final class UnassignGroupFromTenantCommandImpl
   public CamundaFuture<UnassignGroupFromTenantResponse> send() {
     ArgumentUtil.ensureNotNull("groupKey", groupKey);
     final HttpCamundaFuture<UnassignGroupFromTenantResponse> result = new HttpCamundaFuture<>();
-    final String endpoint = String.format("/tenants/%d/groups/%d", tenantKey, groupKey);
+    final String endpoint = String.format("/tenants/%s/groups/%d", tenantId, groupKey);
     httpClient.delete(endpoint, httpRequestConfig.build(), result);
     return result;
   }

--- a/clients/java/src/test/java/io/camunda/client/tenant/AssignGroupToTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/AssignGroupToTenantTest.java
@@ -27,31 +27,30 @@ import org.junit.jupiter.api.Test;
 
 public class AssignGroupToTenantTest extends ClientRestTest {
 
-  private static final long TENANT_KEY = 123L;
+  private static final String TENANT_ID = "foo";
   private static final long GROUP_KEY = 456L;
 
   @Test
   void shouldAssignGroupToTenant() {
     // when
-    client.newAssignGroupToTenantCommand(TENANT_KEY).groupKey(GROUP_KEY).send().join();
+    client.newAssignGroupToTenantCommand(TENANT_ID).groupKey(GROUP_KEY).send().join();
 
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();
     assertThat(requestPath)
-        .isEqualTo(REST_API_PATH + "/tenants/" + TENANT_KEY + "/groups/" + GROUP_KEY);
+        .isEqualTo(REST_API_PATH + "/tenants/" + TENANT_ID + "/groups/" + GROUP_KEY);
   }
 
   @Test
   void shouldRaiseExceptionOnNotFoundTenant() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_KEY + "/groups/" + GROUP_KEY,
+        REST_API_PATH + "/tenants/" + TENANT_ID + "/groups/" + GROUP_KEY,
         () -> new ProblemDetail().title("Not Found").status(404));
 
     // when / then
     assertThatThrownBy(
-            () ->
-                client.newAssignGroupToTenantCommand(TENANT_KEY).groupKey(GROUP_KEY).send().join())
+            () -> client.newAssignGroupToTenantCommand(TENANT_ID).groupKey(GROUP_KEY).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -60,13 +59,12 @@ public class AssignGroupToTenantTest extends ClientRestTest {
   void shouldRaiseExceptionOnNotFoundGroup() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_KEY + "/groups/" + GROUP_KEY,
+        REST_API_PATH + "/tenants/" + TENANT_ID + "/groups/" + GROUP_KEY,
         () -> new ProblemDetail().title("Not Found").status(404));
 
     // when / then
     assertThatThrownBy(
-            () ->
-                client.newAssignGroupToTenantCommand(TENANT_KEY).groupKey(GROUP_KEY).send().join())
+            () -> client.newAssignGroupToTenantCommand(TENANT_ID).groupKey(GROUP_KEY).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -75,13 +73,12 @@ public class AssignGroupToTenantTest extends ClientRestTest {
   void shouldHandleServerError() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_KEY + "/groups/" + GROUP_KEY,
+        REST_API_PATH + "/tenants/" + TENANT_ID + "/groups/" + GROUP_KEY,
         () -> new ProblemDetail().title("Internal Server Error").status(500));
 
     // when / then
     assertThatThrownBy(
-            () ->
-                client.newAssignGroupToTenantCommand(TENANT_KEY).groupKey(GROUP_KEY).send().join())
+            () -> client.newAssignGroupToTenantCommand(TENANT_ID).groupKey(GROUP_KEY).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 500: 'Internal Server Error'");
   }
@@ -90,13 +87,12 @@ public class AssignGroupToTenantTest extends ClientRestTest {
   void shouldRaiseExceptionOnForbiddenRequest() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_KEY + "/groups/" + GROUP_KEY,
+        REST_API_PATH + "/tenants/" + TENANT_ID + "/groups/" + GROUP_KEY,
         () -> new ProblemDetail().title("Forbidden").status(403));
 
     // when / then
     assertThatThrownBy(
-            () ->
-                client.newAssignGroupToTenantCommand(TENANT_KEY).groupKey(GROUP_KEY).send().join())
+            () -> client.newAssignGroupToTenantCommand(TENANT_ID).groupKey(GROUP_KEY).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 403: 'Forbidden'");
   }

--- a/clients/java/src/test/java/io/camunda/client/tenant/AssignMappingToTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/AssignMappingToTenantTest.java
@@ -27,32 +27,32 @@ import org.junit.jupiter.api.Test;
 
 public class AssignMappingToTenantTest extends ClientRestTest {
 
-  private static final long TENANT_KEY = 123L;
+  private static final String TENANT_ID = "tenantId";
   private static final long MAPPING_KEY = 456L;
 
   @Test
   void shouldAssignMappingToTenant() {
     // when
-    client.newAssignMappingToTenantCommand(TENANT_KEY).mappingKey(MAPPING_KEY).send().join();
+    client.newAssignMappingToTenantCommand(TENANT_ID).mappingKey(MAPPING_KEY).send().join();
 
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();
     assertThat(requestPath)
-        .isEqualTo(REST_API_PATH + "/tenants/" + TENANT_KEY + "/mapping-rules/" + MAPPING_KEY);
+        .isEqualTo(REST_API_PATH + "/tenants/" + TENANT_ID + "/mapping-rules/" + MAPPING_KEY);
   }
 
   @Test
   void shouldRaiseExceptionOnNotFoundTenant() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_KEY + "/mapping-rules/" + MAPPING_KEY,
+        REST_API_PATH + "/tenants/" + TENANT_ID + "/mapping-rules/" + MAPPING_KEY,
         () -> new ProblemDetail().title("Not Found").status(404));
 
     // when / then
     assertThatThrownBy(
             () ->
                 client
-                    .newAssignMappingToTenantCommand(TENANT_KEY)
+                    .newAssignMappingToTenantCommand(TENANT_ID)
                     .mappingKey(MAPPING_KEY)
                     .send()
                     .join())
@@ -64,14 +64,14 @@ public class AssignMappingToTenantTest extends ClientRestTest {
   void shouldRaiseExceptionOnNotFoundMapping() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_KEY + "/mapping-rules/" + MAPPING_KEY,
+        REST_API_PATH + "/tenants/" + TENANT_ID + "/mapping-rules/" + MAPPING_KEY,
         () -> new ProblemDetail().title("Not Found").status(404));
 
     // when / then
     assertThatThrownBy(
             () ->
                 client
-                    .newAssignMappingToTenantCommand(TENANT_KEY)
+                    .newAssignMappingToTenantCommand(TENANT_ID)
                     .mappingKey(MAPPING_KEY)
                     .send()
                     .join())
@@ -83,14 +83,14 @@ public class AssignMappingToTenantTest extends ClientRestTest {
   void shouldHandleServerError() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_KEY + "/mapping-rules/" + MAPPING_KEY,
+        REST_API_PATH + "/tenants/" + TENANT_ID + "/mapping-rules/" + MAPPING_KEY,
         () -> new ProblemDetail().title("Internal Server Error").status(500));
 
     // when / then
     assertThatThrownBy(
             () ->
                 client
-                    .newAssignMappingToTenantCommand(TENANT_KEY)
+                    .newAssignMappingToTenantCommand(TENANT_ID)
                     .mappingKey(MAPPING_KEY)
                     .send()
                     .join())
@@ -102,14 +102,14 @@ public class AssignMappingToTenantTest extends ClientRestTest {
   void shouldRaiseExceptionOnForbiddenRequest() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_KEY + "/mapping-rules/" + MAPPING_KEY,
+        REST_API_PATH + "/tenants/" + TENANT_ID + "/mapping-rules/" + MAPPING_KEY,
         () -> new ProblemDetail().title("Forbidden").status(403));
 
     // when / then
     assertThatThrownBy(
             () ->
                 client
-                    .newAssignMappingToTenantCommand(TENANT_KEY)
+                    .newAssignMappingToTenantCommand(TENANT_ID)
                     .mappingKey(MAPPING_KEY)
                     .send()
                     .join())

--- a/clients/java/src/test/java/io/camunda/client/tenant/RemoveUserFromTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/RemoveUserFromTenantTest.java
@@ -34,7 +34,7 @@ public class RemoveUserFromTenantTest extends ClientRestTest {
   @Test
   void shouldRemoveUserFromTenant() {
     // when
-    client.newRemoveUserFromTenantCommand(TENANT_ID).username(USERNAME).send().join();
+    client.newUnassignUserFromTenantCommand(TENANT_ID).username(USERNAME).send().join();
 
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();
@@ -53,7 +53,8 @@ public class RemoveUserFromTenantTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () -> client.newRemoveUserFromTenantCommand(TENANT_ID).username(USERNAME).send().join())
+            () ->
+                client.newUnassignUserFromTenantCommand(TENANT_ID).username(USERNAME).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -67,7 +68,8 @@ public class RemoveUserFromTenantTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () -> client.newRemoveUserFromTenantCommand(TENANT_ID).username(USERNAME).send().join())
+            () ->
+                client.newUnassignUserFromTenantCommand(TENANT_ID).username(USERNAME).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -81,7 +83,8 @@ public class RemoveUserFromTenantTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () -> client.newRemoveUserFromTenantCommand(TENANT_ID).username(USERNAME).send().join())
+            () ->
+                client.newUnassignUserFromTenantCommand(TENANT_ID).username(USERNAME).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 500: 'Internal Server Error'");
   }
@@ -95,7 +98,8 @@ public class RemoveUserFromTenantTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () -> client.newRemoveUserFromTenantCommand(TENANT_ID).username(USERNAME).send().join())
+            () ->
+                client.newUnassignUserFromTenantCommand(TENANT_ID).username(USERNAME).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 403: 'Forbidden'");
   }

--- a/clients/java/src/test/java/io/camunda/client/tenant/UnassignGroupFromTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/client/tenant/UnassignGroupFromTenantTest.java
@@ -30,32 +30,32 @@ import org.junit.jupiter.api.Test;
     "Disabled while groups are not fully supported yet: https://github.com/camunda/camunda/issues/26961 ")
 public class UnassignGroupFromTenantTest extends ClientRestTest {
 
-  private static final long TENANT_KEY = 123L;
+  private static final String TENANT_ID = "tenantId";
   private static final long GROUP_KEY = 456L;
 
   @Test
   void shouldUnassignGroupFromTenant() {
     // when
-    client.newUnassignGroupFromTenantCommand(TENANT_KEY).groupKey(GROUP_KEY).send().join();
+    client.newUnassignGroupFromTenantCommand(TENANT_ID).groupKey(GROUP_KEY).send().join();
 
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();
     assertThat(requestPath)
-        .isEqualTo(REST_API_PATH + "/tenants/" + TENANT_KEY + "/groups/" + GROUP_KEY);
+        .isEqualTo(REST_API_PATH + "/tenants/" + TENANT_ID + "/groups/" + GROUP_KEY);
   }
 
   @Test
   void shouldRaiseExceptionOnNotFoundTenant() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_KEY + "/groups/" + GROUP_KEY,
+        REST_API_PATH + "/tenants/" + TENANT_ID + "/groups/" + GROUP_KEY,
         () -> new ProblemDetail().title("Not Found").status(404));
 
     // when / then
     assertThatThrownBy(
             () ->
                 client
-                    .newUnassignGroupFromTenantCommand(TENANT_KEY)
+                    .newUnassignGroupFromTenantCommand(TENANT_ID)
                     .groupKey(GROUP_KEY)
                     .send()
                     .join())
@@ -67,14 +67,14 @@ public class UnassignGroupFromTenantTest extends ClientRestTest {
   void shouldRaiseExceptionOnNotFoundGroup() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_KEY + "/groups/" + GROUP_KEY,
+        REST_API_PATH + "/tenants/" + TENANT_ID + "/groups/" + GROUP_KEY,
         () -> new ProblemDetail().title("Not Found").status(404));
 
     // when / then
     assertThatThrownBy(
             () ->
                 client
-                    .newUnassignGroupFromTenantCommand(TENANT_KEY)
+                    .newUnassignGroupFromTenantCommand(TENANT_ID)
                     .groupKey(GROUP_KEY)
                     .send()
                     .join())
@@ -86,14 +86,14 @@ public class UnassignGroupFromTenantTest extends ClientRestTest {
   void shouldHandleServerError() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_KEY + "/groups/" + GROUP_KEY,
+        REST_API_PATH + "/tenants/" + TENANT_ID + "/groups/" + GROUP_KEY,
         () -> new ProblemDetail().title("Internal Server Error").status(500));
 
     // when / then
     assertThatThrownBy(
             () ->
                 client
-                    .newUnassignGroupFromTenantCommand(TENANT_KEY)
+                    .newUnassignGroupFromTenantCommand(TENANT_ID)
                     .groupKey(GROUP_KEY)
                     .send()
                     .join())
@@ -105,14 +105,14 @@ public class UnassignGroupFromTenantTest extends ClientRestTest {
   void shouldRaiseExceptionOnForbiddenRequest() {
     // given
     gatewayService.errorOnRequest(
-        REST_API_PATH + "/tenants/" + TENANT_KEY + "/groups/" + GROUP_KEY,
+        REST_API_PATH + "/tenants/" + TENANT_ID + "/groups/" + GROUP_KEY,
         () -> new ProblemDetail().title("Forbidden").status(403));
 
     // when / then
     assertThatThrownBy(
             () ->
                 client
-                    .newUnassignGroupFromTenantCommand(TENANT_KEY)
+                    .newUnassignGroupFromTenantCommand(TENANT_ID)
                     .groupKey(GROUP_KEY)
                     .send()
                     .join())

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/TenantMappingRuleMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/TenantMappingRuleMigrationHandler.java
@@ -66,7 +66,7 @@ public class TenantMappingRuleMigrationHandler extends MigrationHandler<TenantMa
               .orElseGet(() -> mappingServices.createMapping(request).join().getMappingKey());
       for (final Tenant mappingTenant : tenantMappingRule.getAppliedTenants()) {
         final var tenant = tenantServices.getById(mappingTenant.tenantId());
-        assignMappingToTenant(tenant.key(), mappingKey);
+        assignMappingToTenant(tenant.tenantId(), mappingKey);
       }
       return managementIdentityTransformer.toMigrationStatusUpdateRequest(tenantMappingRule, null);
     } catch (final Exception e) {
@@ -75,9 +75,9 @@ public class TenantMappingRuleMigrationHandler extends MigrationHandler<TenantMa
     }
   }
 
-  private void assignMappingToTenant(final long tenantKey, final long mappingKey) {
+  private void assignMappingToTenant(final String tenantId, final long mappingKey) {
     try {
-      tenantServices.addMember(tenantKey, EntityType.MAPPING, mappingKey).join();
+      tenantServices.addMember(tenantId, EntityType.MAPPING, mappingKey).join();
     } catch (final Exception e) {
       if (!isConflictError(e)) {
         throw e;

--- a/migration/identity-migration/src/main/java/io/camunda/migration/identity/UserTenantsMigrationHandler.java
+++ b/migration/identity-migration/src/main/java/io/camunda/migration/identity/UserTenantsMigrationHandler.java
@@ -64,8 +64,8 @@ public class UserTenantsMigrationHandler extends MigrationHandler<UserTenants> {
               .map(MappingEntity::mappingKey)
               .orElseGet(() -> mappingServices.createMapping(mapping).join().getMappingKey());
       for (final Tenant userTenant : userTenants.tenants()) {
-        final var tenantKey = tenantServices.getById(userTenant.tenantId()).key();
-        assignMemberToTenant(tenantKey, mappingKey);
+        final var tenant = tenantServices.getById(userTenant.tenantId());
+        assignMemberToTenant(tenant.tenantId(), mappingKey);
       }
       return managementIdentityTransformer.toMigrationStatusUpdateRequest(userTenants, null);
     } catch (final Exception e) {
@@ -73,9 +73,9 @@ public class UserTenantsMigrationHandler extends MigrationHandler<UserTenants> {
     }
   }
 
-  private void assignMemberToTenant(final long tenantKey, final long mappingKey) {
+  private void assignMemberToTenant(final String tenantId, final long mappingKey) {
     try {
-      tenantServices.addMember(tenantKey, EntityType.MAPPING, mappingKey).join();
+      tenantServices.addMember(tenantId, EntityType.MAPPING, mappingKey).join();
     } catch (final Exception e) {
       if (!isConflictError(e)) {
         throw e;

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/TenantMappingRuleMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/TenantMappingRuleMigrationHandlerTest.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -90,7 +91,7 @@ final class TenantMappingRuleMigrationHandlerTest {
     when(tenantServices.getById(any())).thenReturn(new TenantEntity(1L, "", "", null));
     when(mappingServices.createMapping(any()))
         .thenAnswer(invocation -> CompletableFuture.completedFuture(new MappingRecord()));
-    when(tenantServices.addMember(any(), any(), anyLong()))
+    when(tenantServices.addMember(anyString(), any(), anyLong()))
         .thenReturn(CompletableFuture.completedFuture(new TenantRecord()));
     // when
     migrationHandler.migrate();
@@ -98,7 +99,7 @@ final class TenantMappingRuleMigrationHandlerTest {
     // then
     verify(managementIdentityClient, times(2)).fetchTenantMappingRules(anyInt());
     verify(tenantServices, times(4)).getById(any());
-    verify(tenantServices, times(4)).addMember(any(), any(), anyLong());
+    verify(tenantServices, times(4)).addMember(anyString(), any(), anyLong());
     verify(mappingServices, times(2)).findMapping(any(MappingDTO.class));
   }
 
@@ -157,7 +158,7 @@ final class TenantMappingRuleMigrationHandlerTest {
     when(tenantServices.getById(any())).thenReturn(new TenantEntity(1L, "", "", null));
     when(mappingServices.createMapping(any()))
         .thenAnswer(invocation -> CompletableFuture.completedFuture(new MappingRecord()));
-    when(tenantServices.addMember(any(), any(), anyLong()))
+    when(tenantServices.addMember(anyString(), any(), anyLong()))
         .thenReturn(
             CompletableFuture.failedFuture(
                 new BrokerRejectionException(
@@ -173,7 +174,7 @@ final class TenantMappingRuleMigrationHandlerTest {
     // then
     verify(managementIdentityClient, times(2)).fetchTenantMappingRules(anyInt());
     verify(tenantServices, times(4)).getById(any());
-    verify(tenantServices, times(4)).addMember(any(), any(), anyLong());
+    verify(tenantServices, times(4)).addMember(anyString(), any(), anyLong());
     verify(mappingServices, times(2)).findMapping(any(MappingDTO.class));
     verify(managementIdentityClient, times(2))
         .updateMigrationStatus(

--- a/migration/identity-migration/src/test/java/io/camunda/migration/identity/UserTenantsMigrationHandlerTest.java
+++ b/migration/identity-migration/src/test/java/io/camunda/migration/identity/UserTenantsMigrationHandlerTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
@@ -59,7 +60,7 @@ final class UserTenantsMigrationHandlerTest {
       @Mock(answer = Answers.RETURNS_SELF) final MappingServices mappingServices) {
     when(tenantServices.createTenant(any()))
         .thenReturn(CompletableFuture.completedFuture(new TenantRecord()));
-    when(tenantServices.addMember(any(), any(), anyLong()))
+    when(tenantServices.addMember(anyString(), any(), anyLong()))
         .thenReturn(CompletableFuture.completedFuture(new TenantRecord()));
     when(mappingServices.createMapping(any()))
         .thenReturn(CompletableFuture.completedFuture(new MappingRecord()));
@@ -97,7 +98,7 @@ final class UserTenantsMigrationHandlerTest {
         .thenReturn(CompletableFuture.completedFuture(new TenantRecord()));
     when(mappingServices.createMapping(any()))
         .thenReturn(CompletableFuture.completedFuture(new MappingRecord()));
-    when(tenantServices.addMember(any(), any(), anyLong()))
+    when(tenantServices.addMember(anyString(), any(), anyLong()))
         .thenReturn(CompletableFuture.completedFuture(new TenantRecord()));
 
     // when
@@ -106,7 +107,7 @@ final class UserTenantsMigrationHandlerTest {
     // then
     verify(managementIdentityClient, times(2)).fetchUserTenants(anyInt());
     verify(tenantServices, times(4)).getById(any());
-    verify(tenantServices, times(4)).addMember(any(), any(), anyLong());
+    verify(tenantServices, times(4)).addMember(anyString(), any(), anyLong());
     verify(mappingServices, times(2)).findMapping(any(MappingDTO.class));
   }
 
@@ -165,7 +166,7 @@ final class UserTenantsMigrationHandlerTest {
             new BrokerRejectionException(
                 new BrokerRejection(TenantIntent.ADD_ENTITY, -1, RejectionType.ALREADY_EXISTS, "")))
         .when(tenantServices)
-        .addMember(any(), any(), anyLong());
+        .addMember(anyString(), any(), anyLong());
 
     // when
     migrationHandler.migrate();
@@ -173,7 +174,7 @@ final class UserTenantsMigrationHandlerTest {
     // then
     verify(managementIdentityClient, times(2)).fetchUserTenants(anyInt());
     verify(tenantServices, times(4)).getById(any());
-    verify(tenantServices, times(4)).addMember(any(), any(), anyLong());
+    verify(tenantServices, times(4)).addMember(anyString(), any(), anyLong());
     verify(mappingServices, times(2)).createMapping(any());
     verify(managementIdentityClient, times(2))
         .updateMigrationStatus(

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -93,6 +93,18 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
             .setEntity(entityType, entityKey));
   }
 
+  /**
+   * This is a temporary method which can be removed once groups and mappings are refactored to work
+   * with ids instead of keys.
+   */
+  public CompletableFuture<TenantRecord> addMember(
+      final String tenantId, final EntityType entityType, final long entityKey) {
+    return sendBrokerRequest(
+        BrokerTenantEntityRequest.createAddRequest()
+            .setTenantId(tenantId)
+            .setEntity(entityType, entityKey));
+  }
+
   public CompletableFuture<TenantRecord> addMember(
       final String tenantId, final EntityType entityType, final String entityId) {
     return sendBrokerRequest(

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -105,11 +105,15 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
             .setEntity(entityType, entityId));
   }
 
+  /**
+   * This is a temporary method which can be removed once groups and mappings are refactored to work
+   * with ids instead of keys.
+   */
   public CompletableFuture<TenantRecord> removeMember(
-      final Long tenantKey, final EntityType entityType, final long entityKey) {
+      final String tenantId, final EntityType entityType, final long entityKey) {
     return sendBrokerRequest(
         BrokerTenantEntityRequest.createRemoveRequest()
-            .setTenantKey(tenantKey)
+            .setTenantId(tenantId)
             .setEntity(entityType, entityKey));
   }
 

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -86,8 +86,8 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
   }
 
   /**
-   * This is a temporary method which can be removed once groups and mappings are refactored to work
-   * with ids instead of keys.
+   * TODO: This is a temporary method which can be removed once groups and mappings are refactored
+   * to work with ids instead of keys.
    */
   public CompletableFuture<TenantRecord> addMember(
       final String tenantId, final EntityType entityType, final long entityKey) {
@@ -106,8 +106,8 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
   }
 
   /**
-   * This is a temporary method which can be removed once groups and mappings are refactored to work
-   * with ids instead of keys.
+   * TODO: This is a temporary method which can be removed once groups and mappings are refactored
+   * to work with ids instead of keys.
    */
   public CompletableFuture<TenantRecord> removeMember(
       final String tenantId, final EntityType entityType, final long entityKey) {

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -85,14 +85,6 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
     return sendBrokerRequest(new BrokerTenantDeleteRequest(tenantId));
   }
 
-  public CompletableFuture<TenantRecord> addMember(
-      final Long tenantKey, final EntityType entityType, final long entityKey) {
-    return sendBrokerRequest(
-        BrokerTenantEntityRequest.createAddRequest()
-            .setTenantKey(tenantKey)
-            .setEntity(entityType, entityKey));
-  }
-
   /**
    * This is a temporary method which can be removed once groups and mappings are refactored to work
    * with ids instead of keys.

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -192,18 +192,18 @@ public class TenantServiceTest {
       names = {"USER", "MAPPING", "GROUP"})
   public void shouldAddEntityToTenant(final EntityType entityType) {
     // given
-    final var tenantKey = 100L;
+    final var tenantId = "tenantId";
     final var entityKey = 42;
 
     // when
-    services.addMember(tenantKey, entityType, entityKey);
+    services.addMember(tenantId, entityType, entityKey);
 
     // then
     final BrokerTenantEntityRequest request = stubbedBrokerClient.getSingleBrokerRequest();
     assertThat(request.getIntent()).isEqualTo(TenantIntent.ADD_ENTITY);
     assertThat(request.getValueType()).isEqualTo(ValueType.TENANT);
     final TenantRecord brokerRequestValue = request.getRequestWriter();
-    assertThat(brokerRequestValue.getTenantKey()).isEqualTo(tenantKey);
+    assertThat(brokerRequestValue.getTenantId()).isEqualTo(tenantId);
     assertThat(brokerRequestValue.getEntityKey()).isEqualTo(entityKey);
     assertThat(brokerRequestValue.getEntityType()).isEqualTo(entityType);
   }

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -214,18 +214,18 @@ public class TenantServiceTest {
       names = {"USER", "MAPPING", "GROUP"})
   public void shouldRemoveEntityFromTenant(final EntityType entityType) {
     // given
-    final var tenantKey = 100L;
+    final var tenantId = "tenantId";
     final var entityKey = 42;
 
     // when
-    services.removeMember(tenantKey, entityType, entityKey);
+    services.removeMember(tenantId, entityType, entityKey);
 
     // then
     final BrokerTenantEntityRequest request = stubbedBrokerClient.getSingleBrokerRequest();
     assertThat(request.getIntent()).isEqualTo(TenantIntent.REMOVE_ENTITY);
     assertThat(request.getValueType()).isEqualTo(ValueType.TENANT);
     final TenantRecord brokerRequestValue = request.getRequestWriter();
-    assertThat(brokerRequestValue.getTenantKey()).isEqualTo(tenantKey);
+    assertThat(brokerRequestValue.getTenantId()).isEqualTo(tenantId);
     assertThat(brokerRequestValue.getEntityKey()).isEqualTo(entityKey);
     assertThat(brokerRequestValue.getEntityType()).isEqualTo(entityType);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
@@ -137,9 +137,9 @@ public final class IdentitySetupInitializeProcessor
 
     final var tenant = record.getDefaultTenant();
     tenantState
-        .getTenantKeyById(tenant.getTenantId())
+        .getTenantById(tenant.getTenantId())
         .ifPresentOrElse(
-            tenant::setTenantKey,
+            t -> tenant.setTenantKey(t.getTenantKey()),
             () -> {
               createdNewEntities.set(true);
               final long tenantKey = keyGenerator.nextKey();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
@@ -189,7 +189,7 @@ public final class IdentitySetupInitializeProcessor
                                 role.getRoleKey(), userKey.getUserKey(), EntityType.USER),
                         () -> createUser(user, role.getRoleKey())));
 
-    if (tenantState.getTenantByKey(record.getDefaultTenant().getTenantKey()).isEmpty()) {
+    if (tenantState.getTenantById(record.getDefaultTenant().getTenantId()).isEmpty()) {
       createTenant(record.getDefaultTenant());
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
@@ -122,12 +122,13 @@ public class MappingDeleteProcessor implements DistributedTypedRecordProcessor<M
     final var mappingKey = mapping.getMappingKey();
     deleteAuthorizations(mappingKey);
     for (final var tenantId : mapping.getTenantIdsList()) {
-      final long tenantKey = tenantState.getTenantKeyById(tenantId).orElseThrow();
+      final var tenant = tenantState.getTenantById(tenantId).orElseThrow();
       stateWriter.appendFollowUpEvent(
-          tenantKey,
+          tenant.getTenantKey(),
           TenantIntent.ENTITY_REMOVED,
           new TenantRecord()
-              .setTenantKey(tenantKey)
+              .setTenantKey(tenant.getTenantKey())
+              .setTenantId(tenant.getTenantId())
               .setEntityKey(mappingKey)
               .setEntityType(EntityType.MAPPING));
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -109,18 +109,6 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
 
   /** Loads the persisted tenant by the tenant key if it is set, otherwise by the tenant id. */
   private Either<String, PersistedTenant> getPersistedTenant(final TenantRecord record) {
-    if (record.hasTenantKey()) {
-      final var tenantKey = record.getTenantKey();
-      return tenantState
-          .getTenantByKey(tenantKey)
-          .<Either<String, PersistedTenant>>map(Either::right)
-          .orElseGet(
-              () ->
-                  Either.left(
-                      "Expected to add entity to tenant with key '%s', but no tenant with this key exists."
-                          .formatted(tenantKey)));
-    }
-
     final var tenantId = record.getTenantId();
     return tenantState
         .getTenantById(tenantId)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -76,7 +76,7 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
     final var persistedTenant = tenantLookup.get();
     final var tenantKey = persistedTenant.getTenantKey();
     final var tenantId = persistedTenant.getTenantId();
-    record.setTenantId(tenantId);
+    record.setTenantKey(tenantKey);
 
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.TENANT, PermissionType.UPDATE)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantCreateProcessor.java
@@ -75,7 +75,7 @@ public class TenantCreateProcessor implements DistributedTypedRecordProcessor<Te
   public void processDistributedCommand(final TypedRecord<TenantRecord> command) {
     final var record = command.getValue();
     tenantState
-        .getTenantByKey(record.getTenantKey())
+        .getTenantById(record.getTenantId())
         .ifPresentOrElse(
             tenant -> {
               final var errorMessage =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantCreateProcessor.java
@@ -99,7 +99,7 @@ public class TenantCreateProcessor implements DistributedTypedRecordProcessor<Te
   }
 
   private boolean tenantAlreadyExists(final String tenantId) {
-    return tenantState.getTenantKeyById(tenantId).isPresent();
+    return tenantState.getTenantById(tenantId).isPresent();
   }
 
   private void createTenant(final TypedRecord<TenantRecord> command, final TenantRecord record) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
@@ -142,15 +142,13 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
   private void removeAssignedEntities(final TenantRecord record) {
     final var tenant = tenantState.getTenantById(record.getTenantId()).orElseThrow();
     tenantState
-        .getEntitiesByType(tenant.getTenantKey())
+        .getEntitiesByType(tenant.getTenantId())
         .forEach(
-            (entityType, entityKeys) -> {
+            (entityType, entityIds) -> {
               switch (entityType) {
                 case USER ->
-                    entityKeys.forEach(
-                        entityKey -> {
-                          final var username =
-                              userState.getUser(entityKey).orElseThrow().getUsername();
+                    entityIds.forEach(
+                        username -> {
                           final var entityRecord =
                               new TenantRecord()
                                   .setTenantId(tenant.getTenantId())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
@@ -127,9 +127,9 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
     final var username = user.getUsername();
     deleteAuthorizations(username);
     for (final var tenantId : user.getTenantIdsList()) {
-      final long tenantKey = tenantState.getTenantKeyById(tenantId).orElseThrow();
+      final var tenant = tenantState.getTenantById(tenantId).orElseThrow();
       stateWriter.appendFollowUpEvent(
-          tenantKey,
+          tenant.getTenantKey(),
           TenantIntent.ENTITY_REMOVED,
           new TenantRecord()
               .setTenantId(tenantId)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityAddedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityAddedApplier.java
@@ -35,7 +35,7 @@ public class TenantEntityAddedApplier implements TypedEventApplier<TenantIntent,
     switch (tenant.getEntityType()) {
       case USER -> {
         tenantState.addEntity(tenant);
-        userState.addTenantId(tenant.getTenantId(), tenant.getTenantId());
+        userState.addTenantId(tenant.getEntityId(), tenant.getTenantId());
       }
       case MAPPING -> {
         tenantState.addEntity(tenant);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityAddedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityAddedApplier.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.engine.state.mutable.MutableTenantState;
 import io.camunda.zeebe.engine.state.mutable.MutableUserState;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
-import io.camunda.zeebe.protocol.record.value.EntityType;
 
 public class TenantEntityAddedApplier implements TypedEventApplier<TenantIntent, TenantRecord> {
 
@@ -32,18 +31,11 @@ public class TenantEntityAddedApplier implements TypedEventApplier<TenantIntent,
   }
 
   @Override
-  public void applyState(final long key, final TenantRecord tenant) {
+  public void applyState(final long tenantKey, final TenantRecord tenant) {
     switch (tenant.getEntityType()) {
       case USER -> {
-        final var username = tenant.getEntityId();
-        final var userKey = userState.getUser(username).orElseThrow().getUserKey();
-        final var tenantKey = tenantState.getTenantKeyById(tenant.getTenantId()).orElseThrow();
-        tenantState.addEntity(
-            new TenantRecord()
-                .setTenantKey(tenantKey)
-                .setEntityType(EntityType.USER)
-                .setEntityKey(userKey));
-        userState.addTenantId(username, tenant.getTenantId());
+        tenantState.addEntity(tenant);
+        userState.addTenantId(tenant.getTenantId(), tenant.getTenantId());
       }
       case MAPPING -> {
         tenantState.addEntity(tenant);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityRemovedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityRemovedApplier.java
@@ -28,8 +28,7 @@ public class TenantEntityRemovedApplier implements TypedEventApplier<TenantInten
   public void applyState(final long tenantKey, final TenantRecord tenant) {
     switch (tenant.getEntityType()) {
       case USER -> {
-        final var userKey = userState.getUser(tenant.getEntityId()).orElseThrow().getUserKey();
-        tenantState.removeEntity(tenantKey, userKey);
+        tenantState.removeEntity(tenant);
         userState.removeTenant(tenant.getEntityId(), tenant.getTenantId());
       }
       default ->

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityRemovedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityRemovedApplier.java
@@ -25,10 +25,9 @@ public class TenantEntityRemovedApplier implements TypedEventApplier<TenantInten
   }
 
   @Override
-  public void applyState(final long key, final TenantRecord tenant) {
+  public void applyState(final long tenantKey, final TenantRecord tenant) {
     switch (tenant.getEntityType()) {
       case USER -> {
-        final var tenantKey = tenantState.getTenantKeyById(tenant.getTenantId()).orElseThrow();
         final var userKey = userState.getUser(tenant.getEntityId()).orElseThrow().getUserKey();
         tenantState.removeEntity(tenantKey, userKey);
         userState.removeTenant(tenant.getEntityId(), tenant.getTenantId());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/TenantState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/TenantState.java
@@ -19,30 +19,21 @@ public interface TenantState {
   /**
    * Retrieves the entity type associated with the given tenant key and entity key.
    *
-   * @param tenantKey the key of the tenant
-   * @param entityKey the key of the entity
+   * @param tenantId the id of the tenant
+   * @param entityId the id of the entity
    * @return an {@link Optional} containing the {@link EntityType} if it exists, or an empty {@link
    *     Optional} if not
    */
-  Optional<EntityType> getEntityType(final long tenantKey, final long entityKey);
+  Optional<EntityType> getEntityType(final String tenantId, final String entityId);
 
   /**
-   * Checks if the specified entity is assigned to the given tenant.
+   * Retrieves all entities associated with a given tenant id, grouped by their entity type.
    *
-   * @param entityKey the key of the entity to check
-   * @param tenantKey the key of the tenant
-   * @return true if the entity is assigned to the tenant, false otherwise
-   */
-  boolean isEntityAssignedToTenant(final long entityKey, final long tenantKey);
-
-  /**
-   * Retrieves all entities associated with a given tenant key, grouped by their entity type.
-   *
-   * @param tenantKey the key of the tenant whose entities are being retrieved
+   * @param tenantId the id of the tenant whose entities are being retrieved
    * @return a {@link Map} where each key is an {@link EntityType} and the corresponding value is a
-   *     {@link List} of entity keys associated with that type
+   *     {@link List} of entity ids associated with that type
    */
-  Map<EntityType, List<Long>> getEntitiesByType(long tenantKey);
+  Map<EntityType, List<String>> getEntitiesByType(String tenantId);
 
   /**
    * Loops over all tenants and applies the provided callback. It stops looping over the tenants,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/TenantState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/TenantState.java
@@ -17,23 +17,6 @@ import java.util.function.Function;
 public interface TenantState {
 
   /**
-   * Retrieves a tenant record by its key.
-   *
-   * @param tenantKey the key of the tenant to retrieve
-   * @return an Optional containing the tenant record if it exists, otherwise an empty Optional
-   */
-  Optional<PersistedTenant> getTenantByKey(final long tenantKey);
-
-  /**
-   * Retrieves the tenant key associated with the given tenant ID.
-   *
-   * @param tenantId the unique identifier of the tenant to look up
-   * @return an {@link Optional} containing the tenant key if the tenant exists, or an empty {@link
-   *     Optional} if not
-   */
-  Optional<Long> getTenantKeyById(final String tenantId);
-
-  /**
    * Retrieves the entity type associated with the given tenant key and entity key.
    *
    * @param tenantKey the key of the tenant

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableTenantState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableTenantState.java
@@ -35,10 +35,9 @@ public interface MutableTenantState extends TenantState {
   /**
    * Removes a specific entity from the given tenant.
    *
-   * @param tenantKey the key of the tenant from which the entity will be removed
-   * @param entityKey the key of the entity to be removed from the tenant
+   * @param tenantRecord the tenant record containing the tenant id and the entity to add
    */
-  void removeEntity(final long tenantKey, final long entityKey);
+  void removeEntity(final TenantRecord tenantRecord);
 
   /**
    * Deletes a tenant and all associated data from the state.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/DbTenantState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/DbTenantState.java
@@ -70,6 +70,7 @@ public class DbTenantState implements MutableTenantState {
 
   @Override
   public void addEntity(final TenantRecord tenantRecord) {
+    tenantId.wrapString(tenantRecord.getTenantId());
     entityId.wrapString(tenantRecord.getEntityId());
     entityType.setEntityType(tenantRecord.getEntityType());
     entityByTenantColumnFamily.insert(entityIdByTenantId, entityType);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/DbTenantState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/DbTenantState.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbCompositeKey;
 import io.camunda.zeebe.db.impl.DbForeignKey;
-import io.camunda.zeebe.db.impl.DbLong;
 import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.engine.state.authorization.EntityTypeValue;
 import io.camunda.zeebe.engine.state.mutable.MutableTenantState;
@@ -29,7 +28,6 @@ import java.util.function.Function;
 public class DbTenantState implements MutableTenantState {
 
   private final DbString tenantId = new DbString();
-  private final DbLong tenantKey = new DbLong();
   private final PersistedTenant persistedTenant = new PersistedTenant();
   private final ColumnFamily<DbString, PersistedTenant> tenantsColumnFamily;
 
@@ -56,7 +54,6 @@ public class DbTenantState implements MutableTenantState {
 
   @Override
   public void createTenant(final TenantRecord tenantRecord) {
-    tenantKey.wrapLong(tenantRecord.getTenantKey());
     tenantId.wrapString(tenantRecord.getTenantId());
     persistedTenant.from(tenantRecord);
     tenantsColumnFamily.insert(tenantId, persistedTenant);
@@ -87,7 +84,6 @@ public class DbTenantState implements MutableTenantState {
 
   @Override
   public void delete(final TenantRecord tenantRecord) {
-    tenantKey.wrapLong(tenantRecord.getTenantKey());
     tenantId.wrapString(tenantRecord.getTenantId());
 
     entityByTenantColumnFamily.whileEqualPrefix(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AnonymousAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AnonymousAuthorizationTest.java
@@ -66,12 +66,7 @@ public class AnonymousAuthorizationTest {
     username = UUID.randomUUID().toString();
     final var user = engine.user().newUser(username).create().getValue();
     final var tenantKey = engine.tenant().newTenant().withTenantId(TENANT).create().getKey();
-    engine
-        .tenant()
-        .addEntity(tenantKey)
-        .withEntityId(username)
-        .withEntityType(EntityType.USER)
-        .add();
+    engine.tenant().addEntity(TENANT).withEntityId(username).withEntityType(EntityType.USER).add();
 
     engine
         .authorization()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -630,10 +630,10 @@ public class AuthorizationCheckBehaviorTest {
     final var mappingKey = mapping.getMappingKey();
     final var mappingId = String.valueOf(mappingKey);
     final var tenantId = "tenant";
-    final var tenantKey = engine.tenant().newTenant().withTenantId(tenantId).create().getKey();
+    engine.tenant().newTenant().withTenantId(tenantId).create();
     engine
         .tenant()
-        .addEntity(tenantKey)
+        .addEntity(tenantId)
         .withEntityType(EntityType.MAPPING)
         .withEntityKey(mappingKey)
         .add();
@@ -669,10 +669,10 @@ public class AuthorizationCheckBehaviorTest {
     final var mappingKey = mapping.getMappingKey();
     final var mappingId = String.valueOf(mappingKey);
     final var tenantId = "tenant";
-    final var tenantKey = engine.tenant().newTenant().withTenantId(tenantId).create().getKey();
+    engine.tenant().newTenant().withTenantId(tenantId).create();
     engine
         .tenant()
-        .addEntity(tenantKey)
+        .addEntity(tenantId)
         .withEntityType(EntityType.MAPPING)
         .withEntityKey(mappingKey)
         .add();
@@ -1045,13 +1045,13 @@ public class AuthorizationCheckBehaviorTest {
         engine.mapping().newMapping(claimName).withClaimValue(claimValue).create().getValue();
     final var mappingKey = mapping.getMappingKey();
     final var tenantId = "tenant";
-    final var tenantKey = engine.tenant().newTenant().withTenantId(tenantId).create().getKey();
+    engine.tenant().newTenant().withTenantId(tenantId).create();
     final var command = mockCommandWithMapping(claimName, claimValue);
 
     // when
     engine
         .tenant()
-        .addEntity(tenantKey)
+        .addEntity(tenantId)
         .withEntityType(EntityType.MAPPING)
         .withEntityKey(mappingKey)
         .add();
@@ -1138,8 +1138,8 @@ public class AuthorizationCheckBehaviorTest {
 
   private String createAndAssignTenant(final long entityKey, final EntityType entityType) {
     final var tenantId = UUID.randomUUID().toString();
-    final var tenantKey = engine.tenant().newTenant().withTenantId(tenantId).create().getKey();
-    engine.tenant().addEntity(tenantKey).withEntityKey(entityKey).withEntityType(entityType).add();
+    engine.tenant().newTenant().withTenantId(tenantId).create();
+    engine.tenant().addEntity(tenantId).withEntityKey(entityKey).withEntityType(entityType).add();
     return tenantId;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantMultiPartitionTest.java
@@ -50,11 +50,10 @@ public class AddEntityTenantMultiPartitionTest {
         .create()
         .getKey();
     final var tenantId = UUID.randomUUID().toString();
-    final var tenantKey =
-        engine.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
+    engine.tenant().newTenant().withTenantId(tenantId).create();
     engine
         .tenant()
-        .addEntity(tenantKey)
+        .addEntity(tenantId)
         .withEntityId(username)
         .withEntityType(EntityType.USER)
         .add();
@@ -116,11 +115,10 @@ public class AddEntityTenantMultiPartitionTest {
         .create()
         .getKey();
     final var tenantId = UUID.randomUUID().toString();
-    final var tenantKey =
-        engine.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
+    engine.tenant().newTenant().withTenantId(tenantId).create();
     engine
         .tenant()
-        .addEntity(tenantKey)
+        .addEntity(tenantId)
         .withEntityId(username)
         .withEntityType(EntityType.USER)
         .add();
@@ -153,11 +151,10 @@ public class AddEntityTenantMultiPartitionTest {
 
     // when
     final var tenantId = UUID.randomUUID().toString();
-    final var tenantKey =
-        engine.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
+    engine.tenant().newTenant().withTenantId(tenantId).create();
     engine
         .tenant()
-        .addEntity(tenantKey)
+        .addEntity(tenantId)
         .withEntityId(username)
         .withEntityType(EntityType.USER)
         .add();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantTest.java
@@ -49,7 +49,7 @@ public class AddEntityTenantTest {
     final var updatedTenant =
         engine
             .tenant()
-            .addEntity(tenantKey)
+            .addEntity(tenantId)
             .withEntityKey(entityKey)
             .withEntityType(entityType)
             .add()
@@ -63,6 +63,7 @@ public class AddEntityTenantTest {
         .isNotNull()
         .hasFieldOrPropertyWithValue("entityKey", entityKey)
         .hasFieldOrPropertyWithValue("tenantKey", tenantKey)
+        .hasFieldOrPropertyWithValue("tenantId", tenantId)
         .hasFieldOrPropertyWithValue("entityType", entityType);
   }
 
@@ -88,7 +89,7 @@ public class AddEntityTenantTest {
     final var updatedTenant =
         engine
             .tenant()
-            .addEntity(tenantKey)
+            .addEntity(tenantId)
             .withEntityId(username)
             .withEntityType(entityType)
             .add()
@@ -102,6 +103,7 @@ public class AddEntityTenantTest {
         .isNotNull()
         .hasFieldOrPropertyWithValue("entityId", username)
         .hasFieldOrPropertyWithValue("tenantKey", tenantKey)
+        .hasFieldOrPropertyWithValue("tenantId", tenantId)
         .hasFieldOrPropertyWithValue("entityType", entityType);
   }
 
@@ -125,7 +127,7 @@ public class AddEntityTenantTest {
     final var updatedTenant =
         engine
             .tenant()
-            .addEntity(tenantKey)
+            .addEntity(tenantId)
             .withEntityKey(entityKey)
             .withEntityType(entityType)
             .add()
@@ -139,35 +141,35 @@ public class AddEntityTenantTest {
         .isNotNull()
         .hasFieldOrPropertyWithValue("entityKey", entityKey)
         .hasFieldOrPropertyWithValue("tenantKey", tenantKey)
+        .hasFieldOrPropertyWithValue("tenantId", tenantId)
         .hasFieldOrPropertyWithValue("entityType", entityType);
   }
 
   @Test
   public void shouldRejectIfTenantIsNotPresentWhileAddingEntity() {
     // when try adding entity to a non-existent tenant
-    final var entityKey = 1L;
-    final var notPresentUpdateRecord = engine.tenant().addEntity(entityKey).expectRejection().add();
+    final var nonExistingTenantId = UUID.randomUUID().toString();
+    final var notPresentUpdateRecord =
+        engine.tenant().addEntity(nonExistingTenantId).expectRejection().add();
     // then assert that the rejection is for tenant not found
     assertThat(notPresentUpdateRecord)
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
-            "Expected to add entity to tenant with key '%s', but no tenant with this key exists."
-                .formatted(entityKey));
+            "Expected to add entity to tenant with id '%s', but no tenant with this id exists."
+                .formatted(nonExistingTenantId));
   }
 
   @Test
   public void shouldRejectIfEntityIsNotPresentWhileAddingToTenant() {
     // given
     final var tenantId = UUID.randomUUID().toString();
-    final var tenantRecord =
-        engine.tenant().newTenant().withTenantId(tenantId).withName("Tenant 1").create();
+    engine.tenant().newTenant().withTenantId(tenantId).withName("Tenant 1").create();
 
     // when try adding a non-existent entity to the tenant
-    final var tenantKey = tenantRecord.getValue().getTenantKey();
     final var notPresentUpdateRecord =
         engine
             .tenant()
-            .addEntity(tenantKey)
+            .addEntity(tenantId)
             .withEntityId("does-not-exist")
             .withEntityType(USER)
             .expectRejection()
@@ -186,17 +188,15 @@ public class AddEntityTenantTest {
     // given
     final var user = createUser();
     final var tenantId = UUID.randomUUID().toString();
-    final var tenantRecord =
-        engine.tenant().newTenant().withTenantId(tenantId).withName("Tenant 1").create();
-    final var tenantKey = tenantRecord.getValue().getTenantKey();
+    engine.tenant().newTenant().withTenantId(tenantId).withName("Tenant 1").create();
     final var username = user.getUsername();
-    engine.tenant().addEntity(tenantKey).withEntityId(username).withEntityType(USER).add();
+    engine.tenant().addEntity(tenantId).withEntityId(username).withEntityType(USER).add();
 
     // when try adding a non-existent entity to the tenant
     final var alreadyAssignedRecord =
         engine
             .tenant()
-            .addEntity(tenantKey)
+            .addEntity(tenantId)
             .withEntityId(username)
             .withEntityType(USER)
             .expectRejection()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessorTest.java
@@ -99,7 +99,7 @@ public class TenantDeleteProcessorTest {
 
     engine
         .tenant()
-        .addEntity(tenantKey)
+        .addEntity(tenantId)
         .withEntityId(username)
         .withEntityType(EntityType.USER)
         .add();
@@ -115,6 +115,7 @@ public class TenantDeleteProcessorTest {
             .asList();
 
     assertThat(deletedTenant).hasTenantKey(tenantKey);
+    assertThat(deletedTenant).hasTenantId(tenantId);
     assertThat(tenantRecords).hasSize(2);
     assertThat(tenantRecords)
         .extracting(Record::getIntent)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessorTest.java
@@ -41,7 +41,7 @@ public class TenantDeleteProcessorTest {
             .create()
             .getValue()
             .getTenantKey();
-    assertThat(engine.getProcessingState().getTenantState().getTenantByKey(tenantKey).get())
+    assertThat(engine.getProcessingState().getTenantState().getTenantById(tenantId).get())
         .isNotNull();
 
     // When

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
@@ -66,8 +66,8 @@ public class TenantAppliersTest {
     associateUserWithTenant(tenantKey, tenantId, username);
 
     // then
-    assertThat(tenantState.getEntitiesByType(tenantKey).get(EntityType.USER))
-        .containsExactly(entityKey);
+    assertThat(tenantState.getEntitiesByType(tenantId).get(EntityType.USER))
+        .containsExactly(username);
     final var persistedUser = userState.getUser(entityKey).get();
     assertThat(persistedUser.getTenantIdsList()).containsExactly(tenantId);
   }
@@ -75,7 +75,7 @@ public class TenantAppliersTest {
   @Test
   void shouldAddEntityToTenantWithTypeMapping() {
     // given
-    final long entityKey = 1L;
+    final Long entityKey = 1L;
     mappingState.create(
         new MappingRecord()
             .setMappingKey(entityKey)
@@ -91,7 +91,8 @@ public class TenantAppliersTest {
     tenantEntityAddedApplier.applyState(tenantKey, tenantRecord);
 
     // then
-    assertThat(tenantState.getEntityType(tenantKey, entityKey).get().equals(EntityType.MAPPING));
+    assertThat(tenantState.getEntityType(tenantId, entityKey.toString()).get())
+        .isEqualTo(EntityType.MAPPING);
     final var persistedMapping = mappingState.get(entityKey).get();
     assertThat(persistedMapping.getTenantIdsList()).containsExactly(tenantId);
   }
@@ -134,8 +135,8 @@ public class TenantAppliersTest {
     associateUserWithTenant(tenantKey, tenantId, username);
 
     // Ensure the user is associated with the tenant before removal
-    assertThat(tenantState.getEntitiesByType(tenantKey).get(EntityType.USER))
-        .containsExactly(entityKey);
+    assertThat(tenantState.getEntitiesByType(username).get(EntityType.USER))
+        .containsExactly(username);
     final var persistedUser = userState.getUser(entityKey).get();
     assertThat(persistedUser.getTenantIdsList()).containsExactly(tenantId);
 
@@ -148,7 +149,7 @@ public class TenantAppliersTest {
     tenantEntityRemovedApplier.applyState(tenantKey, tenantRecord);
 
     // then
-    assertThat(tenantState.getEntitiesByType(tenantKey)).isEmpty();
+    assertThat(tenantState.getEntitiesByType(tenantId)).isEmpty();
     final var updatedUser = userState.getUser(entityKey).get();
     assertThat(updatedUser.getTenantIdsList()).isEmpty();
   }
@@ -158,7 +159,7 @@ public class TenantAppliersTest {
       "Disabled while mappings are not supported: https://github.com/camunda/camunda/issues/26981")
   void shouldRemoveEntityFromTenantWithTypeMapping() {
     // given
-    final long entityKey = 1L;
+    final Long entityKey = 1L;
     mappingState.create(
         new MappingRecord()
             .setMappingKey(entityKey)
@@ -172,7 +173,8 @@ public class TenantAppliersTest {
     tenantEntityAddedApplier.applyState(tenantKey, tenantRecord);
 
     // Ensure the mapping is associated with the tenant before removal
-    assertThat(tenantState.getEntityType(tenantKey, entityKey).get().equals(EntityType.MAPPING));
+    assertThat(tenantState.getEntityType(tenantId, entityKey.toString()).get())
+        .isEqualTo(EntityType.MAPPING);
     final var persistedMapping = mappingState.get(entityKey).get();
     assertThat(persistedMapping.getTenantIdsList()).containsExactly(tenantId);
 
@@ -180,7 +182,7 @@ public class TenantAppliersTest {
     tenantEntityRemovedApplier.applyState(tenantKey, tenantRecord);
 
     // then
-    assertThat(tenantState.getEntityType(tenantKey, entityKey)).isEmpty();
+    assertThat(tenantState.getEntityType(tenantId, entityKey.toString())).isEmpty();
     final var updatedMapping = mappingState.get(entityKey).get();
     assertThat(updatedMapping.getTenantIdsList()).isEmpty();
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
@@ -106,13 +106,13 @@ public class TenantAppliersTest {
     final TenantRecord tenantRecord = createTenant(tenantKey, tenantId);
 
     // Ensure the tenant exists before deletion
-    assertThat(tenantState.getTenantByKey(tenantKey)).isPresent();
+    assertThat(tenantState.getTenantById(tenantId)).isPresent();
 
     // when
     tenantDeletedApplier.applyState(tenantKey, tenantRecord);
 
     // then
-    assertThat(tenantState.getTenantByKey(tenantKey)).isEmpty();
+    assertThat(tenantState.getTenantById(tenantId)).isEmpty();
     final var resourceIdentifiers =
         authorizationState.getResourceIdentifiers(
             AuthorizationOwnerType.TENANT,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
@@ -85,7 +85,10 @@ public class TenantAppliersTest {
     final long tenantKey = 11L;
     final var tenantRecord = new TenantRecord().setTenantId(tenantId).setTenantKey(tenantKey);
     tenantState.createTenant(tenantRecord);
-    tenantRecord.setEntityKey(entityKey).setEntityType(EntityType.MAPPING);
+    tenantRecord
+        .setEntityKey(entityKey)
+        .setEntityId(entityKey.toString())
+        .setEntityType(EntityType.MAPPING);
 
     // when
     tenantEntityAddedApplier.applyState(tenantKey, tenantRecord);
@@ -135,7 +138,7 @@ public class TenantAppliersTest {
     associateUserWithTenant(tenantKey, tenantId, username);
 
     // Ensure the user is associated with the tenant before removal
-    assertThat(tenantState.getEntitiesByType(username).get(EntityType.USER))
+    assertThat(tenantState.getEntitiesByType(tenantId).get(EntityType.USER))
         .containsExactly(username);
     final var persistedUser = userState.getUser(entityKey).get();
     assertThat(persistedUser.getTenantIdsList()).containsExactly(tenantId);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/tenant/DbTenantStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/tenant/DbTenantStateTest.java
@@ -80,34 +80,6 @@ public class DbTenantStateTest {
   }
 
   @Test
-  void shouldNotUpdateTenantIdWhenUpdatingName() {
-    // given
-    final long tenantKey = 1L;
-    final String originalTenantId = "tenant-1";
-    final String newTenantId = "tenant-2"; // This should not be updated
-    final String tenantName = "Original Name";
-    final var tenantRecord =
-        new TenantRecord()
-            .setTenantKey(tenantKey)
-            .setTenantId(originalTenantId)
-            .setName(tenantName);
-
-    tenantState.createTenant(tenantRecord);
-
-    // when
-    final var updatedRecord =
-        new TenantRecord().setTenantKey(tenantKey).setTenantId(newTenantId).setName("New Name");
-    tenantState.updateTenant(updatedRecord);
-
-    // then
-    // Verify that tenantId has not been updated
-    final var persistedTenant = tenantState.getTenantById(originalTenantId);
-    assertThat(persistedTenant).isPresent();
-    assertThat(persistedTenant.get().getTenantId()).isEqualTo(originalTenantId);
-    assertThat(persistedTenant.get().getName()).isEqualTo("New Name");
-  }
-
-  @Test
   void shouldAddEntityToTenant() {
     // given
     final long tenantKey = 1L;
@@ -178,25 +150,23 @@ public class DbTenantStateTest {
   @Test
   void shouldRemoveEntityFromTenant() {
     // given
-    final long tenantKey = 1L;
     final String entityId1 = "entityId1";
     final String entityId2 = "entityId2";
     final String tenantId = "tenant-1";
-    final var tenantRecord =
-        new TenantRecord().setTenantKey(tenantKey).setTenantId(tenantId).setName("Tenant One");
+    final var tenantRecord = new TenantRecord().setTenantId(tenantId).setName("Tenant One");
 
     tenantState.createTenant(tenantRecord);
 
     // Add two entities to the tenant
     final var removeEntity1Record =
         new TenantRecord()
-            .setTenantKey(tenantKey)
+            .setTenantId(tenantId)
             .setEntityId(entityId1)
             .setEntityType(EntityType.USER);
     tenantState.addEntity(removeEntity1Record);
     tenantState.addEntity(
         new TenantRecord()
-            .setTenantKey(tenantKey)
+            .setTenantId(tenantId)
             .setEntityId(entityId2)
             .setEntityType(EntityType.USER));
 
@@ -225,7 +195,7 @@ public class DbTenantStateTest {
     tenantState.createTenant(tenantRecord);
     tenantState.addEntity(
         new TenantRecord()
-            .setTenantKey(tenantKey)
+            .setTenantId(tenantId)
             .setEntityId(entityId)
             .setEntityType(EntityType.USER));
 
@@ -252,12 +222,12 @@ public class DbTenantStateTest {
     tenantState.createTenant(tenantRecord);
     tenantState.addEntity(
         new TenantRecord()
-            .setTenantKey(tenantKey)
+            .setTenantId(tenantId)
             .setEntityId(entityId1)
             .setEntityType(EntityType.USER));
     tenantState.addEntity(
         new TenantRecord()
-            .setTenantKey(tenantKey)
+            .setTenantId(tenantId)
             .setEntityId(entityId2)
             .setEntityType(EntityType.MAPPING));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/tenant/DbTenantStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/tenant/DbTenantStateTest.java
@@ -42,7 +42,7 @@ public class DbTenantStateTest {
     tenantState.createTenant(tenantRecord);
 
     // then
-    final var persistedTenant = tenantState.getTenantByKey(tenantKey);
+    final var persistedTenant = tenantState.getTenantById(tenantId);
     assertThat(persistedTenant).isPresent();
     assertThat(persistedTenant.get().getTenantId()).isEqualTo(tenantId);
     assertThat(persistedTenant.get().getName()).isEqualTo(tenantName);
@@ -51,7 +51,7 @@ public class DbTenantStateTest {
   @Test
   void shouldReturnEmptyOptionalIfTenantNotFound() {
     // when
-    final var tenant = tenantState.getTenantByKey(999L);
+    final var tenant = tenantState.getTenantById("foo");
     // then
     assertThat(tenant).isEmpty();
   }
@@ -99,7 +99,7 @@ public class DbTenantStateTest {
     tenantState.updateTenant(updatedRecord);
 
     // then
-    final var persistedTenant = tenantState.getTenantByKey(tenantKey);
+    final var persistedTenant = tenantState.getTenantById(tenantId);
     assertThat(persistedTenant).isPresent();
     assertThat(persistedTenant.get().getName()).isEqualTo(newName);
   }
@@ -126,7 +126,7 @@ public class DbTenantStateTest {
 
     // then
     // Verify that tenantId has not been updated
-    final var persistedTenant = tenantState.getTenantByKey(tenantKey);
+    final var persistedTenant = tenantState.getTenantById(originalTenantId);
     assertThat(persistedTenant).isPresent();
     assertThat(persistedTenant.get().getTenantId()).isEqualTo(originalTenantId);
     assertThat(persistedTenant.get().getName()).isEqualTo("New Name");
@@ -283,7 +283,7 @@ public class DbTenantStateTest {
     tenantState.delete(tenantRecord);
 
     // then
-    final var deletedTenant = tenantState.getTenantByKey(tenantKey);
+    final var deletedTenant = tenantState.getTenantById(tenantId);
     assertThat(deletedTenant).isEmpty();
     final var deletedEntity = tenantState.getEntityType(tenantKey, 100L);
     assertThat(deletedEntity).isEmpty();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/tenant/DbTenantStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/tenant/DbTenantStateTest.java
@@ -57,31 +57,6 @@ public class DbTenantStateTest {
   }
 
   @Test
-  void shouldReturnTenantKeyById() {
-    // given
-    final long tenantKey = 1L;
-    final String tenantId = "tenant-1";
-    final var tenantRecord =
-        new TenantRecord().setTenantKey(tenantKey).setTenantId(tenantId).setName("Tenant One");
-
-    // when
-    tenantState.createTenant(tenantRecord);
-
-    // then
-    final var retrievedKey = tenantState.getTenantKeyById(tenantId);
-    assertThat(retrievedKey).isPresent();
-    assertThat(retrievedKey.get()).isEqualTo(tenantKey);
-  }
-
-  @Test
-  void shouldNotFindTenantByNonExistingId() {
-    // when
-    final var tenantKey = tenantState.getTenantKeyById("non-existent-id");
-    // then
-    assertThat(tenantKey).isEmpty();
-  }
-
-  @Test
   void shouldUpdateTenantName() {
     // given
     final long tenantKey = 1L;
@@ -287,8 +262,6 @@ public class DbTenantStateTest {
     assertThat(deletedTenant).isEmpty();
     final var deletedEntity = tenantState.getEntityType(tenantKey, 100L);
     assertThat(deletedEntity).isEmpty();
-    final var tenantKeyById = tenantState.getTenantKeyById(tenantId);
-    assertThat(tenantKeyById).isEmpty();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/tenant/DbTenantStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/tenant/DbTenantStateTest.java
@@ -111,13 +111,13 @@ public class DbTenantStateTest {
   void shouldAddEntityToTenant() {
     // given
     final long tenantKey = 1L;
-    final long entityKey = 100L;
+    final String entityId = "entityId";
     final String tenantId = "tenant-1";
     final var tenantRecord =
         new TenantRecord()
             .setTenantKey(tenantKey)
             .setTenantId(tenantId)
-            .setEntityKey(entityKey)
+            .setEntityId(entityId)
             .setName("Tenant One");
 
     // when
@@ -125,7 +125,7 @@ public class DbTenantStateTest {
     tenantState.addEntity(tenantRecord);
 
     // then
-    final var entityType = tenantState.getEntityType(tenantKey, entityKey);
+    final var entityType = tenantState.getEntityType(tenantId, entityId);
     assertThat(entityType).isPresent();
     assertThat(entityType.get()).isEqualTo(tenantRecord.getEntityType());
   }
@@ -134,20 +134,20 @@ public class DbTenantStateTest {
   void shouldReturnEmptyEntityTypeIfEntityNotFound() {
     // given
     final long tenantKey = 1L;
-    final long entityKey = 999L;
+    final String entityId = "entityId";
     final String tenantId = "tenant-1";
     final var tenantRecord =
         new TenantRecord()
             .setTenantKey(tenantKey)
             .setTenantId(tenantId)
-            .setEntityKey(entityKey)
+            .setEntityId(entityId)
             .setName("Tenant One");
 
     // when
     tenantState.createTenant(tenantRecord);
 
     // then
-    final var entityType = tenantState.getEntityType(tenantKey, entityKey);
+    final var entityType = tenantState.getEntityType(tenantId, entityId);
     assertThat(entityType).isEmpty();
   }
 
@@ -155,13 +155,13 @@ public class DbTenantStateTest {
   void shouldReturnEntityTypeForExistingTenantAndEntity() {
     // given
     final long tenantKey = 1L;
-    final long entityKey = 100L;
+    final String entityId = "entityId";
     final String tenantId = "tenant-1";
     final var tenantRecord =
         new TenantRecord()
             .setTenantKey(tenantKey)
             .setTenantId(tenantId)
-            .setEntityKey(entityKey)
+            .setEntityId(entityId)
             .setName("Tenant One")
             .setEntityType(EntityType.USER);
 
@@ -170,7 +170,7 @@ public class DbTenantStateTest {
     tenantState.addEntity(tenantRecord);
 
     // then
-    final var entityType = tenantState.getEntityType(tenantKey, entityKey);
+    final var entityType = tenantState.getEntityType(tenantId, entityId);
     assertThat(entityType).isPresent();
     assertThat(entityType.get()).isEqualTo(EntityType.USER);
   }
@@ -179,8 +179,8 @@ public class DbTenantStateTest {
   void shouldRemoveEntityFromTenant() {
     // given
     final long tenantKey = 1L;
-    final long entityKey1 = 100L;
-    final long entityKey2 = 101L;
+    final String entityId1 = "entityId1";
+    final String entityId2 = "entityId2";
     final String tenantId = "tenant-1";
     final var tenantRecord =
         new TenantRecord().setTenantKey(tenantKey).setTenantId(tenantId).setName("Tenant One");
@@ -188,55 +188,29 @@ public class DbTenantStateTest {
     tenantState.createTenant(tenantRecord);
 
     // Add two entities to the tenant
+    final var removeEntity1Record =
+        new TenantRecord()
+            .setTenantKey(tenantKey)
+            .setEntityId(entityId1)
+            .setEntityType(EntityType.USER);
+    tenantState.addEntity(removeEntity1Record);
     tenantState.addEntity(
         new TenantRecord()
             .setTenantKey(tenantKey)
-            .setEntityKey(entityKey1)
-            .setEntityType(EntityType.USER));
-    tenantState.addEntity(
-        new TenantRecord()
-            .setTenantKey(tenantKey)
-            .setEntityKey(entityKey2)
+            .setEntityId(entityId2)
             .setEntityType(EntityType.USER));
 
     // when
-    tenantState.removeEntity(tenantKey, entityKey1);
+    tenantState.removeEntity(removeEntity1Record);
 
     // then
     // Ensure the first entity is removed
-    final var deletedEntity = tenantState.getEntityType(tenantKey, entityKey1);
+    final var deletedEntity = tenantState.getEntityType(tenantId, entityId1);
     assertThat(deletedEntity).isEmpty();
 
     // Ensure the second entity still exists
-    final var remainingEntityType = tenantState.getEntityType(tenantKey, entityKey2).get();
+    final var remainingEntityType = tenantState.getEntityType(tenantId, entityId2).get();
     assertThat(remainingEntityType).isEqualTo(EntityType.USER);
-  }
-
-  @Test
-  void shouldVerifyEntityAssignmentToTenant() {
-    // given
-    final long tenantKey = 1L;
-    final long assignedEntityKey = 100L;
-    final long unassignedEntityKey = 200L;
-    final String tenantId = "tenant-1";
-
-    final var tenantRecord =
-        new TenantRecord().setTenantKey(tenantKey).setTenantId(tenantId).setName("Tenant One");
-
-    // Create tenant and add an assigned entity
-    tenantState.createTenant(tenantRecord);
-    tenantState.addEntity(
-        new TenantRecord()
-            .setTenantKey(tenantKey)
-            .setEntityKey(assignedEntityKey)
-            .setEntityType(EntityType.USER));
-
-    // when & then
-    // Check that the assigned entity is recognized as assigned to the tenant
-    assertThat(tenantState.isEntityAssignedToTenant(assignedEntityKey, tenantKey)).isTrue();
-
-    // Check that an unassigned entity is not recognized as assigned to the tenant
-    assertThat(tenantState.isEntityAssignedToTenant(unassignedEntityKey, tenantKey)).isFalse();
   }
 
   @Test
@@ -244,6 +218,7 @@ public class DbTenantStateTest {
     // given
     final long tenantKey = 1L;
     final String tenantId = "tenant-1";
+    final var entityId = "entityId";
     final var tenantRecord =
         new TenantRecord().setTenantKey(tenantKey).setTenantId(tenantId).setName("Tenant One");
 
@@ -251,7 +226,7 @@ public class DbTenantStateTest {
     tenantState.addEntity(
         new TenantRecord()
             .setTenantKey(tenantKey)
-            .setEntityKey(100L)
+            .setEntityId(entityId)
             .setEntityType(EntityType.USER));
 
     // when
@@ -260,7 +235,7 @@ public class DbTenantStateTest {
     // then
     final var deletedTenant = tenantState.getTenantById(tenantId);
     assertThat(deletedTenant).isEmpty();
-    final var deletedEntity = tenantState.getEntityType(tenantKey, 100L);
+    final var deletedEntity = tenantState.getEntityType(tenantId, entityId);
     assertThat(deletedEntity).isEmpty();
   }
 
@@ -271,25 +246,27 @@ public class DbTenantStateTest {
     final String tenantId = "tenant-1";
     final var tenantRecord =
         new TenantRecord().setTenantKey(tenantKey).setTenantId(tenantId).setName("Tenant One");
+    final var entityId1 = "user";
+    final var entityId2 = "mapping";
 
     tenantState.createTenant(tenantRecord);
     tenantState.addEntity(
         new TenantRecord()
             .setTenantKey(tenantKey)
-            .setEntityKey(100L)
+            .setEntityId(entityId1)
             .setEntityType(EntityType.USER));
     tenantState.addEntity(
         new TenantRecord()
             .setTenantKey(tenantKey)
-            .setEntityKey(200L)
+            .setEntityId(entityId2)
             .setEntityType(EntityType.MAPPING));
 
     // when
-    final var entities = tenantState.getEntitiesByType(tenantKey);
+    final var entities = tenantState.getEntitiesByType(tenantId);
 
     // then
-    assertThat(entities.get(EntityType.USER)).containsExactly(100L);
-    assertThat(entities.get(EntityType.MAPPING)).containsExactly(200L);
+    assertThat(entities.get(EntityType.USER)).containsExactly(entityId1);
+    assertThat(entities.get(EntityType.MAPPING)).containsExactly(entityId2);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/TenantClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/TenantClient.java
@@ -48,17 +48,6 @@ public class TenantClient {
    * Creates a new {@link TenantAddEntityClient} for adding an entity to a tenant. The client uses
    * the internal command writer to submit the add entity commands.
    *
-   * @param tenantKey the key of the tenant
-   * @return a new instance of {@link TenantAddEntityClient}
-   */
-  public TenantAddEntityClient addEntity(final long tenantKey) {
-    return new TenantAddEntityClient(writer, tenantKey);
-  }
-
-  /**
-   * Creates a new {@link TenantAddEntityClient} for adding an entity to a tenant. The client uses
-   * the internal command writer to submit the add entity commands.
-   *
    * @param tenantId the id of the tenant
    * @return a new instance of {@link TenantAddEntityClient}
    */
@@ -273,12 +262,6 @@ public class TenantClient {
     private final CommandWriter writer;
     private final TenantRecord tenantRecord;
     private Function<Long, Record<TenantRecordValue>> expectation = SUCCESS_SUPPLIER;
-
-    public TenantAddEntityClient(final CommandWriter writer, final long tenantKey) {
-      this.writer = writer;
-      tenantRecord = new TenantRecord();
-      tenantRecord.setTenantKey(tenantKey);
-    }
 
     public TenantAddEntityClient(final CommandWriter writer, final String tenantId) {
       this.writer = writer;

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -681,7 +681,7 @@ paths:
       summary: Remove a group from a tenant
       description: Removes a single group from a specified tenant without deleting the group.
       parameters:
-        - name: tenantKey
+        - name: tenantId
           in: path
           required: true
           description: The unique identifier of the tenant.

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -608,7 +608,7 @@ paths:
       summary: Remove a mapping rule from a tenant
       description: Removes a single mapping rule from a specified tenant without deleting the rule.
       parameters:
-        - name: tenantKey
+        - name: tenantId
           in: path
           required: true
           description: The unique identifier of the tenant.

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -637,7 +637,7 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
-  /tenants/{tenantKey}/groups/{groupKey}:
+  /tenants/{tenantId}/groups/{groupKey}:
     put:
       tags:
         - Tenant
@@ -645,7 +645,7 @@ paths:
       summary: Assign a group to a tenant
       description: Assign a single group to a specified tenant.
       parameters:
-        - name: tenantKey
+        - name: tenantId
           in: path
           required: true
           description: The unique identifier of the tenant.

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -564,7 +564,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/UserSearchResult"
 
-  /tenants/{tenantKey}/mapping-rules/{mappingKey}:
+  /tenants/{tenantId}/mapping-rules/{mappingKey}:
     put:
       tags:
         - Tenant
@@ -572,7 +572,7 @@ paths:
       summary: Assign a mapping rule to a tenant
       description: Assign a single mapping rule to a specified tenant.
       parameters:
-        - name: tenantKey
+        - name: tenantId
           in: path
           required: true
           description: The unique identifier of the tenant.

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -114,14 +114,14 @@ public class TenantController {
                 .addMember(tenantKey, EntityType.MAPPING, mappingKey));
   }
 
-  @CamundaPutMapping(path = "/{tenantKey}/groups/{groupKey}")
+  @CamundaPutMapping(path = "/{tenantId}/groups/{groupKey}")
   public CompletableFuture<ResponseEntity<Object>> assignGroupToTenant(
-      @PathVariable final long tenantKey, @PathVariable final long groupKey) {
+      @PathVariable final String tenantId, @PathVariable final long groupKey) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             tenantServices
                 .withAuthentication(RequestMapper.getAuthentication())
-                .addMember(tenantKey, EntityType.GROUP, groupKey));
+                .addMember(tenantId, EntityType.GROUP, groupKey));
   }
 
   @CamundaDeleteMapping(path = "/{tenantId}")

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -104,14 +104,14 @@ public class TenantController {
             userQuery -> searchUsersInTenant(tenantId, userQuery));
   }
 
-  @CamundaPutMapping(path = "/{tenantKey}/mapping-rules/{mappingKey}")
+  @CamundaPutMapping(path = "/{tenantId}/mapping-rules/{mappingKey}")
   public CompletableFuture<ResponseEntity<Object>> assignMappingToTenant(
-      @PathVariable final long tenantKey, @PathVariable final long mappingKey) {
+      @PathVariable final String tenantId, @PathVariable final long mappingKey) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             tenantServices
                 .withAuthentication(RequestMapper.getAuthentication())
-                .addMember(tenantKey, EntityType.MAPPING, mappingKey));
+                .addMember(tenantId, EntityType.MAPPING, mappingKey));
   }
 
   @CamundaPutMapping(path = "/{tenantId}/groups/{groupKey}")

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -144,14 +144,14 @@ public class TenantController {
                 .removeMember(tenantId, EntityType.USER, username));
   }
 
-  @CamundaDeleteMapping(path = "/{tenantKey}/mapping-rules/{mappingKey}")
+  @CamundaDeleteMapping(path = "/{tenantId}/mapping-rules/{mappingKey}")
   public CompletableFuture<ResponseEntity<Object>> removeMappingFromTenant(
-      @PathVariable final long tenantKey, @PathVariable final long mappingKey) {
+      @PathVariable final String tenantId, @PathVariable final long mappingKey) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             tenantServices
                 .withAuthentication(RequestMapper.getAuthentication())
-                .removeMember(tenantKey, EntityType.MAPPING, mappingKey));
+                .removeMember(tenantId, EntityType.MAPPING, mappingKey));
   }
 
   @CamundaDeleteMapping(path = "/{tenantId}/groups/{groupKey}")

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -154,14 +154,14 @@ public class TenantController {
                 .removeMember(tenantKey, EntityType.MAPPING, mappingKey));
   }
 
-  @CamundaDeleteMapping(path = "/{tenantKey}/groups/{groupKey}")
+  @CamundaDeleteMapping(path = "/{tenantId}/groups/{groupKey}")
   public CompletableFuture<ResponseEntity<Object>> removeGroupFromTenant(
-      @PathVariable final long tenantKey, @PathVariable final long groupKey) {
+      @PathVariable final String tenantId, @PathVariable final long groupKey) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             tenantServices
                 .withAuthentication(RequestMapper.getAuthentication())
-                .removeMember(tenantKey, EntityType.GROUP, groupKey));
+                .removeMember(tenantId, EntityType.GROUP, groupKey));
   }
 
   private CompletableFuture<ResponseEntity<Object>> createTenant(final TenantDTO tenantDTO) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -400,23 +400,23 @@ public class TenantControllerTest extends RestControllerTest {
   @MethodSource("provideAddMemberByKeyTestCases")
   void testAddMemberToTenantByKey(final EntityType entityType, final String entityPath) {
     // given
-    final var tenantKey = 100L;
+    final var tenantId = "tenantId";
     final var entityKey = 42L;
 
-    when(tenantServices.addMember(tenantKey, entityType, entityKey))
+    when(tenantServices.addMember(tenantId, entityType, entityKey))
         .thenReturn(CompletableFuture.completedFuture(null));
 
     // when
     webClient
         .put()
-        .uri("%s/%s/%s/%s".formatted(TENANT_BASE_URL, tenantKey, entityPath, entityKey))
+        .uri("%s/%s/%s/%s".formatted(TENANT_BASE_URL, tenantId, entityPath, entityKey))
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
         .isNoContent();
 
     // then
-    verify(tenantServices, times(1)).addMember(tenantKey, entityType, entityKey);
+    verify(tenantServices, times(1)).addMember(tenantId, entityType, entityKey);
   }
 
   @ParameterizedTest

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -446,23 +446,23 @@ public class TenantControllerTest extends RestControllerTest {
   @MethodSource("provideRemoveMemberByKeyTestCases")
   void testRemoveMemberByKeyFromTenant(final EntityType entityType, final String entityPath) {
     // given
-    final var tenantKey = 100L;
+    final var tenantId = "tenantId";
     final var entityKey = 42L;
 
-    when(tenantServices.removeMember(tenantKey, entityType, entityKey))
+    when(tenantServices.removeMember(tenantId, entityType, entityKey))
         .thenReturn(CompletableFuture.completedFuture(null));
 
     // when
     webClient
         .delete()
-        .uri("%s/%s/%s/%s".formatted(TENANT_BASE_URL, tenantKey, entityPath, entityKey))
+        .uri("%s/%s/%s/%s".formatted(TENANT_BASE_URL, tenantId, entityPath, entityKey))
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
         .isNoContent();
 
     // then
-    verify(tenantServices, times(1)).removeMember(tenantKey, entityType, entityKey);
+    verify(tenantServices, times(1)).removeMember(tenantId, entityType, entityKey);
   }
 
   @ParameterizedTest

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -207,6 +207,7 @@ public enum ZbColumnFamilies implements EnumValue {
 
   TENANTS(103),
   ENTITY_BY_TENANT(104),
+  @Deprecated
   TENANT_BY_ID(105),
 
   USER_TASK_INTERMEDIATE_STATES(106),

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignGroupToTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignGroupToTenantTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import java.time.Duration;
+import java.util.UUID;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,11 +55,11 @@ class AssignGroupToTenantTest {
   @Test
   void shouldAssignGroupToTenant() {
     // when
-    client.newAssignGroupToTenantCommand(tenantKey).groupKey(groupKey).send().join();
+    client.newAssignGroupToTenantCommand(TENANT_ID).groupKey(groupKey).send().join();
 
     // then
     ZeebeAssertHelper.assertEntityAssignedToTenant(
-        tenantKey,
+        TENANT_ID,
         groupKey,
         tenant -> {
           assertThat(tenant.getTenantKey()).isEqualTo(tenantKey);
@@ -69,21 +70,21 @@ class AssignGroupToTenantTest {
   @Test
   void shouldRejectIfTenantDoesNotExist() {
     // given
-    final long nonExistentTenantKey = 999999L;
+    final var nonExistentTenantId = UUID.randomUUID().toString();
 
     // when / then
     assertThatThrownBy(
             () ->
                 client
-                    .newAssignGroupToTenantCommand(nonExistentTenantKey)
+                    .newAssignGroupToTenantCommand(nonExistentTenantId)
                     .groupKey(groupKey)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
         .hasMessageContaining(
-            "Expected to add entity to tenant with key '%d', but no tenant with this key exists."
-                .formatted(nonExistentTenantKey));
+            "Expected to add entity to tenant with id '%s', but no tenant with this id exists."
+                .formatted(nonExistentTenantId));
   }
 
   @Test
@@ -95,7 +96,7 @@ class AssignGroupToTenantTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newAssignGroupToTenantCommand(tenantKey)
+                    .newAssignGroupToTenantCommand(TENANT_ID)
                     .groupKey(nonExistentGroupKey)
                     .send()
                     .join())
@@ -109,11 +110,11 @@ class AssignGroupToTenantTest {
   @Test
   void shouldRejectIfAlreadyAssigned() {
     // given
-    client.newAssignGroupToTenantCommand(tenantKey).groupKey(groupKey).send().join();
+    client.newAssignGroupToTenantCommand(TENANT_ID).groupKey(groupKey).send().join();
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignGroupToTenantCommand(tenantKey).groupKey(groupKey).send().join())
+            () -> client.newAssignGroupToTenantCommand(TENANT_ID).groupKey(groupKey).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 400: 'Bad Request'")
         .hasMessageContaining(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignMappingToTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignMappingToTenantTest.java
@@ -70,11 +70,11 @@ class AssignMappingToTenantTest {
   @Test
   void shouldAssignMappingToTenant() {
     // When
-    client.newAssignMappingToTenantCommand(tenantKey).mappingKey(mappingKey).send().join();
+    client.newAssignMappingToTenantCommand(TENANT_ID).mappingKey(mappingKey).send().join();
 
     // Then
     ZeebeAssertHelper.assertEntityAssignedToTenant(
-        tenantKey,
+        TENANT_ID,
         mappingKey,
         tenant -> {
           assertThat(tenant.getTenantKey()).isEqualTo(tenantKey);
@@ -85,21 +85,21 @@ class AssignMappingToTenantTest {
   @Test
   void shouldRejectAssignIfTenantDoesNotExist() {
     // Given
-    final long invalidTenantKey = 99999L;
+    final var invalidTenantId = "invalidTenantId";
 
     // When / Then
     assertThatThrownBy(
             () ->
                 client
-                    .newAssignMappingToTenantCommand(invalidTenantKey)
+                    .newAssignMappingToTenantCommand(invalidTenantId)
                     .mappingKey(mappingKey)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
         .hasMessageContaining(
-            "Command 'ADD_ENTITY' rejected with code 'NOT_FOUND': Expected to add entity to tenant with key '%d', but no tenant with this key exists."
-                .formatted(invalidTenantKey));
+            "Command 'ADD_ENTITY' rejected with code 'NOT_FOUND': Expected to add entity to tenant with id '%s', but no tenant with this id exists."
+                .formatted(invalidTenantId));
   }
 
   @Test
@@ -111,7 +111,7 @@ class AssignMappingToTenantTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newAssignMappingToTenantCommand(tenantKey)
+                    .newAssignMappingToTenantCommand(TENANT_ID)
                     .mappingKey(invalidMappingKey)
                     .send()
                     .join())

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RemoveUserFromTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RemoveUserFromTenantTest.java
@@ -59,7 +59,7 @@ class RemoveUserFromTenantTest {
   @Test
   void shouldRemoveUserFromTenant() {
     // When
-    client.newRemoveUserFromTenantCommand(TENANT_ID).username(USERNAME).send().join();
+    client.newUnassignUserFromTenantCommand(TENANT_ID).username(USERNAME).send().join();
 
     // Then
     ZeebeAssertHelper.assertEntityRemovedFromTenant(
@@ -75,7 +75,7 @@ class RemoveUserFromTenantTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newRemoveUserFromTenantCommand(invalidTenantId)
+                    .newUnassignUserFromTenantCommand(invalidTenantId)
                     .username(USERNAME)
                     .send()
                     .join())
@@ -95,7 +95,7 @@ class RemoveUserFromTenantTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newRemoveUserFromTenantCommand(TENANT_ID)
+                    .newUnassignUserFromTenantCommand(TENANT_ID)
                     .username(invalidUsername)
                     .send()
                     .join())
@@ -123,7 +123,7 @@ class RemoveUserFromTenantTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newRemoveUserFromTenantCommand(TENANT_ID)
+                    .newUnassignUserFromTenantCommand(TENANT_ID)
                     .username(unassignedUsername)
                     .send()
                     .join())

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignGroupFromTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignGroupFromTenantTest.java
@@ -39,10 +39,11 @@ class UnassignGroupFromTenantTest {
   @BeforeEach
   void initClientAndInstances() {
     client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
+    final var tenantId = "tenantId";
     tenantKey =
         client
             .newCreateTenantCommand()
-            .tenantId("tenantId")
+            .tenantId(tenantId)
             .name("Tenant Name")
             .send()
             .join()
@@ -51,7 +52,7 @@ class UnassignGroupFromTenantTest {
     groupKey = client.newCreateGroupCommand().name("group").send().join().getGroupKey();
 
     // Assign group to tenant to set up test scenario
-    client.newAssignGroupToTenantCommand(tenantKey).groupKey(groupKey).send().join();
+    client.newAssignGroupToTenantCommand(tenantId).groupKey(groupKey).send().join();
   }
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignGroupFromTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignGroupFromTenantTest.java
@@ -27,44 +27,43 @@ import org.junit.jupiter.api.Test;
 @ZeebeIntegration
 class UnassignGroupFromTenantTest {
 
+  public static final String TENANT_ID = "tenantId";
+
   @TestZeebe
   private final TestStandaloneBroker zeebe =
       new TestStandaloneBroker().withRecordingExporter(true).withUnauthenticatedAccess();
 
   @AutoClose private CamundaClient client;
 
-  private long tenantKey;
   private long groupKey;
 
   @BeforeEach
   void initClientAndInstances() {
     client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
-    final var tenantId = "tenantId";
-    tenantKey =
-        client
-            .newCreateTenantCommand()
-            .tenantId(tenantId)
-            .name("Tenant Name")
-            .send()
-            .join()
-            .getTenantKey();
+    client
+        .newCreateTenantCommand()
+        .tenantId(TENANT_ID)
+        .name("Tenant Name")
+        .send()
+        .join()
+        .getTenantKey();
 
     groupKey = client.newCreateGroupCommand().name("group").send().join().getGroupKey();
 
     // Assign group to tenant to set up test scenario
-    client.newAssignGroupToTenantCommand(tenantId).groupKey(groupKey).send().join();
+    client.newAssignGroupToTenantCommand(TENANT_ID).groupKey(groupKey).send().join();
   }
 
   @Test
   void shouldUnassignGroupFromTenant() {
     // when
-    client.newUnassignGroupFromTenantCommand(tenantKey).groupKey(groupKey).send().join();
+    client.newUnassignGroupFromTenantCommand(TENANT_ID).groupKey(groupKey).send().join();
 
     // then
     ZeebeAssertHelper.assertGroupUnassignedFromTenant(
-        tenantKey,
+        TENANT_ID,
         (tenant) -> {
-          assertThat(tenant.getTenantKey()).isEqualTo(tenantKey);
+          assertThat(tenant.getTenantId()).isEqualTo(TENANT_ID);
           assertThat(tenant.getEntityKey()).isEqualTo(groupKey);
         });
   }
@@ -72,21 +71,21 @@ class UnassignGroupFromTenantTest {
   @Test
   void shouldRejectIfTenantDoesNotExist() {
     // given
-    final long nonExistentTenantKey = 999999L;
+    final var nonExistentTenantId = "nonExistingTenantId";
 
     // when / then
     assertThatThrownBy(
             () ->
                 client
-                    .newUnassignGroupFromTenantCommand(nonExistentTenantKey)
+                    .newUnassignGroupFromTenantCommand(nonExistentTenantId)
                     .groupKey(groupKey)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
         .hasMessageContaining(
-            "Expected to remove entity from tenant with key '%d', but no tenant with this key exists."
-                .formatted(nonExistentTenantKey));
+            "Expected to remove entity from tenant with id '%s', but no tenant with this id exists."
+                .formatted(nonExistentTenantId));
   }
 
   @Test
@@ -98,15 +97,15 @@ class UnassignGroupFromTenantTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUnassignGroupFromTenantCommand(tenantKey)
+                    .newUnassignGroupFromTenantCommand(TENANT_ID)
                     .groupKey(nonExistentGroupKey)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
         .hasMessageContaining(
-            " Expected to remove entity with key '%d' from tenant with key '%d', but the entity does not exist."
-                .formatted(nonExistentGroupKey, tenantKey));
+            " Expected to remove entity with key '%d' from tenant with id '%s', but the entity does not exist."
+                .formatted(nonExistentGroupKey, TENANT_ID));
   }
 
   @Test
@@ -116,14 +115,14 @@ class UnassignGroupFromTenantTest {
             () ->
                 client
                     // Group key is not assigned
-                    .newUnassignGroupFromTenantCommand(tenantKey)
+                    .newUnassignGroupFromTenantCommand(TENANT_ID)
                     .groupKey(groupKey + 1)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
         .hasMessageContaining(
-            "Expected to remove entity with key '%d' from tenant with key '%d', but the entity does not exist."
-                .formatted(groupKey + 1, tenantKey));
+            "Expected to remove entity with key '%d' from tenant with id '%s', but the entity does not exist."
+                .formatted(groupKey + 1, TENANT_ID));
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
@@ -520,11 +520,11 @@ public final class ZeebeAssertHelper {
   }
 
   public static void assertEntityAssignedToTenant(
-      final long tenantKey, final long entityKey, final Consumer<TenantRecordValue> consumer) {
+      final String tenantId, final long entityKey, final Consumer<TenantRecordValue> consumer) {
     final TenantRecordValue tenantRecordValue =
         RecordingExporter.tenantRecords()
             .withIntent(TenantIntent.ENTITY_ADDED)
-            .withTenantKey(tenantKey)
+            .withTenantId(tenantId)
             .withEntityKey(entityKey)
             .getFirst()
             .getValue();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
@@ -564,11 +564,11 @@ public final class ZeebeAssertHelper {
   }
 
   public static void assertGroupUnassignedFromTenant(
-      final long tenantKey, final Consumer<TenantRecordValue> consumer) {
+      final String tenantId, final Consumer<TenantRecordValue> consumer) {
     final var tenantRecordValue =
         RecordingExporter.tenantRecords()
             .withIntent(TenantIntent.ENTITY_REMOVED)
-            .withTenantKey(tenantKey)
+            .withTenantId(tenantId)
             .getFirst()
             .getValue();
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

We are changing tenants from being key-based to id-based. This means we have to adjust the state classes in the engine. It's easier to store data by id, as that's the data we get. This PR refactors the state to do achieve this.

Unfortunately failing tests had me go a bit deeper than I'd liked. I had to modify the assign/unassign endpoints for Groups and Mappings to also work with tenant ids instead of keys. I may have been able to isolate it by disabling tests, but it needs to happen anyway. I recommend reviewing it by commit. The changes are small and isolated that way.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #27137 
