### PR TITLE
Implement API Controller and Service to Activate an Ad-hoc Subprocess Activity

### DIFF
--- a/service/src/main/java/io/camunda/service/AdHocSubprocessActivityServices.java
+++ b/service/src/main/java/io/camunda/service/AdHocSubprocessActivityServices.java
@@ -21,8 +21,11 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
 import io.camunda.zeebe.model.bpmn.instance.FlowNode;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 
@@ -105,5 +108,16 @@ public class AdHocSubprocessActivityServices extends ApiServices<AdHocSubprocess
     }
 
     return documentation;
+  }
+
+  public CompletableFuture<AdHocSubProcessActivityActivationRecord> activateActivities(
+      final AdHocSubprocessActivateActivitiesRequest request) {
+    // TODO implement
+    return CompletableFuture.failedFuture(new UnsupportedOperationException("Not implemented yet"));
+  }
+
+  public record AdHocSubprocessActivateActivitiesRequest(
+      String adHocSubprocessInstanceKey, List<AdHocSubprocessActivateActivityReference> elements) {
+    public record AdHocSubprocessActivateActivityReference(String elementId) {}
   }
 }

--- a/service/src/main/java/io/camunda/service/AdHocSubprocessActivityServices.java
+++ b/service/src/main/java/io/camunda/service/AdHocSubprocessActivityServices.java
@@ -15,8 +15,10 @@ import io.camunda.search.exception.ErrorMessages;
 import io.camunda.search.query.AdHocSubprocessActivityQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
