### PR TITLE
fix: correctly handle embedded and standalone gateway configs

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/security/SecurityConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/security/SecurityConfiguration.java
@@ -13,16 +13,19 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.condition.NoneNestedConditions;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.ConfigurationCondition.ConfigurationPhase;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -41,7 +44,9 @@ import org.springframework.security.web.servletapi.SecurityContextHolderAwareReq
 @EnableWebSecurity
 @EnableMethodSecurity
 @Configuration(proxyBeanMethods = false)
-public final class SecurityConfiguration {
+public class SecurityConfiguration {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SecurityConfiguration.class);
 
   @Bean
   @Order(Ordered.HIGHEST_PRECEDENCE)
@@ -111,22 +116,46 @@ public final class SecurityConfiguration {
    * set to {@code NONE}. It helps deal with the fact that the gateway can be embedded in the broker
    * or run standalone.
    */
-  static class GatewaySecurityAuthenticationEnabledCondition extends NoneNestedConditions {
+  static class GatewaySecurityAuthenticationEnabledCondition implements Condition {
 
-    public GatewaySecurityAuthenticationEnabledCondition() {
-      super(ConfigurationPhase.REGISTER_BEAN);
+    @Override
+    public boolean matches(final ConditionContext context, final AnnotatedTypeMetadata metadata) {
+      final Environment env = context.getEnvironment();
+      final boolean standaloneGatewayEnabled =
+          "true".equals(env.getProperty("zeebe.gateway.enable"));
+      final boolean standaloneGatewaySecurityNotNone =
+          !"none".equals(env.getProperty("zeebe.gateway.security.authentication.mode"));
+      final boolean embeddedGatewayEnabled =
+          "true".equals(env.getProperty("zeebe.broker.gateway.enable"));
+      final boolean embeddedGatewaySecurityNotNone =
+          !"none".equals(env.getProperty("zeebe.broker.gateway.security.authentication.mode"));
+
+      warnAboutAmbiguity(standaloneGatewayEnabled, embeddedGatewaySecurityNotNone, env);
+
+      return (standaloneGatewayEnabled && standaloneGatewaySecurityNotNone)
+          || (embeddedGatewayEnabled && embeddedGatewaySecurityNotNone);
     }
 
-    @ConditionalOnProperty(
-        prefix = "zeebe.gateway",
-        value = "security.authentication.mode",
-        havingValue = "none")
-    static class StandaloneGatewayCondition {}
+    private void warnAboutAmbiguity(
+        final boolean standaloneGatewayEnabled,
+        final boolean embeddedGatewayEnabled,
+        final Environment env) {
+      final String standaloneGatewaySecurityMode =
+          env.getProperty("zeebe.gateway.security.authentication.mode");
+      final String embeddedGatewaySecurityMode =
+          env.getProperty("zeebe.broker.gateway.security.authentication.mode");
 
-    @ConditionalOnProperty(
-        prefix = "zeebe.broker.gateway",
-        value = "security.authentication.mode",
-        havingValue = "none")
-    static class EmbeddedGatewayCondition {}
+      if (standaloneGatewayEnabled && "identity".equals(embeddedGatewaySecurityMode)) {
+        LOGGER.warn(
+            "Standalone gateway is enabled but embedded gateway security mode is set to identity. "
+                + "This configuration is ambiguous. Only the standalone gateway security mode will be used.");
+      }
+
+      if (embeddedGatewayEnabled && "identity".equals(standaloneGatewaySecurityMode)) {
+        LOGGER.warn(
+            "Embedded gateway is enabled but standalone gateway security mode is set to identity. "
+                + "This configuration is ambiguous. Only the embedded gateway security mode will be used.");
+      }
+    }
   }
 }

--- a/dist/src/test/java/io/camunda/zeebe/shared/security/SecurityConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/security/SecurityConfigurationTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.shared.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.shared.security.SecurityConfigurationTest.TestCase.Builder;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.MethodMetadata;
+
+public class SecurityConfigurationTest {
+
+  @Mock private Environment environment;
+
+  private ConditionContext conditionContext;
+  private MethodMetadata methodMetadata;
+  private final Condition condition =
+      new SecurityConfiguration.GatewaySecurityAuthenticationEnabledCondition();
+
+  @BeforeEach
+  void setUp() throws Exception {
+    MockitoAnnotations.openMocks(this).close();
+    conditionContext = mock(ConditionContext.class);
+    methodMetadata = mock(MethodMetadata.class);
+    when(conditionContext.getEnvironment()).thenReturn(environment);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTestCases")
+  void testGatewaySecurityAuthenticationEnabledCondition(final TestCase testCase) {
+    when(environment.getProperty("zeebe.gateway.enable"))
+        .thenReturn(testCase.standaloneGatewayEnable);
+    when(environment.getProperty("zeebe.gateway.security.authentication.mode"))
+        .thenReturn(testCase.standaloneGatewaySecurityMode);
+    when(environment.getProperty("zeebe.broker.gateway.enable"))
+        .thenReturn(testCase.embeddedGatewayEnable);
+    when(environment.getProperty("zeebe.broker.gateway.security.authentication.mode"))
+        .thenReturn(testCase.embeddedGatewaySecurityMode);
+
+    final boolean result = condition.matches(conditionContext, methodMetadata);
+    assertThat(result).describedAs(testCase.description).isEqualTo(testCase.expectedResult);
+  }
+
+  private static Stream<Arguments> provideTestCases() {
+    return Stream.of(
+        Arguments.of(
+            new TestCase.Builder()
+                .description("Standalone gateway enabled and security mode is none")
+                .standaloneGatewayEnable()
+                .standaloneGatewaySecurityMode("none")
+                .expectedResult(false)
+                .build()),
+        Arguments.of(
+            new TestCase.Builder()
+                .description("Standalone gateway enabled and security mode is identity")
+                .standaloneGatewayEnable()
+                .standaloneGatewaySecurityMode("identity")
+                .expectedResult(true)
+                .build()),
+        Arguments.of(
+            new TestCase.Builder()
+                .description("Embedded gateway enabled and security mode is none")
+                .embeddedGatewayEnable()
+                .embeddedGatewaySecurityMode("none")
+                .expectedResult(false)
+                .build()),
+        Arguments.of(
+            new TestCase.Builder()
+                .description("Embedded gateway enabled and security mode is identity")
+                .embeddedGatewayEnable()
+                .embeddedGatewaySecurityMode("identity")
+                .expectedResult(true)
+                .build()),
+        Arguments.of(
+            new TestCase.Builder()
+                .description(
+                    "Both standalone and embedded gateways enabled with security mode none")
+                .standaloneGatewayEnable()
+                .standaloneGatewaySecurityMode("none")
+                .embeddedGatewayEnable()
+                .embeddedGatewaySecurityMode("none")
+                .expectedResult(false)
+                .build()),
+        Arguments.of(
+            new Builder()
+                .description(
+                    "Standalone gateway enabled, standalone gateway security mode none, embedded gateway security mode identity")
+                .standaloneGatewayEnable()
+                .standaloneGatewaySecurityMode("none")
+                .embeddedGatewaySecurityMode("identity")
+                .expectedResult(false)
+                .build()),
+        Arguments.of(
+            new TestCase.Builder()
+                .description(
+                    "Standalone gateway enabled, standalone gateway security mode identity, embedded gateway security mode none")
+                .standaloneGatewayEnable()
+                .standaloneGatewaySecurityMode("identity")
+                .embeddedGatewaySecurityMode("none")
+                .expectedResult(true)
+                .build()),
+        Arguments.of(
+            new TestCase.Builder()
+                .description(
+                    "Embedded gateway enabled, standalone gateway security mode none, embedded gateway security mode identity")
+                .standaloneGatewaySecurityMode("none")
+                .embeddedGatewayEnable()
+                .embeddedGatewaySecurityMode("identity")
+                .expectedResult(true)
+                .build()),
+        Arguments.of(
+            new Builder()
+                .description(
+                    "Embedded gateway enabled, standalone gateway security mode identity, embedded gateway security mode none")
+                .standaloneGatewaySecurityMode("identity")
+                .embeddedGatewayEnable()
+                .embeddedGatewaySecurityMode("none")
+                .expectedResult(false)
+                .build()));
+  }
+
+  record TestCase(
+      String description,
+      String standaloneGatewayEnable,
+      String standaloneGatewaySecurityMode,
+      String embeddedGatewayEnable,
+      String embeddedGatewaySecurityMode,
+      boolean expectedResult) {
+
+    static class Builder {
+      private String description;
+      private String standaloneGatewayEnable;
+      private String standaloneGatewaySecurityMode;
+      private String embeddedGatewayEnable;
+      private String embeddedGatewaySecurityMode;
+      private boolean expectedResult;
+
+      Builder description(final String description) {
+        this.description = description;
+        return this;
+      }
+
+      Builder standaloneGatewayEnable() {
+        standaloneGatewayEnable = "true";
+        return this;
+      }
+
+      Builder standaloneGatewaySecurityMode(final String standaloneGatewaySecurityMode) {
+        this.standaloneGatewaySecurityMode = standaloneGatewaySecurityMode;
+        return this;
+      }
+
+      Builder embeddedGatewayEnable() {
+        embeddedGatewayEnable = "true";
+        return this;
+      }
+
+      Builder embeddedGatewaySecurityMode(final String embeddedGatewaySecurityMode) {
+        this.embeddedGatewaySecurityMode = embeddedGatewaySecurityMode;
+        return this;
+      }
+
+      Builder expectedResult(final boolean expectedResult) {
+        this.expectedResult = expectedResult;
+        return this;
+      }
+
+      TestCase build() {
+        return new TestCase(
+            description,
+            standaloneGatewayEnable,
+            standaloneGatewaySecurityMode,
+            embeddedGatewayEnable,
+            embeddedGatewaySecurityMode,
+            expectedResult);
+      }
+    }
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationNoneIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationNoneIT.java
@@ -121,7 +121,7 @@ public class GatewayAuthenticationNoneIT {
   private final TestStandaloneBroker zeebe =
       new TestStandaloneBroker()
           .withAdditionalProfile(Profile.IDENTITY_AUTH)
-          .withProperty("zeebe.gateway.security.authentication.mode", "none")
+          .withProperty("zeebe.broker.gateway.security.authentication.mode", "none")
           .withProperty("camunda.identity.issuerBackendUrl", getKeycloakRealmAddress())
           .withProperty("camunda.identity.audience", ZEEBE_CLIENT_AUDIENCE);
 


### PR DESCRIPTION
## Description
An issue was raised where some identity authentication configs were applied to the wrong context. For example when running in standalone gateway mode, the `ZEEBE_BROKER_GATEWAY_SECURITY_AUTHENTICATION_MODE` is applied. This is not expected because it only serves to configure the embedded gateway (different mode). This PR is applying the fix from [8.6](https://github.com/camunda/camunda/pull/28715) to 8.8

A comprehensive set of configs have been tested and can be found on [this sheet](https://docs.google.com/spreadsheets/d/17CbEaXqfjbCAOdEggzAH5ToOqJE4biF5paSzTE_1R2Y/edit?gid=0#gid=0)

## Related issues

related to #27234
related to https://jira.camunda.com/browse/SUPPORT-25058