### PR TITLE
test: Improve task listener test stability

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -466,15 +466,14 @@ public class TaskListenerTest {
     // correct assignee value is present at all stages
     assertThat(
             RecordingExporter.userTaskRecords()
+                .withProcessInstanceKey(processInstanceKey)
                 .limit(r -> r.getIntent() == UserTaskIntent.ASSIGNED))
         .extracting(Record::getIntent, r -> r.getValue().getAssignee())
         .describedAs("Verify that all task listeners were completed with the correct assignee")
         .containsSequence(
-            tuple(UserTaskIntent.ASSIGN, "new_assignee"),
             tuple(UserTaskIntent.ASSIGNING, "new_assignee"),
             tuple(UserTaskIntent.DENY_TASK_LISTENER, "new_assignee"),
             tuple(UserTaskIntent.ASSIGNMENT_DENIED, ""),
-            tuple(UserTaskIntent.ASSIGN, "new_assignee"),
             tuple(UserTaskIntent.ASSIGNING, "new_assignee"),
             tuple(UserTaskIntent.COMPLETE_TASK_LISTENER, "new_assignee"),
             tuple(UserTaskIntent.COMPLETE_TASK_LISTENER, "new_assignee"),
@@ -551,6 +550,7 @@ public class TaskListenerTest {
 
     assertThat(
             RecordingExporter.userTaskRecords()
+                .withProcessInstanceKey(processInstanceKey)
                 .limit(r -> r.getIntent() == UserTaskIntent.ASSIGNMENT_DENIED))
         .extracting(Record::getIntent, r -> r.getValue().getAssignee())
         .describedAs(
@@ -561,7 +561,6 @@ public class TaskListenerTest {
             tuple(UserTaskIntent.ASSIGNING, "first_assignee"),
             tuple(UserTaskIntent.COMPLETE_TASK_LISTENER, "first_assignee"),
             tuple(UserTaskIntent.ASSIGNED, "first_assignee"),
-            tuple(UserTaskIntent.ASSIGN, "second_assignee"),
             tuple(UserTaskIntent.ASSIGNING, "second_assignee"),
             tuple(UserTaskIntent.DENY_TASK_LISTENER, "second_assignee"),
             // second assignee was not persisted
@@ -2320,13 +2319,11 @@ public class TaskListenerTest {
     // Verify the sequence of intents and the `changedAttributes` emitted for the user task
     assertThat(
             RecordingExporter.userTaskRecords()
+                .withProcessInstanceKey(processInstanceKey)
                 .limit(record -> record.getIntent() == UserTaskIntent.ASSIGNED))
         .as("Verify the user task lifecycle and tracking of `changedAttributes`")
         .extracting(Record::getIntent, record -> record.getValue().getChangedAttributes())
-        .containsExactly(
-            tuple(UserTaskIntent.CREATING, List.of()),
-            tuple(UserTaskIntent.CREATED, List.of()),
-            tuple(UserTaskIntent.ASSIGN, List.of()),
+        .containsSequence(
             tuple(UserTaskIntent.ASSIGNING, List.of("assignee")),
             tuple(UserTaskIntent.COMPLETE_TASK_LISTENER, List.of("dueDate", "priority")),
             tuple(UserTaskIntent.CORRECTED, List.of("dueDate", "priority")),
@@ -2471,15 +2468,11 @@ public class TaskListenerTest {
     // then
     assertThat(
             RecordingExporter.userTaskRecords()
+                .withProcessInstanceKey(processInstanceKey)
                 .limit(record -> record.getIntent() == UserTaskIntent.UPDATED))
         .as("Verify the user task record lifecycle and tracking of `changedAttributes`")
         .extracting(Record::getIntent, record -> record.getValue().getChangedAttributes())
-        .containsExactly(
-            tuple(UserTaskIntent.CREATING, List.of()),
-            tuple(UserTaskIntent.CREATED, List.of()),
-            tuple(
-                UserTaskIntent.UPDATE,
-                List.of("candidateGroupsList", "candidateUsersList", "dueDate", "priority")),
+        .containsSequence(
             tuple(UserTaskIntent.UPDATING, List.of("candidateGroupsList", "dueDate", "priority")),
             tuple(UserTaskIntent.COMPLETE_TASK_LISTENER, List.of("dueDate", "followUpDate")),
             tuple(UserTaskIntent.CORRECTED, List.of("dueDate", "followUpDate")),
@@ -2608,15 +2601,11 @@ public class TaskListenerTest {
     // then: verify sequence of intents and `changedAttributes`
     assertThat(
             RecordingExporter.userTaskRecords()
+                .withProcessInstanceKey(processInstanceKey)
                 .limit(record -> record.getIntent() == UserTaskIntent.COMPLETED))
         .as("Verify the user task lifecycle and tracking of `changedAttributes`")
         .extracting(Record::getIntent, record -> record.getValue().getChangedAttributes())
-        .containsExactly(
-            tuple(UserTaskIntent.CREATING, List.of()),
-            tuple(UserTaskIntent.CREATED, List.of()),
-            tuple(UserTaskIntent.ASSIGNING, List.of("assignee")),
-            tuple(UserTaskIntent.ASSIGNED, List.of("assignee")),
-            tuple(UserTaskIntent.COMPLETE, List.of()),
+        .containsSequence(
             tuple(UserTaskIntent.COMPLETING, List.of()), // No direct changes at completion
             tuple(
                 UserTaskIntent.COMPLETE_TASK_LISTENER, List.of("candidateGroupsList", "priority")),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -2200,7 +2200,9 @@ public class TaskListenerTest {
             record.getIntent() == UserTaskIntent.COMPLETE_TASK_LISTENER
                 || record.getIntent() == UserTaskIntent.CORRECTED;
     assertThat(
-            RecordingExporter.userTaskRecords().limit(r -> r.getIntent() == terminalActionIntent))
+            RecordingExporter.userTaskRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(r -> r.getIntent() == terminalActionIntent))
         .filteredOn(isRelevantUserTaskIntent)
         .extracting(Record::getIntent, r -> r.getValue().getChangedAttributes())
         .describedAs(


### PR DESCRIPTION
## Description

This PR addresses and prevents potential flakiness in user task tests by ensuring assertions correctly scope user task records to the relevant process instance.  

### Changes:
- Filter user task records by `processInstanceKey`.
  - Updated all occurrences of `RecordingExporter.userTaskRecords()` to use `.withProcessInstanceKey(processInstanceKey)`, preventing interference from unrelated records.  
- Exclude commands written by tests from assertions.
  - Refactored test assertions to focus solely on records generated by Zeebe (e.g., `ASSIGNING`, `ASSIGNED`, `COMPLETING`, `COMPLETE_TASK_LISTENER`) and ignore commands written by tests, like `ASSIGN`, `COMPLETE`.  


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29060 
