### PR TITLE
docs: add identity bug issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/identity_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/identity_bug_report.md
@@ -9,15 +9,19 @@ assignees: ''
 ---
 
 **Describe the bug**
+
 <!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
+
 <!-- Steps to reproduce the behavior -->
 
 **Expected behavior**
+
 <!-- A clear and concise description of what you expected to happen. -->
 
 **Log/Stacktrace**
+
 <!-- If appropriate, add the full stacktrace which contains the issue. -->
 
 <details><summary>Full Stacktrace</summary>

--- a/.github/ISSUE_TEMPLATE/identity_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/identity_bug_report.md
@@ -1,0 +1,35 @@
+---
+
+name: Identity Bug report
+about: Create a report to help us improve
+title: ''
+labels: ['kind/bug', 'component/identity']
+assignees: ''
+
+---
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**To Reproduce**
+<!-- Steps to reproduce the behavior -->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Log/Stacktrace**
+<!-- If appropriate, add the full stacktrace which contains the issue. -->
+
+<details><summary>Full Stacktrace</summary>
+ <p>
+
+```
+<STACKTRACE>
+```
+
+</p>
+</details>
+
+**Environment:**
+- Camunda Version: <!-- [e.g. 0.20.0] -->
+- Configuration: <!-- [e.g. exporters etc.] -->


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR adds in an Identity bug report issue template to better support bugs being raised to the Identity boards.
