### PR TITLE
Implement Activate Ad-hoc Subprocess Activity in Clients

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClient.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClient.java
@@ -16,6 +16,7 @@
 package io.camunda.client;
 
 import io.camunda.client.api.ExperimentalApi;
+import io.camunda.client.api.command.ActivateAdHocSubprocessActivitiesCommandStep1;
 import io.camunda.client.api.command.AssignGroupToTenantCommandStep1;
 import io.camunda.client.api.command.AssignMappingToTenantCommandStep1;
 import io.camunda.client.api.command.AssignUserTaskCommandStep1;
@@ -899,6 +900,25 @@ public interface CamundaClient extends AutoCloseable, JobClient {
   @ExperimentalApi("https://github.com/camunda/camunda/issues/27930")
   AdHocSubprocessActivityQuery newAdHocSubprocessActivityQuery(
       long processDefinitionKey, String adHocSubprocessId);
+
+  /**
+   * Command to activate activities within an activated ad-hoc subprocess.
+   *
+   * <pre>
+   *   camundaClient
+   *    .newActivateAdHocSubprocessActivitiesCommand(adHocSubprocessInstanceKey)
+   *    .activateElement("A")
+   *    .activateElements("B", "C")
+   *    .activateElements(Arrays.asList("D", "E"))
+   *    .send();
+   * </pre>
+   *
+   * @param adHocSubprocessInstanceKey the key which identifies the corresponding ad-hoc subprocess
+   *     instance
+   * @return a builder for the command
+   */
+  ActivateAdHocSubprocessActivitiesCommandStep1 newActivateAdHocSubprocessActivitiesCommand(
+      String adHocSubprocessInstanceKey);
 
   /**
    * Executes a search request to query user tasks.

--- a/clients/java/src/main/java/io/camunda/client/api/command/ActivateAdHocSubprocessActivitiesCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/ActivateAdHocSubprocessActivitiesCommandStep1.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.command;
+
+import io.camunda.client.api.response.ActivateAdHocSubprocessActivitiesResponse;
+import java.util.Arrays;
+import java.util.Collection;
+
+public interface ActivateAdHocSubprocessActivitiesCommandStep1 {
+
+  /**
+   * Create an {@link io.camunda.client.protocol.rest.AdHocSubprocessActivateActivitiesInstruction}
+   * for the given element id.
+   *
+   * @param elementId the id of the element to activate
+   * @return the builder for this command
+   */
+  ActivateAdHocSubprocessActivitiesCommandStep2 activateElement(final String elementId);
+
+  /**
+   * Create an {@link io.camunda.client.protocol.rest.AdHocSubprocessActivateActivitiesInstruction}
+   * for each of the given element ids.
+   *
+   * @param elementIds the ids of the elements to activate
+   * @return the builder for this command
+   * @throws IllegalArgumentException if elementIds is null or empty
+   */
+  default ActivateAdHocSubprocessActivitiesCommandStep2 activateElements(
+      final Collection<String> elementIds) {
+    if (elementIds == null || elementIds.isEmpty()) {
+      throw new IllegalArgumentException("elementIds must not be empty");
+    }
+
+    ActivateAdHocSubprocessActivitiesCommandStep2 builder = null;
+    for (final String elementId : elementIds) {
+      builder = activateElement(elementId);
+    }
+
+    return builder;
+  }
+
+  /**
+   * Create an {@link io.camunda.client.protocol.rest.AdHocSubprocessActivateActivitiesInstruction}
+   * for each of the given element ids.
+   *
+   * @param elementIds the ids of the elements to activate
+   * @return the builder for this command
+   * @throws IllegalArgumentException if elementIds is null or empty
+   */
+  default ActivateAdHocSubprocessActivitiesCommandStep2 activateElements(
+      final String... elementIds) {
+    return activateElements(Arrays.asList(elementIds));
+  }
+
+  interface ActivateAdHocSubprocessActivitiesCommandStep2
+      extends ActivateAdHocSubprocessActivitiesCommandStep1,
+          FinalCommandStep<ActivateAdHocSubprocessActivitiesResponse> {}
+}

