### PR TITLE
test: ensure gRPC gateway security config is consistent with REST

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/EmbeddedGatewayAuthenticationIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/EmbeddedGatewayAuthenticationIdentityIT.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.gateway;
+
+import io.camunda.application.Profile;
+import io.camunda.zeebe.gateway.impl.configuration.AuthenticationCfg.AuthMode;
+import io.camunda.zeebe.qa.util.cluster.TestGateway;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+
+public class EmbeddedGatewayAuthenticationIdentityIT
+    extends GatewayAuthenticationIdentityAbstractIT<TestStandaloneBroker> {
+
+  private final TestStandaloneBroker zeebe =
+      new TestStandaloneBroker()
+          .withAdditionalProfile(Profile.IDENTITY_AUTH)
+          .withBrokerConfig(
+              cfg -> {
+                final var auth = cfg.getGateway().getSecurity().getAuthentication();
+                auth.setMode(AuthMode.IDENTITY);
+              })
+          .withProperty("camunda.identity.issuerBackendUrl", getKeycloakRealmAddress())
+          .withProperty("camunda.identity.audience", ZEEBE_CLIENT_AUDIENCE);
+
+  @Override
+  protected TestGateway getZeebe() {
+    return zeebe;
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/EmbeddedGatewayAuthenticationIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/EmbeddedGatewayAuthenticationIdentityIT.java
@@ -27,7 +27,7 @@ public class EmbeddedGatewayAuthenticationIdentityIT
           .withProperty("camunda.identity.audience", ZEEBE_CLIENT_AUDIENCE);
 
   @Override
-  protected TestGateway getZeebe() {
+  protected TestGateway<TestStandaloneBroker> getGateway() {
     return zeebe;
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/EmbeddedGatewayAuthenticationNoneIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/EmbeddedGatewayAuthenticationNoneIT.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.gateway;
+
+import io.camunda.application.Profile;
+import io.camunda.zeebe.qa.util.cluster.TestGateway;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+
+public class EmbeddedGatewayAuthenticationNoneIT
+    extends GatewayAuthenticationNoneAbstractIT<TestStandaloneBroker> {
+
+  private final TestStandaloneBroker zeebe =
+      new TestStandaloneBroker()
+          .withAdditionalProfile(Profile.IDENTITY_AUTH)
+          .withProperty("zeebe.broker.gateway.security.authentication.mode", "none")
+          .withProperty("camunda.identity.issuerBackendUrl", getKeycloakRealmAddress())
+          .withProperty("camunda.identity.audience", ZEEBE_CLIENT_AUDIENCE);
+
+  @Override
+  protected TestGateway getZeebe() {
+    return zeebe;
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/EmbeddedGatewayAuthenticationNoneIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/EmbeddedGatewayAuthenticationNoneIT.java
@@ -22,7 +22,7 @@ public class EmbeddedGatewayAuthenticationNoneIT
           .withProperty("camunda.identity.audience", ZEEBE_CLIENT_AUDIENCE);
 
   @Override
-  protected TestGateway getZeebe() {
+  protected TestGateway<TestStandaloneBroker> getGateway() {
     return zeebe;
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationIdentityAbstractIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationIdentityAbstractIT.java
@@ -10,26 +10,30 @@ package io.camunda.zeebe.it.gateway;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import dasniko.testcontainers.keycloak.KeycloakContainer;
-import io.camunda.application.Profile;
 import io.camunda.identity.sdk.Identity;
 import io.camunda.zeebe.client.CredentialsProvider;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.ZeebeClientBuilder;
 import io.camunda.zeebe.client.api.command.CommandWithCommunicationApiStep;
+import io.camunda.zeebe.client.api.command.ProblemException;
 import io.camunda.zeebe.client.api.command.TopologyRequestStep1;
-import io.camunda.zeebe.client.api.response.Topology;
-import io.camunda.zeebe.qa.util.cluster.TestHealthProbe;
-import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestGateway;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.qa.util.testcontainers.DefaultTestContainers;
 import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
+import io.grpc.Status;
+import io.grpc.Status.Code;
+import io.grpc.StatusRuntimeException;
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.function.Supplier;
+import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
+import org.apache.hc.core5.http.HttpStatus;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.assertj.core.api.ThrowableAssertAlternative;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -43,24 +47,18 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
-/**
- * This test is mostly a copy of {@link GatewayAuthenticationIdentityIT} but with the authentication
- * mode set to none. It verifies that the gateway can be configured to not require authentication,
- * even when the {@link Profile#IDENTITY_AUTH} profile is active. In other words, users must be able
- * to override the security configuration with env vars.
- */
 @Testcontainers
 @ZeebeIntegration
-public class GatewayAuthenticationNoneIT {
+public abstract class GatewayAuthenticationIdentityAbstractIT<T extends TestGateway<T>> {
 
   public static final String KEYCLOAK_USER = "admin";
   public static final String KEYCLOAK_PASSWORD = "admin";
   // with authentication enabled, the first grpc response includes the warmup of the identity sdk
   public static final Duration FIRST_REQUEST_TIMEOUT = Duration.ofSeconds(5);
   public static final String SNAPSHOT_TAG = "SNAPSHOT";
+  protected static final String ZEEBE_CLIENT_AUDIENCE = "zeebe-api";
   private static final String KEYCLOAK_PATH_CAMUNDA_REALM = "/realms/camunda-platform";
   private static final String ZEEBE_CLIENT_ID = "zeebe";
-  private static final String ZEEBE_CLIENT_AUDIENCE = "zeebe-api";
   private static final String ZEEBE_CLIENT_SECRET = "zecret";
   private static final Network NETWORK = Network.newNetwork();
 
@@ -117,44 +115,48 @@ public class GatewayAuthenticationNoneIT {
   final ContainerLogsDumper logsWatcher =
       new ContainerLogsDumper(() -> Map.of("keycloak", KEYCLOAK, "identity", IDENTITY));
 
-  @TestZeebe(autoStart = false) // must configure in BeforeAll once containers have been started
-  private final TestStandaloneBroker zeebe =
-      new TestStandaloneBroker()
-          .withAdditionalProfile(Profile.IDENTITY_AUTH)
-          .withProperty("zeebe.broker.gateway.security.authentication.mode", "none")
-          .withProperty("camunda.identity.issuerBackendUrl", getKeycloakRealmAddress())
-          .withProperty("camunda.identity.audience", ZEEBE_CLIENT_AUDIENCE);
-
   @BeforeEach
   void beforeEach() {
-    zeebe.start().await(TestHealthProbe.READY);
+    getZeebe().start();
   }
 
   @ParameterizedTest
-  @MethodSource("provideAPIs")
-  void getTopologyRequestSucceedsWithInvalidAuthToken(
-      final UnaryOperator<TopologyRequestStep1> apiPicker) {
+  @MethodSource("provideInvalidTokenCases")
+  void getTopologyRequestFailsWithInvalidAuthToken(final InvalidTokenTestCase testCase) {
     // given
     try (final var client =
         createZeebeClientBuilder().credentialsProvider(new InvalidAuthTokenProvider()).build()) {
-      // when / then
-      sendRequestAndAssertSuccess(apiPicker, client::newTopologyRequest);
+      // when
+      final Future<?> topologyFuture = testCase.apiPicker.apply(client.newTopologyRequest()).send();
+
+      // then
+      final var assertion =
+          assertThat(topologyFuture)
+              .failsWithin(FIRST_REQUEST_TIMEOUT)
+              .withThrowableOfType(ExecutionException.class);
+      testCase.expectations.accept(assertion);
     }
   }
 
   @ParameterizedTest
-  @MethodSource("provideAPIs")
-  void getTopologyRequestSucceedsWithoutAuthToken(
-      final UnaryOperator<TopologyRequestStep1> apiPicker) {
+  @MethodSource("provideInvalidTokenCases")
+  void getTopologyRequestFailsWithoutAuthToken(final InvalidTokenTestCase testCase) {
     // given
     try (final var client = createZeebeClientBuilder().build()) {
-      // when / then
-      sendRequestAndAssertSuccess(apiPicker, client::newTopologyRequest);
+      // when
+      final Future<?> topologyFuture = testCase.apiPicker.apply(client.newTopologyRequest()).send();
+
+      // then
+      final var assertion =
+          assertThat(topologyFuture)
+              .failsWithin(FIRST_REQUEST_TIMEOUT)
+              .withThrowableOfType(ExecutionException.class);
+      testCase.expectations.accept(assertion);
     }
   }
 
   @ParameterizedTest
-  @MethodSource("provideAPIs")
+  @MethodSource("provideValidTokenCases")
   void getTopologyRequestSucceedsWithValidAuthToken(
       final UnaryOperator<TopologyRequestStep1> apiPicker) {
     // given
@@ -169,31 +171,49 @@ public class GatewayAuthenticationNoneIT {
                         getKeycloakRealmAddress() + "/protocol/openid-connect/token")
                     .build())
             .build()) {
-      // when / then
-      sendRequestAndAssertSuccess(apiPicker, client::newTopologyRequest);
+
+      // when
+      final Future<io.camunda.zeebe.client.api.response.Topology> topologyFuture =
+          apiPicker.apply(client.newTopologyRequest()).send();
+
+      // then
+      assertThat(topologyFuture).succeedsWithin(FIRST_REQUEST_TIMEOUT);
+      // second request should be faster, given the first request warmed up the token validation
+      assertThat(client.newTopologyRequest().send().toCompletableFuture())
+          .succeedsWithin(Duration.ofSeconds(1));
     }
   }
 
-  private static Stream<Named<UnaryOperator<TopologyRequestStep1>>> provideAPIs() {
+  private static Stream<Named<UnaryOperator<TopologyRequestStep1>>> provideValidTokenCases() {
     return Stream.of(
         Named.of("grpc", CommandWithCommunicationApiStep::useGrpc),
         Named.of("rest", CommandWithCommunicationApiStep::useRest));
   }
 
-  private static void sendRequestAndAssertSuccess(
-      final UnaryOperator<TopologyRequestStep1> apiPicker,
-      final Supplier<TopologyRequestStep1> requestSupplier) {
-    // when
-    final Future<Topology> topologyFuture = apiPicker.apply(requestSupplier.get()).send();
-
-    // then
-    assertThat(topologyFuture).succeedsWithin(FIRST_REQUEST_TIMEOUT);
-    // second request should be faster, given the first request warmed up the token validation
-    assertThat(apiPicker.apply(requestSupplier.get()).send().toCompletableFuture())
-        .succeedsWithin(Duration.ofSeconds(1));
+  private static Stream<Named<InvalidTokenTestCase>> provideInvalidTokenCases() {
+    return Stream.of(
+        Named.of(
+            "grpc",
+            new InvalidTokenTestCase(
+                CommandWithCommunicationApiStep::useGrpc,
+                assertion ->
+                    assertion
+                        .havingCause()
+                        .asInstanceOf(InstanceOfAssertFactories.type(StatusRuntimeException.class))
+                        .extracting(StatusRuntimeException::getStatus)
+                        .returns(Code.UNAUTHENTICATED, Status::getCode))),
+        Named.of(
+            "rest",
+            new InvalidTokenTestCase(
+                CommandWithCommunicationApiStep::useRest,
+                assertion ->
+                    assertion
+                        .havingCause()
+                        .asInstanceOf(InstanceOfAssertFactories.type(ProblemException.class))
+                        .returns(HttpStatus.SC_UNAUTHORIZED, ProblemException::code))));
   }
 
-  private static String getKeycloakRealmAddress() {
+  protected static String getKeycloakRealmAddress() {
     return "http://"
         + KEYCLOAK.getHost()
         + ":"
@@ -203,8 +223,8 @@ public class GatewayAuthenticationNoneIT {
 
   private ZeebeClientBuilder createZeebeClientBuilder() {
     return ZeebeClient.newClientBuilder()
-        .grpcAddress(zeebe.grpcAddress())
-        .restAddress(zeebe.restAddress())
+        .grpcAddress(getZeebe().grpcAddress())
+        .restAddress(getZeebe().restAddress())
         .defaultRequestTimeout(Duration.ofMinutes(1))
         .usePlaintext();
   }
@@ -216,6 +236,12 @@ public class GatewayAuthenticationNoneIT {
 
     return dockerImageTag.contains("SNAPSHOT") ? SNAPSHOT_TAG : dockerImageTag;
   }
+
+  protected abstract TestGateway<T> getZeebe();
+
+  protected record InvalidTokenTestCase(
+      UnaryOperator<TopologyRequestStep1> apiPicker,
+      Consumer<ThrowableAssertAlternative<?>> expectations) {}
 
   private static final class InvalidAuthTokenProvider implements CredentialsProvider {
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationIdentityAbstractIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationIdentityAbstractIT.java
@@ -117,7 +117,7 @@ public abstract class GatewayAuthenticationIdentityAbstractIT<T extends TestGate
 
   @BeforeEach
   void beforeEach() {
-    getZeebe().start();
+    getGateway().start();
   }
 
   @ParameterizedTest
@@ -223,8 +223,8 @@ public abstract class GatewayAuthenticationIdentityAbstractIT<T extends TestGate
 
   private ZeebeClientBuilder createZeebeClientBuilder() {
     return ZeebeClient.newClientBuilder()
-        .grpcAddress(getZeebe().grpcAddress())
-        .restAddress(getZeebe().restAddress())
+        .grpcAddress(getGateway().grpcAddress())
+        .restAddress(getGateway().restAddress())
         .defaultRequestTimeout(Duration.ofMinutes(1))
         .usePlaintext();
   }
@@ -237,7 +237,7 @@ public abstract class GatewayAuthenticationIdentityAbstractIT<T extends TestGate
     return dockerImageTag.contains("SNAPSHOT") ? SNAPSHOT_TAG : dockerImageTag;
   }
 
-  protected abstract TestGateway<T> getZeebe();
+  protected abstract TestGateway<T> getGateway();
 
   protected record InvalidTokenTestCase(
       UnaryOperator<TopologyRequestStep1> apiPicker,

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationNoneAbstractIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationNoneAbstractIT.java
@@ -117,7 +117,7 @@ public abstract class GatewayAuthenticationNoneAbstractIT<T extends TestGateway<
 
   @BeforeEach
   void beforeEach() {
-    getZeebe().start();
+    getGateway().start();
   }
 
   @ParameterizedTest
@@ -193,8 +193,8 @@ public abstract class GatewayAuthenticationNoneAbstractIT<T extends TestGateway<
 
   private ZeebeClientBuilder createZeebeClientBuilder() {
     return ZeebeClient.newClientBuilder()
-        .grpcAddress(getZeebe().grpcAddress())
-        .restAddress(getZeebe().restAddress())
+        .grpcAddress(getGateway().grpcAddress())
+        .restAddress(getGateway().restAddress())
         .defaultRequestTimeout(Duration.ofMinutes(1))
         .usePlaintext();
   }
@@ -207,7 +207,7 @@ public abstract class GatewayAuthenticationNoneAbstractIT<T extends TestGateway<
     return dockerImageTag.contains("SNAPSHOT") ? SNAPSHOT_TAG : dockerImageTag;
   }
 
-  protected abstract TestGateway<T> getZeebe();
+  protected abstract TestGateway<T> getGateway();
 
   private static final class InvalidAuthTokenProvider implements CredentialsProvider {
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/StandaloneGatewayAuthenticationIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/StandaloneGatewayAuthenticationIdentityIT.java
@@ -28,7 +28,7 @@ public class StandaloneGatewayAuthenticationIdentityIT
           .withProperty("camunda.identity.audience", ZEEBE_CLIENT_AUDIENCE);
 
   @Override
-  protected TestGateway getZeebe() {
+  protected TestGateway<TestStandaloneGateway> getGateway() {
     return zeebe;
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/StandaloneGatewayAuthenticationIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/StandaloneGatewayAuthenticationIdentityIT.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.gateway;
+
+import io.camunda.application.Profile;
+import io.camunda.zeebe.gateway.impl.configuration.AuthenticationCfg.AuthMode;
+import io.camunda.zeebe.qa.util.cluster.TestGateway;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneGateway;
+
+public class StandaloneGatewayAuthenticationIdentityIT
+    extends GatewayAuthenticationIdentityAbstractIT<TestStandaloneGateway> {
+
+  private final TestStandaloneGateway zeebe =
+      new TestStandaloneGateway()
+          .withAdditionalProfile(Profile.IDENTITY_AUTH)
+          .withGatewayConfig(
+              cfg -> {
+                final var auth = cfg.getSecurity().getAuthentication();
+                auth.setMode(AuthMode.IDENTITY);
+              })
+          .withProperty("zeebe.gateway.enable", "true")
+          .withProperty("camunda.identity.issuerBackendUrl", getKeycloakRealmAddress())
+          .withProperty("camunda.identity.audience", ZEEBE_CLIENT_AUDIENCE);
+
+  @Override
+  protected TestGateway getZeebe() {
+    return zeebe;
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/StandaloneGatewayAuthenticationNoneIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/StandaloneGatewayAuthenticationNoneIT.java
@@ -27,7 +27,7 @@ public class StandaloneGatewayAuthenticationNoneIT
           .withProperty("camunda.identity.audience", ZEEBE_CLIENT_AUDIENCE);
 
   @Override
-  protected TestGateway getZeebe() {
+  protected TestGateway<TestStandaloneGateway> getGateway() {
     return zeebe;
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/StandaloneGatewayAuthenticationNoneIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/StandaloneGatewayAuthenticationNoneIT.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.gateway;
+
+import io.camunda.application.Profile;
+import io.camunda.zeebe.gateway.impl.configuration.AuthenticationCfg.AuthMode;
+import io.camunda.zeebe.qa.util.cluster.TestGateway;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneGateway;
+
+public class StandaloneGatewayAuthenticationNoneIT
+    extends GatewayAuthenticationNoneAbstractIT<TestStandaloneGateway> {
+
+  private final TestStandaloneGateway zeebe =
+      new TestStandaloneGateway()
+          .withAdditionalProfile(Profile.IDENTITY_AUTH)
+          .withGatewayConfig(
+              cfg -> {
+                final var auth = cfg.getSecurity().getAuthentication();
+                auth.setMode(AuthMode.NONE);
+              })
+          .withProperty("camunda.identity.issuerBackendUrl", getKeycloakRealmAddress())
+          .withProperty("camunda.identity.audience", ZEEBE_CLIENT_AUDIENCE);
+
+  @Override
+  protected TestGateway getZeebe() {
+    return zeebe;
+  }
+}


### PR DESCRIPTION
## Description

This PR is adding more integration tests to verify that the REST and gRPC behaviors are consistent for both standalone and embedded gateway authentication modes.

Already existing tests coverage :
- REST/gRPC embedded gateway with security mode NONE
- REST/gRPC embedded gateway with security mode IDENTITY

This PR is adding :
- REST/gRPC standalone gateway with security mode NONE
- REST/gRPC standalone gateway with security mode IDENTITY

## Related issues

related to #28859
follow-up issue from #27234