### PR TITLE
More lenient id validations

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/IdentifierPatterns.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/IdentifierPatterns.java
@@ -13,12 +13,8 @@ public final class IdentifierPatterns {
 
   public static final int MAX_LENGTH = 256;
 
-  /** 1 or more alphanumeric characters, '@', '.', or '_'. */
-  public static final String USERNAME_REGEX = "[a-zA-Z0-9@._]+";
+  /** 1 or more alphanumeric characters, '_', '@', '.', or '-'. */
+  public static final String ID_REGEX = "^[a-zA-Z0-9_@.-]+$";
 
-  /** 1 or more alphanumeric characters. */
-  public static final String ID_REGEX = "[a-zA-Z0-9]+";
-
-  public static final Pattern USERNAME_PATTERN = Pattern.compile(USERNAME_REGEX);
   public static final Pattern ID_PATTERN = Pattern.compile(ID_REGEX);
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/UserValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/UserValidator.java
@@ -11,9 +11,9 @@ import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAG
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_ILLEGAL_CHARACTER;
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_INVALID_EMAIL;
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_TOO_MANY_CHARACTERS;
+import static io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns.ID_PATTERN;
+import static io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns.ID_REGEX;
 import static io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns.MAX_LENGTH;
-import static io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns.USERNAME_PATTERN;
-import static io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns.USERNAME_REGEX;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
 
 import io.camunda.zeebe.gateway.protocol.rest.UserRequest;
@@ -50,8 +50,8 @@ public final class UserValidator {
       violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("username"));
     } else if (username.length() > MAX_LENGTH) {
       violations.add(ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted("username", MAX_LENGTH));
-    } else if (!USERNAME_PATTERN.matcher(username).matches()) {
-      violations.add(ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted("username", USERNAME_REGEX));
+    } else if (!ID_PATTERN.matcher(username).matches()) {
+      violations.add(ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted("username", ID_REGEX));
     }
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.gateway.protocol.rest.TenantCreateRequest;
 import io.camunda.zeebe.gateway.protocol.rest.TenantUpdateRequest;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
@@ -53,7 +54,7 @@ public class TenantControllerTest extends RestControllerTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"foo", "Foo", "foo123"})
+  @ValueSource(strings = {"foo", "Foo", "foo123", "foo_", "foo.", "foo@"})
   void createTenantShouldReturnAccepted(final String id) {
     // given
     final var tenantName = "Test Tenant";
@@ -167,8 +168,7 @@ public class TenantControllerTest extends RestControllerTest {
       strings = {
         "foo~", "foo!", "foo#", "foo$", "foo%", "foo^", "foo&", "foo*", "foo(", "foo)", "foo=",
         "foo+", "foo{", "foo[", "foo}", "foo]", "foo|", "foo\\", "foo:", "foo;", "foo\"", "foo'",
-        "foo<", "foo>", "foo,", "foo?", "foo/", "foo ", "foo@", "foo_", "foo.", "foo\t", "foo\n",
-        "foo\r",
+        "foo<", "foo>", "foo,", "foo?", "foo/", "foo ", "foo\t", "foo\n", "foo\r"
       })
   void shouldRejectTenantCreationWithIllegalCharactersInId(final String id) {
     // given
@@ -192,10 +192,10 @@ public class TenantControllerTest extends RestControllerTest {
               "type": "about:blank",
               "status": 400,
               "title": "INVALID_ARGUMENT",
-              "detail": "The provided tenantId contains illegal characters. It must match the pattern '[a-zA-Z0-9]+'.",
+              "detail": "The provided tenantId contains illegal characters. It must match the pattern '%s'.",
               "instance": "%s"
             }"""
-                .formatted(TENANT_BASE_URL));
+                .formatted(IdentifierPatterns.ID_PATTERN, TENANT_BASE_URL));
 
     // then
     verifyNoInteractions(tenantServices);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
@@ -18,6 +18,7 @@ import io.camunda.service.MappingServices;
 import io.camunda.service.MappingServices.MappingDTO;
 import io.camunda.zeebe.gateway.protocol.rest.MappingRuleCreateRequest;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,7 +42,7 @@ public class MappingControllerTest extends RestControllerTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"foo", "Foo", "foo123"})
+  @ValueSource(strings = {"foo", "Foo", "foo123", "foo_", "foo.", "foo@"})
   void createMappingShouldReturnCreated(final String id) {
     // given
     final var dto = validCreateMappingRequest();
@@ -226,8 +227,7 @@ public class MappingControllerTest extends RestControllerTest {
       strings = {
         "foo~", "foo!", "foo#", "foo$", "foo%", "foo^", "foo&", "foo*", "foo(", "foo)", "foo=",
         "foo+", "foo{", "foo[", "foo}", "foo]", "foo|", "foo\\", "foo:", "foo;", "foo\"", "foo'",
-        "foo<", "foo>", "foo,", "foo?", "foo/", "foo ", "foo@", "foo_", "foo.", "foo\t", "foo\n",
-        "foo\r",
+        "foo<", "foo>", "foo,", "foo?", "foo/", "foo ", "foo\t", "foo\n", "foo\r"
       })
   void shouldRejectMappingCreationWithIllegalCharactersInId(final String id) {
     // given
@@ -246,10 +246,10 @@ public class MappingControllerTest extends RestControllerTest {
               "type": "about:blank",
               "status": 400,
               "title": "INVALID_ARGUMENT",
-              "detail": "The provided id contains illegal characters. It must match the pattern '[a-zA-Z0-9]+'.",
+              "detail": "The provided id contains illegal characters. It must match the pattern '%s'.",
               "instance": "%s"
             }"""
-            .formatted(MAPPING_RULES_PATH));
+            .formatted(IdentifierPatterns.ID_PATTERN, MAPPING_RULES_PATH));
     verifyNoInteractions(mappingServices);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserControllerTest.java
