### PR TITLE
fix: Port content type setting in AWS document store

### DIFF
--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
@@ -62,6 +62,7 @@ public class AwsDocumentStore implements DocumentStore {
   public static final String EXPIRES_AT_METADATA_KEY = "expires-at";
   public static final String FILENAME_METADATA_KEY = "filename";
   public static final String SIZE_METADATA_KEY = "size";
+  public static final String CONTENT_TYPE_METADATA_KEY = "content-type";
   private static final Logger LOGGER = LoggerFactory.getLogger(AwsDocumentStore.class);
   private static final Tag NO_AUTO_DELETE_TAG =
       Tag.builder().key("NoAutoDelete").value("true").build();
@@ -331,6 +332,7 @@ public class AwsDocumentStore implements DocumentStore {
 
     final Map<String, String> metadataMap = new HashMap<>();
 
+    putIfPresent(CONTENT_TYPE_METADATA_KEY, metadata.contentType(), metadataMap);
     putIfPresent(SIZE_METADATA_KEY, metadata.size(), metadataMap);
     putIfPresent(FILENAME_METADATA_KEY, fileName, metadataMap);
     putIfPresent(EXPIRES_AT_METADATA_KEY, metadata.expiresAt(), metadataMap);


### PR DESCRIPTION
## Description

Setting the content type in metadata was done in [main](https://github.com/camunda/camunda/blob/60ef26cc9b0efa32dff846d2b489c2fe8f6d8086/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java#L65) but not in 8.7. This PR fixes that.

There are no test updates for this change because there are no tests that currently do assertions on metadata. I want to address this gap under a new task.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

