### PR TITLE
[Backport stable/8.7] Fix dependency management: use specified versions

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1066,22 +1066,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-webflux</artifactId>
-        <version>${version.spring-boot}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-to-slf4j</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-broker</artifactId>
         <version>${project.version}</version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -952,15 +952,12 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-<<<<<<< HEAD
-=======
 
       <dependency>
         <groupId>com.nimbusds</groupId>
         <artifactId>oauth2-oidc-sdk</artifactId>
         <version>${version.nimbus-sdk}</version>
       </dependency>
->>>>>>> 9f505bf7 (deps: move POM/IMPORT before Spring to allow us to specify desired versions)
 
       <dependency>
         <groupId>org.springframework.boot</groupId>
@@ -1301,31 +1298,12 @@
       </dependency>
 
       <dependency>
-<<<<<<< HEAD
-        <groupId>io.netty</groupId>
-        <artifactId>netty-bom</artifactId>
-        <version>${version.netty}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
         <groupId>io.projectreactor.netty</groupId>
         <artifactId>reactor-netty-http</artifactId>
         <version>${version.reactor-netty}</version>
       </dependency>
 
       <dependency>
-        <groupId>io.micrometer</groupId>
-        <artifactId>micrometer-bom</artifactId>
-        <version>${version.micrometer}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
-=======
->>>>>>> 9f505bf7 (deps: move POM/IMPORT before Spring to allow us to specify desired versions)
         <groupId>org.elasticsearch.client</groupId>
         <artifactId>elasticsearch-rest-client</artifactId>
         <version>${version.elasticsearch}</version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -81,7 +81,7 @@
     <version.prometheus>0.16.0</version.prometheus>
     <version.protobuf>3.25.6</version.protobuf>
     <version.protobuf-common>2.44.0</version.protobuf-common>
-    <version.micrometer>1.13.6</version.micrometer>
+    <version.micrometer>1.14.4</version.micrometer>
     <version.rocksdbjni>9.4.0</version.rocksdbjni>
     <version.sbe>1.33.2</version.sbe>
     <version.scala>2.13.16</version.scala>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -178,7 +178,6 @@
     <version.jwks-rsa>0.22.1</version.jwks-rsa>
     <version.guava.annotations>r03</version.guava.annotations>
     <version.nimbus-jose-jwt>9.41.2</version.nimbus-jose-jwt>
-    <version.nimbus-sdk>11.23.1</version.nimbus-sdk>
     <version.keycloak>26.0.6</version.keycloak>
     <version.keycloak-client>26.0.4</version.keycloak-client>
     <version.jna>5.15.0</version.jna>
@@ -955,12 +954,6 @@
       </dependency>
 
       <dependency>
-        <groupId>com.nimbusds</groupId>
-        <artifactId>oauth2-oidc-sdk</artifactId>
-        <version>${version.nimbus-sdk}</version>
-      </dependency>
-
-      <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot</artifactId>
         <version>${version.spring-boot}</version>
@@ -1082,16 +1075,6 @@
         <scope>import</scope>
       </dependency>
 
-      <!--
-           This should be the last dependency management import of type POM and scope IMPORT; if
-           you put any below, and there is some overlap in the library versions, then Spring's will
-           win every time.
-
-           Typically, if we want to add a POM/IMPORT for a specific library (e.g. Netty), then we
-           want to version. If we do want Spring's version to win, then we should just rely on that
-           instead and do not need to specify a version ourselves.
-      -->
-
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-bom</artifactId>
@@ -1099,6 +1082,16 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
+      <!--
+          This should be the last dependency management import of type POM and scope IMPORT; if
+          you put any below, and there is some overlap in the library versions, then Spring's will
+          win every time.
+
+          Typically, if we want to add a POM/IMPORT for a specific library (e.g. Netty), then we
+          want to version. If we do want Spring's version to win, then we should just rely on that
+          instead and do not need to specify a version ourselves.
+     -->
 
       <dependency>
         <!-- Import dependency management from Spring Boot -->

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -952,6 +952,15 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+<<<<<<< HEAD
+=======
+
+      <dependency>
+        <groupId>com.nimbusds</groupId>
+        <artifactId>oauth2-oidc-sdk</artifactId>
+        <version>${version.nimbus-sdk}</version>
+      </dependency>
+>>>>>>> 9f505bf7 (deps: move POM/IMPORT before Spring to allow us to specify desired versions)
 
       <dependency>
         <groupId>org.springframework.boot</groupId>
