### PR TITLE
[Backport main] Require access to default tenant to use deprecated DeployProcess RPC

### DIFF
--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -83,6 +83,7 @@ public final class RequestMapper extends RequestUtil {
 
   public static BrokerDeployResourceRequest toDeployProcessRequest(
       final DeployProcessRequest grpcRequest) {
+    ensureTenantIdSet("DeployProcess", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
     final BrokerDeployResourceRequest brokerRequest = new BrokerDeployResourceRequest();
 
     for (final ProcessRequestObject process : grpcRequest.getProcessesList()) {


### PR DESCRIPTION
# Description
Backport of #29239 to `main`.

closes #29236