### PR TITLE
fix: fix possible sigsev in tests

### DIFF
--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/LargeStateControllerPerformanceTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/LargeStateControllerPerformanceTest.java
@@ -91,7 +91,11 @@ public class LargeStateControllerPerformanceTest {
             context.snapshotStore());
 
     // when
-    try (final var db = controller.recover().join()) {
+    try (controller) {
+      // the controller closing will close the DB we just opened
+      //noinspection resource
+      final var db = controller.recover().join();
+
       //noinspection unchecked
       return db.getProperty("rocksdb.estimate-live-data-size");
     }


### PR DESCRIPTION
## Description

The performance test closes the DB without closing the state controller, meaning the state controller may still try to access the DB afterwards. This can cause a sigsev when that happens.

Since the state controller is now doing the metrics export, there can be a race condition where the export runs concurrently while the DB is closed. This is only a test issue, since in production, the controller is the only one closing the DB.

To avoid this, we don't close the DB explicitly, but instead close the state.
