### PR TITLE
Document acceptance test module

### DIFF
--- a/qa/README.md
+++ b/qa/README.md
@@ -3,31 +3,28 @@
 This module contains acceptance tests for the whole Camunda 8 platform. Covering multiple components, if not all together, integrated.
 
 In the following document, we shortly highlight general recommendations and how-tos/examples of how to write them. 
-Ensuring we write such tests in a consistent manner and are able to cover all necessary supported environments.
+Ensuring we write such tests in a consistent manner and can cover all necessary supported environments.
 
 ## General
 
 * For simple cases:
   * Make use of the `@MultiDbTest` annotation (if possible).
-  * Per default, it will make use of the `TestStandaloneBroker` class to reduce the scope to a minimum.
-  * The `@MutliDbTest` annotation will make sure to tag your test as a test that should be executed against multiple secondary storages, like: Elasticsearch (ES), OpenSearch (OS), RDBMS, etc.
+  * By default, it will make use of the `TestStandaloneBroker` class to reduce the scope to a minimum.
+  * The `@MutliDbTest` annotation will make sure to tag your test as a test that should be executed against multiple secondary storage, like Elasticsearch (ES), OpenSearch (OS), RDBMS, etc.
   * The `@MutliDbTest` annotation will mark your test class with `@ExtendsWith` using the `CamundaMultiDBExtension`.
-  * The execution against different secondary storage is done on our CI.yml GitHub workflow, where separate jobs exist. A specific test property is set, for the database type, allowing the extension to configure the test application correctly (specific Exporter, etc.)
+  * The execution against different secondary storage is done on our CI.yml GitHub workflow, where separate jobs exist. A specific test property is set for the database type, allowing the extension to configure the test application correctly (specific Exporter, etc.)
 * For advanced cases:    
   * This might apply when you want to run the complete platform or need to configure the broker test application
-  * For running the complete platform, you can make use of `TestSimpleCamundaApplication`, that bundles all components together.
+  * For running the complete platform, you can make use of `TestSimpleCamundaApplication`, which bundles all components together.
   * With that, you can use `@RegisterExtension` and use the `CamundaMultiDBExtension` directly.
   * This might also be necessary for more sophisticated configurations for the Broker. For example, in case you want to test different or specific authentications, etc.
-
-
-
 
 ## Examples:
 
 ### Simple use case
 
 **Need:**
-* We simply need to validate a feature end to end, with small scope running broker, REST API, and exporter
+* We simply need to validate a feature end to end, with a small scope running broker, REST API, and exporter
 
 ```java
 @MultiDbTest
@@ -63,7 +60,7 @@ public class ProcessDefinitionQueryTest {
 
 **Optional:**
 
-* We might not want to run the test for all secondary storages, as it is not yet supported. We can use the `@DisabledIfSystemProperty` annotation
+* We might not want to run the test for all secondary storage, as it is not yet supported. We can use the `@DisabledIfSystemProperty` annotation
 
 ```java
 @Tag("multi-db-test")

--- a/qa/README.md
+++ b/qa/README.md
@@ -3,28 +3,28 @@
 This module contains acceptance tests for the whole Camunda 8 platform. Covering multiple components, if not all together, integrated.
 
 In the following document, we shortly highlight general recommendations and how-tos/examples of how to write them.
-Ensuring we write such tests in a consistent manner and can cover all necessary supported environments.
+This ensures we consistently write such tests and cover all necessary supported environments.
 
 ## General
 
 * For simple cases:
   * Make use of the `@MultiDbTest` annotation (if possible).
-  * By default, it will make use of the `TestStandaloneBroker` class to reduce the scope to a minimum.
-  * The `@MutliDbTest` annotation will make sure to tag your test as a test that should be executed against multiple secondary storage, like Elasticsearch (ES), OpenSearch (OS), RDBMS, etc.
+  * By default, it will use the `TestStandaloneBroker` class to reduce the scope to a minimum.
+  * The `@MutliDbTest` annotation will ensure that your test is tagged as a test that should be executed against multiple secondary storage, such as Elasticsearch (ES), OpenSearch (OS), RDBMS, etc.
   * The `@MutliDbTest` annotation will mark your test class with `@ExtendsWith` using the `CamundaMultiDBExtension`.
