### PR TITLE
fix: ignore unaffected-rows check on selected statements in RDBMS que…

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -63,12 +63,14 @@ import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.Form;
 import io.camunda.zeebe.protocol.record.value.deployment.Process;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
@@ -95,7 +97,11 @@ class RdbmsExporterIT {
     exporter = new RdbmsExporterWrapper(rdbmsService);
     exporter.configure(
         new ExporterContext(
-            null, new ExporterConfiguration("foo", Map.of("maxQueueSize", 0)), 1, null, null));
+            null,
+            new ExporterConfiguration("foo", Map.of("maxQueueSize", 0)),
+            1,
+            Mockito.mock(MeterRegistry.class, Mockito.RETURNS_DEEP_STUBS),
+            null));
     exporter.open(controller);
   }
 


### PR DESCRIPTION
…ue #28874

Fix false-positive error detectors in RDBMS executionQueue

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #28874 
