### PR TITLE
fix: flaky PrefixMigrationIT increase awaitility timeout

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
@@ -203,6 +203,7 @@ public class PrefixMigrationIT {
 
     // Wait for documents to be written to indices
     Awaitility.await("document should be written")
+        .atMost(Duration.ofSeconds(30))
         .untilAsserted(
             () -> {
               final long processInstanceKey = processInstanceEvent.getProcessInstanceKey();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Increase Awaitility timeout for PrefixMigrationIT to remove flakiness

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
