### PR TITLE
[Backport stable/8.7] ci: attempt to fix rejected git tag push problem

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -33,6 +33,7 @@ env:
   RELEASE_BRANCH: ${{ inputs.releaseBranch != '' && inputs.releaseBranch || format('release-{0}', inputs.releaseVersion) }}
   RELEASE_VERSION: ${{ inputs.releaseVersion }}
   GH_TOKEN: ${{ github.token }} # needs to be available for the gh CLI tool
+  GITHUB_TOKEN_USR: ${{ github.token }} # needs to be available for the SCM URL in pom.xml
 jobs:
   release:
     name: Maven Release


### PR DESCRIPTION
# Description
Backport of #28732 to `stable/8.7`.

relates to camunda/camunda#28522