### PR TITLE
[Backport stable/8.6] fix: allow overriding env vars set by c8run

### DIFF
--- a/c8run/main.go
+++ b/c8run/main.go
@@ -325,16 +325,9 @@ func main() {
 			fmt.Print("JAVA_OPTS: " + javaOpts + "\n")
 		}
 
-<<<<<<< HEAD
-		os.Setenv("ES_JAVA_OPTS", "-Xms1g -Xmx1g")
-
-		fmt.Print("Starting Elasticsearch " + elasticsearchVersion + "...\n")
-		fmt.Print("(Hint: you can find the log output in the 'elasticsearch.log' file in the 'log' folder of your distribution.)\n")
-=======
 		if !settings.disableElasticsearch {
 			fmt.Print("Starting Elasticsearch " + elasticsearchVersion + "...\n")
 			fmt.Print("(Hint: you can find the log output in the 'elasticsearch.log' file in the 'log' folder of your distribution.)\n")
->>>>>>> e8f9e22f (fix: if someone explicitly overrides these env vars, use override)
 
 		elasticsearchLogFilePath := filepath.Join(parentDir, "log", "elasticsearch.log")
 		elasticsearchLogFile, err := os.OpenFile(elasticsearchLogFilePath, os.O_RDWR|os.O_CREATE, 0644)

--- a/c8run/main.go
+++ b/c8run/main.go
@@ -140,7 +140,7 @@ func usage(exitcode int) {
 	os.Exit(exitcode)
 }
 
-func setEnvVars() error {
+func setEnvVars(javaHome string) error {
 	envVars := map[string]string{
 		"CAMUNDA_OPERATE_CSRFPREVENTIONENABLED":                  "false",
 		"CAMUNDA_OPERATE_IMPORTER_READERBACKOFF":                 "1000",
@@ -151,9 +151,15 @@ func setEnvVars() error {
 		"ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_PREFIX": "zeebe-record",
 		"ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL":          "http://localhost:9200",
 		"ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME":         "io.camunda.zeebe.exporter.ElasticsearchExporter",
+		"ES_JAVA_HOME": javaHome,
+		"ES_JAVA_OPTS": "-Xms1g -Xmx1g",
 	}
 
 	for key, value := range envVars {
+		currentValue := os.Getenv(key)
+		if currentValue != "" {
+			continue
+		}
 		if err := os.Setenv(key, value); err != nil {
 			return fmt.Errorf("failed to set environment variable %s: %w", key, err)
 		}
@@ -227,11 +233,6 @@ func main() {
 	connectorsPidPath := filepath.Join(baseDir, "connectors.pid")
 	camundaPidPath := filepath.Join(baseDir, "camunda.pid")
 
-	err = setEnvVars()
-	if err != nil {
-		fmt.Println("Failed to set envVars:", err)
-	}
-
 	baseCommand, err := getBaseCommand()
 	if err != nil {
 		fmt.Println(err.Error())
@@ -279,7 +280,11 @@ func main() {
 		javaHome = filepath.Dir(filepath.Dir(path))
 		javaBinary = path
 	}
-	os.Setenv("ES_JAVA_HOME", javaHome)
+
+	err = setEnvVars(javaHome)
+	if err != nil {
+		fmt.Println("Failed to set envVars:", err)
+	}
 
 	if baseCommand == "start" {
 		javaVersion := os.Getenv("JAVA_VERSION")
@@ -320,10 +325,16 @@ func main() {
 			fmt.Print("JAVA_OPTS: " + javaOpts + "\n")
 		}
 
+<<<<<<< HEAD
 		os.Setenv("ES_JAVA_OPTS", "-Xms1g -Xmx1g")
 
 		fmt.Print("Starting Elasticsearch " + elasticsearchVersion + "...\n")
 		fmt.Print("(Hint: you can find the log output in the 'elasticsearch.log' file in the 'log' folder of your distribution.)\n")
+=======
+		if !settings.disableElasticsearch {
+			fmt.Print("Starting Elasticsearch " + elasticsearchVersion + "...\n")
+			fmt.Print("(Hint: you can find the log output in the 'elasticsearch.log' file in the 'log' folder of your distribution.)\n")
+>>>>>>> e8f9e22f (fix: if someone explicitly overrides these env vars, use override)
 
 		elasticsearchLogFilePath := filepath.Join(parentDir, "log", "elasticsearch.log")
 		elasticsearchLogFile, err := os.OpenFile(elasticsearchLogFilePath, os.O_RDWR|os.O_CREATE, 0644)


### PR DESCRIPTION
# Description
Backport of #28840 to `stable/8.6`.

relates to 