@@ -985,12 +994,6 @@
 
       <dependency>
         <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter</artifactId>
-        <version>${version.spring-boot}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-configuration-processor</artifactId>
         <version>${version.spring-boot}</version>
       </dependency>
@@ -1002,14 +1005,93 @@
       </dependency>
 
       <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-json</artifactId>
-        <version>${version.spring-boot}</version>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>${version.google-sdk}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>software.amazon.awssdk</groupId>
+        <artifactId>bom</artifactId>
+        <version>${version.awssdk}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>com.azure</groupId>
+        <artifactId>azure-sdk-bom</artifactId>
+        <version>${version.azure-sdk}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-bom</artifactId>
+        <version>${version.mockito}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>${version.log4j}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>io.github.openfeign</groupId>
+        <artifactId>feign-bom</artifactId>
+        <version>${version.feign}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-bom</artifactId>
+        <version>${version.grpc}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-bom</artifactId>
+        <version>${version.protobuf}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${version.netty}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-bom</artifactId>
+        <version>${version.micrometer}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <!--
-           In order resolve dependency issues with wiremock and spring-boot-dependencies
-           make sure this is declared before spring boot dependencies.
+           This should be the last dependency management import of type POM and scope IMPORT; if
+           you put any below, and there is some overlap in the library versions, then Spring's will
+           win every time.
+
+           Typically, if we want to add a POM/IMPORT for a specific library (e.g. Netty), then we
+           want to version. If we do want Spring's version to win, then we should just rely on that
+           instead and do not need to specify a version ourselves.
       -->
 
       <dependency>
@@ -1158,14 +1240,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-bom</artifactId>
-        <version>${version.mockito}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${version.assertj}</version>
@@ -1197,22 +1271,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-bom</artifactId>
-        <version>${version.log4j}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>io.github.openfeign</groupId>
-        <artifactId>feign-bom</artifactId>
-        <version>${version.feign}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
         <groupId>org.scala-lang</groupId>
         <artifactId>scala-library</artifactId>
         <version>${version.scala}</version>
@@ -1237,28 +1295,13 @@
       </dependency>
 
       <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-bom</artifactId>
-        <version>${version.grpc}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>com.google.protobuf</groupId>
-        <artifactId>protobuf-bom</artifactId>
-        <version>${version.protobuf}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-common-protos</artifactId>
         <version>${version.protobuf-common}</version>
       </dependency>
 
       <dependency>
+<<<<<<< HEAD
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
         <version>${version.netty}</version>
@@ -1281,6 +1324,8 @@
       </dependency>
 
       <dependency>
+=======
+>>>>>>> 9f505bf7 (deps: move POM/IMPORT before Spring to allow us to specify desired versions)
         <groupId>org.elasticsearch.client</groupId>
         <artifactId>elasticsearch-rest-client</artifactId>
         <version>${version.elasticsearch}</version>
@@ -1622,30 +1667,6 @@
         <groupId>com.github.jnr</groupId>
         <artifactId>jnr-posix</artifactId>
         <version>${version.jnr-posix}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>libraries-bom</artifactId>
-        <version>${version.google-sdk}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>software.amazon.awssdk</groupId>
-        <artifactId>bom</artifactId>
-        <version>${version.awssdk}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>com.azure</groupId>
-        <artifactId>azure-sdk-bom</artifactId>
-        <version>${version.azure-sdk}</version>
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
 
       <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -178,6 +178,7 @@
     <version.jwks-rsa>0.22.1</version.jwks-rsa>
     <version.guava.annotations>r03</version.guava.annotations>
     <version.nimbus-jose-jwt>9.41.2</version.nimbus-jose-jwt>
+    <version.nimbus-sdk>11.23.1</version.nimbus-sdk>
     <version.keycloak>26.0.6</version.keycloak>
     <version.keycloak-client>26.0.4</version.keycloak-client>
     <version.jna>5.15.0</version.jna>


### PR DESCRIPTION
# Description
Backport of #27496 to `stable/8.7`.

Reasoning for bumping up `micrometer` dependency:

- This backport fixes io.micrometer:`micrometer-registry-otlp to 1.13.6`
- In `stable/8.7` we have `springboot` provided version `io.micrometer:micrometer-registry-otlp:jar:1.14.4:test`

`MetricsConfigurationIT` won't pass with version `1.13.6`  as spring class `OtlpMetricsProperties`  requires `HistogramFlavor`  and it is not present in` 1.13.6`