### PR TITLE
feat: add MappingCreatedUpdatedHandler

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -41,7 +41,7 @@ import io.camunda.exporter.handlers.ListViewFlowNodeFromJobHandler;
 import io.camunda.exporter.handlers.ListViewFlowNodeFromProcessInstanceHandler;
 import io.camunda.exporter.handlers.ListViewProcessInstanceFromProcessInstanceHandler;
 import io.camunda.exporter.handlers.ListViewVariableFromVariableHandler;
-import io.camunda.exporter.handlers.MappingCreatedHandler;
+import io.camunda.exporter.handlers.MappingCreatedUpdatedHandler;
 import io.camunda.exporter.handlers.MappingDeletedHandler;
 import io.camunda.exporter.handlers.MetricFromDecisionEvaluationHandler;
 import io.camunda.exporter.handlers.MetricFromProcessInstanceHandler;
@@ -261,7 +261,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptors.get(OperationTemplate.class).getFullQualifiedName()),
             new OperationFromIncidentHandler(
                 indexDescriptors.get(OperationTemplate.class).getFullQualifiedName()),
-            new MappingCreatedHandler(
+            new MappingCreatedUpdatedHandler(
                 indexDescriptors.get(MappingIndex.class).getFullQualifiedName()),
             new MappingDeletedHandler(
                 indexDescriptors.get(MappingIndex.class).getFullQualifiedName()),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingCreatedUpdatedHandler.java
@@ -47,7 +47,7 @@ public class MappingCreatedUpdatedHandler
 
   @Override
   public List<String> generateIds(final Record<MappingRecordValue> record) {
-    return List.of(String.valueOf(record.getKey()));
+    return List.of(String.valueOf(record.getValue().getId()));
   }
 
   @Override
@@ -60,6 +60,7 @@ public class MappingCreatedUpdatedHandler
     final MappingRecordValue value = record.getValue();
     entity
         .setKey(value.getMappingKey())
+        .setId(value.getId())
         .setClaimName(value.getClaimName())
         .setClaimValue(value.getClaimValue())
         .setName(value.getName());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingCreatedUpdatedHandler.java
@@ -12,14 +12,20 @@ import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.usermanagement.MappingEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.MappingIntent;
 import io.camunda.zeebe.protocol.record.value.MappingRecordValue;
 import java.util.List;
+import java.util.Set;
 
-public class MappingCreatedHandler implements ExportHandler<MappingEntity, MappingRecordValue> {
+public class MappingCreatedUpdatedHandler
+    implements ExportHandler<MappingEntity, MappingRecordValue> {
+  private static final Set<Intent> SUPPORTED_INTENTS =
+      Set.of(MappingIntent.CREATED, MappingIntent.UPDATED);
+
   private final String indexName;
 
-  public MappingCreatedHandler(final String indexName) {
+  public MappingCreatedUpdatedHandler(final String indexName) {
     this.indexName = indexName;
   }
 
@@ -36,7 +42,7 @@ public class MappingCreatedHandler implements ExportHandler<MappingEntity, Mappi
   @Override
   public boolean handlesRecord(final Record<MappingRecordValue> record) {
     return getHandledValueType().equals(record.getValueType())
-        && MappingIntent.CREATED.equals(record.getIntent());
+        && SUPPORTED_INTENTS.contains(record.getIntent());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MappingCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MappingCreatedUpdatedHandlerTest.java
@@ -70,7 +70,7 @@ public class MappingCreatedUpdatedHandlerTest {
     final var idList = underTest.generateIds(mappingRecord);
 
     // then
-    assertThat(idList).containsExactly(String.valueOf(mappingRecord.getKey()));
+    assertThat(idList).containsExactly(String.valueOf(mappingRecord.getValue().getId()));
   }
 
   @Test
@@ -98,7 +98,7 @@ public class MappingCreatedUpdatedHandlerTest {
     final Record<MappingRecordValue> mappingRecord =
         factory.generateRecord(
             ValueType.MAPPING,
-            r -> r.withIntent(MappingIntent.CREATED).withValue(mappingRecordValue));
+            r -> r.withIntent(MappingIntent.UPDATED).withValue(mappingRecordValue));
 
     // when
     final MappingEntity mappingEntity =
@@ -113,8 +113,7 @@ public class MappingCreatedUpdatedHandlerTest {
     assertThat(mappingEntity.getClaimName()).isEqualTo("updated-claim");
     assertThat(mappingEntity.getClaimValue()).isEqualTo("updated-value");
     assertThat(mappingEntity.getName()).isEqualTo("updated-name");
-    // should not update id
-    assertThat(mappingEntity.getId()).isEqualTo("old-id");
+    assertThat(mappingEntity.getId()).isEqualTo("updated-id");
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR introduces the MappingCreatedUpdatedHandler to process both CREATED and UPDATED mapping events.

Renames the handler and its tests to support the updated behavior.
Updates tests to use parameterized testing for both CREATED and UPDATED intents.
Adjusts the handler's logic for generating IDs and updating entities.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29145 and #29066
