### PR TITLE
Clean up Tenants handler in the RDBMS Exporter

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/TenantWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/TenantWriter.java
@@ -82,13 +82,6 @@ public class TenantWriter {
             tenant.tenantId(),
             "io.camunda.db.rdbms.sql.TenantMapper.delete",
             tenant.tenantId()));
-    executionQueue.executeInQueue(
-        new QueueItem(
-            ContextType.TENANT,
-            WriteStatementType.DELETE,
-            tenant.tenantId(),
-            "io.camunda.db.rdbms.sql.TenantMapper.deleteAllMembers",
-            tenant.tenantId()));
   }
 
   private boolean mergeToQueue(

--- a/db/rdbms/src/main/resources/mapper/TenantMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/TenantMapper.xml
@@ -59,7 +59,6 @@
     parameterType="io.camunda.db.rdbms.write.domain.TenantDbModel"
     flushCache="true">
     UPDATE ${prefix}TENANT SET
-                    TENANT_ID = #{tenantId},
                     NAME = #{name},
                     DESCRIPTION = #{description}
     WHERE TENANT_ID = #{tenantId}

--- a/db/rdbms/src/main/resources/mapper/TenantMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/TenantMapper.xml
@@ -90,13 +90,4 @@
       AND ENTITY_TYPE = #{entityType}
   </delete>
 
-  <delete
-    id="deleteAllMembers"
-    parameterType="java.lang.String"
-    flushCache="true">
-    DELETE
-    FROM ${prefix}TENANT_MEMBER
-    WHERE TENANT_ID = #{tenantId}
-  </delete>
-
 </mapper>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Some smaller improvements:
- We don't need the clean up all members script. Members will be deleted with individual events
- We shouldn't update the tenant id in the update query. The tenant id is the primary key of a tenant.

I was looking at tests, but these scenarios seem to be covered already. The deleteAllMembers script was untested, so no need to remove anything there. There is a test for updating the tenant id. We can't really tests if the tenantId remains unchanged as the update script matches the tenant on the id. So this scenario isn't really possible.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #28966 
