### PR TITLE
[Backport 8.7] fix: use forwardslash for file headers in c8run zip

### DIFF
--- a/c8run/e2e_tests/api_tests.sh
+++ b/c8run/e2e_tests/api_tests.sh
@@ -52,7 +52,7 @@ fi
 
 printf "\nTest: test --config flag\n"
 
-PREFIX="$( curl localhost:9600/actuator/configprops | jq '.contexts.application.beans.["io.camunda.tasklist.property.TasklistProperties"].properties.zeebeElasticsearch.prefix' )"
+PREFIX="$( curl localhost:9600/actuator/configprops | jq '.contexts.Camunda.beans.["io.camunda.tasklist.property.TasklistProperties"].properties.zeebeElasticsearch.prefix' )"
 echo $PREFIX
 if [[ "$PREFIX" != "\"extra-prefix-zeebe-record\"" ]]; then
    echo "test failed"

--- a/c8run/internal/archive/archive.go
+++ b/c8run/internal/archive/archive.go
@@ -226,10 +226,12 @@ func ZipSource(sources []string, target string) error {
 			header.Method = zip.Deflate
 
 			header.Name, err = filepath.Rel(filepath.Dir(source), path)
+			header.Name = strings.ReplaceAll(header.Name, "\\", "/")
 			if err != nil {
 				return fmt.Errorf("ZipSource: failed to determine relative path for %s\n%w\n%s", path, err, debug.Stack())
 			}
 			if info.IsDir() {
+				header.Name = strings.ReplaceAll(header.Name, "\\", "/")
 				header.Name += "/"
 			}
 


### PR DESCRIPTION
## Description

backport https://github.com/camunda/camunda/pull/28936

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
