### PR TITLE
Explain why our contributing guide advises rebasing instead of merge commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,11 +185,11 @@ Before opening your first pull request, please have a look at this [guide](https
 3. The reviewer will look at the pull request in the following days and give you either feedback or accept the changes. Your reviewer might use [emoji code](#review-emoji-code) during the reviewing process.
    1. If there are changes requested, address them in a new commit. Notify the reviewer in a comment if the pull request is ready for review again. If the changes are accepted squash them again in the related commit and force push. Then initiate a merge by adding your PR to the merge queue via the `Merge when ready` button.
    2. If no changes are requested, the reviewer will initiate a merge themselves.
-4. When a merge is initiated, a bot will merge your branch with the latest
+4. If there are merge conflicts, the author of the pull request has to manually rebase their branch onto the target branch (often `main`) and force push. We try to avoid using merge commits in pull requests to keep the history easy to follow, and allow [automated porting of the pull request](#backporting-changes).
+5. When a merge is initiated, a bot will merge your branch with the latest
    `main` and run the CI on it.
    1. If everything goes well, the branch is merged and deleted and the issue and pull request are closed.
-   2. If there are merge conflicts, the author of the pull request has to manually rebase `main` into the issue branch and retrigger a merge attempt.
-   3. If there are CI errors, the author of the pull request has to check if they are caused by its changes and address them. If they are flaky tests, please have a look at this [guide](docs/ci.md#determine-flakiness) on how to handle them. Once the CI errors are resolved, a merge can be retried by simply enqueueing the PR again.
+   2. If there are CI errors, the author of the pull request has to check if they are caused by its changes and address them. If they are flaky tests, please have a look at this [guide](docs/ci.md#determine-flakiness) on how to handle them. Once the CI errors are resolved, a merge can be retried by simply enqueueing the PR again.
 
 ## Reviewing a pull request
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -222,28 +222,16 @@ When this happens and you're still interested in contributing, please feel free 
 
 ## Backporting changes
 
-Some changes need to be copied to older versions. We use the [backport](https://github.com/zeebe-io/backport-action) Github Action to automate this process. Please follow these steps to backport your changes:
+Some changes need to be copied to other (often older) versions. We use the [backport](https://github.com/zeebe-io/backport-action) Github Action to automate this process. Please follow these steps to port your changes:
 
-1. **Label the pull request** with a backport label (e.g. the label `backport stable/1.0` indicates that we want to backport this pull request to the `stable/1.0` branch).
-   - if the pull request is _not yet_ merged, it will be automatically backported when it gets merged.
+1. **Label the pull request** with a backport label (e.g. the label `backport stable/1.0` indicates that we want to port this pull request to the `stable/1.0` branch).
+   - if the pull request is _not yet_ merged, it will be automatically ported when it gets merged.
    - if the pull request is _already_ merged, create a comment on the pull request that contains
-     `/backport` to trigger the automatic backporting.
+     `/backport` to trigger the action.
+   - a pull request can have multiple backport labels, in which case the action ports the pull request to each of those branches.
 2. The GitHub actions bot comments on the pull request once it finishes:
-   - When _successful_, a new backport pull request was automatically created. Simply approve the PR
-     and enqueue it to the merge queue by clicking the `Merge when ready` button.
-   - If it _failed_, please follow these **manual steps**:
-     1. Locally checkout the target branch (e.g. `stable/1.0`).
-     2. Make sure it's up to date with the origin (i.e. `git pull`).
-     3. Checkout a new branch for your backported changes (e.g. `git checkout -b
-        backport-123-to-stable/1.0`).
-     4. Cherry-pick your changes `git cherry-pick -x <sha-1>...<sha-n>`. You may need to resolve
-        conflicts.
-     5. Push your cherry-picked changes `git push`.
-     6. Create a pull request for your backport branch:
-        - Make sure it is clear that this backports in the title (e.g. `[Backport stable/1.0] Title of the original PR`).
-        - Make sure to change the target of the pull request to the correct branch (e.g. `stable/1.0`).
-        - Refer to the pull request in the description to link it (e.g. `backports #123`)
-        - Refer to any issues that were referenced in the original pull request (e.g. `relates to #99`).
+   - When _successful_, a new backport pull request was automatically created. A bot will automatically approve and merge it when it passes the CI. If it doesn't, you'll need to fix the problems and request a new review.
+   - If it _fails_, the action provides instructions in a comment that you need to follow. Once ready, please request a new review.
 
 ## Commit message guidelines
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

We advise rebasing rather than using a merge commit to update a branch, but it was hidden inside the section where a merge was already queued. That's not always the case; sometimes, folks need to update their branch before it is approved.

Therefore, we should highlight this more explicitly. I've also explained why this matters and improved the wording from 'rebase `main` into the branch' to 'rebase onto the target branch'. Note that officially, the target branch is called the 'base', but 'target' is probably a more generally understood term.

This PR also improves the backport instructions, as I noticed that they were outdated when I linked them in the section where we advise rebasing over merge commits.

## Related issues

https://github.com/camunda/camunda/pull/28715#pullrequestreview-2646870880
https://github.com/camunda/camunda/pull/28857#pullrequestreview-2646885409