### PR TITLE
[CPT] Optimize assertion queries

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ElementSelector.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ElementSelector.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.process.test.api.assertions;
 
+import io.camunda.client.api.search.filter.FlownodeInstanceFilter;
 import io.camunda.client.api.search.response.FlowNodeInstance;
 
 /** A selector for BPMN elements. */
@@ -38,4 +39,12 @@ public interface ElementSelector {
   default String describe() {
     return toString();
   }
+
+  /**
+   * Applies the given filter to limit the search of element instances that match the selector.
+   * Default: no filtering.
+   *
+   * @param filter the filter used to limit the element instance search
+   */
+  default void applyFilter(final FlownodeInstanceFilter filter) {}
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ElementSelectors.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ElementSelectors.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.process.test.api.assertions;
 
+import io.camunda.client.api.search.filter.FlownodeInstanceFilter;
 import io.camunda.client.api.search.response.FlowNodeInstance;
 
 /** A collection of predefined {@link ElementSelector}s. */
@@ -56,6 +57,11 @@ public class ElementSelectors {
     @Override
     public String describe() {
       return elementId;
+    }
+
+    @Override
+    public void applyFilter(final FlownodeInstanceFilter filter) {
+      filter.flowNodeId(elementId);
     }
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceSelector.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceSelector.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.process.test.api.assertions;
 
+import io.camunda.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.client.api.search.response.ProcessInstance;
 
 /** A selector for process instances. */
@@ -38,4 +39,12 @@ public interface ProcessInstanceSelector {
   default String describe() {
     return toString();
   }
+
+  /**
+   * Applies the given filter to limit the search of process instances that match the selector.
+   * Default: no filtering.
+   *
+   * @param filter the filter used to limit the process instance search
+   */
+  default void applyFilter(final ProcessInstanceFilter filter) {}
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceSelectors.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceSelectors.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.process.test.api.assertions;
 
+import io.camunda.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.client.api.search.response.ProcessInstance;
 
 /** A collection of predefined {@link ProcessInstanceSelector}s. */
@@ -57,6 +58,11 @@ public class ProcessInstanceSelectors {
     public String describe() {
       return String.format("key: %s", processInstanceKey);
     }
+
+    @Override
+    public void applyFilter(final ProcessInstanceFilter filter) {
+      filter.processInstanceKey(processInstanceKey);
+    }
   }
 
   private static final class ProcessDefinitionIdSelector implements ProcessInstanceSelector {
@@ -75,6 +81,11 @@ public class ProcessInstanceSelectors {
     @Override
     public String describe() {
       return String.format("process-id: '%s'", processDefinitionId);
+    }
+
+    @Override
+    public void applyFilter(final ProcessInstanceFilter filter) {
+      filter.processDefinitionId(processDefinitionId);
     }
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
@@ -36,7 +36,7 @@ public class CamundaDataSource {
     this.client = client;
   }
 
-  public List<FlowNodeInstance> getFlowNodeInstancesByProcessInstanceKey(
+  public List<FlowNodeInstance> findFlowNodeInstancesByProcessInstanceKey(
       final long processInstanceKey) {
     return findFlowNodeInstances(filter -> filter.processInstanceKey(processInstanceKey));
   }
@@ -53,7 +53,7 @@ public class CamundaDataSource {
         .items();
   }
 
-  public List<Variable> getVariablesByProcessInstanceKey(final long processInstanceKey) {
+  public List<Variable> findVariablesByProcessInstanceKey(final long processInstanceKey) {
     return client
         .newVariableQuery()
         .filter(filter -> filter.processInstanceKey(processInstanceKey))
@@ -78,7 +78,7 @@ public class CamundaDataSource {
         .items();
   }
 
-  public List<Incident> getIncidentsByProcessInstanceKey(final long processInstanceKey) {
+  public List<Incident> findIncidentsByProcessInstanceKey(final long processInstanceKey) {
     return client
         .newIncidentQuery()
         .filter(filter -> filter.processInstanceKey(processInstanceKey))

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
@@ -17,6 +17,7 @@ package io.camunda.process.test.impl.assertions;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.SearchRequestPage;
+import io.camunda.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.client.api.search.response.FlowNodeInstance;
 import io.camunda.client.api.search.response.Incident;
 import io.camunda.client.api.search.response.ProcessInstance;
@@ -57,8 +58,13 @@ public class CamundaDataSource {
   }
 
   public List<ProcessInstance> findProcessInstances() {
+    return findProcessInstances(filter -> {});
+  }
+
+  public List<ProcessInstance> findProcessInstances(final Consumer<ProcessInstanceFilter> filter) {
     return client
         .newProcessInstanceQuery()
+        .filter(filter)
         .sort(sort -> sort.startDate().asc())
         .page(DEFAULT_PAGE_REQUEST)
         .send()

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
@@ -17,6 +17,7 @@ package io.camunda.process.test.impl.assertions;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.SearchRequestPage;
+import io.camunda.client.api.search.filter.FlownodeInstanceFilter;
 import io.camunda.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.client.api.search.response.FlowNodeInstance;
 import io.camunda.client.api.search.response.Incident;
@@ -37,9 +38,14 @@ public class CamundaDataSource {
 
   public List<FlowNodeInstance> getFlowNodeInstancesByProcessInstanceKey(
       final long processInstanceKey) {
+    return findFlowNodeInstances(filter -> filter.processInstanceKey(processInstanceKey));
+  }
+
+  public List<FlowNodeInstance> findFlowNodeInstances(
+      final Consumer<FlownodeInstanceFilter> filter) {
     return client
         .newFlownodeInstanceQuery()
-        .filter(filter -> filter.processInstanceKey(processInstanceKey))
+        .filter(filter)
         .sort(sort -> sort.startDate().asc())
         .page(DEFAULT_PAGE_REQUEST)
         .send()

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -228,7 +228,9 @@ public class ProcessInstanceAssertj
   }
 
   private Optional<ProcessInstance> findProcessInstance() {
-    return dataSource.findProcessInstances().stream().filter(actual::test).findFirst();
+    return dataSource.findProcessInstances(actual::applyFilter).stream()
+        .filter(actual::test)
+        .findFirst();
   }
 
   private void awaitProcessInstance() {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
@@ -172,7 +172,7 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, String> {
   }
 
   private Map<String, String> getProcessInstanceVariables(final long processInstanceKey) {
-    return dataSource.getVariablesByProcessInstanceKey(processInstanceKey).stream()
+    return dataSource.findVariablesByProcessInstanceKey(processInstanceKey).stream()
         .collect(Collectors.toMap(Variable::getName, Variable::getValue));
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultCollector.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultCollector.java
@@ -72,18 +72,18 @@ public class CamundaProcessTestResultCollector {
   }
 
   private Map<String, String> collectVariables(final long processInstanceKey) {
-    return dataSource.getVariablesByProcessInstanceKey(processInstanceKey).stream()
+    return dataSource.findVariablesByProcessInstanceKey(processInstanceKey).stream()
         .collect(Collectors.toMap(Variable::getName, Variable::getValue));
   }
 
   private List<Incident> collectOpenIncidents(final long processInstanceKey) {
-    return dataSource.getIncidentsByProcessInstanceKey(processInstanceKey).stream()
+    return dataSource.findIncidentsByProcessInstanceKey(processInstanceKey).stream()
         .filter(incident -> incident.getState().equals(IncidentState.ACTIVE))
         .collect(Collectors.toList());
   }
 
   private List<FlowNodeInstance> collectActiveFlowNodeInstances(final long processInstanceKey) {
-    return dataSource.getFlowNodeInstancesByProcessInstanceKey(processInstanceKey).stream()
+    return dataSource.findFlowNodeInstancesByProcessInstanceKey(processInstanceKey).stream()
         .filter(
             flowNodeInstance -> flowNodeInstance.getState().equals(FlowNodeInstanceState.ACTIVE))
         .collect(Collectors.toList());

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaAssertTest.java
@@ -16,6 +16,7 @@
 package io.camunda.process.test.api;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -52,7 +53,7 @@ public class CamundaAssertTest {
     final long processInstanceKey = 100L;
     when(processInstanceEvent.getProcessInstanceKey()).thenReturn(processInstanceKey);
 
-    when(camundaDataSource.findProcessInstances())
+    when(camundaDataSource.findProcessInstances(any()))
         .thenReturn(
             Collections.singletonList(
                 ProcessInstanceBuilder.newActiveProcessInstance(processInstanceKey).build()));
@@ -62,6 +63,6 @@ public class CamundaAssertTest {
     CamundaAssert.assertThat(processInstanceEvent).isActive();
 
     // then
-    verify(camundaDataSource).findProcessInstances();
+    verify(camundaDataSource).findProcessInstances(any());
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ElementAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ElementAssertTest.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.process.test.api;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -60,7 +61,7 @@ public class ElementAssertTest {
 
   @BeforeEach
   void configureMocks() {
-    when(camundaDataSource.findProcessInstances())
+    when(camundaDataSource.findProcessInstances(any()))
         .thenReturn(
             Collections.singletonList(
                 ProcessInstanceBuilder.newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
@@ -327,7 +328,7 @@ public class ElementAssertTest {
     @Test
     void shouldFailIfProcessInstanceNotFound() {
       // given
-      when(camundaDataSource.findProcessInstances()).thenReturn(Collections.emptyList());
+      when(camundaDataSource.findProcessInstances(any())).thenReturn(Collections.emptyList());
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -466,7 +467,7 @@ public class ElementAssertTest {
     @Test
     void shouldFailIfProcessInstanceNotFound() {
       // given
-      when(camundaDataSource.findProcessInstances()).thenReturn(Collections.emptyList());
+      when(camundaDataSource.findProcessInstances(any())).thenReturn(Collections.emptyList());
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -605,7 +606,7 @@ public class ElementAssertTest {
     @Test
     void shouldFailIfProcessInstanceNotFound() {
       // given
-      when(camundaDataSource.findProcessInstances()).thenReturn(Collections.emptyList());
+      when(camundaDataSource.findProcessInstances(any())).thenReturn(Collections.emptyList());
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ElementAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ElementAssertTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.api.search.filter.FlownodeInstanceFilter;
 import io.camunda.client.api.search.response.FlowNodeInstance;
 import io.camunda.process.test.api.assertions.ElementSelectors;
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
@@ -29,12 +30,15 @@ import io.camunda.process.test.utils.ProcessInstanceBuilder;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.function.Consumer;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -85,6 +89,9 @@ public class ElementAssertTest {
   @Nested
   class ElementSource {
 
+    @Mock private FlownodeInstanceFilter flownodeInstanceFilter;
+    @Captor private ArgumentCaptor<Consumer<FlownodeInstanceFilter>> flowNodeInstanceFilterCapture;
+
     @BeforeEach
     void configureMocks() {
       final FlowNodeInstance flowNodeInstanceA = newActiveFlowNodeInstance("A");
@@ -106,7 +113,13 @@ public class ElementAssertTest {
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // then
-      CamundaAssert.assertThat(processInstanceEvent).hasActiveElements("A", "B");
+      CamundaAssert.assertThat(processInstanceEvent).hasActiveElements("A");
+
+      verify(camundaDataSource).findFlowNodeInstances(flowNodeInstanceFilterCapture.capture());
+
+      flowNodeInstanceFilterCapture.getValue().accept(flownodeInstanceFilter);
+      verify(flownodeInstanceFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(flownodeInstanceFilter).flowNodeId("A");
     }
 
     @Test
@@ -142,8 +155,13 @@ public class ElementAssertTest {
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // then
-      CamundaAssert.assertThat(processInstanceEvent)
-          .hasActiveElements(ElementSelectors.byId("A"), ElementSelectors.byId("B"));
+      CamundaAssert.assertThat(processInstanceEvent).hasActiveElements(ElementSelectors.byId("A"));
+
+      verify(camundaDataSource).findFlowNodeInstances(flowNodeInstanceFilterCapture.capture());
+
+      flowNodeInstanceFilterCapture.getValue().accept(flownodeInstanceFilter);
+      verify(flownodeInstanceFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(flownodeInstanceFilter).flowNodeId("A");
     }
 
     @Test
@@ -173,8 +191,12 @@ public class ElementAssertTest {
 
       // then
       CamundaAssert.assertThat(processInstanceEvent)
-          .hasActiveElements(
-              ElementSelectors.byName("element_A"), ElementSelectors.byName("element_B"));
+          .hasActiveElements(ElementSelectors.byName("element_A"));
+
+      verify(camundaDataSource).findFlowNodeInstances(flowNodeInstanceFilterCapture.capture());
+
+      flowNodeInstanceFilterCapture.getValue().accept(flownodeInstanceFilter);
+      verify(flownodeInstanceFilter).processInstanceKey(PROCESS_INSTANCE_KEY);
     }
 
     @Test

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ElementAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ElementAssertTest.java
@@ -91,7 +91,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceB = newActiveFlowNodeInstance("B");
       final FlowNodeInstance flowNodeInstanceC = newCompletedFlowNodeInstance("C");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB, flowNodeInstanceC));
     }
 
@@ -211,7 +211,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceA = newActiveFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstanceB = newActiveFlowNodeInstance("B");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB));
 
       // when
@@ -227,7 +227,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceActive = newActiveFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstanceCompleted = newCompletedFlowNodeInstance("A");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceCompleted, flowNodeInstanceActive));
 
       // when
@@ -243,7 +243,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceA = newActiveFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstanceB = newActiveFlowNodeInstance("B");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Collections.singletonList(flowNodeInstanceA))
           .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB));
 
@@ -253,8 +253,7 @@ public class ElementAssertTest {
       // then
       CamundaAssert.assertThat(processInstanceEvent).hasActiveElements("A", "B");
 
-      verify(camundaDataSource, times(2))
-          .getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(camundaDataSource, times(2)).findFlowNodeInstances(any());
     }
 
     @Test
@@ -263,7 +262,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceA = newActiveFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstanceB = newActiveFlowNodeInstance("B");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB));
 
       // when
@@ -286,7 +285,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceB = newCompletedFlowNodeInstance("B");
       final FlowNodeInstance flowNodeInstanceC = newTerminatedFlowNodeInstance("C");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB, flowNodeInstanceC));
 
       // when
@@ -301,7 +300,7 @@ public class ElementAssertTest {
                   + "\t- 'C': terminated",
               PROCESS_INSTANCE_KEY);
 
-      verify(camundaDataSource).getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(camundaDataSource).findFlowNodeInstances(any());
     }
 
     @Test
@@ -310,7 +309,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceA = newActiveFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstanceA2 = newActiveFlowNodeInstance("A");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceA2));
 
       // when
@@ -349,7 +348,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceA = newCompletedFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstanceB = newCompletedFlowNodeInstance("B");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB));
 
       // when
@@ -365,7 +364,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceActive = newCompletedFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstanceCompleted = newActiveFlowNodeInstance("A");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceCompleted, flowNodeInstanceActive));
 
       // when
@@ -382,7 +381,7 @@ public class ElementAssertTest {
       final FlowNodeInstance activeFlowNodeInstanceB = newActiveFlowNodeInstance("B");
       final FlowNodeInstance completedFlowNodeInstanceB = newCompletedFlowNodeInstance("B");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceA, activeFlowNodeInstanceB))
           .thenReturn(Arrays.asList(flowNodeInstanceA, completedFlowNodeInstanceB));
 
@@ -392,8 +391,7 @@ public class ElementAssertTest {
       // then
       CamundaAssert.assertThat(processInstanceEvent).hasCompletedElements("A", "B");
 
-      verify(camundaDataSource, times(2))
-          .getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(camundaDataSource, times(2)).findFlowNodeInstances(any());
     }
 
     @Test
@@ -402,7 +400,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceA = newCompletedFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstanceB = newCompletedFlowNodeInstance("B");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB));
 
       // when
@@ -426,7 +424,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceA = newCompletedFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstanceB = newTerminatedFlowNodeInstance("B");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB));
 
       // when
@@ -440,7 +438,7 @@ public class ElementAssertTest {
                   + "\t- 'B': terminated",
               PROCESS_INSTANCE_KEY);
 
-      verify(camundaDataSource).getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(camundaDataSource).findFlowNodeInstances(any());
     }
 
     @Test
@@ -449,7 +447,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceA = newCompletedFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstanceA2 = newCompletedFlowNodeInstance("A");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceA2));
 
       // when
@@ -488,7 +486,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceA = newTerminatedFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstanceB = newTerminatedFlowNodeInstance("B");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB));
 
       // when
@@ -504,7 +502,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceActive = newTerminatedFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstanceCompleted = newActiveFlowNodeInstance("A");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceCompleted, flowNodeInstanceActive));
 
       // when