--- a/clients/java/src/main/java/io/camunda/client/api/response/ActivateAdHocSubprocessActivitiesResponse.java
+++ b/clients/java/src/main/java/io/camunda/client/api/response/ActivateAdHocSubprocessActivitiesResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.api.response;
+
+public interface ActivateAdHocSubprocessActivitiesResponse {}

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientImpl.java
@@ -21,6 +21,7 @@ import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientConfiguration;
 import io.camunda.client.CredentialsProvider;
 import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.ActivateAdHocSubprocessActivitiesCommandStep1;
 import io.camunda.client.api.command.ActivateJobsCommandStep1;
 import io.camunda.client.api.command.AssignGroupToTenantCommandStep1;
 import io.camunda.client.api.command.AssignMappingToTenantCommandStep1;
@@ -103,6 +104,7 @@ import io.camunda.client.api.search.query.UserTaskVariableQuery;
 import io.camunda.client.api.search.query.VariableQuery;
 import io.camunda.client.api.worker.JobClient;
 import io.camunda.client.api.worker.JobWorkerBuilderStep1;
+import io.camunda.client.impl.command.ActivateAdHocSubprocessActivitiesCommandImpl;
 import io.camunda.client.impl.command.AssignGroupToTenantCommandImpl;
 import io.camunda.client.impl.command.AssignMappingToTenantCommandImpl;
 import io.camunda.client.impl.command.AssignUserTaskCommandImpl;
@@ -689,6 +691,13 @@ public final class CamundaClientImpl implements CamundaClient {
                 filter
                     .processDefinitionKey(processDefinitionKey)
                     .adHocSubprocessId(adHocSubprocessId));
