### PR TITLE
test: remove ES/OS exporter from multi db

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
@@ -122,10 +122,9 @@ public class BackupRestoreIT {
             dbUrl = "http://" + container.getHttpHostAddress();
 
             // configure the app
-            configurator.configureElasticsearchSupport(dbUrl, INDEX_PREFIX);
+            configurator.configureElasticsearchSupportIncludingOldExporter(dbUrl, INDEX_PREFIX);
             yield container;
           }
-
           case OPENSEARCH -> {
             final var container =
                 TestSearchContainers.createDefaultOpensearchContainer()
@@ -134,7 +133,8 @@ public class BackupRestoreIT {
                     .withEnv("path.repo", "~/");
             container.start();
             dbUrl = container.getHttpHostAddress();
-            configurator.configureOpenSearchSupport(dbUrl, INDEX_PREFIX, "admin", "admin");
+            configurator.configureOpenSearchSupportIncludingOldExporter(
+                dbUrl, INDEX_PREFIX, "admin", "admin");
             yield container;
           }
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
@@ -236,7 +236,7 @@ public class PrefixMigrationIT {
     final MultiDbConfigurator multiDbConfigurator =
         new MultiDbConfigurator(testSimpleCamundaApplication);
     final var esUrl = String.format("http://localhost:%d", esContainer.getMappedPort(9200));
-    multiDbConfigurator.configureElasticsearchSupport(esUrl, NEW_PREFIX);
+    multiDbConfigurator.configureElasticsearchSupportIncludingOldExporter(esUrl, NEW_PREFIX);
     testSimpleCamundaApplication.start();
     testSimpleCamundaApplication.awaitCompleteTopology();
 

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -9,6 +9,7 @@ package io.camunda.qa.util.multidb;
 
 import io.camunda.exporter.CamundaExporter;
 import io.camunda.search.connect.configuration.DatabaseType;
+import io.camunda.zeebe.exporter.ElasticsearchExporter;
 import io.camunda.zeebe.exporter.opensearch.OpensearchExporter;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
 import java.util.HashMap;
@@ -26,6 +27,22 @@ public class MultiDbConfigurator {
 
   public MultiDbConfigurator(final TestStandaloneApplication<?> testApplication) {
     this.testApplication = testApplication;
+  }
+
+  public void configureElasticsearchSupportIncludingOldExporter(
+      final String elasticsearchUrl, final String indexPrefix) {
+    configureElasticsearchSupport(elasticsearchUrl, indexPrefix);
+
+    testApplication.withExporter(
+        "ElasticsearchExporter",
+        cfg -> {
+          cfg.setClassName(ElasticsearchExporter.class.getName());
+          cfg.setArgs(
+              Map.of(
+                  "url", elasticsearchUrl,
+                  "index", Map.of("prefix", zeebeIndexPrefix()),
+                  "bulk", Map.of("size", 1)));
+        });
   }
 
   public void configureElasticsearchSupport(
@@ -72,6 +89,30 @@ public class MultiDbConfigurator {
                   Map.of("prefix", indexPrefix),
                   "bulk",
                   Map.of("size", 1)));
+        });
+  }
+
+  public void configureOpenSearchSupportIncludingOldExporter(
+      final String opensearchUrl,
+      final String indexPrefix,
+      final String userName,
+      final String userPassword) {
+    configureOpenSearchSupport(opensearchUrl, indexPrefix, userName, userPassword);
+
+    testApplication.withExporter(
+        "OpensearchExporter",
+        cfg -> {
+          cfg.setClassName(OpensearchExporter.class.getName());
+          cfg.setArgs(
+              Map.of(
+                  "url",
+                  opensearchUrl,
+                  "index",
+                  Map.of("prefix", zeebeIndexPrefix()),
+                  "bulk",
+                  Map.of("size", 1),
+                  "authentication",
+                  Map.of("username", userName, "password", userPassword)));
         });
   }
 

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -9,7 +9,6 @@ package io.camunda.qa.util.multidb;
 
 import io.camunda.exporter.CamundaExporter;
 import io.camunda.search.connect.configuration.DatabaseType;
-import io.camunda.zeebe.exporter.ElasticsearchExporter;
 import io.camunda.zeebe.exporter.opensearch.OpensearchExporter;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
 import java.util.HashMap;
@@ -74,17 +73,6 @@ public class MultiDbConfigurator {
                   "bulk",
                   Map.of("size", 1)));
         });
-
-    testApplication.withExporter(
-        "ElasticsearchExporter",
-        cfg -> {
-          cfg.setClassName(ElasticsearchExporter.class.getName());
-          cfg.setArgs(
-              Map.of(
-                  "url", elasticsearchUrl,
-                  "index", Map.of("prefix", zeebeIndexPrefix()),
-                  "bulk", Map.of("size", 1)));
-        });
   }
 
   public void configureOpenSearchSupport(
@@ -146,22 +134,6 @@ public class MultiDbConfigurator {
                   Map.of("prefix", indexPrefix),
                   "bulk",
                   Map.of("size", 1)));
-        });
-
-    testApplication.withExporter(
-        "OpensearchExporter",
-        cfg -> {
-          cfg.setClassName(OpensearchExporter.class.getName());
-          cfg.setArgs(
-              Map.of(
-                  "url",
-                  opensearchUrl,
-                  "index",
-                  Map.of("prefix", zeebeIndexPrefix()),
-                  "bulk",
-                  Map.of("size", 1),
-                  "authentication",
-                  Map.of("username", userName, "password", userPassword)));
         });
   }
 


### PR DESCRIPTION
## Description
 * As we target greenfield, we no longer need to configure ES/OS exporter per default in our IT

## Related issues

closes #28832 
