### PR TITLE
PoC: Migrate from Job-based user task to Camunda User Task

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -35,7 +35,9 @@ import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import org.agrona.DirectBuffer;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -116,10 +118,21 @@ public final class BpmnUserTaskBehavior {
       final BpmnElementContext context,
       final ExecutableUserTask element,
       final UserTaskProperties userTaskProperties) {
+    return createNewUserTask(
+        context,
+        element.getUserTaskProperties().getTaskHeaders(),
+        element.getId(),
+        userTaskProperties);
+  }
+
+  public UserTaskRecord createNewUserTask(
+      final BpmnElementContext context,
+      final Map<String, String> taskHeaders,
+      final DirectBuffer elementId,
+      final UserTaskProperties userTaskProperties) {
     final var userTaskKey = keyGenerator.nextKey();
 
-    final var encodedHeaders =
-        headerEncoder.encode(element.getUserTaskProperties().getTaskHeaders());
+    final var encodedHeaders = headerEncoder.encode(taskHeaders);
 
     final var userTaskRecord =
         new UserTaskRecord()
@@ -137,7 +150,7 @@ public final class BpmnUserTaskBehavior {
             .setProcessDefinitionVersion(context.getProcessVersion())
             .setProcessDefinitionKey(context.getProcessDefinitionKey())
             .setProcessInstanceKey(context.getProcessInstanceKey())
-            .setElementId(element.getId())
+            .setElementId(elementId)
             .setElementInstanceKey(context.getElementInstanceKey())
             .setTenantId(context.getTenantId())
             .setPriority(userTaskProperties.getPriority())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -510,7 +510,7 @@ public final class ProcessInstanceMigrationPreconditions {
    * @param elementInstance element instance to do the check
    * @param processInstanceKey process instance key to be logged
    */
-  public static void requireSameUserTaskImplementation(
+  public static void requireSupportedUserTaskConversion(
       final DeployedProcess targetProcessDefinition,
       final String targetElementId,
       final ElementInstance elementInstance,
@@ -540,7 +540,8 @@ public final class ProcessInstanceMigrationPreconditions {
             ? ZEEBE_USER_TASK_IMPLEMENTATION
             : JOB_WORKER_IMPLEMENTATION;
 
-    if (!targetUserTaskType.equals(sourceUserTaskType)) {
+    if (!(sourceUserTaskType.equals(JOB_WORKER_IMPLEMENTATION)
+        && targetUserTaskType.equals(ZEEBE_USER_TASK_IMPLEMENTATION))) {
       final String reason =
           String.format(
               ERROR_USER_TASK_IMPLEMENTATION_CHANGED,


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

### First iteration

#### Summary

During the first iteration, I was able to migrate from Job Based to Camunda User Task successfully. While doing so, I was able to map related fields between different types. In addition, user task assignment task listener is also triggered if previous user task has an assignee.

Job based user tasks can be migrated to Camunda user tasks in following steps:
- Map job based user task custom headers to user task properties
- Create new user task using mapped task properties and task headers (non user task related headers)
- Assign user task if any assignee exist
- Create task listener job listening user task assignments
- Cancel job based user task job

#### Remarks

- For job based user tasks, `formKey` is used to reference either internal form or an external form. To determine if the `formKey` is external or internal, a check against `formId` is applied. If `formId` is present in the job worker properties, we update `formKey` in Camunda User Task, if not we update `externalFormReference`.

- If the target Camunda User Task listens for assignment events and Job Worker User Task has an assignee, a task listener job will be created during the migration.

- `priority` field is not part of a Job-based User Task. It will be set to default value `50` during the migration.

#### Next
I will verify if task listener job can successfully be completed after the migration, implement embedded form handling and add more test cases to verify correct mapping for different user task properties.