### PR TITLE
[Backport stable/optimize-8.6] fix: replace remoteTagging parameter with git push in optimize release job

### DIFF
--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -180,9 +180,8 @@ jobs:
 
       - name: Prepare release
         run: |
-          mvn -f optimize \
-            -DpushChanges="${{ github.event.inputs.IS_DRY_RUN != 'true' }}" \
-            -DremoteTagging="${{ github.event.inputs.IS_DRY_RUN != 'true' }}" \
+          ./mvnw -f optimize \
+            -DpushChanges=false \
             -DskipTests=true \
             -DignoreSnapshots=true \
             -Prelease,runAssembly \
@@ -195,9 +194,15 @@ jobs:
             --fail-at-end \
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
+      - name: Push Git changes
+        if: ${{ env.IS_DRY_RUN == 'false' }}
+        run: |
+          git push --tags
+          git push --all
+
       - name: Perform release
         run: |
-          mvn -f optimize \
+          ./mvnw -f optimize \
             -DlocalCheckout=true \
             -DskipTests=true \
             -B \


### PR DESCRIPTION
# Description
Backport of #28884 to `stable/optimize-8.6`.

relates to 
original author: @OmranAbazid