### PR TITLE
Fix duplicate gauge registration

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/MessagingMetricsImpl.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/MessagingMetricsImpl.java
@@ -122,7 +122,7 @@ final class MessagingMetricsImpl implements MessagingMetrics {
             Timer.builder(REQUEST_RESPONSE_LATENCY.getName())
                 .description(REQUEST_RESPONSE_LATENCY.getDescription())
                 .serviceLevelObjectives(REQUEST_RESPONSE_LATENCY.getTimerSLOs())
-                .tags(MessagingKeyNames.TOPIC.asString(), t)
+                .tag(MessagingKeyNames.TOPIC.asString(), t)
                 .register(registry));
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocolMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/protocol/SwimMembershipProtocolMetrics.java
@@ -43,7 +43,7 @@ final class SwimMembershipProtocolMetrics {
                 SwimMembershipProtocolMetricsDoc.MEMBERS_INCARNATION_NUMBER.getName(), inside::get)
             .description(
                 SwimMembershipProtocolMetricsDoc.MEMBERS_INCARNATION_NUMBER.getDescription())
-            .tags(SwimKeyNames.MEMBER_ID.asString(), member)
+            .tag(SwimKeyNames.MEMBER_ID.asString(), member)
             .register(registry);
       }
       // always return what is present in the map, not what was just allocated

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/LeaderAppenderMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/LeaderAppenderMetrics.java
@@ -17,18 +17,13 @@
 package io.atomix.raft.metrics;
 
 import io.camunda.zeebe.util.CloseableSilently;
