### PR TITLE
Create meters once to avoid gauge re-registration

### DIFF
--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchMetrics.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchMetrics.java
@@ -7,53 +7,61 @@
  */
 package io.camunda.zeebe.exporter.opensearch;
 
+import io.camunda.zeebe.util.CloseableSilently;
+import io.camunda.zeebe.util.micrometer.MicrometerUtil;
+import io.camunda.zeebe.util.micrometer.StatefulGauge;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
-import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
-import io.micrometer.core.instrument.Timer.ResourceSample;
 import java.time.Duration;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class OpensearchMetrics {
   private static final String NAMESPACE = "zeebe.opensearch.exporter";
 
   private final MeterRegistry meterRegistry;
-  private final AtomicInteger bulkMemorySize = new AtomicInteger(0);
+  private final StatefulGauge bulkMemorySize;
+  private final Timer flushDuration;
+  private final DistributionSummary bulkSize;
+  private final Counter failedFlush;
 
   public OpensearchMetrics(final MeterRegistry meterRegistry) {
     this.meterRegistry = meterRegistry;
+    bulkMemorySize =
+        StatefulGauge.builder(meterName("bulk.memory.size"))
+            .description("Exporter bulk memory size")
+            .register(meterRegistry);
+    flushDuration =
+        Timer.builder(meterName("flush.duration.seconds"))
+            .description("Flush duration of bulk exporters in seconds")
+            .publishPercentileHistogram()
+            .minimumExpectedValue(Duration.ofMillis(10))
+            .register(meterRegistry);
+    bulkSize =
+        DistributionSummary.builder(meterName("bulk.size"))
+            .description("Exporter bulk size")
+            .serviceLevelObjectives(10, 100, 1_000, 10_000, 100_000)
+            .register(meterRegistry);
+    failedFlush =
+        Counter.builder(meterName("failed.flush"))
+            .description("Number of failed flush operations")
+            .register(meterRegistry);
   }
 
-  public ResourceSample measureFlushDuration() {
-    return Timer.resource(meterRegistry, meterName("flush.duration.seconds"))
-        .description("Flush duration of bulk exporters in seconds")
-        .publishPercentileHistogram()
-        .minimumExpectedValue(Duration.ofMillis(10));
+  public CloseableSilently measureFlushDuration() {
+    return MicrometerUtil.timer(flushDuration, Timer.start(meterRegistry));
   }
 
   public void recordBulkSize(final int bulkSize) {
-    DistributionSummary.builder(meterName("bulk.size"))
-        .description("Exporter bulk size")
-        .serviceLevelObjectives(10, 100, 1_000, 10_000, 100_000)
-        .register(meterRegistry)
-        .record(bulkSize);
+    this.bulkSize.record(bulkSize);
   }
 
   public void recordBulkMemorySize(final int bulkMemorySize) {
-    Gauge.builder(meterName("bulk.memory.size"), this.bulkMemorySize, AtomicInteger::get)
-        .description("Exporter bulk memory size")
-        .register(meterRegistry);
-
     this.bulkMemorySize.set(bulkMemorySize);
   }
 
   public void recordFailedFlush() {
-    Counter.builder(meterName("failed.flush"))
-        .description("Number of failed flush operations")
-        .register(meterRegistry)
-        .increment();
+    failedFlush.increment();
   }
 
   private String meterName(final String name) {


### PR DESCRIPTION
## Description

This PR builds the meters once when the class is created. This not only avoids unnecessary allocation when modifying them, but it also ensures we're not re-registering the gauge multiple times.

Note that this was not broken before, as we were always using the same state object :relieved: But it still led to ugly warnings about it.