### PR TITLE
Compact record logger improvements for job records

### DIFF
--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -83,7 +83,6 @@ public class CompactRecordLogger {
 
   private static final Logger LOG = LoggerFactory.getLogger("io.camunda.zeebe.test");
   private static final String BLOCK_SEPARATOR = " ";
-  private static ObjectMapper objectMapper;
 
   // List rather than Map to preserve order
   private static final List<Entry<String, String>> ABBREVIATIONS =
@@ -135,6 +134,7 @@ public class CompactRecordLogger {
   private final ArrayList<Record<?>> records;
 
   private final List<Process> processes = new ArrayList<>();
+  private ObjectMapper objectMapper;
 
   {
     valueLoggers.put(ValueType.DEPLOYMENT, this::summarizeDeployment);

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -617,23 +617,23 @@ public class CompactRecordLogger {
     final StringBuilder result = new StringBuilder();
     if (!value.getElementInstancePath().isEmpty()) {
       result
-          .append(" ElementInstancePath: ")
+          .append(" EI:")
           .append(
               value.getElementInstancePath().stream()
-                  .map(p -> p.stream().map(this::shortenKey).collect(Collectors.joining(" -> ")))
+                  .map(p -> p.stream().map(this::shortenKey).collect(Collectors.joining("->")))
                   .toList());
     }
     if (!value.getProcessDefinitionPath().isEmpty()) {
       result
-          .append(" ProcessDefinitionPath: [")
+          .append(" PD:[")
           .append(
               value.getProcessDefinitionPath().stream()
                   .map(this::shortenKey)
-                  .collect(Collectors.joining(" -> ")))
+                  .collect(Collectors.joining("->")))
           .append("]");
     }
     if (!value.getCallingElementPath().isEmpty()) {
-      result.append(" CallingElementPath: ").append(value.getCallingElementPath());
+      result.append(" CE: ").append(value.getCallingElementPath());
     }
     return result.toString();
   }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -241,14 +241,13 @@ public class CompactRecordLogger {
     if (multiPartition) {
       bulkMessage.append("P[partitionId]");
     }
-    bulkMessage.append("K[key] - [summary of value]\n");
-
     bulkMessage.append(
-        "\tP9K999 - key; #999 - record position; \"ID\" element/process id; @\"elementid\"/[P9K999] - element with ID and key\n");
-    bulkMessage.append(
-        "\tKeys are decomposed into partition id and per partition key (e.g. 2251799813685253 -> P1K005). If single partition, the partition is omitted.\n");
-    bulkMessage.append(
-        "\tLong IDs are shortened (e.g. 'startEvent_5d56488e-0570-416c-ba2d-36d2a3acea78' -> 'star..acea78'\n");
+        """
+        K[key] - [summary of value]
+        \tP9K999 - key; #999 - record position; "ID" element/process id; @"elementid"/[P9K999] - element with ID and key
+        \tKeys are decomposed into partition id and per partition key (e.g. 2251799813685253 -> P1K005). If single partition, the partition is omitted.
+        \tLong IDs are shortened (e.g. 'startEvent_5d56488e-0570-416c-ba2d-36d2a3acea78' -> 'star..acea78'
+        """);
     bulkMessage.append("--------\n");
 
     records.forEach(record -> bulkMessage.append(summarizeRecord(record)).append("\n"));

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -79,7 +79,7 @@ import org.slf4j.LoggerFactory;
 public class CompactRecordLogger {
 
   private static final Logger LOG = LoggerFactory.getLogger("io.camunda.zeebe.test");
-  private static final String BLOCK_SEPARATOR = " - ";
+  private static final String BLOCK_SEPARATOR = " ";
 
   // List rather than Map to preserve order
   private static final List<Entry<String, String>> ABBREVIATIONS =

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -425,18 +425,18 @@ public class CompactRecordLogger {
   private String summarizeJob(final Record<?> record) {
     final var value = (JobRecordValue) record.getValue();
 
-    return summarizeJobRecordValue(record.getKey(), value);
+    return summarizeJobRecordValue(-1L, value);
   }
 
   private String summarizeJobRecordValue(final long jobKey, final JobRecordValue value) {
     final var result = new StringBuilder();
 
     if (jobKey != -1) {
-      result.append(shortenKey(jobKey));
+      result.append(shortenKey(jobKey)).append(" ");
     }
     if (!StringUtils.isEmpty(value.getType())) {
       result
-          .append(" \"")
+          .append("\"")
           .append(value.getType())
           .append("\"")
           .append(summarizeElementInformation(value.getElementId(), value.getElementInstanceKey()));

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -899,7 +899,16 @@ public class CompactRecordLogger {
           summarizeElementInformation(value.getElementId(), value.getElementInstanceKey()));
     }
 
-    addIfNotEmpty(result, value.getChangedAttributes(), " changedAttributes");
+    if (value.getChangedAttributes() != null && !value.getChangedAttributes().isEmpty()) {
+      result
+          .append(" changedAttributes")
+          .append(" \"")
+          .append(
+              value.getChangedAttributes().stream()
+                  .map(CompactRecordLogger::abbreviateToFirstLetters)
+                  .toList())
+          .append("\"");
+    }
     addIfNotEmpty(result, value.getAssignee(), " assignee");
     addIfNotEmpty(result, value.getCandidateUsersList(), " candidateUsersList");
     addIfNotEmpty(result, value.getCandidateGroupsList(), " candidateGroupsList");

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -84,6 +84,13 @@ public class CompactRecordLogger {
   // List rather than Map to preserve order
   private static final List<Entry<String, String>> ABBREVIATIONS =
       List.of(
+          entry("COMPLETE_TASK_LISTENER", "COMP_TL"),
+          entry("DENY_TASK_LISTENER", "DENY_TL"),
+          entry("TASK_LISTENER", "TL"),
+          entry("ASSIGNMENT_DENIED", "ASGN_DENIED"),
+          entry("COMPLETION_DENIED", "COMP_DENIED"),
+          entry("UPDATE_DENIED", "UPDT_DENIED"),
+          entry("SEQUENCE_FLOW_TAKEN", "SQ_FLW_TKN"),
           entry("PROCESS_INSTANCE_CREATION", "CREA"),
           entry("PROCESS_INSTANCE_MODIFICATION", "MOD"),
           entry("PROCESS_INSTANCE", "PI"),
@@ -437,7 +444,7 @@ public class CompactRecordLogger {
     if (!StringUtils.isEmpty(value.getType())) {
       result
           .append("\"")
-          .append(value.getType())
+          .append(StringUtils.abbreviateMiddle(value.getType(), "..", 10))
           .append("\"")
           .append(summarizeElementInformation(value.getElementId(), value.getElementInstanceKey()));
     }
@@ -445,9 +452,9 @@ public class CompactRecordLogger {
     if (value.getJobKind() != null && value.getJobKind() != JobKind.BPMN_ELEMENT) {
       result
           .append(" (")
-          .append(value.getJobKind())
+          .append(abbreviate(value.getJobKind().toString()))
           .append("[")
-          .append(value.getJobListenerEventType())
+          .append(abbreviate(value.getJobListenerEventType().toString()))
           .append("]),");
     }
 

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -247,6 +247,7 @@ public class CompactRecordLogger {
         \tP9K999 - key; #999 - record position; "ID" element/process id; @"elementid"/[P9K999] - element with ID and key
         \tKeys are decomposed into partition id and per partition key (e.g. 2251799813685253 -> P1K005). If single partition, the partition is omitted.
         \tLong IDs are shortened (e.g. 'startEvent_5d56488e-0570-416c-ba2d-36d2a3acea78' -> 'star..acea78'
+        \tHeaders defined in 'Protocol' are abbreviated (e.g. 'io.camunda.zeebe:userTaskKey:2251799813685253' -> 'uTK:K005').
         """);
     bulkMessage.append("--------\n");
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

I needed to see the custom headers of jobs in the compact record log while working on #28252.

This PR ensures we don't lose those improvements:
- log all records slightly more compact
- don't log job key twice
- don't log process information for job
- log custom headers for jobs
- abbreviate job properties
- abbreviate user task changed attributes
- abbreviate `SEQUENCE_FLOW_TAKEN` to `SQ_FLW_TKN` to avoid exceeding 9 chars for intents
- abbreviate new job and user task intents like `ASSIGNMENT_DENIED` and `COMPLETE_TASKLISTENER`
- abbreviate the process instance record paths
- expand legend

<details><summary>Example of new log</summary>
<p>

```
--------
	['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position] K[key] - [summary of value]
	P9K999 - key; #999 - record position; "ID" element/process id; @"elementid"/[P9K999] - element with ID and key
	Keys are decomposed into partition id and per partition key (e.g. 2251799813685253 -> P1K005). If single partition, the partition is omitted.
	Long IDs are shortened (e.g. 'startEvent_5d56488e-0570-416c-ba2d-36d2a3acea78' -> 'star..acea78'
--------
C DPLY CREATE     #1917->   -1    -1 
E PROC CREATED    #1918->#1917 K0593 process.xml -> "process" (version:49)
E DPLY CREATED    #1919->#1917 K0592 process.xml
C CREA CREATE     #1920->   -1    -1 new <process "process"> (default start)  (no vars)
C PI   ACTIVATE   #1921->#1920 K0594 PROCESS "process" in <process "process"[K0594]>
E CREA CREATED    #1922->#1920 K0595 new <process "process"> (default start)  (no vars)
E PI   ACTIVATING #1923->#1920 K0594 PROCESS "process" in <process "process"[K0594]> EI:[K0594] PD:[K0593]
E PI   ACTIVATED  #1924->#1920 K0594 PROCESS "process" in <process "process"[K0594]>
C PI   ACTIVATE   #1925->#1920    -1 START_EVENT "startEv..ef3502e" in <process "process"[K0594]>
E PI   ACTIVATING #1926->#1920 K0596 START_EVENT "startEv..ef3502e" in <process "process"[K0594]> EI:[K0594->K0596] PD:[K0593]
E PI   ACTIVATED  #1927->#1920 K0596 START_EVENT "startEv..ef3502e" in <process "process"[K0594]>
C PI   COMPLETE   #1928->#1920 K0596 START_EVENT "startEv..ef3502e" in <process "process"[K0594]>
E PI   COMPLETING #1929->#1920 K0596 START_EVENT "startEv..ef3502e" in <process "process"[K0594]>
E PI   COMPLETED  #1930->#1920 K0596 START_EVENT "startEv..ef3502e" in <process "process"[K0594]>
E PI   SQ_FLW_TKN #1931->#1920 K0597 SEQUENCE_FLOW "sequenc..8c7a7e0" in <process "process"[K0594]>
C PI   ACTIVATE   #1932->#1920 K0598 USER_TASK "my_user_task" in <process "process"[K0594]>
E PI   ACTIVATING #1933->#1920 K0598 USER_TASK "my_user_task" in <process "process"[K0594]> EI:[K0594->K0598] PD:[K0593]
E UT   CREATING   #1934->#1920 K0599 task @"my_user_task"[K0598] assignee "peregrin" priority '50' in <process "process"[K0594]> (no vars)
E JOB  CREATED    #1935->#1920 K0600 "my_l..ting" @"my_user_task"[K0598] (TL[CREATING]), 3 retries, [uTK:'K0599',p:'50'] (no vars)
E PI   ACTIVATED  #1936->#1920 K0598 USER_TASK "my_user_task" in <process "process"[K0594]>
C JOB  COMPLETE   #1937->   -1 K0600 "my_l..ting" @""[   -1] -1 retries, (no vars)
E JOB  COMPLETED  #1938->#1937 K0600 "my_l..ting" @"my_user_task"[K0598] (TL[CREATING]), 3 retries, [uTK:'K0599',p:'50'] (no vars)
C UT   COMP_TL    #1939->#1937 K0599 task @"my_user_task"[K0598] assignee "peregrin" priority '50' in <process "process"[K0594]> (no vars)
E UT   CREATED    #1940->#1937 K0599 task @"my_user_task"[K0598] assignee "peregrin" priority '50' in <process "process"[K0594]> (no vars)
E UT   ASSIGNING  #1941->#1937 K0599 task @"my_user_task"[K0598] assignee "peregrin" priority '50' in <process "process"[K0594]> (no vars)
E JOB  CREATED    #1942->#1937 K0601 "my_l..b628" @"my_user_task"[K0598] (TL[ASSIGNING]), 3 retries, [uTK:'K0599',a:'peregrin',p:'50'] (no vars)
C JOB  COMPLETE   #1943->   -1 K0601 "my_l..b628" @""[   -1] -1 retries, (no vars)
E JOB  COMPLETED  #1944->#1943 K0601 "my_l..b628" @"my_user_task"[K0598] (TL[ASSIGNING]), 3 retries, [uTK:'K0599',a:'peregrin',p:'50'] (no vars)
C UT   COMP_TL    #1945->#1943 K0599 task @"my_user_task"[K0598] assignee "peregrin" priority '50' in <process "process"[K0594]> (no vars)
E JOB  CREATED    #1946->#1943 K0602 "my_l..28_2" @"my_user_task"[K0598] (TL[ASSIGNING]), 3 retries, [uTK:'K0599',a:'peregrin',p:'50'] (no vars)
C JOB  COMPLETE   #1947->   -1 K0602 "my_l..28_2" @""[   -1] -1 retries, (no vars)
E JOB  COMPLETED  #1948->#1947 K0602 "my_l..28_2" @"my_user_task"[K0598] (TL[ASSIGNING]), 3 retries, [uTK:'K0599',a:'peregrin',p:'50'] (no vars)
C UT   COMP_TL    #1949->#1947 K0599 task @"my_user_task"[K0598] assignee "peregrin" priority '50' in <process "process"[K0594]> (no vars)
E JOB  CREATED    #1950->#1947 K0603 "my_l..28_3" @"my_user_task"[K0598] (TL[ASSIGNING]), 3 retries, [uTK:'K0599',a:'peregrin',p:'50'] (no vars)
C JOB  COMPLETE   #1951->   -1 K0603 "my_l..28_3" @""[   -1] -1 retries, (no vars)
E JOB  COMPLETED  #1952->#1951 K0603 "my_l..28_3" @"my_user_task"[K0598] (TL[ASSIGNING]), 3 retries, [uTK:'K0599',a:'peregrin',p:'50'] (no vars)
C UT   COMP_TL    #1953->#1951 K0599 task @"my_user_task"[K0598] assignee "peregrin" priority '50' in <process "process"[K0594]> (no vars)
E UT   ASSIGNED   #1954->#1951 K0599 task @"my_user_task"[K0598] assignee "peregrin" priority '50' in <process "process"[K0594]> (no vars)
```

</p>
</details> 

<details><summary>Example of the same log before this PR</summary>
<p>

```
--------
	['C'ommand/'E'event/'R'ejection] [valueType] [intent] - #[position]->#[source record position] K[key] - [summary of value]
	P9K999 - key; #999 - record position; "ID" element/process id; @"elementid"/[P9K999] - element with ID and key
	Keys are decomposed into partition id and per partition key (e.g. 2251799813685253 -> P1K005). If single partition, the partition is omitted.
	Long IDs are shortened (e.g. 'startEvent_5d56488e-0570-416c-ba2d-36d2a3acea78' -> 'star..acea78'
--------
C DPLY CREATE                 - #1917->   -1    -1 - 
E PROC CREATED                - #1918->#1917 K0593 - process.xml -> "process" (version:49)
E DPLY CREATED                - #1919->#1917 K0592 - process.xml
C CREA CREATE                 - #1920->   -1    -1 - new <process "process"> (default start)  (no vars)
C PI   ACTIVATE               - #1921->#1920 K0594 - PROCESS "process" in <process "process"[K0594]>
E CREA CREATED                - #1922->#1920 K0595 - new <process "process"> (default start)  (no vars)
E PI   ACTIVATING             - #1923->#1920 K0594 - PROCESS "process" in <process "process"[K0594]> ElementInstancePath: [K0594] ProcessDefinitionPath: [K0593]
E PI   ACTIVATED              - #1924->#1920 K0594 - PROCESS "process" in <process "process"[K0594]>
C PI   ACTIVATE               - #1925->#1920    -1 - START_EVENT "startEv..de75bc4" in <process "process"[K0594]>
E PI   ACTIVATING             - #1926->#1920 K0596 - START_EVENT "startEv..de75bc4" in <process "process"[K0594]> ElementInstancePath: [K0594 -> K0596] ProcessDefinitionPath: [K0593]
E PI   ACTIVATED              - #1927->#1920 K0596 - START_EVENT "startEv..de75bc4" in <process "process"[K0594]>
C PI   COMPLETE               - #1928->#1920 K0596 - START_EVENT "startEv..de75bc4" in <process "process"[K0594]>
E PI   COMPLETING             - #1929->#1920 K0596 - START_EVENT "startEv..de75bc4" in <process "process"[K0594]>
E PI   COMPLETED              - #1930->#1920 K0596 - START_EVENT "startEv..de75bc4" in <process "process"[K0594]>
E PI   SEQ_FLOW_TAKEN         - #1931->#1920 K0597 - SEQUENCE_FLOW "sequenc..9d84e6b" in <process "process"[K0594]>
C PI   ACTIVATE               - #1932->#1920 K0598 - USER_TASK "my_user_task" in <process "process"[K0594]>
E PI   ACTIVATING             - #1933->#1920 K0598 - USER_TASK "my_user_task" in <process "process"[K0594]> ElementInstancePath: [K0594 -> K0598] ProcessDefinitionPath: [K0593]
E UT   CREATING               - #1934->#1920 K0599 - task @"my_user_task"[K0598] assignee "peregrin" priority '50' in <process "process"[K0594]> (no vars)
E JOB  CREATED                - #1935->#1920 K0600 - K0600 "my_listener_33ee165e-909f-4255-bad9-9d449b71403a_creating" @"my_user_task"[K0598] (TASK_LISTENER[CREATING]), 3 retries, in <process "process"[K0594]> (no vars)
E PI   ACTIVATED              - #1936->#1920 K0598 - USER_TASK "my_user_task" in <process "process"[K0594]>
C JOB  COMPLETE               - #1937->   -1 K0600 - K0600 "my_listener_33ee165e-909f-4255-bad9-9d449b71403a_creating" @""[   -1] -1 retries, in <process ?[?]> (no vars)
E JOB  COMPLETED              - #1938->#1937 K0600 - K0600 "my_listener_33ee165e-909f-4255-bad9-9d449b71403a_creating" @"my_user_task"[K0598] (TASK_LISTENER[CREATING]), 3 retries, in <process "process"[K0594]> (no vars)
C UT   COMPLETE_TASK_LISTENER - #1939->#1937 K0599 - task @"my_user_task"[K0598] assignee "peregrin" priority '50' in <process "process"[K0594]> (no vars)
E UT   CREATED                - #1940->#1937 K0599 - task @"my_user_task"[K0598] assignee "peregrin" priority '50' in <process "process"[K0594]> (no vars)
E UT   ASSIGNING              - #1941->#1937 K0599 - task @"my_user_task"[K0598] assignee "peregrin" priority '50' in <process "process"[K0594]> (no vars)
E JOB  CREATED                - #1942->#1937 K0601 - K0601 "my_listener_33ee165e-909f-4255-bad9-9d449b71403a" @"my_user_task"[K0598] (TASK_LISTENER[ASSIGNING]), 3 retries, in <process "process"[K0594]> (no vars)
C JOB  COMPLETE               - #1943->   -1 K0601 - K0601 "my_listener_33ee165e-909f-4255-bad9-9d449b71403a" @""[   -1] -1 retries, in <process ?[?]> (no vars)
E JOB  COMPLETED              - #1944->#1943 K0601 - K0601 "my_listener_33ee165e-909f-4255-bad9-9d449b71403a" @"my_user_task"[K0598] (TASK_LISTENER[ASSIGNING]), 3 retries, in <process "process"[K0594]> (no vars)
C UT   COMPLETE_TASK_LISTENER - #1945->#1943 K0599 - task @"my_user_task"[K0598] assignee "peregrin" priority '50' in <process "process"[K0594]> (no vars)
E JOB  CREATED                - #1946->#1943 K0602 - K0602 "my_listener_33ee165e-909f-4255-bad9-9d449b71403a_2" @"my_user_task"[K0598] (TASK_LISTENER[ASSIGNING]), 3 retries, in <process "process"[K0594]> (no vars)
C JOB  COMPLETE               - #1947->   -1 K0602 - K0602 "my_listener_33ee165e-909f-4255-bad9-9d449b71403a_2" @""[   -1] -1 retries, in <process ?[?]> (no vars)
E JOB  COMPLETED              - #1948->#1947 K0602 - K0602 "my_listener_33ee165e-909f-4255-bad9-9d449b71403a_2" @"my_user_task"[K0598] (TASK_LISTENER[ASSIGNING]), 3 retries, in <process "process"[K0594]> (no vars)
C UT   COMPLETE_TASK_LISTENER - #1949->#1947 K0599 - task @"my_user_task"[K0598] assignee "peregrin" priority '50' in <process "process"[K0594]> (no vars)
E JOB  CREATED                - #1950->#1947 K0603 - K0603 "my_listener_33ee165e-909f-4255-bad9-9d449b71403a_3" @"my_user_task"[K0598] (TASK_LISTENER[ASSIGNING]), 3 retries, in <process "process"[K0594]> (no vars)
C JOB  COMPLETE               - #1951->   -1 K0603 - K0603 "my_listener_33ee165e-909f-4255-bad9-9d449b71403a_3" @""[   -1] -1 retries, in <process ?[?]> (no vars)
E JOB  COMPLETED              - #1952->#1951 K0603 - K0603 "my_listener_33ee165e-909f-4255-bad9-9d449b71403a_3" @"my_user_task"[K0598] (TASK_LISTENER[ASSIGNING]), 3 retries, in <process "process"[K0594]> (no vars)
C UT   COMPLETE_TASK_LISTENER - #1953->#1951 K0599 - task @"my_user_task"[K0598] assignee "peregrin" priority '50' in <process "process"[K0594]> (no vars)
E UT   ASSIGNED               - #1954->#1951 K0599 - task @"my_user_task"[K0598] assignee "peregrin" priority '50' in <process "process"[K0594]> (no vars)
```

</p>
</details> 

## Related issues

encountered during #28252 