### PR TITLE
Re-enable Operate Multi-Tenancy test

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaOidcUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOidcUserService.java
@@ -62,6 +62,9 @@ public class CamundaOidcUserService extends OidcUserService {
     final List<MappingEntity> mappings = mappingServices.getMatchingMappings(claims);
     final Set<Long> mappingKeys =
         mappings.stream().map(MappingEntity::mappingKey).collect(Collectors.toSet());
+    // TODO remove mapping when refactoring to IDs
+    final Set<String> mappingIds =
+        mappingKeys.stream().map(String::valueOf).collect(Collectors.toSet());
     if (mappingKeys.isEmpty()) {
       LOG.debug("No mappings found for these claims: {}", claims);
     }
@@ -79,7 +82,7 @@ public class CamundaOidcUserService extends OidcUserService {
                         mappingKeys.stream()
                             .map(String::valueOf)) // TODO remove mapping when refactoring to IDs
                     .collect(Collectors.toSet())),
-            tenantServices.getTenantsByMemberKeys(mappingKeys).stream()
+            tenantServices.getTenantsByMemberIds(mappingIds).stream()
                 .map(TenantDTO::fromEntity)
                 .toList(),
             groupServices.getGroupsByMemberKeys(mappingKeys).stream()

--- a/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
@@ -64,7 +64,7 @@ public class CamundaUserDetailsService implements UserDetailsService {
                 .collect(Collectors.toSet()));
 
     final var tenants =