-import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.camunda.zeebe.util.micrometer.StatefulGauge;
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Gauge;
-import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Stream;
 
 public class LeaderAppenderMetrics extends RaftMetrics implements CloseableSilently {
   private final MeterRegistry meterRegistry;

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftMetrics.java
@@ -19,10 +19,6 @@ package io.atomix.raft.metrics;
 import org.slf4j.LoggerFactory;
 
 public class RaftMetrics {
-  protected static final String NAMESPACE = "atomix";
-  protected static final String PARTITION_GROUP_NAME_LABEL = "partitionGroupName";
-  protected static final String PARTITION_LABEL = "partition";
-
   protected final String partition;
   protected final String partitionGroupName;
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftReplicationMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftReplicationMetrics.java
@@ -31,12 +31,12 @@ public class RaftReplicationMetrics extends RaftMetrics {
     commitIndex =
         StatefulGauge.builder(COMMIT_INDEX.getName())
             .description(COMMIT_INDEX.getDescription())
-            .tags(RaftKeyNames.PARTITION_GROUP.asString(), partitionGroupName)
+            .tag(RaftKeyNames.PARTITION_GROUP.asString(), partitionGroupName)
             .register(registry);
     appendIndex =
         StatefulGauge.builder(APPEND_INDEX.getName())
             .description(APPEND_INDEX.getDescription())
-            .tags(RaftKeyNames.PARTITION_GROUP.asString(), partitionGroupName)
+            .tag(RaftKeyNames.PARTITION_GROUP.asString(), partitionGroupName)
             .register(registry);
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftServiceMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftServiceMetrics.java
@@ -35,7 +35,7 @@ public final class RaftServiceMetrics extends RaftMetrics {
         Timer.builder(COMPACTION_TIME.getName())
             .description(COMPACTION_TIME.getDescription())
             .serviceLevelObjectives(COMPACTION_TIME.getTimerSLOs())
-            .tags(RaftKeyNames.PARTITION_GROUP.asString(), partitionGroupName)
+            .tag(RaftKeyNames.PARTITION_GROUP.asString(), partitionGroupName)
             .register(registry);
     this.registry = registry;
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftStartupMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftStartupMetrics.java
@@ -17,29 +17,30 @@ package io.atomix.raft.metrics;
 
 import static io.atomix.raft.metrics.RaftStartupMetricsDoc.*;
 
+import io.camunda.zeebe.util.micrometer.StatefulGauge;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class RaftStartupMetrics extends RaftMetrics {
 
-  private final AtomicLong bootstrapDuration;
-  private final AtomicLong joinDuration;
+  private final StatefulGauge bootstrapDuration;
+  private final StatefulGauge joinDuration;
 
   public RaftStartupMetrics(final String partitionName, final MeterRegistry registry) {
     super(partitionName);
-    bootstrapDuration = new AtomicLong(0L);
-    joinDuration = new AtomicLong(0L);
 
-    Gauge.builder(BOOTSTRAP_DURATION.getName(), bootstrapDuration::get)
-        .description(BOOTSTRAP_DURATION.getDescription())
-        .tags(RaftKeyNames.PARTITION_GROUP.asString(), partitionGroupName)
-        .register(registry);
+    bootstrapDuration =
+        StatefulGauge.builder(BOOTSTRAP_DURATION.getName())
+            .description(BOOTSTRAP_DURATION.getDescription())
+            .tags(RaftKeyNames.PARTITION_GROUP.asString(), partitionGroupName)
+            .register(registry);
 
-    Gauge.builder(JOIN_DURATION.getName(), joinDuration::get)
-        .description(JOIN_DURATION.getDescription())
-        .tags(RaftKeyNames.PARTITION_GROUP.asString(), partitionGroupName)
-        .register(registry);
+    joinDuration =
+        StatefulGauge.builder(JOIN_DURATION.getName())
+            .description(JOIN_DURATION.getDescription())
+            .tags(RaftKeyNames.PARTITION_GROUP.asString(), partitionGroupName)
+            .register(registry);
   }
 
   public void observeBootstrapDuration(final long durationMillis) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftStartupMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftStartupMetrics.java
@@ -33,13 +33,13 @@ public class RaftStartupMetrics extends RaftMetrics {
     bootstrapDuration =
         StatefulGauge.builder(BOOTSTRAP_DURATION.getName())
             .description(BOOTSTRAP_DURATION.getDescription())
-            .tags(RaftKeyNames.PARTITION_GROUP.asString(), partitionGroupName)
+            .tag(RaftKeyNames.PARTITION_GROUP.asString(), partitionGroupName)
             .register(registry);
 
     joinDuration =
         StatefulGauge.builder(JOIN_DURATION.getName())
             .description(JOIN_DURATION.getDescription())
-            .tags(RaftKeyNames.PARTITION_GROUP.asString(), partitionGroupName)
+            .tag(RaftKeyNames.PARTITION_GROUP.asString(), partitionGroupName)
             .register(registry);
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftStartupMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftStartupMetrics.java
@@ -18,9 +18,7 @@ package io.atomix.raft.metrics;
 import static io.atomix.raft.metrics.RaftStartupMetricsDoc.*;
 
 import io.camunda.zeebe.util.micrometer.StatefulGauge;
-import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
-import java.util.concurrent.atomic.AtomicLong;
 
 public class RaftStartupMetrics extends RaftMetrics {
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/SnapshotReplicationMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/SnapshotReplicationMetrics.java
@@ -17,6 +17,7 @@ package io.atomix.raft.metrics;
 
 import static io.atomix.raft.metrics.SnapshotReplicationMetricsDoc.*;
 
+import io.camunda.zeebe.util.micrometer.StatefulGauge;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Objects;
@@ -24,32 +25,32 @@ import java.util.concurrent.atomic.AtomicLong;
 
 public class SnapshotReplicationMetrics extends RaftMetrics {
 
-  private final AtomicLong count;
-  private final AtomicLong duration;
+  private final StatefulGauge count;
+  private final StatefulGauge duration;
 
   public SnapshotReplicationMetrics(final String partitionName, final MeterRegistry meterRegistry) {
     super(partitionName);
     Objects.requireNonNull(meterRegistry, "meterRegistry cannot be null");
 
-    count = new AtomicLong(0L);
-    Gauge.builder(COUNT.getName(), count::get)
-        .description(COUNT.getDescription())
-        .tags(PARTITION_GROUP_NAME_LABEL, partitionGroupName)
-        .register(meterRegistry);
+    count =
+        StatefulGauge.builder(COUNT.getName())
+            .description(COUNT.getDescription())
+            .tags(PARTITION_GROUP_NAME_LABEL, partitionGroupName)
+            .register(meterRegistry);
 
-    duration = new AtomicLong(0L);
-    Gauge.builder(DURATION.getName(), duration::get)
-        .description(DURATION.getDescription())
-        .tags(PARTITION_GROUP_NAME_LABEL, partitionGroupName)
-        .register(meterRegistry);
+    duration =
+        StatefulGauge.builder(DURATION.getName())
+            .description(DURATION.getDescription())
+            .tags(PARTITION_GROUP_NAME_LABEL, partitionGroupName)
+            .register(meterRegistry);
   }
 
   public void incrementCount() {
-    count.incrementAndGet();
+    count.increment();
   }
 
   public void decrementCount() {
-    count.decrementAndGet();
+    count.decrement();
   }
 
   public void setCount(final int value) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/SnapshotReplicationMetrics.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/metrics/SnapshotReplicationMetrics.java
@@ -17,8 +17,8 @@ package io.atomix.raft.metrics;
 
 import static io.atomix.raft.metrics.SnapshotReplicationMetricsDoc.*;
 
-import io.camunda.zeebe.util.micrometer.StatefulGauge;
 import io.camunda.zeebe.util.CloseableSilently;
+import io.camunda.zeebe.util.micrometer.StatefulGauge;
 import io.micrometer.core.instrument.MeterRegistry;
 
 public class SnapshotReplicationMetrics extends RaftMetrics implements CloseableSilently {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -26,7 +26,7 @@ import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import io.atomix.raft.cluster.impl.RaftMemberContext;
 import io.atomix.raft.impl.RaftContext;
-import io.atomix.raft.metrics.LeaderMetrics;
+import io.atomix.raft.metrics.LeaderAppenderMetrics;
 import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.ConfigureRequest;
@@ -70,7 +70,7 @@ final class LeaderAppender {
   private final RaftContext raft;
   private boolean open = true;
 
-  private final LeaderMetrics metrics;
+  private final LeaderAppenderMetrics metrics;
   private final long leaderTime;
   private final long leaderIndex;
   private final long electionTimeout;
@@ -85,7 +85,7 @@ final class LeaderAppender {
     log =
         ContextualLoggerFactory.getLogger(
             getClass(), LoggerContext.builder(RaftServer.class).addValue(raft.getName()).build());
-    metrics = new LeaderMetrics(raft.getName(), raft.getMeterRegistry());
+    metrics = new LeaderAppenderMetrics(raft.getName(), raft.getMeterRegistry());
     maxBatchSizePerAppend = raft.getMaxAppendBatchSize();
     leaderTime = System.currentTimeMillis();
     leaderIndex =
@@ -864,6 +864,7 @@ final class LeaderAppender {
 
   public void close() {
     open = false;
+    metrics.close();
     completeCommits(raft.getCommitIndex());
     appendFutures
         .values()

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -105,6 +105,8 @@ public class PassiveRole extends InactiveRole {
           "Failed to purge pending snapshots, which may result in unnecessary disk usage and should be monitored",
           e);
     }
+
+    snapshotReplicationMetrics.close();
     return super.stop();
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/metrics/BackupManagerMetrics.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/metrics/BackupManagerMetrics.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.backup.metrics.BackupManagerMetricsDoc.*;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.collection.Table;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.camunda.zeebe.util.micrometer.StatefulGauge;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -20,13 +21,16 @@ import java.util.EnumMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BackupManagerMetrics {
 
+  public static final Logger LOGGER = LoggerFactory.getLogger(BackupManagerMetrics.class);
   private final MeterRegistry registry;
   private final Table<OperationType, OperationResult, Counter> totalOperations =
       Table.ofEnum(OperationType.class, OperationResult.class, Counter[]::new);
-  private final Map<OperationType, AtomicLong> operationInProgress =
+  private final Map<OperationType, StatefulGauge> operationInProgress =
       new EnumMap<>(OperationType.class);
   private final Map<OperationType, Timer> backupOperationLatency =
       new EnumMap<>(OperationType.class);
@@ -75,27 +79,23 @@ public class BackupManagerMetrics {
   private Timer registerBackupLatency(final OperationType operationType) {
     return Timer.builder(BACKUP_OPERATIONS_LATENCY.getName())
         .description(BACKUP_OPERATIONS_LATENCY.getDescription())
-        .tags(MetricKeyName.OPERATION.asString(), operationType.name())
+        .tag(MetricKeyName.OPERATION.asString(), operationType.name())
         .register(registry);
   }
 
-  private AtomicLong getOperationInProgress(final OperationType operationType) {
-    var value = operationInProgress.get(operationType);
-    if (value == null) {
-      value = new AtomicLong();
-      operationInProgress.put(operationType, value);
-      Gauge.builder(BACKUP_OPERATIONS_IN_PROGRESS.getName(), value::get)
-          .description(BACKUP_OPERATIONS_IN_PROGRESS.getDescription())
-          .register(registry);
-    }
-    return value;
+  private StatefulGauge registerOperationInProgress(final OperationType operationType) {
+    return StatefulGauge.builder(BACKUP_OPERATIONS_IN_PROGRESS.getName())
+        .description(BACKUP_OPERATIONS_IN_PROGRESS.getDescription())
+        .tag(MetricKeyName.OPERATION.asString(), operationType.name())
+        .register(registry);
   }
 
   private OperationMetrics start(final OperationType operation) {
     final var timer =
         backupOperationLatency.computeIfAbsent(operation, this::registerBackupLatency);
+    operationInProgress.computeIfAbsent(operation, this::registerOperationInProgress).increment();
+
     final var timerSample = MicrometerUtil.timer(timer, Timer.start(registry.config().clock()));
-    getOperationInProgress(operation).incrementAndGet();
     return new OperationMetrics(timerSample, operation);
   }
 
@@ -110,7 +110,15 @@ public class BackupManagerMetrics {
 
     public <T> void complete(final T ignored, final Throwable throwable) {
       timer.close();
-      getOperationInProgress(operation).decrementAndGet();
+      final var gauge = operationInProgress.get(operation);
+      if (gauge != null) {
+        gauge.decrement();
+      } else {
+        LOGGER.warn(
+            "Expected to decrement count of operations in progress of type {}, but none was found",
+            operation);
+      }
+
       final var result = throwable != null ? OperationResult.FAILED : OperationResult.COMPLETED;
       totalOperations
           .computeIfAbsent(operation, result, BackupManagerMetrics.this::registerTotalOperation)

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/metrics/BackupManagerMetrics.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/metrics/BackupManagerMetrics.java
@@ -14,13 +14,11 @@ import io.camunda.zeebe.util.collection.Table;
 import io.camunda.zeebe.util.micrometer.MicrometerUtil;
 import io.camunda.zeebe.util.micrometer.StatefulGauge;
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicLong;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/metrics/CheckpointMetrics.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/metrics/CheckpointMetrics.java
@@ -60,7 +60,7 @@ public class CheckpointMetrics {
   private Counter registerCheckpointRecords(final CheckpointMetricsResultValue value) {
     return Counter.builder(CHECKPOINTS_RECORDS.getName())
         .description(CHECKPOINTS_RECORDS.getDescription())
-        .tags(CheckpointMetricsKeyName.RESULT.asString(), value.value())
+        .tag(CheckpointMetricsKeyName.RESULT.asString(), value.value())
         .register(registry);
   }
 }

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/metrics/CheckpointMetrics.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/metrics/CheckpointMetrics.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.backup.metrics;
 
 import static io.camunda.zeebe.backup.metrics.CheckpointMetricsDoc.*;
 
+import io.camunda.zeebe.util.micrometer.StatefulGauge;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -21,19 +22,21 @@ public class CheckpointMetrics {
   private final MeterRegistry registry;
   private final Map<CheckpointMetricsResultValue, Counter> checkpointRecords =
       new EnumMap<>(CheckpointMetricsResultValue.class);
-  private final AtomicLong checkpointPosition = new AtomicLong(0L);
-  private final AtomicLong checkpointId = new AtomicLong(0L);
+  private final StatefulGauge checkpointPosition;
+  private final StatefulGauge checkpointId;
 
   public CheckpointMetrics(final MeterRegistry meterRegistry) {
     registry = Objects.requireNonNull(meterRegistry, "registry cannot be null");
 
-    Gauge.builder(CHECKPOINT_POSITION.getName(), checkpointPosition::get)
-        .description(CHECKPOINT_POSITION.getDescription())
-        .register(meterRegistry);
+    checkpointPosition =
+        StatefulGauge.builder(CHECKPOINT_POSITION.getName())
+            .description(CHECKPOINT_POSITION.getDescription())
+            .register(meterRegistry);
 
-    Gauge.builder(CHECKPOINT_POSITION.getName(), checkpointPosition::get)
-        .description(CHECKPOINT_POSITION.getDescription())
-        .register(meterRegistry);
+    checkpointId =
+        StatefulGauge.builder(CHECKPOINT_ID.getName())
+            .description(CHECKPOINT_POSITION.getDescription())
+            .register(meterRegistry);
   }
 
   public void created(final long checkpointId, final long checkpointPosition) {

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/metrics/CheckpointMetrics.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/metrics/CheckpointMetrics.java
@@ -11,12 +11,10 @@ import static io.camunda.zeebe.backup.metrics.CheckpointMetricsDoc.*;
 
 import io.camunda.zeebe.util.micrometer.StatefulGauge;
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicLong;
 
 public class CheckpointMetrics {
   private final MeterRegistry registry;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
@@ -96,7 +96,7 @@ public class ExecutionLatencyMetrics {
             () -> collection.get(partitionId).get())
         .description(
             "The current cached instances for counting their execution latency. If only short-lived instances are handled this can be seen or observed as the current active instance count.")
-        .tags("type", type)
+        .tag("type", type)
         .register(meterRegistry);
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
@@ -7,96 +7,69 @@
  */
 package io.camunda.zeebe.broker.exporter.metrics;
 
-import io.micrometer.core.instrument.Gauge;
+import static io.camunda.zeebe.broker.exporter.metrics.ExecutionLatencyMetricsDoc.CACHED_INSTANCES;
+import static io.camunda.zeebe.broker.exporter.metrics.ExecutionLatencyMetricsDoc.JOB_ACTIVATION_TIME;
+import static io.camunda.zeebe.broker.exporter.metrics.ExecutionLatencyMetricsDoc.JOB_LIFETIME;
+import static io.camunda.zeebe.broker.exporter.metrics.ExecutionLatencyMetricsDoc.PROCESS_INSTANCE_EXECUTION;
+
+import io.camunda.zeebe.broker.exporter.metrics.ExecutionLatencyMetricsDoc.CacheKeyNames;
+import io.camunda.zeebe.broker.exporter.metrics.ExecutionLatencyMetricsDoc.CacheType;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.camunda.zeebe.util.micrometer.StatefulGauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.time.Duration;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Stream;
 
 public class ExecutionLatencyMetrics {
 
-  private static final Duration[] JOB_LIFE_TIME_BUCKETS =
-      Stream.of(25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 10000, 15000, 30000, 45000)
-          .map(Duration::ofMillis)
-          .toArray(Duration[]::new);
-
-  private static final Duration[] JOB_ACTIVATION_TIME_BUCKETS =
-      Stream.of(10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 10000, 15000, 30000)
-          .map(Duration::ofMillis)
-          .toArray(Duration[]::new);
-
-  private static final Duration[] PROCESS_INSTANCE_EXECUTION_BUCKETS =
-      Stream.of(50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 10000, 15000, 30000, 45000, 60000)
-          .map(Duration::ofMillis)
-          .toArray(Duration[]::new);
-
-  private final MeterRegistry meterRegistry;
-  private final Map<Integer, AtomicInteger> currentCachedInstanceJobsCount =
-      new ConcurrentHashMap<>();
-  private final Map<Integer, AtomicInteger> currentCacheInstanceProcessInstances =
-      new ConcurrentHashMap<>();
-  private final int partitionId;
+  private final StatefulGauge currentCachedInstanceJobsCount;
+  private final StatefulGauge currentCacheInstanceProcessInstances;
+  private final Timer processInstanceExecutionTime;
+  private final Timer jobLifeTime;
+  private final Timer jobActivationTime;
 
   public ExecutionLatencyMetrics() {
-    this(new SimpleMeterRegistry(), 1);
+    this(new SimpleMeterRegistry());
   }
 
-  public ExecutionLatencyMetrics(final MeterRegistry meterRegistry, final int partitionId) {
-    this.meterRegistry = meterRegistry;
-    this.partitionId = partitionId;
+  public ExecutionLatencyMetrics(final MeterRegistry meterRegistry) {
+
+    processInstanceExecutionTime =
+        MicrometerUtil.buildTimer(PROCESS_INSTANCE_EXECUTION).register(meterRegistry);
+    jobLifeTime = MicrometerUtil.buildTimer(JOB_LIFETIME).register(meterRegistry);
+    jobActivationTime = MicrometerUtil.buildTimer(JOB_ACTIVATION_TIME).register(meterRegistry);
+    currentCacheInstanceProcessInstances =
+        registerCacheCount(CacheType.PROCESS_INSTANCES, meterRegistry);
+    currentCachedInstanceJobsCount = registerCacheCount(CacheType.JOBS, meterRegistry);
+  }
+
+  private StatefulGauge registerCacheCount(
+      final CacheType type, final MeterRegistry meterRegistry) {
+    return StatefulGauge.builder(CACHED_INSTANCES.getName())
+        .description(CACHED_INSTANCES.getDescription())
+        .tag(CacheKeyNames.TYPE.asString(), type.getTagValue())
+        .register(meterRegistry);
   }
 
   public void observeProcessInstanceExecutionTime(
       final long creationTimeMs, final long completionTimeMs) {
-    Timer.builder("zeebe.process.instance.execution.time")
-        .description("The execution time of processing a complete process instance")
-        .sla(PROCESS_INSTANCE_EXECUTION_BUCKETS)
-        .register(meterRegistry)
-        .record(completionTimeMs - creationTimeMs, TimeUnit.MILLISECONDS);
+    processInstanceExecutionTime.record(completionTimeMs - creationTimeMs, TimeUnit.MILLISECONDS);
   }
 
   public void observeJobLifeTime(final long creationTimeMs, final long completionTimeMs) {
-    Timer.builder("zeebe.job.life.time")
-        .description("The life time of an job")
-        .sla(JOB_LIFE_TIME_BUCKETS)
-        .register(meterRegistry)
-        .record(completionTimeMs - creationTimeMs, TimeUnit.MILLISECONDS);
+    jobLifeTime.record(completionTimeMs - creationTimeMs, TimeUnit.MILLISECONDS);
   }
 
   public void observeJobActivationTime(final long creationTimeMs, final long activationTimeMs) {
-    Timer.builder("zeebe.job.activation.time")
-        .description("The time until an job was activated")
-        .sla(JOB_ACTIVATION_TIME_BUCKETS)
-        .register(meterRegistry)
-        .record(activationTimeMs - creationTimeMs, TimeUnit.MILLISECONDS);
+    jobActivationTime.record(activationTimeMs - creationTimeMs, TimeUnit.MILLISECONDS);
   }
 
   public void setCurrentJobsCount(final int count) {
-    setCurrentCachedInstanceGauge(count, "jobs");
+    currentCachedInstanceJobsCount.set(count);
   }
 
   public void setCurrentProcessInstanceCount(final int count) {
-    setCurrentCachedInstanceGauge(count, "processInstances");
-  }
-
-  private void setCurrentCachedInstanceGauge(final int count, final String type) {
-    final var collection =
-        "jobs".equals(type) ? currentCachedInstanceJobsCount : currentCacheInstanceProcessInstances;
-
-    collection.putIfAbsent(partitionId, new AtomicInteger());
-    collection.get(partitionId).set(count);
-
-    Gauge.builder(
-            "zeebe.execution.latency.current.cached.instances",
-            () -> collection.get(partitionId).get())
-        .description(
-            "The current cached instances for counting their execution latency. If only short-lived instances are handled this can be seen or observed as the current active instance count.")
-        .tag("type", type)
-        .register(meterRegistry);
+    currentCacheInstanceProcessInstances.set(count);
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetricsDoc.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetricsDoc.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.exporter.metrics;
+
+import io.camunda.zeebe.broker.exporter.stream.ExporterMetricsDoc.ExporterContainerKeyNames;
+import io.camunda.zeebe.util.micrometer.ExtendedMeterDocumentation;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil.PartitionKeyNames;
+import io.micrometer.common.docs.KeyName;
+import io.micrometer.core.instrument.Meter.Type;
+import java.time.Duration;
+
+@SuppressWarnings("NullableProblems")
+public enum ExecutionLatencyMetricsDoc implements ExtendedMeterDocumentation {
+  /**
+   * The current cached entities for counting their execution latency. If only short-lived instances
+   * are handled this can be seen or observed as the current active instance count.
+   */
+  CACHED_INSTANCES {
+    @Override
+    public String getDescription() {
+      return """
+        The current cached entities for counting their execution latency. If only \
+        short-lived instances are handled this can be seen or observed as the current active \
+        instance count.""";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.execution.latency.current.cached.instances";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.GAUGE;
+    }
+
+    @Override
+    public KeyName[] getKeyNames() {
+      return CacheKeyNames.values();
+    }
+
+    @Override
+    public KeyName[] getAdditionalKeyNames() {
+      return KeyName.merge(PartitionKeyNames.values(), ExporterContainerKeyNames.values());
+    }
+  },
+
+  /** The execution time of processing a complete process instance */
+  PROCESS_INSTANCE_EXECUTION {
+    private static final Duration[] BUCKETS = {
+      Duration.ofMillis(50),
+      Duration.ofMillis(75),
+      Duration.ofMillis(100),
+      Duration.ofMillis(250),
+      Duration.ofMillis(500),
+      Duration.ofMillis(750),
+      Duration.ofSeconds(1),
+      Duration.ofMillis(2500),
+      Duration.ofSeconds(5),
+      Duration.ofSeconds(10),
+      Duration.ofSeconds(15),
+      Duration.ofSeconds(30),
+      Duration.ofSeconds(45),
+      Duration.ofMinutes(1)
+    };
+
+    @Override
+    public String getDescription() {
+      return "The execution time of processing a complete process instance";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.process.instance.execution.time";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+  },
+
+  /** The lifetime of a job */
+  JOB_LIFETIME {
+    private static final Duration[] BUCKETS = {
+      Duration.ofMillis(50),
+      Duration.ofMillis(75),
+      Duration.ofMillis(100),
+      Duration.ofMillis(250),
+      Duration.ofMillis(500),
+      Duration.ofMillis(750),
+      Duration.ofSeconds(1),
+      Duration.ofMillis(2500),
+      Duration.ofSeconds(5),
+      Duration.ofSeconds(10),
+      Duration.ofSeconds(15),
+      Duration.ofSeconds(30),
+      Duration.ofSeconds(45)
+    };
+
+    @Override
+    public String getDescription() {
+      return "The lifetime of a job";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.job.life.time";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+  },
+
+  /** The time until a job was activated */
+  JOB_ACTIVATION_TIME {
+    private static final Duration[] BUCKETS = {
+      Duration.ofMillis(50),
+      Duration.ofMillis(75),
+      Duration.ofMillis(100),
+      Duration.ofMillis(250),
+      Duration.ofMillis(500),
+      Duration.ofMillis(750),
+      Duration.ofSeconds(1),
+      Duration.ofMillis(2500),
+      Duration.ofSeconds(5),
+      Duration.ofSeconds(10),
+      Duration.ofSeconds(15),
+      Duration.ofSeconds(30)
+    };
+
+    @Override
+    public String getDescription() {
+      return "The time until a job was activated";
+    }
+
+    @Override
+    public String getName() {
+      return "zeebe.job.activation.time";
+    }
+
+    @Override
+    public Type getType() {
+      return Type.TIMER;
+    }
+
+    @Override
+    public Duration[] getTimerSLOs() {
+      return BUCKETS;
+    }
+  };
+
+  public enum CacheKeyNames implements KeyName {
+    /** The type of entities stored in the cache; see {@link CacheType} for possible values */
+    TYPE {
+      @Override
+      public String asString() {
+        return "type";
+      }
+    }
+  }
+
+  public enum CacheType {
+    JOBS("jobs"),
+    PROCESS_INSTANCES("processInstances");
+
+    private final String tagValue;
+
+    CacheType(final String tagValue) {
+      this.tagValue = tagValue;
+    }
+
+    public String getTagValue() {
+      return tagValue;
+    }
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java
@@ -52,32 +52,21 @@ public class MetricsExporter implements Exporter {
   private InstantSource clock;
 
   private Controller controller;
-  private MeterRegistry meterRegistry;
 
   public MetricsExporter() {
-    this(
-        new ExecutionLatencyMetrics(),
-        new TtlKeyCache(TIME_TO_LIVE.toMillis()),
-        new TtlKeyCache(TIME_TO_LIVE.toMillis()),
-        null);
+    this(new TtlKeyCache(TIME_TO_LIVE.toMillis()), new TtlKeyCache(TIME_TO_LIVE.toMillis()));
   }
 
   @VisibleForTesting
-  MetricsExporter(
-      final ExecutionLatencyMetrics executionLatencyMetrics,
-      final TtlKeyCache processInstanceCache,
-      final TtlKeyCache jobCache,
-      final MeterRegistry meterRegistry) {
-    this.executionLatencyMetrics = executionLatencyMetrics;
+  MetricsExporter(final TtlKeyCache processInstanceCache, final TtlKeyCache jobCache) {
     this.processInstanceCache = processInstanceCache;
     this.jobCache = jobCache;
-    this.meterRegistry = meterRegistry;
   }
 
   @Override
   public void configure(final Context context) throws Exception {
-    meterRegistry = context.getMeterRegistry();
-    executionLatencyMetrics = new ExecutionLatencyMetrics(meterRegistry, context.getPartitionId());
+    final MeterRegistry meterRegistry = context.getMeterRegistry();
+    executionLatencyMetrics = new ExecutionLatencyMetrics(meterRegistry);
     clock = context.clock();
     context.setFilter(
         new RecordFilter() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetricsDoc.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetricsDoc.java
@@ -135,6 +135,16 @@ public enum ExporterMetricsDoc implements ExtendedMeterDocumentation {
     }
   };
 
+  public enum ExporterContainerKeyNames implements KeyName {
+    /** Identifies which exporter is emitting a metric */
+    EXPORTER_ID {
+      @Override
+      public String asString() {
+        return "exporterId";
+      }
+    }
+  }
+
   enum ExporterActionKeyNames implements KeyName {
     SKIPPED {
       @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/metrics/TopologyManagerMetrics.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/metrics/TopologyManagerMetrics.java
@@ -46,7 +46,7 @@ public class TopologyManagerMetrics {
     return Timer.builder(OPERATION_DURATION.getName())
         .description(OPERATION_DURATION.getDescription())
         .serviceLevelObjectives(OPERATION_DURATION.getTimerSLOs())
-        .tags(TopologyManagerMetricsKeyName.OPERATION.asString(), operation)
+        .tag(TopologyManagerMetricsKeyName.OPERATION.asString(), operation)
         .register(registry);
   }
 

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorMetricsImpl.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorMetricsImpl.java
@@ -36,7 +36,7 @@ final class ActorMetricsImpl implements ActorMetrics {
   private Timer createSchedulingTimer(final SubscriptionType subscriptionType) {
     return Timer.builder(SCHEDULING_LATENCY.getName())
         .description(SCHEDULING_LATENCY.getDescription())
-        .tags(ActorMetricsKeyName.SUBSCRIPTION_TYPE.asString(), subscriptionType.getName())
+        .tag(ActorMetricsKeyName.SUBSCRIPTION_TYPE.asString(), subscriptionType.getName())
         .serviceLevelObjectives(SCHEDULING_LATENCY.getTimerSLOs())
         .register(registry);
   }
@@ -44,7 +44,7 @@ final class ActorMetricsImpl implements ActorMetrics {
   private Timer createExecutionTimer(final String actorName) {
     return Timer.builder(EXECUTION_LATENCY.getName())
         .description(EXECUTION_LATENCY.getDescription())
-        .tags(ActorMetricsKeyName.ACTOR_NAME.asString(), actorName)
+        .tag(ActorMetricsKeyName.ACTOR_NAME.asString(), actorName)
         .serviceLevelObjectives(EXECUTION_LATENCY.getTimerSLOs())
         .register(registry);
   }
@@ -59,7 +59,7 @@ final class ActorMetricsImpl implements ActorMetrics {
   private Gauge createJobQueueLength(final String actorName, final AtomicLong value) {
     return Gauge.builder(JOB_QUEUE_LENGTH.getName(), value::get)
         .description(JOB_QUEUE_LENGTH.getDescription())
-        .tags(ActorMetricsKeyName.ACTOR_NAME.asString(), actorName)
+        .tag(ActorMetricsKeyName.ACTOR_NAME.asString(), actorName)
         .register(registry);
   }
 


### PR DESCRIPTION
## Description

This PR fixes duplicate gauge registration: one was using the wrong name (checkpoint stuff), and the others by turning the gauges into stateful ones, which should return the same state (for a given partition).

There were a few instances which _may_ not result in duplicate registrations, but I figured let's just use the stateful ones to be safe.

Finally, it fixes a small typo of using the singular `tag(String, String)` variant for builders instead of the `tags(String...)`. It shouldn't have too much impact, but it can be easy to misuse the second one as the value could be mistakenly picked up as another key.
