### PR TITLE
OpenSearch ISM creation failure

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/opensearch/OpensearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/opensearch/OpensearchEngineClient.java
@@ -214,11 +214,18 @@ public class OpensearchEngineClient implements SearchEngineClient {
                 policyName, deletionMinAge, response.getBody().get().bodyAsString()));
       }
 
-    } catch (final IOException | OpenSearchException e) {
+    } catch (final IOException | OpenSearchException exception) {
+      final String exceptionMessage = exception.getMessage();
+      if (exceptionMessage.contains("already exists")) {
+        LOG.warn(
+            "Expected to create ISM policy with name '{}', but failed with: '{}'.",
+            policyName,
+            exceptionMessage);
+        return;
+      }
       final var errMsg =
           String.format("Failed to create index state management policy [%s]", policyName);
-      LOG.error(errMsg, e);
-      throw new OpensearchExporterException(errMsg, e);
+      throw new OpensearchExporterException(errMsg, exception);
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -163,15 +163,20 @@ final class CamundaExporterIT {
               final var p2ExporterController = new ExporterTestController();
               p2Exporter.open(p2ExporterController);
             });
-    assertThat(future).isNotCompletedExceptionally();
-    assertThat(future).isCompleted();
+    Awaitility.await("Partition one has been opened successfully")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              assertThat(future).isNotCompletedExceptionally();
+              assertThat(future).isCompleted();
+            });
   }
 
   @TestTemplate
   void shouldOpenDifferentPartitionsWithRetention(
       final ExporterConfiguration config, final SearchClientAdapter ignored) {
     // given
-    final RetentionConfiguration retention = config.getArchiver().getRetention();
+    final RetentionConfiguration retention = config.getHistory().getRetention();
     retention.setEnabled(true);
     retention.setPolicyName("shouldOpenDifferentPartitionsWithRetention");
     final var p1Exporter = new CamundaExporter();
@@ -197,8 +202,13 @@ final class CamundaExporterIT {
               final var p2ExporterController = new ExporterTestController();
               p2Exporter.open(p2ExporterController);
             });
-    assertThat(future).isNotCompletedExceptionally();
-    assertThat(future).isCompleted();
+    Awaitility.await("Partition one has been opened successfully")
+        .atMost(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> {
+              assertThat(future).isNotCompletedExceptionally();
+              assertThat(future).isCompleted();
+            });
   }
 
   @TestTemplate


### PR DESCRIPTION
## Description


1. Validate that Exporters can be opened on different partitions
 with retention enabled.
    1. When we create ISM policy on OS it fails with 409
       already exist error, instead of recreating or updating
       the policy as ES would.
3. We need to swallow such errors, to make sure the Exporter is able to
     start, without issues.
4. We removed error logs here as well, as the catching code should log/handle such exceptions

<!-- Describe the goal and purpose of this PR. -->


## Related issues

closes https://github.com/camunda/camunda/issues/29114
