### PR TITLE
Deprecate Zeebe client API classes for document handling

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -63,7 +63,7 @@ import io.camunda.zeebe.client.impl.ZeebeClientImpl;
 /**
  * The client to communicate with a Zeebe broker/cluster.
  *
- * @deprecated since 8.8 for removal in 8.0, replaced by {@link io.camunda.client.CamundaClient}
+ * @deprecated since 8.8 for removal in 8.9, replaced by {@link io.camunda.client.CamundaClient}
  */
 @Deprecated
 public interface ZeebeClient extends AutoCloseable, JobClient {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateDocumentBatchCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateDocumentBatchCommandStep1.java
@@ -21,6 +21,11 @@ import java.io.InputStream;
 import java.time.Duration;
 import java.util.Map;
 
+/**
+ * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ *     io.camunda.client.api.command.CreateDocumentBatchCommandStep1}
+ */
+@Deprecated
 public interface CreateDocumentBatchCommandStep1
     extends FinalCommandStep<DocumentReferenceBatchResponse> {
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateDocumentCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateDocumentCommandStep1.java
@@ -20,6 +20,11 @@ import java.io.InputStream;
 import java.time.Duration;
 import java.util.Map;
 
+/**
+ * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ *     io.camunda.client.api.command.CreateDocumentCommandStep1}
+ */
+@Deprecated
 public interface CreateDocumentCommandStep1 extends DocumentBuilderStep1 {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateDocumentLinkCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CreateDocumentLinkCommandStep1.java
@@ -18,7 +18,13 @@ package io.camunda.zeebe.client.api.command;
 import io.camunda.zeebe.client.api.response.DocumentLinkResponse;
 import java.time.Duration;
 
-/** Command to create a document link in the document store. */
+/**
+ * Command to create a document link in the document store.
+ *
+ * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ *     io.camunda.client.api.command.CreateDocumentLinkCommandStep1}
+ */
+@Deprecated
 public interface CreateDocumentLinkCommandStep1 extends FinalCommandStep<DocumentLinkResponse> {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/DeleteDocumentCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/DeleteDocumentCommandStep1.java
@@ -17,7 +17,13 @@ package io.camunda.zeebe.client.api.command;
 
 import io.camunda.zeebe.client.api.response.DeleteDocumentResponse;
 
-/** Command to delete a document from the document store. */
+/**
+ * Command to delete a document from the document store.
+ *
+ * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ *     io.camunda.client.api.command.DeleteDocumentCommandStep1}
+ */
+@Deprecated
 public interface DeleteDocumentCommandStep1 extends FinalCommandStep<DeleteDocumentResponse> {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/DocumentBuilderStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/DocumentBuilderStep1.java
@@ -19,6 +19,11 @@ import java.io.InputStream;
 import java.time.Duration;
 import java.util.Map;
 
+/**
+ * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ *     io.camunda.client.api.command.DocumentBuilderStep1}
+ */
+@Deprecated
 public interface DocumentBuilderStep1 {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/fetch/DocumentContentGetRequest.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/fetch/DocumentContentGetRequest.java
@@ -22,7 +22,11 @@ import java.io.InputStream;
  * Command to get the content of a document from the document store.
  *
  * <p>The document content is returned as an {@link InputStream}.
+ *
+ * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ *     io.camunda.client.api.fetch.DocumentContentGetRequest}
  */
+@Deprecated
 public interface DocumentContentGetRequest extends FinalCommandStep<InputStream> {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DeleteDocumentResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DeleteDocumentResponse.java
@@ -15,4 +15,9 @@
  */
 package io.camunda.zeebe.client.api.response;
 
+/**
+ * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ *     io.camunda.client.api.response.DeleteDocumentResponse}
+ */
+@Deprecated
 public interface DeleteDocumentResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DocumentLinkResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DocumentLinkResponse.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.response;
 
 import java.time.OffsetDateTime;
 
+/**
+ * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ *     io.camunda.client.api.response.DocumentLinkResponse}
+ */
+@Deprecated
 public interface DocumentLinkResponse {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DocumentMetadata.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DocumentMetadata.java
@@ -18,6 +18,11 @@ package io.camunda.zeebe.client.api.response;
 import java.time.OffsetDateTime;
 import java.util.Map;
 
+/**
+ * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ *     io.camunda.client.api.response.DocumentMetadata}
+ */
+@Deprecated
 public interface DocumentMetadata {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DocumentReferenceBatchResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DocumentReferenceBatchResponse.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.response;
 
 import java.util.List;
 
+/**
+ * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ *     io.camunda.client.api.response.DocumentReferenceBatchResponse}
+ */
+@Deprecated
 public interface DocumentReferenceBatchResponse {
 
   /**

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DocumentReferenceResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DocumentReferenceResponse.java
@@ -17,6 +17,11 @@ package io.camunda.zeebe.client.api.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * @deprecated since 8.8 for removal in 8.9, replaced by {@link
+ *     io.camunda.client.api.response.DocumentReferenceResponse}
+ */
+@Deprecated
 public interface DocumentReferenceResponse {
 
   @JsonProperty("camunda.document.type")


### PR DESCRIPTION
## Description

Deprecates further Zeebe client classes that relate to document handling.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

related to https://github.com/camunda/camunda/issues/27277
