### PR TITLE
release: route 8.6+ dry run notifications to dedicated Slack channel

### DIFF
--- a/.github/workflows/camunda-platform-release-main-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-main-dry-run.yml
@@ -1,4 +1,6 @@
+---
 name: Camunda Platform Release Dry Run from main
+
 on:
   workflow_dispatch:
     inputs:
@@ -31,64 +33,50 @@ jobs:
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: ${{ matrix.latest }}
       dryRun: true
-  notify:
-    name: Send slack notification
-    runs-on: ubuntu-latest
-    needs: [ dry-run-release ]
-    if: ${{ github.event_name == 'schedule' }}
-    steps:
-      - id: slack-notify-failure
-        name: Send failure slack notification
-        uses: slackapi/slack-github-action@v2.0.0
-        if: ${{ always() && needs.dry-run-release.result != 'success' }}
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          # For posting a rich message using Block Kit
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":alarm: *Release Dry Run* from `main` failed! :alarm:\n"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Please check the related workflow execution: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
-                  }
-                }
-              ]
-            }
-      - id: slack-notify-success
-        name: Send success slack notification
-        uses: slackapi/slack-github-action@v2.0.0
-        if: ${{ always() && needs.dry-run-release.result == 'success' }}
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          # For posting a rich message using Block Kit
-          payload: |
-            {
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":tada: *Release Dry Run* from `main` succeeded! :tada:\n"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Nothing to check today. Good job! :clap:\n"
-                  }
-                }
-              ]
-            }
 
+  notify:
+    name: Send Slack notification
+    runs-on: ubuntu-latest
+    needs: [dry-run-release]
+    if: always()
+    timeout-minutes: 5
+    permissions: {}  # GITHUB_TOKEN unused in this job
+    steps:
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@7709c609789c5e27b757a85817483caadbb5939a # v3.3.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
+
+      - name: Send failure Slack notification
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        if: ${{ always() && needs.dry-run-release.result != 'success' && github.event_name == 'schedule' }}
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alarm: *Release Dry Run* on `${{ inputs.branch || 'main' }}` failed!\n"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Please check this <https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}|GHA workflow run>."
+                  }
+                }
+              ]
+            }

--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -1,11 +1,15 @@
+---
+# NOTE: This workflow is not just for Zeebe, but also for 8.6+ monorepo release!
 name: Zeebe Release Dry Run from stable branches
+
 on:
-  workflow_dispatch: { }
+  workflow_dispatch: {}
   schedule:
     # Runs at 02:00 every week day; see this link for more: https://crontab.guru/#0_2_*_*_1-5
     - cron: '0 2 * * 1-5'
 
 jobs:
+  # Camunda Platform release
   dry-run-release-87:
     name: "Release from stable/8.7"
     uses: camunda/camunda/.github/workflows/camunda-platform-release.yml@stable/8.7
@@ -30,6 +34,8 @@ jobs:
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: true
       dryRun: true
+
+  # Zeebe release
   dry-run-release-85:
     name: "Release from stable/8.5"
     uses: camunda/camunda/.github/workflows/zeebe-release.yml@stable/8.5
@@ -66,16 +72,66 @@ jobs:
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: true
       dryRun: true
-  notify:
-    name: Send slack notification
+
+  notify-camunda:
+    name: Send Slack notification for 8.6+
     runs-on: ubuntu-latest
-    needs: [ dry-run-release-83, dry-run-release-84, dry-run-release-85, dry-run-release-86 ]
-    if: ${{ always() }}
+    needs: [dry-run-release-86, dry-run-release-87]
+    if: always()
+    timeout-minutes: 5
+    permissions: {}  # GITHUB_TOKEN unused in this job
+    steps:
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@7709c609789c5e27b757a85817483caadbb5939a # v3.3.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/products/camunda/ci/github-actions SLACK_TOPMONOREPORELEASE_WEBHOOK_URL;
+
+      - name: Send failure Slack notification
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        if: ${{ always() && (needs.dry-run-release-86.result != 'success' || needs.dry-run-release-87.result != 'success') && github.event_name == 'schedule' }}
+        with:
+          webhook: ${{ steps.secrets.outputs.SLACK_TOPMONOREPORELEASE_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alarm: *Release Dry Run* on `stable/*` failed!\n"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Please check this <https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}|GHA workflow run>."
+                  }
+                }
+              ]
+            }
+
+  notify-zeebe:
+    name: Send Slack notification for Zeebe up to 8.5
+    runs-on: ubuntu-latest
+    needs: [dry-run-release-83, dry-run-release-84, dry-run-release-85]
+    if: always()
+    timeout-minutes: 5
+    permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
       - id: slack-notify-failure
         name: Send failure slack notification
-        uses: slackapi/slack-github-action@v2.0.0
-        if: ${{ always() && (needs.dry-run-release-83.result != 'success' || needs.dry-run-release-84.result != 'success' || needs.dry-run-release-85.result != 'success' || needs.dry-run-release-86.result != 'success') }}
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        if: ${{ always() && (needs.dry-run-release-83.result != 'success' || needs.dry-run-release-84.result != 'success' || needs.dry-run-release-85.result != 'success') }}
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -101,8 +157,8 @@ jobs:
             }
       - id: slack-notify-success
         name: Send success slack notification
-        uses: slackapi/slack-github-action@v2.0.0
-        if: ${{ always() && needs.dry-run-release-83.result == 'success' && needs.dry-run-release-84.result == 'success' && needs.dry-run-release-85.result == 'success' && needs.dry-run-release-86.result == 'success' }}
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        if: ${{ always() && needs.dry-run-release-83.result == 'success' && needs.dry-run-release-84.result == 'success' && needs.dry-run-release-85.result == 'success' }}
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
## Description

This PR adjusts the existing 8.6+ release dry run jobs to send notifications via Slack to dedicated channel (unrelated to Zeebe). It will not send success notifications anymore to avoid noise.

Note: the notification logic for 8.7 wasn't properly working so no notifications have been sent so far, ever, for that version. This PR also fixes that.

Notifications for Zeebe stable releases 8.3 til 8.5 are still send to previous Zeebe-related channel.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes) - not needed since notification handling all done in scheduled jobs on `main`

## Related issues

Related #28873 
