### PR TITLE
ci: move Slack notifications to different channel

### DIFF
--- a/.github/workflows/camunda-helm-integration.yml
+++ b/.github/workflows/camunda-helm-integration.yml
@@ -2,7 +2,7 @@ name: Camunda Helm Chart Integration Test
 
 on:
   schedule:
-    - cron: "0 5 * * *"
+    - cron: "0 5 * * 1-5"  # Mondays to Fridays, to keep it actionable
   pull_request:
     paths:
       - ".github/workflows/camunda-helm-integration.yml"
@@ -36,18 +36,32 @@ jobs:
         secret/data/products/zeebe/ci/zeebe REGISTRY_HUB_DOCKER_COM_PSW | TEST_DOCKER_PASSWORD;
         secret/data/github.com/organizations/camunda NEXUS_USR | TEST_DOCKER_USERNAME_CAMUNDA_CLOUD;
         secret/data/github.com/organizations/camunda NEXUS_PSW | TEST_DOCKER_PASSWORD_CAMUNDA_CLOUD;
+
   notify:
-    name: Send slack notification
+    name: Send Slack notification
     runs-on: ubuntu-latest
     needs: [helm-deploy]
-    if: ${{ always() }}
+    if: always()
+    timeout-minutes: 5
+    permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
-      - id: slack-notify-failure
-        name: Send failure slack notification
-        uses: slackapi/slack-github-action@v2.0.0
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0 # v3.1.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPOCI_WEBHOOK_URL;
+
+      - name: Send failure Slack notification
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         if: ${{ always() && needs.helm-deploy.result != 'success' }}
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPOCI_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           # For posting a rich message using Block Kit
           payload: |
@@ -57,14 +71,14 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":alarm: *Helm chart Integration Tests* from `main` failed! :alarm:\n"
+                    "text": ":alarm: *Helm chart Integration Tests* on `main` failed!\n"
                   }
                 },
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "Please check the related workflow execution: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
+                    "text": "Please check this <https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}|GHA workflow run>."
                   }
                 }
               ]

--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -2,9 +2,12 @@
 name: Statistics Daily
 
 on:
-  workflow_dispatch: {}
   schedule:
-    - cron: '0 8 * * 2-5'  # Tuesdays to Fridays
+    - cron: '0 8 * * 2-5'  # Tuesdays to Fridays, to keep it actionable
+  pull_request:
+    paths:
+      - '.github/workflows/statistics-daily.yml'
+  workflow_dispatch: {}
 
 jobs:
   flaky-tests:
@@ -24,7 +27,7 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           exportEnv: false # we rely on step outputs, no need for environment variables
           secrets: |
-            secret/data/products/camunda/ci/github-actions SLACK_ZEEBECI_WEBHOOK_URL;
+            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPOCI_WEBHOOK_URL;
             secret/data/products/zeebe/ci/ci-analytics gcloud_sa_key;
 
       - name: Login to Google Cloud
@@ -53,7 +56,8 @@ jobs:
             echo "MESSAGE<<EOF"
             echo "📈 ~$(echo "scale=1; 100 * $NUMBER_OF_FLAKYTESTS_JOBS / $NUMBER_OF_ALL_JOBS" | bc)% of jobs had flaky tests yesterday ($NUMBER_OF_FLAKYTESTS_JOBS from total of $NUMBER_OF_ALL_JOBS jobs)."
             echo ""
-            echo "🥇 Top 5 flakiest tests yesterday:"
+            echo ""
+            echo "🥇 *Top 5 flakiest tests yesterday:*"
             echo ""
             echo "$TOP5_FLAKYTESTS" | jq -c '.[]' | while read -r top_flakytest; do
               NUMBER_OF_FLAKES=$(echo "$top_flakytest" | jq -r '.number_of_flakes')
@@ -62,14 +66,21 @@ jobs:
               echo "• ${NUMBER_OF_FLAKES}x \`${TEST_CLASS_NAME##*.}.$TEST_NAME\`\n"
             done
             echo ""
-            echo "📊 Check out <https://dashboard.int.camunda.com/d/ae2j69npxh3b4f/flaky-tests-camunda-camunda-monorepo?orgId=1&from=now-1d%2Fd&to=now-1d%2Fd&timezone=browser&var-branch=main|Grafana for links and more details.>"
+            echo "📊 Check out <https://dashboard.int.camunda.com/d/ae2j69npxh3b4f/flaky-tests-camunda-camunda-monorepo?orgId=1&from=now-1d%2Fd&to=now-1d%2Fd&timezone=browser&var-branch=main|Grafana for links and more details>."
             echo "EOF"
           } >> $GITHUB_OUTPUT
 
+      - name: Debug notificatoin
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          echo '${{ steps.message.outputs.MESSAGE }}'
+
       - name: Send notification
+        if: github.event_name != 'pull_request'
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
-          webhook: ${{ steps.secrets.outputs.SLACK_ZEEBECI_WEBHOOK_URL }}
+          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPOCI_WEBHOOK_URL }}
           webhook-type: webhook-trigger
           # For posting a rich message using Block Kit
           payload: |


### PR DESCRIPTION
## Description

This PR achieves two things:

* finishing touches for https://github.com/camunda/camunda/issues/28302 to let daily flaky test statistics be posted to #top-monorepo-ci channel
    * debug mode added and working in https://github.com/camunda/camunda/actions/runs/13587974042/job/37987144552 to not create noise when testing the workflow
* let Helm chart Integration Test failures be posted to #top-monorepo-ci since not really actionable by Zeebe team alone + only run on weekdays since nobody can act on weekends
    * works in https://camunda.slack.com/archives/C071KP5BTHB/p1740745404235839

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes) - not needed since this is about scheduled jobs on `main`

## Related issues

