### PR TITLE
ci: c8run setting closed-at field if c8run issue closed

### DIFF
--- a/.github/workflows/c8run-closed-issue.yaml
+++ b/.github/workflows/c8run-closed-issue.yaml
@@ -1,10 +1,26 @@
-name: Close Issue
+name: "C8Run: Issue Closed"
 
 on:
   issues:
     types:
       - closed
-        
+
+permissions:
+  actions: write
+  attestations: none
+  checks: write
+  contents: read
+  deployments: none
+  id-token: none
+  issues: write
+  discussions: none
+  packages: none
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: write
+
 jobs:
   update-closed-at-field:
     name: Update closed at field

--- a/.github/workflows/c8run-closed-issue.yaml
+++ b/.github/workflows/c8run-closed-issue.yaml
@@ -1,0 +1,44 @@
+name: Close Issue
+
+on:
+  issues:
+    types:
+      - closed
+        
+jobs:
+  update-closed-at-field:
+    name: Update closed at field
+    runs-on: ubuntu-latest
+    steps:
+        - name: Prepare variables and check label
+          id: vars
+          run: |
+            echo "project_id=33" >> "$GITHUB_OUTPUT"
+            echo "now=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+        
+            labels=$(jq -r '.issue.labels[].name' "$GITHUB_EVENT_PATH")
+            if echo "$labels" | grep -q  "^component/c8run$"; then
+              echo "match=true" >> "$GITHUB_OUTPUT"
+            else
+              exit 1
+            fi
+
+        - name: Generate GitHub token
+          if: ${{ steps.vars.outputs.match == 'true' }}
+          uses: tibdex/github-app-token@v2
+          id: generate-github-token
+          with:
+            app_id: ${{ secrets.GH_APP_ID_DISTRO_CI }}
+            private_key: ${{ secrets.GH_APP_PRIVATE_KEY_DISTRO_CI }}
+
+        - name: Update Closed At field
+          if: ${{ steps.vars.outputs.match == 'true' }}
+          uses: github/update-project-action@f980378bc179626af5b4e20ec05ec39c7f7a6f6d # main
+          id: update-closed-at
+          with:
+            github_token: ${{ steps.generate-github-token.outputs.token }}
+            organization: ${{ github.repository_owner }}
+            project_number: ${{ steps.vars.outputs.project_id }}
+            content_id: ${{ github.event.issue.node_id }}
+            field: Closed At
+            value: ${{ steps.vars.outputs.now }}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

similar to https://github.com/camunda/camunda-platform-helm/pull/3028 but for c8run issues.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