@@ -521,7 +519,7 @@ public class ElementAssertTest {
       final FlowNodeInstance activeFlowNodeInstanceB = newActiveFlowNodeInstance("B");
       final FlowNodeInstance terminatedFlowNodeInstanceB = newTerminatedFlowNodeInstance("B");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceA, activeFlowNodeInstanceB))
           .thenReturn(Arrays.asList(flowNodeInstanceA, terminatedFlowNodeInstanceB));
 
@@ -531,8 +529,7 @@ public class ElementAssertTest {
       // then
       CamundaAssert.assertThat(processInstanceEvent).hasTerminatedElements("A", "B");
 
-      verify(camundaDataSource, times(2))
-          .getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(camundaDataSource, times(2)).findFlowNodeInstances(any());
     }
 
     @Test
@@ -541,7 +538,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceA = newTerminatedFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstanceB = newTerminatedFlowNodeInstance("B");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB));
 
       // when
@@ -565,7 +562,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceA = newCompletedFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstanceB = newTerminatedFlowNodeInstance("B");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB));
 
       // when
@@ -579,7 +576,7 @@ public class ElementAssertTest {
                   + "\t- 'A': completed",
               PROCESS_INSTANCE_KEY);
 
-      verify(camundaDataSource).getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(camundaDataSource).findFlowNodeInstances(any());
     }
 
     @Test
