### PR TITLE
Extend quickly build

### DIFF
--- a/identity/pom.xml
+++ b/identity/pom.xml
@@ -20,7 +20,6 @@
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit-jupiter-api.version>5.10.2</junit-jupiter-api.version>
-    <skip.fe.build>false</skip.fe.build>
   </properties>
 
   <dependencies>

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -35,7 +35,6 @@
     <maven.compiler.target>21</maven.compiler.target>
     <maven.compiler.source>21</maven.compiler.source>
 
-    <skip.fe.build>false</skip.fe.build>
     <skipSurefire>false</skipSurefire>
     <testForkCount>${env.LIMITS_CPU}</testForkCount>
     <includeITNames>**/*IT.java</includeITNames>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -268,6 +268,8 @@
     <!-- disable other non-essential goals -->
     <flatten.skip>${quickly}</flatten.skip>
     <assembly.skipAssembly>${quickly}</assembly.skipAssembly>
+    <!-- disable frontend yarn builds -->
+    <skip.fe.build>${quickly}</skip.fe.build>
   </properties>
 
   <dependencyManagement>

--- a/tasklist/pom.xml
+++ b/tasklist/pom.xml
@@ -37,7 +37,6 @@
     <maven.compiler.target>21</maven.compiler.target>
     <maven.compiler.source>21</maven.compiler.source>
 
-    <skip.fe.build>false</skip.fe.build>
     <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 


### PR DESCRIPTION
## Description

Previously, `skip.fe.build` need to be configured separately. This commit allows to set `skip.fe.build=true` when quickly is set

Furthermore, removes the default definitions in Identity, Tasklist, and Operate, to avoid unnecessary clashes or overrides.

