### PR TITLE
refactor: disable importers

### DIFF
--- a/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
@@ -36,7 +36,7 @@ public class StandaloneCamunda {
     MainSupport.putSystemPropertyIfAbsent(
         "spring.banner.location", "classpath:/assets/camunda_banner.txt");
 
-    final var defaultActiveProfiles = getDefaultActiveProfiles();
+    final var defaultProperties = getDefaultProperties();
     final var standaloneCamundaApplication =
         MainSupport.createDefaultApplicationBuilder()
             .sources(
@@ -47,7 +47,9 @@ public class StandaloneCamunda {
                 WebappsModuleConfiguration.class,
                 BrokerModuleConfiguration.class,
                 GatewayModuleConfiguration.class)
-            .properties(defaultActiveProfiles)
+            // https://docs.spring.io/spring-boot/docs/2.3.9.RELEASE/reference/html/spring-boot-features.html#boot-features-external-config
+            // Default properties are only used, if not overridden by any other config
+            .properties(defaultProperties)
             .initializers(
                 new DefaultAuthenticationInitializer(),
                 new HealthConfigurationInitializer(),
@@ -58,9 +60,14 @@ public class StandaloneCamunda {
     standaloneCamundaApplication.run(args);
   }
 
-  public static Map<String, Object> getDefaultActiveProfiles() {
+  public static Map<String, Object> getDefaultProperties() {
     final var defaultProperties = new HashMap<String, Object>();
     defaultProperties.put(SPRING_PROFILES_ACTIVE_PROPERTY, DEFAULT_CAMUNDA_PROFILES);
+    // Per default, we target a green field installation with the StandaloneCamunda application.
+    // Meaning, we will disable the importers per default
+    // Importers can still be enabled by configuration
+    defaultProperties.put("camunda.operate.importerEnabled", "false");
+    defaultProperties.put("camunda.tasklist.importerEnabled", "false");
     return defaultProperties;
   }
 }


### PR DESCRIPTION
## Description

 * We target greenfield installation with the StandaloneCamunda app
 * Importers are only needed for old/brown field installations, such we disable Importer per default
 * Importers are disabled by default properties
 * Default properties can be overridden by any other configuration based on Spring docs
<!-- Describe the goal and purpose of this PR. -->

## Alternative

We could also argue for setting the default importerEnabled to `false'. Here, I was not sure whether this was something we wanted, especially if we still want to run StandaloneOperate (which is likely a brown field scenario). Furthermore, it might also involve a bit more work for adjusting integration tests. But I haven't validated it.

## Related issues

Context: https://camunda.slack.com/archives/C05QBRGMA9F/p1740560922880599?thread_ts=1739367026.901869&cid=C05QBRGMA9F

closes https://github.com/camunda/camunda/issues/28830
