### PR TITLE
build: fix container health check

### DIFF
--- a/.github/actions/compose/healthy.sh
+++ b/.github/actions/compose/healthy.sh
@@ -3,22 +3,8 @@
 # docker compose --> v2 (GA)
 # docker-compose --> v1 (missing some newer flags)
 # Edge case; Self-hosted runners don't support "docker compose" yet even though on v2
-VERSION=$(docker-compose version --short)
 
-echo "Detected docker-compose version: $VERSION"
-
-if [[ "$VERSION" =~ ^1\.[0-9]+\.[0-9]+ ]]; then
-    # if docker-compose is v1, we're setting it to docker compose, which should be v2
-    echo "Detected v1, setting to v2"
-    echo "Using docker compose (not docker-compose): $(docker compose version)"
-    DOCKER_COMMAND="docker compose -f ${FILE} ${COMPOSE_FLAGS}"
-else
-    # e.g. locally or on self-hosted runners docker-compose can be v2
-    echo "Detected v2"
-    echo "Using docker-compose (not docker compose): $(docker-compose version)"
-    DOCKER_COMMAND="docker-compose -f ${FILE} ${COMPOSE_FLAGS}"
-fi
-
+DOCKER_COMMAND="docker compose -f ${FILE} ${COMPOSE_FLAGS}"
 eval $DOCKER_COMMAND ps
 eval $DOCKER_COMMAND logs
 

--- a/optimize/client/docker-compose.yml
+++ b/optimize/client/docker-compose.yml
@@ -193,7 +193,7 @@ services:
     ports:
       - '28080:8080'
     healthcheck:
-      test: ['CMD-SHELL', "wget -O - -q 'http://localhost:28080/actuator/health/readiness'"]
+      test: ['CMD-SHELL', "wget -O - -q 'http://localhost:8080/actuator/health/readiness'"]
       interval: 30s
       timeout: 1s
       retries: 5
@@ -225,7 +225,7 @@ services:
     ports:
       - '28080:8080'
     healthcheck:
-      test: ['CMD-SHELL', "wget -O - -q 'http://localhost:28080/actuator/health/readiness'"]
+      test: ['CMD-SHELL', "wget -O - -q 'http://localhost:8080/actuator/health/readiness'"]
       interval: 30s
       timeout: 1s
       retries: 5


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
* the use of the deprecated command `docker-compose` instead of the new `docker compose` is causing issues in some pipelines, with the consequence that we're not actually checking whether the containers are healthy or not
* in fact, we couldn't detect that the health check for operate was wrong (it was using the exposed port against localhost instead of the internal port that's effectively available within localhost)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
