### PR TITLE
fix: credentials cache path can be configured in spring sdk

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
@@ -342,6 +342,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
           .audience(camundaClientProperties.getZeebe().getAudience())
           .authorizationServerUrl(camundaClientProperties.getAuth().getIssuer())
           .scope(camundaClientProperties.getZeebe().getScope())
+          .credentialsCachePath(camundaClientProperties.getAuth().getCredentialsCachePath())
           .build();
     }
     return new NoopCredentialsProvider();

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/common/AuthProperties.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/common/AuthProperties.java
@@ -22,6 +22,15 @@ public class AuthProperties {
   private String clientSecret;
 
   private String issuer;
+  private String credentialsCachePath;
+
+  public String getCredentialsCachePath() {
+    return credentialsCachePath;
+  }
+
+  public void setCredentialsCachePath(final String credentialsCachePath) {
+    this.credentialsCachePath = credentialsCachePath;
+  }
 
   public String getIssuer() {
     return issuer;

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/CamundaClientPropertiesTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/CamundaClientPropertiesTest.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.zeebe.spring.client.properties;
 

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/CamundaClientPropertiesTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/CamundaClientPropertiesTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.spring.client.properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+public class CamundaClientPropertiesTest {
+
+  @Nested
+  @SpringBootTest(
+      classes = CamundaClientPropertiesTestConfig.class,
+      properties = {"camunda.client.auth.credentials-cache-path=/some/path"})
+  class CredentialsCachePathConfigTest {
+    @Autowired CamundaClientProperties camundaClientProperties;
+
+    @Test
+    void shouldApplyProperty() {
+      assertThat(camundaClientProperties.getAuth().getCredentialsCachePath())
+          .isEqualTo("/some/path");
+    }
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #26006