@@ -21,6 +21,7 @@ import io.camunda.service.UserServices.UserDTO;
 import io.camunda.zeebe.gateway.protocol.rest.UserRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserUpdateRequest;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.validator.IdentifierPatterns;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import java.net.URI;
@@ -55,7 +56,7 @@ public class UserControllerTest extends RestControllerTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"foo", "Foo", "foo@bar.baz", "f_oo@bar.baz", "foo123"})
+  @ValueSource(strings = {"foo", "Foo", "foo@bar.baz", "f_oo@bar.baz", "foo123", "foo-"})
   void createUserShouldReturnCreated(final String username) {
     // given
     final var dto = validCreateUserRequest(username);
@@ -331,7 +332,7 @@ public class UserControllerTest extends RestControllerTest {
       strings = {
         "foo~", "foo!", "foo#", "foo$", "foo%", "foo^", "foo&", "foo*", "foo(", "foo)", "foo=",
         "foo+", "foo{", "foo[", "foo}", "foo]", "foo|", "foo\\", "foo:", "foo;", "foo\"", "foo'",
-        "foo<", "foo>", "foo,", "foo?", "foo/", "foo ", "foo\t", "foo\n", "foo\r",
+        "foo<", "foo>", "foo,", "foo?", "foo/", "foo ", "foo\t", "foo\n", "foo\r"
       })
   void shouldRejectUserCreationWithIllegalCharactersInUsername(final String username) {
     // given
@@ -345,10 +346,10 @@ public class UserControllerTest extends RestControllerTest {
               "type": "about:blank",
               "status": 400,
               "title": "INVALID_ARGUMENT",
-              "detail": "The provided username contains illegal characters. It must match the pattern '[a-zA-Z0-9@._]+'.",
+              "detail": "The provided username contains illegal characters. It must match the pattern '%s'.",
               "instance": "%s"
             }"""
-            .formatted(USER_BASE_URL));
+            .formatted(IdentifierPatterns.ID_PATTERN, USER_BASE_URL));
     verifyNoInteractions(userServices);
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

In old-identity we accept alphanumeric characters, _, - and . characters for tenant ids. Due to migration reasons we
must ensure we accept these same characters in new identity. It isn't sensible to have a different identifier for
tenants specifically, so we will accept these same characters for group, role and mapping ids.

I've decided to also add the @ character. The only difference between usernames and other ids was this character. By
aligning this we don't need a specific pattern anymore.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes N/A
See discussion regarding this PR [here](https://camunda.slack.com/archives/C06UYJMMETZ/p1741013559505339).
