### PR TITLE
Prevent application startup on invalid security config

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -848,7 +848,6 @@
             <dependency>org.springframework.boot:spring-boot-starter-web</dependency>
             <dependency>org.openapitools:jackson-databind-nullable</dependency>
             <dependency>jakarta.servlet:jakarta.servlet-api</dependency>
-            <dependency>jakarta.annotation:jakarta.annotation-api</dependency>
 
             <!-- Needed for configuring the Identity SDK by providing an IdentityConfiguration bean -->
             <dependency>io.camunda:identity-spring-boot-autoconfigure</dependency>

--- a/dist/src/main/java/io/camunda/application/commons/security/CamundaSecurityConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/security/CamundaSecurityConfiguration.java
@@ -10,6 +10,8 @@ package io.camunda.application.commons.security;
 import io.camunda.application.commons.security.CamundaSecurityConfiguration.CamundaSecurityProperties;
 import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -19,10 +21,33 @@ import org.springframework.context.annotation.Configuration;
 @EnableConfigurationProperties(CamundaSecurityProperties.class)
 public class CamundaSecurityConfiguration {
 
+  private final CamundaSecurityProperties camundaSecurityProperties;
+
+  @Autowired
+  public CamundaSecurityConfiguration(final CamundaSecurityProperties camundaSecurityProperties) {
+    this.camundaSecurityProperties = camundaSecurityProperties;
+  }
+
   @Bean
   public MultiTenancyConfiguration multiTenancyConfiguration(
       final SecurityConfiguration securityConfiguration) {
     return securityConfiguration.getMultiTenancy();
+  }
+
+  @PostConstruct
+  public void validate() {
+    final var multiTenancyEnabled = camundaSecurityProperties.getMultiTenancy().isEnabled();
+    final var apiUnprotected = camundaSecurityProperties.getAuthentication().getUnprotectedApi();
+
+    if (multiTenancyEnabled && apiUnprotected) {
+      throw new IllegalStateException(
+          "Multi-tenancy is enabled (%s=%b), but the API is unprotected (%s=%b). Please enable API protection if you want to make use of multi-tenancy."
+              .formatted(
+                  "camunda.security.multi-tenancy.enabled",
+                  true,
+                  "camunda.security.authentication.unprotected-api",
+                  true));
+    }
   }
 
   @ConfigurationProperties("camunda.security")

--- a/dist/src/test/java/io/camunda/application/commons/security/CamundaSecurityConfigurationTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/security/CamundaSecurityConfigurationTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.security;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.application.MainSupport;
+import io.camunda.application.commons.CommonsModuleConfiguration;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.BeanCreationException;
+
+public class CamundaSecurityConfigurationTest {
+
+  @Test
+  public void whenMultiTenancyEnabledAndApiUnprotectedThenFailsToStart() {
+    final var application =
+        MainSupport.createDefaultApplicationBuilder()
+            .sources(CommonsModuleConfiguration.class)
+            .build();
+
+    final var mtProperty = "camunda.security.multi-tenancy.enabled";
+    final var apiProperty = "camunda.security.authentication.unprotected-api";
+    application.setDefaultProperties(
+        Map.of(
+            mtProperty, true,
+            apiProperty, true));
+
+    assertThatThrownBy(application::run)
+        .isInstanceOf(BeanCreationException.class)
+        .cause()
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            "Multi-tenancy is enabled (%s=true), but the API is unprotected (%s=true). Please enable API protection if you want to make use of multi-tenancy."
+                .formatted(mtProperty, apiProperty));
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

It makes no sense to enable multi-tenancy when the API is unprotected. An unprotected API means we don't know which user makes a request. As a result we also cannot retrieve the tenants that are assigned to the user. The configuration setup  is invalid.  In these scenarios it's desirable to fail early and prevent startup altogether.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29235 
