### PR TITLE
feat: c8run mac binaries are now signed and notarized

### DIFF
--- a/.github/actions/sign-and-notarize/action.yml
+++ b/.github/actions/sign-and-notarize/action.yml
@@ -1,0 +1,61 @@
+name: "Sign & Notarize macOS code"
+description: "Signs with Developer ID App certificate and notarizes the resulting zip file."
+
+inputs:
+  p12-base64:
+    description: "Base64-encoded .p12 Developer ID cert"
+    required: true
+  p12-password:
+    description: "Password for the .p12 certificate"
+    required: false
+  developer-id-cert-name:
+    description: "Full name of your Developer ID Application cert, e.g., 'Developer ID Application: My Company (TEAMID)'"
+    required: true
+  apple-id:
+    description: "Apple ID for notarization"
+    required: true
+  app-password:
+    description: "Apple app-specific password for notarization"
+    required: true
+  team-id:
+    description: "Apple Developer Team ID"
+    required: true
+  path:
+    description: "Path to folder/binary that needs signing"
+    required: true
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: Import Developer ID .p12
+      shell: bash
+      run: |
+        #brew install coreutils
+        echo -n "$APPLE_CERTIFICATE" | base64 --decode > dev_id.p12
+        security create-keychain -p "" build.keychain
+        security default-keychain -s build.keychain
+        security unlock-keychain -p "" build.keychain
+        security set-keychain-settings -t 3600 -u build.keychain
+        security import dev_id.p12 -k ~/Library/Keychains/build.keychain -f pkcs12 -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+        security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "" build.keychain
+        security list-keychains -s build.keychain $(security list-keychains | sed 's/\"//g')
+        security default-keychain -s build.keychain
+        security find-identity -p codesigning -v
+        chmod +x ./.github/actions/sign-and-notarize/sign_and_notarize.sh
+
+    - name: Sign distribution
+      shell: bash
+      run: |
+        ./.github/actions/sign-and-notarize/sign_and_notarize.sh \
+          "$INPUT_PATH" \
+          "$APPLE_COMMON_NAME" \
+          "$INPUT_APPLE_ID" \
+          "$INPUT_APP_PASSWORD" \
+          "$INPUT_TEAM_ID"
+      env:
+        INPUT_PATH: ${{ inputs.path }}
+        INPUT_APPLE_ID: ${{ inputs.apple-id }}
+        INPUT_APP_PASSWORD: ${{ inputs.app-password }}
+        INPUT_TEAM_ID: ${{ inputs.team-id }}
+

