### PR TITLE
[Backport stable/8.7] fix: NettyDnsMetrics use a MeterProvider instead of a HashMap to avoid concurrency issues

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyDnsMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyDnsMetrics.java
@@ -10,6 +10,7 @@ package io.atomix.cluster.messaging.impl;
 import static io.atomix.cluster.messaging.impl.NettyDnsMetricsDoc.*;
 
 import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Meter.MeterProvider;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.channel.ChannelFuture;
 import io.netty.handler.codec.dns.DnsQuestion;
@@ -17,26 +18,26 @@ import io.netty.handler.codec.dns.DnsResponseCode;
 import io.netty.resolver.dns.DnsQueryLifecycleObserver;
 import java.net.InetSocketAddress;
 import java.util.List;
-import org.agrona.collections.Int2ObjectHashMap;
 
 final class NettyDnsMetrics implements DnsQueryLifecycleObserver {
 
-  private final MeterRegistry registry;
   private final Counter error;
   private final Counter written;
   private final Counter succeded;
 
   /** indexed by {@link DnsResponseCode#intValue()} */
-  private final Int2ObjectHashMap<Counter> failed;
+  private final MeterProvider<Counter> failed;
 
   NettyDnsMetrics(final MeterRegistry registry) {
-    this.registry = registry;
     error = Counter.builder(ERROR.getName()).description(ERROR.getDescription()).register(registry);
     written =
         Counter.builder(WRITTEN.getName()).description(WRITTEN.getDescription()).register(registry);
     succeded =
         Counter.builder(SUCCESS.getName()).description(SUCCESS.getDescription()).register(registry);
-    failed = new Int2ObjectHashMap<>();
+    failed =
+        Counter.builder(FAILED.getName())
+            .description(FAILED.getDescription())
+            .withRegistry(registry);
   }
 
   @Override
@@ -59,7 +60,7 @@ final class NettyDnsMetrics implements DnsQueryLifecycleObserver {
 
   @Override
   public DnsQueryLifecycleObserver queryNoAnswer(final DnsResponseCode code) {
-    failed.computeIfAbsent(code.intValue(), v -> registerFailed(code)).increment();
+    failed.withTag(NettyDnsKeyName.CODE.asString(), code.toString()).increment();
     return this;
   }
 
@@ -71,12 +72,5 @@ final class NettyDnsMetrics implements DnsQueryLifecycleObserver {
   @Override
   public void querySucceed() {
     succeded.increment();
-  }
-
-  private Counter registerFailed(final DnsResponseCode code) {
-    return Counter.builder(FAILED.getName())
-        .description(FAILED.getDescription())
-        .tags(NettyDnsKeyName.CODE.asString(), code.toString())
-        .register(registry);
   }
 }


### PR DESCRIPTION
# Description
Backport of #28555 to `stable/8.7`.

relates to #28556