### PR TITLE
Run HistoryCleanupIT with CamundaExporter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,11 @@ jobs:
           # Disabling to make sure we can delete indices via wildcards
           # https://www.elastic.co/guide/en/elasticsearch/reference/current/index-management-settings.html
           action.destructive_requires_name: "false"
+          # We need to configure ILM to run more often, to make sure data is cleaned up earlier
+          # Useful for tests where we verify history clean up
+          # Default is 10m
+          # https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-settings.html
+          indices.lifecycle.poll_interval: "1s"
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-build
@@ -317,7 +322,7 @@ jobs:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [ detect-changes ]
     name: "[IT] OpenSearch"
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions: {}  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-8-default
     env:
@@ -347,6 +352,14 @@ jobs:
           # We have to specify an initial password to bootstrap OpenSearch
           # https://opensearch.org/blog/replacing-default-admin-credentials/
           OPENSEARCH_INITIAL_ADMIN_PASSWORD: "yourStrongPassword123!"
+          # We need to configure ISM to run more often, to make sure data is cleaned up earlier
+          # Useful for tests where we verify history clean up
+          # Default is 5 - unit is minutes
+          # https://opensearch.org/docs/latest/im-plugin/ism/settings/
+          plugins.index_state_management.job_interval: "1"
+          # A randomized delay that is added to a job’s base run time to prevent a surge of activity from all indexes at the same time.
+          plugins.index_state_management.jitter: "0"
+          knn.algo_param.index_thread_qty: 4
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-build
@@ -370,7 +383,7 @@ jobs:
       - name: Run integration test with externalized OS
         run: >
           ./mvnw -B -T 1 --no-snapshot-updates
-          -D forkCount=1
+          -D forkCount=2
           -D maven.javadoc.skip=true
           -D skipUTs -D skipChecks
           -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceQueryTest.java