--- a/.github/actions/sign-and-notarize/sign_and_notarize.sh
+++ b/.github/actions/sign-and-notarize/sign_and_notarize.sh
@@ -1,0 +1,229 @@
+#!/bin/bash
+#
+# exclude_sign_notarize_reinject_absolute.sh
+#
+# 1) Moves out top-level items in <C8RUN_DIR> whose names begin with:
+#      - camunda-zeebe
+#      - connector-runtime-bundle
+#      - elasticsearch
+#    so they are excluded from code signing.
+# 2) Signs the rest of c8run (Mach-O, .app, .jar).
+# 3) Builds c8run_signed.zip (without the excluded items) using ditto.
+# 4) Notarizes c8run_signed.zip with xcrun notarytool submit.
+# 5) If status is Accepted, unzips c8run_signed.zip, re-adds excluded items,
+#    then re-zips as c8run_complete.zip.
+#
+# Usage:
+#   ./exclude_sign_notarize_reinject_absolute.sh <C8RUN_DIR> \
+#       "<Developer ID Application: Cert (TEAMID)>" <AppleIDEmail> <AppPassword> <TeamID>
+#
+# Example:
+#   ./exclude_sign_notarize_reinject_absolute.sh ./c8run \
+#       "Developer ID Application: Camunda Services GmbH (TEAMID)" \
+#       "you@example.com" "abcd-wxyz" "TEAMID1234"
+#
+# NOTE: c8run_complete.zip includes un-signed items that were excluded. So
+# if they contain Mach-O code, Gatekeeper may still block them. The notary
+# service only scanned what was in c8run_signed.zip.
+
+set -e  # exit on error
+
+if [ "$#" -ne 5 ]; then
+  echo "Usage: $0 <C8RUN_DIR> \"Developer ID Application: Cert (TEAMID)\" <AppleIDEmail> <AppPassword> <TeamID>"
+  exit 1
+fi
+
+C8RUN_DIR="$1"
+CERT_NAME="$2"
+APPLE_ID="$3"
+APPLE_PASS="$4"
+APPLE_TEAM="$5"
+
+# Ensure c8run exists
+if [ ! -d "$C8RUN_DIR" ]; then
+  echo "Error: '$C8RUN_DIR' is not a directory."
+  exit 1
+fi
+
+##############################################
+# Patterns to exclude at top-level:
+##############################################
+EXCLUDE_PREFIXES=("camunda-zeebe" "connector-runtime-bundle" "elasticsearch")
+
+##############################################
+# Temp dirs for exclude items + notarize steps
+##############################################
+TMP_EXCLUDE_DIR="$(mktemp -d)"
+TMP_NOTARIZE_DIR="$(mktemp -d)"
+echo "Created temp dirs: $TMP_EXCLUDE_DIR, $TMP_NOTARIZE_DIR"
+
+##############################################
+# A) Exclude subfolders/items from c8run
+##############################################
+echo "=== Step A: Excluding top-level items that begin with: ${EXCLUDE_PREFIXES[*]} ==="
+
+find "$C8RUN_DIR" -maxdepth 1 \( -type f -o -type d \) -print0 | while IFS= read -r -d '' item; do
+  base="$(basename "$item")"
+  # Skip if it's c8run itself or hidden
+  if [ "$base" = "$(basename "$C8RUN_DIR")" ] || [[ "$base" == .* ]]; then
+    continue
+  fi
+
+
+  for prefix in "${EXCLUDE_PREFIXES[@]}"; do
+    if [[ "$base" == "$prefix"* ]]; then
+
+      # find the dylibs in the excluded folder and create a tmp fs for them
+      for dylib in $( find $item -name "*.dylib" ); do
+        zip -r "$TMP_EXCLUDE_DIR/$base-dylibs.zip" "$dylib"
+      done
+
+      echo "  -> Excluding $base -> $TMP_EXCLUDE_DIR"
+      mv "$item" "$TMP_EXCLUDE_DIR"
+      break
+    fi
+  done
+
+  for dylibzip in $( find "$TMP_EXCLUDE_DIR" -name "*-dylibs.zip" ); do
+    unzip $dylibzip
+    rm $dylibzip
+  done
+done
+
+##############################################
+# B) Functions to sign Mach-O + jars
+##############################################
+sign_macho_in_folder() {
+  local folder="$1"
+  local signed_count=0
+
+  echo "  -> Scanning for Mach-O/.app in: $folder"
+  while IFS= read -r -d '' candidate; do
+    echo "Candidate $candidate"
+
+    # If .app
+    if [ -d "$candidate" ] && [[ "$candidate" == *.app ]]; then
+      echo "    Found .app: $candidate"
+      if codesign --force --deep --options runtime --timestamp --sign "$CERT_NAME" "$candidate"; then
+        ((signed_count++))
+      else
+        echo "[Error] .app sign failed: $candidate"
+      fi
+      continue
+    fi
+
+    # If Mach-O file
+    if [ -f "$candidate" ]; then
+      if [[ "$candidate" == *.app/* ]]; then
+        continue  # skip inside .app
+      fi
+      if file -b "$candidate" | grep -q "Mach-O"; then
+        echo "    Signing Mach-O: $candidate"
+        if codesign --verbose=4 --force --options runtime --timestamp --sign "$CERT_NAME" "$candidate"; then
+          ((signed_count++))
+        else
+          echo "[Error] Mach-O sign failed: $candidate"
+        fi
+      fi
+    fi
+
+  done < <(find "$folder" -print0)
+
+  echo "  -> Signed $signed_count item(s) in $folder"
+}
+
+sign_jars_in_folder() {
+  local folder="$1"
+  local jar_count=0
+  local jar_processed=0
+
+  echo "  -> Searching for jars in: $folder"
+  find "$folder" -type f -name '*.jar' -print0 | while IFS= read -r -d '' jar_file; do
+    ((jar_count++))
+    echo "    Processing jar: $jar_file"
+    jar_abs="$(cd "$(dirname "$jar_file")" && pwd -P)/$(basename "$jar_file")"
+
+    tmpjar="$(mktemp -d)"
+    (cd "$tmpjar" && jar xvf "$jar_abs" >/dev/null)
+
+    # sign Mach-O inside jar
+    sign_macho_in_folder "$tmpjar"
+
+    rm -f "$jar_abs"
+    mkdir -p "$(dirname "$jar_abs")"
+
+    (cd "$tmpjar" && jar cvf "$jar_abs" . >/dev/null)
+    rm -rf "$tmpjar"
+
+    ((jar_processed++))
+    echo "    -> Rebuilt $jar_abs"
+  done
+
+  echo "  -> Found $jar_count jars, re-built $jar_processed"
+}
+
+##############################################
+# C) Sign c8run
+##############################################
+echo "=== Step B: Signing leftover c8run content ==="
+sign_macho_in_folder "$C8RUN_DIR"
+sign_jars_in_folder "$C8RUN_DIR"
+
+##############################################
+# D) Create c8run_signed.zip with ditto
+##############################################
+echo "=== Step C: Creating c8run_signed.zip with ditto (excluding removed items) ==="
+(
+  cd "$(dirname "$C8RUN_DIR")"
+  /usr/bin/ditto -c -k --keepParent "$(basename "$C8RUN_DIR")" c8run_signed.zip
+)
+SIGNED_ZIP_PATH="$(cd "$(dirname "$C8RUN_DIR")" && pwd -P)/c8run_signed.zip"
+echo "Created: $SIGNED_ZIP_PATH"
+
+##############################################
+# E) Notarize c8run_signed.zip
+##############################################
+echo "=== Step D: Notarizing c8run_signed.zip ==="
+xcrun notarytool submit "$SIGNED_ZIP_PATH" \
+  --apple-id "$APPLE_ID" \
+  --password "$APPLE_PASS" \
+  --team-id "$APPLE_TEAM" \
+  --wait
+echo "Notarization succeeded (status: Accepted)"
+
+##############################################
+# F) Re-inject the excluded items & re-zip
+##############################################
+echo "=== Step E: Rebuilding final c8run_complete.zip with excluded items ==="
+mkdir -p "$TMP_NOTARIZE_DIR/notarized"
+# Unzip the notarized zip
+unzip -q "$SIGNED_ZIP_PATH" -d "$TMP_NOTARIZE_DIR/notarized"
+
+# Move excluded items back into c8run
+echo "  -> Re-inserting excluded items into c8run"
+find "$TMP_EXCLUDE_DIR" -mindepth 1 -maxdepth 1 -print0 | while IFS= read -r -d '' excluded; do
+  base="$(basename "$excluded")"
+  echo "    -> $base"
+  rsync --ignore-existing -ar "$excluded" "$TMP_NOTARIZE_DIR/notarized/c8run/"
+done
+
+# Build c8run_complete.zip
+(
+  cd "$TMP_NOTARIZE_DIR/notarized"
+  /usr/bin/ditto -c -k --keepParent c8run c8run_complete.zip
+)
+FINAL_ZIP="$(dirname "$C8RUN_DIR")/c8run_complete.zip"
+mv "$TMP_NOTARIZE_DIR/notarized/c8run_complete.zip" "$FINAL_ZIP"
+
+echo "All done. Final archive with excluded items is: $FINAL_ZIP"
+
+##############################################
+# Cleanup
+##############################################
+rm -rf "$TMP_EXCLUDE_DIR" "$TMP_NOTARIZE_DIR"
+
+cat <<EOM
+Note: c8run_complete.zip includes the previously excluded items, which remain
+unsigned/unnotarized if they contain Mach-O. Apple only notarized c8run_signed.zip.
+EOM
+

--- a/.github/workflows/c8run-release.yaml
+++ b/.github/workflows/c8run-release.yaml
@@ -90,7 +90,7 @@ jobs:
     needs: init
     name: C8Run - ${{ matrix.os.name }}
     runs-on: ${{ matrix.os.id }}
-    timeout-minutes: 15
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -103,12 +103,12 @@ jobs:
             command: ./c8run
           - name: MacOS (ARM64)
             id: macos-latest
-            artifactFileSuffix: darwin-aarch64.tar.gz
+            artifactFileSuffix: darwin-aarch64.zip
             workingDir: ./c8run
             command: ./c8run
           - name: MacOS (AMD64)
             id: macos-13
-            artifactFileSuffix: darwin-x86_64.tar.gz
+            artifactFileSuffix: darwin-x86_64.zip
             workingDir: ./c8run
             command: ./c8run
           - name: Windows (AMD64)
@@ -136,6 +136,12 @@ jobs:
           secrets: |
             secret/data/products/distribution/ci NEXUS_USERNAME;
             secret/data/products/distribution/ci NEXUS_PASSWORD;
+            secret/data/products/distribution/ci APPLE_CERTIFICATE;
+            secret/data/products/distribution/ci APPLE_CERTIFICATE_PASSWORD;
+            secret/data/products/distribution/ci APPLE_DEVELOPER_ID;
+            secret/data/products/distribution/ci APPLE_DEVELOPER_PASSWORD;
+            secret/data/products/distribution/ci APPLE_TEAM_ID;
+            secret/data/products/distribution/ci APPLE_COMMON_NAME;
             secret/data/common/jenkins/downloads-camunda-cloud_google_sa_key DOWNLOAD_CENTER_GCLOUD_KEY_BYTES | GCP_CREDENTIALS_NAME;
       - uses: actions/setup-go@v5
         with:
@@ -144,12 +150,45 @@ jobs:
       - name: Build artifact
         working-directory: ${{ matrix.os.workingDir }}
         run: go build
+
       - name: Create artifact package
         working-directory: ${{ matrix.os.workingDir }}
         run: ${{ matrix.os.command }} package
         env:
           JAVA_ARTIFACTS_USER: ${{ steps.secrets.outputs.NEXUS_USERNAME }}
           JAVA_ARTIFACTS_PASSWORD: ${{ steps.secrets.outputs.NEXUS_PASSWORD }}
+
+      - name: extract package
+        if: startsWith(matrix.os.name, 'MacOS')
+        run: |
+          mkdir tmp
+          mv "$C8RUN_NAME_ORIGINAL" tmp
+          cd tmp
+          unzip "$C8RUN_NAME_ORIGINAL"
+        shell: bash
+        working-directory: ./c8run
+        env:
+          C8RUN_NAME_ORIGINAL: "camunda8-run-${{ inputs.camundaAppsRelease }}-${{ matrix.os.artifactFileSuffix }}"
+
+      - name: Sign and notarize
+        if: startsWith(matrix.os.name, 'MacOS')
+        uses: ./.github/actions/sign-and-notarize
+        with:
+          p12-base64: ${{ steps.secrets.outputs.APPLE_CERTIFICATE }}
+          p12-password: ${{ steps.secrets.outputs.APPLE_CERTIFICATE_PASSWORD }}
+          developer-id-cert-name: ${{ steps.secrets.outputs.APPLE_DEVELOPER_ID }}
+          apple-id: ${{ steps.secrets.outputs.APPLE_DEVELOPER_ID }}
+          app-password: ${{ steps.secrets.outputs.APPLE_DEVELOPER_PASSWORD }}
+          team-id: ${{ steps.secrets.outputs.APPLE_TEAM_ID }}
+          path: ./c8run/tmp/c8run
+
+      - name: Replace old mac artifact with codesigned version
+        if: startsWith(matrix.os.name, 'MacOS')
+        run: |
+          mv ./c8run/tmp/c8run_complete.zip ./c8run/$C8RUN_NAME_ORIGINAL
+        env:
+          C8RUN_NAME_ORIGINAL: "camunda8-run-${{ inputs.camundaAppsRelease }}-${{ matrix.os.artifactFileSuffix }}"
+
       - name: Copy artifact
         working-directory: ${{ matrix.os.workingDir }}
         env:

--- a/c8run/internal/archive/archive.go
+++ b/c8run/internal/archive/archive.go
@@ -115,9 +115,9 @@ func ExtractTarGzArchive(filename string, xpath string) error {
 	_, err = os.Stat(absPath)
 	if errors.Is(err, os.ErrNotExist) {
 		err = os.Mkdir(absPath, ReadWriteMode)
-                if err != nil {
-		        return fmt.Errorf("ExtractTarGzArchive: failed to make directory %s\n%w\n%s", absPath, err, debug.Stack())
-                }
+		if err != nil {
+			return fmt.Errorf("ExtractTarGzArchive: failed to make directory %s\n%w\n%s", absPath, err, debug.Stack())
+		}
 	}
 
 	tr := tar.NewReader(gz)
@@ -225,11 +225,8 @@ func ZipSource(sources []string, target string) error {
 
 			header.Method = zip.Deflate
 
-			header.Name, err = filepath.Rel(filepath.Dir(source), path)
+			header.Name = path
 			header.Name = strings.ReplaceAll(header.Name, "\\", "/")
-			if err != nil {
-				return fmt.Errorf("ZipSource: failed to determine relative path for %s\n%w\n%s", path, err, debug.Stack())
-			}
 			if info.IsDir() {
 				header.Name = strings.ReplaceAll(header.Name, "\\", "/")
 				header.Name += "/"

--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -50,31 +50,38 @@ func downloadAndExtract(filePath, url, extractDir string, authToken string, extr
 	return nil
 }
 
-func setOsSpecificValues() (string, string, string, func(string, string) error, error) {
+func setOsSpecificValues() (string, string, string, string, func(string, string) error, error) {
 	var architecture string
 	var osType string = runtime.GOOS
 	var pkgName string
+        var finalOutputExtension string
 	var extractFunc func(string, string) error
 
 	switch osType {
 	case "windows":
 		architecture = "x86_64"
 		pkgName = ".zip"
+                finalOutputExtension = ".zip"
 		extractFunc = archive.UnzipSource
-		return osType, architecture, pkgName, extractFunc, nil
+		return osType, architecture, pkgName, finalOutputExtension, extractFunc, nil
 	case "linux", "darwin":
 		pkgName = ".tar.gz"
+                if osType == "linux" {
+                        finalOutputExtension = ".tar.gz"
+                } else {
+                        finalOutputExtension = ".zip"
+                }
 		extractFunc = archive.ExtractTarGzArchive
 		if runtime.GOARCH == "amd64" {
 			architecture = "x86_64"
 		} else if runtime.GOARCH == "arm64" {
 			architecture = "aarch64"
 		} else {
-			return "", "", "", nil, fmt.Errorf("unsupported architecture: %s", runtime.GOARCH)
+			return "", "", "", "", nil, fmt.Errorf("unsupported architecture: %s", runtime.GOARCH)
 		}
-		return osType, architecture, pkgName, extractFunc, nil
+		return osType, architecture, pkgName, finalOutputExtension, extractFunc, nil
 	default:
-		return "", "", "", nil, fmt.Errorf("unsupported operating system: %s", osType)
+		return "", "", "", "", nil, fmt.Errorf("unsupported operating system: %s", osType)
 	}
 }
 
@@ -155,7 +162,7 @@ func BuildJavaScripts() error {
 }
 
 func New(camundaVersion, elasticsearchVersion, connectorsVersion, composeTag string) error {
-	var osType, architecture, pkgName, extractFunc, err = setOsSpecificValues()
+	var osType, architecture, pkgName, finalOutputExtension, extractFunc, err = setOsSpecificValues()
 	if err != nil {
 		fmt.Printf("%+v", err)
 		os.Exit(1)
@@ -213,10 +220,10 @@ func New(camundaVersion, elasticsearchVersion, connectorsVersion, composeTag str
 	}
 
 	filesToArchive := getFilesToArchive(osType, elasticsearchVersion, connectorsFilePath, camundaVersion, composeExtractionPath)
-	outputFileName := "camunda8-run-" + camundaVersion + "-" + osType + "-" + architecture + pkgName
+	outputFileName := "camunda8-run-" + camundaVersion + "-" + osType + "-" + architecture + finalOutputExtension
 	outputPath := filepath.Join("c8run", outputFileName)
 
-	if osType == "linux" || osType == "darwin" {
+	if osType == "linux" {
 		if err := createTarGzArchive(filesToArchive, outputPath); err != nil {
 			return fmt.Errorf("Package %s: %w", osType, err)
 		}

--- a/c8run/internal/unix/unix.go
+++ b/c8run/internal/unix/unix.go
@@ -45,7 +45,7 @@ func (w *UnixC8Run) VersionCmd(javaBinaryPath string) *exec.Cmd {
 
 func (w *UnixC8Run) ElasticsearchCmd(elasticsearchVersion string, parentDir string) *exec.Cmd {
 	elasticsearchCmdString := filepath.Join(parentDir, "elasticsearch-"+elasticsearchVersion, "bin", "elasticsearch")
-	elasticsearchCmd := exec.Command(elasticsearchCmdString, "-E", "xpack.ml.enabled=false", "-E", "xpack.security.enabled=false")
+	elasticsearchCmd := exec.Command(elasticsearchCmdString, "-E", "xpack.ml.enabled=false", "-E", "xpack.security.enabled=false", "-E", "discovery.type=single-node")
 	elasticsearchCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	return elasticsearchCmd
 }

--- a/c8run/internal/windows/windows.go
+++ b/c8run/internal/windows/windows.go
@@ -35,7 +35,7 @@ func (w *WindowsC8Run) VersionCmd(javaBinaryPath string) *exec.Cmd {
 }
 
 func (w *WindowsC8Run) ElasticsearchCmd(elasticsearchVersion string, parentDir string) *exec.Cmd {
-	elasticsearchCmd := exec.Command(filepath.Join(parentDir, "elasticsearch-"+elasticsearchVersion, "bin", "elasticsearch.bat"), "-E", "xpack.ml.enabled=false", "-E", "xpack.security.enabled=false")
+	elasticsearchCmd := exec.Command(filepath.Join(parentDir, "elasticsearch-"+elasticsearchVersion, "bin", "elasticsearch.bat"), "-E", "xpack.ml.enabled=false", "-E", "xpack.security.enabled=false", "-E", "discovery.type=single-node")
 
 	elasticsearchCmd.SysProcAttr = &syscall.SysProcAttr{
 		CreationFlags: 0x08000000 | 0x00000200, // CREATE_NO_WINDOW, CREATE_NEW_PROCESS_GROUP : https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags


### PR DESCRIPTION
## Description

Prior to this PR, whenever you try to run `./c8run` on MacOS, you get an error:

> c8run Not Opened Apple could not verify c8run is free of malware that may harm your Mac or compromise your privacy.

The reason for this error message is that MacOS comes with some protections against running binary executables. The protection is called Gatekeeper. To not receive this error message, we must sign+notarize the binary during the release process. This PR does that.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/camunda/issues/25177
