### PR TITLE
build: delete ignored changes on new releases

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -183,6 +183,16 @@ jobs:
           FILE=$(./mvnw -B help:evaluate -Dexpression=ignored.changes.file -q -DforceStdout)
           rm -f "clients/java/${FILE}" "test/${FILE}" "exporter-api/${FILE}" "protocol/${FILE}" "bpmn-model/${FILE}"
           git commit -am "build(project): update java compat versions"
+      - name: Delete version-specific allowed API breaking changes
+        run: |
+          IFS='\n' readarray -t files <<< $(find . -name 'ignored-changes.json')
+          for file in "${files[@]}"; do
+            if [ '${{ inputs.dryRun }}' = 'false' ]; then
+              "[DRY RUN] rm -f ${file}"
+            else
+              rm -f "${file}"
+            fi
+          done
       - name: Push Changes to Release branch
         if: ${{ inputs.dryRun == false }}
         run: git push origin "${RELEASE_BRANCH}"


### PR DESCRIPTION
## Description

This PR adds back deleting the `ignored-changes.json` files on new releases. [As per the description here](https://github.com/camunda/camunda/wiki/Breaking-Changes), `ignored-changes.json` files contain bypass configuration to allow certain breaking changes for specific version.

On a new version, they should then be removed. Anything more permanent should then go in the `revapi.json` of a module.

This used to be the case, but was broken during the monorepo merge.