+  }
+
+  @Override
+  public ActivateAdHocSubprocessActivitiesCommandStep1 newActivateAdHocSubprocessActivitiesCommand(
+      final String adHocSubprocessInstanceKey) {
+    return new ActivateAdHocSubprocessActivitiesCommandImpl(
+        httpClient, jsonMapper, adHocSubprocessInstanceKey);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ActivateAdHocSubprocessActivitiesCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ActivateAdHocSubprocessActivitiesCommandImpl.java
@@ -71,7 +71,7 @@ public final class ActivateAdHocSubprocessActivitiesCommandImpl
     final HttpCamundaFuture<ActivateAdHocSubprocessActivitiesResponse> result =
         new HttpCamundaFuture<>();
     httpClient.post(
-        "/element-instances/ad-hoc-activities/" + adHocSubprocessInstanceKey + "/activate",
+        "/element-instances/ad-hoc-activities/" + adHocSubprocessInstanceKey + "/activation",
         jsonMapper.toJson(httpRequestObject),
         httpRequestConfig.build(),
         result);

--- a/clients/java/src/main/java/io/camunda/client/impl/command/ActivateAdHocSubprocessActivitiesCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/ActivateAdHocSubprocessActivitiesCommandImpl.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.command;
+
+import io.camunda.client.api.CamundaFuture;
+import io.camunda.client.api.JsonMapper;
+import io.camunda.client.api.command.ActivateAdHocSubprocessActivitiesCommandStep1;
+import io.camunda.client.api.command.ActivateAdHocSubprocessActivitiesCommandStep1.ActivateAdHocSubprocessActivitiesCommandStep2;
+import io.camunda.client.api.command.FinalCommandStep;
+import io.camunda.client.api.response.ActivateAdHocSubprocessActivitiesResponse;
+import io.camunda.client.impl.http.HttpCamundaFuture;
+import io.camunda.client.impl.http.HttpClient;
+import io.camunda.client.protocol.rest.AdHocSubprocessActivateActivitiesInstruction;
+import io.camunda.client.protocol.rest.AdHocSubprocessActivateActivityReference;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public final class ActivateAdHocSubprocessActivitiesCommandImpl
+    implements ActivateAdHocSubprocessActivitiesCommandStep1,
+        ActivateAdHocSubprocessActivitiesCommandStep2 {
+
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  private final String adHocSubprocessInstanceKey;
+  private final AdHocSubprocessActivateActivitiesInstruction httpRequestObject;
+
+  public ActivateAdHocSubprocessActivitiesCommandImpl(
+      final HttpClient httpClient,
+      final JsonMapper jsonMapper,
+      final String adHocSubprocessInstanceKey) {
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    httpRequestConfig = httpClient.newRequestConfig();
+
+    this.adHocSubprocessInstanceKey = adHocSubprocessInstanceKey;
+    httpRequestObject = new AdHocSubprocessActivateActivitiesInstruction();
+  }
+
+  @Override
+  public ActivateAdHocSubprocessActivitiesCommandStep2 activateElement(final String elementId) {
+    httpRequestObject.addElementsItem(
+        new AdHocSubprocessActivateActivityReference().elementId(elementId));
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<ActivateAdHocSubprocessActivitiesResponse> requestTimeout(
+      final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public CamundaFuture<ActivateAdHocSubprocessActivitiesResponse> send() {
+    final HttpCamundaFuture<ActivateAdHocSubprocessActivitiesResponse> result =
+        new HttpCamundaFuture<>();
+    httpClient.post(
+        "/element-instances/ad-hoc-activities/" + adHocSubprocessInstanceKey + "/activate",
+        jsonMapper.toJson(httpRequestObject),
+        httpRequestConfig.build(),
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/client/impl/response/ActivateAdHocSubprocessActivitiesResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/ActivateAdHocSubprocessActivitiesResponseImpl.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.response;
+
+import io.camunda.client.api.response.ActivateAdHocSubprocessActivitiesResponse;
+
+public class ActivateAdHocSubprocessActivitiesResponseImpl
+    implements ActivateAdHocSubprocessActivitiesResponse {}

--- a/clients/java/src/test/java/io/camunda/client/adhocsubprocess/AdHocSubprocessActivityActivationTest.java
+++ b/clients/java/src/test/java/io/camunda/client/adhocsubprocess/AdHocSubprocessActivityActivationTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.adhocsubprocess;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.client.api.command.ActivateAdHocSubprocessActivitiesCommandStep1;
+import io.camunda.client.api.command.ActivateAdHocSubprocessActivitiesCommandStep1.ActivateAdHocSubprocessActivitiesCommandStep2;
+import io.camunda.client.protocol.rest.AdHocSubprocessActivateActivitiesInstruction;
+import io.camunda.client.protocol.rest.AdHocSubprocessActivateActivityReference;
+import io.camunda.client.util.ClientRestTest;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+public class AdHocSubprocessActivityActivationTest extends ClientRestTest {
+
+  private static final String AD_HOC_SUBPROCESS_INSTANCE_KEY = "123456789";
+
+  @ParameterizedTest
+  @MethodSource("requestModifiers")
+  void shouldActivateAdHocSubprocessActivities(
+      final Function<
+              ActivateAdHocSubprocessActivitiesCommandStep1,
+              ActivateAdHocSubprocessActivitiesCommandStep2>
+          requestModifier) {
+    final ActivateAdHocSubprocessActivitiesCommandStep1 command =
+        client.newActivateAdHocSubprocessActivitiesCommand(AD_HOC_SUBPROCESS_INSTANCE_KEY);
+    requestModifier.apply(command).send().join();
+
+    final AdHocSubprocessActivateActivitiesInstruction request =
+        gatewayService.getLastRequest(AdHocSubprocessActivateActivitiesInstruction.class);
+    assertThat(request.getElements())
+        .extracting(AdHocSubprocessActivateActivityReference::getElementId)
+        .containsExactly("A", "B", "C");
+  }
+
+  @Test
+  void shouldActivateAdHocSubprocessActivitiesCombiningActivationMethods() {
+    client
+        .newActivateAdHocSubprocessActivitiesCommand(AD_HOC_SUBPROCESS_INSTANCE_KEY)
+        .activateElement("A")
+        .activateElements("B", "C")
+        .activateElements(Arrays.asList("D", "E"))
+        .send()
+        .join();
+
+    final AdHocSubprocessActivateActivitiesInstruction request =
+        gatewayService.getLastRequest(AdHocSubprocessActivateActivitiesInstruction.class);
+    assertThat(request.getElements())
+        .extracting(AdHocSubprocessActivateActivityReference::getElementId)
+        .containsExactly("A", "B", "C", "D", "E");
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  void throwsExceptionWhenElementsCollectionIsNullOrEmpty(final Collection<String> elementIds) {
+    final ActivateAdHocSubprocessActivitiesCommandStep1 command =
+        client.newActivateAdHocSubprocessActivitiesCommand(AD_HOC_SUBPROCESS_INSTANCE_KEY);
+
+    assertThatThrownBy(() -> command.activateElements(elementIds))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("elementIds must not be empty");
+  }
+
+  @Test
+  void throwsExceptionWhenElementsArrayIsEmpty() {
+    final ActivateAdHocSubprocessActivitiesCommandStep1 command =
+        client.newActivateAdHocSubprocessActivitiesCommand(AD_HOC_SUBPROCESS_INSTANCE_KEY);
+
+    assertThatThrownBy(() -> command.activateElements(new String[] {}))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("elementIds must not be empty");
+  }
+
+  static Stream<
+          Function<
+              ActivateAdHocSubprocessActivitiesCommandStep1,
+              ActivateAdHocSubprocessActivitiesCommandStep2>>
+      requestModifiers() {
+    return Stream.of(
+        command -> command.activateElement("A").activateElement("B").activateElement("C"),
+        command -> command.activateElements("A", "B", "C"),
+        command -> command.activateElements(Arrays.asList("A", "B", "C")));
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ActivateAdHocSubprocessActivityTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ActivateAdHocSubprocessActivityTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.client.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.SignalIntent;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+@ZeebeIntegration
+public class ActivateAdHocSubprocessActivityTest {
+
+  private static final String AD_HOC_SUB_PROCESS_ELEMENT_ID = "ad-hoc";
+
+  @AutoClose CamundaClient client;
+
+  @TestZeebe
+  final TestStandaloneBroker zeebe =
+      new TestStandaloneBroker().withRecordingExporter(true).withUnauthenticatedAccess();
+
+  ZeebeResourcesHelper resourcesHelper;
+  private String processId;
+  private ProcessInstanceEvent processInstance;
+
+  @BeforeEach
+  public void init(final TestInfo testInfo) {
+    client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
+    resourcesHelper = new ZeebeResourcesHelper(client);
+
+    deploy(testInfo);
+    processInstance =
+        client.newCreateInstanceCommand().bpmnProcessId(processId).latestVersion().send().join();
+  }
+
+  @Test
+  void shouldActivateAdHocSubprocessActivities(final TestInfo testInfo) {
+    // allows us to wait for the signal to be broadcasted
+    client.newBroadcastSignalCommand().signalName("signal").send().join();
+
+    assertThat(
+            RecordingExporter.records()
+                .limit(signalBroadcasted("signal"))
+                .processInstanceRecords()
+                .withProcessInstanceKey(processInstance.getProcessInstanceKey()))
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .contains(tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .doesNotContain(
+            tuple("A", ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple("B", ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple("C", ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
+
+    final var activatedAdHocSubprocess =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstance.getProcessInstanceKey())
+            .withElementId(AD_HOC_SUB_PROCESS_ELEMENT_ID)
+            .getFirst();
+
+    // when
+    client
+        .newActivateAdHocSubprocessActivitiesCommand(
+            String.valueOf(activatedAdHocSubprocess.getKey()))
+        .activateElements("A", "C")
+        .send()
+        .join();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstance.getProcessInstanceKey())
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .contains(
+            tuple("A", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("C", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  void shouldReturnErrorOnCommandRejection(final TestInfo testInfo) {
+    final var activatedAdHocSubprocess =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstance.getProcessInstanceKey())
+            .withElementId(AD_HOC_SUB_PROCESS_ELEMENT_ID)
+            .getFirst();
+
+    assertThatThrownBy(
+            () ->
+                client
+                    .newActivateAdHocSubprocessActivitiesCommand(
+                        String.valueOf(activatedAdHocSubprocess.getKey()))
+                    .activateElements("A", "A")
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 400: 'Bad Request'")
+        .hasMessageContaining(
+            "Command 'ACTIVATE' rejected with code 'INVALID_ARGUMENT': Expected to activate activities for ad-hoc subprocess with key '%s', but duplicate activities were given."
+                .formatted(activatedAdHocSubprocess.getKey()));
+  }
+
+  private void deploy(final TestInfo testInfo) {
+    processId = "process-" + testInfo.getTestMethod().get().getName();
+
+    resourcesHelper.deployProcess(
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .adHocSubProcess(
+                AD_HOC_SUB_PROCESS_ELEMENT_ID,
+                adHocSubProcess -> {
+                  adHocSubProcess.task("A");
+                  adHocSubProcess.task("B");
+                  adHocSubProcess.task("C");
+                })
+            .endEvent()
+            .done());
+  }
+
+  private static Predicate<Record<RecordValue>> signalBroadcasted(final String signalName) {
+    return r ->
+        r.getIntent() == SignalIntent.BROADCASTED
+            && ((SignalRecord) r.getValue()).getSignalName().equals(signalName);
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ActivateAdHocSubprocessActivityTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ActivateAdHocSubprocessActivityTest.java
@@ -16,17 +16,21 @@ import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.builder.AdHocSubProcessBuilder;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
 import io.camunda.zeebe.protocol.record.Record;
-import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.record.ProcessInstanceRecordStream;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
-import java.util.function.Predicate;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,27 +52,29 @@ public class ActivateAdHocSubprocessActivityTest {
   private ProcessInstanceEvent processInstance;
 
   @BeforeEach
-  public void init(final TestInfo testInfo) {
+  public void init() {
     client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
     resourcesHelper = new ZeebeResourcesHelper(client);
-
-    deploy(testInfo);
-    processInstance =
-        client.newCreateInstanceCommand().bpmnProcessId(processId).latestVersion().send().join();
   }
 
   @Test
-  void shouldActivateAdHocSubprocessActivities(final TestInfo testInfo) {
-    // allows us to wait for the signal to be broadcasted
-    client.newBroadcastSignalCommand().signalName("signal").send().join();
+  void shouldActivateActivitiesAndCompleteProcess(final TestInfo testInfo) {
+    // given
+    deployAndStartInstance(
+        testInfo,
+        adHocSubProcess -> {
+          adHocSubProcess.task("A");
+          adHocSubProcess.task("B");
+          adHocSubProcess.task("C");
+        });
 
-    assertThat(
-            RecordingExporter.records()
-                .limit(signalBroadcasted("signal"))
-                .processInstanceRecords()
-                .withProcessInstanceKey(processInstance.getProcessInstanceKey()))
+    client.newBroadcastSignalCommand().signalName("setup_signal").send().join();
+
+    assertThat(recordsUpToSignal("setup_signal"))
         .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .describedAs("Expect ad-hoc subprocess to be activated")
         .contains(tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .describedAs("Expect no activities to be activated")
         .doesNotContain(
             tuple("A", ProcessInstanceIntent.ACTIVATE_ELEMENT),
             tuple("B", ProcessInstanceIntent.ACTIVATE_ELEMENT),
@@ -95,6 +101,7 @@ public class ActivateAdHocSubprocessActivityTest {
                 .withProcessInstanceKey(processInstance.getProcessInstanceKey())
                 .limitToProcessInstanceCompleted())
         .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .describedAs("Expect activated activities and whole process to be completed")
         .contains(
             tuple("A", ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple("C", ProcessInstanceIntent.ELEMENT_COMPLETED),
@@ -103,13 +110,157 @@ public class ActivateAdHocSubprocessActivityTest {
   }
 
   @Test
-  void shouldReturnErrorOnCommandRejection(final TestInfo testInfo) {
+  void shouldActivateActivitiesAndCompleteProcessOnlyWhenCompletionConditionIsMet(
+      final TestInfo testInfo) {
+    // given
+    deployAndStartInstance(
+        testInfo,
+        adHocSubProcess -> {
+          adHocSubProcess.completionCondition("condition");
+          adHocSubProcess.task("A");
+          adHocSubProcess.task("B");
+          adHocSubProcess.serviceTask("ServiceTask", b -> b.zeebeJobType("testType"));
+        },
+        Map.of("condition", false));
+
     final var activatedAdHocSubprocess =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
             .withProcessInstanceKey(processInstance.getProcessInstanceKey())
             .withElementId(AD_HOC_SUB_PROCESS_ELEMENT_ID)
             .getFirst();
 
+    // when1
+    client
+        .newActivateAdHocSubprocessActivitiesCommand(
+            String.valueOf(activatedAdHocSubprocess.getKey()))
+        .activateElements("A", "B")
+        .send()
+        .join();
+
+    client.newBroadcastSignalCommand().signalName("signal1").send().join();
+
+    // then1
+    assertThat(recordsUpToSignal("signal1"))
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .describedAs(
+            "Expect ad-hoc process instance not to be completed until completion condition is not met")
+        .contains(
+            tuple("A", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("B", ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(
+            tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
+
+    // when2
+    client
+        .newActivateAdHocSubprocessActivitiesCommand(
+            String.valueOf(activatedAdHocSubprocess.getKey()))
+        .activateElements("ServiceTask")
+        .send()
+        .join();
+
+    final var createdJob =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstance.getProcessInstanceKey())
+            .getFirst();
+
+    // complete service task with completion condition variable changing to true
+    client.newCompleteCommand(createdJob.getKey()).variable("condition", true).send().join();
+
+    // then2
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstance.getProcessInstanceKey())
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .describedAs("Expect activated activities and whole process to be completed")
+        .contains(
+            tuple("ServiceTask", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  void shouldCancelRemainingInstancesWhenCompletionConditionIsMetAfterActivatingActivities(
+      final TestInfo testInfo) {
+    // given
+    deployAndStartInstance(
+        testInfo,
+        adHocSubProcess -> {
+          adHocSubProcess.completionCondition("condition");
+          adHocSubProcess.cancelRemainingInstances(true);
+          adHocSubProcess.task("A");
+          adHocSubProcess.task("B");
+          adHocSubProcess.serviceTask("ServiceTask", b -> b.zeebeJobType("testType")).task("C");
+        },
+        Map.of("condition", true));
+
+    client.newBroadcastSignalCommand().signalName("setup_signal").send().join();
+
+    assertThat(recordsUpToSignal("setup_signal"))
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .describedAs("Expect ad-hoc subprocess to be activated")
+        .contains(tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .describedAs("Expect no activities to be activated")
+        .doesNotContain(
+            tuple("A", ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple("B", ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple("ServiceTask", ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
+
+    final var activatedAdHocSubprocess =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstance.getProcessInstanceKey())
+            .withElementId(AD_HOC_SUB_PROCESS_ELEMENT_ID)
+            .getFirst();
+
+    // when
+    client
+        .newActivateAdHocSubprocessActivitiesCommand(
+            String.valueOf(activatedAdHocSubprocess.getKey()))
+        .activateElements("A", "ServiceTask")
+        .send()
+        .join();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstance.getProcessInstanceKey())
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .describedAs("Expect service task to be terminated after completion of A")
+        .contains(
+            tuple("A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("ServiceTask", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("A", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("ServiceTask", ProcessInstanceIntent.TERMINATE_ELEMENT),
+            tuple("ServiceTask", ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .describedAs(
+            "Expect service task to never complete and task depending on service task to never be activated")
+        .doesNotContain(
+            tuple("ServiceTask", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("C", ProcessInstanceIntent.ELEMENT_ACTIVATED));
+  }
+
+  @Test
+  void shouldReturnErrorOnCommandRejection(final TestInfo testInfo) {
+    // given
+    deployAndStartInstance(
+        testInfo,
+        adHocSubProcess -> {
+          adHocSubProcess.task("A");
+          adHocSubProcess.task("B");
+          adHocSubProcess.task("C");
+        });
+
+    final var activatedAdHocSubprocess =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstance.getProcessInstanceKey())
+            .withElementId(AD_HOC_SUB_PROCESS_ELEMENT_ID)
+            .getFirst();
+
+    // when/then
     assertThatThrownBy(
             () ->
                 client
@@ -125,26 +276,41 @@ public class ActivateAdHocSubprocessActivityTest {
                 .formatted(activatedAdHocSubprocess.getKey()));
   }
 
-  private void deploy(final TestInfo testInfo) {
+  private void deployAndStartInstance(
+      final TestInfo testInfo, final Consumer<AdHocSubProcessBuilder> modifier) {
+    deployAndStartInstance(testInfo, modifier, Collections.emptyMap());
+  }
+
+  private void deployAndStartInstance(
+      final TestInfo testInfo,
+      final Consumer<AdHocSubProcessBuilder> modifier,
+      final Map<String, Object> variables) {
     processId = "process-" + testInfo.getTestMethod().get().getName();
 
     resourcesHelper.deployProcess(
         Bpmn.createExecutableProcess(processId)
             .startEvent()
-            .adHocSubProcess(
-                AD_HOC_SUB_PROCESS_ELEMENT_ID,
-                adHocSubProcess -> {
-                  adHocSubProcess.task("A");
-                  adHocSubProcess.task("B");
-                  adHocSubProcess.task("C");
-                })
+            .adHocSubProcess(AD_HOC_SUB_PROCESS_ELEMENT_ID, modifier)
             .endEvent()
             .done());
+
+    processInstance =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .variables(variables)
+            .send()
+            .join();
   }
 
-  private static Predicate<Record<RecordValue>> signalBroadcasted(final String signalName) {
-    return r ->
-        r.getIntent() == SignalIntent.BROADCASTED
-            && ((SignalRecord) r.getValue()).getSignalName().equals(signalName);
+  private ProcessInstanceRecordStream recordsUpToSignal(final String signalName) {
+    return RecordingExporter.records()
+        .limit(
+            r ->
+                r.getIntent() == SignalIntent.BROADCASTED
+                    && ((SignalRecord) r.getValue()).getSignalName().equals(signalName))
+        .processInstanceRecords()
+        .withProcessInstanceKey(processInstance.getProcessInstanceKey());
   }
 }


### PR DESCRIPTION
## Description

- Adds client implementations for requesting to activate ad-hoc subprocess activities.

Builds on https://github.com/camunda/camunda/pull/29062

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29053
