### PR TITLE
fix: use forwardslash for file headers in c8run zip

### DIFF
--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -67,7 +67,7 @@ jobs:
         shell: bash
         id: build-dist
         run: |
-          ./mvnw -B -T1C -DskipTests -DskipChecks -Dflatten.skip=true package
+          ./mvnw -B -T1C -DskipTests -DskipChecks -Dflatten.skip=true -Dskip.fe.build=false package
           export ARTIFACT=$(./mvnw -pl dist/ help:evaluate -Dexpression=project.build.finalName -q -DforceStdout)
           echo "distball=dist/target/${ARTIFACT}.tar.gz" >> $GITHUB_OUTPUT
           echo "distzip=dist/target/${ARTIFACT}.zip" >> $GITHUB_OUTPUT

--- a/c8run/e2e_tests/api_tests.sh
+++ b/c8run/e2e_tests/api_tests.sh
@@ -44,7 +44,7 @@ fi
 
 printf "\nTest: test --config flag\n"
 
-PREFIX="$( curl localhost:9600/actuator/configprops | jq '.contexts.application.beans.["io.camunda.tasklist.property.TasklistProperties"].properties.zeebeElasticsearch.prefix' )"
+PREFIX="$( curl localhost:9600/actuator/configprops | jq '.contexts.Camunda.beans.["io.camunda.tasklist.property.TasklistProperties"].properties.zeebeElasticsearch.prefix' )"
 echo $PREFIX
 if [[ "$PREFIX" != "\"extra-prefix-zeebe-record\"" ]]; then
    echo "test failed"

--- a/c8run/internal/archive/archive.go
+++ b/c8run/internal/archive/archive.go
@@ -226,10 +226,12 @@ func ZipSource(sources []string, target string) error {
 			header.Method = zip.Deflate
 
 			header.Name, err = filepath.Rel(filepath.Dir(source), path)
+			header.Name = strings.ReplaceAll(header.Name, "\\", "/")
 			if err != nil {
 				return fmt.Errorf("ZipSource: failed to determine relative path for %s\n%w\n%s", path, err, debug.Stack())
 			}
 			if info.IsDir() {
+				header.Name = strings.ReplaceAll(header.Name, "\\", "/")
 				header.Name += "/"
 			}
 


### PR DESCRIPTION
## Description

The golang zip library expects filenames to use forwardslashes instead of backslashes despite the OS differences between windows and linux. 

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/camunda/issues/29010
