### PR TITLE
Remove `entityKey` from `TenantRecord`

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -255,14 +255,6 @@ public class RecordFixtures {
 
   protected static ImmutableRecord<RecordValue> getTenantRecord(
       final Long tenantKey, final String tenantId, final TenantIntent intent) {
-    return getTenantRecord(tenantKey, tenantId, intent, null);
-  }
-
-  protected static ImmutableRecord<RecordValue> getTenantRecord(
-      final Long tenantKey,
-      final String tenantId,
-      final TenantIntent intent,
-      final Long entityKey) {
     final Record<RecordValue> recordValueRecord = FACTORY.generateRecord(ValueType.TENANT);
     return ImmutableRecord.builder()
         .from(recordValueRecord)
@@ -275,8 +267,7 @@ public class RecordFixtures {
                 .from((TenantRecordValue) recordValueRecord.getValue())
                 .withTenantId(tenantId)
                 .withTenantKey(tenantKey)
-                .withEntityKey(entityKey != null ? entityKey : 0)
-                .withEntityType(entityKey != null ? EntityType.USER : null)
+                .withEntityType(EntityType.USER)
                 .build())
         .build();
   }

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -91,10 +91,11 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
    */
   public CompletableFuture<TenantRecord> addMember(
       final String tenantId, final EntityType entityType, final long entityKey) {
+    final var entityId = String.valueOf(entityKey);
     return sendBrokerRequest(
         BrokerTenantEntityRequest.createAddRequest()
             .setTenantId(tenantId)
-            .setEntity(entityType, entityKey));
+            .setEntity(entityType, entityId));
   }
 
   public CompletableFuture<TenantRecord> addMember(
@@ -111,10 +112,11 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
    */
   public CompletableFuture<TenantRecord> removeMember(
       final String tenantId, final EntityType entityType, final long entityKey) {
+    final var entityId = String.valueOf(entityKey);
     return sendBrokerRequest(
         BrokerTenantEntityRequest.createRemoveRequest()
             .setTenantId(tenantId)
-            .setEntity(entityType, entityKey));
+            .setEntity(entityType, entityId));
   }
 
   public CompletableFuture<TenantRecord> removeMember(

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -193,10 +193,10 @@ public class TenantServiceTest {
   public void shouldAddEntityToTenant(final EntityType entityType) {
     // given
     final var tenantId = "tenantId";
-    final var entityKey = 42;
+    final var entityId = "entityId";
 
     // when
-    services.addMember(tenantId, entityType, entityKey);
+    services.addMember(tenantId, entityType, entityId);
 
     // then
     final BrokerTenantEntityRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -204,7 +204,7 @@ public class TenantServiceTest {
     assertThat(request.getValueType()).isEqualTo(ValueType.TENANT);
     final TenantRecord brokerRequestValue = request.getRequestWriter();
     assertThat(brokerRequestValue.getTenantId()).isEqualTo(tenantId);
-    assertThat(brokerRequestValue.getEntityKey()).isEqualTo(entityKey);
+    assertThat(brokerRequestValue.getEntityId()).isEqualTo(entityId);
     assertThat(brokerRequestValue.getEntityType()).isEqualTo(entityType);
   }
 
@@ -215,10 +215,10 @@ public class TenantServiceTest {
   public void shouldRemoveEntityFromTenant(final EntityType entityType) {
     // given
     final var tenantId = "tenantId";
-    final var entityKey = 42;
+    final var entityId = "entityId";
 
     // when
-    services.removeMember(tenantId, entityType, entityKey);
+    services.removeMember(tenantId, entityType, entityId);
 
     // then
     final BrokerTenantEntityRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -226,7 +226,7 @@ public class TenantServiceTest {
     assertThat(request.getValueType()).isEqualTo(ValueType.TENANT);
     final TenantRecord brokerRequestValue = request.getRequestWriter();
     assertThat(brokerRequestValue.getTenantId()).isEqualTo(tenantId);
-    assertThat(brokerRequestValue.getEntityKey()).isEqualTo(entityKey);
+    assertThat(brokerRequestValue.getEntityId()).isEqualTo(entityId);
     assertThat(brokerRequestValue.getEntityType()).isEqualTo(entityType);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
@@ -129,7 +129,7 @@ public class MappingDeleteProcessor implements DistributedTypedRecordProcessor<M
           new TenantRecord()
               .setTenantKey(tenant.getTenantKey())
               .setTenantId(tenant.getTenantId())
-              .setEntityKey(mappingKey)
+              .setEntityId(mapping.getId())
               .setEntityType(EntityType.MAPPING));
     }
     for (final var roleKey : mapping.getRoleKeysList()) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -127,13 +127,13 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
   private boolean validateEntityAssignment(
       final TypedRecord<TenantRecord> command, final String tenantId) {
     final var entityType = command.getValue().getEntityType();
-    final var entityKey = command.getValue().getEntityKey();
+    final var entityId = command.getValue().getEntityId();
     return switch (entityType) {
       case USER -> checkUserAssignment(command, tenantId);
-      case MAPPING -> checkMappingAssignment(entityKey, command, tenantId);
-      case GROUP -> checkGroupAssignment(entityKey, command, tenantId);
+      case MAPPING -> checkMappingAssignment(entityId, command, tenantId);
+      case GROUP -> checkGroupAssignment(entityId, command, tenantId);
       default ->
-          throw new IllegalStateException(formatErrorMessage(entityKey, tenantId, "doesn't exist"));
+          throw new IllegalStateException(formatErrorMessage(entityId, tenantId, "doesn't exist"));
     };
   }
 
@@ -162,56 +162,57 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
   }
 
   private boolean checkMappingAssignment(
-      final long entityKey, final TypedRecord<TenantRecord> command, final String tenantId) {
-    final var mapping = mappingState.get(entityKey);
+      final String mappingId, final TypedRecord<TenantRecord> command, final String tenantId) {
+    final var mapping = mappingState.get(mappingId);
     if (mapping.isEmpty()) {
       rejectCommand(
           command,
           RejectionType.NOT_FOUND,
-          formatErrorMessage(entityKey, tenantId, "doesn't exist"));
+          formatErrorMessage(mappingId, tenantId, "doesn't exist"));
       return false;
     }
     if (mapping.get().getTenantIdsList().contains(tenantId)) {
-      createEntityNotExistRejectCommand(command, entityKey, tenantId);
+      createEntityNotExistRejectCommand(command, mappingId, tenantId);
       return false;
     }
     return true;
   }
 
   private boolean checkGroupAssignment(
-      final long entityKey, final TypedRecord<TenantRecord> command, final String tenantId) {
-    final var group = groupState.get(entityKey);
+      final String entityId, final TypedRecord<TenantRecord> command, final String tenantId) {
+    // TODO remove the Long parsing once Groups are migrated to work with ids instead of keys
+    final var group = groupState.get(Long.parseLong(entityId));
 
     if (group.isEmpty()) {
-      createEntityNotExistRejectCommand(command, entityKey, tenantId);
+      createEntityNotExistRejectCommand(command, entityId, tenantId);
       return false;
     }
 
     if (group.get().getTenantIdsList().contains(tenantId)) {
-      createAlreadyAssignedRejectCommand(command, entityKey, tenantId);
+      createAlreadyAssignedRejectCommand(command, entityId, tenantId);
       return false;
     }
     return true;
   }
 
   private void createEntityNotExistRejectCommand(
-      final TypedRecord<TenantRecord> command, final long entityKey, final String tenantId) {
+      final TypedRecord<TenantRecord> command, final String entityId, final String tenantId) {
     rejectCommand(
-        command, RejectionType.NOT_FOUND, formatErrorMessage(entityKey, tenantId, "doesn't exist"));
+        command, RejectionType.NOT_FOUND, formatErrorMessage(entityId, tenantId, "doesn't exist"));
   }
 
   private void createAlreadyAssignedRejectCommand(
-      final TypedRecord<TenantRecord> command, final long entityKey, final String tenantId) {
+      final TypedRecord<TenantRecord> command, final String entityId, final String tenantId) {
     rejectCommand(
         command,
         RejectionType.INVALID_ARGUMENT,
-        formatErrorMessage(entityKey, tenantId, "is already assigned to the tenant"));
+        formatErrorMessage(entityId, tenantId, "is already assigned to the tenant"));
   }
 
   private String formatErrorMessage(
-      final long entityKey, final String tenantId, final String reason) {
-    return "Expected to add entity with key '%s' to tenant with tenantId '%s', but the entity %s."
-        .formatted(entityKey, tenantId, reason);
+      final String entityId, final String tenantId, final String reason) {
+    return "Expected to add entity with id '%s' to tenant with tenantId '%s', but the entity %s."
+        .formatted(entityId, tenantId, reason);
   }
 
   private void rejectCommandWithUnauthorizedError(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
@@ -160,8 +160,8 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
                 default ->
                     throw new UnsupportedOperationException(
                         String.format(
-                            "Expected to remove entity with key %d and type %s from tenant %s, but type %s is not supported.",
-                            record.getEntityKey(),
+                            "Expected to remove entity with id %s and type %s from tenant %s, but type %s is not supported.",
+                            record.getEntityId(),
                             record.getEntityType(),
                             tenant.getTenantId(),
                             entityType));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityAddedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityAddedApplier.java
@@ -39,17 +39,18 @@ public class TenantEntityAddedApplier implements TypedEventApplier<TenantIntent,
       }
       case MAPPING -> {
         tenantState.addEntity(tenant);
-        mappingState.addTenant(tenant.getEntityKey(), tenant.getTenantId());
+        mappingState.addTenant(tenant.getEntityId(), tenant.getTenantId());
       }
       case GROUP -> {
         tenantState.addEntity(tenant);
-        groupState.addTenant(tenant.getEntityKey(), tenant.getTenantId());
+        // TODO remove the Long parsing once Groups are migrated to work with ids instead of keys
+        groupState.addTenant(Long.parseLong(tenant.getEntityId()), tenant.getTenantId());
       }
       default ->
           throw new IllegalStateException(
               String.format(
-                  "Expected to add entity '%d' to tenant '%s', but entities of type '%s' cannot be added to tenants",
-                  tenant.getEntityKey(), tenant.getTenantId(), tenant.getEntityType()));
+                  "Expected to add entity '%s' to tenant '%s', but entities of type '%s' cannot be added to tenants",
+                  tenant.getEntityId(), tenant.getTenantId(), tenant.getEntityType()));
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityRemovedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityRemovedApplier.java
@@ -34,8 +34,8 @@ public class TenantEntityRemovedApplier implements TypedEventApplier<TenantInten
       default ->
           throw new UnsupportedOperationException(
               String.format(
-                  "Expected to remove entity with key %d and type %s from tenant %s, but type %s is not supported.",
-                  tenant.getEntityKey(),
+                  "Expected to remove entity with id %s and type %s from tenant %s, but type %s is not supported.",
+                  tenant.getEntityId(),
                   tenant.getEntityType(),
                   tenant.getTenantId(),
                   tenant.getEntityType()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
@@ -96,9 +96,9 @@ public class DbMappingState implements MutableMappingState {
   }
 
   @Override
-  public void addTenant(final long mappingKey, final String tenantId) {
-    this.mappingKey.wrapLong(mappingKey);
-    final var fkClaim = claimByKeyColumnFamily.get(this.mappingKey);
+  public void addTenant(final String mappingId, final String tenantId) {
+    this.mappingId.wrapString(mappingId);
+    final var fkClaim = claimByIdColumnFamily.get(this.mappingId);
     if (fkClaim != null) {
       final var claim = fkClaim.inner();
       final var persistedMapping = mappingColumnFamily.get(claim);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMappingState.java
@@ -16,7 +16,7 @@ public interface MutableMappingState extends MappingState {
 
   void addRole(final long mappingKey, final long roleKey);
 
-  void addTenant(final long mappingKey, final String tenantId);
+  void addTenant(final String mappingId, final String tenantId);
 
   void addGroup(final long mappingKey, final long groupKey);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -23,10 +23,12 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.MappingRecordValue;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
@@ -61,12 +63,7 @@ public class AuthorizationCheckBehaviorTest {
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(
-        user.getUserKey(),
-        user.getUsername(),
-        AuthorizationOwnerType.USER,
-        resourceType,
-        permissionType,
-        resourceId);
+        user.getUsername(), AuthorizationOwnerType.USER, resourceType, permissionType, resourceId);
     final var command = mockCommand(user.getUsername());
 
     // when
@@ -105,7 +102,6 @@ public class AuthorizationCheckBehaviorTest {
     final var resourceId1 = UUID.randomUUID().toString();
     final var resourceId2 = UUID.randomUUID().toString();
     addPermission(
-        user.getUserKey(),
         user.getUsername(),
         AuthorizationOwnerType.USER,
         resourceType,
@@ -149,8 +145,7 @@ public class AuthorizationCheckBehaviorTest {
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
-    addPermission(
-        roleKey, roleId, AuthorizationOwnerType.ROLE, resourceType, permissionType, resourceId);
+    addPermission(roleId, AuthorizationOwnerType.ROLE, resourceType, permissionType, resourceId);
     final var command = mockCommand(user.getUsername());
 
     // when
@@ -173,7 +168,6 @@ public class AuthorizationCheckBehaviorTest {
     final var resourceId1 = UUID.randomUUID().toString();
     final var resourceId2 = UUID.randomUUID().toString();
     addPermission(
-        roleKey,
         roleId,
         AuthorizationOwnerType.ROLE,
         resourceType,
@@ -200,8 +194,7 @@ public class AuthorizationCheckBehaviorTest {
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
-    addPermission(
-        groupKey, groupId, AuthorizationOwnerType.GROUP, resourceType, permissionType, resourceId);
+    addPermission(groupId, AuthorizationOwnerType.GROUP, resourceType, permissionType, resourceId);
     final var command = mockCommand(user.getUsername());
 
     // when
@@ -224,7 +217,6 @@ public class AuthorizationCheckBehaviorTest {
     final var resourceId1 = UUID.randomUUID().toString();
     final var resourceId2 = UUID.randomUUID().toString();
     addPermission(
-        groupKey,
         groupId,
         AuthorizationOwnerType.GROUP,
         resourceType,
@@ -250,12 +242,7 @@ public class AuthorizationCheckBehaviorTest {
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(
-        user.getUserKey(),
-        user.getUsername(),
-        AuthorizationOwnerType.USER,
-        resourceType,
-        permissionType,
-        resourceId);
+        user.getUsername(), AuthorizationOwnerType.USER, resourceType, permissionType, resourceId);
     final var tenantId = createAndAssignTenant(user.getUsername(), EntityType.USER);
     final var command = mockCommand(user.getUsername());
 
@@ -277,12 +264,7 @@ public class AuthorizationCheckBehaviorTest {
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(
-        user.getUserKey(),
-        user.getUsername(),
-        AuthorizationOwnerType.USER,
-        resourceType,
-        permissionType,
-        resourceId);
+        user.getUsername(), AuthorizationOwnerType.USER, resourceType, permissionType, resourceId);
     final var groupKey = createGroup(user.getUserKey(), EntityType.USER);
     final var tenantId = createAndAssignTenant(groupKey, EntityType.GROUP);
     final var command = mockCommand(user.getUsername());
@@ -305,12 +287,7 @@ public class AuthorizationCheckBehaviorTest {
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(
-        user.getUserKey(),
-        user.getUsername(),
-        AuthorizationOwnerType.USER,
-        resourceType,
-        permissionType,
-        resourceId);
+        user.getUsername(), AuthorizationOwnerType.USER, resourceType, permissionType, resourceId);
     final var anotherTenantId = "authorizedForAnotherTenant";
     createAndAssignTenant(user.getUsername(), EntityType.USER);
     final var command = mockCommand(user.getUsername());
@@ -330,19 +307,13 @@ public class AuthorizationCheckBehaviorTest {
     // given
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
-    final var mappingKey = createMapping(claimName, claimValue);
-    final var mappingId = String.valueOf(mappingKey);
+    final var mappingId = createMapping(claimName, claimValue).getId();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(
-        mappingKey,
-        mappingId,
-        AuthorizationOwnerType.MAPPING,
-        resourceType,
-        permissionType,
-        resourceId);
-    final var tenantId = createAndAssignTenant(mappingKey, EntityType.MAPPING);
+        mappingId, AuthorizationOwnerType.MAPPING, resourceType, permissionType, resourceId);
+    final var tenantId = createAndAssignTenant(mappingId, EntityType.MAPPING);
     final var command = mockCommandWithMapping(claimName, claimValue);
 
     // when
@@ -360,19 +331,13 @@ public class AuthorizationCheckBehaviorTest {
     // given
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
-    final var mappingKey = createMapping(claimName, claimValue);
-    final var mappingId = String.valueOf(mappingKey);
+    final var mapping = createMapping(claimName, claimValue);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(
-        mappingKey,
-        mappingId,
-        AuthorizationOwnerType.MAPPING,
-        resourceType,
-        permissionType,
-        resourceId);
-    final var groupKey = createGroup(mappingKey, EntityType.MAPPING);
+        mapping.getId(), AuthorizationOwnerType.MAPPING, resourceType, permissionType, resourceId);
+    final var groupKey = createGroup(mapping.getMappingKey(), EntityType.MAPPING);
     final var tenantId = createAndAssignTenant(groupKey, EntityType.GROUP);
     final var command = mockCommandWithMapping(claimName, claimValue);
 
@@ -391,20 +356,14 @@ public class AuthorizationCheckBehaviorTest {
     // given
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
-    final var mappingKey = createMapping(claimName, claimValue);
-    final var mappingId = String.valueOf(mappingKey);
+    final var mappingId = createMapping(claimName, claimValue).getId();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(
-        mappingKey,
-        mappingId,
-        AuthorizationOwnerType.MAPPING,
-        resourceType,
-        permissionType,
-        resourceId);
+        mappingId, AuthorizationOwnerType.MAPPING, resourceType, permissionType, resourceId);
     final var anotherTenantId = "authorizedForAnotherTenant";
-    createAndAssignTenant(mappingKey, EntityType.MAPPING);
+    createAndAssignTenant(mappingId, EntityType.MAPPING);
     final var command = mockCommandWithMapping(claimName, claimValue);
 
     // when
@@ -445,9 +404,9 @@ public class AuthorizationCheckBehaviorTest {
     // given
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
-    final var mappingKey = createMapping(claimName, claimValue);
-    final var tenantId1 = createAndAssignTenant(mappingKey, EntityType.MAPPING);
-    final var tenantId2 = createAndAssignTenant(mappingKey, EntityType.MAPPING);
+    final var mappingId = createMapping(claimName, claimValue).getId();
+    final var tenantId1 = createAndAssignTenant(mappingId, EntityType.MAPPING);
+    final var tenantId2 = createAndAssignTenant(mappingId, EntityType.MAPPING);
     final var command = mockCommandWithMapping(claimName, claimValue);
 
     // when
@@ -494,8 +453,8 @@ public class AuthorizationCheckBehaviorTest {
     // given
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
-    final var mappingKey = createMapping(claimName, claimValue);
-    final var groupKey = createGroup(mappingKey, EntityType.MAPPING);
+    final var mapping = createMapping(claimName, claimValue);
+    final var groupKey = createGroup(mapping.getMappingKey(), EntityType.MAPPING);
     final var tenantId1 = createAndAssignTenant(groupKey, EntityType.GROUP);
     final var tenantId2 = createAndAssignTenant(groupKey, EntityType.GROUP);
     final var command = mockCommandWithMapping(claimName, claimValue);
@@ -561,12 +520,7 @@ public class AuthorizationCheckBehaviorTest {
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(
-        user.getUserKey(),
-        user.getUsername(),
-        AuthorizationOwnerType.USER,
-        resourceType,
-        permissionType,
-        resourceId);
+        user.getUsername(), AuthorizationOwnerType.USER, resourceType, permissionType, resourceId);
     final var command = mockCommandWithAnonymousUser();
 
     // when
@@ -597,18 +551,11 @@ public class AuthorizationCheckBehaviorTest {
     final var claimValue = UUID.randomUUID().toString();
     final var mapping =
         engine.mapping().newMapping(claimName).withClaimValue(claimValue).create().getValue();
-    final var mappingKey = mapping.getMappingKey();
-    final var mappingId = String.valueOf(mappingKey);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(
-        mappingKey,
-        mappingId,
-        AuthorizationOwnerType.MAPPING,
-        resourceType,
-        permissionType,
-        resourceId);
+        mapping.getId(), AuthorizationOwnerType.MAPPING, resourceType, permissionType, resourceId);
     final var command = mockCommandWithMapping(claimName, claimValue);
 
     // when
@@ -627,26 +574,19 @@ public class AuthorizationCheckBehaviorTest {
     final var claimValue = UUID.randomUUID().toString();
     final var mapping =
         engine.mapping().newMapping(claimName).withClaimValue(claimValue).create().getValue();
-    final var mappingKey = mapping.getMappingKey();
-    final var mappingId = String.valueOf(mappingKey);
     final var tenantId = "tenant";
     engine.tenant().newTenant().withTenantId(tenantId).create();
     engine
         .tenant()
         .addEntity(tenantId)
         .withEntityType(EntityType.MAPPING)
-        .withEntityKey(mappingKey)
+        .withEntityId(mapping.getId())
         .add();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(
-        mappingKey,
-        mappingId,
-        AuthorizationOwnerType.MAPPING,
-        resourceType,
-        permissionType,
-        resourceId);
+        mapping.getId(), AuthorizationOwnerType.MAPPING, resourceType, permissionType, resourceId);
     final var command = mockCommandWithMapping(claimName, claimValue);
 
     // when
@@ -666,26 +606,19 @@ public class AuthorizationCheckBehaviorTest {
     final var claimValue = UUID.randomUUID().toString();
     final var mapping =
         engine.mapping().newMapping(claimName).withClaimValue(claimValue).create().getValue();
-    final var mappingKey = mapping.getMappingKey();
-    final var mappingId = String.valueOf(mappingKey);
     final var tenantId = "tenant";
     engine.tenant().newTenant().withTenantId(tenantId).create();
     engine
         .tenant()
         .addEntity(tenantId)
         .withEntityType(EntityType.MAPPING)
-        .withEntityKey(mappingKey)
+        .withEntityId(mapping.getId())
         .add();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(
-        mappingKey,
-        mappingId,
-        AuthorizationOwnerType.MAPPING,
-        resourceType,
-        permissionType,
-        resourceId);
+        mapping.getId(), AuthorizationOwnerType.MAPPING, resourceType, permissionType, resourceId);
     final var command = mockCommandWithMapping(claimName, claimValue);
 
     // when
@@ -795,24 +728,26 @@ public class AuthorizationCheckBehaviorTest {
     // given
     final var firstClaimName = UUID.randomUUID().toString();
     final var firstClaimValue = UUID.randomUUID().toString();
-    final var firstMappingKey =
+    final var firstMappingId =
         engine
             .mapping()
             .newMapping(firstClaimName)
             .withClaimValue(firstClaimValue)
             .withId(UUID.randomUUID().toString())
             .create()
-            .getKey();
+            .getValue()
+            .getId();
     final var secondClaimName = UUID.randomUUID().toString();
     final var secondClaimValue = UUID.randomUUID().toString();
-    final var secondMappingKey =
+    final var secondMappingId =
         engine
             .mapping()
             .newMapping(secondClaimName)
             .withClaimValue(secondClaimValue)
             .withId(UUID.randomUUID().toString())
             .create()
-            .getKey();
+            .getValue()
+            .getId();
 
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
@@ -821,7 +756,7 @@ public class AuthorizationCheckBehaviorTest {
     engine
         .authorization()
         .newAuthorization()
-        .withOwnerId(String.valueOf(firstMappingKey))
+        .withOwnerId(String.valueOf(firstMappingId))
         .withOwnerType(AuthorizationOwnerType.MAPPING)
         .withResourceType(resourceType)
         .withPermissions(permissionType)
@@ -830,7 +765,7 @@ public class AuthorizationCheckBehaviorTest {
     engine
         .authorization()
         .newAuthorization()
-        .withOwnerId(String.valueOf(secondMappingKey))
+        .withOwnerId(String.valueOf(secondMappingId))
         .withOwnerType(AuthorizationOwnerType.MAPPING)
         .withResourceType(resourceType)
         .withPermissions(permissionType)
@@ -870,23 +805,25 @@ public class AuthorizationCheckBehaviorTest {
     // given
     final var claimName = UUID.randomUUID().toString();
     final var firstClaimValue = UUID.randomUUID().toString();
-    final var firstMappingKey =
+    final var firstMappingId =
         engine
             .mapping()
             .newMapping(claimName)
             .withClaimValue(firstClaimValue)
             .withId(UUID.randomUUID().toString())
             .create()
-            .getKey();
+            .getValue()
+            .getId();
     final var secondClaimValue = UUID.randomUUID().toString();
-    final var secondMappingKey =
+    final var secondMappingId =
         engine
             .mapping()
             .newMapping(claimName)
             .withClaimValue(secondClaimValue)
             .withId(UUID.randomUUID().toString())
             .create()
-            .getKey();
+            .getValue()
+            .getId();
 
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
@@ -895,7 +832,7 @@ public class AuthorizationCheckBehaviorTest {
     engine
         .authorization()
         .newAuthorization()
-        .withOwnerId(String.valueOf(firstMappingKey))
+        .withOwnerId(String.valueOf(firstMappingId))
         .withOwnerType(AuthorizationOwnerType.MAPPING)
         .withResourceType(resourceType)
         .withPermissions(permissionType)
@@ -904,7 +841,7 @@ public class AuthorizationCheckBehaviorTest {
     engine
         .authorization()
         .newAuthorization()
-        .withOwnerId(String.valueOf(secondMappingKey))
+        .withOwnerId(String.valueOf(secondMappingId))
         .withOwnerType(AuthorizationOwnerType.MAPPING)
         .withResourceType(resourceType)
         .withPermissions(permissionType)
@@ -943,18 +880,11 @@ public class AuthorizationCheckBehaviorTest {
     final var claimValue = UUID.randomUUID().toString();
     final var mapping =
         engine.mapping().newMapping(claimName).withClaimValue(claimValue).create().getValue();
-    final var mappingKey = mapping.getMappingKey();
-    final var mappingId = String.valueOf(mappingKey);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(
-        mappingKey,
-        mappingId,
-        AuthorizationOwnerType.MAPPING,
-        resourceType,
-        permissionType,
-        resourceId);
+        mapping.getId(), AuthorizationOwnerType.MAPPING, resourceType, permissionType, resourceId);
     final var command = mockCommandWithMapping(claimName, claimValue);
 
     // when
@@ -987,8 +917,7 @@ public class AuthorizationCheckBehaviorTest {
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
-    addPermission(
-        roleKey, roleId, AuthorizationOwnerType.ROLE, resourceType, permissionType, resourceId);
+    addPermission(roleId, AuthorizationOwnerType.ROLE, resourceType, permissionType, resourceId);
     final var command = mockCommandWithMapping(claimName, claimValue);
 
     // when
@@ -1021,8 +950,7 @@ public class AuthorizationCheckBehaviorTest {
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
-    addPermission(
-        groupKey, groupId, AuthorizationOwnerType.GROUP, resourceType, permissionType, resourceId);
+    addPermission(groupId, AuthorizationOwnerType.GROUP, resourceType, permissionType, resourceId);
     final var command = mockCommandWithMapping(claimName, claimValue);
 
     // when
@@ -1041,9 +969,14 @@ public class AuthorizationCheckBehaviorTest {
     // given
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
-    final var mapping =
-        engine.mapping().newMapping(claimName).withClaimValue(claimValue).create().getValue();
-    final var mappingKey = mapping.getMappingKey();
+    final var mappingId = Strings.newRandomValidIdentityId();
+    engine
+        .mapping()
+        .newMapping(claimName)
+        .withClaimValue(claimValue)
+        .withId(mappingId)
+        .create()
+        .getValue();
     final var tenantId = "tenant";
     engine.tenant().newTenant().withTenantId(tenantId).create();
     final var command = mockCommandWithMapping(claimName, claimValue);
@@ -1053,7 +986,7 @@ public class AuthorizationCheckBehaviorTest {
         .tenant()
         .addEntity(tenantId)
         .withEntityType(EntityType.MAPPING)
-        .withEntityKey(mappingKey)
+        .withEntityId(mappingId)
         .add();
 
     // then
@@ -1112,12 +1045,27 @@ public class AuthorizationCheckBehaviorTest {
     return groupKey;
   }
 
-  private long createMapping(final String claimName, final String claimValue) {
-    return engine.mapping().newMapping(claimName).withClaimValue(claimValue).create().getKey();
+  private MappingRecordValue createMapping(final String claimName, final String claimValue) {
+    return engine
+        .mapping()
+        .newMapping(claimName)
+        .withClaimValue(claimValue)
+        .withId(Strings.newRandomValidIdentityId())
+        .create()
+        .getValue();
+  }
+
+  // TODO remove this method once Mappings and Groups are migrated to work with ids instead of
+  private void addPermission(
+      final Long ownerKey,
+      final AuthorizationOwnerType ownerType,
+      final AuthorizationResourceType resourceType,
+      final PermissionType permissionType,
+      final String... resourceIds) {
+    addPermission(String.valueOf(ownerKey), ownerType, resourceType, permissionType, resourceIds);
   }
 
   private void addPermission(
-      final long ownerKey,
       final String ownerId,
       final AuthorizationOwnerType ownerType,
       final AuthorizationResourceType resourceType,
@@ -1136,11 +1084,9 @@ public class AuthorizationCheckBehaviorTest {
     }
   }
 
-  private String createAndAssignTenant(final long entityKey, final EntityType entityType) {
-    final var tenantId = UUID.randomUUID().toString();
-    engine.tenant().newTenant().withTenantId(tenantId).create();
-    engine.tenant().addEntity(tenantId).withEntityKey(entityKey).withEntityType(entityType).add();
-    return tenantId;
+  // TODO remove this method once Mappings and Groups are migrated to work with ids instead of
+  private String createAndAssignTenant(final Long entityKey, final EntityType entityType) {
+    return createAndAssignTenant(String.valueOf(entityKey), entityType);
   }
 
   private String createAndAssignTenant(final String entityId, final EntityType entityType) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
@@ -63,6 +63,7 @@ public class MappingAppliersTest {
     final var mappingRecord =
         new MappingRecord()
             .setMappingKey(mappingKey)
+            .setId(mappingId)
             .setClaimName(claimName)
             .setClaimValue(claimValue)
             .setName(claimName);
@@ -80,12 +81,12 @@ public class MappingAppliersTest {
     // create tenant
     final long tenantKey = 3L;
     final var tenantId = "tenant";
-    mappingState.addTenant(mappingKey, tenantId);
+    mappingState.addTenant(mappingId, tenantId);
     final var tenant =
         new TenantRecord()
             .setTenantId(tenantId)
             .setTenantKey(tenantKey)
-            .setEntityKey(mappingKey)
+            .setEntityId(mappingId)
             .setEntityType(EntityType.MAPPING);
     tenantState.createTenant(tenant);
     tenantState.addEntity(tenant);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
@@ -75,28 +75,21 @@ public class TenantAppliersTest {
   @Test
   void shouldAddEntityToTenantWithTypeMapping() {
     // given
-    final Long entityKey = 1L;
+    final var mappingId = "mappingId";
     mappingState.create(
-        new MappingRecord()
-            .setMappingKey(entityKey)
-            .setClaimName("claimName")
-            .setClaimValue("claimValue"));
+        new MappingRecord().setId(mappingId).setClaimName("claimName").setClaimValue("claimValue"));
     final String tenantId = "tenantId";
     final long tenantKey = 11L;
     final var tenantRecord = new TenantRecord().setTenantId(tenantId).setTenantKey(tenantKey);
     tenantState.createTenant(tenantRecord);
-    tenantRecord
-        .setEntityKey(entityKey)
-        .setEntityId(entityKey.toString())
-        .setEntityType(EntityType.MAPPING);
+    tenantRecord.setEntityId(mappingId).setEntityType(EntityType.MAPPING);
 
     // when
     tenantEntityAddedApplier.applyState(tenantKey, tenantRecord);
 
     // then
-    assertThat(tenantState.getEntityType(tenantId, entityKey.toString()).get())
-        .isEqualTo(EntityType.MAPPING);
-    final var persistedMapping = mappingState.get(entityKey).get();
+    assertThat(tenantState.getEntityType(tenantId, mappingId).get()).isEqualTo(EntityType.MAPPING);
+    final var persistedMapping = mappingState.get(mappingId).get();
     assertThat(persistedMapping.getTenantIdsList()).containsExactly(tenantId);
   }
 
@@ -162,31 +155,27 @@ public class TenantAppliersTest {
       "Disabled while mappings are not supported: https://github.com/camunda/camunda/issues/26981")
   void shouldRemoveEntityFromTenantWithTypeMapping() {
     // given
-    final Long entityKey = 1L;
+    final var mappingId = "mappingId";
     mappingState.create(
-        new MappingRecord()
-            .setMappingKey(entityKey)
-            .setClaimName("claimName")
-            .setClaimValue("claimValue"));
+        new MappingRecord().setId(mappingId).setClaimName("claimName").setClaimValue("claimValue"));
     final String tenantId = "tenantId";
     final long tenantKey = 11L;
     final var tenantRecord = new TenantRecord().setTenantId(tenantId).setTenantKey(tenantKey);
     tenantState.createTenant(tenantRecord);
-    tenantRecord.setEntityKey(entityKey).setEntityType(EntityType.MAPPING);
+    tenantRecord.setEntityId(mappingId).setEntityType(EntityType.MAPPING);
     tenantEntityAddedApplier.applyState(tenantKey, tenantRecord);
 
     // Ensure the mapping is associated with the tenant before removal
-    assertThat(tenantState.getEntityType(tenantId, entityKey.toString()).get())
-        .isEqualTo(EntityType.MAPPING);
-    final var persistedMapping = mappingState.get(entityKey).get();
+    assertThat(tenantState.getEntityType(tenantId, mappingId).get()).isEqualTo(EntityType.MAPPING);
+    final var persistedMapping = mappingState.get(mappingId).get();
     assertThat(persistedMapping.getTenantIdsList()).containsExactly(tenantId);
 
     // when
     tenantEntityRemovedApplier.applyState(tenantKey, tenantRecord);
 
     // then
-    assertThat(tenantState.getEntityType(tenantId, entityKey.toString())).isEmpty();
-    final var updatedMapping = mappingState.get(entityKey).get();
+    assertThat(tenantState.getEntityType(tenantId, mappingId)).isEmpty();
+    final var updatedMapping = mappingState.get(mappingId).get();
     assertThat(updatedMapping.getTenantIdsList()).isEmpty();
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingStateTest.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableMappingState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
+import io.camunda.zeebe.test.util.Strings;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -174,13 +175,18 @@ public class MappingStateTest {
     final long key = 1L;
     final String claimName = "foo";
     final String claimValue = "bar";
+    final String mappingId = Strings.newRandomValidIdentityId();
     final var mapping =
-        new MappingRecord().setMappingKey(key).setClaimName(claimName).setClaimValue(claimValue);
+        new MappingRecord()
+            .setId(mappingId)
+            .setMappingKey(key)
+            .setClaimName(claimName)
+            .setClaimValue(claimValue);
     mappingState.create(mapping);
     final var tenantId = "tenant";
 
     // when
-    mappingState.addTenant(key, tenantId);
+    mappingState.addTenant(mappingId, tenantId);
 
     // then
     final var persistedMapping = mappingState.get(key).get();
@@ -193,11 +199,16 @@ public class MappingStateTest {
     final long key = 1L;
     final String claimName = "foo";
     final String claimValue = "bar";
+    final String mappingId = Strings.newRandomValidIdentityId();
     final var mapping =
-        new MappingRecord().setMappingKey(key).setClaimName(claimName).setClaimValue(claimValue);
+        new MappingRecord()
+            .setId(mappingId)
+            .setMappingKey(key)
+            .setClaimName(claimName)
+            .setClaimValue(claimValue);
     mappingState.create(mapping);
     final var tenantId = "tenant";
-    mappingState.addTenant(key, tenantId);
+    mappingState.addTenant(mappingId, tenantId);
 
     // when
     mappingState.removeTenant(key, tenantId);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/TenantClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/TenantClient.java
@@ -130,17 +130,6 @@ public class TenantClient {
     }
 
     /**
-     * Sets the entityKey for the tenant record.
-     *
-     * @param entityKey the key of the tenant entity
-     * @return this instance
-     */
-    public TenantCreationClient withEntityKey(final Long entityKey) {
-      tenantRecord.setEntityKey(entityKey);
-      return this;
-    }
-
-    /**
      * Creates the tenant record and returns the resulting record.
      *
      * @return the created tenant record
@@ -211,17 +200,6 @@ public class TenantClient {
     }
 
     /**
-     * Sets the entityKey for the tenant record.
-     *
-     * @param entityKey the key of the tenant entity
-     * @return this instance
-     */
-    public TenantUpdateClient withEntityKey(final Long entityKey) {
-      tenantRecord.setEntityKey(entityKey);
-      return this;
-    }
-
-    /**
      * Submits the update command for the tenant record and returns the updated record.
      *
      * @return the updated tenant record
@@ -267,11 +245,6 @@ public class TenantClient {
       this.writer = writer;
       tenantRecord = new TenantRecord();
       tenantRecord.setTenantId(tenantId);
-    }
-
-    public TenantAddEntityClient withEntityKey(final long entityKey) {
-      tenantRecord.setEntityKey(entityKey);
-      return this;
     }
 
     public TenantAddEntityClient withEntityId(final String entityId) {

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerTenantEntityRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerTenantEntityRequest.java
@@ -44,16 +44,6 @@ public final class BrokerTenantEntityRequest extends BrokerExecuteCommand<Tenant
     return this;
   }
 
-  public BrokerTenantEntityRequest setEntity(final EntityType entityType, final long entityKey) {
-    if (!ALLOWED_ENTITY_TYPES.contains(entityType)) {
-      throw new IllegalArgumentException(
-          "For now, tenants can only be assigned to %s".formatted(ALLOWED_ENTITY_TYPES));
-    }
-    tenantDto.setEntityType(entityType);
-    tenantDto.setEntityKey(entityKey);
-    return this;
-  }
-
   public BrokerTenantEntityRequest setEntity(final EntityType entityType, final String entityId) {
     if (!ALLOWED_ENTITY_TYPES.contains(entityType)) {
       throw new IllegalArgumentException(

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/tenant/TenantRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/tenant/TenantRecord.java
@@ -24,18 +24,16 @@ public final class TenantRecord extends UnifiedRecordValue implements TenantReco
   private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
   private final StringProperty nameProp = new StringProperty("name", "");
   private final StringProperty descriptionProp = new StringProperty("description", "");
-  private final LongProperty entityKeyProp = new LongProperty("entityKey", DEFAULT_KEY);
   private final StringProperty entityIdProp = new StringProperty("entityId", "");
   private final EnumProperty<EntityType> entityTypeProp =
       new EnumProperty<>("entityType", EntityType.class, EntityType.UNSPECIFIED);
 
   public TenantRecord() {
-    super(7);
+    super(6);
     declareProperty(tenantKeyProp)
         .declareProperty(tenantIdProp)
         .declareProperty(nameProp)
         .declareProperty(descriptionProp)
-        .declareProperty(entityKeyProp)
         .declareProperty(entityIdProp)
         .declareProperty(entityTypeProp);
   }
@@ -98,16 +96,6 @@ public final class TenantRecord extends UnifiedRecordValue implements TenantReco
     }
 
     descriptionProp.setValue(description);
-    return this;
-  }
-
-  @Override
-  public long getEntityKey() {
-    return entityKeyProp.getValue();
-  }
-
-  public TenantRecord setEntityKey(final long entityKey) {
-    entityKeyProp.setValue(entityKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2822,7 +2822,6 @@ final class JsonSerializableToJsonTest {
                     .setTenantId("tenant-abc")
                     .setName("Test Tenant")
                     .setDescription("Test Description")
-                    .setEntityKey(456L)
                     .setEntityId("entity-xyz")
                     .setEntityType(EntityType.USER),
         """
@@ -2831,7 +2830,6 @@ final class JsonSerializableToJsonTest {
           "tenantId": "tenant-abc",
           "name": "Test Tenant",
           "description": "Test Description",
-          "entityKey": 456,
           "entityId": "entity-xyz",
           "entityType": "USER"
         }
@@ -2849,7 +2847,6 @@ final class JsonSerializableToJsonTest {
             "tenantId": "",
             "name": "",
             "description": "",
-            "entityKey": -1,
             "entityId": "",
             "entityType": "UNSPECIFIED"
           }
@@ -3057,7 +3054,6 @@ final class JsonSerializableToJsonTest {
           "tenantId": "id",
           "name": "name",
           "description": "",
-          "entityKey": -1,
           "entityId": "",
           "entityType": "UNSPECIFIED"
         },
@@ -3100,7 +3096,6 @@ final class JsonSerializableToJsonTest {
               "tenantId": "",
               "name": "",
               "description": "",
-              "entityKey": -1,
               "entityId": "",
               "entityType": "UNSPECIFIED"
           },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/TenantRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/TenantRecordValue.java
@@ -35,9 +35,6 @@ public interface TenantRecordValue extends RecordValue {
 
   String getDescription();
 
-  /** Key of the entity associated with this tenant. */
-  long getEntityKey();
-
   /** Identifier of the entity associated with this tenant. */
   String getEntityId();
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignGroupToTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignGroupToTenantTest.java
@@ -58,9 +58,10 @@ class AssignGroupToTenantTest {
     client.newAssignGroupToTenantCommand(TENANT_ID).groupKey(groupKey).send().join();
 
     // then
+    // TODO remove the String parsing once Groups are migrated to work with ids instead of keys
     ZeebeAssertHelper.assertEntityAssignedToTenant(
         TENANT_ID,
-        groupKey,
+        String.valueOf(groupKey),
         tenant -> {
           assertThat(tenant.getTenantKey()).isEqualTo(tenantKey);
           assertThat(tenant.getEntityType()).isEqualTo(EntityType.GROUP);
@@ -103,7 +104,7 @@ class AssignGroupToTenantTest {
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
         .hasMessageContaining(
-            "Expected to add entity with key '%d' to tenant with tenantId '%s', but the entity doesn't exist."
+            "Expected to add entity with id '%d' to tenant with tenantId '%s', but the entity doesn't exist."
                 .formatted(nonExistentGroupKey, TENANT_ID));
   }
 
@@ -118,7 +119,7 @@ class AssignGroupToTenantTest {
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 400: 'Bad Request'")
         .hasMessageContaining(
-            "Expected to add entity with key '%d' to tenant with tenantId '%s', but the entity is already assigned to the tenant."
+            "Expected to add entity with id '%d' to tenant with tenantId '%s', but the entity is already assigned to the tenant."
                 .formatted(groupKey, TENANT_ID));
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignMappingToTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignMappingToTenantTest.java
@@ -29,7 +29,7 @@ class AssignMappingToTenantTest {
   private static final String CLAIM_NAME = "claimName";
   private static final String CLAIM_VALUE = "claimValue";
   private static final String NAME = "name";
-  private static final String ID = "id";
+  private static final String ID = "123456789";
 
   @TestZeebe
   private final TestStandaloneBroker zeebe =
@@ -37,7 +37,6 @@ class AssignMappingToTenantTest {
 
   @AutoClose private CamundaClient client;
 
-  private long tenantKey;
   private long mappingKey;
 
   @BeforeEach
@@ -45,14 +44,7 @@ class AssignMappingToTenantTest {
     client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
 
     // Create Tenant
-    tenantKey =
-        client
-            .newCreateTenantCommand()
-            .tenantId(TENANT_ID)
-            .name("Initial Tenant Name")
-            .send()
-            .join()
-            .getTenantKey();
+    client.newCreateTenantCommand().tenantId(TENANT_ID).name("Initial Tenant Name").send().join();
 
     // Create Mapping
     mappingKey =
@@ -70,14 +62,15 @@ class AssignMappingToTenantTest {
   @Test
   void shouldAssignMappingToTenant() {
     // When
-    client.newAssignMappingToTenantCommand(TENANT_ID).mappingKey(mappingKey).send().join();
+    // TODO remove the Long parsing once Mappings are migrated to work with ids instead of keys
+    client.newAssignMappingToTenantCommand(TENANT_ID).mappingKey(Long.parseLong(ID)).send().join();
 
     // Then
     ZeebeAssertHelper.assertEntityAssignedToTenant(
         TENANT_ID,
-        mappingKey,
+        ID,
         tenant -> {
-          assertThat(tenant.getTenantKey()).isEqualTo(tenantKey);
+          assertThat(tenant.getTenantId()).isEqualTo(TENANT_ID);
           assertThat(tenant.getEntityType()).isEqualTo(EntityType.MAPPING);
         });
   }
@@ -118,7 +111,7 @@ class AssignMappingToTenantTest {
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
         .hasMessageContaining(
-            "Expected to add entity with key '%d' to tenant with tenantId '%s', but the entity doesn't exist."
+            "Expected to add entity with id '%d' to tenant with tenantId '%s', but the entity doesn't exist."
                 .formatted(invalidMappingKey, TENANT_ID));
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignGroupFromTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignGroupFromTenantTest.java
@@ -64,7 +64,9 @@ class UnassignGroupFromTenantTest {
         TENANT_ID,
         (tenant) -> {
           assertThat(tenant.getTenantId()).isEqualTo(TENANT_ID);
-          assertThat(tenant.getEntityKey()).isEqualTo(groupKey);
+          // TODO remove the String parsing once Groups are migrated to work with ids instead of
+          // keys
+          assertThat(tenant.getEntityId()).isEqualTo(String.valueOf(groupKey));
         });
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
@@ -520,12 +520,12 @@ public final class ZeebeAssertHelper {
   }
 
   public static void assertEntityAssignedToTenant(
-      final String tenantId, final long entityKey, final Consumer<TenantRecordValue> consumer) {
+      final String tenantId, final String entityId, final Consumer<TenantRecordValue> consumer) {
     final TenantRecordValue tenantRecordValue =
         RecordingExporter.tenantRecords()
             .withIntent(TenantIntent.ENTITY_ADDED)
             .withTenantId(tenantId)
-            .withEntityKey(entityKey)
+            .withEntityId(entityId)
             .getFirst()
             .getValue();
 

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -938,8 +938,6 @@ public class CompactRecordLogger {
         .append(formatId(value.getTenantId()))
         .append(", Name=")
         .append(formatId(value.getName()))
-        .append(", EntityKey=")
-        .append(shortenKey(value.getEntityKey()))
         .append(", EntityId=")
         .append(formatId(value.getEntityId()))
         .append("]");

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/TenantRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/TenantRecordStream.java
@@ -36,10 +36,6 @@ public class TenantRecordStream
     return valueFilter(v -> v.getName().equals(name));
   }
 
-  public TenantRecordStream withEntityKey(final long entityKey) {
-    return valueFilter(v -> v.getEntityKey() == entityKey);
-  }
-
   public TenantRecordStream withEntityId(final String entityId) {
     return valueFilter(v -> v.getEntityId().equals(entityId));
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Tenants are now id-based, and so will all the entities that can get assigned to a tenant. We no longer have a need for the `entityKey` and should remove it. The property is used in 3 scenarios:

- Assigning/Unassigning a user. This is simple and mostly worked already since the user migration from key to username is already completed.
- Assigning/unassigning a group. Groups don't have an id yet. Because of this we use the key for now. By parsing the key to a String we can pretend it's an id. This parsing needs to be replaced when we refactor Groups to work with ids.
- Assigning/unassigning a mapping. Mappings do have an id. Because of this we can just use the id. It did require some
fixes in code that weren't done before.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #28831
