### PR TITLE
fix: qualify `key` properties in REST API spec

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5182,7 +5182,7 @@ components:
         email:
           description: The email of the user.
           type: "string"
-        key:
+        userKey:
           description: The key of the user.
           type: "string"
     UserSearchResult:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5242,7 +5242,7 @@ components:
         name:
           type: string
           description: The role name.
-        key:
+        roleKey:
           type: string
           description: The role key.
         assignedMemberKeys:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -298,7 +298,9 @@ public final class SearchQueryResponseMapper {
   }
 
   public static RoleResult toRole(final RoleEntity roleEntity) {
-    return new RoleResult().roleKey(KeyUtil.keyToString(roleEntity.roleKey())).name(roleEntity.name());
+    return new RoleResult()
+        .roleKey(KeyUtil.keyToString(roleEntity.roleKey()))
+        .name(roleEntity.name());
   }
 
   private static List<GroupResult> toGroups(final List<GroupEntity> groups) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -487,7 +487,7 @@ public final class SearchQueryResponseMapper {
 
   public static UserResult toUser(final UserEntity user) {
     return new UserResult()
-        .key(KeyUtil.keyToString(user.userKey()))
+        .userKey(KeyUtil.keyToString(user.userKey()))
         .username(user.username())
         .email(user.email())
         .name(user.name());

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -298,7 +298,7 @@ public final class SearchQueryResponseMapper {
   }
 
   public static RoleResult toRole(final RoleEntity roleEntity) {
-    return new RoleResult().key(KeyUtil.keyToString(roleEntity.roleKey())).name(roleEntity.name());
+    return new RoleResult().roleKey(KeyUtil.keyToString(roleEntity.roleKey())).name(roleEntity.name());
   }
 
   private static List<GroupResult> toGroups(final List<GroupEntity> groups) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -58,7 +58,7 @@ public class RoleQueryControllerTest extends RestControllerTest {
             """
             {
               "name": "Role Name",
-              "key": "100"
+              "roleKey": "100"
             }""");
 
     // then
@@ -130,15 +130,15 @@ public class RoleQueryControllerTest extends RestControllerTest {
           {
              "items": [
                {
-                 "key": "100",
+                 "roleKey": "100",
                  "name": "Role 1"
                },
                {
-                 "key": "200",
+                 "roleKey": "200",
                  "name": "Role 2"
                },
                {
-                 "key": "300",
+                 "roleKey": "300",
                  "name": "Role 12"
                }
              ],

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserQueryControllerTest.java
@@ -40,7 +40,7 @@ public class UserQueryControllerTest extends RestControllerTest {
       """
           {
               "items": [
-                 { "key": "1",
+                 { "userKey": "1",
                    "username": "username1",
                    "name": "name1",
                    "email": "email1"


### PR DESCRIPTION
## Description

Adds qualifying prefixes to `key` properties in the API schema:

- `RoleResult`.`key` -> `RoleResult`.`roleKey`
- `UserResult`.`key` -> `UserResult`.`userKey`

Prompted by https://github.com/camunda/camunda/issues/26671#issuecomment-2678383738, and identified separately in [slack](https://camunda.slack.com/archives/C06UKS51QV9/p1741159629212219). 

### Method

Because I really don't know what I'm doing here, as recommended by @tmetzke and from CONTRIBUTING.md, this is how I made my changes and validated them. If there are other things I should have done, please let me know. 

1. Change name in spec
2. run `./mvnw clean install -Dquickly` to find build errors
3. Change name at error location
4. run `./mvnw clean install -Dquickly` to validate successful build
5. run `./mvnw verify -Dquickly -DskipTests=false` to run tests -- though I'm still waiting for these to finish 😅 .