-  * The execution against different secondary storage is done on our CI.yml GitHub workflow, where separate jobs exist. A specific test property is set for the database type, allowing the extension to configure the test application correctly (specific Exporter, etc.)
+  * The execution against different secondary storage is done on our CI.yml GitHub workflow, where separate jobs exist. A specific test property is set for the database type, allowing the extension to configure the test application correctly (specific Exporter, etc.).
 * For advanced cases:
-  * This might apply when you want to run the complete platform or need to configure the broker test application
-  * For running the complete platform, you can make use of `TestSimpleCamundaApplication`, which bundles all components together.
-  * With that, you can use `@RegisterExtension` and use the `CamundaMultiDBExtension` directly.
-  * This might also be necessary for more sophisticated configurations for the Broker. For example, in case you want to test different or specific authentications, etc.
+  * This might apply when you want to run the complete platform or need to configure the broker test application.
+  * To run the complete platform, you can use `TestSimpleCamundaApplication`, which bundles all components together.
+  * With that, you can use `@RegisterExtension` and `CamundaMultiDBExtension` directly.
+  * This might also be necessary for more sophisticated broker configurations, such as testing different or specific authentications.
 
 ## Examples:
 
 ### Simple use case
 
 **Need:**
-* We simply need to validate a feature end to end, with a small scope running broker, REST API, and exporter
+* We need to validate a feature end to end, with a small scope running broker, REST API, and exporter
 
 ```java
 @MultiDbTest
@@ -54,7 +54,7 @@ public class ProcessDefinitionQueryTest {
 
 **Need:**
 
-* We need to configure the broker for certain authentication
+* We need to configure the broker for specific authentication
 * We need to make use of the `@RegisterExtension` to pass in the Broker, pre-configured
 * We need to make sure that the test is tagged with `@Tag("multi-db-test")`
 
@@ -89,13 +89,13 @@ class SomeIT {
 
 ### Authentication E2E tests
 
-There are some special features for the authentication tests that we should highlight here.
+We should highlight some special features for the authentication tests here.
 
-* For the tests, users (that are used in tests) can be predefined annotated with `@UserDefinition` such they are created and an authenticated client is created later
+* For the tests, users (that are used in tests) can be predefined and annotated with `@UserDefinition`. As such, they are created, and an authenticated client is created later.
 * Authenticated clients can be created via `@Authenticated` annotation, specifying a user to be used.
-* Mostly, authentication tests can't use the `@MultiDbTest` annotation as of now, as they need to configure the broker or camunda application specifically
-  * In consequence, they need to be tagged with `@Tag("multi-db-test")` separately to make sure we run tests against all environements
-  * They need to make use of the `@RegisterExtension` to pass in the Broker, pre-configured
+* Mostly, authentication tests can't use the `@MultiDbTest` annotation as of now, as they need to configure the broker or Camunda application specifically
+  * As a consequence, they need to be tagged with `@Tag("multi-db-test")` separately to ensure we run tests against all environments
+  * They need to use the `@RegisterExtension` to pass in the Broker, pre-configured
 
 **Example:**
 

--- a/qa/README.md
+++ b/qa/README.md
@@ -1,0 +1,158 @@
+# Acceptance tests
+
+This module contains acceptance tests for the whole Camunda 8 platform. Covering multiple components, if not all together, integrated.
+
+In the following document, we shortly highlight general recommendations and how-tos/examples of how to write them. 
+Ensuring we write such tests in a consistent manner and are able to cover all necessary supported environments.
+
+## General
+
+* For simple cases:
+  * Make use of the `@MultiDbTest` annotation (if possible).
+  * Per default, it will make use of the `TestStandaloneBroker` class to reduce the scope to a minimum.
+  * The `@MutliDbTest` annotation will make sure to tag your test as a test that should be executed against multiple secondary storages, like: Elasticsearch (ES), OpenSearch (OS), RDBMS, etc.
+  * The `@MutliDbTest` annotation will mark your test class with `@ExtendsWith` using the `CamundaMultiDBExtension`.
+  * The execution against different secondary storage is done on our CI.yml GitHub workflow, where separate jobs exist. A specific test property is set, for the database type, allowing the extension to configure the test application correctly (specific Exporter, etc.)
+* For advanced cases:    
+  * This might apply when you want to run the complete platform or need to configure the broker test application
+  * For running the complete platform, you can make use of `TestSimpleCamundaApplication`, that bundles all components together.
+  * With that, you can use `@RegisterExtension` and use the `CamundaMultiDBExtension` directly.
+  * This might also be necessary for more sophisticated configurations for the Broker. For example, in case you want to test different or specific authentications, etc.
+
+
+
+
+## Examples:
+
+### Simple use case
+
+**Need:**
+* We simply need to validate a feature end to end, with small scope running broker, REST API, and exporter
+
+```java
+@MultiDbTest
+public class ProcessDefinitionQueryTest {
+
+  private static CamundaClient camundaClient; // <- will be injected
+
+  // Some logic to set up tests, like BeforeAll: deploy processes
+
+  @Test
+  void shouldSearchByFromWithLimit() {
+    // when
+    final var resultAll = camundaClient.newProcessDefinitionQuery().send().join();
+    final var thirdKey = resultAll.items().get(2).getProcessDefinitionKey();
+
+    final var resultSearchFrom =
+        camundaClient.newProcessDefinitionQuery().page(p -> p.limit(2).from(2)).send().join();
+
+    // then
+    assertThat(resultSearchFrom.items().size()).isEqualTo(2);
+    assertThat(resultSearchFrom.items().stream().findFirst().get().getProcessDefinitionKey())
+        .isEqualTo(thirdKey);
+  }
+```
+
+### Advanced use case
+
+**Need:**
+
+* We need to configure the broker for certain authentication
+* We need to make use of the `@RegisterExtension` to pass in the Broker, pre-configured
+* We need to make sure that the test is tagged with `@Tag("multi-db-test")`
+
+**Optional:**
+
+* We might not want to run the test for all secondary storages, as it is not yet supported. We can use the `@DisabledIfSystemProperty` annotation
+
+```java
+@Tag("multi-db-test")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+class SomeIT {
+
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
+
+  @RegisterExtension
+  static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(BROKER);
+
+  private static CamundaClient camundaClient; // <- will be injected
+
+  @Test
+  void someTest() {
+    // when
+    final var processDefinitions = client.newProcessDefinitionQuery().send().join().items();
+
+    // then
+    assertThat(processDefinitions).hasSize(2);
+    assertThat(processDefinitions.stream().map(p -> p.getProcessDefinitionId()).toList())
+        .containsExactlyInAnyOrder("service_tasks_v1", "service_tasks_v2");
+  }
+```
+
+### Authentication E2E tests
+
+There are some special features for the authentication tests that we should highlight here.
+
+ * For the tests, users (that are used in tests) can be predefined annotated with `@UserDefinition` such they are created and an authenticated client is created later
+ * Authenticated clients can be created via `@Authenticated` annotation, specifying a user to be used.
+ * Mostly, authentication tests can't use the `@MultiDbTest` annotation as of now, as they need to configure the broker or camunda application specifically
+   * In consequence, they need to be tagged with `@Tag("multi-db-test")` separately to make sure we run tests against all environements
+   * They need to make use of the `@RegisterExtension` to pass in the Broker, pre-configured
+
+**Example:**
+
+```java
+@Tag("multi-db-test")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
+class ProcessAuthorizationIT {
+
+  static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
+
+  @RegisterExtension
+  static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(BROKER);
+
+  private static final String ADMIN = "admin";
+  private static final String RESTRICTED = "restricted-user";
+
+  @UserDefinition
+  private static final User ADMIN_USER =
+      new User(
+          ADMIN,
+          "password",
+          List.of(
+              new Permissions(RESOURCE, CREATE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_DEFINITION, List.of("*"))));
+
+  @UserDefinition
+  private static final User RESTRICTED_USER =
+      new User(
+          RESTRICTED,
+          "password",
+          List.of(
+              new Permissions(
+                  PROCESS_DEFINITION,
+                  READ_PROCESS_DEFINITION,
+                  List.of("service_tasks_v1", "service_tasks_v2"))));
+
+  @BeforeAll
+  static void setUp(@Authenticated(ADMIN) final CamundaClient adminClient) {
+    final List<String> processes =
+        List.of("service_tasks_v1.bpmn", "service_tasks_v2.bpmn", "incident_process_v1.bpmn");
+    processes.forEach(process -> deployResource(adminClient, String.format("process/%s", process)));
+    waitForProcessesToBeDeployed(adminClient, processes.size());
+  }
+
+  @Test
+  void searchShouldReturnAuthorizedProcessDefinitions(
+      @Authenticated(RESTRICTED) final CamundaClient userClient) {
+    // when
+    final var processDefinitions = userClient.newProcessDefinitionQuery().send().join().items();
+
+    // then
+    assertThat(processDefinitions).hasSize(2);
+    assertThat(processDefinitions.stream().map(p -> p.getProcessDefinitionId()).toList())
+        .containsExactlyInAnyOrder("service_tasks_v1", "service_tasks_v2");
+  }
+```

--- a/qa/README.md
+++ b/qa/README.md
@@ -2,7 +2,7 @@
 
 This module contains acceptance tests for the whole Camunda 8 platform. Covering multiple components, if not all together, integrated.
 
-In the following document, we shortly highlight general recommendations and how-tos/examples of how to write them. 
+In the following document, we shortly highlight general recommendations and how-tos/examples of how to write them.
 Ensuring we write such tests in a consistent manner and can cover all necessary supported environments.
 
 ## General
@@ -13,7 +13,7 @@ Ensuring we write such tests in a consistent manner and can cover all necessary 
   * The `@MutliDbTest` annotation will make sure to tag your test as a test that should be executed against multiple secondary storage, like Elasticsearch (ES), OpenSearch (OS), RDBMS, etc.
   * The `@MutliDbTest` annotation will mark your test class with `@ExtendsWith` using the `CamundaMultiDBExtension`.
   * The execution against different secondary storage is done on our CI.yml GitHub workflow, where separate jobs exist. A specific test property is set for the database type, allowing the extension to configure the test application correctly (specific Exporter, etc.)
-* For advanced cases:    
+* For advanced cases:
   * This might apply when you want to run the complete platform or need to configure the broker test application
   * For running the complete platform, you can make use of `TestSimpleCamundaApplication`, which bundles all components together.
   * With that, you can use `@RegisterExtension` and use the `CamundaMultiDBExtension` directly.
@@ -91,11 +91,11 @@ class SomeIT {
 
 There are some special features for the authentication tests that we should highlight here.
 
- * For the tests, users (that are used in tests) can be predefined annotated with `@UserDefinition` such they are created and an authenticated client is created later
- * Authenticated clients can be created via `@Authenticated` annotation, specifying a user to be used.
- * Mostly, authentication tests can't use the `@MultiDbTest` annotation as of now, as they need to configure the broker or camunda application specifically
-   * In consequence, they need to be tagged with `@Tag("multi-db-test")` separately to make sure we run tests against all environements
-   * They need to make use of the `@RegisterExtension` to pass in the Broker, pre-configured
+* For the tests, users (that are used in tests) can be predefined annotated with `@UserDefinition` such they are created and an authenticated client is created later
+* Authenticated clients can be created via `@Authenticated` annotation, specifying a user to be used.
+* Mostly, authentication tests can't use the `@MultiDbTest` annotation as of now, as they need to configure the broker or camunda application specifically
+  * In consequence, they need to be tagged with `@Tag("multi-db-test")` separately to make sure we run tests against all environements
+  * They need to make use of the `@RegisterExtension` to pass in the Broker, pre-configured
 
 **Example:**
 
@@ -153,3 +153,4 @@ class ProcessAuthorizationIT {
         .containsExactlyInAnyOrder("service_tasks_v1", "service_tasks_v2");
   }
 ```
+

--- a/qa/README.md
+++ b/qa/README.md
@@ -1,6 +1,6 @@
 # Acceptance tests
 
-This module contains acceptance tests for the whole Camunda 8 platform. Covering multiple components, if not all together, integrated.
+This module contains acceptance tests for the whole Camunda 8 platform, covering multiple or even all components at the same time in an integrated manner.
 
 In the following document, we shortly highlight general recommendations and how-tos/examples of how to write them.
 This ensures we consistently write such tests and cover all necessary supported environments.


### PR DESCRIPTION
## Description

*  Write down certain information how to write new acceptance tests (right now still called `qa/it`, but this will change).
* Cover multidb usage, and special cases for authentication

> [!Note]
>
> Pretty sure it is far from perfect, but might be sufficient for the first iteration.


## Related issues

related https://github.com/camunda/camunda/issues/28159