+import io.camunda.service.AdHocSubprocessActivityServices.AdHocSubprocessActivateActivitiesRequest.AdHocSubprocessActivateActivityReference;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateAdHocSubprocessActivityRequest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.AdHocSubProcess;
@@ -112,8 +114,15 @@ public class AdHocSubprocessActivityServices extends ApiServices<AdHocSubprocess
 
   public CompletableFuture<AdHocSubProcessActivityActivationRecord> activateActivities(
       final AdHocSubprocessActivateActivitiesRequest request) {
-    // TODO implement
-    return CompletableFuture.failedFuture(new UnsupportedOperationException("Not implemented yet"));
+    final var brokerRequest =
+        new BrokerActivateAdHocSubprocessActivityRequest()
+            .setAdHocSubProcessInstanceKey(request.adHocSubprocessInstanceKey());
+
+    request.elements().stream()
+        .map(AdHocSubprocessActivateActivityReference::elementId)
+        .forEach(brokerRequest::addElement);
+
+    return sendBrokerRequest(brokerRequest);
   }
 
   public record AdHocSubprocessActivateActivitiesRequest(

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3418,6 +3418,50 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  # TODO can we return a meaningful response?
+  /element-instances/ad-hoc-activities/{adHocSubprocessInstanceKey}/activate:
+    post:
+      tags:
+        - Ad-hoc subprocess
+      operationId: activateAdHocSubprocessActivities
+      summary: Activate activities within an ad-hoc subprocess
+      description: |
+        Activates selected activities within an ad-hoc subprocess identified by element ID.
+        The provided element IDs must exist within the ad-hoc subprocess instance identified by the
+        provided adHocSubprocessInstanceKey.
+      parameters:
+        - name: adHocSubprocessInstanceKey
+          in: path
+          required: true
+          description: The key of the ad-hoc subprocess instance that contains the activities.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdHocSubprocessActivateActivitiesInstruction"
+      responses:
+        "204":
+          description: The ad-hoc subprocess instance is modified.
+        "400":
+          $ref: "#/components/responses/InvalidData"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: |
+            The ad-hoc subprocess instance is not found or the provided key does not identify an
+            ad-hoc subprocess.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   /signals/broadcast:
     post:
       tags:
@@ -4815,6 +4859,24 @@ components:
         tenantId:
           description: The tenant ID for this activity.
           type: string
+    AdHocSubprocessActivateActivitiesInstruction:
+      type: object
+      properties:
+        elements:
+          description: Activities to activate.
+          type: array
+          items:
+            $ref: "#/components/schemas/AdHocSubprocessActivateActivityReference"
+      required:
+        - elements
+    AdHocSubprocessActivateActivityReference:
+      type: object
+      properties:
+        elementId:
+          description: The ID of the element that should be activated.
+          type: string
+      required:
+        - elementId
     DecisionDefinitionSearchQuerySortRequest:
       type: object
       properties:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3418,8 +3418,7 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
-  # TODO can we return a meaningful response?
-  /element-instances/ad-hoc-activities/{adHocSubprocessInstanceKey}/activate:
+  /element-instances/ad-hoc-activities/{adHocSubprocessInstanceKey}/activation:
     post:
       tags:
         - Ad-hoc subprocess

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -8,13 +8,13 @@
 package io.camunda.zeebe.gateway.rest;
 
 import static io.camunda.zeebe.gateway.rest.util.KeyUtil.tryParseLong;
+import static io.camunda.zeebe.gateway.rest.validator.AdHocSubprocessActivityRequestValidator.validateAdHocSubprocessSearchActivitiesRequest;
 import static io.camunda.zeebe.gateway.rest.validator.AuthorizationRequestValidator.validateAuthorizationRequest;
 import static io.camunda.zeebe.gateway.rest.validator.ClockValidator.validateClockPinRequest;
 import static io.camunda.zeebe.gateway.rest.validator.DocumentValidator.validateDocumentLinkParams;
 import static io.camunda.zeebe.gateway.rest.validator.DocumentValidator.validateDocumentMetadata;
 import static io.camunda.zeebe.gateway.rest.validator.ElementRequestValidator.validateVariableRequest;
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
-import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE;
 import static io.camunda.zeebe.gateway.rest.validator.EvaluateDecisionRequestValidator.validateEvaluateDecisionRequest;
 import static io.camunda.zeebe.gateway.rest.validator.JobRequestValidator.validateJobActivationRequest;
 import static io.camunda.zeebe.gateway.rest.validator.JobRequestValidator.validateJobErrorRequest;
@@ -29,7 +29,6 @@ import static io.camunda.zeebe.gateway.rest.validator.ProcessInstanceRequestVali
 import static io.camunda.zeebe.gateway.rest.validator.ProcessInstanceRequestValidator.validateMigrateProcessInstanceRequest;
 import static io.camunda.zeebe.gateway.rest.validator.ProcessInstanceRequestValidator.validateModifyProcessInstanceRequest;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.createProblemDetail;
-import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
 import static io.camunda.zeebe.gateway.rest.validator.ResourceRequestValidator.validateResourceDeletion;
 import static io.camunda.zeebe.gateway.rest.validator.SignalRequestValidator.validateSignalBroadcastRequest;
 import static io.camunda.zeebe.gateway.rest.validator.UserTaskRequestValidator.validateAssignmentRequest;
@@ -134,7 +133,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
@@ -812,28 +810,15 @@ public class RequestMapper {
           createProblemDetail(List.of(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("filter"))).get());
     }
 
-    final var processDefinitionKey = tryParseLong(filter.getProcessDefinitionKey());
+    final var processDefinitionKey = tryParseLong(filter.getProcessDefinitionKey()).orElse(null);
 
     return getResult(
-        validate(
-            violations -> {
-              if (processDefinitionKey.isEmpty() || processDefinitionKey.get() <= 0) {
-                violations.add(
-                    ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE.formatted(
-                        "filter.processDefinitionKey",
-                        filter.getProcessDefinitionKey(),
-                        "a non-negative numeric value"));
-              }
-
-              if (StringUtils.isBlank(filter.getAdHocSubprocessId())) {
-                violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("filter.adHocSubprocessId"));
-              }
-            }),
+        validateAdHocSubprocessSearchActivitiesRequest(filter, processDefinitionKey),
         () ->
             AdHocSubprocessActivityQuery.builder()
                 .filter(
                     AdHocSubprocessActivityFilter.builder()
-                        .processDefinitionKey(processDefinitionKey.get())
+                        .processDefinitionKey(processDefinitionKey)
                         .adHocSubprocessId(filter.getAdHocSubprocessId())
                         .build())
                 .build());

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.rest;
 
 import static io.camunda.zeebe.gateway.rest.util.KeyUtil.tryParseLong;
