### PR TITLE
Avoid warning when closing OS exporter if open was not called

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -95,6 +95,8 @@ public class ElasticsearchExporter implements Exporter {
 
   @Override
   public void close() {
+    // the client is only created in some lifecycles, so during others (e.g. validation) it may not
+    // exist, in which case there's no point flushing or doing anything
     if (client != null) {
       try {
         flush();
@@ -109,6 +111,7 @@ public class ElasticsearchExporter implements Exporter {
         log.warn("Failed to close elasticsearch client", e);
       }
     }
+
     try {
       pluginRepository.close();
     } catch (final Exception e) {

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -79,18 +79,21 @@ public class OpensearchExporter implements Exporter {
 
   @Override
   public void close() {
+    // the client is only created in some lifecycles, so during others (e.g. validation) it may not
+    // exist, in which case there's no point flushing or doing anything
+    if (client != null) {
+      try {
+        flush();
+        updateLastExportedPosition();
+      } catch (final Exception e) {
+        log.warn("Failed to flush records before closing exporter.", e);
+      }
 
-    try {
-      flush();
-      updateLastExportedPosition();
-    } catch (final Exception e) {
-      log.warn("Failed to flush records before closing exporter.", e);
-    }
-
-    try {
-      client.close();
-    } catch (final Exception e) {
-      log.warn("Failed to close opensearch client", e);
+      try {
+        client.close();
+      } catch (final Exception e) {
+        log.warn("Failed to close opensearch client", e);
+      }
     }
 
     try {


### PR DESCRIPTION
## Description

This PR avoids 2 logged warnings about an NPE when closing the OS exporter if `#open` was never called. This is a valid usage, as we don't call `open` on purging or during validation.

Note that this was fixed for ES already, so it was likely just an oversight on OS.

Omitted a regression test, because well there's "nothing" really happening, just an ugly warning :)