@@ -37,6 +37,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -447,14 +448,25 @@ public class ProcessInstanceAndFlowNodeInstanceQueryTest {
 
   @Test
   void shouldQueryProcessInstancesByStateCompleted() {
-    // when
-    final var result =
-        camundaClient.newProcessInstanceQuery().filter(f -> f.state(COMPLETED)).send().join();
+    Awaitility.await("process is completed")
+        .untilAsserted(
+            () -> {
 
-    // then
-    assertThat(result.items().size()).isEqualTo(3);
-    assertThat(result.items().stream().map(ProcessInstance::getProcessDefinitionId).toList())
-        .containsExactlyInAnyOrder("parent_process_v1", "child_process_v1", "manual_process");
+              // when
+              final var result =
+                  camundaClient
+                      .newProcessInstanceQuery()
+                      .filter(f -> f.state(COMPLETED))
+                      .send()
+                      .join();
+
+              // then
+              assertThat(result.items().size()).isEqualTo(3);
+              assertThat(
+                      result.items().stream().map(ProcessInstance::getProcessDefinitionId).toList())
+                  .containsExactlyInAnyOrder(
+                      "parent_process_v1", "child_process_v1", "manual_process");
+            });
   }
 
   @Test

--- a/qa/integration-tests/src/test/java/io/camunda/it/historycleanup/HistoryCleanupIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/historycleanup/HistoryCleanupIT.java
@@ -19,13 +19,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.response.UserTask;
-import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.HistoryMultiDbTest;
 import java.time.Duration;
 import java.util.Objects;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
-@MultiDbTest
+@HistoryMultiDbTest
 public class HistoryCleanupIT {
 
   static final String RESOURCE_NAME = "process/process_with_assigned_user_task.bpmn";

--- a/qa/integration-tests/src/test/java/io/camunda/it/historycleanup/HistoryCleanupIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/historycleanup/HistoryCleanupIT.java
@@ -19,21 +19,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.search.response.UserTask;
-import io.camunda.it.utils.BrokerITInvocationProvider;
-import org.junit.jupiter.api.TestTemplate;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import java.time.Duration;
+import java.util.Objects;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
 
+@MultiDbTest
 public class HistoryCleanupIT {
 
   static final String RESOURCE_NAME = "process/process_with_assigned_user_task.bpmn";
+  private static CamundaClient camundaClient;
 
-  // TODO use MultiDbTest when camunda exporter also supports it
-  @RegisterExtension
-  static final BrokerITInvocationProvider PROVIDER =
-      new BrokerITInvocationProvider().withoutCamundaExporter();
-
-  @TestTemplate
-  void shouldDeleteProcessesWhichAreMarkedForCleanup(final CamundaClient camundaClient) {
+  @Test
+  void shouldDeleteProcessesWhichAreMarkedForCleanup() {
     // given
     deployResource(camundaClient, RESOURCE_NAME).getProcesses().getFirst();
     waitForProcessesToBeDeployed(camundaClient, 1);
@@ -43,8 +42,13 @@ public class HistoryCleanupIT {
     waitForFlowNodeInstances(camundaClient, 2);
 
     // when we complete the user task
+    Awaitility.await("until a task is available for completion")
+        .atMost(Duration.ofMinutes(1))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .until(
+            () -> camundaClient.newUserTaskQuery().send().join().items().getFirst(),
+            Objects::nonNull);
     final UserTask userTask = camundaClient.newUserTaskQuery().send().join().items().getFirst();
-    assertThat(userTask).isNotNull();
     camundaClient.newUserTaskCompleteCommand(userTask.getUserTaskKey()).send().join();
 
     // then process should be ended
@@ -52,14 +56,21 @@ public class HistoryCleanupIT {
 
     // and soon it should be gone
     waitUntilProcessInstanceIsGone(camundaClient, processInstanceEvent.getProcessInstanceKey());
-    final var taskAmount =
-        camundaClient
-            .newUserTaskQuery()
-            .filter(b -> b.userTaskKey(userTask.getUserTaskKey()))
-            .send()
-            .join()
-            .page()
-            .totalItems();
-    assertThat(taskAmount).isZero();
+
+    Awaitility.await("should wait until tasks are deleted")
+        .atMost(Duration.ofMinutes(5))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              final var taskAmount =
+                  camundaClient
+                      .newUserTaskQuery()
+                      .filter(b -> b.userTaskKey(userTask.getUserTaskKey()))
+                      .send()
+                      .join()
+                      .page()
+                      .totalItems();
+              assertThat(taskAmount).isZero();
+            });
   }
 }

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -244,7 +244,12 @@ public class CamundaMultiDBExtension
 
   private ElasticsearchContainer setupElasticsearch() {
     final ElasticsearchContainer elasticsearchContainer =
-        TestSearchContainers.createDefeaultElasticsearchContainer();
+        TestSearchContainers.createDefeaultElasticsearchContainer()
+            // We need to configure ILM to run more often, to make sure data is cleaned up earlier
+            // Useful for tests where we verify history clean up
+            // Default is 10m
+            // https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-settings.html
+            .withEnv("indices.lifecycle.poll_interval", "1s");
     elasticsearchContainer.start();
     closeables.add(elasticsearchContainer);
     return elasticsearchContainer;

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -230,7 +230,7 @@ public class CamundaMultiDBExtension
             DEFAULT_OS_ADMIN_USER,
             DEFAULT_OS_ADMIN_PW,
             isHistoryRelatedTest);
-        final var expectedDescriptors = new IndexDescriptors(testPrefix, true).all();
+        final var expectedDescriptors = new IndexDescriptors(testPrefix, false).all();
         setupHelper = new ElasticOpenSearchSetupHelper(DEFAULT_OS_URL, expectedDescriptors);
       }
       case RDBMS -> multiDbConfigurator.configureRDBMSSupport();

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -167,7 +167,7 @@ public class CamundaMultiDBExtension
   public static final Duration TIMEOUT_DATA_AVAILABILITY =
       Optional.ofNullable(System.getProperty(PROP_TEST_INTEGRATION_OPENSEARCH_AWS_TIMEOUT))
           .map(val -> Duration.ofSeconds(Long.parseLong(val)))
-          .orElse(Duration.ofSeconds(30));
+          .orElse(Duration.ofMinutes(2));
   public static final String DEFAULT_ES_URL = "http://localhost:9200";
   public static final String DEFAULT_OS_URL = "http://localhost:9200";
   public static final String DEFAULT_OS_ADMIN_USER = "admin";

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/HistoryMultiDbTest.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/HistoryMultiDbTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.multidb;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Extension of the {@link MultiDbTest} annotation, to mark a test as history related test, which
+ * should be tested against multiple databases.
+ *
+ * <p>Annotation communicates to {@link CamundaMultiDBExtension} such that configures history clean
+ * up.
+ *
+ * @see MultiDbTest
+ */
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@MultiDbTest
+public @interface HistoryMultiDbTest {}

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -71,6 +71,20 @@ public class MultiDbConfigurator {
                       io.camunda.search.connect.configuration.DatabaseType.ELASTICSEARCH),
                   "index",
                   Map.of("prefix", indexPrefix),
+                  "archiver",
+                  Map.of(
+                      "waitPeriodBeforeArchiving",
+                      retentionEnabled ? "1s" : "1h", // find completed instances almost directly
+                      "retention",
+                      Map.of(
+                          "enabled",
+                          "true",
+                          "policyName",
+                          indexPrefix + "-ilm",
+                          "minimumAge",
+                          // 0s causes ILM to move data asap - it is normally the default
+                          // https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
+                          "0s")),
                   "bulk",
                   Map.of("size", 1)));
         });
