### PR TITLE
build: update makefile to fix Operate Identity dev setup

### DIFF
--- a/operate/Makefile
+++ b/operate/Makefile
@@ -54,17 +54,22 @@ env-sso-up:
 
 .PHONY: env-identity-up
 env-identity-up:
-	@docker compose -f ./operate/config/docker-compose.identity.yml up -d identity elasticsearch zeebe \
-	&& mvn install -DskipTests=true -Dskip.fe.build=true -DskipChecks -DskipQaBuild \
-	&& CAMUNDA_IDENTITY_ISSUER=http://localhost:18080/auth/realms/camunda-platform \
-	   CAMUNDA_IDENTITY_ISSUER_BACKEND_URL=http://localhost:18080/auth/realms/camunda-platform \
-       CAMUNDA_IDENTITY_CLIENT_ID=operate \
-       CAMUNDA_IDENTITY_CLIENT_SECRET=the-cake-is-alive \
-       CAMUNDA_IDENTITY_AUDIENCE=operate-api \
-       CAMUNDA_OPERATE_PERSISTENT_SESSIONS_ENABLED=false \
-       SERVER_SERVLET_CONTEXT_PATH=/operate \
-       SERVER_PORT=8081 \
-	   mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml exec:java -Dexec.mainClass="io.camunda.application.StandaloneOperate" -Dspring.profiles.active=dev,dev-data,identity-auth
+	docker compose -f docker-compose.yml up -d elasticsearch \
+    && mvn install -DskipTests=true -Dskip.fe.build=false -DskipChecks -DskipQaBuild \
+	&& CAMUNDA_OPERATE_IMPORTERENABLED=false \
+	ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME=io.camunda.exporter.CamundaExporter \
+	ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_SIZE=1 \
+	ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_DELAY=1 \
+	ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_TYPE=elasticsearch \
+	ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_URL=http://localhost:9200 \
+	ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_SHOULDWAITFORIMPORTERS=false \
+	CAMUNDA_SECURITY_AUTHENTICATION_METHOD=BASIC \
+	CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI=false \
+	CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED=true \
+	mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml exec:java \
+	  -Dexec.mainClass="io.camunda.application.StandaloneCamunda" \
+	  -Dspring.profiles.active=operate,broker,dev,dev-data,consolidated-auth,identity
+
 
 .PHONY: env-down
 env-down:

--- a/operate/README.md
+++ b/operate/README.md
@@ -19,7 +19,7 @@ This starts elasticsearch and zeebe docker containers, then installs operate loc
 You can shutdown the application with Control-C.
 At the first run it takes some time to resolve all dependencies.
 
-### Use docker
+### Use Camunda 8 with Elasticsearch docker container
 
 To run the application locally you can use `docker`, `docker-compose` and
 `make`. Make sure to have a recent version of these tools installed
@@ -30,21 +30,35 @@ Windows users need to install `make` manually on their shell. You can find
 instructions on how to do it
 [here](https://gist.github.com/evanwill/0207876c3243bbb6863e65ec5dc3f058#make).
 
-To spawn the full local environment, run this command in the root folder:
+#### Zeebe + Operate + Elasticsearch
+
+To run Camunda 8 with Zeebe and Operate profiles, run this command in the operate folder:
 
 ```
 make env-up
 ```
 
-The app will be running at `localhost:8080`.
+The Operate webapp will be running at `localhost:8080/operate`.
 
-To stop:
+#### Zeebe + Operate + Identity + Elasticsearch
+
+To run Camunda 8 with Zeebe, Operate and Identity profiles, run this command in the operate folder:
+
+```
+make env-identity-up
+```
+
+The Operate webapp will be running at `localhost:8080/operate`.
+
+The Identity webapp will be running at `localhost:8080/identity`.
+
+#### Stop dev environment
 
 ```
 make env-down
 ```
 
-To see the status of the environment, you can run:
+#### Check status of the environment
 
 ```
 make env-status
@@ -54,7 +68,7 @@ This command should pull/build the necessary containers to run the
 application locally, the first run might take a while. This includes
 a local elasticsearch, zeebe, operate backend and frontend.
 
-You can clean your local docker environment using:
+#### Clean your local docker environment
 
 ```
 make env-clean


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR replaces the old operate/identity dev setup with a working up to date one.

The `env-identity_up` Makefile target is basically the same as `env-up` with the following additions:

env vars:
- CAMUNDA_SECURITY_AUTHENTICATION_METHOD=BASIC
- CAMUNDA_SECURITY_AUTHENTICATION_UNPROTECTEDAPI=false
- CAMUNDA_SECURITY_AUTHORIZATIONS_ENABLED=true 

Spring profile:
- identity

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
