### PR TITLE
Implement Record and RecordProcessor to Activate an Ad-hoc Subprocess Activity

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -874,6 +874,7 @@
         #     userTask: true
         #     variable: true
         #     variableDocument: true
+        #     adHocSubProcessActivityActivation: true
         #
         #   retention:
         #     enabled: false

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -957,6 +957,7 @@
         #     userTask: true
         #     variable: true
         #     variableDocument: true
+        #     adHocSubProcessActivityActivation: true
 
       # Camunda Exporter ----------
       # An example configuration for the camunda exporter:

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -871,6 +871,7 @@
         #     userTask: true
         #     variable: true
         #     variableDocument: true
+        #     adHocSubProcessActivityActivation: true
 
       # Camunda Exporter ----------
       # An example configuration for the camunda exporter:

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -788,6 +788,7 @@
         #     userTask: true
         #     variable: true
         #     variableDocument: true
+        #     adHocSubProcessActivityActivation: true
         #
         #   retention:
         #     enabled: false

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestSupport.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestSupport.java
@@ -66,6 +66,8 @@ public final class TestSupport {
       case BATCH_OPERATION_CREATION -> config.batchOperationCreation = value;
       case BATCH_OPERATION_CHUNK -> config.batchOperationChunk = value;
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
+      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
+          config.adHocSubProcessActivityActivation = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);
@@ -115,6 +117,8 @@ public final class TestSupport {
       case BATCH_OPERATION_CREATION -> config.batchOperationCreation = value;
       case BATCH_OPERATION_CHUNK -> config.batchOperationChunk = value;
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
+      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
+          config.adHocSubProcessActivityActivation = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestSupport.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestSupport.java
@@ -67,6 +67,8 @@ public final class TestSupport {
       case BATCH_OPERATION_CREATION -> config.batchOperationCreation = value;
       case BATCH_OPERATION_CHUNK -> config.batchOperationChunk = value;
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
+      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
+          config.adHocSubProcessActivityActivation = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);
@@ -118,6 +120,8 @@ public final class TestSupport {
       case BATCH_OPERATION_CREATION -> config.batchOperationCreation = value;
       case BATCH_OPERATION_CHUNK -> config.batchOperationChunk = value;
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
+      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
+          config.adHocSubProcessActivityActivation = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.broker.transport.RequestReaderException;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
@@ -73,6 +74,9 @@ public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequ
     RECORDS_BY_TYPE.put(ValueType.RESOURCE_DELETION, ResourceDeletionRecord::new);
     RECORDS_BY_TYPE.put(ValueType.USER_TASK, UserTaskRecord::new);
     RECORDS_BY_TYPE.put(ValueType.PROCESS_INSTANCE_MIGRATION, ProcessInstanceMigrationRecord::new);
+    RECORDS_BY_TYPE.put(
+        ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
+        AdHocSubProcessActivityActivationRecord::new);
     RECORDS_BY_TYPE.put(ValueType.COMPENSATION_SUBSCRIPTION, CompensationSubscriptionRecord::new);
     RECORDS_BY_TYPE.put(ValueType.MESSAGE_CORRELATION, MessageCorrelationRecord::new);
     RECORDS_BY_TYPE.put(ValueType.USER, UserRecord::new);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -128,7 +128,7 @@ public final class BpmnProcessors {
         keyGenerator);
     addProcessInstanceBatchStreamProcessors(typedRecordProcessors, processingState, writers);
     addAdHocSubProcessActivityStreamProcessors(
-        typedRecordProcessors, processingState, writers, keyGenerator);
+        typedRecordProcessors, processingState, writers, authCheckBehavior, keyGenerator);
 
     return bpmnStreamProcessor;
   }
@@ -332,10 +332,12 @@ public final class BpmnProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final MutableProcessingState processingState,
       final Writers writers,
+      final AuthorizationCheckBehavior authCheckBehavior,
       final KeyGenerator keyGenerator) {
     typedRecordProcessors.onCommand(
         ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
         AdHocSubProcessActivityActivationIntent.ACTIVATE,
-        new AdHocSubProcessActivityActivateProcessor(writers, processingState, keyGenerator));
+        new AdHocSubProcessActivityActivateProcessor(
+            writers, processingState, authCheckBehavior, keyGenerator));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
+import io.camunda.zeebe.engine.processing.adhocsubprocess.AdHocSubProcessActivityActivateProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnStreamProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
@@ -42,6 +43,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -125,6 +127,8 @@ public final class BpmnProcessors {
         authCheckBehavior,
         keyGenerator);
     addProcessInstanceBatchStreamProcessors(typedRecordProcessors, processingState, writers);
+    addAdHocSubProcessActivityStreamProcessors(
+        typedRecordProcessors, processingState, writers, keyGenerator);
 
     return bpmnStreamProcessor;
   }
@@ -322,5 +326,16 @@ public final class BpmnProcessors {
                 processingState.getKeyGenerator(),
                 processingState.getElementInstanceState(),
                 processingState.getProcessState()));
