### PR TITLE
fix: Revert org.apache.httpcomponents.core5:httpcore5 upgrade to v5.3.3 (#29004)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,6 +22,12 @@
   },
   "packageRules": [
     {
+      "description": "Temporary rule to prevent issue introduced in v5.3.3 (see issue #29004)",
+      "matchManagers": ["maven"],
+      "matchPackageNames": ["org.apache.httpcomponents.core5:httpcore5"],
+      "allowedVersions": "<=5.3.2"
+    },
+    {
       "matchBaseBranches": ["/^stable\\/8\\..*/"],
       "matchUpdateTypes": [
         "minor",

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -60,7 +60,7 @@
     <version.httpasyncclient>4.1.5</version.httpasyncclient>
     <version.httpclient>4.5.14</version.httpclient>
     <version.httpclient5>5.4.2</version.httpclient5>
-    <version.httpcore5>5.3.3</version.httpcore5>
+    <version.httpcore5>5.3.2</version.httpcore5>
     <version.httpcomponents>4.4.16</version.httpcomponents>
     <version.identity>8.5.13</version.identity>
     <version.jackson>2.18.3</version.jackson>


### PR DESCRIPTION
## Description

Revert org.apache.httpcomponents.core5:httpcore5 upgrade to v5.3.3

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29004
