### PR TITLE
Task listener to provide reason to deny: exporters changes

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/JobTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/JobTemplate.java
@@ -38,8 +38,8 @@ public class JobTemplate extends OperateTemplateDescriptor
   public static final String JOB_KEY = "key";
   public static final String PARTITION_ID = "partitionId";
   public static final String JOB_FAILED_WITH_RETRIES_LEFT = "jobFailedWithRetriesLeft";
-  public static final String JOB_DENIED = "jobDenied"; // true/false
-  public static final String JOB_DENIED_REASON = "jobDeniedReason";
+  public static final String JOB_DENIED = "denied"; // true/false
+  public static final String JOB_DENIED_REASON = "deniedReason";
 
   public JobTemplate(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/JobTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/JobTemplate.java
@@ -38,6 +38,8 @@ public class JobTemplate extends OperateTemplateDescriptor
   public static final String JOB_KEY = "key";
   public static final String PARTITION_ID = "partitionId";
   public static final String JOB_FAILED_WITH_RETRIES_LEFT = "jobFailedWithRetriesLeft";
+  public static final String JOB_DENIED = "jobDenied"; // true/false
+  public static final String JOB_DENIED_REASON = "jobDeniedReason";
 
   public JobTemplate(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/JobEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/JobEntity.java
@@ -40,6 +40,9 @@ public class JobEntity extends OperateZeebeEntity<JobEntity> {
 
   private Long position;
 
+  private Boolean jobDenied;
+  private String jobDeniedReason;
+
   public Long getProcessInstanceKey() {
     return processInstanceKey;
   }
@@ -211,6 +214,24 @@ public class JobEntity extends OperateZeebeEntity<JobEntity> {
     return this;
   }
 
+  public Boolean isJobDenied() {
+    return jobDenied;
+  }
+
+  public JobEntity setJobDenied(final Boolean jobDenied) {
+    this.jobDenied = jobDenied;
+    return this;
+  }
+
+  public String getJobDeniedReason() {
+    return jobDeniedReason;
+  }
+
+  public JobEntity setJobDeniedReason(final String jobDeniedReason) {
+    this.jobDeniedReason = jobDeniedReason;
+    return this;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(
@@ -233,7 +254,9 @@ public class JobEntity extends OperateZeebeEntity<JobEntity> {
         jobFailedWithRetriesLeft,
         jobKind,
         listenerEventType,
-        position);
+        position,
+        jobDenied,
+        jobDeniedReason);
   }
 
   @Override
@@ -266,7 +289,9 @@ public class JobEntity extends OperateZeebeEntity<JobEntity> {
         && Objects.equals(customHeaders, jobEntity.customHeaders)
         && Objects.equals(jobKind, jobEntity.jobKind)
         && Objects.equals(listenerEventType, jobEntity.listenerEventType)
-        && Objects.equals(position, jobEntity.position);
+        && Objects.equals(position, jobEntity.position)
+        && Objects.equals(jobDenied, jobEntity.jobDenied)
+        && Objects.equals(jobDeniedReason, jobEntity.jobDeniedReason);
   }
 
   @Override
@@ -320,6 +345,10 @@ public class JobEntity extends OperateZeebeEntity<JobEntity> {
         + '\''
         + ", position="
         + position
+        + ", jobDenied="
+        + jobDenied
+        + ", jobDeniedReason="
+        + jobDeniedReason
         + "} "
         + super.toString();
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/JobEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/JobEntity.java
@@ -40,8 +40,8 @@ public class JobEntity extends OperateZeebeEntity<JobEntity> {
 
   private Long position;
 
-  private Boolean jobDenied;
-  private String jobDeniedReason;
+  private Boolean denied;
+  private String deniedReason;
 
   public Long getProcessInstanceKey() {
     return processInstanceKey;
@@ -214,21 +214,21 @@ public class JobEntity extends OperateZeebeEntity<JobEntity> {
     return this;
   }
 
-  public Boolean isJobDenied() {
-    return jobDenied;
+  public Boolean isDenied() {
+    return denied;
   }
 
-  public JobEntity setJobDenied(final Boolean jobDenied) {
-    this.jobDenied = jobDenied;
+  public JobEntity setDenied(final Boolean denied) {
+    this.denied = denied;
     return this;
   }
 
-  public String getJobDeniedReason() {
-    return jobDeniedReason;
+  public String getDeniedReason() {
+    return deniedReason;
   }
 
-  public JobEntity setJobDeniedReason(final String jobDeniedReason) {
-    this.jobDeniedReason = jobDeniedReason;
+  public JobEntity setDeniedReason(final String deniedReason) {
+    this.deniedReason = deniedReason;
     return this;
   }
 
@@ -255,8 +255,8 @@ public class JobEntity extends OperateZeebeEntity<JobEntity> {
         jobKind,
         listenerEventType,
         position,
-        jobDenied,
-        jobDeniedReason);
+        denied,
+        deniedReason);
   }
 
   @Override
@@ -290,8 +290,8 @@ public class JobEntity extends OperateZeebeEntity<JobEntity> {
         && Objects.equals(jobKind, jobEntity.jobKind)
         && Objects.equals(listenerEventType, jobEntity.listenerEventType)
         && Objects.equals(position, jobEntity.position)
-        && Objects.equals(jobDenied, jobEntity.jobDenied)
-        && Objects.equals(jobDeniedReason, jobEntity.jobDeniedReason);
+        && Objects.equals(denied, jobEntity.denied)
+        && Objects.equals(deniedReason, jobEntity.deniedReason);
   }
 
   @Override
@@ -346,9 +346,9 @@ public class JobEntity extends OperateZeebeEntity<JobEntity> {
         + ", position="
         + position
         + ", jobDenied="
-        + jobDenied
+        + denied
         + ", jobDeniedReason="
-        + jobDeniedReason
+        + deniedReason
         + "} "
         + super.toString();
   }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-job.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-job.json
@@ -71,10 +71,10 @@
       "position" : {
         "type": "long"
       },
-      "jobDenied" : {
+      "denied" : {
         "type" : "boolean"
       },
-      "jobDeniedReason": {
+      "deniedReason": {
         "type": "keyword"
       }
     }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-job.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-job.json
@@ -70,6 +70,12 @@
       },
       "position" : {
         "type": "long"
+      },
+      "jobDenied" : {
+        "type" : "boolean"
+      },
+      "jobDeniedReason": {
+        "type": "keyword"
       }
     }
   }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-job.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-job.json
@@ -71,10 +71,10 @@
       "position" : {
         "type": "long"
       },
-      "jobDenied" : {
+      "denied" : {
         "type" : "boolean"
       },
-      "jobDeniedReason": {
+      "deniedReason": {
         "type": "keyword"
       }
     }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-job.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-job.json
@@ -70,6 +70,12 @@
       },
       "position" : {
         "type": "long"
+      },
+      "jobDenied" : {
+        "type" : "boolean"
+      },
+      "jobDeniedReason": {
+        "type": "keyword"
       }
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
@@ -13,6 +13,8 @@ import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate
 import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.ERROR_MESSAGE;
 import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.FLOW_NODE_ID;
 import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.JOB_DEADLINE;
+import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.JOB_DENIED;
+import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.JOB_DENIED_REASON;
 import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.JOB_FAILED_WITH_RETRIES_LEFT;
 import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.JOB_STATE;
 import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.JOB_WORKER;
@@ -100,7 +102,10 @@ public class JobHandler implements ExportHandler<JobEntity, JobRecordValue> {
         .setEndTime(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())))
         .setCustomHeaders(recordValue.getCustomHeaders())
         .setJobKind(recordValue.getJobKind().name())
-        .setFlowNodeId(recordValue.getElementId());
+        .setFlowNodeId(recordValue.getElementId())
+        .setJobDenied(recordValue.getResult() == null ? null : recordValue.getResult().isDenied())
+        .setJobDeniedReason(
+            recordValue.getResult() == null ? null : recordValue.getResult().getDeniedReason());
 
     if (recordValue.getJobListenerEventType() != null) {
       entity.setListenerEventType(recordValue.getJobListenerEventType().name());
@@ -126,6 +131,12 @@ public class JobHandler implements ExportHandler<JobEntity, JobRecordValue> {
     final Map<String, Object> updateFields = new HashMap<>();
     if (jobEntity.getFlowNodeId() != null) {
       updateFields.put(FLOW_NODE_ID, jobEntity.getFlowNodeId());
+    }
+    if (jobEntity.getJobDeniedReason() != null) {
+      updateFields.put(JOB_DENIED_REASON, jobEntity.getJobDeniedReason());
+    }
+    if (jobEntity.isJobDenied() != null) {
+      updateFields.put(JOB_DENIED, jobEntity.isJobDenied());
     }
     updateFields.put(JOB_WORKER, jobEntity.getWorker());
     updateFields.put(JOB_STATE, jobEntity.getState());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
@@ -102,10 +102,13 @@ public class JobHandler implements ExportHandler<JobEntity, JobRecordValue> {
         .setEndTime(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())))
         .setCustomHeaders(recordValue.getCustomHeaders())
         .setJobKind(recordValue.getJobKind().name())
-        .setFlowNodeId(recordValue.getElementId())
-        .setJobDenied(recordValue.getResult() == null ? null : recordValue.getResult().isDenied())
-        .setJobDeniedReason(
-            recordValue.getResult() == null ? null : recordValue.getResult().getDeniedReason());
+        .setFlowNodeId(recordValue.getElementId());
+
+    if (record.getIntent() == JobIntent.COMPLETED) {
+      entity
+          .setDenied(recordValue.getResult().isDenied())
+          .setDeniedReason(recordValue.getResult().getDeniedReason());
+    }
 
     if (recordValue.getJobListenerEventType() != null) {
       entity.setListenerEventType(recordValue.getJobListenerEventType().name());
@@ -132,11 +135,11 @@ public class JobHandler implements ExportHandler<JobEntity, JobRecordValue> {
     if (jobEntity.getFlowNodeId() != null) {
       updateFields.put(FLOW_NODE_ID, jobEntity.getFlowNodeId());
     }
-    if (jobEntity.getJobDeniedReason() != null) {
-      updateFields.put(JOB_DENIED_REASON, jobEntity.getJobDeniedReason());
+    if (jobEntity.getDeniedReason() != null) {
+      updateFields.put(JOB_DENIED_REASON, jobEntity.getDeniedReason());
     }
-    if (jobEntity.isJobDenied() != null) {
-      updateFields.put(JOB_DENIED, jobEntity.isJobDenied());
+    if (jobEntity.isDenied() != null) {
+      updateFields.put(JOB_DENIED, jobEntity.isDenied());
     }
     updateFields.put(JOB_WORKER, jobEntity.getWorker());
     updateFields.put(JOB_STATE, jobEntity.getState());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
@@ -28,11 +28,11 @@ import static org.mockito.Mockito.verify;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.operate.template.JobTemplate;
 import io.camunda.webapps.schema.entities.operate.JobEntity;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutableJobResultValue;
 import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
@@ -172,7 +172,11 @@ final class JobHandlerTest {
             .withJobListenerEventType(jobListenerEventType)
             .withDeadline(deadline)
             .withErrorCode(errorCode)
-            .withResult(new JobResult().setDenied(jobDenied).setDeniedReason(jobDeniedReason))
+            .withResult(
+                ImmutableJobResultValue.builder()
+                    .withDenied(jobDenied)
+                    .withDeniedReason(jobDeniedReason)
+                    .build())
             .build();
     final Record<JobRecordValue> record =
         factory.generateRecord(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
@@ -380,8 +380,8 @@ final class JobHandlerTest {
     final String bpmnProcessId = "bpmnProcessId";
     final long processDefinitionKey = 555L;
     final OffsetDateTime endTime = OffsetDateTime.now();
-    final Boolean jobDenied = true;
-    final String jobDeniedReason = "reason to deny";
+    final Boolean denied = true;
+    final String deniedReason = "reason to deny";
 
     final Map<String, String> customHeaders = Map.of("key", "val");
     final JobEntity jobEntity =
@@ -397,8 +397,8 @@ final class JobHandlerTest {
             .setDeadline(deadline)
             .setProcessDefinitionKey(processDefinitionKey)
             .setBpmnProcessId(bpmnProcessId)
-            .setDenied(jobDenied)
-            .setDeniedReason(jobDeniedReason);
+            .setDenied(denied)
+            .setDeniedReason(deniedReason);
 
     final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();
     expectedUpdateFields.put(JOB_WORKER, jobEntity.getWorker());
@@ -411,8 +411,8 @@ final class JobHandlerTest {
     expectedUpdateFields.put(JOB_DEADLINE, jobEntity.getDeadline());
     expectedUpdateFields.put(PROCESS_DEFINITION_KEY, jobEntity.getProcessDefinitionKey());
     expectedUpdateFields.put(BPMN_PROCESS_ID, jobEntity.getBpmnProcessId());
-    expectedUpdateFields.put(JOB_DENIED, jobDenied);
-    expectedUpdateFields.put(JOB_DENIED_REASON, jobDeniedReason);
+    expectedUpdateFields.put(JOB_DENIED, denied);
+    expectedUpdateFields.put(JOB_DENIED_REASON, deniedReason);
 
     final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);
 
@@ -439,8 +439,8 @@ final class JobHandlerTest {
     final String bpmnProcessId = "bpmnProcessId";
     final long processDefinitionKey = 555L;
     final OffsetDateTime endTime = OffsetDateTime.now();
-    final Boolean jobDenied = true;
-    final String jobDeniedReason = "reason to deny";
+    final Boolean denied = true;
+    final String deniedReason = "reason to deny";
 
     final Map<String, String> customHeaders = Map.of("key", "val");
     final JobEntity jobEntity =
@@ -458,8 +458,8 @@ final class JobHandlerTest {
             .setProcessDefinitionKey(processDefinitionKey)
             .setBpmnProcessId(bpmnProcessId)
             .setJobFailedWithRetriesLeft(true)
-            .setDenied(jobDenied)
-            .setDeniedReason(jobDeniedReason);
+            .setDenied(denied)
+            .setDeniedReason(deniedReason);
 
     final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();
     expectedUpdateFields.put(FLOW_NODE_ID, jobEntity.getFlowNodeId());
@@ -474,8 +474,8 @@ final class JobHandlerTest {
     expectedUpdateFields.put(JOB_DEADLINE, jobEntity.getDeadline());
     expectedUpdateFields.put(PROCESS_DEFINITION_KEY, jobEntity.getProcessDefinitionKey());
     expectedUpdateFields.put(BPMN_PROCESS_ID, jobEntity.getBpmnProcessId());
-    expectedUpdateFields.put(JOB_DENIED, jobDenied);
-    expectedUpdateFields.put(JOB_DENIED_REASON, jobDeniedReason);
+    expectedUpdateFields.put(JOB_DENIED, denied);
+    expectedUpdateFields.put(JOB_DENIED_REASON, deniedReason);
 
     final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);
 


### PR DESCRIPTION
## Description
This PR is a part of [Allow task listener to provide reason to deny](https://github.com/camunda/camunda/issues/27141) and includes changes to Exporters.

- ES and OS exporters templates were already updated in the previous PRs, so no changes here.

`Camunda exporter` work:
After discussion with the team the decision was made to only update `JobHandler` `update` and `flush` methods as Operate may be interested in the job result which has to be stored in the `JobEntity`.

Two new fields `jobDenied` and `jobDeniedReason` were introduced in `JobEntity` to indicate if the job was denied and the reason why the job was denied. After discussion with the team the conclusion was made that currently this approach is preferable over introducing a nested `JobResultEntity` object.

Operate job templates were updated for both ES and OS and the tests were added to verify the change.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #27273
