### PR TITLE
[Backport stable/8.6] ci: include Tasklist docker tests in the common CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -500,8 +500,9 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
-  build-tasklist-backend:
+  tasklist-backend-tests:
     if: needs.detect-changes.outputs.tasklist-backend-changes == 'true'
+<<<<<<< HEAD
     needs: [detect-changes]
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -539,6 +540,11 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+=======
+    needs: [ detect-changes ]
+    uses: ./.github/workflows/tasklist-docker-tests.yml
+    secrets: inherit
+>>>>>>> 428d7afe (ci: include Tasklist docker tests in the common CI)
 
   optimize-frontend-unit-tests:
     if: needs.detect-changes.outputs.optimize-frontend-changes == 'true'
@@ -695,7 +701,6 @@ jobs:
       - actionlint
       - build-operate-backend
       - build-platform-frontend
-      - build-tasklist-backend
       - detect-changes
       - docker-checks
       - identity-frontend-tests
@@ -706,6 +711,11 @@ jobs:
       - optimize-backend-unit-tests
       - optimize-frontend-unit-tests
       - protobuf-checks
+<<<<<<< HEAD
+=======
+      - rdbms-h2-integration-tests
+      - tasklist-backend-tests
+>>>>>>> 428d7afe (ci: include Tasklist docker tests in the common CI)
       - tasklist-frontend-tests
       - zeebe-ci
     steps:

--- a/.github/workflows/tasklist-docker-tests.yml
+++ b/.github/workflows/tasklist-docker-tests.yml
@@ -1,6 +1,7 @@
 ---
 name: Tasklist Docker Tests
 on:
+<<<<<<< HEAD
   push:
     branches:
       - 'main'
@@ -35,43 +36,41 @@ concurrency:
 jobs:
   integration-tests:
     name: Docker container tests
+=======
+  workflow_dispatch: { }
+  workflow_call: { }
+
+jobs:
+  integration-tests:
+    name: Tasklist Docker tests
+>>>>>>> 428d7afe (ci: include Tasklist docker tests in the common CI)
     runs-on: gcp-core-4-default
-    timeout-minutes: 40
-    env:
-      TASKLIST_TEST_DOCKER_IMAGE: localhost:5000/camunda/tasklist:current-test
-      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+    timeout-minutes: 15
+    permissions: {}  # GITHUB_TOKEN unused in this job
     services:
       registry:
         image: registry:2
         ports:
           - 5000:5000
     steps:
-      - name: Check out repository code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - name: Test Dockerfile with Hadolint
-        uses: hadolint/hadolint-action@v3.1.0
+      - uses: actions/checkout@v4
+      - uses: hadolint/hadolint-action@v3.1.0
         with:
           ignore: DL3018 # redundant when pinning the base image
           dockerfile: tasklist.Dockerfile
-      - name: Import Secrets
-        id: secrets
-        uses: hashicorp/vault-action@a1b77a09293a4366e48a5067a86692ac6e94fdc0
+      - uses: ./.github/actions/setup-build
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secrets: |
-            secret/data/github.com/organizations/camunda NEXUS_USR;
-            secret/data/github.com/organizations/camunda NEXUS_PSW;
-      - name: Setup Java
-        uses: actions/setup-java@v4
+          dockerhub-readonly: true
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - id: build-backend
+        uses: ./.github/actions/build-zeebe
         with:
-          distribution: "adopt"
-          java-version: "21"
-      - name: Setup Maven
-        uses: ./.github/actions/setup-maven-dist
+          maven-extra-args: -D skip.fe.build -D skipOptimize
+      - uses: ./.github/actions/build-platform-docker
         with:
+<<<<<<< HEAD
           maven-version: "3.9.6"
           set-mvnw: true
       # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
@@ -99,16 +98,20 @@ jobs:
           DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: .
+=======
+          repository: localhost:5000/camunda/tasklist
+          version: current-test
+>>>>>>> 428d7afe (ci: include Tasklist docker tests in the common CI)
           push: true
-          tags: ${{ env.TASKLIST_TEST_DOCKER_IMAGE }}
-          file: tasklist.Dockerfile
+          distball: ${{ steps.build-backend.outputs.distball }}
+          dockerfile: tasklist.Dockerfile
       - name: Run Docker tests
-        run: ./mvnw -pl tasklist/qa/integration-tests -DskipChecks -Dtest=StartupIT -Dsurefire.failIfNoSpecifiedTests=false -Dspring.profiles.active=docker-test test
+        run: ./mvnw --no-snapshot-updates -pl tasklist/qa/integration-tests -DskipChecks -Dtest=StartupIT -Dsurefire.failIfNoSpecifiedTests=false -Dspring.profiles.active=docker-test test
       - name: Upload Test Report
         if: failure()
         uses: ./.github/actions/collect-test-artifacts
         with:
-          name: "docker tests"
+          name: "tasklist docker tests"
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
# Description
Backport of #29005 to `stable/8.6`.

relates to 