@@ -144,6 +158,20 @@ public class MultiDbConfigurator {
                       userPassword),
                   "index",
                   Map.of("prefix", indexPrefix),
+                  "archiver",
+                  Map.of(
+                      "waitPeriodBeforeArchiving",
+                      retentionEnabled ? "1s" : "1h", // find completed instances almost directly
+                      "retention",
+                      Map.of(
+                          "enabled",
+                          "true",
+                          "policyName",
+                          indexPrefix + "-ilm",
+                          "minimumAge",
+                          // 0s causes ILM to move data asap - it is normally the default
+                          // https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
+                          "0s")),
                   "bulk",
                   Map.of("size", 1)));
         });

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -31,6 +31,11 @@ public class MultiDbConfigurator {
 
   public void configureElasticsearchSupport(
       final String elasticsearchUrl, final String indexPrefix) {
+    configureElasticsearchSupport(elasticsearchUrl, indexPrefix, false);
+  }
+
+  public void configureElasticsearchSupport(
+      final String elasticsearchUrl, final String indexPrefix, final boolean retentionEnabled) {
     this.indexPrefix = indexPrefix;
     final Map<String, Object> elasticsearchProperties = new HashMap<>();
 
@@ -78,7 +83,7 @@ public class MultiDbConfigurator {
                       "retention",
                       Map.of(
                           "enabled",
-                          "true",
+                          Boolean.toString(retentionEnabled),
                           "policyName",
                           indexPrefix + "-ilm",
                           "minimumAge",
@@ -106,6 +111,15 @@ public class MultiDbConfigurator {
       final String indexPrefix,
       final String userName,
       final String userPassword) {
+    configureOpenSearchSupport(opensearchUrl, indexPrefix, userName, userPassword, false);
+  }
+
+  public void configureOpenSearchSupport(
+      final String opensearchUrl,
+      final String indexPrefix,
+      final String userName,
+      final String userPassword,
+      final boolean retentionEnabled) {
     this.indexPrefix = indexPrefix;
 
     final Map<String, Object> opensearchProperties = new HashMap<>();
@@ -165,7 +179,7 @@ public class MultiDbConfigurator {
                       "retention",
                       Map.of(
                           "enabled",
-                          "true",
+                          Boolean.toString(retentionEnabled),
                           "policyName",
                           indexPrefix + "-ilm",
                           "minimumAge",

--- a/qa/util/src/test/java/io/camunda/qa/util/multidb/MultiDbConfiguratorTest.java
+++ b/qa/util/src/test/java/io/camunda/qa/util/multidb/MultiDbConfiguratorTest.java
@@ -25,21 +25,6 @@ public class MultiDbConfiguratorTest {
   public static final String EXPECTED_PW = "pw";
 
   @Test
-  public void shouldRegisterOperateAndTasklistPropertiesByDefault() {
-    // given
-    final var testSimpleCamundaApplication = new TestSimpleCamundaApplication();
-
-    // when
-    new MultiDbConfigurator(testSimpleCamundaApplication);
-
-    // then
-
-    final BrokerBasedProperties brokerBasedProperties =
-        testSimpleCamundaApplication.bean(BrokerBasedProperties.class);
-    assertThat(brokerBasedProperties.getExporters()).isEmpty();
-  }
-
-  @Test
   public void shouldConfigureWithElasticsearch() {
     // given
     final var testSimpleCamundaApplication = new TestSimpleCamundaApplication();
@@ -106,6 +91,91 @@ public class MultiDbConfiguratorTest {
                 EXPECTED_PREFIX,
                 "type",
                 io.camunda.search.connect.configuration.DatabaseType.ELASTICSEARCH));
+
+    assertThat(exporterArgs.get("archiver"))
+        .isEqualTo(
+            Map.of(
+                "waitPeriodBeforeArchiving",
+                "1s",
+                "retention",
+                Map.of(
+                    "enabled",
+                    Boolean.toString(false),
+                    "policyName",
+                    EXPECTED_PREFIX + "-ilm",
+                    "minimumAge",
+                    "0s")));
+  }
+
+  @Test
+  public void shouldConfigureElasticsearchWithRetention() {
+    // given
+    final var testSimpleCamundaApplication = new TestSimpleCamundaApplication();
+    final MultiDbConfigurator multiDbConfigurator =
+        new MultiDbConfigurator(testSimpleCamundaApplication);
+
+    // when
+    multiDbConfigurator.configureElasticsearchSupport(EXPECTED_URL, EXPECTED_PREFIX, true);
+
+    // then
+
+    final BrokerBasedProperties brokerBasedProperties =
+        testSimpleCamundaApplication.bean(BrokerBasedProperties.class);
+    assertThat(brokerBasedProperties).isNotNull();
+
+    final ExporterCfg camundaExporter = brokerBasedProperties.getExporters().get("CamundaExporter");
+    assertThat(camundaExporter).isNotNull();
+
+    final Map<String, Object> exporterArgs = camundaExporter.getArgs();
+    assertThat(exporterArgs.get("archiver"))
+        .isEqualTo(
+            Map.of(
+                "waitPeriodBeforeArchiving",
+                "1s",
+                "retention",
+                Map.of(
+                    "enabled",
+                    Boolean.toString(true),
+                    "policyName",
+                    EXPECTED_PREFIX + "-ilm",
+                    "minimumAge",
+                    "0s")));
+  }
+
+  @Test
+  public void shouldConfigureWithOpenSearchWithRetention() {
+    // given
+    final var testSimpleCamundaApplication = new TestSimpleCamundaApplication();
+    final MultiDbConfigurator multiDbConfigurator =
+        new MultiDbConfigurator(testSimpleCamundaApplication);
+
+    // when
+    multiDbConfigurator.configureOpenSearchSupport(
+        EXPECTED_URL, EXPECTED_PREFIX, EXPECTED_USER, EXPECTED_PW, true);
+
+    // then
+
+    final BrokerBasedProperties brokerBasedProperties =
+        testSimpleCamundaApplication.bean(BrokerBasedProperties.class);
+    assertThat(brokerBasedProperties).isNotNull();
+
+    final ExporterCfg camundaExporter = brokerBasedProperties.getExporters().get("CamundaExporter");
+    assertThat(camundaExporter).isNotNull();
+
+    final Map<String, Object> exporterArgs = camundaExporter.getArgs();
+    assertThat(exporterArgs.get("archiver"))
+        .isEqualTo(
+            Map.of(
+                "waitPeriodBeforeArchiving",
+                "1s",
+                "retention",
+                Map.of(
+                    "enabled",
+                    Boolean.toString(true),
+                    "policyName",
+                    EXPECTED_PREFIX + "-ilm",
+                    "minimumAge",
+                    "0s")));
   }
 
   @Test
@@ -185,6 +255,20 @@ public class MultiDbConfiguratorTest {
                 EXPECTED_USER,
                 "password",
                 EXPECTED_PW));
+
+    assertThat(exporterArgs.get("archiver"))
+        .isEqualTo(
+            Map.of(
+                "waitPeriodBeforeArchiving",
+                "1s",
+                "retention",
+                Map.of(
+                    "enabled",
+                    Boolean.toString(false),
+                    "policyName",
+                    EXPECTED_PREFIX + "-ilm",
+                    "minimumAge",
+                    "0s")));
   }
 
   private <T> void assertProperty(


### PR DESCRIPTION
## Description

Migrating the HistoryCleanupIT, to remove the BrokerITInvocationProvider eventually.

As a pre-requisite we had to make sure that the CamundaExporter is correctly configured, such that it is able to delete data quickly. Furthermore, per default ISM/ILM is run only 5-10 minutes per default, we need to reduce this to test history cleanup reliably and quickly.


## What the PR does

 * Introducing a new annotation HistoryMultiDbTest, that extends the MultiDbTest, to mark a test to be run against multi databases and enabling history clean up. This is to not run into issues with other tests.
 * Configuring the CamundaExporter with archiver configs, including retention.
 * When HistoryMultiDbTest is detected retention is enabled
 * Configuring the ES/OS service container in CI and local test container ILM/ISM setting, such as they are executed more frequently, to clean up data earlier
 * Migrate the HistoryCleanupIT

Successful run of the test:

![2025-03-03_12-34](https://github.com/user-attachments/assets/b19a7ad6-a511-4c77-af73-f36297f83501)
