### PR TITLE
refactor: remove C7 serialization config from Optimize C8

### DIFF
--- a/optimize-distro/src/config/environment-config.yaml
+++ b/optimize-distro/src/config/environment-config.yaml
@@ -114,11 +114,6 @@ import:
     # Cron expression for when the identity sync should run, defaults to every second hour.
     cronTrigger: '0 */2 * * *'
 
-serialization:
-  # Define a custom date format that should be used for
-  # fetching date data from the engine(should be the same as in the engine)
-  engineDateFormat: yyyy-MM-dd'T'HH:mm:ss.SSSZ
-
 email:
   # A switch to control email sending process.
   enabled: false

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/entities/EntityImportService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/entities/EntityImportService.java
@@ -30,7 +30,6 @@ import io.camunda.optimize.service.entities.report.ReportImportService;
 import io.camunda.optimize.service.exceptions.OptimizeImportFileInvalidException;
 import io.camunda.optimize.service.exceptions.OptimizeValidationException;
 import io.camunda.optimize.service.security.AuthorizedCollectionService;
-import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.mapper.ObjectMapperFactory;
 import io.camunda.optimize.service.util.mapper.OptimizeDateTimeFormatterFactory;
 import jakarta.validation.ConstraintViolation;
@@ -44,30 +43,25 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
 import org.springframework.stereotype.Component;
 
 @Component
 public class EntityImportService {
 
-  private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(EntityImportService.class);
   private final ReportImportService reportImportService;
   private final DashboardImportService dashboardImportService;
   private final AuthorizedCollectionService authorizedCollectionService;
   private final CollectionService collectionService;
-  private final ConfigurationService configurationService;
 
   public EntityImportService(
       final ReportImportService reportImportService,
       final DashboardImportService dashboardImportService,
       final AuthorizedCollectionService authorizedCollectionService,
-      final CollectionService collectionService,
-      final ConfigurationService configurationService) {
+      final CollectionService collectionService) {
     this.reportImportService = reportImportService;
     this.dashboardImportService = dashboardImportService;
     this.authorizedCollectionService = authorizedCollectionService;
     this.collectionService = collectionService;
-    this.configurationService = configurationService;
   }
 
   public List<EntityIdResponseDto> importEntities(
@@ -136,8 +130,7 @@ public class EntityImportService {
     }
 
     final ObjectMapper objectMapper =
-        new ObjectMapperFactory(
-                new OptimizeDateTimeFormatterFactory().getObject(), configurationService)
+        new ObjectMapperFactory(new OptimizeDateTimeFormatterFactory().getObject())
             .createOptimizeMapper();
 
     try {

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/db/SchemaUpgradeClientFactory.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/db/SchemaUpgradeClientFactory.java
@@ -47,9 +47,7 @@ public final class SchemaUpgradeClientFactory {
           metadataService,
           upgradeDependencies.configurationService(),
           esClient,
-          new ObjectMapperFactory(
-                  new OptimizeDateTimeFormatterFactory().getObject(),
-                  upgradeDependencies.configurationService())
+          new ObjectMapperFactory(new OptimizeDateTimeFormatterFactory().getObject())
               .createOptimizeMapper());
     } else if (upgradeDependencies.databaseType().equals(DatabaseType.OPENSEARCH)) {
       final OptimizeOpenSearchClient osClient =
@@ -65,9 +63,7 @@ public final class SchemaUpgradeClientFactory {
               mappingUtil.getAllMappings(upgradeDependencies.indexNameService().getIndexPrefix())),
           metadataService,
           osClient,
-          new ObjectMapperFactory(
-                  new OptimizeDateTimeFormatterFactory().getObject(),
-                  upgradeDependencies.configurationService())
+          new ObjectMapperFactory(new OptimizeDateTimeFormatterFactory().getObject())
               .createOptimizeMapper());
     } else {
       throw new UnsupportedOperationException(
@@ -89,16 +85,14 @@ public final class SchemaUpgradeClientFactory {
           (ElasticSearchMetadataService) metadataService,
           configurationService,
           esClient,
-          new ObjectMapperFactory(
-                  new OptimizeDateTimeFormatterFactory().getObject(), configurationService)
+          new ObjectMapperFactory(new OptimizeDateTimeFormatterFactory().getObject())
               .createOptimizeMapper());
     } else if (dbClient instanceof final OptimizeOpenSearchClient osClient) {
       return new SchemaUpgradeClientOS(
           (OpenSearchSchemaManager) schemaManager,
           (OpenSearchMetadataService) metadataService,
           osClient,
-          new ObjectMapperFactory(
-                  new OptimizeDateTimeFormatterFactory().getObject(), configurationService)
+          new ObjectMapperFactory(new OptimizeDateTimeFormatterFactory().getObject())
               .createOptimizeMapper());
     } else {
       throw new UnsupportedOperationException(

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationService.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationService.java
@@ -78,7 +78,6 @@ public class ConfigurationService {
   private SecurityConfiguration securityConfiguration;
   private UsersConfiguration usersConfiguration;
   private ZeebeConfiguration configuredZeebe;
-  private String engineDateFormat;
   private Long initialBackoff;
   private Long maximumBackoff;
   // engine import settings
@@ -296,17 +295,6 @@ public class ConfigurationService {
   @JsonIgnore
   public AuthConfiguration getAuthConfiguration() {
     return getSecurityConfiguration().getAuth();
-  }
-
-  public String getEngineDateFormat() {
-    if (engineDateFormat == null) {
-      engineDateFormat = configJsonContext.read(ConfigurationServiceConstants.ENGINE_DATE_FORMAT);
-    }
-    return engineDateFormat;
-  }
-
-  public void setEngineDateFormat(final String engineDateFormat) {
-    this.engineDateFormat = engineDateFormat;
   }
 
   public int getImportIndexAutoStorageIntervalInSec() {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceConstants.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/ConfigurationServiceConstants.java
@@ -140,7 +140,6 @@ public final class ConfigurationServiceConstants {
   public static final String ES_INDEX_NESTED_DOCUMENTS_LIMIT =
       "$.es.settings.index.nested_documents_limit";
 
-  public static final String ENGINE_DATE_FORMAT = "$.serialization.engineDateFormat";
   public static final String CONTAINER_HOST = "$.container.host";
   public static final String CONTAINER_CONTEXT_PATH = "$.container.contextPath";
   public static final String CONTAINER_KEYSTORE_PASSWORD = "$.container.keystore.password";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/mapper/ObjectMapperFactory.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/mapper/ObjectMapperFactory.java
@@ -21,8 +21,6 @@ import io.camunda.optimize.dto.optimize.DefinitionOptimizeResponseDto;
 import io.camunda.optimize.dto.optimize.query.collection.CollectionEntity;
 import io.camunda.optimize.dto.optimize.query.report.ReportDefinitionDto;
 import io.camunda.optimize.dto.optimize.rest.AuthorizedReportDefinitionResponseDto;
-import io.camunda.optimize.service.util.configuration.ConfigurationService;
-import io.camunda.optimize.service.util.configuration.ConfigurationServiceBuilder;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
@@ -36,21 +34,15 @@ import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 public class ObjectMapperFactory {
 
   private static final ObjectMapperFactory FACTORY =
-      new ObjectMapperFactory(
-          new OptimizeDateTimeFormatterFactory().getObject(),
-          ConfigurationServiceBuilder.createDefaultConfiguration());
+      new ObjectMapperFactory(new OptimizeDateTimeFormatterFactory().getObject());
   public static final ObjectMapper OPTIMIZE_MAPPER = FACTORY.createOptimizeMapper();
   public static final ObjectMapper OPTIMIZE_MAPPER_UNKNOWN_FAIL_DISABLED =
       FACTORY.createOptimizeMapper(false);
 
   private final DateTimeFormatter optimizeDateTimeFormatter;
-  private final ConfigurationService configurationService;
 
-  public ObjectMapperFactory(
-      final DateTimeFormatter optimizeDateTimeFormatter,
-      final ConfigurationService configurationService) {
+  public ObjectMapperFactory(final DateTimeFormatter optimizeDateTimeFormatter) {
     this.optimizeDateTimeFormatter = optimizeDateTimeFormatter;
-    this.configurationService = configurationService;
   }
 
   @Qualifier("optimizeMapper")
@@ -62,16 +54,6 @@ public class ObjectMapperFactory {
 
   public ObjectMapper createOptimizeMapper(final boolean unknownPropsEnable) {
     return buildObjectMapper(optimizeDateTimeFormatter, unknownPropsEnable);
-  }
-
-  @Qualifier("engineMapper")
-  @Bean
-  public ObjectMapper createEngineMapper() {
-    return buildObjectMapper(createEngineDateTimeFormatter(), true);
-  }
-
-  private DateTimeFormatter createEngineDateTimeFormatter() {
-    return DateTimeFormatter.ofPattern(configurationService.getEngineDateFormat());
   }
 
   private ObjectMapper buildObjectMapper(

--- a/optimize/util/optimize-commons/src/main/resources/service-config.yaml
+++ b/optimize/util/optimize-commons/src/main/resources/service-config.yaml
@@ -487,11 +487,6 @@ es:
       className: ${CAMUNDA_OPTIMIZE_ELASTICSEARCH_INTERCEPTORPLUGINS_4_CLASSNAME:}
       jarPath: ${CAMUNDA_OPTIMIZE_ELASTICSEARCH_INTERCEPTORPLUGINS_4_JARPATH:}
 
-serialization:
-  # Define a custom date format that should be used for
-  # fetching date data from the engine(should be the same as in the engine)
-  engineDateFormat: yyyy-MM-dd'T'HH:mm:ss.SSSZ
-
 alerting:
   quartz:
     jobStore: 'org.quartz.simpl.RAMJobStore'


### PR DESCRIPTION
## Description

This is part of the "C7 config cleanup from C8". Because there's a lot of configs that need cleaning, I'm breaking this work down into multiple PRs. This one is focused on "serialization config" cleanup. For these updates the corresponding section in [C8 docs](https://docs.camunda.io/optimize/next/self-managed/optimize-deployment/configuration/system-configuration/) have been updated in [this PR](https://github.com/camunda/camunda-docs/pull/5089)

## Related issues

related to #13375
