### PR TITLE
ci: enforce fields named "...Key" are of type `string` in API spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -937,7 +937,7 @@ jobs:
           vacuum lint zeebe/gateway-protocol/src/main/proto/rest-api.yaml
           --ruleset zeebe/gateway-protocol/vacuum-ruleset.yaml
           --ignore-file zeebe/gateway-protocol/vacuum-ignores.yaml
-          --details --errors
+          --details --no-clip --errors
         shell: bash
       - name: Observe build status
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -937,7 +937,7 @@ jobs:
           vacuum lint zeebe/gateway-protocol/src/main/proto/rest-api.yaml
           --ruleset zeebe/gateway-protocol/vacuum-ruleset.yaml
           --ignore-file zeebe/gateway-protocol/vacuum-ignores.yaml
-          --function zeebe/gateway-protocol/vacuum-rules
+          --functions zeebe/gateway-protocol/vacuum-rules
           --details --no-clip --errors
         shell: bash
       - name: Observe build status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -937,6 +937,7 @@ jobs:
           vacuum lint zeebe/gateway-protocol/src/main/proto/rest-api.yaml
           --ruleset zeebe/gateway-protocol/vacuum-ruleset.yaml
           --ignore-file zeebe/gateway-protocol/vacuum-ignores.yaml
+          --function zeebe/gateway-protocol/vacuum-rules
           --details --no-clip --errors
         shell: bash
       - name: Observe build status

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateDocumentBatchCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateDocumentBatchCommandImpl.java
@@ -27,6 +27,7 @@ import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.DocumentReferenceBatchResponseImpl;
 import io.camunda.client.impl.util.DocumentBuilder;
+import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.DocumentCreationBatchResponse;
 import java.io.InputStream;
 import java.time.Duration;
@@ -91,7 +92,7 @@ public class CreateDocumentBatchCommandImpl implements CreateDocumentBatchComman
           document.getMetadata().setProcessDefinitionId(processDefinitionId);
         }
         if (processInstanceKey != null) {
-          document.getMetadata().setProcessInstanceKey(processInstanceKey);
+          document.getMetadata().setProcessInstanceKey(ParseUtil.keyToString(processInstanceKey));
         }
         final String metadataString = jsonMapper.toJson(document.getMetadata());
         final MultipartPart part =

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateDocumentCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateDocumentCommandImpl.java
@@ -27,6 +27,7 @@ import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.DocumentReferenceResponseImpl;
 import io.camunda.client.impl.util.DocumentBuilder;
+import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.DocumentReference;
 import java.io.InputStream;
 import java.time.Duration;