+  }
+
+  private static void addAdHocSubProcessActivityStreamProcessors(
+      final TypedRecordProcessors typedRecordProcessors,
+      final MutableProcessingState processingState,
+      final Writers writers,
+      final KeyGenerator keyGenerator) {
+    typedRecordProcessors.onCommand(
+        ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
+        AdHocSubProcessActivityActivationIntent.ACTIVATE,
+        new AdHocSubProcessActivityActivateProcessor(writers, processingState, keyGenerator));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessActivityActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessActivityActivateProcessor.java
@@ -126,12 +126,12 @@ public class AdHocSubProcessActivityActivateProcessor
     }
 
     if (!adHocSubprocessElementInstance.isActive()) {
-      final var errorMessage =
+      writeRejectionError(
+          command,
+          RejectionType.INVALID_STATE,
           String.format(
               ERROR_MSG_ADHOC_SUBPROCESS_IS_NOT_ACTIVE,
-              command.getValue().getAdHocSubProcessInstanceKey());
-      rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, errorMessage);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_STATE, errorMessage);
+              command.getValue().getAdHocSubProcessInstanceKey()));
 
       return;
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessActivityActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessActivityActivateProcessor.java
@@ -155,7 +155,7 @@ public class AdHocSubProcessActivityActivateProcessor
     if (!elementsNotInAdHocSubProcess.isEmpty()) {
       writeRejectionError(
           command,
-          RejectionType.INVALID_STATE,
+          RejectionType.NOT_FOUND,
           String.format(
               ERROR_MSG_ELEMENTS_NOT_FOUND,
               command.getValue().getAdHocSubProcessInstanceKey(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessActivityActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessActivityActivateProcessor.java
@@ -42,11 +42,11 @@ public class AdHocSubProcessActivityActivateProcessor
   private static final String ERROR_MSG_ADHOC_SUBPROCESS_NOT_FOUND =
       "Expected to activate activities for ad-hoc subprocess but no ad-hoc subprocess instance found with key '%s'.";
   private static final String ERROR_MSG_DUPLICATE_ACTIVITIES =
-      "Expected to activate activities for ad-hoc subprocess '%s', but duplicate activities were given.";
+      "Expected to activate activities for ad-hoc subprocess with key '%s', but duplicate activities were given.";
   private static final String ERROR_MSG_ADHOC_SUBPROCESS_IS_FINAL =
-      "Expected to activate activities for ad-hoc subprocess '%s', but it is either completed or terminated.";
+      "Expected to activate activities for ad-hoc subprocess with key '%s', but it has either been completed or terminated.";
   private static final String ERROR_MSG_ADHOC_SUBPROCESS_IS_NOT_ACTIVE =
-      "Expected to activate activities for ad-hoc subprocess '%s', but it is not active.";
+      "Expected to activate activities for ad-hoc subprocess with key '%s', but it is not active.";
   private static final String ERROR_MSG_ELEMENTS_NOT_FOUND =
       "Expected to activate activities for ad-hoc subprocess with key '%s', but the given elements %s do not exist.";
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessActivityActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessActivityActivateProcessor.java
@@ -111,7 +111,6 @@ public class AdHocSubProcessActivityActivateProcessor
       return;
     }
 
-    final var adHocSubprocessElementId = adHocSubprocessElementInstance.getValue().getElementId();
     if (adHocSubprocessElementInstance.isInFinalState()) {
       writeRejectionError(
           command,
@@ -192,22 +191,6 @@ public class AdHocSubProcessActivityActivateProcessor
         AdHocSubProcessActivityActivationIntent.ACTIVATED,
         command.getValue(),
         command);
-  }
-
-  @Override
-  public ProcessingError tryHandleError(
-      final TypedRecord<AdHocSubProcessActivityActivationRecord> command, final Throwable error) {
-    return switch (error) {
-      case final IllegalArgumentException e -> {
-        writeRejectionError(command, RejectionType.INVALID_ARGUMENT, e.getMessage());
-        yield ProcessingError.EXPECTED_ERROR;
-      }
-      case final IllegalStateException e -> {
-        writeRejectionError(command, RejectionType.INVALID_STATE, e.getMessage());
-        yield ProcessingError.EXPECTED_ERROR;
-      }
-      default -> ProcessingError.UNEXPECTED_ERROR;
-    };
   }
 
   private void writeRejectionError(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessActivityActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessActivityActivateProcessor.java
@@ -41,8 +41,8 @@ public class AdHocSubProcessActivityActivateProcessor
       "Expected to activate activities for ad-hoc subprocess but no ad-hoc subprocess instance found with key '%s'.";
   private static final String ERROR_MSG_DUPLICATE_ACTIVITIES =
       "Expected to activate activities for ad-hoc subprocess with key '%s', but duplicate activities were given.";
-  private static final String ERROR_MSG_ADHOC_SUBPROCESS_IS_FINAL =
-      "Expected to activate activities for ad-hoc subprocess with key '%s', but it has either been completed or terminated.";
+  private static final String ERROR_MSG_ADHOC_SUBPROCESS_IS_NO_ACTIVE =
+      "Expected to activate activities for ad-hoc subprocess with key '%s', but it is not active.";
   private static final String ERROR_MSG_ADHOC_SUBPROCESS_IS_NOT_ACTIVE =
       "Expected to activate activities for ad-hoc subprocess with key '%s', but it is not active.";
   private static final String ERROR_MSG_ELEMENTS_NOT_FOUND =
@@ -88,6 +88,17 @@ public class AdHocSubProcessActivityActivateProcessor
       return;
     }
 
+    if (!adHocSubprocessElementInstance.isActive()) {
+      writeRejectionError(
+          command,
+          RejectionType.INVALID_STATE,
+          String.format(
+              ERROR_MSG_ADHOC_SUBPROCESS_IS_NO_ACTIVE,
+              command.getValue().getAdHocSubProcessInstanceKey()));
+
+      return;
+    }
+
     final var authResult = authorize(command, adHocSubprocessElementInstance);
     if (authResult.isLeft()) {
       final var rejection = authResult.getLeft();
@@ -107,17 +118,6 @@ public class AdHocSubProcessActivityActivateProcessor
           RejectionType.INVALID_ARGUMENT,
           String.format(
               ERROR_MSG_DUPLICATE_ACTIVITIES, command.getValue().getAdHocSubProcessInstanceKey()));
-
-      return;
-    }
-
-    if (adHocSubprocessElementInstance.isInFinalState()) {
-      writeRejectionError(
-          command,
-          RejectionType.INVALID_STATE,
-          String.format(
-              ERROR_MSG_ADHOC_SUBPROCESS_IS_FINAL,
-              command.getValue().getAdHocSubProcessInstanceKey()));
 
       return;
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessActivityActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessActivityActivateProcessor.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.adhocsubprocess;
+
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableAdHocSubProcess;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationFlowNode;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue.AdHocSubProcessActivityActivationFlowNodeValue;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import java.util.List;
+
+public class AdHocSubProcessActivityActivateProcessor
+    implements TypedRecordProcessor<AdHocSubProcessActivityActivationRecord> {
+
+  private final StateWriter stateWriter;
+  private final TypedResponseWriter responseWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final TypedCommandWriter commandWriter;
+  private final ElementInstanceState elementInstanceState;
+  private final ProcessState processState;
+  private final KeyGenerator keyGenerator;
+
+  public AdHocSubProcessActivityActivateProcessor(
+      final Writers writers,
+      final ProcessingState processingState,
+      final KeyGenerator keyGenerator) {
+    stateWriter = writers.state();
+    responseWriter = writers.response();
+    rejectionWriter = writers.rejection();
+    commandWriter = writers.command();
+    processState = processingState.getProcessState();
+    elementInstanceState = processingState.getElementInstanceState();
+    this.keyGenerator = keyGenerator;
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<AdHocSubProcessActivityActivationRecord> command) {
+    // todo: authz check
+
+    final var hasDuplicates =
+        command.getValue().getFlowNodes().stream()
+                .map(AdHocSubProcessActivityActivationFlowNodeValue::getFlowNodeId)
+                .distinct()
+                .count()
+            != command.getValue().getFlowNodes().size();
+    if (hasDuplicates) {
+      throw new DuplicateFlowNodesException(
+          command.getValue().getFlowNodes().stream()
+              .map(AdHocSubProcessActivityActivationFlowNodeValue::getFlowNodeId)
+              .toList());
+    }
+
+    final var adHocSubprocessElementInstance =
+        elementInstanceState.getInstance(
+            Long.parseLong(command.getValue().getAdHocSubProcessInstanceKey()));
+    if (adHocSubprocessElementInstance == null) {
+      throw new AdHocSubProcessInstanceIsNullException(
+          command.getValue().getAdHocSubProcessInstanceKey());
+    }
+
+    final var adHocSubprocessElementId = adHocSubprocessElementInstance.getValue().getElementId();
+    final var adHocSubprocessState = adHocSubprocessElementInstance.getState();
+    switch (adHocSubprocessState) {
+      case ELEMENT_COMPLETED, ELEMENT_TERMINATED ->
+          throw new AdHocSubProcessAlreadyDoneException(adHocSubprocessElementId);
+    }
+
+    if (adHocSubprocessState != ProcessInstanceIntent.ELEMENT_ACTIVATED) {
+      throw new AdHocSubProcessInstanceNotActivatedException(
+          command.getValue().getAdHocSubProcessInstanceKey());
+    }
+
+    final var adHocSubprocessDefinition =
+        processState
+            .getProcessByKeyAndTenant(
+                adHocSubprocessElementInstance.getValue().getProcessDefinitionKey(),
+                adHocSubprocessElementInstance.getValue().getTenantId())
+            .getProcess();
+
+    final var adHocSubprocessElement =
+        adHocSubprocessDefinition.getElementById(
+            adHocSubprocessElementInstance.getValue().getElementId());
+    final var adHocActivitiesById =
+        ((ExecutableAdHocSubProcess) adHocSubprocessElement).getAdHocActivitiesById();
+
+    // test that the given flow nodes exist within it
+    final var flowNodesNotInAdHocSubProcess =
+        command.getValue().flowNodes().stream()
+            .map(AdHocSubProcessActivityActivationFlowNode::getFlowNodeId)
+            .filter(flowNodeId -> !adHocActivitiesById.containsKey(flowNodeId))
+            .toList();
+    if (!flowNodesNotInAdHocSubProcess.isEmpty()) {
+      throw new FlowNodesNotPresentException(
+          adHocSubprocessElementId, flowNodesNotInAdHocSubProcess);
+    }
+
+    // activate the flow nodes
+    for (final var flowNode : command.getValue().getFlowNodes()) {
+      final var flowNodeToActivate =
+          adHocSubprocessDefinition.getElementById(flowNode.getFlowNodeId());
+      final var flowNodeProcessInstanceRecord = new ProcessInstanceRecord();
+      flowNodeProcessInstanceRecord.wrap(adHocSubprocessElementInstance.getValue());
+      flowNodeProcessInstanceRecord
+          // todo: should this have the same flow scope key as its parent?
+          .setFlowScopeKey(adHocSubprocessElementInstance.getKey())
+          .setElementId(flowNodeToActivate.getId())
+          // todo: are the element type and event type required?
+          .setBpmnElementType(flowNodeToActivate.getElementType())
+          .setBpmnEventType(flowNodeToActivate.getEventType());
+
+      final long elementToActivateInstanceKey = keyGenerator.nextKey();
+      commandWriter.appendFollowUpCommand(
+          elementToActivateInstanceKey,
+          ProcessInstanceIntent.ACTIVATE_ELEMENT,
+          flowNodeProcessInstanceRecord);
+    }
+
+    stateWriter.appendFollowUpEvent(
+        command.getKey(), AdHocSubProcessActivityActivationIntent.ACTIVATED, command.getValue());
+
+    responseWriter.writeEventOnCommand(
+        command.getKey(),
+        AdHocSubProcessActivityActivationIntent.ACTIVATED,
+        command.getValue(),
+        command);
+  }
+
+  @Override
+  public ProcessingError tryHandleError(
+      final TypedRecord<AdHocSubProcessActivityActivationRecord> command, final Throwable error) {
+    rejectionWriter.appendRejection(command, RejectionType.INVALID_ARGUMENT, error.getMessage());
+    responseWriter.writeRejectionOnCommand(
+        command, RejectionType.INVALID_ARGUMENT, error.getMessage());
+
+    return ProcessingError.EXPECTED_ERROR;
+  }
+
+  private static final class DuplicateFlowNodesException extends IllegalStateException {
+    private static final String ERROR_MESSAGE = "Duplicate flow nodes %s not allowed.";
+
+    private DuplicateFlowNodesException(final List<String> flowNodeIds) {
+      super(String.format(ERROR_MESSAGE, flowNodeIds));
+    }
+  }
+
+  private static final class FlowNodesNotPresentException extends IllegalStateException {
+    private static final String ERROR_MESSAGE =
+        "Flow nodes %s do not exist in ad-hoc subprocess <%s>";
+
+    private FlowNodesNotPresentException(
+        final String adHocSubprocessId, final List<String> flowNodeIds) {
+      super(String.format(ERROR_MESSAGE, flowNodeIds, adHocSubprocessId));
+    }
+  }
+
+  private static final class AdHocSubProcessAlreadyDoneException extends IllegalStateException {
+    private static final String ERROR_MESSAGE =
+        "Ad-hoc subprocess <%s> is already in a terminal state. Cannot activate any further activities.";
+
+    private AdHocSubProcessAlreadyDoneException(final String adHocSubprocessElementId) {
+      super(String.format(ERROR_MESSAGE, adHocSubprocessElementId));
+    }
+  }
+
+  private static final class AdHocSubProcessInstanceIsNullException extends IllegalStateException {
+    private static final String ERROR_MESSAGE = "Ad-hoc subprocess instance <%s> is.";
+
+    private AdHocSubProcessInstanceIsNullException(final String adHocSubprocessInstanceKey) {
+      super(String.format(ERROR_MESSAGE, adHocSubprocessInstanceKey));
+    }
+  }
+
+  private static final class AdHocSubProcessInstanceNotActivatedException
+      extends IllegalStateException {
+    private static final String ERROR_MESSAGE = "Ad-hoc subprocess instance <%s> is.";
+
+    private AdHocSubProcessInstanceNotActivatedException(final String adHocSubprocessInstanceKey) {
+      super(String.format(ERROR_MESSAGE, adHocSubprocessInstanceKey));
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessActivityActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessActivityActivateProcessor.java
@@ -80,7 +80,7 @@ public class AdHocSubProcessActivityActivateProcessor
     if (adHocSubprocessElementInstance == null) {
       writeRejectionError(
           command,
-          RejectionType.INVALID_STATE,
+          RejectionType.NOT_FOUND,
           String.format(
               ERROR_MSG_ADHOC_SUBPROCESS_NOT_FOUND,
               command.getValue().getAdHocSubProcessInstanceKey()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessActivityActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/adhocsubprocess/AdHocSubProcessActivityActivateProcessor.java
@@ -47,6 +47,8 @@ public class AdHocSubProcessActivityActivateProcessor
       "Expected to activate activities for ad-hoc subprocess '%s', but it is either completed or terminated.";
   private static final String ERROR_MSG_ADHOC_SUBPROCESS_IS_NOT_ACTIVE =
       "Expected to activate activities for ad-hoc subprocess '%s', but it is not active.";
+  private static final String ERROR_MSG_ELEMENTS_NOT_FOUND =
+      "Expected to activate activities for ad-hoc subprocess with key '%s', but the given elements %s do not exist.";
 
   private final StateWriter stateWriter;
   private final TypedResponseWriter responseWriter;
@@ -154,7 +156,15 @@ public class AdHocSubProcessActivityActivateProcessor
             .filter(elementId -> !adHocActivitiesById.containsKey(elementId))
             .toList();
     if (!elementsNotInAdHocSubProcess.isEmpty()) {
-      throw new ElementNotFoundException(adHocSubprocessElementId, elementsNotInAdHocSubProcess);
+      writeRejectionError(
+          command,
+          RejectionType.INVALID_STATE,
+          String.format(
+              ERROR_MSG_ELEMENTS_NOT_FOUND,
+              command.getValue().getAdHocSubProcessInstanceKey(),
+              elementsNotInAdHocSubProcess));
+
+      return;
     }
 
     // activate the elements
@@ -242,16 +252,6 @@ public class AdHocSubProcessActivityActivateProcessor
 
     private DuplicateElementsException(final List<String> elementIds) {
       super(String.format(ERROR_MESSAGE, elementIds));
-    }
-  }
-
-  private static final class ElementNotFoundException extends IllegalStateException {
-    private static final String ERROR_MESSAGE =
-        "Elements %s do not exist in ad-hoc subprocess <%s>";
-
-    private ElementNotFoundException(
-        final String adHocSubprocessId, final List<String> elementIds) {
-      super(String.format(ERROR_MESSAGE, elementIds, adHocSubprocessId));
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionSt
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.ClockIntent;
@@ -126,6 +127,8 @@ public final class EventAppliers implements EventApplier {
     registerCommandDistributionAppliers(state);
     registerEscalationAppliers();
     registerResourceDeletionAppliers();
+
+    registerAdHocSubProcessActivityActivationAppliers();
 
     registerUserAppliers(state);
     registerAuthorizationAppliers(state);
@@ -524,6 +527,10 @@ public final class EventAppliers implements EventApplier {
   private void registerResourceDeletionAppliers() {
     register(ResourceDeletionIntent.DELETING, NOOP_EVENT_APPLIER);
     register(ResourceDeletionIntent.DELETED, NOOP_EVENT_APPLIER);
+  }
+
+  private void registerAdHocSubProcessActivityActivationAppliers() {
+    register(AdHocSubProcessActivityActivationIntent.ACTIVATED, NOOP_EVENT_APPLIER);
   }
 
   private void registerClockAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/adhocsubprocess/ActivateAdHocSubProcessActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/adhocsubprocess/ActivateAdHocSubProcessActivityTest.java
@@ -84,8 +84,9 @@ public class ActivateAdHocSubProcessActivityTest {
             .key(adHocSubProcessInstanceKey));
 
     assertThat(
-            RecordingExporter.processInstanceRecords().withProcessInstanceKey(processInstanceKey))
-        // todo add short-circuit `limit` call?
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
         .extracting(r -> r.getValue().getElementId(), Record::getIntent)
         .contains(
             tuple("A", ProcessInstanceIntent.ACTIVATE_ELEMENT),
@@ -111,7 +112,8 @@ public class ActivateAdHocSubProcessActivityTest {
 
     assertThat(
             RecordingExporter.adHocSubProcessActivityActivationRecords()
-                .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey)))
+                .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
+                .limitToAdHocSubProcessInstanceCompleted())
         .extracting(r -> r.getValue().getElements().getFirst().getElementId(), Record::getIntent)
         .contains(tuple("A", AdHocSubProcessActivityActivationIntent.ACTIVATED));
   }
@@ -131,7 +133,9 @@ public class ActivateAdHocSubProcessActivityTest {
             .key(adHocSubProcessInstanceKey));
 
     assertThat(
-            RecordingExporter.processInstanceRecords().withProcessInstanceKey(processInstanceKey))
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
         .extracting(r -> r.getValue().getElementId(), Record::getIntent)
         .contains(
             tuple("A", ProcessInstanceIntent.ACTIVATE_ELEMENT),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/adhocsubprocess/ActivateAdHocSubProcessActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/adhocsubprocess/ActivateAdHocSubProcessActivityTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.adhocsubprocess;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AdHocSubProcessBuilder;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ActivateAdHocSubProcessActivityTest {
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String AD_HOC_SUB_PROCESS_ELEMENT_ID = "ad-hoc";
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  private long processInstanceKey;
+  private long adHocSubProcessInstanceKey;
+
+  @Before
+  public void setUp() {
+    final BpmnModelInstance processInstance =
+        process(
+            adHocSubProcess -> {
+              adHocSubProcess.task("A");
+              adHocSubProcess.task("B");
+              adHocSubProcess.task("C");
+            });
+    ENGINE.deployment().withXmlResource(processInstance).deploy();
+    processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    adHocSubProcessInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.AD_HOC_SUB_PROCESS)
+            .map(Record::getKey)
+            .limit(1)
+            .toList()
+            .getFirst();
+  }
+
+  private BpmnModelInstance process(final Consumer<AdHocSubProcessBuilder> modifier) {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .adHocSubProcess(AD_HOC_SUB_PROCESS_ELEMENT_ID, modifier)
+        .endEvent()
+        .done();
+  }
+
+  @Test
+  public void
+      givenRunningAdhocSubProcessInstanceWhenActivatingExistingFlowNodeThenTheFlowNodeIsActivated() {
+    final var adHocSubProcessActivityActivationRecord =
+        new AdHocSubProcessActivityActivationRecord()
+            .setAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey));
+    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("A");
+
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .adHocSubProcessActivityActivation(adHocSubProcessActivityActivationRecord)
+            .key(adHocSubProcessInstanceKey));
+
+    assertThat(
+            RecordingExporter.processInstanceRecords().withProcessInstanceKey(processInstanceKey))
+        // todo add short-circuit `limit` call?
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .contains(
+            tuple("A", ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple("A", ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .doesNotContainAnyElementsOf(
+            List.of(
+                tuple("B", ProcessInstanceIntent.ACTIVATE_ELEMENT),
+                tuple("C", ProcessInstanceIntent.ACTIVATE_ELEMENT)));
+  }
+
+  @Test
+  public void
+      givenRunningAdhocSubProcessInstanceWhenSuccessfullyActivatingAFlowNodeThenSubsequentActivatedEventIsSent() {
+    final var adHocSubProcessActivityActivationRecord =
+        new AdHocSubProcessActivityActivationRecord()
+            .setAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey));
+    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("A");
+
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .adHocSubProcessActivityActivation(adHocSubProcessActivityActivationRecord)
+            .key(adHocSubProcessInstanceKey));
+
+    assertThat(
+            RecordingExporter.adHocSubProcessActivityActivationRecords()
+                .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey)))
+        // todo add short-circuit `limit` call?
+        .extracting(r -> r.getValue().getFlowNodes().getFirst().getFlowNodeId(), Record::getIntent)
+        .contains(tuple("A", AdHocSubProcessActivityActivationIntent.ACTIVATED));
+  }
+
+  @Test
+  public void
+      givenRunningAdhocSubProcessInstanceWhenActivatingMoreThanOneFlowNodeThenAllGivenFlowNodesAreActivated() {
+    final var adHocSubProcessActivityActivationRecord =
+        new AdHocSubProcessActivityActivationRecord()
+            .setAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey));
+    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("A");
+    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("B");
+
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .adHocSubProcessActivityActivation(adHocSubProcessActivityActivationRecord)
+            .key(adHocSubProcessInstanceKey));
+
+    assertThat(
+            RecordingExporter.processInstanceRecords().withProcessInstanceKey(processInstanceKey))
+        // todo add short-circuit `limit` call?
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .contains(
+            tuple("A", ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple("A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("B", ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple("B", ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .doesNotContainAnyElementsOf(List.of(tuple("C", ProcessInstanceIntent.ACTIVATE_ELEMENT)));
+  }
+
+  @Test
+  public void
+      givenRunningAdhocSubProcessInstanceWhenActivatingFlowNodeThatDoesNotExistThenTheActivationIsRejected() {
+    final var adHocSubProcessActivityActivationRecord =
+        new AdHocSubProcessActivityActivationRecord()
+            .setAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey));
+    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("does-not-exist");
+
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .adHocSubProcessActivityActivation(adHocSubProcessActivityActivationRecord)
+            .key(adHocSubProcessInstanceKey));
+
+    assertThat(
+            RecordingExporter.adHocSubProcessActivityActivationRecords()
+                .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
+                .onlyCommandRejections()
+                .limit(1))
+        .extracting(r -> r.getValue().getFlowNodes().getFirst().getFlowNodeId(), Record::getIntent)
+        .describedAs("Expected flow node that doesn't exist to be rejected.")
+        .contains(tuple("does-not-exist", AdHocSubProcessActivityActivationIntent.ACTIVATE));
+  }
+
+  @Test
+  public void
+      givenAdhocSubProcessInATerminalStateWhenActivatingFlowNodesThenTheActivationIsRejected() {
+    final var adHocSubProcessActivityActivationRecord =
+        new AdHocSubProcessActivityActivationRecord()
+            .setAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey));
+    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("A");
+
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .adHocSubProcessActivityActivation(adHocSubProcessActivityActivationRecord)
+            .key(adHocSubProcessInstanceKey));
+
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .adHocSubProcessActivityActivation(adHocSubProcessActivityActivationRecord)
+            .key(adHocSubProcessInstanceKey));
+
+    assertThat(
+            RecordingExporter.adHocSubProcessActivityActivationRecords()
+                .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
+                .onlyCommandRejections()
+                .limit(1))
+        .describedAs(
+            "Expected activation to be rejected because the adhoc subprocess has completed.")
+        .isNotEmpty();
+  }
+
+  @Test
+  public void
+      givenRunningAdhocSubProcessWhenAttemptingToActivateDuplicateFlowNodesThenTheActivationIsRejected() {
+    final var adHocSubProcessActivityActivationRecord =
+        new AdHocSubProcessActivityActivationRecord()
+            .setAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey));
+    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("A");
+    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("A");
+
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .adHocSubProcessActivityActivation(adHocSubProcessActivityActivationRecord)
+            .key(adHocSubProcessInstanceKey));
+
+    assertThat(
+            RecordingExporter.adHocSubProcessActivityActivationRecords()
+                .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
+                .onlyCommandRejections()
+                .limit(1))
+        .describedAs(
+            "Expected activation to be rejected because duplicate flow nodes are provided.")
+        .isNotEmpty();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/adhocsubprocess/ActivateAdHocSubProcessActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/adhocsubprocess/ActivateAdHocSubProcessActivityTest.java
@@ -72,11 +72,11 @@ public class ActivateAdHocSubProcessActivityTest {
 
   @Test
   public void
-      givenRunningAdhocSubProcessInstanceWhenActivatingExistingFlowNodeThenTheFlowNodeIsActivated() {
+      givenRunningAdhocSubProcessInstanceWhenActivatingExistingElementThenTheElementIsActivated() {
     final var adHocSubProcessActivityActivationRecord =
         new AdHocSubProcessActivityActivationRecord()
             .setAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey));
-    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("A");
+    adHocSubProcessActivityActivationRecord.elements().add().setElementId("A");
 
     ENGINE.writeRecords(
         RecordToWrite.command()
@@ -98,11 +98,11 @@ public class ActivateAdHocSubProcessActivityTest {
 
   @Test
   public void
-      givenRunningAdhocSubProcessInstanceWhenSuccessfullyActivatingAFlowNodeThenSubsequentActivatedEventIsSent() {
+      givenRunningAdhocSubProcessInstanceWhenSuccessfullyActivatingAElementThenSubsequentActivatedEventIsSent() {
     final var adHocSubProcessActivityActivationRecord =
         new AdHocSubProcessActivityActivationRecord()
             .setAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey));
-    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("A");
+    adHocSubProcessActivityActivationRecord.elements().add().setElementId("A");
 
     ENGINE.writeRecords(
         RecordToWrite.command()
@@ -112,19 +112,18 @@ public class ActivateAdHocSubProcessActivityTest {
     assertThat(
             RecordingExporter.adHocSubProcessActivityActivationRecords()
                 .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey)))
-        // todo add short-circuit `limit` call?
-        .extracting(r -> r.getValue().getFlowNodes().getFirst().getFlowNodeId(), Record::getIntent)
+        .extracting(r -> r.getValue().getElements().getFirst().getElementId(), Record::getIntent)
         .contains(tuple("A", AdHocSubProcessActivityActivationIntent.ACTIVATED));
   }
 
   @Test
   public void
-      givenRunningAdhocSubProcessInstanceWhenActivatingMoreThanOneFlowNodeThenAllGivenFlowNodesAreActivated() {
+      givenRunningAdhocSubProcessInstanceWhenActivatingMoreThanOneElementThenAllGivenElementsAreActivated() {
     final var adHocSubProcessActivityActivationRecord =
         new AdHocSubProcessActivityActivationRecord()
             .setAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey));
-    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("A");
-    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("B");
+    adHocSubProcessActivityActivationRecord.elements().add().setElementId("A");
+    adHocSubProcessActivityActivationRecord.elements().add().setElementId("B");
 
     ENGINE.writeRecords(
         RecordToWrite.command()
@@ -133,7 +132,6 @@ public class ActivateAdHocSubProcessActivityTest {
 
     assertThat(
             RecordingExporter.processInstanceRecords().withProcessInstanceKey(processInstanceKey))
-        // todo add short-circuit `limit` call?
         .extracting(r -> r.getValue().getElementId(), Record::getIntent)
         .contains(
             tuple("A", ProcessInstanceIntent.ACTIVATE_ELEMENT),
@@ -145,11 +143,11 @@ public class ActivateAdHocSubProcessActivityTest {
 
   @Test
   public void
-      givenRunningAdhocSubProcessInstanceWhenActivatingFlowNodeThatDoesNotExistThenTheActivationIsRejected() {
+      givenRunningAdhocSubProcessInstanceWhenActivatingElementThatDoesNotExistThenTheActivationIsRejected() {
     final var adHocSubProcessActivityActivationRecord =
         new AdHocSubProcessActivityActivationRecord()
             .setAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey));
-    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("does-not-exist");
+    adHocSubProcessActivityActivationRecord.elements().add().setElementId("does-not-exist");
 
     ENGINE.writeRecords(
         RecordToWrite.command()
@@ -161,18 +159,18 @@ public class ActivateAdHocSubProcessActivityTest {
                 .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
                 .onlyCommandRejections()
                 .limit(1))
-        .extracting(r -> r.getValue().getFlowNodes().getFirst().getFlowNodeId(), Record::getIntent)
+        .extracting(r -> r.getValue().getElements().getFirst().getElementId(), Record::getIntent)
         .describedAs("Expected flow node that doesn't exist to be rejected.")
         .contains(tuple("does-not-exist", AdHocSubProcessActivityActivationIntent.ACTIVATE));
   }
 
   @Test
   public void
-      givenAdhocSubProcessInATerminalStateWhenActivatingFlowNodesThenTheActivationIsRejected() {
+      givenAdhocSubProcessInATerminalStateWhenActivatingElementsThenTheActivationIsRejected() {
     final var adHocSubProcessActivityActivationRecord =
         new AdHocSubProcessActivityActivationRecord()
             .setAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey));
-    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("A");
+    adHocSubProcessActivityActivationRecord.elements().add().setElementId("A");
 
     ENGINE.writeRecords(
         RecordToWrite.command()
@@ -196,12 +194,12 @@ public class ActivateAdHocSubProcessActivityTest {
 
   @Test
   public void
-      givenRunningAdhocSubProcessWhenAttemptingToActivateDuplicateFlowNodesThenTheActivationIsRejected() {
+      givenRunningAdhocSubProcessWhenAttemptingToActivateDuplicateElementsThenTheActivationIsRejected() {
     final var adHocSubProcessActivityActivationRecord =
         new AdHocSubProcessActivityActivationRecord()
             .setAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey));
-    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("A");
-    adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("A");
+    adHocSubProcessActivityActivationRecord.elements().add().setElementId("A");
+    adHocSubProcessActivityActivationRecord.elements().add().setElementId("A");
 
     ENGINE.writeRecords(
         RecordToWrite.command()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/adhocsubprocess/ActivateAdHocSubProcessActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/adhocsubprocess/ActivateAdHocSubProcessActivityTest.java
@@ -89,7 +89,7 @@ public class ActivateAdHocSubProcessActivityTest {
 
   @Test
   public void
-      givenRunningAdhocSubProcessInstanceWhenSuccessfullyActivatingAElementThenSubsequentActivatedEventIsSent() {
+      givenRunningAdhocSubProcessInstanceWhenElementIsSuccessfullyActivatedThenActivatedEventIsWrittenToLog() {
     ENGINE
         .adHocSubProcessActivity()
         .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/adhocsubprocess/ActivateAdHocSubProcessActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/adhocsubprocess/ActivateAdHocSubProcessActivityTest.java
@@ -91,6 +91,36 @@ public class ActivateAdHocSubProcessActivityTest {
 
   @Test
   public void
+      givenRunningAdhocSubProcessInstanceWhenActivatingExistingElementThenTheElementHasCorrectTreePath() {
+    ENGINE
+        .adHocSubProcessActivity()
+        .withAdHocSubProcessInstanceKey(String.valueOf(adHocSubProcessInstanceKey))
+        .withElementIds("A")
+        .activate();
+
+    final var generatedActivityInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.TASK)
+            .withElementId("A")
+            .map(Record::getKey)
+            .limit(1)
+            .toList()
+            .getFirst();
+
+    final var expectedElementPath =
+        List.of(
+            List.of(processInstanceKey, adHocSubProcessInstanceKey, generatedActivityInstanceKey));
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), r -> r.getValue().getElementInstancePath())
+        .contains(tuple("A", expectedElementPath));
+  }
+
+  @Test
+  public void
       givenRunningAdhocSubProcessInstanceWhenElementIsSuccessfullyActivatedThenActivatedEventIsWrittenToLog() {
     ENGINE
         .adHocSubProcessActivity()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.util.TestInterPartitionCommandSender.CommandInterceptor;
+import io.camunda.zeebe.engine.util.client.AdHocSubProcessActivityClient;
 import io.camunda.zeebe.engine.util.client.AuthorizationClient;
 import io.camunda.zeebe.engine.util.client.BatchOperationClient;
 import io.camunda.zeebe.engine.util.client.ClockClient;
@@ -380,6 +381,10 @@ public final class EngineRule extends ExternalResource {
 
   public ResourceFetchClient resourceFetch() {
     return new ResourceFetchClient(environmentRule);
+  }
+
+  public AdHocSubProcessActivityClient adHocSubProcessActivity() {
+    return new AdHocSubProcessActivityClient(environmentRule);
   }
 
   public SignalClient signal() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordToWrite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordToWrite.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.util;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
@@ -23,6 +24,7 @@ import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
@@ -34,6 +36,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
@@ -161,6 +164,15 @@ public final class RecordToWrite implements LogAppendEntry {
   public RecordToWrite scale(final ScaleIntent intent, final ScaleRecord value) {
     recordMetadata.valueType(ValueType.SCALE).intent(intent);
     unifiedRecordValue = value;
+    return this;
+  }
+
+  public RecordToWrite adHocSubProcessActivityActivation(
+      final AdHocSubProcessActivityActivationRecordValue value) {
+    recordMetadata
+        .valueType(ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION)
+        .intent(AdHocSubProcessActivityActivationIntent.ACTIVATE);
+    unifiedRecordValue = (AdHocSubProcessActivityActivationRecord) value;
     return this;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AdHocSubProcessActivityClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AdHocSubProcessActivityClient.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.util.client;
+
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.List;
+import java.util.function.Function;
+
+public class AdHocSubProcessActivityClient {
+  private static final Function<Long, Record<AdHocSubProcessActivityActivationRecordValue>>
+      SUCCESS_EXPECTATION =
+          (position) ->
+              RecordingExporter.adHocSubProcessActivityActivationRecords()
+                  .withIntent(AdHocSubProcessActivityActivationIntent.ACTIVATED)
+                  .withSourceRecordPosition(position)
+                  .getFirst();
+  private static final Function<Long, Record<AdHocSubProcessActivityActivationRecordValue>>
+      REJECTION_EXPECTATION =
+          (position) ->
+              RecordingExporter.adHocSubProcessActivityActivationRecords()
+                  .onlyCommandRejections()
+                  .withIntent(AdHocSubProcessActivityActivationIntent.ACTIVATE)
+                  .withSourceRecordPosition(position)
+                  .getFirst();
+
+  private final CommandWriter writer;
+  private final AdHocSubProcessActivityActivationRecord adHocSubProcessActivityActivationRecord =
+      new AdHocSubProcessActivityActivationRecord();
+  private Function<Long, Record<AdHocSubProcessActivityActivationRecordValue>> expectation =
+      SUCCESS_EXPECTATION;
+  private List<String> authorizedTenantIds = List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+  public AdHocSubProcessActivityClient(final CommandWriter writer) {
+    this.writer = writer;
+  }
+
+  public Record<AdHocSubProcessActivityActivationRecordValue> activate() {
+    final var position =
+        writer.writeCommand(
+            AdHocSubProcessActivityActivationIntent.ACTIVATE,
+            adHocSubProcessActivityActivationRecord,
+            authorizedTenantIds.toArray(new String[0]));
+
+    return expectation.apply(position);
+  }
+
+  public AdHocSubProcessActivityClient expectRejection() {
+    expectation = REJECTION_EXPECTATION;
+    return this;
+  }
+
+  public AdHocSubProcessActivityClient withAdHocSubProcessInstanceKey(
+      final String adHocSubProcessInstanceKey) {
+    adHocSubProcessActivityActivationRecord.setAdHocSubProcessInstanceKey(
+        adHocSubProcessInstanceKey);
+    return this;
+  }
+
+  public AdHocSubProcessActivityClient withElementIds(final String... elementIds) {
+    for (final String elementId : elementIds) {
+      adHocSubProcessActivityActivationRecord.elements().add().setElementId(elementId);
+    }
+    return this;
+  }
+
+  public AdHocSubProcessActivityClient withAuthorizedTenantIds(final String... tenantIds) {
+    authorizedTenantIds = List.of(tenantIds);
+    return this;
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -297,6 +297,9 @@ public class ElasticsearchExporter implements Exporter {
       if (index.processMessageSubscription) {
         createValueIndexTemplate(ValueType.PROCESS_MESSAGE_SUBSCRIPTION, version);
       }
+      if (index.adHocSubProcessActivityActivation) {
+        createValueIndexTemplate(ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION, version);
+      }
       if (index.decisionRequirements) {
         createValueIndexTemplate(ValueType.DECISION_REQUIREMENTS, version);
       }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -138,6 +138,8 @@ public class ElasticsearchExporterConfiguration {
         return index.compensationSubscription;
       case MESSAGE_CORRELATION:
         return index.messageCorrelation;
+      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION:
+        return index.adHocSubProcessActivityActivation;
       default:
         return false;
     }
@@ -199,6 +201,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean processMessageSubscription = true;
     public boolean variable = true;
     public boolean variableDocument = true;
+    public boolean adHocSubProcessActivityActivation = true;
 
     public boolean checkpoint = false;
     public boolean timer = true;
@@ -313,6 +316,8 @@ public class ElasticsearchExporterConfiguration {
           + signalSubscription
           + ", resourceDeletion="
           + resourceDeletion
+          + ", adHocSubProcessActivityActivation="
+          + adHocSubProcessActivityActivation
           + ", commandDistribution="
           + commandDistribution
           + ", form="

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-activity-activation-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-activity-activation-template.json
@@ -14,7 +14,7 @@
       "index.queries.cache.enabled": false
     },
     "aliases": {
-      "zeebe-record-process-instance-modification": {}
+      "zeebe-record-ad-hoc-subprocess-activity-activation": {}
     },
     "mappings": {
       "properties": {
@@ -24,9 +24,9 @@
             "adHocSubProcessInstanceKey": {
               "type": "keyword"
             },
-            "flowNodes": {
+            "elements": {
               "properties": {
-                "flowNodeId": {
+                "elementId": {
                   "type": "keyword"
                 }
               }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-activity-activation-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-activity-activation-template.json
@@ -1,0 +1,42 @@
+{
+  "index_patterns": [
+    "zeebe-record_ad-hoc-subprocess-activity-activation_*"
+  ],
+  "composed_of": [
+    "zeebe-record"
+  ],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-process-instance-modification": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "adHocSubProcessInstanceKey": {
+              "type": "keyword"
+            },
+            "flowNodes": {
+              "properties": {
+                "flowNodeId": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "tenantId": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -66,6 +66,8 @@ final class TestSupport {
       case BATCH_OPERATION_CREATION -> config.batchOperationCreation = value;
       case BATCH_OPERATION_CHUNK -> config.batchOperationChunk = value;
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
+      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
+          config.adHocSubProcessActivityActivation = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -267,6 +267,9 @@ public class OpensearchExporter implements Exporter {
       if (index.processMessageSubscription) {
         createValueIndexTemplate(ValueType.PROCESS_MESSAGE_SUBSCRIPTION, version);
       }
+      if (index.adHocSubProcessActivityActivation) {
+        createValueIndexTemplate(ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION, version);
+      }
       if (index.decisionRequirements) {
         createValueIndexTemplate(ValueType.DECISION_REQUIREMENTS, version);
       }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -137,6 +137,8 @@ public class OpensearchExporterConfiguration {
         return index.compensationSubscription;
       case MESSAGE_CORRELATION:
         return index.messageCorrelation;
+      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION:
+        return index.adHocSubProcessActivityActivation;
       default:
         return false;
     }
@@ -188,6 +190,7 @@ public class OpensearchExporterConfiguration {
     public boolean processMessageSubscription = true;
     public boolean variable = true;
     public boolean variableDocument = true;
+    public boolean adHocSubProcessActivityActivation = true;
 
     public boolean checkpoint = false;
     public boolean timer = true;
@@ -301,6 +304,8 @@ public class OpensearchExporterConfiguration {
           + signalSubscription
           + ", resourceDeletion="
           + resourceDeletion
+          + ", adHocSubProcessActivityActivation="
+          + adHocSubProcessActivityActivation
           + ", recordDistribution="
           + commandDistribution
           + ", form="

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-activity-activation-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-activity-activation-template.json
@@ -14,7 +14,7 @@
       "index.queries.cache.enabled": false
     },
     "aliases": {
-      "zeebe-record-process-instance-modification": {}
+      "zeebe-record-ad-hoc-subprocess-activity-activation": {}
     },
     "mappings": {
       "properties": {
@@ -24,9 +24,9 @@
             "adHocSubProcessInstanceKey": {
               "type": "keyword"
             },
-            "flowNodes": {
+            "elements": {
               "properties": {
-                "flowNodeId": {
+                "elementId": {
                   "type": "keyword"
                 }
               }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-activity-activation-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-ad-hoc-sub-process-activity-activation-template.json
@@ -1,0 +1,42 @@
+{
+  "index_patterns": [
+    "zeebe-record_ad-hoc-subprocess-activity-activation_*"
+  ],
+  "composed_of": [
+    "zeebe-record"
+  ],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-process-instance-modification": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "adHocSubProcessInstanceKey": {
+              "type": "keyword"
+            },
+            "flowNodes": {
+              "properties": {
+                "flowNodeId": {
+                  "type": "keyword"
+                }
+              }
+            },
+            "tenantId": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -67,6 +67,8 @@ final class TestSupport {
       case BATCH_OPERATION_CREATION -> config.batchOperationCreation = value;
       case BATCH_OPERATION_CHUNK -> config.batchOperationChunk = value;
       case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
+      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION ->
+          config.adHocSubProcessActivityActivation = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivityActivationElement.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivityActivationElement.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ObjectValue;
-import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue.AdHocSubProcessActivityActivationFlowNodeValue;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue.AdHocSubProcessActivityActivationElementValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 
 @JsonIgnoreProperties({
@@ -18,23 +18,23 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
   "encodedLength",
   "empty"
 })
-public final class AdHocSubProcessActivityActivationFlowNode extends ObjectValue
-    implements AdHocSubProcessActivityActivationFlowNodeValue {
+public final class AdHocSubProcessActivityActivationElement extends ObjectValue
+    implements AdHocSubProcessActivityActivationElementValue {
 
-  private final StringProperty flowNodeId = new StringProperty("flowNodeId");
+  private final StringProperty elementId = new StringProperty("elementId");
 
-  public AdHocSubProcessActivityActivationFlowNode() {
+  public AdHocSubProcessActivityActivationElement() {
     super(1);
-    declareProperty(flowNodeId);
+    declareProperty(elementId);
   }
 
   @Override
-  public String getFlowNodeId() {
-    return BufferUtil.bufferAsString(flowNodeId.getValue());
+  public String getElementId() {
+    return BufferUtil.bufferAsString(elementId.getValue());
   }
 
-  public AdHocSubProcessActivityActivationFlowNode setFlowNodeId(final String flowNodeId) {
-    this.flowNodeId.setValue(flowNodeId);
+  public AdHocSubProcessActivityActivationElement setElementId(final String elementId) {
+    this.elementId.setValue(elementId);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivityActivationFlowNode.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivityActivationFlowNode.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.ObjectValue;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue.AdHocSubProcessActivityActivationFlowNodeValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+
+@JsonIgnoreProperties({
+  /* These fields are inherited from ObjectValue; there have no purpose in exported JSON records*/
+  "encodedLength",
+  "empty"
+})
+public final class AdHocSubProcessActivityActivationFlowNode extends ObjectValue
+    implements AdHocSubProcessActivityActivationFlowNodeValue {
+
+  private final StringProperty flowNodeId = new StringProperty("flowNodeId");
+
+  public AdHocSubProcessActivityActivationFlowNode() {
+    super(1);
+    declareProperty(flowNodeId);
+  }
+
+  @Override
+  public String getFlowNodeId() {
+    return BufferUtil.bufferAsString(flowNodeId.getValue());
+  }
+
+  public AdHocSubProcessActivityActivationFlowNode setFlowNodeId(final String flowNodeId) {
+    this.flowNodeId.setValue(flowNodeId);
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivityActivationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivityActivationRecord.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ValueArray;
@@ -52,10 +53,12 @@ public final class AdHocSubProcessActivityActivationRecord extends UnifiedRecord
   }
 
   /**
-   * This function exists only to make setting up the test for the `JsonSerializableToJsonTest`.
+   * Returns the {@link ValueArray} of `elements` which then can have more elements added/removed.
+   * This is used in setting up test scenarios.
    *
    * @return a {@link ValueArray} of flow nodes that can easily be added to.
    */
+  @JsonIgnore
   public ValueArray<AdHocSubProcessActivityActivationElement> elements() {
     return elements;
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivityActivationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivityActivationRecord.java
@@ -23,15 +23,15 @@ public final class AdHocSubProcessActivityActivationRecord extends UnifiedRecord
 
   private final StringProperty adHocSubProcessInstanceKey =
       new StringProperty("adHocSubProcessInstanceKey", DEFAULT_STRING);
-  private final ArrayProperty<AdHocSubProcessActivityActivationFlowNode> flowNodes =
-      new ArrayProperty<>("flowNodes", AdHocSubProcessActivityActivationFlowNode::new);
+  private final ArrayProperty<AdHocSubProcessActivityActivationElement> elements =
+      new ArrayProperty<>("elements", AdHocSubProcessActivityActivationElement::new);
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public AdHocSubProcessActivityActivationRecord() {
     super(3);
     declareProperty(adHocSubProcessInstanceKey)
-        .declareProperty(flowNodes)
+        .declareProperty(elements)
         .declareProperty(tenantIdProp);
   }
 
@@ -47,9 +47,9 @@ public final class AdHocSubProcessActivityActivationRecord extends UnifiedRecord
   }
 
   @Override
-  public List<AdHocSubProcessActivityActivationFlowNodeValue> getFlowNodes() {
-    return flowNodes.stream()
-        .map(AdHocSubProcessActivityActivationFlowNodeValue.class::cast)
+  public List<AdHocSubProcessActivityActivationElementValue> getElements() {
+    return elements.stream()
+        .map(AdHocSubProcessActivityActivationElementValue.class::cast)
         .toList();
   }
 
@@ -58,8 +58,8 @@ public final class AdHocSubProcessActivityActivationRecord extends UnifiedRecord
    *
    * @return a {@link ValueArray} of flow nodes that can easily be added to.
    */
-  public ValueArray<AdHocSubProcessActivityActivationFlowNode> flowNodes() {
-    return flowNodes;
+  public ValueArray<AdHocSubProcessActivityActivationElement> elements() {
+    return elements;
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivityActivationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivityActivationRecord.java
@@ -25,14 +25,12 @@ public final class AdHocSubProcessActivityActivationRecord extends UnifiedRecord
       new StringProperty("adHocSubProcessInstanceKey", DEFAULT_STRING);
   private final ArrayProperty<AdHocSubProcessActivityActivationElement> elements =
       new ArrayProperty<>("elements", AdHocSubProcessActivityActivationElement::new);
-  private final StringProperty tenantIdProp =
+  private final StringProperty tenantId =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public AdHocSubProcessActivityActivationRecord() {
     super(3);
-    declareProperty(adHocSubProcessInstanceKey)
-        .declareProperty(elements)
-        .declareProperty(tenantIdProp);
+    declareProperty(adHocSubProcessInstanceKey).declareProperty(elements).declareProperty(tenantId);
   }
 
   @Override
@@ -64,11 +62,11 @@ public final class AdHocSubProcessActivityActivationRecord extends UnifiedRecord
 
   @Override
   public String getTenantId() {
-    return BufferUtil.bufferAsString(tenantIdProp.getValue());
+    return BufferUtil.bufferAsString(tenantId.getValue());
   }
 
   public AdHocSubProcessActivityActivationRecord setTenantId(final String tenantId) {
-    tenantIdProp.setValue(tenantId);
+    this.tenantId.setValue(tenantId);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivityActivationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/adhocsubprocess/AdHocSubProcessActivityActivationRecord.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess;
+
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.ValueArray;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
+
+public final class AdHocSubProcessActivityActivationRecord extends UnifiedRecordValue
+    implements AdHocSubProcessActivityActivationRecordValue {
+
+  private static final String DEFAULT_STRING = "";
+
+  private final StringProperty adHocSubProcessInstanceKey =
+      new StringProperty("adHocSubProcessInstanceKey", DEFAULT_STRING);
+  private final ArrayProperty<AdHocSubProcessActivityActivationFlowNode> flowNodes =
+      new ArrayProperty<>("flowNodes", AdHocSubProcessActivityActivationFlowNode::new);
+  private final StringProperty tenantIdProp =
+      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+  public AdHocSubProcessActivityActivationRecord() {
+    super(3);
+    declareProperty(adHocSubProcessInstanceKey)
+        .declareProperty(flowNodes)
+        .declareProperty(tenantIdProp);
+  }
+
+  @Override
+  public String getAdHocSubProcessInstanceKey() {
+    return BufferUtil.bufferAsString(adHocSubProcessInstanceKey.getValue());
+  }
+
+  public AdHocSubProcessActivityActivationRecord setAdHocSubProcessInstanceKey(
+      final String adHocSubProcessInstanceKey) {
+    this.adHocSubProcessInstanceKey.setValue(adHocSubProcessInstanceKey);
+    return this;
+  }
+
+  @Override
+  public List<AdHocSubProcessActivityActivationFlowNodeValue> getFlowNodes() {
+    return flowNodes.stream()
+        .map(AdHocSubProcessActivityActivationFlowNodeValue.class::cast)
+        .toList();
+  }
+
+  /**
+   * This function exists only to make setting up the test for the `JsonSerializableToJsonTest`.
+   *
+   * @return a {@link ValueArray} of flow nodes that can easily be added to.
+   */
+  public ValueArray<AdHocSubProcessActivityActivationFlowNode> flowNodes() {
+    return flowNodes;
+  }
+
+  @Override
+  public String getTenantId() {
+    return BufferUtil.bufferAsString(tenantIdProp.getValue());
+  }
+
+  public AdHocSubProcessActivityActivationRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.impl.record.CopiedRecord;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.VersionInfo;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
@@ -2205,6 +2206,50 @@ final class JsonSerializableToJsonTest {
         {
           "resourceKey":1,
           "tenantId": "<default>"
+        }
+        """
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ////////////////////////// AdHocSubProcessActivityActivationRecord //////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "AdHocSubProcessActivityActivationRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final var adHocSubProcessActivityActivationRecord =
+                  new AdHocSubProcessActivityActivationRecord()
+                      .setAdHocSubProcessInstanceKey("1234")
+                      .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+              adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("123");
+
+              return adHocSubProcessActivityActivationRecord;
+            },
+        """
+        {
+          "adHocSubProcessInstanceKey": "1234",
+          "tenantId": "<default>",
+          "flowNodes": [
+            {
+              "flowNodeId": "123"
+            }
+          ]
+        }
+        """
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      /////////////////////// Empty AdHocSubProcessActivityActivationRecord ///////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty AdHocSubProcessActivityActivationRecord",
+        (Supplier<UnifiedRecordValue>) AdHocSubProcessActivityActivationRecord::new,
+        """
+        {
+          "adHocSubProcessInstanceKey": "",
+          "tenantId": "<default>",
+          "flowNodes": []
         }
         """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2222,7 +2222,7 @@ final class JsonSerializableToJsonTest {
                       .setAdHocSubProcessInstanceKey("1234")
                       .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
-              adHocSubProcessActivityActivationRecord.flowNodes().add().setFlowNodeId("123");
+              adHocSubProcessActivityActivationRecord.elements().add().setElementId("123");
 
               return adHocSubProcessActivityActivationRecord;
             },
@@ -2230,9 +2230,9 @@ final class JsonSerializableToJsonTest {
         {
           "adHocSubProcessInstanceKey": "1234",
           "tenantId": "<default>",
-          "flowNodes": [
+          "elements": [
             {
-              "flowNodeId": "123"
+              "elementId": "123"
             }
           ]
         }
@@ -2249,7 +2249,7 @@ final class JsonSerializableToJsonTest {
         {
           "adHocSubProcessInstanceKey": "",
           "tenantId": "<default>",
-          "flowNodes": []
+          "elements": []
         }
         """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.protocol.record;
 
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
@@ -65,6 +66,7 @@ import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.RedistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
@@ -242,6 +244,11 @@ public final class ValueTypeMapping {
     mapping.put(
         ValueType.PROCESS_INSTANCE_BATCH,
         new Mapping<>(ProcessInstanceBatchRecordValue.class, ProcessInstanceBatchIntent.class));
+    mapping.put(
+        ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
+        new Mapping<>(
+            AdHocSubProcessActivityActivationRecordValue.class,
+            AdHocSubProcessActivityActivationIntent.class));
     mapping.put(ValueType.FORM, new Mapping<>(Form.class, FormIntent.class));
     mapping.put(ValueType.RESOURCE, new Mapping<>(Resource.class, ResourceIntent.class));
     mapping.put(

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AdHocSubProcessActivityActivationIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AdHocSubProcessActivityActivationIntent.java
@@ -15,20 +15,9 @@
  */
 package io.camunda.zeebe.protocol.record.intent;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public enum AdHocSubProcessActivityActivationIntent implements Intent {
   ACTIVATE(0),
   ACTIVATED(1);
-
-  private static final Map<Short, Intent> LOOKUP = new HashMap<>();
-
-  static {
-    for (final AdHocSubProcessActivityActivationIntent value : values()) {
-      LOOKUP.put(value.getIntent(), value);
-    }
-  }
 
   private final short value;
 
@@ -56,6 +45,13 @@ public enum AdHocSubProcessActivityActivationIntent implements Intent {
   }
 
   public static Intent from(final short value) {
-    return LOOKUP.getOrDefault(value, Intent.UNKNOWN);
+    switch (value) {
+      case 0:
+        return ACTIVATE;
+      case 1:
+        return ACTIVATED;
+      default:
+        return Intent.UNKNOWN;
+    }
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AdHocSubProcessActivityActivationIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/AdHocSubProcessActivityActivationIntent.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum AdHocSubProcessActivityActivationIntent implements Intent {
+  ACTIVATE(0),
+  ACTIVATED(1);
+
+  private static final Map<Short, Intent> LOOKUP = new HashMap<>();
+
+  static {
+    for (final AdHocSubProcessActivityActivationIntent value : values()) {
+      LOOKUP.put(value.getIntent(), value);
+    }
+  }
+
+  private final short value;
+
+  AdHocSubProcessActivityActivationIntent(final int value) {
+    this.value = (short) value;
+  }
+
+  public short getIntent() {
+    return value;
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case ACTIVATED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  public static Intent from(final short value) {
+    return LOOKUP.getOrDefault(value, Intent.UNKNOWN);
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -73,7 +73,8 @@ public interface Intent {
           IdentitySetupIntent.class,
           BatchOperationIntent.class,
           BatchOperationChunkIntent.class,
-          BatchOperationExecutionIntent.class);
+          BatchOperationExecutionIntent.class,
+          AdHocSubProcessActivityActivationIntent.class);
   short NULL_VAL = 255;
   Intent UNKNOWN = UnknownIntent.UNKNOWN;
 
@@ -149,6 +150,8 @@ public interface Intent {
         return CommandDistributionIntent.from(intent);
       case PROCESS_INSTANCE_BATCH:
         return ProcessInstanceBatchIntent.from(intent);
+      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION:
+        return AdHocSubProcessActivityActivationIntent.from(intent);
       case FORM:
         return FormIntent.from(intent);
       case RESOURCE:
@@ -238,6 +241,8 @@ public interface Intent {
         return DeploymentDistributionIntent.valueOf(intent);
       case PROCESS_EVENT:
         return ProcessEventIntent.valueOf(intent);
+      case AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION:
+        return AdHocSubProcessActivityActivationIntent.valueOf(intent);
       case DECISION:
         return DecisionIntent.valueOf(intent);
       case DECISION_REQUIREMENTS:

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AdHocSubProcessActivityActivationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AdHocSubProcessActivityActivationRecordValue.java
@@ -38,12 +38,11 @@ public interface AdHocSubProcessActivityActivationRecordValue extends RecordValu
   /**
    * @return the list of flow node ids of the activities that need to be activated.
    */
-  List<AdHocSubProcessActivityActivationFlowNodeValue> getFlowNodes();
+  List<AdHocSubProcessActivityActivationElementValue> getElements();
 
   @Value.Immutable
-  @ImmutableProtocol(
-      builder = ImmutableAdHocSubProcessActivityActivationFlowNodeValue.Builder.class)
-  interface AdHocSubProcessActivityActivationFlowNodeValue {
-    String getFlowNodeId();
+  @ImmutableProtocol(builder = ImmutableAdHocSubProcessActivityActivationElementValue.Builder.class)
+  interface AdHocSubProcessActivityActivationElementValue {
+    String getElementId();
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AdHocSubProcessActivityActivationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AdHocSubProcessActivityActivationRecordValue.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import java.util.List;
+import org.immutables.value.Value;
+
+/**
+ * Represents a command to activate activities in a given ad-hoc subprocess.
+ *
+ * <p>See {@link io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent}
+ * for intents.
+ */
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableAdHocSubProcessActivityActivationRecordValue.Builder.class)
+public interface AdHocSubProcessActivityActivationRecordValue extends RecordValue, TenantOwned {
+
+  /**
+   * @return the instance key of the ad-hoc subprocess that will have its activities activated.
+   */
+  String getAdHocSubProcessInstanceKey();
+
+  /**
+   * @return the list of flow node ids of the activities that need to be activated.
+   */
+  List<AdHocSubProcessActivityActivationFlowNodeValue> getFlowNodes();
+
+  @Value.Immutable
+  @ImmutableProtocol(
+      builder = ImmutableAdHocSubProcessActivityActivationFlowNodeValue.Builder.class)
+  interface AdHocSubProcessActivityActivationFlowNodeValue {
+    String getFlowNodeId();
+  }
+}

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -68,6 +68,7 @@
       <validValue name="BATCH_OPERATION_CREATION">50</validValue>
       <validValue name="BATCH_OPERATION_EXECUTION">51</validValue>
       <validValue name="BATCH_OPERATION_CHUNK">52</validValue>
+      <validValue name="AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION">53</validValue>
 
       <!-- Management records / record not related to process automation -->
       <validValue name="REDISTRIBUTION">252</validValue>

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.stream.impl;
 
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
@@ -97,6 +98,9 @@ public final class TypedEventRegistry {
     registry.put(ValueType.DECISION_REQUIREMENTS, DecisionRequirementsRecord.class);
     registry.put(ValueType.DECISION_EVALUATION, DecisionEvaluationRecord.class);
     registry.put(ValueType.RESOURCE_DELETION, ResourceDeletionRecord.class);
+    registry.put(
+        ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
+        AdHocSubProcessActivityActivationRecord.class);
     registry.put(ValueType.COMMAND_DISTRIBUTION, CommandDistributionRecord.class);
 
     registry.put(ValueType.CHECKPOINT, CheckpointRecord.class);

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AdHocSubProcessActivityActivationRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AdHocSubProcessActivityActivationRecordStream.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue;
+import java.util.stream.Stream;
+
+public class AdHocSubProcessActivityActivationRecordStream
+    extends ExporterRecordStream<
+        AdHocSubProcessActivityActivationRecordValue,
+        AdHocSubProcessActivityActivationRecordStream> {
+
+  public AdHocSubProcessActivityActivationRecordStream(
+      final Stream<Record<AdHocSubProcessActivityActivationRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected AdHocSubProcessActivityActivationRecordStream supply(
+      final Stream<Record<AdHocSubProcessActivityActivationRecordValue>> wrappedStream) {
+    return new AdHocSubProcessActivityActivationRecordStream(wrappedStream);
+  }
+
+  public AdHocSubProcessActivityActivationRecordStream withAdHocSubProcessInstanceKey(
+      final String adHocSubProcessInstanceKey) {
+    return valueFilter(
+        record -> record.getAdHocSubProcessInstanceKey().equals(adHocSubProcessInstanceKey));
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AdHocSubProcessActivityActivationRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AdHocSubProcessActivityActivationRecordStream.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.test.util.record;
 
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue;
 import java.util.stream.Stream;
 
@@ -31,5 +32,12 @@ public class AdHocSubProcessActivityActivationRecordStream
       final String adHocSubProcessInstanceKey) {
     return valueFilter(
         record -> record.getAdHocSubProcessInstanceKey().equals(adHocSubProcessInstanceKey));
+  }
+
+  public AdHocSubProcessActivityActivationRecordStream limitToAdHocSubProcessInstanceCompleted() {
+    return limit(
+        r ->
+            r.getIntent() == ProcessInstanceIntent.ELEMENT_COMPLETED
+                && r.getKey() == Long.parseLong(r.getValue().getAdHocSubProcessInstanceKey()));
   }
 }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -99,7 +99,7 @@ public class CompactRecordLogger {
           entry("PROCESS_INSTANCE_MODIFICATION", "MOD"),
           entry("PROCESS_INSTANCE", "PI"),
           entry("PROCESS", "PROC"),
-          entry("AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION", "ADHOC_ACT"),
+          entry("AD_HOC_SUB_PROC_ACTIVITY_ACTIVATION", "AH_ACT"),
           entry("TIMER", "TIME"),
           entry("MESSAGE", "MSG"),
           entry("SUBSCRIPTION", "SUB"),

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
@@ -98,6 +99,7 @@ public class CompactRecordLogger {
           entry("PROCESS_INSTANCE_MODIFICATION", "MOD"),
           entry("PROCESS_INSTANCE", "PI"),
           entry("PROCESS", "PROC"),
+          entry("AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION", "ADHOC_ACT"),
           entry("TIMER", "TIME"),
           entry("MESSAGE", "MSG"),
           entry("SUBSCRIPTION", "SUB"),
@@ -154,6 +156,9 @@ public class CompactRecordLogger {
         ValueType.PROCESS_INSTANCE_MODIFICATION, this::summarizeProcessInstanceModification);
     valueLoggers.put(
         ValueType.PROCESS_MESSAGE_SUBSCRIPTION, this::summarizeProcessInstanceSubscription);
+    valueLoggers.put(
+        ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
+        this::summarizeAdHocSubProcessActivityActivation);
     valueLoggers.put(ValueType.VARIABLE, this::summarizeVariable);
     valueLoggers.put(ValueType.TIMER, this::summarizeTimer);
     valueLoggers.put(ValueType.ERROR, this::summarizeError);
@@ -763,6 +768,19 @@ public class CompactRecordLogger {
         .append(" (tenant: %s)".formatted(value.getTenantId()));
 
     return result.toString();
+  }
+
+  private String summarizeAdHocSubProcessActivityActivation(final Record<?> record) {
+    final var value = (AdHocSubProcessActivityActivationRecordValue) record.getValue();
+
+    final var builder = new StringBuilder();
+    builder
+        .append(String.format("ACTIVATE flow nodes %s", value.getFlowNodes()))
+        .append(
+            String.format(
+                " in adhoc subprocess [%s]",
+                shortenKey(Long.parseLong(value.getAdHocSubProcessInstanceKey()))));
+    return builder.toString();
   }
 
   private String summarizeVariable(final Record<?> record) {

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -775,7 +775,7 @@ public class CompactRecordLogger {
 
     final var builder = new StringBuilder();
     builder
-        .append(String.format("ACTIVATE flow nodes %s", value.getFlowNodes()))
+        .append(String.format("ACTIVATE elements %s", value.getElements()))
         .append(
             String.format(
                 " in adhoc subprocess [%s]",

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -46,6 +46,7 @@ import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
+import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
@@ -437,6 +438,14 @@ public final class RecordingExporter implements Exporter {
   public static ResourceDeletionRecordStream resourceDeletionRecords(
       final ResourceDeletionIntent intent) {
     return resourceDeletionRecords().withIntent(intent);
+  }
+
+  public static AdHocSubProcessActivityActivationRecordStream
+      adHocSubProcessActivityActivationRecords() {
+    return new AdHocSubProcessActivityActivationRecordStream(
+        records(
+            ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
+            AdHocSubProcessActivityActivationRecordValue.class));
   }
 
   public static FormRecordStream formRecords() {


### PR DESCRIPTION
## Description

- Adds a new `RecordValue` and `Record` called `AdHocSubProcessActivityActivationRecordValue` and `AdHocSubProcessActivityActivationRecord` respectively.
  - This is the command record that is used by the processor to activate the activity.
- Adds a new processor to process the new command.
- Adds support for the new `RecordValue` in `OpenSearch` and `ElasticSearch`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #28474
