### PR TITLE
Adjust inconsistent OpenAPI attribute names

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/response/DocumentReferenceBatchResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/DocumentReferenceBatchResponse.java
@@ -39,7 +39,7 @@ public interface DocumentReferenceBatchResponse {
     /**
      * @return the filename of the failed document
      */
-    String getFilename();
+    String getFileName();
 
     /**
      * @return the failure description

--- a/clients/java/src/main/java/io/camunda/client/impl/response/DocumentReferenceBatchResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/DocumentReferenceBatchResponseImpl.java
@@ -65,8 +65,8 @@ public class DocumentReferenceBatchResponseImpl implements DocumentReferenceBatc
     }
 
     @Override
-    public String getFilename() {
-      return failedDocumentDetail.getFilename();
+    public String getFileName() {
+      return failedDocumentDetail.getFileName();
     }
 
     @Override

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1293,7 +1293,7 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
-  /process-definitions/{processDefinitionsKey}/form:
+  /process-definitions/{processDefinitionKey}/form:
     get:
       tags:
         - Process definition
@@ -1304,7 +1304,7 @@ paths:
 
         Note that this endpoint will only return linked forms. This endpoint does not support embedded forms.
       parameters:
-        - name: processDefinitionsKey
+        - name: processDefinitionKey
           in: path
           required: true
           description: The process key.
@@ -1603,7 +1603,7 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
-  /flownode-instances/{flownodeInstanceKey}:
+  /flownode-instances/{flowNodeInstanceKey}:
     get:
       tags:
         - Flow node instance
@@ -1612,7 +1612,7 @@ paths:
       description: |
         Returns flow node instance as JSON.
       parameters:
-        - name: flownodeInstanceKey
+        - name: flowNodeInstanceKey
           in: path
           required: true
           description: The assigned key of the flow node instance, which acts as a unique identifier for this flow node instance.
@@ -2723,7 +2723,7 @@ paths:
 
         The caller must provide a file name for each document, which will be used in case of a multi-status response
         to identify which documents failed to upload. The file name can be provided in the `Content-Disposition` header
-        of the file part or in the `filename` field of the metadata part. If both are provided, the `filename` field
+        of the file part or in the `fileName` field of the metadata part. If both are provided, the `fileName` field
         takes precedence.
 
         In case of a multi-status response, the response body will contain a list of `DocumentBatchProblemDetail` objects,
@@ -6416,7 +6416,7 @@ components:
     DocumentCreationFailureDetail:
       type: object
       properties:
-        filename:
+        fileName:
           type: string
           description: The name of the file.
         detail:
@@ -7088,3 +7088,4 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -224,7 +224,7 @@ public final class ResponseMapper {
               final var detail = new DocumentCreationFailureDetail();
               final var defaultProblemDetail = mapDocumentErrorToProblem(error.error());
               detail.setDetail(defaultProblemDetail.getDetail());
-              detail.setFilename(error.request().metadata().fileName());
+              detail.setFileName(error.request().metadata().fileName());
               response.addFailedDocumentsItem(detail);
             });
     return ResponseEntity.status(HttpStatus.MULTI_STATUS)


### PR DESCRIPTION
## Description

Correct attributes in the OpenAPI that don't use a consistent case or singular form.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #28864 