-        tenantServices.getTenantsByMemberKey(userKey).stream()
+        tenantServices.getTenantsByMemberId(username).stream()
             .map(
                 entity ->
                     new TenantDTO(

--- a/qa/integration-tests/src/test/java/io/camunda/it/operate/OperateMultiTenancyIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/operate/OperateMultiTenancyIT.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 @MultiDbTest
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "os")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class OperateMultiTenancyIT {

--- a/qa/integration-tests/src/test/java/io/camunda/it/operate/OperateMultiTenancyIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/operate/OperateMultiTenancyIT.java
@@ -14,13 +14,11 @@ import static org.springframework.http.HttpStatus.OK;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.qa.util.cluster.TestStandaloneCamunda;
-import io.camunda.security.entity.AuthenticationMethod;
 import io.camunda.zeebe.it.util.AuthorizationsUtil;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import java.time.Duration;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @ZeebeIntegration
@@ -38,10 +36,7 @@ public class OperateMultiTenancyIT {
 
   @ZeebeIntegration.TestZeebe
   private final TestStandaloneCamunda testInstance =
-      new TestStandaloneCamunda()
-          .withCamundaExporter()
-          .withAuthenticationMethod(AuthenticationMethod.BASIC)
-          .withMultiTenancyEnabled();
+      new TestStandaloneCamunda().withCamundaExporter().withBasicAuth().withMultiTenancyEnabled();
 
   @BeforeEach
   public void beforeEach() {
@@ -77,7 +72,6 @@ public class OperateMultiTenancyIT {
   }
 
   @Test
-  @Disabled
   public void shouldGetProcessByKeyOnlyForProcessesInAuthenticatedTenants() {
     try (final var operateClient1 = testInstance.newOperateClient(USERNAME_1, PASSWORD);
         final var operateClient2 = testInstance.newOperateClient(USERNAME_2, PASSWORD)) {

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestSimpleCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestSimpleCamundaApplication.java
@@ -148,6 +148,11 @@ public final class TestSimpleCamundaApplication
     return withSecurityConfig(cfg -> cfg.getAuthorizations().setEnabled(true));
   }
 
+  public TestSimpleCamundaApplication withMultiTenancyEnabled() {
+    withAuthenticatedAccess();
+    return withSecurityConfig(cfg -> cfg.getMultiTenancy().setEnabled(true));
+  }
+
   @Override
   public TestSimpleCamundaApplication self() {
     return this;
@@ -249,6 +254,10 @@ public final class TestSimpleCamundaApplication
 
   public TestRestOperateClient newOperateClient() {
     return new TestRestOperateClient(restAddress());
+  }
+
+  public TestRestOperateClient newOperateClient(final String username, final String password) {
+    return new TestRestOperateClient(restAddress(), username, password);
   }
 
   public TestRestTasklistClient newTasklistClient() {

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneCamunda.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneCamunda.java
@@ -374,6 +374,7 @@ public final class TestStandaloneCamunda extends TestSpringApplication<TestStand
   }
 
   public TestStandaloneCamunda withMultiTenancyEnabled() {
-    return withSecurityConfig(securityConfig -> securityConfig.getMultiTenancy().setEnabled(true));
+    return withAuthenticatedAccess()
+        .withSecurityConfig(securityConfig -> securityConfig.getMultiTenancy().setEnabled(true));
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantFilterTransformer.java
@@ -10,8 +10,8 @@ package io.camunda.search.clients.transformers.filter;
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.hasChildQuery;
 import static io.camunda.search.clients.query.SearchQueryBuilders.hasParentQuery;
-import static io.camunda.search.clients.query.SearchQueryBuilders.longTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.matchNone;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex.KEY;
 import static io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex.NAME;
@@ -35,13 +35,13 @@ public class TenantFilterTransformer extends IndexFilterTransformer<TenantFilter
         filter.key() == null ? null : term(KEY, filter.key()),
         filter.tenantId() == null ? null : term(TENANT_ID, filter.tenantId()),
         filter.name() == null ? null : term(NAME, filter.name()),
-        filter.memberKeys() == null || filter.memberKeys().isEmpty()
+        filter.memberIds() == null
             ? null
-            : filter.memberKeys().isEmpty()
+            : filter.memberIds().isEmpty()
                 ? matchNone()
                 : hasChildQuery(
                     IdentityJoinRelationshipType.MEMBER.getType(),
-                    longTerms(TenantIndex.MEMBER_KEY, filter.memberKeys())),
+                    stringTerms(TenantIndex.MEMBER_ID, filter.memberIds())),
         filter.entityType() == null
             ? null
             : term(TenantIndex.MEMBER_TYPE, filter.entityType().name()),

--- a/search/search-domain/src/main/java/io/camunda/search/filter/TenantFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/TenantFilter.java
@@ -18,7 +18,7 @@ public record TenantFilter(
     String name,
     String joinParentId,
     EntityType entityType,
-    Set<Long> memberKeys)
+    Set<String> memberIds)
     implements FilterBase {
 
   public static TenantFilter of(final Function<Builder, Builder> builderFunction) {
@@ -32,7 +32,7 @@ public record TenantFilter(
     private String name;
     private String joinParentId;
     private EntityType entityType;
-    private Set<Long> memberKeys;
+    private Set<String> memberIds;
 
     public Builder key(final Long value) {
       key = value;
@@ -64,14 +64,14 @@ public record TenantFilter(
       return this;
     }
 
-    public Builder memberKeys(final Set<Long> value) {
-      memberKeys = value;
+    public Builder memberIds(final Set<String> value) {
+      memberIds = value;
       return this;
     }
 
     @Override
     public TenantFilter build() {
-      return new TenantFilter(key, tenantId, name, joinParentId, entityType, memberKeys);
+      return new TenantFilter(key, tenantId, name, joinParentId, entityType, memberIds);
     }
   }
 }

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -128,12 +128,12 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
             .setEntity(entityType, entityId));
   }
 
-  public Collection<TenantEntity> getTenantsByMemberKey(final long memberKey) {
-    return getTenantsByMemberKeys(Set.of(memberKey));
+  public Collection<TenantEntity> getTenantsByMemberId(final String memberId) {
+    return getTenantsByMemberIds(Set.of(memberId));
   }
 
-  public List<TenantEntity> getTenantsByMemberKeys(final Set<Long> memberKeys) {
-    return findAll(TenantQuery.of(q -> q.filter(b -> b.memberKeys(memberKeys))));
+  public List<TenantEntity> getTenantsByMemberIds(final Set<String> memberIds) {
+    return findAll(TenantQuery.of(q -> q.filter(b -> b.memberIds(memberIds))));
   }
 
   public TenantEntity getById(final String tenantId) {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/TenantIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/TenantIndex.java
@@ -22,7 +22,7 @@ public class TenantIndex extends UserManagementIndexDescriptor implements Prio5B
   public static final String NAME = "name";
   public static final String JOIN = "join";
   public static final String MEMBER_TYPE = "memberType";
-  public static final String MEMBER_KEY = "memberKey";
+  public static final String MEMBER_ID = "memberId";
   public static final String PARENT = "parent";
 
   public static final EntityJoinRelationFactory<String> JOIN_RELATION_FACTORY =


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This test was temporarily disabled due to the identity work on multi-tenancy. This has now reached a stage where we can
re-enable this test.

When re-enabling I discovered a bug where we were still trying to retrieve a member's tenants by the member key. Since the tenants and members are now stored using the member id this needed to be changed in order for the test to succeed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #27160 