+import static io.camunda.zeebe.gateway.rest.validator.AdHocSubprocessActivityRequestValidator.validateAdHocSubprocessActivationRequest;
 import static io.camunda.zeebe.gateway.rest.validator.AdHocSubprocessActivityRequestValidator.validateAdHocSubprocessSearchActivitiesRequest;
 import static io.camunda.zeebe.gateway.rest.validator.AuthorizationRequestValidator.validateAuthorizationRequest;
 import static io.camunda.zeebe.gateway.rest.validator.ClockValidator.validateClockPinRequest;
@@ -46,6 +47,8 @@ import io.camunda.search.filter.AdHocSubprocessActivityFilter;
 import io.camunda.search.query.AdHocSubprocessActivityQuery;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authentication.Builder;
+import io.camunda.service.AdHocSubprocessActivityServices.AdHocSubprocessActivateActivitiesRequest;
+import io.camunda.service.AdHocSubprocessActivityServices.AdHocSubprocessActivateActivitiesRequest.AdHocSubprocessActivateActivityReference;
 import io.camunda.service.AuthorizationServices.CreateAuthorizationRequest;
 import io.camunda.service.AuthorizationServices.UpdateAuthorizationRequest;
 import io.camunda.service.DocumentServices.DocumentCreateRequest;
@@ -66,6 +69,7 @@ import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.service.UserServices.UserDTO;
 import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.auth.ClaimTransformer;
+import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivateActivitiesInstruction;
 import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivitySearchQuery;
 import io.camunda.zeebe.gateway.protocol.rest.AuthorizationRequest;
 import io.camunda.zeebe.gateway.protocol.rest.CancelProcessInstanceRequest;
@@ -822,6 +826,22 @@ public class RequestMapper {
                         .adHocSubprocessId(filter.getAdHocSubprocessId())
                         .build())
                 .build());
+  }
+
+  public static Either<ProblemDetail, AdHocSubprocessActivateActivitiesRequest>
+      toAdHocSubprocessActivateActivitiesRequest(
+          final String adHocSubprocessInstanceKey,
+          final AdHocSubprocessActivateActivitiesInstruction request) {
+    return getResult(
+        validateAdHocSubprocessActivationRequest(request),
+        () ->
+            new AdHocSubprocessActivateActivitiesRequest(
+                adHocSubprocessInstanceKey,
+                request.getElements().stream()
+                    .map(
+                        element ->
+                            new AdHocSubprocessActivateActivityReference(element.getElementId()))
+                    .toList()));
   }
 
   private static List<ProcessInstanceModificationActivateInstruction>

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityController.java
@@ -44,7 +44,7 @@ public class AdHocSubprocessActivityController {
   }
 
   @CamundaPostMapping(path = "/{adHocSubprocessInstanceKey}/activation")
