### PR TITLE
Allow task listener to provide reason to deny: java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobCommandStep1.java
@@ -195,6 +195,7 @@ public interface CompleteJobCommandStep1
      * }</pre>
      *
      * @param isDenied indicates if the worker has denied the reason for the job
+     * @param deniedReason indicates the reason why the worker denied the job
      * @return the builder for this command. Call {@link #send()} to complete the command and send
      *     it to the broker.
      */

--- a/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobCommandStep1.java
@@ -181,6 +181,29 @@ public interface CompleteJobCommandStep1
     CompleteJobCommandStep2 deny(boolean isDenied);
 
     /**
+     * Indicates the reason why the worker denied the work. For example, a user task listener can
+     * deny the completion of a task by setting the deny flag to true and specifying the reason to
+     * deny. In this example, the completion of a task is represented by a job that the worker can
+     * complete as denied and provided the reason to deny. As a result, the completion request is
+     * rejected and the task remains active. Defaults to an empty string.
+     *
+     * <p>Example usage:
+     *
+     * <pre>{@code
+     * client.newCompleteJobCommand(jobKey)
+     *     .withResult()
+     *     .deny(true)
+     *     .denyReason("Reason to deny lifecycle transition")
+     *     .send();
+     * }</pre>
+     *
+     * @param deniedReason indicates the reason why the worker denied the job
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    CompleteJobCommandStep2 denyReason(String deniedReason);
+
+    /**
      * Applies corrections to the user task attributes.
      *
      * <p>This method allows the worker to modify key attributes of the user task (such as {@code

--- a/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobCommandStep1.java
@@ -181,6 +181,26 @@ public interface CompleteJobCommandStep1
     CompleteJobCommandStep2 deny(boolean isDenied);
 
     /**
+     * Indicates whether the worker denies the work, i.e. explicitly doesn't approve it and provides
+     * the reason to deny. As a result, the completion request is rejected and the task remains
+     * active.
+     *
+     * <p>Example usage:
+     *
+     * <pre>{@code
+     * client.newCompleteJobCommand(jobKey)
+     *     .withResult()
+     *     .deny(true, "Reason to deny lifecycle transition")
+     *     .send();
+     * }</pre>
+     *
+     * @param isDenied indicates if the worker has denied the reason for the job
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    CompleteJobCommandStep2 deny(boolean isDenied, String deniedReason);
+
+    /**
      * Indicates the reason why the worker denied the work. For example, a user task listener can
      * deny the completion of a task by setting the deny flag to true and specifying the reason to
      * deny. In this example, the completion of a task is represented by a job that the worker can
@@ -193,7 +213,7 @@ public interface CompleteJobCommandStep1
      * client.newCompleteJobCommand(jobKey)
      *     .withResult()
      *     .deny(true)
-     *     .denyReason("Reason to deny lifecycle transition")
+     *     .deniedReason("Reason to deny lifecycle transition")
      *     .send();
      * }</pre>
      *
@@ -201,7 +221,7 @@ public interface CompleteJobCommandStep1
      * @return the builder for this command. Call {@link #send()} to complete the command and send
      *     it to the broker.
      */
-    CompleteJobCommandStep2 denyReason(String deniedReason);
+    CompleteJobCommandStep2 deniedReason(String deniedReason);
 
     /**
      * Applies corrections to the user task attributes.

--- a/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobResult.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CompleteJobResult.java
@@ -21,6 +21,7 @@ import java.util.function.UnaryOperator;
 public class CompleteJobResult {
 
   private boolean isDenied;
+  private String deniedReason;
   private JobResultCorrections corrections;
 
   public CompleteJobResult() {
@@ -39,6 +40,19 @@ public class CompleteJobResult {
    */
   public CompleteJobResult deny(final boolean isDenied) {
     this.isDenied = isDenied;
+    return this;
+  }
+
+  /**
+   * Indicates the reason why the worker denied the job. For example, a user task listener can deny
+   * the completion of a task by setting the deny flag to true and specifying the reason to deny.
+   * Defaults to an empty string.
+   *
+   * @param deniedReason indicates the reason why the worker denied the job
+   * @return this job result
+   */
+  public CompleteJobResult deniedReason(final String deniedReason) {
+    this.deniedReason = deniedReason;
     return this;
   }
 
@@ -144,6 +158,10 @@ public class CompleteJobResult {
 
   public boolean isDenied() {
     return isDenied;
+  }
+
+  public String getDeniedReason() {
+    return deniedReason;
   }
 
   public JobResultCorrections getCorrections() {

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CompleteJobCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CompleteJobCommandImpl.java
@@ -110,7 +110,7 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
   public CompleteJobCommandStep1 withResult(final CompleteJobResult jobResult) {
     return withResult()
         .deny(jobResult.isDenied())
-        .denyReason(jobResult.getDeniedReason())
+        .deniedReason(jobResult.getDeniedReason())
         .correct(jobResult.getCorrections())
         .resultDone();
   }
@@ -148,7 +148,12 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
   }
 
   @Override
-  public CompleteJobCommandStep2 denyReason(final String deniedReason) {
+  public CompleteJobCommandStep2 deny(final boolean isDenied, final String deniedReason) {
+    return deny(isDenied).deniedReason(deniedReason);
+  }
+
+  @Override
+  public CompleteJobCommandStep2 deniedReason(final String deniedReason) {
     resultRest.setDeniedReason(deniedReason);
     resultGrpc.setDeniedReason(deniedReason == null ? "" : deniedReason);
     onResultChange();

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CompleteJobCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CompleteJobCommandImpl.java
@@ -108,7 +108,11 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
 
   @Override
   public CompleteJobCommandStep1 withResult(final CompleteJobResult jobResult) {
-    return withResult().deny(jobResult.isDenied()).correct(jobResult.getCorrections()).resultDone();
+    return withResult()
+        .deny(jobResult.isDenied())
+        .denyReason(jobResult.getDeniedReason())
+        .correct(jobResult.getCorrections())
+        .resultDone();
   }
 
   @Override
@@ -118,6 +122,7 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
     final CompleteJobResult reconstructedJobResult =
         new CompleteJobResult()
             .deny(resultRest.getDenied() != null ? resultRest.getDenied() : false)
+            .deniedReason(resultRest.getDeniedReason())
             .correct(reconstructCorrections());
     return withResult(jobResultModifier.apply(reconstructedJobResult));
   }
@@ -138,6 +143,14 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
   public CompleteJobCommandStep2 deny(final boolean isDenied) {
     resultRest.setDenied(isDenied);
     resultGrpc.setDenied(isDenied);
+    onResultChange();
+    return this;
+  }
+
+  @Override
+  public CompleteJobCommandStep2 denyReason(final String deniedReason) {
+    resultRest.setDeniedReason(deniedReason);
+    resultGrpc.setDeniedReason(deniedReason == null ? "" : deniedReason);
     onResultChange();
     return this;
   }

--- a/clients/java/src/test/java/io/camunda/client/job/CompleteJobTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/CompleteJobTest.java
@@ -69,6 +69,7 @@ public final class CompleteJobTest extends ClientTest {
     assertThat(request.getVariables()).isEmpty();
     // gRPC provides the result with default value, so checking for default property value here.
     assertThat(request.getResult().getDenied()).isFalse();
+    assertThat(request.getResult().getDeniedReason()).isEmpty();
 
     rule.verifyDefaultRequestTimeout();
   }
@@ -199,6 +200,7 @@ public final class CompleteJobTest extends ClientTest {
     final CompleteJobRequest request = gatewayService.getLastRequest();
     assertThat(request.getJobKey()).isEqualTo(job.getKey());
     assertThat(request.getResult().getDenied()).isFalse();
+    assertThat(request.getResult().getDeniedReason()).isEmpty();
 
     rule.verifyDefaultRequestTimeout();
   }
@@ -216,23 +218,32 @@ public final class CompleteJobTest extends ClientTest {
     final CompleteJobRequest request = gatewayService.getLastRequest();
     assertThat(request.getJobKey()).isEqualTo(job.getKey());
     assertThat(request.getResult().getDenied()).isFalse();
+    assertThat(request.getResult().getDeniedReason()).isEmpty();
 
     rule.verifyDefaultRequestTimeout();
   }
 
   @Test
-  public void shouldCompleteJobWithResultDeniedTrue() {
+  public void shouldCompleteJobWithResultDeniedTrueAndDeniedReason() {
     // given
     final ActivatedJob job = Mockito.mock(ActivatedJob.class);
     Mockito.when(job.getKey()).thenReturn(12L);
 
     // when
-    client.newCompleteCommand(job).withResult().deny(true).send().join();
+    client
+        .newCompleteCommand(job)
+        .withResult()
+        .deny(true)
+        .denyReason("Reason to deny lifecycle transition")
+        .send()
+        .join();
 
     // then
     final CompleteJobRequest request = gatewayService.getLastRequest();
     assertThat(request.getJobKey()).isEqualTo(job.getKey());
     assertThat(request.getResult().getDenied()).isTrue();
+    assertThat(request.getResult().getDeniedReason())
+        .isEqualTo("Reason to deny lifecycle transition");
 
     rule.verifyDefaultRequestTimeout();
   }
@@ -250,6 +261,7 @@ public final class CompleteJobTest extends ClientTest {
     final CompleteJobRequest request = gatewayService.getLastRequest();
     assertThat(request.getJobKey()).isEqualTo(job.getKey());
     assertThat(request.getResult().getDenied()).isFalse();
+    assertThat(request.getResult().getDeniedReason()).isEmpty();
 
     rule.verifyDefaultRequestTimeout();
   }
@@ -261,12 +273,18 @@ public final class CompleteJobTest extends ClientTest {
     Mockito.when(job.getKey()).thenReturn(12L);
 
     // when
-    client.newCompleteCommand(job).withResult(r -> r.deny(true)).send().join();
+    client
+        .newCompleteCommand(job)
+        .withResult(r -> r.deny(true).deniedReason("Reason to deny lifecycle transition"))
+        .send()
+        .join();
 
     // then
     final CompleteJobRequest request = gatewayService.getLastRequest();
     assertThat(request.getJobKey()).isEqualTo(job.getKey());
     assertThat(request.getResult().getDenied()).isTrue();
+    assertThat(request.getResult().getDeniedReason())
+        .isEqualTo("Reason to deny lifecycle transition");
 
     rule.verifyDefaultRequestTimeout();
   }
@@ -291,6 +309,7 @@ public final class CompleteJobTest extends ClientTest {
     final CompleteJobRequest request = gatewayService.getLastRequest();
     assertThat(request.getJobKey()).isEqualTo(job.getKey());
     assertThat(request.getResult().getDenied()).isFalse();
+    assertThat(request.getResult().getDeniedReason()).isEmpty();
     assertThat(request.getVariables()).isEqualTo("{\"we_can\":\"still_set_vars\"}");
 
     rule.verifyDefaultRequestTimeout();
@@ -464,6 +483,7 @@ public final class CompleteJobTest extends ClientTest {
             .setResult(
                 JobResult.newBuilder()
                     .setDenied(false)
+                    .setDeniedReason("")
                     .setCorrections(
                         JobResultCorrections.newBuilder()
                             .setAssignee("Test")
@@ -515,6 +535,7 @@ public final class CompleteJobTest extends ClientTest {
             .setResult(
                 JobResult.newBuilder()
                     .setDenied(false)
+                    .setDeniedReason("")
                     .setCorrections(
                         JobResultCorrections.newBuilder()
                             .setAssignee("Test")

--- a/clients/java/src/test/java/io/camunda/client/job/CompleteJobTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/CompleteJobTest.java
@@ -234,7 +234,31 @@ public final class CompleteJobTest extends ClientTest {
         .newCompleteCommand(job)
         .withResult()
         .deny(true)
-        .denyReason("Reason to deny lifecycle transition")
+        .deniedReason("Reason to deny lifecycle transition")
+        .send()
+        .join();
+
+    // then
+    final CompleteJobRequest request = gatewayService.getLastRequest();
+    assertThat(request.getJobKey()).isEqualTo(job.getKey());
+    assertThat(request.getResult().getDenied()).isTrue();
+    assertThat(request.getResult().getDeniedReason())
+        .isEqualTo("Reason to deny lifecycle transition");
+
+    rule.verifyDefaultRequestTimeout();
+  }
+
+  @Test
+  public void shouldCompleteJobWithResultDeniedWithAndDeniedReason() {
+    // given
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+
+    // when
+    client
+        .newCompleteCommand(job)
+        .withResult()
+        .deny(true, "Reason to deny lifecycle transition")
         .send()
         .join();
 

--- a/clients/java/src/test/java/io/camunda/client/job/rest/CompleteJobRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/CompleteJobRestTest.java
@@ -167,9 +167,25 @@ class CompleteJobRestTest extends ClientRestTest {
         .newCompleteCommand(jobKey)
         .withResult()
         .deny(denied)
-        .denyReason(deniedReason)
+        .deniedReason(deniedReason)
         .send()
         .join();
+
+    // then
+    final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);
+    assertThat(request.getResult()).isNotNull();
+    assertThat(request.getResult().getDenied()).isEqualTo(denied);
+    assertThat(request.getResult().getDeniedReason()).isEqualTo(deniedReason);
+  }
+
+  @ParameterizedTest
+  @MethodSource("denialDetails")
+  void shouldCompleteWithResultDeniedWithReason(final boolean denied, final String deniedReason) {
+    // given
+    final long jobKey = 12;
+
+    // when
+    client.newCompleteCommand(jobKey).withResult().deny(denied, deniedReason).send().join();
 
     // then
     final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);

--- a/clients/java/src/test/java/io/camunda/client/job/rest/CompleteJobRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/rest/CompleteJobRestTest.java
@@ -30,9 +30,11 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 
 class CompleteJobRestTest extends ClientRestTest {
@@ -149,34 +151,51 @@ class CompleteJobRestTest extends ClientRestTest {
     JsonUtil.assertEquality(JsonUtil.toJson(request.getVariables()), expectedVariable);
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  void shouldCompleteWithResult(final boolean denied) {
-    // given
-    final long jobKey = 12;
-
-    // when
-    client.newCompleteCommand(jobKey).withResult().deny(denied).send().join();
-
-    // then
-    final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);
-    assertThat(request.getResult()).isNotNull();
-    assertThat(request.getResult().getDenied()).isEqualTo(denied);
+  private static Stream<Arguments> denialDetails() {
+    return Stream.of(
+        Arguments.of(true, "Reason to deny lifecycle transition"), Arguments.of(false, null));
   }
 
   @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  void shouldCompleteWithResultObject(final boolean denied) {
+  @MethodSource("denialDetails")
+  void shouldCompleteWithResult(final boolean denied, final String deniedReason) {
     // given
     final long jobKey = 12;
 
     // when
-    client.newCompleteCommand(jobKey).withResult(r -> r.deny(denied)).send().join();
+    client
+        .newCompleteCommand(jobKey)
+        .withResult()
+        .deny(denied)
+        .denyReason(deniedReason)
+        .send()
+        .join();
 
     // then
     final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);
     assertThat(request.getResult()).isNotNull();
     assertThat(request.getResult().getDenied()).isEqualTo(denied);
+    assertThat(request.getResult().getDeniedReason()).isEqualTo(deniedReason);
+  }
+
+  @ParameterizedTest
+  @MethodSource("denialDetails")
+  void shouldCompleteWithResultObject(final boolean denied, final String deniedReason) {
+    // given
+    final long jobKey = 12;
+
+    // when
+    client
+        .newCompleteCommand(jobKey)
+        .withResult(r -> r.deny(denied).deniedReason(deniedReason))
+        .send()
+        .join();
+
+    // then
+    final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);
+    assertThat(request.getResult()).isNotNull();
+    assertThat(request.getResult().getDenied()).isEqualTo(denied);
+    assertThat(request.getResult().getDeniedReason()).isEqualTo(deniedReason);
   }
 
   @Test
@@ -216,6 +235,7 @@ class CompleteJobRestTest extends ClientRestTest {
     final JobCompletionRequest request = gatewayService.getLastRequest(JobCompletionRequest.class);
     assertThat(request.getResult()).isNotNull();
     assertThat(request.getResult().getDenied()).isNull();
+    assertThat(request.getResult().getDeniedReason()).isNull();
   }
 
   @Test


### PR DESCRIPTION
## Description

This is a part of [allow task listener to provide reason to deny](https://github.com/camunda/camunda/issues/27141) issue.
In order to have small and readable PRs I've decided to split this issue into two.
This is the first PR for Java Client implementation for `deniedReason`

What is in this PR:
- `deniedReason` was added to `JobCompleteResult`
- `deniedReason` was added to `JobCompleteCommand`
- Updated unit tests for both gRPC and REST

What is NOT in this PR:
- Integration tests
- Passing response rejection value back to the client (providing the `deniedReason` as a part of `ProblemDetail`)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #27270