@@ -588,7 +585,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceA = newCompletedFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstanceA2 = newCompletedFlowNodeInstance("A");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceA2));
 
       // when
@@ -633,7 +630,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceC2 = newActiveFlowNodeInstance("C");
       final FlowNodeInstance flowNodeInstanceC3 = newActiveFlowNodeInstance("C");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(
               Arrays.asList(
                   flowNodeInstanceA,
@@ -659,7 +656,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstance1 = newActiveFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstance2 = newActiveFlowNodeInstance("A");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstance1, flowNodeInstance2));
 
       // when
@@ -681,7 +678,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceA = newActiveFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstanceB = newActiveFlowNodeInstance("B");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB));
 
       // when
@@ -702,7 +699,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceA1 = newCompletedFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstanceA2 = newTerminatedFlowNodeInstance("A");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceA1, flowNodeInstanceA2));
 
       // when
@@ -721,8 +718,7 @@ public class ElementAssertTest {
     @Test
     void shouldFailIfNotCreated() {
       // given
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.emptyList());
+      when(camundaDataSource.findFlowNodeInstances(any())).thenReturn(Collections.emptyList());
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -767,7 +763,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceB = newActiveFlowNodeInstance("B");
       final FlowNodeInstance flowNodeInstanceA2 = newActiveFlowNodeInstance("A");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceA1, flowNodeInstanceB))
           .thenReturn(Arrays.asList(flowNodeInstanceA1, flowNodeInstanceB, flowNodeInstanceA2));
 
