### PR TITLE
PoC listen to the `creating` event

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/TaskListenerValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/TaskListenerValidator.java
@@ -28,6 +28,7 @@ public class TaskListenerValidator implements ModelElementValidator<ZeebeTaskLis
 
   private static final List<ZeebeTaskListenerEventType> SUPPORTED_VALUES =
       Arrays.asList(
+          ZeebeTaskListenerEventType.creating,
           ZeebeTaskListenerEventType.assigning,
           ZeebeTaskListenerEventType.updating,
           ZeebeTaskListenerEventType.completing);
@@ -35,6 +36,7 @@ public class TaskListenerValidator implements ModelElementValidator<ZeebeTaskLis
   @SuppressWarnings("deprecation")
   private static final List<ZeebeTaskListenerEventType> SUPPORTED_DEPRECATED_VALUES =
       Arrays.asList(
+          ZeebeTaskListenerEventType.create,
           ZeebeTaskListenerEventType.assignment,
           ZeebeTaskListenerEventType.update,
           ZeebeTaskListenerEventType.complete);

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskListenersValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskListenersValidationTest.java
@@ -70,9 +70,9 @@ public class ZeebeTaskListenersValidationTest {
       mode = EnumSource.Mode.EXCLUDE,
       // supported event types
       names = {
-        "assigning", "updating", "completing",
+        "creating", "assigning", "updating", "completing",
         // deprecated event types
-        "assignment", "update", "complete"
+        "create", "assignment", "update", "complete"
       })
   void testEventTypeNotSupported(final ZeebeTaskListenerEventType unsupportedEventType) {
     // given
@@ -95,8 +95,8 @@ public class ZeebeTaskListenersValidationTest {
             ZeebeTaskListener.class,
             String.format(
                 "Task listener event type '%s' is not supported. "
-                    + "Currently, only 'assigning', 'updating', 'completing' event types "
-                    + "and 'assignment', 'update', 'complete' deprecated event types are supported.",
+                    + "Currently, only 'creating', 'assigning', 'updating', 'completing' event types "
+                    + "and 'create', 'assignment', 'update', 'complete' deprecated event types are supported.",
                 unsupportedEventType)));
   }
 
