### PR TITLE
[Backport main] fix: add document data consumer to enable document fetching in the client

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/ApiResponseConsumer.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/ApiResponseConsumer.java
@@ -15,11 +15,11 @@
  */
 package io.camunda.zeebe.client.impl.http;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.client.impl.http.ApiResponseConsumer.ApiResponse;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.message.BasicHttpResponse;
+import org.apache.hc.core5.http.nio.AsyncEntityConsumer;
 import org.apache.hc.core5.http.nio.support.AbstractAsyncResponseConsumer;
 import org.apache.hc.core5.http.protocol.HttpContext;
 
@@ -36,8 +36,8 @@ import org.apache.hc.core5.http.protocol.HttpContext;
 final class ApiResponseConsumer<T>
     extends AbstractAsyncResponseConsumer<ApiResponse<T>, ApiEntity<T>> {
 
-  ApiResponseConsumer(final ObjectMapper jsonMapper, final Class<T> type, final int maxCapacity) {
-    super(new ApiEntityConsumer<>(jsonMapper, type, maxCapacity));
+  ApiResponseConsumer(final AsyncEntityConsumer<ApiEntity<T>> entityConsumer) {
+    super(entityConsumer);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/CircularBufferInputStream.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/CircularBufferInputStream.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.http;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import javax.annotation.Nonnull;
+
+/**
+ * A custom input stream that stores data in a circular buffer with a fixed capacity. This
+ * implementation offers a non-blocking asynchronous API for writing the data into the buffer.
+ *
+ * <p>The writing thread can check the available space in the buffer by calling {@link
+ * #getAvailableSpace()}. If the buffer is full, the writing thread must avoid writing more data. A
+ * callback can be set by the writing thread to be notified when space is available in the buffer.
+ * See {@link CapacityCallback}.
+ *
+ * <p>The buffer space is freed up as the reading thread reads the data from the buffer. The reading
+ * thread consumes data using the standard {@link InputStream} API, blocking if no data is
+ * available.
+ */
+public class CircularBufferInputStream extends InputStream {
+
+  private final byte[] buffer;
+  private final int capacity;
+  private int readPos = 0;
+  private int writePos = 0;
+  private int availableData = 0;
+  private boolean endOfStream = false;
+  private IOException exception = null;
+  private CapacityCallback capacityCallback;
+
+  public CircularBufferInputStream(final int capacity) {
+    this.capacity = capacity;
+    buffer = new byte[capacity];
+  }
+
+  public synchronized void setCapacityCallback(final CapacityCallback capacityCallback) {
+    this.capacityCallback = capacityCallback;
+  }
+
+  /**
+   * Writes the data into the buffer. This method does not block the calling thread if the buffer is
+   * full, instead it throws an {@link IOException}. This means that the writing thread must handle
+   * capacity issues by proactively checking the available space in the buffer before writing data.
+   *
+   * @throws IOException if the buffer is full
+   */
+  public synchronized void write(final ByteBuffer data) throws IOException {
+    if (exception != null) {
+      throw exception;
+    }
+    final int dataSize = data.remaining();
+    final int availableSpace = getAvailableSpace();
+    if (dataSize > availableSpace) {
+      throw new IOException("Buffer is full");
+    }
+
+    final int firstCopyLength = Math.min(dataSize, capacity - writePos);
+    data.get(buffer, writePos, firstCopyLength);
+    writePos = (writePos + firstCopyLength) % capacity;
+
+    final int remaining = dataSize - firstCopyLength;
+    if (remaining > 0) {
+      // Wrap around
+      data.get(buffer, writePos, remaining);
+      writePos = (writePos + remaining) % capacity;
+    }
+    availableData += dataSize;
+
+    // Notify any waiting readers
+    notifyAll();
+  }
+
+  public synchronized void endOfStream() {
+    endOfStream = true;
+    notifyAll();
+  }
+
+  public synchronized void signalError(final IOException e) {
+    exception = e;
+    notifyAll();
+  }
+
+  @Override
+  public synchronized int read() throws IOException {
+    if (canConsumeData()) {
+      return -1;
+    }
+
+    final int b = buffer[readPos] & 0xFF;
+    readPos = (readPos + 1) % capacity;
+    availableData--;
+
+    // Notify any waiting writers
+    notifyAll();
+
+    // Inform capacity callback
+    if (capacityCallback != null) {
+      capacityCallback.onCapacityAvailable(1);
+    }
+
+    return b;
+  }
+
+  @Override
+  public synchronized int read(@Nonnull final byte[] b, final int off, final int len)
+      throws IOException {
+    if (off < 0 || len < 0 || len > b.length - off) {
+      throw new IndexOutOfBoundsException();
+    }
+    if (len == 0) {
+      return 0;
+    }
+
+    if (canConsumeData()) {
+      return -1;
+    }
+
+    int bytesRead = 0;
+    final int bytesToRead = Math.min(len, availableData);
+
+    final int firstCopyLength = Math.min(bytesToRead, capacity - readPos);
+    System.arraycopy(buffer, readPos, b, off, firstCopyLength);
+    readPos = (readPos + firstCopyLength) % capacity;
+    bytesRead += firstCopyLength;
+    availableData -= firstCopyLength;
+
+    final int remaining = bytesToRead - firstCopyLength;
+    if (remaining > 0) {
+      System.arraycopy(buffer, readPos, b, off + firstCopyLength, remaining);
+      readPos = (readPos + remaining) % capacity;
+      bytesRead += remaining;
+      availableData -= remaining;
+    }
+
+    // Notify any waiting writers
+    notifyAll();
+
+    // Inform capacity callback
+    if (capacityCallback != null) {
+      capacityCallback.onCapacityAvailable(bytesRead);
+    }
+
+    return bytesRead;
+  }
+
+  private boolean canConsumeData() throws IOException {
+    while (availableData == 0 && exception == null && !endOfStream) {
+      try {
+        wait();
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IOException("Interrupted while reading", e);
+      }
+    }
+    if (exception != null) {
+      final IOException ex = exception;
+      exception = null;
+      throw ex;
+    }
+    return availableData == 0;
+  }
+
+  public synchronized int getAvailableSpace() {
+    return capacity - availableData;
+  }
+
+  public interface CapacityCallback {
+    void onCapacityAvailable(int increment);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/DocumentDataConsumer.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/DocumentDataConsumer.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.http;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.client.impl.http.CircularBufferInputStream.CapacityCallback;
+import io.camunda.zeebe.client.impl.http.TypedApiEntityConsumer.JsonApiEntityConsumer;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.EntityDetails;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.nio.AsyncEntityConsumer;
+import org.apache.hc.core5.http.nio.CapacityChannel;
+
+/**
+ * An asynchronous consumer for binary data that represents a document.
+ *
+ * <p>This implementation guarantees that the data is consumed in a non-blocking manner, and that
+ * the data is stored in a buffer with a fixed capacity. The consumer works with a {@link
+ * CapacityChannel} to notify the I/O layer when more data can be read from the network.
+ *
+ * <p>If the server returns:
+ *
+ * <ul>
+ *   <li>application/octet-stream: the data is returned as an {@link InputStream}
+ *   <li>application/problem+json: the data is returned as a {@link
+ *       io.camunda.client.protocol.rest.ProblemDetail}
+ * </ul>
+ *
+ * Anything else will cause an error to be propagated to the caller.
+ *
+ * <p>The input stream response is returned via the result callback immediately as soon as the
+ * content type is determined to be {@code application/octet-stream}. This allows the caller to
+ * start reading the data in a streaming fashion and does not require the entire response body to be
+ * buffered in memory.
+ *
+ * @param <T> the type of the successful response body, always an {@link InputStream}
+ */
+public class DocumentDataConsumer<T>
+    implements AsyncEntityConsumer<ApiEntity<T>>, CapacityCallback {
+
+  private final CircularBufferInputStream inputStream;
+  private FutureCallback<ApiEntity<T>> resultCallback;
+  private final int maxCapacity;
+  private volatile CapacityChannel capacityChannel;
+  private volatile boolean completed = false;
+  private volatile boolean problemDetail = false;
+
+  private final JsonApiEntityConsumer<InputStream> problemDetailConsumer;
+
+  public DocumentDataConsumer(final int bufferCapacity, final ObjectMapper json) {
+    maxCapacity = bufferCapacity;
+    inputStream = new CircularBufferInputStream(bufferCapacity);
+    try {
+      problemDetailConsumer = new JsonApiEntityConsumer<>(json, InputStream.class, false);
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void streamStart(
+      final EntityDetails entityDetails, final FutureCallback<ApiEntity<T>> resultCallback) {
+    this.resultCallback = resultCallback;
+    final ContentType contentType =
+        entityDetails != null ? ContentType.parse(entityDetails.getContentType()) : null;
+    if (ContentType.APPLICATION_PROBLEM_JSON.isSameMimeType(contentType)) {
+      problemDetail = true;
+    } else {
+      problemDetail = false;
+      inputStream.setCapacityCallback(this);
+      resultCallback.completed((ApiEntity<T>) ApiEntity.of(inputStream));
+    }
+  }
+
+  @Override
+  public void failed(final Exception cause) {
+    if (cause instanceof IOException) {
+      inputStream.signalError((IOException) cause);
+    } else {
+      inputStream.signalError(new IOException(cause));
+    }
+    if (resultCallback != null && !completed) {
+      resultCallback.failed(cause);
+    }
+  }
+
+  @Override
+  public ApiEntity<T> getContent() {
+    if (problemDetail) {
+      try {
+        return (ApiEntity<T>) problemDetailConsumer.generateContent();
+      } catch (final IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    return (ApiEntity<T>) ApiEntity.of(inputStream);
+  }
+
+  @Override
+  public void updateCapacity(final CapacityChannel capacityChannel) throws IOException {
+    if (problemDetail) {
+      capacityChannel.update(maxCapacity - problemDetailConsumer.getBufferedBytes());
+      return;
+    }
+
+    this.capacityChannel = capacityChannel;
+    final int availableSpace = inputStream.getAvailableSpace();
+    if (availableSpace > 0) {
+      capacityChannel.update(availableSpace);
+    }
+  }
+
+  @Override
+  public void consume(final ByteBuffer src) throws IOException {
+    if (problemDetail) {
+      problemDetailConsumer.consumeData(src, false);
+    }
+    inputStream.write(src);
+  }
+
+  @Override
+  public void streamEnd(final List<? extends Header> trailers) throws IOException {
+    if (problemDetail) {
+      problemDetailConsumer.consumeData(ByteBuffer.allocate(0), true);
+      resultCallback.completed((ApiEntity<T>) problemDetailConsumer.generateContent());
+      return;
+    }
+
+    inputStream.endOfStream();
+    completed = true;
+  }
+
+  @Override
+  public void releaseResources() {
+    // nothing to release
+  }
+
+  @Override
+  public void onCapacityAvailable(final int increment) {
+    if (capacityChannel != null && increment > 0) {
+      try {
+        capacityChannel.update(increment);
+      } catch (final IOException e) {
+        failed(e);
+      }
+    }
+  }
+}

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/http/DocumentDataConsumerTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/http/DocumentDataConsumerTest.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.zeebe.client.protocol.rest.ProblemDetail;
+import io.camunda.client.protocol.rest.ProblemDetail;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/http/DocumentDataConsumerTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/http/DocumentDataConsumerTest.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.client.protocol.rest.ProblemDetail;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.EntityDetails;
+import org.junit.jupiter.api.Test;
+
+public class DocumentDataConsumerTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  void testWithDocumentDataWithinBufferCapacity() throws IOException {
+    // given
+    final byte[] data = "Test content".getBytes();
+    final DocumentDataConsumer<InputStream> consumer =
+        new DocumentDataConsumer<>(data.length, objectMapper);
+    final EntityDetails entityDetails = mock(EntityDetails.class);
+    when(entityDetails.getContentType())
+        .thenReturn(ContentType.APPLICATION_OCTET_STREAM.getMimeType());
+    when(entityDetails.getContentLength()).thenReturn((long) data.length);
+    final Callback callback = spy(new Callback());
+
+    // when
+    consumer.streamStart(entityDetails, callback);
+
+    // then
+    // stream is returned immediately
+    verify(callback).completed(any());
+    assertThat(callback).isNotNull();
+
+    consumer.consume(ByteBuffer.wrap(data));
+    consumer.streamEnd(Collections.emptyList());
+
+    final byte[] content = new byte[data.length];
+    final int dataRead = callback.inputStream.read(content);
+    assertThat(dataRead).isEqualTo(data.length);
+    assertThat(content).isEqualTo(data);
+    verifyNoMoreInteractions(callback);
+  }
+
+  @Test
+  void testWithDocumentDataExceedingBufferCapacity() throws IOException {
+    // given
+    final byte[] data = "Test content".getBytes();
+    final DocumentDataConsumer<InputStream> consumer =
+        new DocumentDataConsumer<>(data.length - 1, objectMapper);
+    final EntityDetails entityDetails = mock(EntityDetails.class);
+    when(entityDetails.getContentType())
+        .thenReturn(ContentType.APPLICATION_OCTET_STREAM.getMimeType());
+    when(entityDetails.getContentLength()).thenReturn((long) data.length);
+    final Callback callback = spy(new Callback());
+
+    // when
+    consumer.streamStart(entityDetails, callback);
+
+    // then
+    // stream is returned immediately
+    verify(callback).completed(any());
+    assertThat(callback).isNotNull();
+
+    final AtomicInteger reportedCapacity = spy(new AtomicInteger());
+    consumer.updateCapacity(reportedCapacity::set);
+
+    assertThat(reportedCapacity.get()).isEqualTo(data.length - 1);
+    // error is thrown when data exceeds buffer capacity
+    assertThrows(IOException.class, () -> consumer.consume(ByteBuffer.wrap(data)));
+
+    final byte[] partialData = Arrays.copyOf(data, reportedCapacity.get());
+    consumer.consume(ByteBuffer.wrap(partialData));
+
+    consumer.updateCapacity(reportedCapacity::set);
+    verify(reportedCapacity, times(1)).set(anyInt()); // capacity wasn't updated immediately
+
+    final byte[] content = new byte[reportedCapacity.get()];
+    final int dataRead = callback.inputStream.read(content);
+
+    assertThat(dataRead).isEqualTo(reportedCapacity.get());
+    assertThat(content).isEqualTo(partialData);
+    assertThat(reportedCapacity.get()).isEqualTo(data.length - 1); // capacity is updated now
+
+    final byte[] remainingData = Arrays.copyOfRange(data, reportedCapacity.get(), data.length);
+    consumer.consume(ByteBuffer.wrap(remainingData));
+    consumer.streamEnd(Collections.emptyList());
+    final byte[] remainingContent = new byte[remainingData.length];
+    final int remainingDataRead = callback.inputStream.read(remainingContent);
+    assertThat(remainingDataRead).isEqualTo(remainingData.length);
+    assertThat(remainingContent).isEqualTo(remainingData);
+
+    verifyNoMoreInteractions(callback);
+  }
+
+  @Test
+  void testProblemDetail() throws IOException {
+
+    // given
+    final String problemDetailResponse =
+        "{\"type\":\"about:blank\",\"title\":\"Something went wrong\",\"status\":400,\"detail\":\"Invalid request\",\"instance\":\"/v1/entity/123\"}";
+    final ByteBuffer byteBuffer = ByteBuffer.wrap(problemDetailResponse.getBytes());
+    final DocumentDataConsumer<InputStream> consumer =
+        new DocumentDataConsumer<>(256, objectMapper);
+    final EntityDetails entityDetails = mock(EntityDetails.class);
+    when(entityDetails.getContentType())
+        .thenReturn(ContentType.APPLICATION_PROBLEM_JSON.getMimeType());
+    final Callback callback = spy(new Callback());
+
+    // when
+    // Start the stream with content type application/problem+json
+    consumer.streamStart(entityDetails, callback);
+    verifyNoInteractions(callback); // stream is not returned immediately
+
+    // Feed the data
+    consumer.consume(byteBuffer);
+    consumer.streamEnd(Collections.emptyList());
+
+    verify(callback).completed(any());
+    assertThat(callback.problemDetail).isNotNull();
+
+    // then
+    final ProblemDetail problemDetail = callback.problemDetail;
+    assertThat(problemDetail).isNotNull();
+    assertThat(problemDetail.getType()).isEqualTo(URI.create("about:blank"));
+    assertThat(problemDetail.getTitle()).isEqualTo("Something went wrong");
+    assertThat(problemDetail.getStatus()).isEqualTo(400);
+    assertThat(problemDetail.getDetail()).isEqualTo("Invalid request");
+    assertThat(problemDetail.getInstance()).isEqualTo(URI.create("/v1/entity/123"));
+  }
+
+  @Test
+  void canReadSingleCharsFromStream() throws IOException {
+    // given
+    final byte[] data = "Test content".getBytes();
+    final DocumentDataConsumer<InputStream> consumer =
+        new DocumentDataConsumer<>(data.length, objectMapper);
+    final EntityDetails entityDetails = mock(EntityDetails.class);
+    when(entityDetails.getContentType())
+        .thenReturn(ContentType.APPLICATION_OCTET_STREAM.getMimeType());
+    when(entityDetails.getContentLength()).thenReturn((long) data.length);
+    final Callback callback = spy(new Callback());
+
+    // when
+    consumer.streamStart(entityDetails, callback);
+
+    // then
+    // stream is returned immediately
+    verify(callback).completed(any());
+    assertThat(callback).isNotNull();
+
+    consumer.consume(ByteBuffer.wrap(data));
+    consumer.streamEnd(Collections.emptyList());
+
+    for (final byte b : data) {
+      final byte[] content = new byte[1];
+      final int dataRead = callback.inputStream.read(content);
+      assertThat(dataRead).isEqualTo(1);
+      assertThat(content[0]).isEqualTo(b);
+    }
+
+    assertThat(callback.inputStream.read()).isEqualTo(-1);
+
+    verifyNoMoreInteractions(callback);
+  }
+
+  @Test
+  void canReadMultipleCharsFromStream() throws IOException {
+    // given
+    final byte[] data = "Test content".getBytes();
+    final DocumentDataConsumer<InputStream> consumer =
+        new DocumentDataConsumer<>(data.length, objectMapper);
+    final EntityDetails entityDetails = mock(EntityDetails.class);
+    when(entityDetails.getContentType())
+        .thenReturn(ContentType.APPLICATION_OCTET_STREAM.getMimeType());
+    when(entityDetails.getContentLength()).thenReturn((long) data.length);
+    final Callback callback = spy(new Callback());
+
+    // when
+    consumer.streamStart(entityDetails, callback);
+
+    // then
+    // stream is returned immediately
+    verify(callback).completed(any());
+    assertThat(callback).isNotNull();
+
+    consumer.consume(ByteBuffer.wrap(data));
+    consumer.streamEnd(Collections.emptyList());
+
+    final byte[] content = new byte[data.length];
+    final int dataRead = callback.inputStream.read(content);
+    assertThat(dataRead).isEqualTo(data.length);
+    assertThat(content).isEqualTo(data);
+    assertThat(callback.inputStream.read()).isEqualTo(-1);
+
+    verifyNoMoreInteractions(callback);
+  }
+
+  @Test
+  void canConsumeArbitraryContentType() throws IOException {
+    // given
+    final byte[] data = "Test content".getBytes();
+    final DocumentDataConsumer<InputStream> consumer =
+        new DocumentDataConsumer<>(data.length, objectMapper);
+    final EntityDetails entityDetails = mock(EntityDetails.class);
+    when(entityDetails.getContentType()).thenReturn("application/pdf");
+    when(entityDetails.getContentLength()).thenReturn((long) data.length);
+    final Callback callback = spy(new Callback());
+
+    // when
+    consumer.streamStart(entityDetails, callback);
+
+    // then
+    // stream is returned immediately
+    verify(callback).completed(any());
+    assertThat(callback).isNotNull();
+
+    consumer.consume(ByteBuffer.wrap(data));
+    consumer.streamEnd(Collections.emptyList());
+
+    final byte[] content = new byte[data.length];
+    final int dataRead = callback.inputStream.read(content);
+    assertThat(dataRead).isEqualTo(data.length);
+    assertThat(content).isEqualTo(data);
+    assertThat(callback.inputStream.read()).isEqualTo(-1);
+
+    verifyNoMoreInteractions(callback);
+  }
+
+  static class Callback implements FutureCallback<ApiEntity<InputStream>> {
+
+    public InputStream inputStream;
+    public ProblemDetail problemDetail;
+
+    @Override
+    public void completed(final ApiEntity<InputStream> result) {
+      if (result instanceof ApiEntity.Response) {
+        inputStream = result.response();
+      } else if (result instanceof ApiEntity.Error) {
+        problemDetail = result.problem();
+      } else {
+        throw new IllegalStateException("Unexpected result type: " + result.getClass());
+      }
+    }
+
+    @Override
+    public void failed(final Exception ex) {}
+
+    @Override
+    public void cancelled() {}
+  }
+}


### PR DESCRIPTION
# Description
Backport of #27837 to `main`.

relates to camunda/team-connectors#992