### PR TITLE
refactor: spring security chain simplification

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -88,10 +88,6 @@
       <artifactId>jsr305</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/authentication/src/main/java/io/camunda/authentication/ConditionalOnUnprotectedApi.java
+++ b/authentication/src/main/java/io/camunda/authentication/ConditionalOnUnprotectedApi.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication;
+
+import io.camunda.authentication.ConditionalOnUnprotectedApi.ApiProtectedCondition;
+import io.camunda.authentication.config.AuthenticationProperties;
+import io.camunda.security.configuration.AuthenticationConfiguration;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Optional;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.core.env.Environment;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Documented
+@Conditional(ApiProtectedCondition.class)
+public @interface ConditionalOnUnprotectedApi {
+
+  class ApiProtectedCondition implements Condition {
+    @Override
+    public boolean matches(final ConditionContext context, final AnnotatedTypeMetadata metadata) {
+      final Environment env = context.getEnvironment();
+      return Optional.ofNullable(
+              env.getProperty(AuthenticationProperties.API_UNPROTECTED, Boolean.class))
+          .orElse(AuthenticationConfiguration.DEFAULT_UNPROTECTED_API);
+    }
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -7,11 +7,9 @@
  */
 package io.camunda.authentication.config;
 
-import static org.springframework.security.web.util.matcher.AntPathRequestMatcher.antMatcher;
-
-import com.google.common.collect.Sets;
 import io.camunda.authentication.CamundaUserDetailsService;
 import io.camunda.authentication.ConditionalOnAuthenticationMethod;
+import io.camunda.authentication.ConditionalOnUnprotectedApi;
 import io.camunda.authentication.filters.TenantRequestAttributeFilter;
 import io.camunda.authentication.filters.WebApplicationAuthorizationCheckFilter;
 import io.camunda.authentication.handler.AuthFailureHandler;
@@ -25,7 +23,6 @@ import io.camunda.service.TenantServices;
 import io.camunda.service.UserServices;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.Arrays;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +32,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
 import org.springframework.security.config.Customizer;
@@ -43,11 +39,13 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -55,23 +53,27 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 @Profile("consolidated-auth")
 public class WebSecurityConfig {
   public static final String SESSION_COOKIE = "camunda-session";
-  private static final int ORDER_WEBAPP_API_PROTECTION = 1;
-  private static final int ORDER_UNPROTECTED_API = 2;
-  private static final int ORDER_LOGIN_LOGOUT_HANDLING = 3;
+
   private static final Logger LOG = LoggerFactory.getLogger(WebSecurityConfig.class);
+  // Used for chains that grant unauthenticated access, always comes first.
+  private static final int ORDER_UNPROTECTED = 0;
+  // Used for chains that protect the APIs or Webapp paths.
+  private static final int ORDER_WEBAPP_API = 1;
+  // Intended for a "catch-all-unhandled"-chain protecting all resources by default
+  private static final int ORDER_UNHANDLED = 2;
   private static final String LOGIN_URL = "/login";
   private static final String LOGOUT_URL = "/logout";
-  private static final Set<String> API_PATHS = Set.of("/v1/**", "/v2/**");
-  private static final Set<String> UNAUTHENTICATED_PATHS =
+  private static final Set<String> API_PATHS = Set.of("/api/**", "/v1/**", "/v2/**");
+  private static final Set<String> UNPROTECTED_API_PATHS =
       Set.of(
-          LOGIN_URL,
-          "/",
-          // webapps are single page apps
-          "/identity/**",
-          "/operate/**",
-          "/tasklist/**",
           // these v2 endpoints are public
           "/v2/license",
+          // deprecated Tasklist v1 Public Endpoints
+          "/v1/external/process/**");
+  private static final Set<String> WEBAPP_PATHS =
+      Set.of("/login", "/logout", "/identity/**", "/operate/**", "/tasklist/**");
+  private static final Set<String> UNPROTECTED_PATHS =
+      Set.of(
           // endpoint for failure forwarding
           "/error",
           // all actuator endpoints
@@ -81,7 +83,6 @@ public class WebSecurityConfig {
           "/health",
           "/startup",
           // deprecated Tasklist v1 Public Endpoints
-          "/v1/external/process/**",
           "/new/**");
 
   @Bean
@@ -92,136 +93,51 @@ public class WebSecurityConfig {
   }
 
   @Bean
-  @ConditionalOnAuthenticationMethod(AuthenticationMethod.BASIC)
-  public CamundaUserDetailsService camundaUserDetailsService(
-      final UserServices userServices,
-      final AuthorizationServices authorizationServices,
-      final RoleServices roleServices,
-      final TenantServices tenantServices) {
-    return new CamundaUserDetailsService(
-        userServices, authorizationServices, roleServices, tenantServices);
-  }
-
-  @Bean
-  @ConditionalOnAuthenticationMethod(AuthenticationMethod.OIDC)
-  public ClientRegistrationRepository clientRegistrationRepository(
-      final SecurityConfiguration securityConfiguration) {
-    return new InMemoryClientRegistrationRepository(
-        OidcClientRegistration.create(securityConfiguration.getAuthentication().getOidc()));
-  }
-
-  @Bean
-  @ConditionalOnAuthenticationMethod(AuthenticationMethod.OIDC)
-  @Order(ORDER_WEBAPP_API_PROTECTION)
-  public SecurityFilterChain oidcHttpSecurity(
-      final HttpSecurity httpSecurity,
-      final AuthFailureHandler authFailureHandler,
-      final ClientRegistrationRepository clientRegistrationRepository)
+  @Order(ORDER_UNPROTECTED)
+  public SecurityFilterChain unprotectedPathsSecurityFilterChain(final HttpSecurity httpSecurity)
       throws Exception {
-    return baseHttpSecurity(httpSecurity, authFailureHandler, UNAUTHENTICATED_PATHS)
-        .oauth2ResourceServer(
-            oauth2 ->
-                oauth2.jwt(
-                    jwtConfigurer ->
-                        jwtConfigurer.jwkSetUri(
-                            clientRegistrationRepository
-                                .findByRegistrationId(OidcClientRegistration.REGISTRATION_ID)
-                                .getProviderDetails()
-                                .getJwkSetUri())))
-        .oauth2Login(oauthLoginConfigurer -> {})
-        .oidcLogout(httpSecurityOidcLogoutConfigurer -> {})
-        .logout(
-            (logout) ->
-                logout
-                    .logoutUrl(LOGOUT_URL)
-                    .logoutSuccessHandler(this::genericSuccessHandler)
-                    .deleteCookies())
-        .build();
-  }
-
-  private void genericSuccessHandler(
-      final HttpServletRequest request,
-      final HttpServletResponse response,
-      final Authentication authentication) {
-    response.setStatus(HttpStatus.NO_CONTENT.value());
-  }
-
-  @Bean
-  @ConditionalOnAuthenticationMethod(AuthenticationMethod.BASIC)
-  @Order(ORDER_WEBAPP_API_PROTECTION)
-  public SecurityFilterChain httpBasicAuthSecurityFilterChain(
-      final HttpSecurity httpSecurity,
-      final AuthFailureHandler authFailureHandler,
-      final SecurityConfiguration securityConfiguration)
-      throws Exception {
-    LOG.info("HTTP Basic authentication is enabled");
-    return baseHttpSecurity(
-            withSecurityMatcher(
-                httpSecurity,
-                request ->
-                    isBasicAuthRequest(request)
-                        // If authentication isn't disabled for the API, all API requests without a
-                        // session cookie or Referer header are treated as basic auth requests to
-                        // work around a limitation of Java's HTTP client, which only sends an
-                        // Authorization header after the server sends a WWW-Authenticate header in
-                        // a 401 response.
-                        || securityConfiguration.isApiProtected()
-                            && isApiRequest(request)
-                            && !isFrontendRequest(request)),
-            authFailureHandler,
-            UNAUTHENTICATED_PATHS)
-        .httpBasic(Customizer.withDefaults())
+    return httpSecurity
+        .securityMatcher(UNPROTECTED_PATHS.toArray(String[]::new))
+        .authorizeHttpRequests(
+            (authorizeHttpRequests) -> authorizeHttpRequests.anyRequest().permitAll())
+        .headers(WebSecurityConfig::setupStrictTransportSecurity)
+        .csrf(AbstractHttpConfigurer::disable)
+        .cors(AbstractHttpConfigurer::disable)
+        .formLogin(AbstractHttpConfigurer::disable)
+        .anonymous(AbstractHttpConfigurer::disable)
         .build();
   }
 
   @Bean
-  @Order(ORDER_UNPROTECTED_API)
-  public SecurityFilterChain unprotectedApiAccessSecurityFilterChain(
-      final HttpSecurity httpSecurity,
-      final AuthFailureHandler authFailureHandler,
-      final SecurityConfiguration securityConfiguration)
+  @ConditionalOnUnprotectedApi
+  @Order(ORDER_UNPROTECTED)
+  public SecurityFilterChain unprotectedApiAuthSecurityFilterChain(final HttpSecurity httpSecurity)
       throws Exception {
-    if (securityConfiguration.isApiProtected()) {
-      return null;
-    }
-
     LOG.warn(
-        "The API is accessible without authentication. Please disable {} for any deployment.",
+        "The API is unprotected. Please disable {} for any deployment.",
         AuthenticationProperties.API_UNPROTECTED);
-    return baseHttpSecurity(
-            withSecurityMatcher(
-                httpSecurity, request -> isApiRequest(request) && !hasSessionCookie(request)),
-            authFailureHandler,
-            Sets.union(UNAUTHENTICATED_PATHS, API_PATHS))
+    return httpSecurity
+        .securityMatcher(API_PATHS.toArray(String[]::new))
+        .authorizeHttpRequests(
+            (authorizeHttpRequests) -> authorizeHttpRequests.anyRequest().permitAll())
+        .headers(WebSecurityConfig::setupStrictTransportSecurity)
+        .csrf(AbstractHttpConfigurer::disable)
+        .cors(AbstractHttpConfigurer::disable)
+        .formLogin(AbstractHttpConfigurer::disable)
+        .anonymous(AbstractHttpConfigurer::disable)
         .build();
   }
 
   @Bean
-  @ConditionalOnAuthenticationMethod(AuthenticationMethod.BASIC)
-  @Order(ORDER_LOGIN_LOGOUT_HANDLING)
-  public SecurityFilterChain loginAuthSecurityFilterChain(
-      final HttpSecurity httpSecurity, final AuthFailureHandler authFailureHandler)
-      throws Exception {
-    LOG.info("Configuring login auth");
-    return baseHttpSecurity(httpSecurity, authFailureHandler, UNAUTHENTICATED_PATHS)
-        .formLogin(
-            formLogin ->
-                formLogin
-                    .loginPage(LOGIN_URL)
-                    .loginProcessingUrl(LOGIN_URL)
-                    .failureHandler(authFailureHandler)
-                    .successHandler(this::genericSuccessHandler))
-        .logout(
-            (logout) ->
-                logout
-                    .logoutUrl(LOGOUT_URL)
-                    .logoutSuccessHandler(this::genericSuccessHandler)
-                    .deleteCookies(SESSION_COOKIE))
-        .exceptionHandling(
-            exceptionHandling ->
-                exceptionHandling
-                    .authenticationEntryPoint(authFailureHandler)
-                    .accessDeniedHandler(authFailureHandler))
+  @Order(ORDER_UNHANDLED)
+  public SecurityFilterChain protectedUnhandledPathsSecurityFilterChain(
+      final HttpSecurity httpSecurity) throws Exception {
+    // all resources not yet explicitly handled by any previous chain require an authenticated user
+    // thus by default unhandled paths are always protected
+    return httpSecurity
+        .securityMatcher("/**")
+        .authorizeHttpRequests(
+            (authorizeHttpRequests) -> authorizeHttpRequests.anyRequest().denyAll())
         .build();
   }
 
@@ -232,74 +148,172 @@ public class WebSecurityConfig {
   }
 
   @Bean
-  public FilterRegistrationBean<WebApplicationAuthorizationCheckFilter>
-      applicationAuthorizationFilterFilterRegistrationBean(
-          final WebApplicationAuthorizationCheckFilter filter) {
-    final FilterRegistrationBean<WebApplicationAuthorizationCheckFilter> registration =
-        new FilterRegistrationBean<>();
-    registration.setFilter(filter);
-    registration.addUrlPatterns("/identity/*", "/operate/*", "/tasklist/*");
-    return registration;
-  }
-
-  @Bean
-  public WebApplicationAuthorizationCheckFilter webApplicationAuthorizationCheckFilter(
+  public WebApplicationAuthorizationCheckFilter applicationAuthorizationFilterFilter(
       final SecurityConfiguration securityConfiguration) {
     return new WebApplicationAuthorizationCheckFilter(securityConfiguration);
   }
 
-  private static boolean isBasicAuthRequest(final HttpServletRequest request) {
-    final String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
-    return authorizationHeader != null && authorizationHeader.startsWith("Basic ");
+  private static void noContentSuccessHandler(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final Authentication authentication) {
+    response.setStatus(HttpStatus.NO_CONTENT.value());
   }
 
-  private static boolean isFrontendRequest(final HttpServletRequest request) {
-    return hasSessionCookie(request) || request.getHeader(HttpHeaders.REFERER) != null;
+  private static void setupStrictTransportSecurity(final HeadersConfigurer<HttpSecurity> headers) {
+    headers.httpStrictTransportSecurity(
+        (httpStrictTransportSecurity) ->
+            httpStrictTransportSecurity
+                .includeSubDomains(true)
+                .maxAgeInSeconds(63072000)
+                .preload(true));
   }
 
-  private static boolean hasSessionCookie(final HttpServletRequest request) {
-    if (request.getCookies() == null) {
-      return false;
+  @Configuration
+  @ConditionalOnAuthenticationMethod(AuthenticationMethod.BASIC)
+  public static class BasicConfiguration {
+    @Bean
+    public CamundaUserDetailsService camundaUserDetailsService(
+        final UserServices userServices,
+        final AuthorizationServices authorizationServices,
+        final RoleServices roleServices,
+        final TenantServices tenantServices) {
+      return new CamundaUserDetailsService(
+          userServices, authorizationServices, roleServices, tenantServices);
     }
-    return Arrays.stream(request.getCookies())
-        .anyMatch(cookie -> cookie.getName().equals(SESSION_COOKIE));
+
+    @Bean
+    @Order(ORDER_WEBAPP_API)
+    public SecurityFilterChain httpBasicApiAuthSecurityFilterChain(
+        final HttpSecurity httpSecurity, final AuthFailureHandler authFailureHandler)
+        throws Exception {
+      LOG.info("The API is protected by HTTP Basic authentication.");
+      return httpSecurity
+          .securityMatcher(API_PATHS.toArray(String[]::new))
+          .authorizeHttpRequests(
+              (authorizeHttpRequests) ->
+                  authorizeHttpRequests
+                      .requestMatchers(UNPROTECTED_API_PATHS.toArray(String[]::new))
+                      .permitAll()
+                      .anyRequest()
+                      .authenticated())
+          .headers(WebSecurityConfig::setupStrictTransportSecurity)
+          .csrf(AbstractHttpConfigurer::disable)
+          .cors(AbstractHttpConfigurer::disable)
+          .formLogin(AbstractHttpConfigurer::disable)
+          .anonymous(AbstractHttpConfigurer::disable)
+          .httpBasic(Customizer.withDefaults())
+          .exceptionHandling(
+              // this prevents the usage of the default BasicAuthenticationEntryPoint returning
+              // a WWW-Authenticate header that causes browsers to prompt for basic login
+              exceptionHandling ->
+                  exceptionHandling
+                      .authenticationEntryPoint(authFailureHandler)
+                      .accessDeniedHandler(authFailureHandler))
+          // do not create a session on api authentication, that's to be done on webapp login only
+          .sessionManagement(
+              (sessionManagement) ->
+                  sessionManagement.sessionCreationPolicy(SessionCreationPolicy.NEVER))
+          .build();
+    }
+
+    @Bean
+    @Order(ORDER_WEBAPP_API)
+    public SecurityFilterChain httpBasicWebappAuthSecurityFilterChain(
+        final HttpSecurity httpSecurity,
+        final AuthFailureHandler authFailureHandler,
+        final WebApplicationAuthorizationCheckFilter webApplicationAuthorizationCheckFilter)
+        throws Exception {
+      LOG.info("Web Applications Login/Logout is setup.");
+      return httpSecurity
+          .securityMatcher(WEBAPP_PATHS.toArray(String[]::new))
+          // webapps are accessible without any authentication required
+          .authorizeHttpRequests(
+              (authorizeHttpRequests) -> authorizeHttpRequests.anyRequest().permitAll())
+          .csrf(AbstractHttpConfigurer::disable)
+          .cors(AbstractHttpConfigurer::disable)
+          .anonymous(AbstractHttpConfigurer::disable)
+          // http basic auth is possible to obtain a session
+          .httpBasic(Customizer.withDefaults())
+          // login/logout is still possible to obtain a session
+          // the session grants access to the API as well, via #httpBasicApiAuthSecurityFilterChain
+          .formLogin(
+              formLogin ->
+                  formLogin
+                      .loginPage(LOGIN_URL)
+                      .loginProcessingUrl(LOGIN_URL)
+                      .failureHandler(authFailureHandler)
+                      .successHandler(WebSecurityConfig::noContentSuccessHandler))
+          .logout(
+              (logout) ->
+                  logout
+                      .logoutUrl(LOGOUT_URL)
+                      .logoutSuccessHandler(WebSecurityConfig::noContentSuccessHandler)
+                      .deleteCookies(SESSION_COOKIE))
+          .exceptionHandling(
+              exceptionHandling ->
+                  exceptionHandling
+                      .authenticationEntryPoint(authFailureHandler)
+                      .accessDeniedHandler(authFailureHandler))
+          .addFilterAfter(webApplicationAuthorizationCheckFilter, AuthorizationFilter.class)
+          .build();
+    }
   }
 
-  private static boolean isApiRequest(final HttpServletRequest request) {
-    return API_PATHS.stream().anyMatch(path -> antMatcher(path).matches(request));
-  }
+  @Configuration
+  @ConditionalOnAuthenticationMethod(AuthenticationMethod.OIDC)
+  public static class OidcConfiguration {
+    @Bean
+    public ClientRegistrationRepository clientRegistrationRepository(
+        final SecurityConfiguration securityConfiguration) {
+      return new InMemoryClientRegistrationRepository(
+          OidcClientRegistration.create(securityConfiguration.getAuthentication().getOidc()));
+    }
 
-  private static HttpSecurity withSecurityMatcher(
-      final HttpSecurity httpSecurity, final RequestMatcher requestMatcher) {
-    return httpSecurity.securityMatchers(matchers -> matchers.requestMatchers(requestMatcher));
-  }
-
-  private HttpSecurity baseHttpSecurity(
-      final HttpSecurity httpSecurity,
-      final AuthFailureHandler authFailureHandler,
-      final Set<String> unauthenticatedPaths)
-      throws Exception {
-    return httpSecurity
-        .authorizeHttpRequests(
-            (authorizeHttpRequests) ->
-                authorizeHttpRequests
-                    .requestMatchers(unauthenticatedPaths.toArray(String[]::new))
-                    .permitAll()
-                    .anyRequest()
-                    .authenticated())
-        .headers(
-            (headers) ->
-                headers.httpStrictTransportSecurity(
-                    (httpStrictTransportSecurity) ->
-                        httpStrictTransportSecurity
-                            .includeSubDomains(true)
-                            .maxAgeInSeconds(63072000)
-                            .preload(true)))
-        .exceptionHandling(
-            (exceptionHandling) -> exceptionHandling.accessDeniedHandler(authFailureHandler))
-        .csrf(AbstractHttpConfigurer::disable)
-        .cors(AbstractHttpConfigurer::disable)
-        .formLogin(AbstractHttpConfigurer::disable)
-        .anonymous(AbstractHttpConfigurer::disable);
+    @Bean
+    @Order(ORDER_WEBAPP_API)
+    public SecurityFilterChain oidcHttpSecurity(
+        final HttpSecurity httpSecurity,
+        final AuthFailureHandler authFailureHandler,
+        final ClientRegistrationRepository clientRegistrationRepository,
+        final WebApplicationAuthorizationCheckFilter webApplicationAuthorizationCheckFilter)
+        throws Exception {
+      return httpSecurity
+          .securityMatcher(API_PATHS.toArray(new String[0]))
+          .securityMatcher(WEBAPP_PATHS.toArray(new String[0]))
+          .authorizeHttpRequests(
+              (authorizeHttpRequests) ->
+                  authorizeHttpRequests
+                      .requestMatchers(UNPROTECTED_API_PATHS.toArray(String[]::new))
+                      .permitAll()
+                      .anyRequest()
+                      .authenticated())
+          .headers(WebSecurityConfig::setupStrictTransportSecurity)
+          .exceptionHandling(
+              (exceptionHandling) -> exceptionHandling.accessDeniedHandler(authFailureHandler))
+          .csrf(AbstractHttpConfigurer::disable)
+          .cors(AbstractHttpConfigurer::disable)
+          .formLogin(AbstractHttpConfigurer::disable)
+          .anonymous(AbstractHttpConfigurer::disable)
+          .oauth2ResourceServer(
+              oauth2 ->
+                  oauth2.jwt(
+                      jwtConfigurer ->
+                          jwtConfigurer.jwkSetUri(
+                              clientRegistrationRepository
+                                  .findByRegistrationId(OidcClientRegistration.REGISTRATION_ID)
+                                  .getProviderDetails()
+                                  .getJwkSetUri())))
+          .oauth2Login(oauthLoginConfigurer -> {})
+          .oidcLogout(httpSecurityOidcLogoutConfigurer -> {})
+          .logout(
+              (logout) ->
+                  logout
+                      .logoutUrl(LOGOUT_URL)
+                      .logoutSuccessHandler(WebSecurityConfig::noContentSuccessHandler)
+                      .deleteCookies())
+          .addFilterAfter(webApplicationAuthorizationCheckFilter, AuthorizationFilter.class)
+          .build();
+    }
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
@@ -19,7 +19,6 @@ import io.camunda.qa.util.cluster.HistoryBackupClient;
 import io.camunda.qa.util.cluster.TestSimpleCamundaApplication;
 import io.camunda.qa.util.multidb.MultiDbConfigurator;
 import io.camunda.search.connect.configuration.DatabaseType;
-import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.webapps.backup.BackupService.SnapshotRequest;
 import io.camunda.webapps.backup.BackupStateDto;
 import io.camunda.webapps.backup.Metadata;
@@ -105,8 +104,7 @@ public class BackupRestoreIT {
   }
 
   private void setup(final BackupRestoreTestConfig config) throws Exception {
-    testStandaloneApplication =
-        new TestSimpleCamundaApplication().withAuthenticationMethod(AuthenticationMethod.BASIC);
+    testStandaloneApplication = new TestSimpleCamundaApplication().withUnauthenticatedAccess();
     configurator = new MultiDbConfigurator(testStandaloneApplication);
     testStandaloneApplication.withBrokerConfig(this::configureZeebeBackupStore);
     final String dbUrl;

--- a/qa/integration-tests/src/test/java/io/camunda/it/operate/OperatePermissionsIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/operate/OperatePermissionsIT.java
@@ -53,7 +53,7 @@ public class OperatePermissionsIT {
     testInstance =
         new TestStandaloneCamunda()
             .withCamundaExporter()
-            .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true))
+            .withAuthorizationsEnabled()
             .withAuthenticationMethod(AuthenticationMethod.BASIC);
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistAssignUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistAssignUserTaskAuthorizationIT.java
@@ -58,7 +58,7 @@ public class TasklistAssignUserTaskAuthorizationIT {
   private TestStandaloneCamunda standaloneCamunda =
       new TestStandaloneCamunda()
           .withCamundaExporter()
-          .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true))
+          .withAuthorizationsEnabled()
           .withAuthenticationMethod(AuthenticationMethod.BASIC);
 
   @BeforeEach

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistCompleteUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistCompleteUserTaskAuthorizationIT.java
@@ -57,7 +57,7 @@ public class TasklistCompleteUserTaskAuthorizationIT {
   private TestStandaloneCamunda standaloneCamunda =
       new TestStandaloneCamunda()
           .withCamundaExporter()
-          .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true))
+          .withAuthorizationsEnabled()
           .withAuthenticationMethod(AuthenticationMethod.BASIC);
 
   @BeforeEach

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistCreateProcessInstanceAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistCreateProcessInstanceAuthorizationIT.java
@@ -47,7 +47,7 @@ public class TasklistCreateProcessInstanceAuthorizationIT {
   private final TestStandaloneCamunda standaloneCamunda =
       new TestStandaloneCamunda()
           .withCamundaExporter()
-          .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true))
+          .withAuthorizationsEnabled()
           .withAuthenticationMethod(AuthenticationMethod.BASIC);
 
   @BeforeEach

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistProcessDefinitionAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistProcessDefinitionAuthorizationIT.java
@@ -53,7 +53,7 @@ public class TasklistProcessDefinitionAuthorizationIT {
   private TestStandaloneCamunda broker =
       new TestStandaloneCamunda()
           .withCamundaExporter()
-          .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true))
+          .withAuthorizationsEnabled()
           .withSecurityConfig(
               c ->
                   c.getInitialization()

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistUnassignUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/TasklistUnassignUserTaskAuthorizationIT.java
@@ -56,7 +56,7 @@ public class TasklistUnassignUserTaskAuthorizationIT {
   private TestStandaloneCamunda standaloneCamunda =
       new TestStandaloneCamunda()
           .withCamundaExporter()
-          .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true))
+          .withAuthorizationsEnabled()
           .withAuthenticationMethod(AuthenticationMethod.BASIC);
 
   @BeforeEach

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistAssignUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistAssignUserTaskAuthorizationIT.java
@@ -58,7 +58,7 @@ public class CompatibilityTasklistAssignUserTaskAuthorizationIT {
   private TestStandaloneCamunda standaloneCamunda =
       new TestStandaloneCamunda()
           .withCamundaExporter()
-          .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true))
+          .withAuthorizationsEnabled()
           .withProperty("camunda.tasklist.zeebe.compatibility.enabled", true)
           .withAuthenticationMethod(AuthenticationMethod.BASIC);
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistCompleteUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistCompleteUserTaskAuthorizationIT.java
@@ -55,7 +55,7 @@ public class CompatibilityTasklistCompleteUserTaskAuthorizationIT {
   private TestStandaloneCamunda standaloneCamunda =
       new TestStandaloneCamunda()
           .withCamundaExporter()
-          .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true))
+          .withAuthorizationsEnabled()
           .withProperty("camunda.tasklist.zeebe.compatibility.enabled", true)
           .withAuthenticationMethod(AuthenticationMethod.BASIC);
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistCreateProcessInstanceAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistCreateProcessInstanceAuthorizationIT.java
@@ -47,7 +47,7 @@ public class CompatibilityTasklistCreateProcessInstanceAuthorizationIT {
   private TestStandaloneCamunda standaloneCamunda =
       new TestStandaloneCamunda()
           .withCamundaExporter()
-          .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true))
+          .withAuthorizationsEnabled()
           .withProperty("camunda.tasklist.zeebe.compatibility.enabled", true)
           .withAuthenticationMethod(AuthenticationMethod.BASIC);
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistUnassignUserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/tasklist/compatibility/CompatibilityTasklistUnassignUserTaskAuthorizationIT.java
@@ -55,7 +55,7 @@ public class CompatibilityTasklistUnassignUserTaskAuthorizationIT {
   private TestStandaloneCamunda standaloneCamunda =
       new TestStandaloneCamunda()
           .withCamundaExporter()
-          .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true))
+          .withAuthorizationsEnabled()
           .withProperty("camunda.tasklist.zeebe.compatibility.enabled", true)
           .withAuthenticationMethod(AuthenticationMethod.BASIC);
 

--- a/security/security-core/src/main/java/io/camunda/security/configuration/AuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/AuthenticationConfiguration.java
@@ -11,11 +11,12 @@ import io.camunda.security.entity.AuthenticationMethod;
 
 public class AuthenticationConfiguration {
   public static final AuthenticationMethod DEFAULT_METHOD = AuthenticationMethod.BASIC;
+  public static final boolean DEFAULT_UNPROTECTED_API = true;
 
   private AuthenticationMethod method = DEFAULT_METHOD;
   private OidcAuthenticationConfiguration oidcAuthenticationConfiguration =
       new OidcAuthenticationConfiguration();
-  private boolean unprotectedApi = true;
+  private boolean unprotectedApi = DEFAULT_UNPROTECTED_API;
 
   public boolean getUnprotectedApi() {
     return unprotectedApi;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/BasicAuthOverGrpcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/BasicAuthOverGrpcIT.java
@@ -47,9 +47,8 @@ public class BasicAuthOverGrpcIT {
   private final TestStandaloneBroker broker =
       new TestStandaloneBroker()
           .withRecordingExporter(true)
-          .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true))
-          .withAuthenticationMethod(AuthenticationMethod.BASIC)
-          .withAuthenticatedAccess();
+          .withAuthorizationsEnabled()
+          .withAuthenticationMethod(AuthenticationMethod.BASIC);
 
   @BeforeEach
   void beforeEach() {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/BasicAuthOverRestIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/BasicAuthOverRestIT.java
@@ -46,7 +46,7 @@ final class BasicAuthOverRestIT {
   private TestStandaloneBroker broker =
       new TestStandaloneBroker()
           .withRecordingExporter(true)
-          .withSecurityConfig(c -> c.getAuthorizations().setEnabled(true))
+          .withAuthorizationsEnabled()
           .withAuthenticationMethod(AuthenticationMethod.BASIC);
 
   @BeforeEach


### PR DESCRIPTION
## Description

This introduces 3 types of ordered security chains, to separate setups of public paths, api/webapp paths and protecting paths not explicitly handled, ideally benefiting readability:

1. Chain for permitting access to all unprotected resources (order 0)
2. Chain for protecting API/webapp paths (order 1)
3. Chain to protect all unhandled paths by default (order 2)

I also removed the helper `baseHttpSecurity` method in favor of inlining, allowing to holistically read and understand a chain in one place. This comes at the cost of duplication but I personally prefer it that way, instead of having to navigate the helper methods and remembering what is done there and what not.

Additionally I grouped beans by method into nested config classes, to also benefit quickly overseeing what each method incorporates in terms of spring security setup.

While working with the API I also noticed that the previous setup actually created a session when authenticating with basic auth on the API directly, which is only relevant for webapp usage, thus I disabled session creation for the API.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)