### PR TITLE
fix: don't try to write responses without request id

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/CollaborationDeploymentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/CollaborationDeploymentTest.java
@@ -85,6 +85,6 @@ public final class CollaborationDeploymentTest {
 
   private static Function<DeploymentClient, Record<DeploymentRecordValue>> deploy(
       final String resource) {
-    return deploymentClient -> deploymentClient.withXmlClasspathResource(resource).deploy();
+    return deploymentClient -> deploymentClient.withXmlClasspathResource(resource).deploy("test");
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SuccessfulDeploymentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/SuccessfulDeploymentTest.java
@@ -108,11 +108,11 @@ public final class SuccessfulDeploymentTest {
 
   private static Function<DeploymentClient, Record<DeploymentRecordValue>> deploy(
       final String resource) {
-    return deploymentClient -> deploymentClient.withXmlClasspathResource(resource).deploy();
+    return deploymentClient -> deploymentClient.withXmlClasspathResource(resource).deploy("test");
   }
 
   private static Function<DeploymentClient, Record<DeploymentRecordValue>> deploy(
       final BpmnModelInstance process) {
-    return deploymentClient -> deploymentClient.withXmlResource(process).deploy();
+    return deploymentClient -> deploymentClient.withXmlResource(process).deploy("test");
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
@@ -47,6 +47,7 @@ public class ScaleUpTest {
     final var command =
         RecordToWrite.command()
             .scale(ScaleIntent.SCALE_UP, new ScaleRecord().setDesiredPartitionCount(3));
+    command.recordMetadata().requestId(123);
 
     // when
     engine.writeRecords(command);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.operationRe
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.RecordMetadataEncoder;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -94,6 +95,9 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
       final String rejectionReason,
       final long requestId,
       final int requestStreamId) {
+    if (requestId == RecordMetadataEncoder.requestIdNullValue()) {
+      return this;
+    }
     final var metadata =
         new RecordMetadata()
             .recordType(recordType)

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -1303,7 +1303,7 @@ public final class StreamProcessorTest {
         ValueType.PROCESS_INSTANCE,
         RejectionType.NULL_VAL,
         "",
-        -1,
+        123, // Provide a fake request id to ensure the response is not ignored
         -1);
     when(defaultMockedRecordProcessor.process(any(), any())).thenReturn(resultBuilder.build());
     streamPlatform.startStreamProcessor();

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -123,6 +123,30 @@ public final class StreamProcessorTest {
   }
 
   @Test
+  public void shouldNotRespondWithoutRequestId() {
+    // given
+    final var builder = new BufferedProcessingResultBuilder((recordLength, batchLength) -> true);
+
+    // when - responding with an invalid request id
+    final var result =
+        builder
+            .withResponse(
+                RecordType.COMMAND,
+                1L,
+                ProcessInstanceIntent.ACTIVATE_ELEMENT,
+                Records.processInstance(1),
+                ValueType.PROCESS_INSTANCE,
+                RejectionType.NULL_VAL,
+                "test",
+                -1,
+                1)
+            .build();
+
+    // then - there is no processing response
+    assertThat(result.getProcessingResponse()).isEmpty();
+  }
+
+  @Test
   public void shouldCallStreamProcessorLifecycleOnFail() {
     // given
     final var mockProcessorLifecycleAware = streamPlatform.getMockProcessorLifecycleAware();


### PR DESCRIPTION
There is no sense in trying to respond when we don't even know the request id. Bail out early instead.
This fixes warnings from code paths where we do not check properly whether to respond or not.

Reported here: https://camunda.slack.com/archives/C05DH1F5TAR/p1740751721237549