### PR TITLE
Validate tenants for REST job activation requests

### DIFF
--- a/search/search-client/src/main/java/io/camunda/util/CollectionUtil.java
+++ b/search/search-client/src/main/java/io/camunda/util/CollectionUtil.java
@@ -10,8 +10,10 @@ package io.camunda.util;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public final class CollectionUtil {
@@ -54,6 +56,29 @@ public final class CollectionUtil {
   public static <T> List<T> addValuesToList(final List<T> list, final List<T> values) {
     final List<T> result = Objects.requireNonNullElse(list, new ArrayList<>());
     result.addAll(Objects.requireNonNullElse(values, new ArrayList<>()));
+    return result;
+  }
+
+  /**
+   * Adds given values to a set.
+   *
+   * <p>This method can handle null-values gracefully.
+   *
+   * <p>This means, if either one of the given set is empty, and empty HashSet will be used instead.
+   *
+   * <p>Example:
+   *
+   * <p>* addValuesToSet(null, Set.of(1)) -> Set(1) * addValuesToSet(Set.of(1), null) -> Set(1) *
+   * addValuesToSet(null, null) -> Set() * addValuesToSet(Set.of(1), Set.of(2)) -> Set(1, 2)
+   *
+   * @param set where the values should be added to
+   * @param values the values which should be added
+   * @return the given set (when not empty) otherwise a new set containing the values
+   * @param <T> the set value type
+   */
+  public static <T> Set<T> addValuesToSet(final Set<T> set, final Collection<T> values) {
+    final Set<T> result = Objects.requireNonNullElse(set, new HashSet<>());
+    result.addAll(Objects.requireNonNullElse(values, new HashSet<>()));
     return result;
   }
 

--- a/service/src/main/java/io/camunda/service/security/auth/Authentication.java
+++ b/service/src/main/java/io/camunda/service/security/auth/Authentication.java
@@ -8,15 +8,18 @@
 package io.camunda.service.security.auth;
 
 import static io.camunda.util.CollectionUtil.addValuesToList;
+import static io.camunda.util.CollectionUtil.addValuesToSet;
 
 import io.camunda.service.search.filter.FilterBase;
 import io.camunda.util.ObjectBuilder;
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 public record Authentication(
     String authenticatedUserId,
     List<String> authenticatedGroupIds,
-    List<String> authenticatedTenantIds,
+    Set<String> authenticatedTenantIds,
     String token)
     implements FilterBase {
 
@@ -24,7 +27,7 @@ public record Authentication(
 
     private String user;
     private List<String> groups;
-    private List<String> tenants;
+    private Set<String> tenants;
     private String token;
 
     public Builder user(final String value) {
@@ -42,11 +45,11 @@ public record Authentication(
     }
 
     public Builder tenant(final String tenant) {
-      return tenants(List.of(tenant));
+      return tenants(Set.of(tenant));
     }
 
-    public Builder tenants(final List<String> values) {
-      tenants = addValuesToList(tenants, values);
+    public Builder tenants(final Collection<String> values) {
+      tenants = addValuesToSet(tenants, values);
       return this;
     }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -90,7 +90,9 @@ import io.camunda.zeebe.util.Either;
 import java.io.IOException;
 import java.io.InputStream;
 import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -436,7 +438,7 @@ public class RequestMapper {
   }
 
   public static Authentication getAuthentication() {
-    final Set<String> authorizedTenants = getAuthorizedTenants();
+    final List<String> authorizedTenants = TenantAttributeHolder.tenantIds();
 
     final String token =
         Authorization.jwtEncoder()
@@ -449,7 +451,8 @@ public class RequestMapper {
   }
 
   public static Set<String> getAuthorizedTenants() {
-    return TenantAttributeHolder.tenantIds();
+    final List<String> tenantIds = TenantAttributeHolder.tenantIds();
+    return tenantIds == null ? Collections.emptySet() : new HashSet<>(tenantIds);
   }
 
   public static Authentication getAnonymousAuthentication() {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -94,6 +94,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -435,7 +436,7 @@ public class RequestMapper {
   }
 
   public static Authentication getAuthentication() {
-    final List<String> authorizedTenants = TenantAttributeHolder.tenantIds();
+    final Set<String> authorizedTenants = getAuthorizedTenants();
 
     final String token =
         Authorization.jwtEncoder()
@@ -445,6 +446,10 @@ public class RequestMapper {
             .withClaim(Authorization.AUTHORIZED_TENANTS, authorizedTenants)
             .encode();
     return new Builder().token(token).tenants(authorizedTenants).build();
+  }
+
+  public static Set<String> getAuthorizedTenants() {
+    return TenantAttributeHolder.tenantIds();
   }
 
   public static Authentication getAnonymousAuthentication() {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -19,7 +19,9 @@ import static io.camunda.zeebe.gateway.rest.validator.JobRequestValidator.valida
 import static io.camunda.zeebe.gateway.rest.validator.MessageRequestValidator.validateMessageCorrelationRequest;
 import static io.camunda.zeebe.gateway.rest.validator.MessageRequestValidator.validateMessagePublicationRequest;
 import static io.camunda.zeebe.gateway.rest.validator.MultiTenancyValidator.validateAuthorization;
+import static io.camunda.zeebe.gateway.rest.validator.MultiTenancyValidator.validateAuthorizations;
 import static io.camunda.zeebe.gateway.rest.validator.MultiTenancyValidator.validateTenantId;
+import static io.camunda.zeebe.gateway.rest.validator.MultiTenancyValidator.validateTenantIds;
 import static io.camunda.zeebe.gateway.rest.validator.ProcessInstanceRequestValidator.validateCancelProcessInstanceRequest;
 import static io.camunda.zeebe.gateway.rest.validator.ProcessInstanceRequestValidator.validateCreateProcessInstanceRequest;
 import static io.camunda.zeebe.gateway.rest.validator.ProcessInstanceRequestValidator.validateMigrateProcessInstanceRequest;
@@ -165,15 +167,30 @@ public class RequestMapper {
   }
 
   public static Either<ProblemDetail, ActivateJobsRequest> toJobsActivationRequest(
-      final JobActivationRequest activationRequest) {
+      final JobActivationRequest activationRequest, final boolean multiTenancyEnabled) {
 
-    return getResult(
-        validateJobActivationRequest(activationRequest),
-        () ->
+    final Either<ProblemDetail, List<String>> validationResponse =
+        validateTenantIds(
+                getStringListOrEmpty(activationRequest, JobActivationRequest::getTenantIds),
+                multiTenancyEnabled,
+                "Activate Jobs")
+            .flatMap(
+                tenantIds ->
+                    validateAuthorizations(tenantIds, multiTenancyEnabled, "Activate Jobs")
+                        .map(Either::<ProblemDetail, List<String>>left)
+                        .orElseGet(() -> Either.right(tenantIds)))
+            .flatMap(
+                tenantIds ->
+                    validateJobActivationRequest(activationRequest)
+                        .map(Either::<ProblemDetail, List<String>>left)
+                        .orElseGet(() -> Either.right(tenantIds)));
+
+    return validationResponse.map(
+        tenantIds ->
             new ActivateJobsRequest(
                 activationRequest.getType(),
                 activationRequest.getMaxJobsToActivate(),
-                getStringListOrEmpty(activationRequest, JobActivationRequest::getTenantIds),
+                tenantIds,
                 activationRequest.getTimeout(),
                 getStringOrEmpty(activationRequest, JobActivationRequest::getWorker),
                 getStringListOrEmpty(activationRequest, JobActivationRequest::getFetchVariable),

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/TenantAttributeHolder.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/TenantAttributeHolder.java
@@ -10,8 +10,10 @@ package io.camunda.zeebe.gateway.rest;
 import static io.camunda.zeebe.protocol.record.value.TenantOwned.DEFAULT_TENANT_IDENTIFIER;
 import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
 
@@ -20,14 +22,15 @@ public final class TenantAttributeHolder {
 
   private TenantAttributeHolder() {}
 
-  public static List<String> tenantIds() {
+  public static Set<String> tenantIds() {
     final var requestAttributes = getCurrentRequestAttributes();
     return getTenantsOrDefaultTenant(requestAttributes);
   }
 
   public static void withTenantIds(final List<String> tenantIds) {
     final var requestAttributes = getCurrentRequestAttributes();
-    final var tenantsOptional = Optional.ofNullable(tenantIds);
+    final var tenantsOptional =
+        Optional.ofNullable(tenantIds == null ? null : new HashSet<>(tenantIds));
     requestAttributes.setAttribute(ATTRIBUTE_KEY, tenantsOptional, SCOPE_REQUEST);
   }
 
@@ -35,13 +38,13 @@ public final class TenantAttributeHolder {
     return RequestContextHolder.currentRequestAttributes();
   }
 
-  private static List<String> getTenantsOrDefaultTenant(final RequestAttributes requestAttributes) {
+  private static Set<String> getTenantsOrDefaultTenant(final RequestAttributes requestAttributes) {
     final var tenants = requestAttributes.getAttribute(ATTRIBUTE_KEY, SCOPE_REQUEST);
 
     if (tenants != null) {
-      return ((Optional<List<String>>) tenants).orElse(null);
+      return ((Optional<Set<String>>) tenants).orElse(null);
     } else {
-      return List.of(DEFAULT_TENANT_IDENTIFIER);
+      return Set.of(DEFAULT_TENANT_IDENTIFIER);
     }
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/TenantAttributeHolder.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/TenantAttributeHolder.java
@@ -10,10 +10,8 @@ package io.camunda.zeebe.gateway.rest;
 import static io.camunda.zeebe.protocol.record.value.TenantOwned.DEFAULT_TENANT_IDENTIFIER;
 import static org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
 
@@ -22,15 +20,14 @@ public final class TenantAttributeHolder {
 
   private TenantAttributeHolder() {}
 
-  public static Set<String> tenantIds() {
+  public static List<String> tenantIds() {
     final var requestAttributes = getCurrentRequestAttributes();
     return getTenantsOrDefaultTenant(requestAttributes);
   }
 
   public static void withTenantIds(final List<String> tenantIds) {
     final var requestAttributes = getCurrentRequestAttributes();
-    final var tenantsOptional =
-        Optional.ofNullable(tenantIds == null ? null : new HashSet<>(tenantIds));
+    final var tenantsOptional = Optional.ofNullable(tenantIds);
     requestAttributes.setAttribute(ATTRIBUTE_KEY, tenantsOptional, SCOPE_REQUEST);
   }
 
@@ -38,13 +35,13 @@ public final class TenantAttributeHolder {
     return RequestContextHolder.currentRequestAttributes();
   }
 
-  private static Set<String> getTenantsOrDefaultTenant(final RequestAttributes requestAttributes) {
+  private static List<String> getTenantsOrDefaultTenant(final RequestAttributes requestAttributes) {
     final var tenants = requestAttributes.getAttribute(ATTRIBUTE_KEY, SCOPE_REQUEST);
 
     if (tenants != null) {
-      return ((Optional<Set<String>>) tenants).orElse(null);
+      return ((Optional<List<String>>) tenants).orElse(null);
     } else {
-      return Set.of(DEFAULT_TENANT_IDENTIFIER);
+      return List.of(DEFAULT_TENANT_IDENTIFIER);
     }
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.rest.controller;
 
 import io.camunda.service.JobServices;
 import io.camunda.service.JobServices.ActivateJobsRequest;
+import io.camunda.zeebe.gateway.impl.configuration.MultiTenancyCfg;
 import io.camunda.zeebe.gateway.protocol.rest.JobActivationRequest;
 import io.camunda.zeebe.gateway.protocol.rest.JobActivationResponse;
 import io.camunda.zeebe.gateway.protocol.rest.JobCompletionRequest;
@@ -36,19 +37,22 @@ public class JobController {
 
   private final ResponseObserverProvider responseObserverProvider;
   private final JobServices<JobActivationResponse> jobServices;
+  private final MultiTenancyCfg multiTenancyCfg;
 
   @Autowired
   public JobController(
       final JobServices<JobActivationResponse> jobServices,
-      final ResponseObserverProvider responseObserverProvider) {
+      final ResponseObserverProvider responseObserverProvider,
+      final MultiTenancyCfg multiTenancyCfg) {
     this.jobServices = jobServices;
     this.responseObserverProvider = responseObserverProvider;
+    this.multiTenancyCfg = multiTenancyCfg;
   }
 
   @CamundaPostMapping(path = "/activation")
   public CompletableFuture<ResponseEntity<Object>> activateJobs(
       @RequestBody final JobActivationRequest activationRequest) {
-    return RequestMapper.toJobsActivationRequest(activationRequest)
+    return RequestMapper.toJobsActivationRequest(activationRequest, multiTenancyCfg.isEnabled())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::activateJobs);
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ErrorMessages.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ErrorMessages.java
@@ -27,6 +27,8 @@ public final class ErrorMessages {
   public static final String ERROR_MESSAGE_AT_LEAST_ONE_FIELD = "At least one of %s is required";
   public static final String ERROR_MESSAGE_INVALID_TENANT =
       "Expected to handle request %s with tenant identifier '%s', but %s";
+  public static final String ERROR_MESSAGE_INVALID_TENANTS =
+      "Expected to handle request %s with tenant identifiers %s, but %s";
   public static final String ERROR_MESSAGE_ONLY_ONE_FIELD = "Only one of %s is allowed";
   public static final String ERROR_MESSAGE_INVALID_EMAIL = "The provided email '%s' is not valid";
   public static final String ERROR_MESSAGE_ALL_REQUIRED_FIELD = "All %s are required";

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/MultiTenancyValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/MultiTenancyValidator.java
@@ -48,7 +48,7 @@ public final class MultiTenancyValidator {
     }
 
     final var authorizedTenants = RequestMapper.getAuthorizedTenants();
-    if (authorizedTenants == null || !authorizedTenants.containsAll(tenantIds)) {
+    if (!authorizedTenants.containsAll(tenantIds)) {
       return Optional.of(
           RestErrorMapper.createProblemDetail(
               HttpStatus.UNAUTHORIZED,
@@ -58,7 +58,7 @@ public final class MultiTenancyValidator {
                       tenantIds.getFirst(),
                       "the user is not authorized for that tenant")
                   : ERROR_MESSAGE_INVALID_TENANTS.formatted(
-                      commandName, tenantIds, "the user is not authorized for that tenant"),
+                      commandName, tenantIds, "the user is not authorized for all those tenants"),
               HttpStatus.UNAUTHORIZED.name()));
     }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/MultiTenancyValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/MultiTenancyValidator.java
@@ -47,7 +47,7 @@ public final class MultiTenancyValidator {
       return Optional.empty();
     }
 
-    final var authorizedTenants = RequestMapper.getAuthentication().authenticatedTenantIds();
+    final var authorizedTenants = RequestMapper.getAuthorizedTenants();
     if (authorizedTenants == null || !authorizedTenants.containsAll(tenantIds)) {
       return Optional.of(
           RestErrorMapper.createProblemDetail(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/MultiTenancyValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/MultiTenancyValidator.java
@@ -56,9 +56,9 @@ public final class MultiTenancyValidator {
                   ? ERROR_MESSAGE_INVALID_TENANT.formatted(
                       commandName,
                       tenantIds.getFirst(),
-                      "tenant is not authorized to perform this request")
+                      "the user is not authorized for that tenant")
                   : ERROR_MESSAGE_INVALID_TENANTS.formatted(
-                      commandName, tenantIds, "tenant is not authorized to perform this request"),
+                      commandName, tenantIds, "the user is not authorized for that tenant"),
               HttpStatus.UNAUTHORIZED.name()));
     }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsRestTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsRestTest.java
@@ -955,7 +955,7 @@ public class LongPollingActivateJobsRestTest {
             .maxJobsToActivate(MAX_JOBS_TO_ACTIVATE)
             .requestTimeout(500L)
             .timeout(1000L);
-    final var requestMappingResult = RequestMapper.toJobsActivationRequest(restRequest);
+    final var requestMappingResult = RequestMapper.toJobsActivationRequest(restRequest, false);
     if (requestMappingResult.isLeft()) {
       fail("REST Request mapping failed unexpectedly: " + requestMappingResult.getLeft());
     }
@@ -1040,7 +1040,7 @@ public class LongPollingActivateJobsRestTest {
 
   private InflightActivateJobsRequest<JobActivationResponse> toInflightActivateJobsRequest(
       final JobActivationRequest restRequest) {
-    final var requestMappingResult = RequestMapper.toJobsActivationRequest(restRequest);
+    final var requestMappingResult = RequestMapper.toJobsActivationRequest(restRequest, false);
     if (requestMappingResult.isLeft()) {
       fail("REST Request mapping failed unexpectedly: " + requestMappingResult.getLeft());
     }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsRestTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsRestTest.java
@@ -54,6 +54,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
@@ -126,7 +127,7 @@ public class LongPollingActivateJobsRestTest {
     failJobStub.registerWith(brokerClient);
 
     tenantAttributeHolderMock = mockStatic(TenantAttributeHolder.class);
-    tenantAttributeHolderMock.when(TenantAttributeHolder::tenantIds).thenReturn(List.of());
+    tenantAttributeHolderMock.when(TenantAttributeHolder::tenantIds).thenReturn(Set.of());
   }
 
   @AfterEach

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsRestTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsRestTest.java
@@ -54,7 +54,6 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
@@ -127,7 +126,7 @@ public class LongPollingActivateJobsRestTest {
     failJobStub.registerWith(brokerClient);
 
     tenantAttributeHolderMock = mockStatic(TenantAttributeHolder.class);
-    tenantAttributeHolderMock.when(TenantAttributeHolder::tenantIds).thenReturn(Set.of());
+    tenantAttributeHolderMock.when(TenantAttributeHolder::tenantIds).thenReturn(List.of());
   }
 
   @AfterEach

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerTest.java
@@ -7,9 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest;
 
-import io.camunda.service.security.auth.Authentication;
 import io.camunda.zeebe.gateway.rest.config.JacksonConfig;
-import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import org.mockito.MockedStatic;
@@ -33,9 +31,7 @@ public abstract class RestControllerTest {
       final String tenantId, final Function<WebTestClient, ResponseSpec> function) {
     try (final MockedStatic<RequestMapper> mockRequestMapper =
         Mockito.mockStatic(RequestMapper.class, Mockito.CALLS_REAL_METHODS)) {
-      mockRequestMapper
-          .when(RequestMapper::getAuthentication)
-          .thenReturn(new Authentication("user", List.of("group"), Set.of(tenantId), "token"));
+      mockRequestMapper.when(RequestMapper::getAuthorizedTenants).thenReturn(Set.of(tenantId));
       return function.apply(webClient);
     }
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.rest;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.zeebe.gateway.rest.config.JacksonConfig;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -34,7 +35,7 @@ public abstract class RestControllerTest {
         Mockito.mockStatic(RequestMapper.class, Mockito.CALLS_REAL_METHODS)) {
       mockRequestMapper
           .when(RequestMapper::getAuthentication)
-          .thenReturn(new Authentication("user", List.of("group"), List.of(tenantId), "token"));
+          .thenReturn(new Authentication("user", List.of("group"), Set.of(tenantId), "token"));
       return function.apply(webClient);
     }
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.rest.controller;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import com.jayway.jsonpath.JsonPath;
 import io.camunda.service.JobServices;
@@ -46,6 +47,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec;
 import org.springframework.util.unit.DataSize;
 
 @WebMvcTest(JobController.class)
@@ -67,13 +69,13 @@ public class JobControllerLongPollingTest extends RestControllerTest {
   void shouldActivateJobsImmediatelyIfAvailable() {
     // given
     final ActivateJobsStub stub = new ActivateJobsStub();
-    stub.addAvailableJobs("TEST", 2);
+    stub.addAvailableJobs("TEST-immediate", 2);
     stub.registerWith(stubbedBrokerClient);
 
     final var request =
         """
         {
-          "type": "TEST",
+          "type": "TEST-immediate",
           "maxJobsToActivate": 2,
           "requestTimeout": 100,
           "timeout": 100,
@@ -81,44 +83,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
           "tenantIds": [],
           "worker": "bar"
         }""";
-    final var expectedBody =
-        """
-        {
-          "jobs": [
-            {
-              "jobKey": 4503599627370496,
-              "type": "TEST",
-              "processInstanceKey": 123,
-              "processDefinitionKey": 4532,
-              "processDefinitionVersion": 23,
-              "elementInstanceKey": 459,
-              "retries": 12,
-              "deadline": 123123123,
-              "tenantId": "<default>",
-              "variables": {"bar": "world", "foo": 13},
-              "customHeaders": {"bar": "val", "foo": 12},
-              "processDefinitionId": "stubProcess",
-              "elementId": "stubActivity",
-              "worker": "bar"
-            },
-            {
-              "jobKey": 4503599627370497,
-              "type": "TEST",
-              "processInstanceKey": 123,
-              "processDefinitionKey": 4532,
-              "processDefinitionVersion": 23,
-              "elementInstanceKey": 459,
-              "retries": 12,
-              "deadline": 123123123,
-              "tenantId": "<default>",
-              "variables": {"bar": "world", "foo": 13},
-              "customHeaders": {"bar": "val", "foo": 12},
-              "processDefinitionId": "stubProcess",
-              "elementId": "stubActivity",
-              "worker": "bar"
-            }
-          ]
-        }""";
+
     // when / then
     webClient
         .post()
@@ -132,7 +97,10 @@ public class JobControllerLongPollingTest extends RestControllerTest {
         .expectHeader()
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
-        .json(expectedBody);
+        .jsonPath("$.jobs[0].type")
+        .isEqualTo("TEST-immediate")
+        .jsonPath("$.jobs[1].type")
+        .isEqualTo("TEST-immediate");
 
     Mockito.verify(responseObserver, Mockito.times(1)).onNext(any());
     Mockito.verify(responseObserver).onCompleted();
@@ -142,13 +110,13 @@ public class JobControllerLongPollingTest extends RestControllerTest {
   void shouldActivateJobsImmediatelyIfAvailableWithStringKeys() {
     // given
     final ActivateJobsStub stub = new ActivateJobsStub();
-    stub.addAvailableJobs("TEST", 2);
+    stub.addAvailableJobs("TEST-immediate-string-keys", 2);
     stub.registerWith(stubbedBrokerClient);
 
     final var request =
         """
         {
-          "type": "TEST",
+          "type": "TEST-immediate-string-keys",
           "maxJobsToActivate": 2,
           "requestTimeout": 100,
           "timeout": 100,
@@ -156,44 +124,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
           "tenantIds": [],
           "worker": "bar"
         }""";
-    final var expectedBody =
-        """
-        {
-          "jobs": [
-            {
-              "jobKey": "2251799813685248",
-              "type": "TEST",
-              "processInstanceKey": "123",
-              "processDefinitionKey": "4532",
-              "processDefinitionVersion": 23,
-              "elementInstanceKey": "459",
-              "retries": 12,
-              "deadline": 123123123,
-              "tenantId": "<default>",
-              "variables": {},
-              "customHeaders": {},
-              "processDefinitionId": "stubProcess",
-              "elementId": "stubActivity",
-              "worker": "bar"
-            },
-            {
-              "jobKey": "2251799813685249",
-              "type": "TEST",
-              "processInstanceKey": "123",
-              "processDefinitionKey": "4532",
-              "processDefinitionVersion": 23,
-              "elementInstanceKey": "459",
-              "retries": 12,
-              "deadline": 123123123,
-              "tenantId": "<default>",
-              "variables": {},
-              "customHeaders": {},
-              "processDefinitionId": "stubProcess",
-              "elementId": "stubActivity",
-              "worker": "bar"
-            }
-          ]
-        }""";
+
     // when / then
     webClient
         .post()
@@ -207,7 +138,10 @@ public class JobControllerLongPollingTest extends RestControllerTest {
         .expectHeader()
         .contentType(RequestMapper.MEDIA_TYPE_KEYS_STRING)
         .expectBody()
-        .json(expectedBody);
+        .jsonPath("$.jobs[0].type")
+        .isEqualTo("TEST-immediate-string-keys")
+        .jsonPath("$.jobs[1].type")
+        .isEqualTo("TEST-immediate-string-keys");
 
     Mockito.verify(responseObserver, Mockito.times(1)).onNext(any());
     Mockito.verify(responseObserver).onCompleted();
@@ -222,7 +156,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
     final var request =
         """
         {
-          "type": "TEST",
+          "type": "TEST-no-jobs",
           "maxJobsToActivate": 10,
           "requestTimeout": 100,
           "timeout": 100,
@@ -263,7 +197,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
     final var request =
         """
         {
-          "type": "TEST",
+          "type": "TEST-round-robin",
           "maxJobsToActivate": 2,
           "requestTimeout": 100,
           "timeout": 100,
@@ -276,7 +210,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
      * The job activation handler is created once for all tests, so previous tests can have moved
      * the round-robin index by any number already.
      */
-    stub.addAvailableJobs("TEST", 1);
+    stub.addAvailableJobs("TEST-round-robin", 1);
     final String result =
         webClient
             .post()
@@ -303,7 +237,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
       final int expectedPartitionId = (basePartition + partitionOffset - 1) % partitionsCount + 1;
       // reset the results and add new jobs that can be fetched
       responseObserver.reset();
-      stub.addAvailableJobs("TEST", 2);
+      stub.addAvailableJobs("TEST-round-robin", 2);
       // when/then
       webClient
           .post()
@@ -339,7 +273,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
     final var request =
         """
         {
-          "type": "TEST",
+          "type": "TEST-rejection",
           "maxJobsToActivate": 10,
           "requestTimeout": 100,
           "timeout": 100,
@@ -374,6 +308,90 @@ public class JobControllerLongPollingTest extends RestControllerTest {
         .json(expectedBody);
 
     assertThat(callCounter).hasValue(1);
+  }
+
+  @Test
+  void shouldAllowActivateJobWithAuthorizedTenantWhenMultiTenancyEnabled() {
+    // given
+    when(multiTenancyCfg.isEnabled()).thenReturn(true);
+    final ActivateJobsStub stub = new ActivateJobsStub();
+    stub.registerWith(stubbedBrokerClient);
+
+    final var request =
+        """
+        {
+          "type": "TEST-authorized-tenant",
+          "maxJobsToActivate": 2,
+          "requestTimeout": 100,
+          "timeout": 100,
+          "fetchVariable": [],
+          "tenantIds": ["tenantId"],
+          "worker": "bar"
+        }""";
+
+    final var expectedBody =
+        """
+        {
+          "jobs": []
+        }""";
+
+    // when then
+    final ResponseSpec response =
+        withMultiTenancy(
+            "tenantId",
+            client ->
+                client
+                    .post()
+                    .uri(JOBS_BASE_URL + "/activation")
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(request)
+                    .exchange()
+                    .expectStatus()
+                    .isOk());
+
+    response.expectHeader().contentType(MediaType.APPLICATION_JSON).expectBody().json(expectedBody);
+  }
+
+  @Test
+  void shouldAllowActivateJobWithDefaultTenantWhenMultiTenancyDisabled() {
+    // given
+    when(multiTenancyCfg.isEnabled()).thenReturn(false);
+    final ActivateJobsStub stub = new ActivateJobsStub();
+    stub.registerWith(stubbedBrokerClient);
+
+    final var request =
+        """
+        {
+          "type": "TEST-default-tenant",
+          "maxJobsToActivate": 2,
+          "requestTimeout": 100,
+          "timeout": 100,
+          "fetchVariable": [],
+          "tenantIds": ["<default>"],
+          "worker": "bar"
+        }""";
+
+    final var expectedBody =
+        """
+        {
+          "jobs": []
+        }""";
+
+    // when then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/activation")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(expectedBody);
   }
 
   @TestConfiguration

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerRejectionResponse;
 import io.camunda.zeebe.gateway.api.job.ActivateJobsStub;
 import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
+import io.camunda.zeebe.gateway.impl.configuration.MultiTenancyCfg;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
 import io.camunda.zeebe.gateway.metrics.LongPollingMetrics;
@@ -41,6 +42,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
@@ -54,6 +56,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
   @Autowired ActivateJobsHandler<JobActivationResponse> activateJobsHandler;
   @Autowired StubbedBrokerClient stubbedBrokerClient;
   @SpyBean ResettableJobActivationRequestResponseObserver responseObserver;
+  @MockBean MultiTenancyCfg multiTenancyCfg;
 
   @BeforeEach
   void setup() {
@@ -75,7 +78,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
           "requestTimeout": 100,
           "timeout": 100,
           "fetchVariable": [],
-          "tenantIds": ["default"],
+          "tenantIds": [],
           "worker": "bar"
         }""";
     final var expectedBody =
@@ -91,7 +94,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
               "elementInstanceKey": 459,
               "retries": 12,
               "deadline": 123123123,
-              "tenantId": "default",
+              "tenantId": "<default>",
               "variables": {"bar": "world", "foo": 13},
               "customHeaders": {"bar": "val", "foo": 12},
               "processDefinitionId": "stubProcess",
@@ -107,7 +110,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
               "elementInstanceKey": 459,
               "retries": 12,
               "deadline": 123123123,
-              "tenantId": "default",
+              "tenantId": "<default>",
               "variables": {"bar": "world", "foo": 13},
               "customHeaders": {"bar": "val", "foo": 12},
               "processDefinitionId": "stubProcess",
@@ -150,7 +153,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
           "requestTimeout": 100,
           "timeout": 100,
           "fetchVariable": [],
-          "tenantIds": ["default"],
+          "tenantIds": [],
           "worker": "bar"
         }""";
     final var expectedBody =
@@ -166,7 +169,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
               "elementInstanceKey": "459",
               "retries": 12,
               "deadline": 123123123,
-              "tenantId": "default",
+              "tenantId": "<default>",
               "variables": {},
               "customHeaders": {},
               "processDefinitionId": "stubProcess",
@@ -182,7 +185,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
               "elementInstanceKey": "459",
               "retries": 12,
               "deadline": 123123123,
-              "tenantId": "default",
+              "tenantId": "<default>",
               "variables": {},
               "customHeaders": {},
               "processDefinitionId": "stubProcess",
@@ -224,7 +227,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
           "requestTimeout": 100,
           "timeout": 100,
           "fetchVariable": ["foo"],
-          "tenantIds": ["default"],
+          "tenantIds": [],
           "worker": "bar"
         }""";
     final var expectedBody =
@@ -264,7 +267,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
           "maxJobsToActivate": 2,
           "requestTimeout": 100,
           "timeout": 100,
-          "tenantIds": ["default"],
+          "tenantIds": [],
           "worker": "bar"
         }""";
 
@@ -341,7 +344,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
           "requestTimeout": 100,
           "timeout": 100,
           "fetchVariable": ["foo"],
-          "tenantIds": ["default"],
+          "tenantIds": [],
           "worker": "bar"
         }""";
     final var expectedBody =

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerRejectionResponse;
 import io.camunda.zeebe.gateway.api.job.ActivateJobsStub;
 import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
+import io.camunda.zeebe.gateway.impl.configuration.MultiTenancyCfg;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.RoundRobinActivateJobsHandler;
 import io.camunda.zeebe.gateway.protocol.rest.JobActivationResponse;
@@ -39,6 +40,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.http.MediaType;
@@ -52,6 +54,7 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
   @Autowired ActivateJobsHandler<JobActivationResponse> activateJobsHandler;
   @Autowired StubbedBrokerClient stubbedBrokerClient;
   @SpyBean ResettableJobActivationRequestResponseObserver responseObserver;
+  @MockBean MultiTenancyCfg multiTenancyCfg;
 
   @BeforeEach
   void setup() {
@@ -81,7 +84,7 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
           "requestTimeout": 100,
           "timeout": 100,
           "fetchVariable": [],
-          "tenantIds": ["default"],
+          "tenantIds": [],
           "worker": "bar"
         }""";
 
@@ -98,7 +101,7 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
               "elementInstanceKey": 459,
               "retries": 12,
               "deadline": 123123123,
-              "tenantId": "default",
+              "tenantId": "<default>",
               "variables": {},
               "customHeaders": {},
               "processDefinitionId": "stubProcess",
@@ -114,7 +117,7 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
               "elementInstanceKey": 459,
               "retries": 12,
               "deadline": 123123123,
-              "tenantId": "default",
+              "tenantId": "<default>",
               "variables": {},
               "customHeaders": {},
               "processDefinitionId": "stubProcess",
@@ -160,7 +163,7 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
           "requestTimeout": 100,
           "timeout": 100,
           "fetchVariable": ["foo"],
-          "tenantIds": ["default"],
+          "tenantIds": [],
           "worker": "bar"
         }""";
     final var expectedBody =
@@ -200,7 +203,7 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
           "maxJobsToActivate": 2,
           "requestTimeout": 100,
           "timeout": 100,
-          "tenantIds": ["default"],
+          "tenantIds": [],
           "worker": "bar"
         }""";
 
@@ -255,7 +258,7 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
           "requestTimeout": 100,
           "timeout": 100,
           "fetchVariable": ["foo"],
-          "tenantIds": ["default"],
+          "tenantIds": [],
           "worker": "bar"
         }""";
     final var expectedBody =

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -536,13 +536,14 @@ public class JobControllerTest extends RestControllerTest {
               "type": "about:blank",
               "status": 401,
               "title": "UNAUTHORIZED",
-              "detail": "Expected to handle request Activate Jobs with tenant %s, but the user is not authorized for that tenant",
+              "detail": "Expected to handle request Activate Jobs with tenant %s, but the user is not authorized for %s",
               "instance": "%s"
             }"""
                 .formatted(
                     tenantIds.size() == 1
                         ? "identifier '" + tenantIds.getFirst() + "'"
                         : "identifiers " + tenantIds,
+                    tenantIds.size() == 1 ? "that tenant" : "all those tenants",
                     JOBS_BASE_URL + "/activation"));
     verifyNoInteractions(jobServices);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -536,7 +536,7 @@ public class JobControllerTest extends RestControllerTest {
               "type": "about:blank",
               "status": 401,
               "title": "UNAUTHORIZED",
-              "detail": "Expected to handle request Activate Jobs with tenant %s, but tenant is not authorized to perform this request",
+              "detail": "Expected to handle request Activate Jobs with tenant %s, but the user is not authorized for that tenant",
               "instance": "%s"
             }"""
                 .formatted(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -11,22 +11,30 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.service.JobServices;
 import io.camunda.service.JobServices.UpdateJobChangeset;
 import io.camunda.service.security.auth.Authentication;
+import io.camunda.zeebe.gateway.impl.configuration.MultiTenancyCfg;
 import io.camunda.zeebe.gateway.protocol.rest.JobActivationResponse;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec;
 
 @WebMvcTest(JobController.class)
 public class JobControllerTest extends RestControllerTest {
@@ -34,6 +42,7 @@ public class JobControllerTest extends RestControllerTest {
   static final String JOBS_BASE_URL = "/v2/jobs";
 
   @MockBean JobServices<JobActivationResponse> jobServices;
+  @MockBean MultiTenancyCfg multiTenancyCfg;
   @MockBean ResponseObserverProvider responseObserverProvider;
 
   @BeforeEach
@@ -484,5 +493,65 @@ public class JobControllerTest extends RestControllerTest {
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody()
         .json(expectedBody);
+  }
+
+  @ParameterizedTest
+  @MethodSource("tenantLists")
+  void shouldRejectActivateJobWithUnauthorizedTenantWhenMultiTenancyEnabled(
+      final List<String> tenantIds) {
+    // given
+    when(multiTenancyCfg.isEnabled()).thenReturn(true);
+    final var request =
+        """
+        {
+          "type": "TEST",
+          "maxJobsToActivate": 2,
+          "requestTimeout": 100,
+          "timeout": 100,
+          "fetchVariable": [],
+          "tenantIds": %s,
+          "worker": "bar"
+        }"""
+            .formatted(tenantIds.stream().map("\"%s\""::formatted).toList());
+
+    // when then
+    final ResponseSpec response =
+        withMultiTenancy(
+            "tenantId",
+            client ->
+                client
+                    .post()
+                    .uri(JOBS_BASE_URL + "/activation")
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(request)
+                    .exchange()
+                    .expectStatus()
+                    .isUnauthorized());
+    response
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "status": 401,
+              "title": "UNAUTHORIZED",
+              "detail": "Expected to handle request Activate Jobs with tenant %s, but tenant is not authorized to perform this request",
+              "instance": "%s"
+            }"""
+                .formatted(
+                    tenantIds.size() == 1
+                        ? "identifier '" + tenantIds.getFirst() + "'"
+                        : "identifiers " + tenantIds,
+                    JOBS_BASE_URL + "/activation"));
+    verifyNoInteractions(jobServices);
+  }
+
+  static Stream<Arguments> tenantLists() {
+    return Stream.of(
+        Arguments.of(List.of("unauthorizedTenant")),
+        Arguments.of(List.of("tenantId", "unauthorizedTenant")),
+        Arguments.of(List.of("tenantId", "<default>")),
+        Arguments.of(List.of("<default>")));
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageControllerTest.java
@@ -266,7 +266,7 @@ public class MessageControllerTest extends RestControllerTest {
               "type": "about:blank",
               "status": 400,
               "title": "INVALID_ARGUMENT",
-              "detail": "Expected to handle request Correlate Message with tenant identifier 'null', but no tenant identifier was provided.",
+              "detail": "Expected to handle request Correlate Message with tenant identifiers [], but no tenant identifier was provided.",
               "instance": "%s"
             }"""
                 .formatted(CORRELATION_ENDPOINT));

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/MessageControllerTest.java
@@ -415,7 +415,7 @@ public class MessageControllerTest extends RestControllerTest {
               "type": "about:blank",
               "status": 401,
               "title": "UNAUTHORIZED",
-              "detail": "Expected to handle request Correlate Message with tenant identifier 'unauthorizedTenant', but tenant is not authorized to perform this request",
+              "detail": "Expected to handle request Correlate Message with tenant identifier 'unauthorizedTenant', but the user is not authorized for that tenant",
               "instance": "%s"
             }"""
                 .formatted(CORRELATION_ENDPOINT));

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
@@ -274,7 +274,7 @@ public class ResourceControllerTest extends RestControllerTest {
               "type": "about:blank",
               "status": 401,
               "title": "UNAUTHORIZED",
-              "detail": "Expected to handle request Deploy Resources with tenant identifier 'unauthorizedTenant', but tenant is not authorized to perform this request",
+              "detail": "Expected to handle request Deploy Resources with tenant identifier 'unauthorizedTenant', but the user is not authorized for that tenant",
               "instance": "%s"
             }"""
                 .formatted(DEPLOY_RESOURCES_ENDPOINT));

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ResourceControllerTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.rest.controller;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.service.ResourceServices;
@@ -32,6 +33,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec;
 
 @WebMvcTest(ResourceController.class)
 public class ResourceControllerTest extends RestControllerTest {
@@ -236,6 +238,47 @@ public class ResourceControllerTest extends RestControllerTest {
              "tenantId":"<default>"
           }
          """);
+  }
+
+  @Test
+  void shouldRejectDeployResourcesWithUnauthorizedTenantWhenMultiTenancyEnabled() {
+    // given
+    when(multiTenancyCfg.isEnabled()).thenReturn(true);
+
+    final var filename = "process.bpmn";
+    final var contentType = MediaType.APPLICATION_OCTET_STREAM;
+    final var content = new byte[] {1, 2, 3};
+    final var multipartBodyBuilder = new MultipartBodyBuilder();
+    multipartBodyBuilder.part("resources", content).contentType(contentType).filename(filename);
+    multipartBodyBuilder.part("tenantId", "unauthorizedTenant");
+
+    // when then
+    final ResponseSpec response =
+        withMultiTenancy(
+            "tenantId",
+            client ->
+                client
+                    .post()
+                    .uri(DEPLOY_RESOURCES_ENDPOINT)
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .bodyValue(multipartBodyBuilder.build())
+                    .accept(MediaType.APPLICATION_JSON)
+                    .exchange()
+                    .expectStatus()
+                    .isUnauthorized());
+    response
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "status": 401,
+              "title": "UNAUTHORIZED",
+              "detail": "Expected to handle request Deploy Resources with tenant identifier 'unauthorizedTenant', but tenant is not authorized to perform this request",
+              "instance": "%s"
+            }"""
+                .formatted(DEPLOY_RESOURCES_ENDPOINT));
+    verifyNoInteractions(resourceServices);
   }
 
   @Test


### PR DESCRIPTION
## Description

Validate the provided tenant IDs of REST job activation requests.
This ensures clients can only activate jobs for tenants they are authorized to access.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29194 
