### PR TITLE
fix: populate storeId in batch upload doc response

### DIFF
--- a/service/src/test/java/io/camunda/service/DocumentServicesTest.java
+++ b/service/src/test/java/io/camunda/service/DocumentServicesTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.document.api.DocumentCreationRequest;
+import io.camunda.document.api.DocumentMetadataModel;
+import io.camunda.document.api.DocumentReference;
+import io.camunda.document.api.DocumentStore;
+import io.camunda.document.api.DocumentStoreRecord;
+import io.camunda.document.store.SimpleDocumentStoreRegistry;
+import io.camunda.security.auth.Authentication;
+import io.camunda.service.DocumentServices.DocumentCreateRequest;
+import io.camunda.service.DocumentServices.DocumentReferenceResponse;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.util.Either;
+import java.io.ByteArrayInputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class DocumentServicesTest {
+
+  private DocumentServices services;
+  private final SimpleDocumentStoreRegistry registry = mock(SimpleDocumentStoreRegistry.class);
+
+  @BeforeEach
+  public void before() {
+    services =
+        new DocumentServices(
+            mock(BrokerClient.class),
+            mock(SecurityContextProvider.class),
+            mock(Authentication.class),
+            registry);
+  }
+
+  @Test
+  public void shouldUploadBatchWithoutStoreId() {
+    // given
+    final var storeRecord = mock(DocumentStoreRecord.class);
+    final var storeInstance = mock(DocumentStore.class);
+    final var storeId = "in-memory-store";
+    when(storeRecord.instance()).thenReturn(storeInstance);
+    when(storeRecord.storeId()).thenReturn(storeId);
+    when(registry.getDefaultDocumentStore()).thenReturn(storeRecord);
+
+    final var content1 = "hello world";
+    final var file1 = createDocRequest(content1);
+    final var expectedResult1 = createDocumentReference(file1);
+    when(storeInstance.createDocument(
+            new DocumentCreationRequest(
+                file1.documentId(), file1.contentInputStream(), file1.metadata())))
+        .thenReturn(CompletableFuture.completedFuture(Either.right(expectedResult1)));
+
+    final var content2 = "Sup\nworld";
+    final var file2 = createDocRequest(content2);
+    final var expectedResult2 = createDocumentReference(file2);
+    when(storeInstance.createDocument(
+            new DocumentCreationRequest(
+                file2.documentId(), file2.contentInputStream(), file2.metadata())))
+        .thenReturn(CompletableFuture.completedFuture(Either.right(expectedResult2)));
+
+    // when
+    final var response = services.createDocumentBatch(List.of(file1, file2)).join();
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response).size().isEqualTo(2);
+
+    assertThat(response.get(0).isRight()).isTrue();
+    assertThat(response.get(0).get())
+        .isEqualTo(
+            new DocumentReferenceResponse(
+                expectedResult1.documentId(),
+                storeId,
+                expectedResult1.contentHash(),
+                expectedResult1.metadata()));
+
+    assertThat(response.get(1).isRight()).isTrue();
+    assertThat(response.get(1).get())
+        .isEqualTo(
+            new DocumentReferenceResponse(
+                expectedResult2.documentId(),
+                storeId,
+                expectedResult2.contentHash(),
+                expectedResult2.metadata()));
+
+    verify(registry, times(2)).getDefaultDocumentStore();
+    verify(storeRecord, times(2)).instance();
+  }
+
+  private DocumentCreateRequest createDocRequest(final String content) {
+    return new DocumentCreateRequest(
+        null,
+        null,
+        new ByteArrayInputStream(content.getBytes()),
+        new DocumentMetadataModel(
+            "text/plain",
+            UUID.randomUUID() + ".txt",
+            null,
+            (long) content.length(),
+            null,
+            null,
+            Map.of()));
+  }
+
+  private DocumentReference createDocumentReference(final DocumentCreateRequest request) {
+    return new DocumentReference(
+        request.documentId() != null ? request.documentId() : UUID.randomUUID().toString(),
+        UUID.randomUUID().toString(),
+        new DocumentMetadataModel(
+            request.metadata().contentType(),
+            request.metadata().fileName(),
+            null,
+            request.metadata().size(),
+            request.metadata().processDefinitionId(),
+            request.metadata().processInstanceKey(),
+            request.metadata().customProperties()));
+  }
+}


### PR DESCRIPTION
## Description

Before

```
{
    "createdDocuments": [
        {
            "camunda.document.type": "camunda",
            "documentId": "f3822ebe-0dcb-41df-9d33-3021ac6e3c73",
            "contentHash": "5e33cf725cd6062ffea9d47ef278808e872b8cf8796fce043c1823eb29e677f6",
            "metadata": {
                "contentType": "image/jpeg",
                "fileName": "doc_handling.jpg",
                "size": 40171,
                "customProperties": {}
            }
        },
        {
            "camunda.document.type": "camunda",
            "documentId": "c40c09f9-3810-4559-92d8-5f820d54bff4",
            "contentHash": "02027882d03fbee820a7e4231b2dff107fbd2b1390f6798ad4fe50bd9a913600",
            "metadata": {
                "contentType": "application/pdf",
                "fileName": "example.pdf",
                "size": 174316,
                "customProperties": {}
            }
        }
    ],
    "failedDocuments": []
}
```
Notice the absence of `storeId`.

After

```
{
    "createdDocuments": [
        {
            "camunda.document.type": "camunda",
            "storeId": "inmemory",
            "documentId": "3e5ef62b-fff5-4198-806a-169377e8dff7",
            "contentHash": "5e33cf725cd6062ffea9d47ef278808e872b8cf8796fce043c1823eb29e677f6",
            "metadata": {
                "contentType": "image/jpeg",
                "fileName": "doc_handling.jpg",
                "size": 40171,
                "customProperties": {}
            }
        },
        {
            "camunda.document.type": "camunda",
            "storeId": "inmemory",
            "documentId": "e3d215be-f48d-4fc5-ba59-b2b3a098d3c2",
            "contentHash": "02027882d03fbee820a7e4231b2dff107fbd2b1390f6798ad4fe50bd9a913600",
            "metadata": {
                "contentType": "application/pdf",
                "fileName": "example.pdf",
                "size": 174316,
                "customProperties": {}
            }
        }
    ],
    "failedDocuments": []
}
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Relates to https://github.com/camunda/camunda/issues/29106