-  public CompletableFuture<ResponseEntity<Object>> modifyProcessInstance(
+  public CompletableFuture<ResponseEntity<Object>> activateAdHocSubprocessActivities(
       @PathVariable final String adHocSubprocessInstanceKey,
       @RequestBody final AdHocSubprocessActivateActivitiesInstruction activationRequest) {
     return RequestMapper.toAdHocSubprocessActivateActivitiesRequest(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityController.java
@@ -11,13 +11,17 @@ import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.search.query.AdHocSubprocessActivityQuery;
 import io.camunda.service.AdHocSubprocessActivityServices;
+import io.camunda.service.AdHocSubprocessActivityServices.AdHocSubprocessActivateActivitiesRequest;
+import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivateActivitiesInstruction;
 import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivitySearchQuery;
 import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivitySearchQueryResult;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import java.util.concurrent.CompletableFuture;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -39,6 +43,15 @@ public class AdHocSubprocessActivityController {
         .fold(RestErrorMapper::mapProblemToResponse, this::searchAdHocSubprocessActivities);
   }
 
+  @CamundaPostMapping(path = "/{adHocSubprocessInstanceKey}/activate")
+  public CompletableFuture<ResponseEntity<Object>> modifyProcessInstance(
+      @PathVariable final String adHocSubprocessInstanceKey,
+      @RequestBody final AdHocSubprocessActivateActivitiesInstruction activationRequest) {
+    return RequestMapper.toAdHocSubprocessActivateActivitiesRequest(
+            adHocSubprocessInstanceKey, activationRequest)
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::activateActivities);
+  }
+
   private ResponseEntity<AdHocSubprocessActivitySearchQueryResult> searchAdHocSubprocessActivities(
       final AdHocSubprocessActivityQuery query) {
     try {
@@ -57,5 +70,14 @@ public class AdHocSubprocessActivityController {
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
+  }
+
+  private CompletableFuture<ResponseEntity<Object>> activateActivities(
+      final AdHocSubprocessActivateActivitiesRequest request) {
+    return RequestMapper.executeServiceMethodWithNoContentResult(
+        () ->
+            adHocSubprocessActivityServices
+                .withAuthentication(RequestMapper.getAuthentication())
+                .activateActivities(request));
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityController.java
@@ -43,7 +43,7 @@ public class AdHocSubprocessActivityController {
         .fold(RestErrorMapper::mapProblemToResponse, this::searchAdHocSubprocessActivities);
   }
 
-  @CamundaPostMapping(path = "/{adHocSubprocessInstanceKey}/activate")
+  @CamundaPostMapping(path = "/{adHocSubprocessInstanceKey}/activation")
   public CompletableFuture<ResponseEntity<Object>> modifyProcessInstance(
       @PathVariable final String adHocSubprocessInstanceKey,
       @RequestBody final AdHocSubprocessActivateActivitiesInstruction activationRequest) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/AdHocSubprocessActivityRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/AdHocSubprocessActivityRequestValidator.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAG
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
 
+import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivateActivitiesInstruction;
 import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivityFilter;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
@@ -32,6 +33,24 @@ public class AdHocSubprocessActivityRequestValidator {
 
           if (StringUtils.isBlank(filter.getAdHocSubprocessId())) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("filter.adHocSubprocessId"));
+          }
+        });
+  }
+
+  public static Optional<ProblemDetail> validateAdHocSubprocessActivationRequest(
+      final AdHocSubprocessActivateActivitiesInstruction request) {
+    return validate(
+        violations -> {
+          // TODO validate duplicate element IDs here?
+          if (request.getElements() == null || request.getElements().isEmpty()) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("elements"));
+          } else {
+            for (int i = 0; i < request.getElements().size(); i++) {
+              if (StringUtils.isBlank(request.getElements().get(i).getElementId())) {
+                violations.add(
+                    ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("elements[%d].elementId".formatted(i)));
+              }
+            }
           }
         });
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/AdHocSubprocessActivityRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/AdHocSubprocessActivityRequestValidator.java
@@ -41,7 +41,6 @@ public class AdHocSubprocessActivityRequestValidator {
       final AdHocSubprocessActivateActivitiesInstruction request) {
     return validate(
         violations -> {
-          // TODO validate duplicate element IDs here?
           if (request.getElements() == null || request.getElements().isEmpty()) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("elements"));
           } else {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/AdHocSubprocessActivityRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/AdHocSubprocessActivityRequestValidator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.validator;
+
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE;
+import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
+
+import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivityFilter;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.http.ProblemDetail;
+
+public class AdHocSubprocessActivityRequestValidator {
+
+  public static Optional<ProblemDetail> validateAdHocSubprocessSearchActivitiesRequest(
+      final AdHocSubprocessActivityFilter filter, final Long processDefinitionKey) {
+    return validate(
+        violations -> {
+          if (processDefinitionKey == null || processDefinitionKey <= 0) {
+            violations.add(
+                ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE.formatted(
+                    "filter.processDefinitionKey",
+                    processDefinitionKey,
+                    "a non-negative numeric value"));
+          }
+
+          if (StringUtils.isBlank(filter.getAdHocSubprocessId())) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("filter.adHocSubprocessId"));
+          }
+        });
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityControllerTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.entities.AdHocSubprocessActivityEntity;
@@ -21,11 +22,15 @@ import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.AdHocSubprocessActivityServices;
+import io.camunda.service.AdHocSubprocessActivityServices.AdHocSubprocessActivateActivitiesRequest;
+import io.camunda.service.AdHocSubprocessActivityServices.AdHocSubprocessActivateActivitiesRequest.AdHocSubprocessActivateActivityReference;
 import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivityResult;
 import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivityResult.TypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.AdHocSubprocessActivitySearchQueryResult;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -41,6 +46,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 class AdHocSubprocessActivityControllerTest extends RestControllerTest {
   private static final String AD_HOC_ACTIVITIES_URL = "/v2/element-instances/ad-hoc-activities";
   private static final String SEARCH_ACTIVITIES_URL = AD_HOC_ACTIVITIES_URL + "/search";
+  private static final String ACTIVATE_ACTIVITIES_URL =
+      AD_HOC_ACTIVITIES_URL + "/{adHocSubprocessInstanceKey}/activate";
 
   @MockitoBean private AdHocSubprocessActivityServices adHocSubprocessActivityServices;
 
@@ -171,6 +178,8 @@ class AdHocSubprocessActivityControllerTest extends RestControllerTest {
             """)
           .jsonPath(".detail")
           .isEqualTo(expectedErrorDetail);
+
+      verifyNoInteractions(adHocSubprocessActivityServices);
     }
 
     @Test
@@ -274,6 +283,124 @@ class AdHocSubprocessActivityControllerTest extends RestControllerTest {
               }
               """,
               "No filter.adHocSubprocessId provided."));
+    }
+  }
+
+  @Nested
+  class ActivateActivities {
+
+    private static final String AD_HOC_SUBPROCESS_INSTANCE_KEY = "123456789";
+
+    @Test
+    void shouldActivateActivities() {
+      when(adHocSubprocessActivityServices.activateActivities(
+              any(AdHocSubprocessActivateActivitiesRequest.class)))
+          .thenReturn(
+              CompletableFuture.completedFuture(new AdHocSubProcessActivityActivationRecord()));
+
+      webClient
+          .post()
+          .uri(ACTIVATE_ACTIVITIES_URL, AD_HOC_SUBPROCESS_INSTANCE_KEY)
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(
+              """
+            {
+              "elements": [
+                {"elementId": "A"},
+                {"elementId": "B"},
+                {"elementId": "C"}
+              ]
+            }
+            """)
+          .exchange()
+          .expectStatus()
+          .isNoContent();
+
+      verify(adHocSubprocessActivityServices)
+          .activateActivities(
+              assertArg(
+                  request -> {
+                    assertThat(request.adHocSubprocessInstanceKey())
+                        .isEqualTo(AD_HOC_SUBPROCESS_INSTANCE_KEY);
+
+                    assertThat(request.elements())
+                        .extracting(AdHocSubprocessActivateActivityReference::elementId)
+                        .containsExactly("A", "B", "C");
+                  }));
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidActivateParameters")
+    void shouldReturnBadRequestWhenValidationFails(
+        final String request, final String expectedErrorDetail) {
+      webClient
+          .post()
+          .uri(ACTIVATE_ACTIVITIES_URL, AD_HOC_SUBPROCESS_INSTANCE_KEY)
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(request)
+          .exchange()
+          .expectStatus()
+          .isBadRequest()
+          .expectBody()
+          .json(
+              """
+            {
+                "type": "about:blank",
+                "title": "INVALID_ARGUMENT",
+                "status": 400,
+                "instance": "/v2/element-instances/ad-hoc-activities/%s/activate"
+            }
+            """
+                  .formatted(AD_HOC_SUBPROCESS_INSTANCE_KEY))
+          .jsonPath(".detail")
+          .isEqualTo(expectedErrorDetail);
+
+      verifyNoInteractions(adHocSubprocessActivityServices);
+    }
+
+    static Stream<Arguments> invalidActivateParameters() {
+      return Stream.of(
+          arguments(
+              """
+              {}
+              """,
+              "No elements provided."),
+          arguments(
+              """
+              {
+                "elements": []
+              }
+              """,
+              "No elements provided."),
+          arguments(
+              """
+              {
+                "elements": [
+                  {}
+                ]
+              }
+              """,
+              "No elements[0].elementId provided."),
+          arguments(
+              """
+              {
+                "elements": [
+                  { "elementId": null }
+                ]
+              }
+              """,
+              "No elements[0].elementId provided."),
+          arguments(
+              """
+              {
+                "elements": [
+                  { "elementId": "    " }
+                ]
+              }
+              """,
+              "No elements[0].elementId provided."));
     }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdHocSubprocessActivityControllerTest.java
@@ -47,7 +47,7 @@ class AdHocSubprocessActivityControllerTest extends RestControllerTest {
   private static final String AD_HOC_ACTIVITIES_URL = "/v2/element-instances/ad-hoc-activities";
   private static final String SEARCH_ACTIVITIES_URL = AD_HOC_ACTIVITIES_URL + "/search";
   private static final String ACTIVATE_ACTIVITIES_URL =
-      AD_HOC_ACTIVITIES_URL + "/{adHocSubprocessInstanceKey}/activate";
+      AD_HOC_ACTIVITIES_URL + "/{adHocSubprocessInstanceKey}/activation";
 
   @MockitoBean private AdHocSubprocessActivityServices adHocSubprocessActivityServices;
 
@@ -350,7 +350,7 @@ class AdHocSubprocessActivityControllerTest extends RestControllerTest {
                 "type": "about:blank",
                 "title": "INVALID_ARGUMENT",
                 "status": 400,
-                "instance": "/v2/element-instances/ad-hoc-activities/%s/activate"
+                "instance": "/v2/element-instances/ad-hoc-activities/%s/activation"
             }
             """
                   .formatted(AD_HOC_SUBPROCESS_INSTANCE_KEY))

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerActivateAdHocSubprocessActivityRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerActivateAdHocSubprocessActivityRequest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.impl.record.value.adhocsubprocess.AdHocSubProcessActivityActivationRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
+import org.agrona.DirectBuffer;
+
+public class BrokerActivateAdHocSubprocessActivityRequest
+    extends BrokerExecuteCommand<AdHocSubProcessActivityActivationRecord> {
+
+  private final AdHocSubProcessActivityActivationRecord requestDto =
+      new AdHocSubProcessActivityActivationRecord();
+
+  public BrokerActivateAdHocSubprocessActivityRequest() {
+    super(
+        ValueType.AD_HOC_SUB_PROCESS_ACTIVITY_ACTIVATION,
+        AdHocSubProcessActivityActivationIntent.ACTIVATE);
+  }
+
+  public BrokerActivateAdHocSubprocessActivityRequest setAdHocSubProcessInstanceKey(
+      final String adHocSubProcessInstanceKey) {
+    requestDto.setAdHocSubProcessInstanceKey(adHocSubProcessInstanceKey);
+    return this;
+  }
+
+  public BrokerActivateAdHocSubprocessActivityRequest addElement(final String elementId) {
+    requestDto.elements().add().setElementId(elementId);
+    return this;
+  }
+
+  @Override
+  public AdHocSubProcessActivityActivationRecord getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected AdHocSubProcessActivityActivationRecord toResponseDto(final DirectBuffer buffer) {
+    final AdHocSubProcessActivityActivationRecord responseDto =
+        new AdHocSubProcessActivityActivationRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}


### PR DESCRIPTION
## Description

- Adds a controller and service component in the gateway to request the broker to activate the provided flow nodes in the given ad-hoc subprocess instance.

Builds on https://github.com/camunda/camunda/pull/29061


## Related issues

closes #28475