@@ -777,8 +773,7 @@ public class ElementAssertTest {
       // then
       CamundaAssert.assertThat(processInstanceEvent).hasActiveElement("A", 2);
 
-      verify(camundaDataSource, times(2))
-          .getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(camundaDataSource, times(2)).findFlowNodeInstances(any());
     }
   }
 
@@ -797,7 +792,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceC2 = newCompletedFlowNodeInstance("C");
       final FlowNodeInstance flowNodeInstanceC3 = newCompletedFlowNodeInstance("C");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(
               Arrays.asList(
                   flowNodeInstanceA,
@@ -823,7 +818,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstance1 = newCompletedFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstance2 = newCompletedFlowNodeInstance("A");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstance1, flowNodeInstance2));
 
       // when
@@ -845,7 +840,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceA = newCompletedFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstanceB = newCompletedFlowNodeInstance("B");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB));
 
       // when
@@ -866,7 +861,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceA1 = newTerminatedFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstanceA2 = newActiveFlowNodeInstance("A");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceA1, flowNodeInstanceA2));
 
       // when
@@ -885,8 +880,7 @@ public class ElementAssertTest {
     @Test
     void shouldFailIfNotCreated() {
       // given
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.emptyList());
+      when(camundaDataSource.findFlowNodeInstances(any())).thenReturn(Collections.emptyList());
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -931,7 +925,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceA2 = newActiveFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstanceA3 = newCompletedFlowNodeInstance("A");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceA1, flowNodeInstanceA2))
           .thenReturn(Arrays.asList(flowNodeInstanceA1, flowNodeInstanceA3));
 
@@ -941,8 +935,7 @@ public class ElementAssertTest {
       // then
       CamundaAssert.assertThat(processInstanceEvent).hasCompletedElement("A", 2);
 
-      verify(camundaDataSource, times(2))
-          .getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(camundaDataSource, times(2)).findFlowNodeInstances(any());
     }
   }
 
@@ -961,7 +954,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceC2 = newTerminatedFlowNodeInstance("C");
       final FlowNodeInstance flowNodeInstanceC3 = newTerminatedFlowNodeInstance("C");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(
               Arrays.asList(
                   flowNodeInstanceA,
@@ -987,7 +980,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstance1 = newTerminatedFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstance2 = newTerminatedFlowNodeInstance("A");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstance1, flowNodeInstance2));
 
       // when
@@ -1009,7 +1002,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceA = newTerminatedFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstanceB = newTerminatedFlowNodeInstance("B");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB));
 
       // when
@@ -1030,7 +1023,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceA1 = newCompletedFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstanceA2 = newActiveFlowNodeInstance("A");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceA1, flowNodeInstanceA2));
 
       // when