@@ -177,7 +178,7 @@ public class CreateDocumentCommandImpl extends DocumentBuilder
 
   @Override
   public CreateDocumentCommandStep2 processInstanceKey(final long processInstanceKey) {
-    super.getMetadata().setProcessInstanceKey(processInstanceKey);
+    super.getMetadata().setProcessInstanceKey(ParseUtil.keyToString(processInstanceKey));
     return this;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/DocumentMetadataImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/DocumentMetadataImpl.java
@@ -16,6 +16,7 @@
 package io.camunda.client.impl.response;
 
 import io.camunda.client.api.response.DocumentMetadata;
+import io.camunda.client.impl.util.ParseUtil;
 import java.time.OffsetDateTime;
 import java.util.Map;
 
@@ -63,7 +64,7 @@ public class DocumentMetadataImpl implements DocumentMetadata {
 
   @Override
   public Long getProcessInstanceKey() {
-    return response.getProcessInstanceKey();
+    return ParseUtil.parseLongOrNull(response.getProcessInstanceKey());
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateDocumentBatchCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateDocumentBatchCommandImpl.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.client.impl.command;
 
 import static io.camunda.zeebe.client.impl.command.ArgumentUtil.ensureNotNull;
 
+import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.DocumentCreationBatchResponse;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
@@ -91,7 +92,7 @@ public class CreateDocumentBatchCommandImpl implements CreateDocumentBatchComman
           document.getMetadata().setProcessDefinitionId(processDefinitionId);
         }
         if (processInstanceKey != null) {
-          document.getMetadata().setProcessInstanceKey(processInstanceKey);
+          document.getMetadata().setProcessInstanceKey(ParseUtil.keyToString(processInstanceKey));
         }
         final String metadataString = jsonMapper.toJson(document.getMetadata());
         final MultipartPart part =

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateDocumentCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateDocumentCommandImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.command;
 
+import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.DocumentReference;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
@@ -175,7 +176,7 @@ public class CreateDocumentCommandImpl extends DocumentBuilder
 
   @Override
   public CreateDocumentCommandStep2 processInstanceKey(final long processInstanceKey) {
-    super.getMetadata().setProcessInstanceKey(processInstanceKey);
+    super.getMetadata().setProcessInstanceKey(ParseUtil.keyToString(processInstanceKey));
     return this;
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DocumentMetadataImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DocumentMetadataImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.response;
 
+import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.zeebe.client.api.response.DocumentMetadata;
 import java.time.OffsetDateTime;
 import java.util.Map;
@@ -63,7 +64,7 @@ public class DocumentMetadataImpl implements DocumentMetadata {
 
   @Override
   public Long getProcessInstanceKey() {
-    return response.getProcessInstanceKey();
+    return ParseUtil.parseLongOrNull(response.getProcessInstanceKey());
   }
 
   @Override

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -583,8 +583,7 @@ paths:
           required: true
           description: The unique identifier of the mapping rule.
           schema:
-            type: integer
-            format: int64
+            type: string
       responses:
         "202":
           description: The mapping rule was successfully assigned to the tenant.
@@ -619,8 +618,7 @@ paths:
           required: true
           description: The unique identifier of the mapping rule.
           schema:
-            type: integer
-            format: int64
+            type: string
       responses:
         "202":
           description: The mapping rule was successfully removed from the tenant.
@@ -656,8 +654,7 @@ paths:
           required: true
           description: The unique identifier of the group.
           schema:
-            type: integer
-            format: int64
+            type: string
       responses:
         "202":
           description: The group was successfully assigned to the tenant.
@@ -692,8 +689,7 @@ paths:
           required: true
           description: The unique identifier of the group.
           schema:
-            type: integer
-            format: int64
+            type: string
       responses:
         "202":
           description: The group was successfully removed from the tenant.
@@ -2024,8 +2020,7 @@ paths:
           required: true
           description: The key of the authorization to delete.
           schema:
-            type: integer
-            format: int64
+            type: string
       requestBody:
         content:
           application/json:
@@ -2057,8 +2052,7 @@ paths:
           required: true
           description: The key of the authorization to delete.
           schema:
-            type: integer
-            format: int64
+            type: string
       responses:
         "204":
           description: The authorization was deleted successfully.
@@ -2399,8 +2393,7 @@ paths:
           required: true
           description: The user key.
           schema:
-            type: integer
-            format: int64
+            type: string
       responses:
         "202":
           description: The user was assigned successfully to the group.
@@ -6550,8 +6543,7 @@ components:
           type: string
           description: The ID of the process definition that created the document.
         processInstanceKey:
-          type: integer
-          format: int64
+          type: string
           description: The key of the process instance that created the document.
         customProperties:
           type: object

--- a/zeebe/gateway-protocol/vacuum-rules/verifyKeyTypesPaths.js
+++ b/zeebe/gateway-protocol/vacuum-rules/verifyKeyTypesPaths.js
@@ -9,7 +9,7 @@ function runRule(input) {
   if (/Key$/.test(name) && type !== "string") {
     return [
       {
-        message: "`...Key` properties must be of type `string`.",
+        message: `\`${name}\` parameter must be of type \`string\`.`,
       },
     ];
   }

--- a/zeebe/gateway-protocol/vacuum-rules/verifyKeyTypesPaths.js
+++ b/zeebe/gateway-protocol/vacuum-rules/verifyKeyTypesPaths.js
@@ -1,0 +1,17 @@
+function runRule(input) {
+  // `input` is a single path parameter.
+  //   Identify if its name ends with Key, and it is not a string.
+  const {
+    name,
+    schema: { type },
+  } = input;
+
+  if (/Key$/.test(name) && type !== "string") {
+    return [
+      {
+        message: "`...Key` properties must be of type `string`.",
+      },
+    ];
+  }
+  return null;
+}

--- a/zeebe/gateway-protocol/vacuum-rules/verifyKeyTypesSchemas.js
+++ b/zeebe/gateway-protocol/vacuum-rules/verifyKeyTypesSchemas.js
@@ -1,0 +1,13 @@
+function runRule(input) {
+  // `input` is an entire schema object with all properties.
+  //   Identify all properties that end with Key, and are not strings.
+  return Object.entries(input)
+    .filter(([name, schema]) => {
+      return /Key$/.test(name) && schema.type !== "string";
+    })
+    .map((_) => {
+      return {
+        message: "`...Key` properties must be of type `string`.",
+      };
+    });
+}

--- a/zeebe/gateway-protocol/vacuum-rules/verifyKeyTypesSchemas.js
+++ b/zeebe/gateway-protocol/vacuum-rules/verifyKeyTypesSchemas.js
@@ -1,13 +1,17 @@
 function runRule(input) {
   // `input` is an entire schema object with all properties.
-  //   Identify all properties that end with Key, and are not strings.
+  //   Identify all properties that end with Key, and are not strings or allOfs.
   return Object.entries(input)
     .filter(([name, schema]) => {
-      return /Key$/.test(name) && schema.type !== "string";
+      return (
+        /Key$/.test(name) &&
+        schema.type !== "string" &&
+        !Array.isArray(schema.allOf)
+      );
     })
     .map(([name]) => {
       return {
-        message: `\`${name}\` property must be of type \`string\`.`,
+        message: `\`${name}\` property must be of type \`string\` or \`BasicStringFilterProperty\`.`,
       };
     });
 }

--- a/zeebe/gateway-protocol/vacuum-rules/verifyKeyTypesSchemas.js
+++ b/zeebe/gateway-protocol/vacuum-rules/verifyKeyTypesSchemas.js
@@ -9,8 +9,7 @@ function runRule(input) {
         !composesBasicStringFilterProperty(schema)
       );
     })
-    .map(([name, schema]) => {
-      console.log(JSON.stringify(schema, null, 2));
+    .map(([name]) => {
       return {
         message: `\`${name}\` property must be of type \`string\` or \`BasicStringFilterProperty\`.`,
       };

--- a/zeebe/gateway-protocol/vacuum-rules/verifyKeyTypesSchemas.js
+++ b/zeebe/gateway-protocol/vacuum-rules/verifyKeyTypesSchemas.js
@@ -6,12 +6,29 @@ function runRule(input) {
       return (
         /Key$/.test(name) &&
         schema.type !== "string" &&
-        !Array.isArray(schema.allOf)
+        !composesBasicStringFilterProperty(schema)
       );
     })
-    .map(([name]) => {
+    .map(([name, schema]) => {
+      console.log(JSON.stringify(schema, null, 2));
       return {
         message: `\`${name}\` property must be of type \`string\` or \`BasicStringFilterProperty\`.`,
       };
     });
+}
+
+function composesBasicStringFilterProperty(schema) {
+  // This is what we're looking for, but it catches false negatives!
+  //   For some reason, _some_ allOf arrays are expanded inline, while most include the unexpanded `$ref`.
+
+  //   if (!Array.isArray(schema.allOf)) {
+  //     return false;
+  //   }
+
+  //   return schema.allOf.some((subSchema) => {
+  //     return subSchema.$ref === "#/components/schemas/BasicStringFilterProperty";
+  //   });
+
+  // This is a simpler alternative, which could catch false positives instead, if we compose a schema other than BasicStringFilterProperty.
+  return Array.isArray(schema.allOf);
 }

--- a/zeebe/gateway-protocol/vacuum-rules/verifyKeyTypesSchemas.js
+++ b/zeebe/gateway-protocol/vacuum-rules/verifyKeyTypesSchemas.js
@@ -5,9 +5,9 @@ function runRule(input) {
     .filter(([name, schema]) => {
       return /Key$/.test(name) && schema.type !== "string";
     })
-    .map((_) => {
+    .map(([name]) => {
       return {
-        message: "`...Key` properties must be of type `string`.",
+        message: `\`${name}\` property must be of type \`string\`.`,
       };
     });
 }

--- a/zeebe/gateway-protocol/vacuum-ruleset.yaml
+++ b/zeebe/gateway-protocol/vacuum-ruleset.yaml
@@ -4,9 +4,7 @@ rules:
   operation-tag-defined: error
   no-period-in-summary:
     category:
-      description: Operations are the core of the contract, they define paths and HTTP methods. These rules check operations have been well constructed, looks for operationId, parameter, schema and return types in depth.
       id: operations
-      name: Operations
     description: Path summary must not include period
     formats:
       - oas3
@@ -23,12 +21,30 @@ rules:
     type: validation
   require-property-descriptions:
     category:
-      description: Documentation is really important, in OpenAPI, just about everything can and should have a description. This set of rules checks for absent descriptions, poor quality descriptions (copy/paste), or short descriptions.
       id: descriptions
-      name: Descriptions
     description: Schema properties must have a description.
     given: $.components.schemas[*].properties[*]
     then:
       field: description
       function: truthy
+    severity: error
+  operation-key-properties-must-be-strings:
+    category:
+      id: operations
+    id: operation-key-properties-must-be-strings
+    description: "`...Key` parameters must be of type `string`."
+    howToFix: Make the `...Key` property a `string`.
+    given: $.paths[*][*].parameters[*]
+    then:
+      function: verifyKeyTypesPaths
+    severity: error
+  schema-key-properties-must-be-strings:
+    category:
+      id: schemas
+    id: schema-key-properties-must-be-strings
+    description: "`...Key` parameters must be of type `string`."
+    howToFix: Make the `...Key` property a `string`.
+    given: $.components.schemas[*].properties
+    then:
+      function: verifyKeyTypesSchemas
     severity: error

--- a/zeebe/gateway-protocol/vacuum-ruleset.yaml
+++ b/zeebe/gateway-protocol/vacuum-ruleset.yaml
@@ -42,7 +42,7 @@ rules:
     category:
       id: schemas
     id: schema-key-properties-must-be-strings
-    description: "`...Key` parameters must be of type `string`."
+    description: "`...Key` properties must be of type `string`."
     howToFix: Make the `...Key` property a `string`.
     given: $.components.schemas[*].properties
     then:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -652,7 +652,7 @@ public class RequestMapper {
         expiresAt,
         file.getSize(),
         metadata.getProcessDefinitionId(),
-        metadata.getProcessInstanceKey(),
+        KeyUtil.keyToLong(metadata.getProcessInstanceKey()),
         metadata.getCustomProperties());
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -281,7 +281,7 @@ public final class ResponseMapper {
             .size(internalMetadata.size())
             .contentType(internalMetadata.contentType())
             .processDefinitionId(internalMetadata.processDefinitionId())
-            .processInstanceKey(internalMetadata.processInstanceKey());
+            .processInstanceKey(KeyUtil.keyToString(internalMetadata.processInstanceKey()));
     Optional.ofNullable(internalMetadata.customProperties())
         .ifPresent(map -> map.forEach(externalMetadata::putCustomPropertiesItem));
     return new DocumentReference()


### PR DESCRIPTION
## Description

Prompted by https://github.com/camunda/camunda/issues/27169#issuecomment-2688856574.

Adds custom vacuum rules to validate that fields in the spec whose name ends with `Key` are of type `string`.

Does not yet correct the violations of this rule, because I want to make sure we want to enforce this rule.  

## Implementation details & decisions

- Vacuum supports custom rules written in either [Go](https://quobix.com/vacuum/api/custom-functions/) or [JavaScript](https://quobix.com/vacuum/api/custom-javascript-functions/). I chose JavaScript because I don't know Go, and I think JavaScript is more widely understood. Let me know if you disagree and think these rules should be written in Go.
- I only checked for names _ending_ in `Key`, because I think we expect key names to be qualified with their entity, and any properties named just `key` are incorrect in a different way.
- I'll add a couple inline notes for other small details.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)


closes #