@@ -106,9 +106,9 @@ public class ZeebeTaskListenersValidationTest {
       value = ZeebeTaskListenerEventType.class,
       // supported event types
       names = {
-        "assigning", "updating", "completing",
+        "creating", "assigning", "updating", "completing",
         // deprecated event types
-        "assignment", "update", "complete"
+        "create", "assignment", "update", "complete"
       })
   void testEventTypeSupported(final ZeebeTaskListenerEventType supportedEventType) {
     // given

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -376,6 +376,7 @@ public final class BpmnJobBehavior {
   private static JobListenerEventType fromTaskListenerEventType(
       final ZeebeTaskListenerEventType eventType) {
     return switch (eventType) {
+      case creating -> JobListenerEventType.CREATING;
       case assigning -> JobListenerEventType.ASSIGNING;
       case updating -> JobListenerEventType.UPDATING;
       case completing -> JobListenerEventType.COMPLETING;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -36,7 +36,6 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,7 +124,7 @@ public final class BpmnUserTaskBehavior {
         new UserTaskRecord()
             .setVariables(DocumentValue.EMPTY_DOCUMENT)
             .setUserTaskKey(userTaskKey)
-            .setAssignee(StringUtils.EMPTY)
+            .setAssignee(userTaskProperties.getAssignee())
             .setCandidateGroupsList(userTaskProperties.getCandidateGroups())
             .setCandidateUsersList(userTaskProperties.getCandidateUsers())
             .setDueDate(userTaskProperties.getDueDate())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -143,6 +143,7 @@ public final class BpmnUserTaskBehavior {
             .setCreationTimestamp(clock.millis());
 
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CREATING, userTaskRecord);
+
     return userTaskRecord;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
@@ -156,16 +156,16 @@ public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<Ex
         userTaskBehavior.createNewUserTask(context, element, userTaskProperties);
     var lifecycleState = LifecycleState.CREATING;
 
-    // assignee is set in the creating event to support assigning after creating listeners.
-    // however, it should not be part of the created event as the assignee should be considered
-    // unset until the assigning event is triggered.
-    userTaskRecord.unsetAssignee();
-
     final var nextListener =
         element.getTaskListeners(ZeebeTaskListenerEventType.creating).stream().findFirst();
     if (nextListener.isPresent()) {
       jobBehavior.createNewTaskListenerJob(context, userTaskRecord, nextListener.get(), null);
     } else {
+      // assignee is set in the creating event to support assigning after creating listeners.
+      // however, it should not be part of the created event as the assignee should be considered
+      // unset until the assigning event is triggered.
+      userTaskRecord.unsetAssignee();
+
       userTaskBehavior.userTaskCreated(userTaskRecord);
       lifecycleState = LifecycleState.CREATED;
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
@@ -156,6 +156,11 @@ public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<Ex
         userTaskBehavior.createNewUserTask(context, element, userTaskProperties);
     var lifecycleState = LifecycleState.CREATING;
 
+    // assignee is set in the creating event to support assigning after creating listeners.
+    // however, it should not be part of the created event as the assignee should be considered
+    // unset until the assigning event is triggered.
+    userTaskRecord.unsetAssignee();
+
     final var nextListener =
         element.getTaskListeners(ZeebeTaskListenerEventType.creating).stream().findFirst();
     if (nextListener.isPresent()) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
@@ -153,7 +153,11 @@ public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<Ex
       final UserTaskProperties userTaskProperties) {
     final var userTaskRecord =
         userTaskBehavior.createNewUserTask(context, element, userTaskProperties);
-    userTaskBehavior.userTaskCreated(userTaskRecord);
+    element.getTaskListeners(ZeebeTaskListenerEventType.creating).stream()
+        .findFirst()
+        .ifPresentOrElse(
+            listener -> jobBehavior.createNewTaskListenerJob(context, userTaskRecord, listener),
+            () -> userTaskBehavior.userTaskCreated(userTaskRecord));
     return new UserTaskCreationResult(userTaskProperties, userTaskRecord);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -153,7 +153,7 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
             });
   }
 
-  private void processFailedCommand(TypedRecord<? extends UnifiedRecordValue> failedCommand) {
+  private void processFailedCommand(final TypedRecord<? extends UnifiedRecordValue> failedCommand) {
     if (failedCommand.getValue() instanceof ProcessInstanceRecord) {
       bpmnStreamProcessor.processRecord((TypedRecord<ProcessInstanceRecord>) failedCommand);
     } else if (failedCommand.getValue() instanceof UserTaskRecord) {
@@ -223,11 +223,12 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
   private Either<String, UserTaskIntent> getFailedUserTaskCommandIntent(
       final LifecycleState lifecycleState) {
     return switch (lifecycleState) {
+      case CREATING -> Either.right(UserTaskIntent.CREATE);
       case ASSIGNING -> Either.right(UserTaskIntent.ASSIGN);
       case CLAIMING -> Either.right(UserTaskIntent.CLAIM);
       case UPDATING -> Either.right(UserTaskIntent.UPDATE);
       case COMPLETING -> Either.right(UserTaskIntent.COMPLETE);
-      case CREATING, CANCELING ->
+      case CANCELING ->
           Either.left(String.format(LIFECYCLE_STATE_CONVERSION_NOT_SUPPORTED_MSG, lifecycleState));
       default ->
           Either.left(String.format(UNEXPECTED_LIFECYCLE_STATE_CONVERSION_MSG, lifecycleState));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandProcessors.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAssignProc
 import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskClaimProcessor;
 import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCommandProcessor;
 import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCompleteProcessor;
+import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCreateProcessor;
 import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskUpdateProcessor;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
@@ -46,6 +47,8 @@ public final class UserTaskCommandProcessors {
     commandToProcessor =
         new EnumMap<>(
             Map.of(
+                UserTaskIntent.CREATE,
+                new UserTaskCreateProcessor(processingState, writers, authCheckBehavior),
                 UserTaskIntent.ASSIGN,
                 new UserTaskAssignProcessor(processingState, writers, authCheckBehavior),
                 UserTaskIntent.CLAIM,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandProcessors.java
@@ -48,7 +48,12 @@ public final class UserTaskCommandProcessors {
         new EnumMap<>(
             Map.of(
                 UserTaskIntent.CREATE,
-                new UserTaskCreateProcessor(processingState, writers, authCheckBehavior),
+                new UserTaskCreateProcessor(
+                    processingState,
+                    writers,
+                    authCheckBehavior,
+                    bpmnBehaviors.userTaskBehavior(),
+                    bpmnBehaviors.jobBehavior()),
                 UserTaskIntent.ASSIGN,
                 new UserTaskAssignProcessor(processingState, writers, authCheckBehavior),
                 UserTaskIntent.CLAIM,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -85,7 +85,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
   public void processRecord(final TypedRecord<UserTaskRecord> command) {
     final UserTaskIntent intent = (UserTaskIntent) command.getIntent();
     switch (intent) {
-      case ASSIGN, CLAIM, COMPLETE, UPDATE -> processOperationCommand(command, intent);
+      case CREATE, ASSIGN, CLAIM, COMPLETE, UPDATE -> processOperationCommand(command, intent);
       case COMPLETE_TASK_LISTENER -> processCompleteTaskListener(command);
       case DENY_TASK_LISTENER -> processDenyTaskListener(command);
       default -> throw new UnsupportedOperationException("Unexpected user task intent: " + intent);
@@ -268,6 +268,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
 
   private ZeebeTaskListenerEventType mapIntentToEventType(final UserTaskIntent intent) {
     return switch (intent) {
+      case CREATING -> ZeebeTaskListenerEventType.creating;
       case ASSIGN, CLAIM -> ZeebeTaskListenerEventType.assigning;
       case UPDATE -> ZeebeTaskListenerEventType.updating;
       case COMPLETE -> ZeebeTaskListenerEventType.completing;
@@ -316,11 +317,12 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
 
     final var userTaskIntent =
         switch (lifecycleState) {
+          case CREATING -> UserTaskIntent.CREATE;
           case ASSIGNING -> UserTaskIntent.ASSIGN;
           case CLAIMING -> UserTaskIntent.CLAIM;
           case UPDATING -> UserTaskIntent.UPDATE;
           case COMPLETING -> UserTaskIntent.COMPLETE;
-          case CREATING, CANCELING ->
+          case CANCELING ->
               throw new UnsupportedOperationException(
                   "Conversion from '%s' user task lifecycle state to a user task command is not yet supported"
                       .formatted(lifecycleState));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -268,7 +268,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
 
   private ZeebeTaskListenerEventType mapIntentToEventType(final UserTaskIntent intent) {
     return switch (intent) {
-      case CREATING -> ZeebeTaskListenerEventType.creating;
+      case CREATE -> ZeebeTaskListenerEventType.creating;
       case ASSIGN, CLAIM -> ZeebeTaskListenerEventType.assigning;
       case UPDATE -> ZeebeTaskListenerEventType.updating;
       case COMPLETE -> ZeebeTaskListenerEventType.completing;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCreateProcessor.java
@@ -81,6 +81,8 @@ public final class UserTaskCreateProcessor implements UserTaskCommandProcessor {
       final TypedRecord<UserTaskRecord> command, final UserTaskRecord userTaskRecord) {
     final long userTaskKey = command.getKey();
 
+    final var intermediateAssignee = userTaskState.getIntermediateAssignee(userTaskKey);
+
     if (command.hasRequestMetadata()) {
       stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CREATED, userTaskRecord);
       responseWriter.writeEventOnCommand(
@@ -100,8 +102,8 @@ public final class UserTaskCreateProcessor implements UserTaskCommandProcessor {
                   metadata.getRequestStreamId()));
     }
 
-    if (userTaskRecord.hasAssignee()) {
-      assignUserTask(userTaskRecord, userTaskRecord.getAssignee());
+    if (intermediateAssignee != null) {
+      assignUserTask(userTaskRecord, intermediateAssignee);
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCreateProcessor.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.usertask.processors;
+
+import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+
+public final class UserTaskCreateProcessor implements UserTaskCommandProcessor {
+
+  private static final String DEFAULT_ACTION = "create";
+
+  private final UserTaskState userTaskState;
+  private final StateWriter stateWriter;
+  private final TypedResponseWriter responseWriter;
+  private final UserTaskCommandPreconditionChecker preconditionChecker;
+
+  public UserTaskCreateProcessor(
+      final ProcessingState state,
+      final Writers writers,
+      final AuthorizationCheckBehavior authCheckBehavior) {
+    userTaskState = state.getUserTaskState();
+    stateWriter = writers.state();
+    responseWriter = writers.response();
+    preconditionChecker =
+        new UserTaskCommandPreconditionChecker(
+            List.of(LifecycleState.CREATING),
+            "create",
+            state.getUserTaskState(),
+            authCheckBehavior);
+  }
+
+  @Override
+  public Either<Rejection, UserTaskRecord> validateCommand(
+      final TypedRecord<UserTaskRecord> command) {
+    return preconditionChecker.check(command);
+  }
+
+  @Override
+  public void onCommand(
+      final TypedRecord<UserTaskRecord> command, final UserTaskRecord userTaskRecord) {
+    throw new UnsupportedOperationException("Not yet implemented");
+    // possibly not needed at all
+  }
+
+  @Override
+  public void onFinalizeCommand(
+      final TypedRecord<UserTaskRecord> command, final UserTaskRecord userTaskRecord) {
+    final long userTaskKey = command.getKey();
+
+    if (command.hasRequestMetadata()) {
+      stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CREATED, userTaskRecord);
+      responseWriter.writeEventOnCommand(
+          userTaskKey, UserTaskIntent.CREATED, userTaskRecord, command);
+    } else {
+      final var recordRequestMetadata = userTaskState.findRecordRequestMetadata(userTaskKey);
+      stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CREATED, userTaskRecord);
+
+      recordRequestMetadata.ifPresent(
+          metadata ->
+              responseWriter.writeResponse(
+                  userTaskKey,
+                  UserTaskIntent.CREATED,
+                  userTaskRecord,
+                  ValueType.USER_TASK,
+                  metadata.getRequestId(),
+                  metadata.getRequestStreamId()));
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCreateProcessor.java
@@ -103,6 +103,9 @@ public final class UserTaskCreateProcessor implements UserTaskCommandProcessor {
     }
 
     if (intermediateAssignee != null) {
+      // clean up the changed attributes because we have already finished the creation, and are now
+      // starting a new transition to assigning
+      userTaskRecord.resetChangedAttributes();
       assignUserTask(userTaskRecord, intermediateAssignee);
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCreatedApplier.java
@@ -52,6 +52,7 @@ final class JobCreatedApplier implements TypedEventApplier<JobIntent, JobRecord>
 
   private ZeebeTaskListenerEventType toTaskListenerEventType(final JobListenerEventType eventType) {
     return switch (eventType) {
+      case CREATING -> ZeebeTaskListenerEventType.creating;
       case COMPLETING -> ZeebeTaskListenerEventType.completing;
       case UPDATING -> ZeebeTaskListenerEventType.updating;
       case ASSIGNING -> ZeebeTaskListenerEventType.assigning;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignedV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignedV2Applier.java
@@ -38,6 +38,7 @@ public final class UserTaskAssignedV2Applier
     // Clear operational data related to the current assign(claim) transition
     userTaskState.deleteIntermediateState(key);
     userTaskState.deleteRecordRequestMetadata(key);
+    // todo clean up intermediate assignee
 
     final var elementInstance = elementInstanceState.getInstance(value.getElementInstanceKey());
     if (elementInstance != null) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignedV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignedV2Applier.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
-import java.util.List;
 
 public final class UserTaskAssignedV2Applier
     implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
@@ -32,7 +31,7 @@ public final class UserTaskAssignedV2Applier
   public void applyState(final long key, final UserTaskRecord value) {
     final var userTaskRecord = new UserTaskRecord();
     userTaskRecord.wrapWithoutVariables(value);
-    userTaskState.update(userTaskRecord.setChangedAttributes(List.of()).setAction(""));
+    userTaskState.update(userTaskRecord.resetChangedAttributes().setAction(""));
     userTaskState.updateUserTaskLifecycleState(key, LifecycleState.CREATED);
 
     // Clear operational data related to the current assign(claim) transition

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignmentDeniedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignmentDeniedApplier.java
@@ -33,6 +33,7 @@ public class UserTaskAssignmentDeniedApplier
     userTaskState.updateUserTaskLifecycleState(key, LifecycleState.CREATED);
     userTaskState.deleteIntermediateState(key);
     userTaskState.deleteRecordRequestMetadata(key);
+    // todo clean up intermediate assignee
 
     final long elementInstanceKey = value.getElementInstanceKey();
     final ElementInstance elementInstance = elementInstanceState.getInstance(elementInstanceKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatedApplier.java
@@ -31,6 +31,5 @@ public final class UserTaskCreatedApplier
 
     // Clear operational data related to the current update transition
     userTaskState.deleteIntermediateState(key);
-    userTaskState.deleteRecordRequestMetadata(key);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatedApplier.java
@@ -26,5 +26,9 @@ public final class UserTaskCreatedApplier
   @Override
   public void applyState(final long key, final UserTaskRecord value) {
     userTaskState.updateUserTaskLifecycleState(key, LifecycleState.CREATED);
+
+    // Clear operational data related to the current update transition
+    userTaskState.deleteIntermediateState(key);
+    userTaskState.deleteRecordRequestMetadata(key);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatedApplier.java
@@ -25,6 +25,8 @@ public final class UserTaskCreatedApplier
 
   @Override
   public void applyState(final long key, final UserTaskRecord value) {
+    // we need to update the user task record, to unset the assignee
+    userTaskState.update(value);
     userTaskState.updateUserTaskLifecycleState(key, LifecycleState.CREATED);
 
     // Clear operational data related to the current update transition

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingApplier.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -28,7 +29,9 @@ public final class UserTaskCreatingApplier
 
   @Override
   public void applyState(final long key, final UserTaskRecord value) {
+    // todo: should we actually store the user task fully already, or wait until we finalize?
     userTaskState.create(value);
+    userTaskState.storeIntermediateState(value, LifecycleState.CREATING);
 
     final long elementInstanceKey = value.getElementInstanceKey();
     if (elementInstanceKey > 0) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingApplier.java
@@ -30,7 +30,12 @@ public final class UserTaskCreatingApplier
   @Override
   public void applyState(final long key, final UserTaskRecord value) {
     // todo: should we actually store the user task fully already, or wait until we finalize?
+    //    final var assignee = value.getAssignee();
+    //    value.unsetAssignee();
     userTaskState.create(value);
+
+    //    value.setAssignee(assignee);
+    //    value.setAssigneeChanged();
     userTaskState.storeIntermediateState(value, LifecycleState.CREATING);
 
     final long elementInstanceKey = value.getElementInstanceKey();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCreatingApplier.java
@@ -30,13 +30,13 @@ public final class UserTaskCreatingApplier
   @Override
   public void applyState(final long key, final UserTaskRecord value) {
     // todo: should we actually store the user task fully already, or wait until we finalize?
-    //    final var assignee = value.getAssignee();
-    //    value.unsetAssignee();
-    userTaskState.create(value);
+    final var copy = value.copy();
+    copy.unsetAssignee();
+    userTaskState.create(copy);
 
-    //    value.setAssignee(assignee);
-    //    value.setAssigneeChanged();
-    userTaskState.storeIntermediateState(value, LifecycleState.CREATING);
+    userTaskState.storeIntermediateState(copy, LifecycleState.CREATING);
+
+    userTaskState.storeIntermediateAssignee(key, value.getAssignee());
 
     final long elementInstanceKey = value.getElementInstanceKey();
     if (elementInstanceKey > 0) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/UserTaskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/UserTaskState.java
@@ -15,6 +15,8 @@ import java.util.Optional;
 
 public interface UserTaskState {
 
+  String getIntermediateAssignee(long key);
+
   LifecycleState getLifecycleState(final long userTaskKey);
 
   UserTaskRecord getUserTask(final long userTaskKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/TaskListenerIndicesRecord.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/TaskListenerIndicesRecord.java
@@ -16,6 +16,8 @@ import org.agrona.concurrent.UnsafeBuffer;
 
 public final class TaskListenerIndicesRecord extends UnpackedObject implements DbValue {
 
+  private final IntegerProperty creatingTaskListenerIndexProp =
+      new IntegerProperty("creatingTaskListenerIndex", 0);
   private final IntegerProperty assigningTaskListenerIndexProp =
       new IntegerProperty("assigningTaskListenerIndex", 0);
   private final IntegerProperty updatingTaskListenerIndexProp =
@@ -24,14 +26,16 @@ public final class TaskListenerIndicesRecord extends UnpackedObject implements D
       new IntegerProperty("completingTaskListenerIndex", 0);
 
   TaskListenerIndicesRecord() {
-    super(3);
-    declareProperty(assigningTaskListenerIndexProp)
+    super(4);
+    declareProperty(creatingTaskListenerIndexProp)
+        .declareProperty(assigningTaskListenerIndexProp)
         .declareProperty(updatingTaskListenerIndexProp)
         .declareProperty(completingTaskListenerIndexProp);
   }
 
   public Integer getTaskListenerIndex(final ZeebeTaskListenerEventType eventType) {
     return switch (eventType) {
+      case creating -> creatingTaskListenerIndexProp.getValue();
       case assigning -> assigningTaskListenerIndexProp.getValue();
       case updating -> updatingTaskListenerIndexProp.getValue();
       case completing -> completingTaskListenerIndexProp.getValue();
@@ -42,6 +46,7 @@ public final class TaskListenerIndicesRecord extends UnpackedObject implements D
 
   public void incrementTaskListenerIndex(final ZeebeTaskListenerEventType eventType) {
     switch (eventType) {
+      case creating -> creatingTaskListenerIndexProp.increment();
       case assigning -> assigningTaskListenerIndexProp.increment();
       case updating -> updatingTaskListenerIndexProp.increment();
       case completing -> completingTaskListenerIndexProp.increment();
@@ -52,6 +57,7 @@ public final class TaskListenerIndicesRecord extends UnpackedObject implements D
 
   public void resetTaskListenerIndex(final ZeebeTaskListenerEventType eventType) {
     switch (eventType) {
+      case creating -> creatingTaskListenerIndexProp.reset();
       case assigning -> assigningTaskListenerIndexProp.reset();
       case updating -> updatingTaskListenerIndexProp.reset();
       case completing -> completingTaskListenerIndexProp.reset();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserTaskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserTaskState.java
@@ -33,4 +33,6 @@ public interface MutableUserTaskState extends UserTaskState {
       final long userTaskKey, final UserTaskRecordRequestMetadata recordRequestMetadata);
 
   void deleteRecordRequestMetadata(final long userTaskKey);
+
+  void storeIntermediateAssignee(final long key, String assignee);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -851,6 +851,16 @@ public class TaskListenerTest {
 
   @Test
   public void
+      shouldCreateJobNoRetriesIncidentForCreatingListenerAndContinueAfterResolutionOnTaskCreation() {
+    verifyIncidentCreationOnListenerJobWithoutRetriesAndResolution(
+        ZeebeTaskListenerEventType.creating,
+        UnaryOperator.identity(),
+        userTaskClient -> {},
+        UserTaskIntent.CREATED);
+  }
+
+  @Test
+  public void
       shouldCreateJobNoRetriesIncidentForAssigningListenerAndContinueAfterResolutionOnTaskAssignAfterCreation() {
     verifyIncidentCreationOnListenerJobWithoutRetriesAndResolution(
         ZeebeTaskListenerEventType.assigning,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -3512,6 +3512,14 @@ public class TaskListenerTest {
         .describedAs(
             "Expect to ignore the correction, the assigning listener sees the initial assignee")
         .containsEntry(Protocol.USER_TASK_ASSIGNEE_HEADER_NAME, "initial_assignee");
+
+    assertThat(
+            RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNING)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getValue()
+                .getChangedAttributes())
+        .containsExactly(UserTaskRecord.ASSIGNEE);
   }
 
   private static void completeRecreatedJobWithType(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -170,11 +170,7 @@ public class TaskListenerTest {
     assertUserTaskRecordWithIntent(
         processInstanceKey,
         UserTaskIntent.CREATED,
-        userTask ->
-            Assertions.assertThat(userTask)
-                .hasAction("my_custom_action")
-                .hasVariables(Map.of("foo_var", "bar"))
-                .hasNoChangedAttributes());
+        userTask -> Assertions.assertThat(userTask).hasNoChangedAttributes());
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -8,6 +8,12 @@
 package io.camunda.zeebe.engine.processing.bpmn.activity.listeners.task;
 
 import static io.camunda.zeebe.engine.processing.job.JobCompleteProcessor.TL_JOB_COMPLETION_WITH_VARS_NOT_SUPPORTED_MESSAGE;
+import static io.camunda.zeebe.test.util.record.RecordingExporter.jobRecords;
+import static io.camunda.zeebe.test.util.record.RecordingExporter.records;
+import static java.util.Map.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.client.UserTaskClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -38,14 +44,11 @@ import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.FormMetadataValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
-import static io.camunda.zeebe.test.util.record.RecordingExporter.jobRecords;
-import static io.camunda.zeebe.test.util.record.RecordingExporter.records;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import static java.util.Map.entry;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -54,8 +57,6 @@ import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Ignore;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -3253,7 +3253,9 @@ public class TaskListenerTest {
         .ofInstance(processInstanceKey)
         .withType(listenerType)
         .withResult(
-            new JobResult().setCorrections(new JobResultCorrections().setAssignee("new_assignee")))
+            new JobResult()
+                .setCorrections(new JobResultCorrections().setAssignee("new_assignee"))
+                .setCorrectedAttributes(List.of(UserTaskRecord.ASSIGNEE)))
         .complete();
 
     // then

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/AssignUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/AssignUserTaskTest.java
@@ -121,7 +121,7 @@ public final class AssignUserTaskTest {
             r -> r.getValue().getAction(),
             r -> r.getValue().getChangedAttributes())
         .containsExactly(
-            tuple(UserTaskIntent.CREATING, StringUtils.EMPTY, action, List.of()),
+            tuple(UserTaskIntent.CREATING, assignee, action, List.of()),
             tuple(UserTaskIntent.CREATED, StringUtils.EMPTY, action, List.of()),
             // The `assignee` property isn't yet available during the `CREATED` event
             // as it becomes effective only during the assignment phase.
@@ -258,7 +258,7 @@ public final class AssignUserTaskTest {
             r -> r.getValue().getAction(),
             r -> r.getValue().getChangedAttributes())
         .containsExactly(
-            tuple(UserTaskIntent.CREATING, "", "", List.of()),
+            tuple(UserTaskIntent.CREATING, initialAssignee, "", List.of()),
             tuple(UserTaskIntent.CREATED, "", "", List.of()),
             // The `assignee` property isn't yet available during the `CREATING/CREATED` events
             // as it becomes effective only during the assignment phase.

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -733,4 +733,9 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     setChangedAttributes(changedAttributes);
     return this;
   }
+
+  public UserTaskRecord resetChangedAttributes() {
+    changedAttributesProp.reset();
+    return this;
+  }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -725,4 +725,8 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   public boolean hasAssignee() {
     return !BufferUtil.equals(assigneeProp.getValue(), BufferUtil.wrapString(EMPTY_STRING));
   }
+
+  public void unsetAssignee() {
+    assigneeProp.setValue(EMPTY_STRING);
+  }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -726,7 +726,11 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     return !BufferUtil.equals(assigneeProp.getValue(), BufferUtil.wrapString(EMPTY_STRING));
   }
 
-  public void unsetAssignee() {
+  public UserTaskRecord unsetAssignee() {
     assigneeProp.setValue(EMPTY_STRING);
+    final var changedAttributes = getChangedAttributes();
+    changedAttributes.remove(ASSIGNEE);
+    setChangedAttributes(changedAttributes);
+    return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -721,4 +721,8 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     processInstanceKeyProp.setValue(key);
     return this;
   }
+
+  public boolean hasAssignee() {
+    return !BufferUtil.equals(assigneeProp.getValue(), BufferUtil.wrapString(EMPTY_STRING));
+  }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -231,7 +231,8 @@ public enum ZbColumnFamilies implements EnumValue {
 
   USERNAME_BY_USER_KEY(119),
   CLAIM_BY_ID(120),
-  AUTHORIZATION_KEYS_BY_OWNER(121);
+  AUTHORIZATION_KEYS_BY_OWNER(121),
+  USER_TASK_INTERMEDIATE_ASSIGNEE(122);
 
   private final int value;
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserTaskIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserTaskIntent.java
@@ -102,7 +102,8 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
    * corrections within the same update transition are discarded, and the user task remains in its
    * prior state.
    */
-  UPDATE_DENIED(21);
+  UPDATE_DENIED(21),
+  CREATE(22);
 
   private final short value;
   private final boolean shouldBanInstance;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobListenerEventType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobListenerEventType.java
@@ -56,5 +56,7 @@ public enum JobListenerEventType {
    * `priority`. It allows executing custom logic before the task is updated, to correct user task
    * data, and to deny the update.
    */
-  UPDATING
+  UPDATING,
+
+  CREATING
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Includes:
- responding to the `creating` event
- providing access to the `assignee` in the `creating` event if user task defines an assignee in the process
- allowing `creating` listener to correct the `assignee`
  - this is useful when the user task does not define an assignee but one should be set when creating
  - note that the correction may be ignored by subsequent `assigning` listeners

## Related issues

closes #28252 