@@ -1049,8 +1042,7 @@ public class ElementAssertTest {
     @Test
     void shouldFailIfNotCreated() {
       // given
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
-          .thenReturn(Collections.emptyList());
+      when(camundaDataSource.findFlowNodeInstances(any())).thenReturn(Collections.emptyList());
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -1095,7 +1087,7 @@ public class ElementAssertTest {
       final FlowNodeInstance flowNodeInstanceA2 = newActiveFlowNodeInstance("A");
       final FlowNodeInstance flowNodeInstanceA3 = newTerminatedFlowNodeInstance("A");
 
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Arrays.asList(flowNodeInstanceA1, flowNodeInstanceA2))
           .thenReturn(Arrays.asList(flowNodeInstanceA1, flowNodeInstanceA3));
 
@@ -1105,8 +1097,7 @@ public class ElementAssertTest {
       // then
       CamundaAssert.assertThat(processInstanceEvent).hasTerminatedElement("A", 2);
 
-      verify(camundaDataSource, times(2))
-          .getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(camundaDataSource, times(2)).findFlowNodeInstances(any());
     }
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.process.test.api;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -76,7 +77,7 @@ public class ProcessInstanceAssertTest {
 
     @BeforeEach
     void configureMocks() {
-      when(camundaDataSource.findProcessInstances())
+      when(camundaDataSource.findProcessInstances(any()))
           .thenReturn(
               Arrays.asList(
                   ProcessInstanceBuilder.newActiveProcessInstance(ACTIVE_PROCESS_INSTANCE_KEY)
@@ -96,7 +97,7 @@ public class ProcessInstanceAssertTest {
       CamundaAssert.assertThat(processInstanceEvent).isActive();
 
       // then
-      verify(camundaDataSource).findProcessInstances();
+      verify(camundaDataSource).findProcessInstances(any());
     }
 
     @Test
@@ -110,7 +111,7 @@ public class ProcessInstanceAssertTest {
       CamundaAssert.assertThat(processInstanceEvent).isActive();
 
       // then
-      verify(camundaDataSource).findProcessInstances();
+      verify(camundaDataSource).findProcessInstances(any());
     }
 
     @Test
@@ -125,7 +126,7 @@ public class ProcessInstanceAssertTest {
               COMPLETED_PROCESS_INSTANCE_KEY);
 
       // then
-      verify(camundaDataSource).findProcessInstances();
+      verify(camundaDataSource).findProcessInstances(any());
     }
 
     @Test
@@ -137,7 +138,7 @@ public class ProcessInstanceAssertTest {
       CamundaAssert.assertThat(processInstanceResult).isActive();
 
       // then
-      verify(camundaDataSource).findProcessInstances();
+      verify(camundaDataSource).findProcessInstances(any());
     }
 
     @Test
@@ -154,7 +155,7 @@ public class ProcessInstanceAssertTest {
               COMPLETED_PROCESS_INSTANCE_KEY);
 
       // then
-      verify(camundaDataSource).findProcessInstances();
+      verify(camundaDataSource).findProcessInstances(any());
     }
 
     @Test
@@ -164,7 +165,7 @@ public class ProcessInstanceAssertTest {
           .isActive();
 
       // then
-      verify(camundaDataSource).findProcessInstances();
+      verify(camundaDataSource).findProcessInstances(any());
     }
 
     @Test
@@ -180,7 +181,7 @@ public class ProcessInstanceAssertTest {
               COMPLETED_PROCESS_INSTANCE_KEY);
 
       // then
-      verify(camundaDataSource).findProcessInstances();
+      verify(camundaDataSource).findProcessInstances(any());
     }
 
     @Test
@@ -189,7 +190,7 @@ public class ProcessInstanceAssertTest {
       CamundaAssert.assertThat(ProcessInstanceSelectors.byProcessId("active-process")).isActive();
 
       // then
-      verify(camundaDataSource).findProcessInstances();
+      verify(camundaDataSource).findProcessInstances(any());
     }
 
     @Test
@@ -205,7 +206,7 @@ public class ProcessInstanceAssertTest {
               "completed-process");
 
       // then
-      verify(camundaDataSource).findProcessInstances();
+      verify(camundaDataSource).findProcessInstances(any());
     }
   }
 
@@ -215,7 +216,7 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldBeActive() {
       // given
-      when(camundaDataSource.findProcessInstances())
+      when(camundaDataSource.findProcessInstances(any()))
           .thenReturn(
               Collections.singletonList(
                   ProcessInstanceBuilder.newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
@@ -230,7 +231,7 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldFailIfCompleted() {
       // given
-      when(camundaDataSource.findProcessInstances())
+      when(camundaDataSource.findProcessInstances(any()))
           .thenReturn(
               Collections.singletonList(
                   ProcessInstanceBuilder.newCompletedProcessInstance(PROCESS_INSTANCE_KEY)
@@ -249,7 +250,7 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldFailIfTerminated() {
       // given
-      when(camundaDataSource.findProcessInstances())
+      when(camundaDataSource.findProcessInstances(any()))
           .thenReturn(
               Collections.singletonList(
                   ProcessInstanceBuilder.newTerminatedProcessInstance(PROCESS_INSTANCE_KEY)
@@ -268,7 +269,7 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldFailIfNotFound() {
       // given
-      when(camundaDataSource.findProcessInstances()).thenReturn(Collections.emptyList());
+      when(camundaDataSource.findProcessInstances(any())).thenReturn(Collections.emptyList());
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -287,7 +288,7 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldBeCompleted() {
       // given
-      when(camundaDataSource.findProcessInstances())
+      when(camundaDataSource.findProcessInstances(any()))
           .thenReturn(
               Collections.singletonList(
                   ProcessInstanceBuilder.newCompletedProcessInstance(PROCESS_INSTANCE_KEY)
@@ -303,7 +304,7 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldFailIfTerminated() {
       // given
-      when(camundaDataSource.findProcessInstances())
+      when(camundaDataSource.findProcessInstances(any()))
           .thenReturn(
               Collections.singletonList(
                   ProcessInstanceBuilder.newTerminatedProcessInstance(PROCESS_INSTANCE_KEY)
@@ -323,7 +324,7 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldWaitUntilCompleted() {
       // given
-      when(camundaDataSource.findProcessInstances())
+      when(camundaDataSource.findProcessInstances(any()))
           .thenReturn(
               Collections.singletonList(
                   ProcessInstanceBuilder.newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()))
@@ -338,13 +339,13 @@ public class ProcessInstanceAssertTest {
       // then
       CamundaAssert.assertThat(processInstanceEvent).isCompleted();
 
-      verify(camundaDataSource, times(2)).findProcessInstances();
+      verify(camundaDataSource, times(2)).findProcessInstances(any());
     }
 
     @Test
     void shouldFailIfActive() {
       // given
-      when(camundaDataSource.findProcessInstances())
+      when(camundaDataSource.findProcessInstances(any()))
           .thenReturn(
               Collections.singletonList(
                   ProcessInstanceBuilder.newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
@@ -359,13 +360,13 @@ public class ProcessInstanceAssertTest {
               "Process instance [key: %d] should be completed but was active.",
               PROCESS_INSTANCE_KEY);
 
-      verify(camundaDataSource, atLeast(2)).findProcessInstances();
+      verify(camundaDataSource, atLeast(2)).findProcessInstances(any());
     }
 
     @Test
     void shouldFailIfNotFound() {
       // given
-      when(camundaDataSource.findProcessInstances()).thenReturn(Collections.emptyList());
+      when(camundaDataSource.findProcessInstances(any())).thenReturn(Collections.emptyList());
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -385,7 +386,7 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldBeTerminated() {
       // given
-      when(camundaDataSource.findProcessInstances())
+      when(camundaDataSource.findProcessInstances(any()))
           .thenReturn(
               Collections.singletonList(
                   ProcessInstanceBuilder.newTerminatedProcessInstance(PROCESS_INSTANCE_KEY)
@@ -401,7 +402,7 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldFailIfCompleted() {
       // given
-      when(camundaDataSource.findProcessInstances())
+      when(camundaDataSource.findProcessInstances(any()))
           .thenReturn(
               Collections.singletonList(
                   ProcessInstanceBuilder.newCompletedProcessInstance(PROCESS_INSTANCE_KEY)
@@ -421,7 +422,7 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldWaitUntilTerminated() {
       // given
-      when(camundaDataSource.findProcessInstances())
+      when(camundaDataSource.findProcessInstances(any()))
           .thenReturn(
               Collections.singletonList(
                   ProcessInstanceBuilder.newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()))
@@ -436,13 +437,13 @@ public class ProcessInstanceAssertTest {
       // then
       CamundaAssert.assertThat(processInstanceEvent).isTerminated();
 
-      verify(camundaDataSource, times(2)).findProcessInstances();
+      verify(camundaDataSource, times(2)).findProcessInstances(any());
     }
 
     @Test
     void shouldFailIfActive() {
       // given
-      when(camundaDataSource.findProcessInstances())
+      when(camundaDataSource.findProcessInstances(any()))
           .thenReturn(
               Collections.singletonList(
                   ProcessInstanceBuilder.newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
@@ -457,13 +458,13 @@ public class ProcessInstanceAssertTest {
               "Process instance [key: %d] should be terminated but was active.",
               PROCESS_INSTANCE_KEY);
 
-      verify(camundaDataSource, atLeast(2)).findProcessInstances();
+      verify(camundaDataSource, atLeast(2)).findProcessInstances(any());
     }
 
     @Test
     void shouldFailIfNotFound() {
       // given
-      when(camundaDataSource.findProcessInstances()).thenReturn(Collections.emptyList());
+      when(camundaDataSource.findProcessInstances(any())).thenReturn(Collections.emptyList());
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -483,7 +484,7 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldBeCreatedIfActive() {
       // given
-      when(camundaDataSource.findProcessInstances())
+      when(camundaDataSource.findProcessInstances(any()))
           .thenReturn(
               Collections.singletonList(
                   ProcessInstanceBuilder.newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
@@ -498,7 +499,7 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldBeCreatedIfCompleted() {
       // given
-      when(camundaDataSource.findProcessInstances())
+      when(camundaDataSource.findProcessInstances(any()))
           .thenReturn(
               Collections.singletonList(
                   ProcessInstanceBuilder.newCompletedProcessInstance(PROCESS_INSTANCE_KEY)
@@ -514,7 +515,7 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldBeCreatedIfTerminated() {
       // given
-      when(camundaDataSource.findProcessInstances())
+      when(camundaDataSource.findProcessInstances(any()))
           .thenReturn(
               Collections.singletonList(
                   ProcessInstanceBuilder.newTerminatedProcessInstance(PROCESS_INSTANCE_KEY)
@@ -530,7 +531,7 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldFailIfNotCreated() {
       // given
-      when(camundaDataSource.findProcessInstances()).thenReturn(Collections.emptyList());
+      when(camundaDataSource.findProcessInstances(any())).thenReturn(Collections.emptyList());
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -554,7 +555,7 @@ public class ProcessInstanceAssertTest {
 
     @BeforeEach
     void configureMocks() {
-      when(camundaDataSource.findProcessInstances())
+      when(camundaDataSource.findProcessInstances(any()))
           .thenReturn(
               Collections.singletonList(
                   ProcessInstanceBuilder.newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -585,7 +585,7 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldAssertStateAndElements() {
       // given
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Collections.singletonList(activeFlowNodeInstance));
 
       // when
@@ -611,7 +611,7 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldAssertElementsAndState() {
       // given
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Collections.singletonList(activeFlowNodeInstance));
 
       // when
@@ -637,7 +637,7 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldAssertElementsAndVariables() {
       // given
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Collections.singletonList(activeFlowNodeInstance));
 
       when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
@@ -653,7 +653,7 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldAssertVariablesAndElements() {
       // given
-      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Collections.singletonList(activeFlowNodeInstance));
 
       when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.client.api.response.ProcessInstanceResult;
+import io.camunda.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.client.api.search.response.FlowNodeInstance;
 import io.camunda.client.api.search.response.Variable;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelectors;
@@ -34,12 +35,15 @@ import io.camunda.process.test.utils.VariableBuilder;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.function.Consumer;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -74,6 +78,8 @@ public class ProcessInstanceAssertTest {
     private static final long COMPLETED_PROCESS_INSTANCE_KEY = 2L;
 
     @Mock private ProcessInstanceResult processInstanceResult;
+    @Mock private ProcessInstanceFilter processInstanceFilter;
+    @Captor private ArgumentCaptor<Consumer<ProcessInstanceFilter>> processInstanceFilterCapture;
 
     @BeforeEach
     void configureMocks() {
@@ -97,7 +103,10 @@ public class ProcessInstanceAssertTest {
       CamundaAssert.assertThat(processInstanceEvent).isActive();
 
       // then
-      verify(camundaDataSource).findProcessInstances(any());
+      verify(camundaDataSource).findProcessInstances(processInstanceFilterCapture.capture());
+
+      processInstanceFilterCapture.getValue().accept(processInstanceFilter);
+      verify(processInstanceFilter).processInstanceKey(ACTIVE_PROCESS_INSTANCE_KEY);
     }
 
     @Test
@@ -111,7 +120,10 @@ public class ProcessInstanceAssertTest {
       CamundaAssert.assertThat(processInstanceEvent).isActive();
 
       // then
-      verify(camundaDataSource).findProcessInstances(any());
+      verify(camundaDataSource).findProcessInstances(processInstanceFilterCapture.capture());
+
+      processInstanceFilterCapture.getValue().accept(processInstanceFilter);
+      verify(processInstanceFilter).processInstanceKey(ACTIVE_PROCESS_INSTANCE_KEY);
     }
 
     @Test
@@ -138,7 +150,10 @@ public class ProcessInstanceAssertTest {
       CamundaAssert.assertThat(processInstanceResult).isActive();
 
       // then
-      verify(camundaDataSource).findProcessInstances(any());
+      verify(camundaDataSource).findProcessInstances(processInstanceFilterCapture.capture());
+
+      processInstanceFilterCapture.getValue().accept(processInstanceFilter);
+      verify(processInstanceFilter).processInstanceKey(ACTIVE_PROCESS_INSTANCE_KEY);
     }
 
     @Test
@@ -165,7 +180,10 @@ public class ProcessInstanceAssertTest {
           .isActive();
 
       // then
-      verify(camundaDataSource).findProcessInstances(any());
+      verify(camundaDataSource).findProcessInstances(processInstanceFilterCapture.capture());
+
+      processInstanceFilterCapture.getValue().accept(processInstanceFilter);
+      verify(processInstanceFilter).processInstanceKey(ACTIVE_PROCESS_INSTANCE_KEY);
     }
 
     @Test
@@ -190,7 +208,10 @@ public class ProcessInstanceAssertTest {
       CamundaAssert.assertThat(ProcessInstanceSelectors.byProcessId("active-process")).isActive();
 
       // then
-      verify(camundaDataSource).findProcessInstances(any());
+      verify(camundaDataSource).findProcessInstances(processInstanceFilterCapture.capture());
+
+      processInstanceFilterCapture.getValue().accept(processInstanceFilter);
+      verify(processInstanceFilter).processDefinitionId("active-process");
     }
 
     @Test

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -598,7 +598,7 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldAssertStateAndVariables() {
       // given
-      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Collections.singletonList(variable));
 
       // when
@@ -624,7 +624,7 @@ public class ProcessInstanceAssertTest {
     @Test
     void shouldAssertVariablesAndState() {
       // given
-      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Collections.singletonList(variable));
 
       // when
@@ -640,7 +640,7 @@ public class ProcessInstanceAssertTest {
       when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Collections.singletonList(activeFlowNodeInstance));
 
-      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Collections.singletonList(variable));
 
       // when
@@ -656,7 +656,7 @@ public class ProcessInstanceAssertTest {
       when(camundaDataSource.findFlowNodeInstances(any()))
           .thenReturn(Collections.singletonList(activeFlowNodeInstance));
 
-      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Collections.singletonList(variable));
 
       // when

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
@@ -106,7 +106,7 @@ public class VariableAssertTest {
       final Variable variableA = newVariable("a", "1");
       final Variable variableB = newVariable("b", "2");
 
-      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Arrays.asList(variableA, variableB));
 
       // when
@@ -122,7 +122,7 @@ public class VariableAssertTest {
       final Variable variableA = newVariable("a", "1");
       final Variable variableB = newVariable("b", "2");
 
-      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Collections.singletonList(variableA))
           .thenReturn(Arrays.asList(variableA, variableB));
 
@@ -132,7 +132,7 @@ public class VariableAssertTest {
       // then
       CamundaAssert.assertThat(processInstanceEvent).hasVariableNames("a", "b");
 
-      verify(camundaDataSource, times(2)).getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(camundaDataSource, times(2)).findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
     }
 
     @Test
@@ -141,7 +141,7 @@ public class VariableAssertTest {
       final Variable variableA = newVariable("a", "1");
       final Variable variableB = newVariable("b", "2");
 
-      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Arrays.asList(variableA, variableB));
 
       // when
@@ -181,7 +181,7 @@ public class VariableAssertTest {
       // given
       final Variable variableA = newVariable("a", variableValue);
 
-      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Collections.singletonList(variableA));
 
       // when
@@ -197,7 +197,7 @@ public class VariableAssertTest {
       final Variable variableA = newVariable("a", "1");
       final Variable variableB = newVariable("b", "2");
 
-      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Collections.singletonList(variableB))
           .thenReturn(Arrays.asList(variableA, variableB));
 
@@ -207,7 +207,7 @@ public class VariableAssertTest {
       // then
       CamundaAssert.assertThat(processInstanceEvent).hasVariable("a", 1);
 
-      verify(camundaDataSource, times(2)).getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(camundaDataSource, times(2)).findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
     }
 
     @Test
@@ -216,7 +216,7 @@ public class VariableAssertTest {
       final Variable variableValue1 = newVariable("a", "1");
       final Variable variableValue2 = newVariable("a", "2");
 
-      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Collections.singletonList(variableValue1))
           .thenReturn(Collections.singletonList(variableValue2));
 
@@ -226,7 +226,7 @@ public class VariableAssertTest {
       // then
       CamundaAssert.assertThat(processInstanceEvent).hasVariable("a", 2);
 
-      verify(camundaDataSource, times(2)).getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(camundaDataSource, times(2)).findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
     }
 
     @Test
@@ -235,7 +235,7 @@ public class VariableAssertTest {
       final Variable variableA = newVariable("a", "1");
       final Variable variableB = newVariable("b", "2");
 
-      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Arrays.asList(variableA, variableB));
 
       // when
@@ -255,7 +255,7 @@ public class VariableAssertTest {
       final Variable variableA = newVariable("a", "1");
       final Variable variableB = newVariable("b", "2");
 
-      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Arrays.asList(variableA, variableB));
 
       // when
@@ -275,7 +275,7 @@ public class VariableAssertTest {
       // given
       final Variable variableA = newVariable("a", variableValue);
 
-      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Collections.singletonList(variableA));
 
       // when
@@ -314,7 +314,7 @@ public class VariableAssertTest {
       final Variable variableA = newVariable("a", variableValue);
       final Variable variableB = newVariable("b", "100");
 
-      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Arrays.asList(variableA, variableB));
 
       // when
@@ -333,7 +333,7 @@ public class VariableAssertTest {
       final Variable variableA = newVariable("a", "1");
       final Variable variableB = newVariable("b", "2");
 
-      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Collections.singletonList(variableA))
           .thenReturn(Arrays.asList(variableA, variableB));
 
@@ -346,7 +346,7 @@ public class VariableAssertTest {
       expectedVariables.put("b", 2);
       CamundaAssert.assertThat(processInstanceEvent).hasVariables(expectedVariables);
 
-      verify(camundaDataSource, times(2)).getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(camundaDataSource, times(2)).findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
     }
 
     @Test
@@ -356,7 +356,7 @@ public class VariableAssertTest {
       final Variable variableValue2 = newVariable("a", "2");
       final Variable variableB = newVariable("b", "2");
 
-      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Arrays.asList(variableValue1, variableB))
           .thenReturn(Arrays.asList(variableValue2, variableB));
 
@@ -369,7 +369,7 @@ public class VariableAssertTest {
       expectedVariables.put("b", 2);
       CamundaAssert.assertThat(processInstanceEvent).hasVariables(expectedVariables);
 
-      verify(camundaDataSource, times(2)).getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+      verify(camundaDataSource, times(2)).findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
     }
 
     @Test
@@ -378,7 +378,7 @@ public class VariableAssertTest {
       final Variable variableA = newVariable("a", "1");
       final Variable variableB = newVariable("b", "2");
 
-      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Arrays.asList(variableA, variableB));
 
       // when
@@ -403,7 +403,7 @@ public class VariableAssertTest {
       final Variable variableB = newVariable("b", "2");
       final Variable variableC = newVariable("c", "3");
 
-      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Arrays.asList(variableA, variableB, variableC));
 
       // when
@@ -427,7 +427,7 @@ public class VariableAssertTest {
       // given
       final Variable variableA = newVariable("a", variableValue);
 
-      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+      when(camundaDataSource.findVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
           .thenReturn(Collections.singletonList(variableA));
 
       // when

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.process.test.api;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -72,7 +73,7 @@ public class VariableAssertTest {
 
   @BeforeEach
   void configureMocks() {
-    when(camundaDataSource.findProcessInstances())
+    when(camundaDataSource.findProcessInstances(any()))
         .thenReturn(
             Collections.singletonList(
                 ProcessInstanceBuilder.newActiveProcessInstance(PROCESS_INSTANCE_KEY).build()));
@@ -159,7 +160,7 @@ public class VariableAssertTest {
     @Test
     void shouldFailIfProcessInstanceNotFound() {
       // given
-      when(camundaDataSource.findProcessInstances()).thenReturn(Collections.emptyList());
+      when(camundaDataSource.findProcessInstances(any())).thenReturn(Collections.emptyList());
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -291,7 +292,7 @@ public class VariableAssertTest {
     @Test
     void shouldFailIfProcessInstanceNotFound() {
       // given
-      when(camundaDataSource.findProcessInstances()).thenReturn(Collections.emptyList());
+      when(camundaDataSource.findProcessInstances(any())).thenReturn(Collections.emptyList());
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
@@ -446,7 +447,7 @@ public class VariableAssertTest {
     @Test
     void shouldFailIfProcessInstanceNotFound() {
       // given
-      when(camundaDataSource.findProcessInstances()).thenReturn(Collections.emptyList());
+      when(camundaDataSource.findProcessInstances(any())).thenReturn(Collections.emptyList());
 
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultCollectorTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultCollectorTest.java
@@ -113,14 +113,14 @@ public class CamundaProcessResultCollectorTest {
     when(camundaDataSource.findProcessInstances())
         .thenReturn(Arrays.asList(PROCESS_INSTANCE_1, PROCESS_INSTANCE_2));
 
-    when(camundaDataSource.getVariablesByProcessInstanceKey(
+    when(camundaDataSource.findVariablesByProcessInstanceKey(
             PROCESS_INSTANCE_1.getProcessInstanceKey()))
         .thenReturn(
             Arrays.asList(
                 VariableBuilder.newVariable("var-1", "1").build(),
                 VariableBuilder.newVariable("var-2", "2").build()));
 
-    when(camundaDataSource.getVariablesByProcessInstanceKey(
+    when(camundaDataSource.findVariablesByProcessInstanceKey(
             PROCESS_INSTANCE_2.getProcessInstanceKey()))
         .thenReturn(Collections.singletonList(VariableBuilder.newVariable("var-3", "3").build()));
 
@@ -160,11 +160,11 @@ public class CamundaProcessResultCollectorTest {
             .setIncidentKey(11L)
             .build();
 
-    when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(
+    when(camundaDataSource.findFlowNodeInstancesByProcessInstanceKey(
             PROCESS_INSTANCE_1.getProcessInstanceKey()))
         .thenReturn(Arrays.asList(flowNodeInstance1, flowNodeInstance2));
 
-    when(camundaDataSource.getIncidentsByProcessInstanceKey(
+    when(camundaDataSource.findIncidentsByProcessInstanceKey(
             PROCESS_INSTANCE_1.getProcessInstanceKey()))
         .thenReturn(
             Arrays.asList(
@@ -190,11 +190,11 @@ public class CamundaProcessResultCollectorTest {
             .setIncident(false)
             .build();
 
-    when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(
+    when(camundaDataSource.findFlowNodeInstancesByProcessInstanceKey(
             PROCESS_INSTANCE_2.getProcessInstanceKey()))
         .thenReturn(Arrays.asList(flowNodeInstance3, flowNodeInstance4));
 
-    when(camundaDataSource.getIncidentsByProcessInstanceKey(
+    when(camundaDataSource.findIncidentsByProcessInstanceKey(
             PROCESS_INSTANCE_2.getProcessInstanceKey()))
         .thenReturn(
             Collections.singletonList(
@@ -229,7 +229,7 @@ public class CamundaProcessResultCollectorTest {
     when(camundaDataSource.findProcessInstances())
         .thenReturn(Arrays.asList(PROCESS_INSTANCE_1, PROCESS_INSTANCE_2));
 
-    when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(
+    when(camundaDataSource.findFlowNodeInstancesByProcessInstanceKey(
             PROCESS_INSTANCE_1.getProcessInstanceKey()))
         .thenReturn(
             Arrays.asList(
@@ -240,7 +240,7 @@ public class CamundaProcessResultCollectorTest {
                         "B", PROCESS_INSTANCE_1.getProcessInstanceKey())
                     .build()));
 
-    when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(
+    when(camundaDataSource.findFlowNodeInstancesByProcessInstanceKey(
             PROCESS_INSTANCE_2.getProcessInstanceKey()))
         .thenReturn(
             Arrays.asList(


### PR DESCRIPTION
## Description

These changes optimize the queries for process instance and element assertions. 

- Introduce a new method `applyFilter()` in the process instance and element selectors to limit the query for the assertion 
- Implement the method for the pre-defined selectors
- No implementation for the flow node name because there is no filter option yet

## Related issues

follow-up of https://github.com/camunda/camunda/pull/28822

related to https://github.com/camunda/camunda/issues/19263
