### PR TITLE
[POC]: Add Standalone backups application

### DIFF
--- a/backup-manager.yml
+++ b/backup-manager.yml
@@ -1,14 +1,3 @@
-zeebe.broker.exporters.elasticsearch:
-  className: io.camunda.zeebe.exporter.ElasticsearchExporter
-  args:
-    index:
-      createTemplate: true
-    retention:
-      enabled: true
-    # Example assuming an existing user called 'camunda-admin' who has 'superuser' privileges
-    authentication:
-      username: camunda-admin
-      password: camunda123
 camunda:
   operate:
     backup:
@@ -18,9 +7,6 @@ camunda:
       username: camunda-admin
       password: camunda123
       healthCheckEnabled: false
-    archiver:
-      # Optional, only if ILM is enabled
-      ilmEnabled: true
   tasklist:
     backup:
       repositoryName: "els-test"
@@ -29,6 +15,3 @@ camunda:
       username: camunda-admin
       password: camunda123
       healthCheckEnabled: false
-    archiver:
-      # Optional, only if ILM is enabled
-      ilmEnabled: true

--- a/backup-manager.yml
+++ b/backup-manager.yml
@@ -1,0 +1,34 @@
+zeebe.broker.exporters.elasticsearch:
+  className: io.camunda.zeebe.exporter.ElasticsearchExporter
+  args:
+    index:
+      createTemplate: true
+    retention:
+      enabled: true
+    # Example assuming an existing user called 'camunda-admin' who has 'superuser' privileges
+    authentication:
+      username: camunda-admin
+      password: camunda123
+camunda:
+  operate:
+    backup:
+      repositoryName: "els-test"
+    elasticsearch:
+      # Example assuming an existing user called 'camunda-admin' who has 'superuser' privileges
+      username: camunda-admin
+      password: camunda123
+      healthCheckEnabled: false
+    archiver:
+      # Optional, only if ILM is enabled
+      ilmEnabled: true
+  tasklist:
+    backup:
+      repositoryName: "els-test"
+    elasticsearch:
+      # Example assuming an existing user called 'camunda-admin' who has 'superuser' privileges
+      username: camunda-admin
+      password: camunda123
+      healthCheckEnabled: false
+    archiver:
+      # Optional, only if ILM is enabled
+      ilmEnabled: true

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -596,7 +596,7 @@
               <mainClass>io.camunda.application.StandaloneSchemaManager</mainClass>
             </program>
             <program>
-              <id>backup</id>
+              <id>backup-webapps</id>
               <mainClass>io.camunda.application.StandaloneBackupManager</mainClass>
             </program>
             <program>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -550,6 +550,10 @@
       <artifactId>testcontainers</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
 
   </dependencies>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -267,11 +267,6 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -597,6 +597,10 @@
               <mainClass>io.camunda.application.StandaloneSchemaManager</mainClass>
             </program>
             <program>
+              <id>backup</id>
+              <mainClass>io.camunda.application.StandaloneBackupManager</mainClass>
+            </program>
+            <program>
               <id>tasklist</id>
               <mainClass>io.camunda.application.StandaloneTasklist</mainClass>
             </program>

--- a/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
@@ -12,6 +12,7 @@ import io.camunda.operate.webapp.backup.BackupService;
 import io.camunda.tasklist.webapp.es.backup.BackupManager;
 import io.camunda.tasklist.webapp.management.dto.BackupStateDto;
 import io.camunda.tasklist.webapp.management.dto.TakeBackupRequestDto;
+import java.util.Arrays;
 import java.util.EnumSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,7 +84,7 @@ public class StandaloneBackupManager implements CommandLineRunner {
     MainSupport.putSystemPropertyIfAbsent(
         "spring.banner.location", "classpath:/assets/camunda_banner.txt");
 
-    LOG.info("Creating/updating Elasticsearch schema for Camunda ...");
+    LOG.info("Creating a backup for Operate and Tasklist elasticsearch indices ...");
 
     MainSupport.createDefaultApplicationBuilder()
         .web(WebApplicationType.NONE)
@@ -105,7 +106,7 @@ public class StandaloneBackupManager implements CommandLineRunner {
   public void run(final String... args) throws Exception {
     if (args.length != 1) {
       throw new IllegalArgumentException(
-          String.format("Expected one argument, the backup ID, but got %d", args.length));
+          String.format("Expected one argument, the backup ID, but got: %s", Arrays.asList(args)));
     }
 
     final long backupId;
@@ -172,12 +173,12 @@ public class StandaloneBackupManager implements CommandLineRunner {
           failureReason.append(
               " Tasklist indices backup failure: %s.".formatted(tasklistBackup.getFailureReason()));
         }
-        LOG.error("Backup with id:[{}] failed.{}", backupId, failureReason);
-        throw new IllegalStateException("Backup with id:[%d] failed".formatted(backupId));
+        throw new IllegalStateException(
+            "Backup with id:[%d] failed.%s".formatted(backupId, failureReason));
       }
     }
 
-    LOG.info("Backup with id:[{}}] is completed!", backupId);
+    LOG.info("Backup with id:[{}] is completed!", backupId);
   }
 
   private boolean isCompletedBackup(

--- a/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
@@ -162,17 +162,29 @@ public class StandaloneBackupManager implements CommandLineRunner {
     LOG.info("... triggered Elasticsearch snapshot based on Camunda's backup procedure");
   }
 
+  // LEARNING - basePackageClasses - defining a class causes to scan the whole package with * doing
+  // a traversal to include all childs
+  // This approach doesnt work pretty good as we include a lot of other things
+
   @SpringBootConfiguration
   @EnableConfigurationProperties(BrokerBasedProperties.class)
   @ConfigurationPropertiesScan
   @ComponentScan(
+      //      basePackages = {"io.camunda.operate.*"}
       basePackageClasses = {
         //        OperateUserDetailsService.class, - Not needed
         // Schema startup - to have access on index descriptors
         // TODO: Find a better way
         //        io.camunda.tasklist.schema.SchemaStartup.class, // - Not needed
         io.camunda.tasklist.schema.indices.IndexDescriptor.class,
+        io.camunda.tasklist.schema.templates.TemplateDescriptor.class,
         io.camunda.operate.schema.indices.IndexDescriptor.class,
+        io.camunda.operate.schema.templates.TemplateDescriptor.class,
+        // we need this metrics for the ElasticsearchImportStore; todo: why do we need it?
+        // WE DONT WANT THIS
+        //        io.camunda.operate.Metrics.class,
+        //        io.camunda.tasklist.Metrics.class,
+
         //        io.camunda.operate.schema.SchemaStartup.class, // - Not needed
         // Backup services from Operate / Tasklist - to be used to create backups
         io.camunda.operate.webapp.backup.BackupService.class,
@@ -181,9 +193,15 @@ public class StandaloneBackupManager implements CommandLineRunner {
         // Containing the properties/configurations for Operate/Tasklist
         OperateProperties.class,
         TasklistProperties.class,
+        io.camunda.operate.conditions.DatabaseInfo.class,
         // To set up the right clients, that have to be used by other components
-        io.camunda.tasklist.es.RetryElasticsearchClient.class,
+        io.camunda.operate.connect.ElasticsearchConnector
+            .class, // we need this to find the right clients for Operate
+        // WE DONT WANT THIS
+        io.camunda.operate.tenant.TenantAwareElasticsearchClient
+            .class, // needed for decision store - that is pulled in from somwhere TODO; clarify
         io.camunda.operate.store.elasticsearch.RetryElasticsearchClient.class,
+        io.camunda.tasklist.es.RetryElasticsearchClient.class,
         // Object mapper used by other components
         DefaultObjectMapperConfiguration.class,
       },

--- a/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.application;
 
-import static org.springframework.core.env.AbstractEnvironment.ACTIVE_PROFILES_PROPERTY_NAME;
-
 import io.camunda.application.StandaloneSchemaManager.SchemaManagerConfiguration.BrokerBasedProperties;
 import io.camunda.application.commons.sources.DefaultObjectMapperConfiguration;
 import io.camunda.application.listeners.ApplicationErrorListener;
@@ -19,14 +17,12 @@ import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.webapp.es.backup.BackupManager;
 import io.camunda.tasklist.webapp.management.dto.BackupStateDto;
 import io.camunda.tasklist.webapp.management.dto.TakeBackupRequestDto;
-import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import java.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.WebApplicationType;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
@@ -81,18 +77,11 @@ import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGe
 public class StandaloneBackupManager implements CommandLineRunner {
 
   private static final Logger LOG = LoggerFactory.getLogger(StandaloneBackupManager.class);
-  private static final String SPRING_PROFILES_ACTIVE_PROPERTY = ACTIVE_PROFILES_PROPERTY_NAME;
-  private static final String DEFAULT_CAMUNDA_PROFILES =
-      String.join(",", Profile.OPERATE.getId(), Profile.TASKLIST.getId());
-  private final BrokerBasedProperties brokerProperties;
   private final BackupManager tasklistBackupManager;
   private final BackupService operateBackupManager;
 
   public StandaloneBackupManager(
-      final BrokerBasedProperties brokerProperties,
-      final BackupManager tasklistBackupManager,
-      final BackupService operateBackupManager) {
-    this.brokerProperties = brokerProperties;
+      final BackupManager tasklistBackupManager, final BackupService operateBackupManager) {
     this.tasklistBackupManager = tasklistBackupManager;
     this.operateBackupManager = operateBackupManager;
   }
@@ -112,16 +101,11 @@ public class StandaloneBackupManager implements CommandLineRunner {
 
     LOG.info("Creating/updating Elasticsearch schema for Camunda ...");
 
-    //    final var defaultActiveProfiles = getDefaultActiveProfiles();
     MainSupport.createDefaultApplicationBuilder()
         .web(WebApplicationType.NONE)
         .logStartupInfo(true)
         .sources(
             BackupManagerConfiguration.class,
-            //            CommonsModuleConfiguration.class,
-            //            OperateModuleConfiguration.class,
-            //            TasklistModuleConfiguration.class,
-            //            WebappModuleConfiguration.class,
             StandaloneBackupManager.class,
             io.camunda.tasklist.JacksonConfig.class,
             io.camunda.operate.JacksonConfig.class)
@@ -134,13 +118,6 @@ public class StandaloneBackupManager implements CommandLineRunner {
     // blocking shutdown.
     System.exit(0);
   }
-
-  //
-  //  public static Map<String, Object> getDefaultActiveProfiles() {
-  //    final var defaultProperties = new HashMap<String, Object>();
-  //    defaultProperties.put(SPRING_PROFILES_ACTIVE_PROPERTY, DEFAULT_CAMUNDA_PROFILES);
-  //    return defaultProperties;
-  //  }
 
   @Override
   public void run(final String... args) throws Exception {
@@ -204,16 +181,6 @@ public class StandaloneBackupManager implements CommandLineRunner {
         }
       } while (snapshotObservation);
 
-      //      final var elasticsearchConfig =
-      //          new ExporterConfiguration(
-      //                  "elasticsearch",
-      // brokerProperties.getExporters().get("elasticsearch").getArgs())
-      //              .instantiate(ElasticsearchExporterConfiguration.class);
-
-      //      tasklistBackupManager.getBackupState()
-      // Not needed
-      //      new io.camunda.zeebe.exporter.SchemaManager(elasticsearchConfig).createSchema();
-      //      operateUserDetailsService.initializeUsers();
     } catch (final Exception e) {
       LOG.error("Expected to trigger ES snapshots for backupId {}, but failed", backupId, e);
       throw e;
@@ -222,30 +189,18 @@ public class StandaloneBackupManager implements CommandLineRunner {
     LOG.info("... triggered Elasticsearch snapshot based on Camunda's backup procedure");
   }
 
-  // LEARNING - basePackageClasses - defining a class causes to scan the whole package with * doing
-  // a traversal to include all childs
-  // This approach doesnt work pretty good as we include a lot of other things
-
   @SpringBootConfiguration
   @EnableConfigurationProperties(BrokerBasedProperties.class)
   @ConfigurationPropertiesScan
   @ComponentScan(
-      //      basePackages = {"io.camunda.operate.*"}
+      // LEARNING - basePackageClasses - defining a class causes to scan the whole package with *
+      // doing
+      // a traversal to include all childs
       basePackageClasses = {
-        //        OperateUserDetailsService.class, - Not needed
-        // Schema startup - to have access on index descriptors
-        // TODO: Find a better way
-        //        io.camunda.tasklist.schema.SchemaStartup.class, // - Not needed
         io.camunda.tasklist.schema.indices.IndexDescriptor.class,
         io.camunda.tasklist.schema.templates.TemplateDescriptor.class,
         io.camunda.operate.schema.indices.IndexDescriptor.class,
         io.camunda.operate.schema.templates.TemplateDescriptor.class,
-        // we need this metrics for the ElasticsearchImportStore; todo: why do we need it?
-        // WE DONT WANT THIS
-        //        io.camunda.operate.Metrics.class,
-        //        io.camunda.tasklist.Metrics.class,
-
-        //        io.camunda.operate.schema.SchemaStartup.class, // - Not needed
         // Backup services from Operate / Tasklist - to be used to create backups
         io.camunda.operate.webapp.backup.BackupService.class,
         io.camunda.operate.webapp.elasticsearch.backup.ElasticsearchBackupRepository.class,
@@ -258,18 +213,9 @@ public class StandaloneBackupManager implements CommandLineRunner {
         io.camunda.operate.connect.ElasticsearchConnector
             .class, // we need this to find the right clients for Operate
         ElasticsearchConnector.class,
-        // WE DONT WANT THIS
-        //        io.camunda.operate.tenant.TenantAwareElasticsearchClient
-        //            .class, // needed for decision store - that is pulled in from somwhere TODO;
-        // clarify
-        //        io.camunda.operate.store.elasticsearch.RetryElasticsearchClient.class,
-        //        io.camunda.tasklist.es.RetryElasticsearchClient.class,
         // Object mapper used by other components
         DefaultObjectMapperConfiguration.class,
       },
       nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
-  public static class BackupManagerConfiguration {
-    @ConfigurationProperties("zeebe.broker")
-    public static final class BrokerBasedProperties extends BrokerCfg {}
-  }
+  public static class BackupManagerConfiguration {}
 }

--- a/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
@@ -19,6 +19,7 @@ import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.webapp.es.backup.BackupManager;
 import io.camunda.tasklist.webapp.management.dto.TakeBackupRequestDto;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import java.util.Arrays;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.CommandLineRunner;
@@ -142,7 +143,20 @@ public class StandaloneBackupManager implements CommandLineRunner {
 
   @Override
   public void run(final String... args) throws Exception {
-    final var backupId = 0xCAFEL;
+    if (args.length != 1) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Expected one argument, the backup ID, but got: [%s]", Arrays.asList(args)));
+    }
+
+    final long backupId;
+    try {
+      backupId = Long.parseLong(args[0]);
+    } catch (final NumberFormatException nfe) {
+      throw new IllegalArgumentException(
+          String.format("Expected as argument the backup ID as long, but got %s", args[0]));
+    }
+
     try {
       // Operate
       final var operateTakeBackupRequestDto =

--- a/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
@@ -12,7 +12,6 @@ import io.camunda.application.commons.sources.DefaultObjectMapperConfiguration;
 import io.camunda.application.listeners.ApplicationErrorListener;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.webapp.backup.BackupService;
-import io.camunda.tasklist.connect.ElasticsearchConnector;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.webapp.es.backup.BackupManager;
 import io.camunda.tasklist.webapp.management.dto.BackupStateDto;
@@ -212,7 +211,7 @@ public class StandaloneBackupManager implements CommandLineRunner {
         // To set up the right clients, that have to be used by other components
         io.camunda.operate.connect.ElasticsearchConnector
             .class, // we need this to find the right clients for Operate
-        ElasticsearchConnector.class,
+        io.camunda.tasklist.connect.ElasticsearchConnector.class,
         // Object mapper used by other components
         DefaultObjectMapperConfiguration.class,
       },

--- a/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneBackupManager.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application;
+
+import io.camunda.application.StandaloneSchemaManager.SchemaManagerConfiguration.BrokerBasedProperties;
+import io.camunda.application.commons.sources.DefaultObjectMapperConfiguration;
+import io.camunda.application.listeners.ApplicationErrorListener;
+import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.webapp.security.auth.OperateUserDetailsService;
+import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.exporter.ElasticsearchExporterConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
+
+/**
+ * Backup indices for ElasticSearch by running this standalone application.
+ *
+ * <p>Example properties:
+ *
+ * <pre>
+ * camunda.operate.elasticsearch.indexPrefix=operate
+ * camunda.operate.elasticsearch.clusterName=elasticsearch
+ * camunda.operate.elasticsearch.url=https://localhost:9200
+ * camunda.operate.elasticsearch.ssl.selfSigned=true
+ * camunda.operate.elasticsearch.ssl.verifyHostname=false
+ * camunda.operate.elasticsearch.ssl.certificatePath=C:/.../config/certs/http_ca.crt
+ * camunda.operate.elasticsearch.username=camunda-admin
+ * camunda.operate.elasticsearch.password=camunda123
+ *
+ * camunda.operate.zeebeElasticsearch.indexPrefix=zeebe-record
+ * camunda.operate.zeebeElasticsearch.clusterName=elasticsearch
+ * camunda.operate.zeebeElasticsearch.url=https://localhost:9200
+ * camunda.operate.zeebeElasticsearch.ssl.selfSigned=true
+ * camunda.operate.zeebeElasticsearch.ssl.verifyHostname=false
+ * camunda.operate.zeebeElasticsearch.ssl.certificatePath=C:/.../config/certs/http_ca.crt
+ * camunda.operate.zeebeElasticsearch.username=camunda-admin
+ * camunda.operate.zeebeElasticsearch.password=camunda123
+ *
+ * camunda.tasklist.elasticsearch.indexPrefix=tasklist
+ * camunda.tasklist.elasticsearch.clusterName=elasticsearch
+ * camunda.tasklist.elasticsearch.url=https://localhost:9200
+ * camunda.tasklist.elasticsearch.ssl.selfSigned=true
+ * camunda.tasklist.elasticsearch.ssl.verifyHostname=false
+ * camunda.tasklist.elasticsearch.ssl.certificatePath=C:/.../config/certs/http_ca.crt
+ * camunda.tasklist.elasticsearch.username=camunda-admin
+ * camunda.tasklist.elasticsearch.password=camunda123
+ *
+ * camunda.tasklist.zeebeElasticsearch.indexPrefix=zeebe-record
+ * camunda.tasklist.zeebeElasticsearch.clusterName=elasticsearch
+ * camunda.tasklist.zeebeElasticsearch.url=https://localhost:9200
+ * camunda.tasklist.zeebeElasticsearch.ssl.selfSigned=true
+ * camunda.tasklist.zeebeElasticsearch.ssl.verifyHostname=false
+ * camunda.tasklist.zeebeElasticsearch.ssl.certificatePath=C:/.../config/certs/http_ca.crt
+ * camunda.tasklist.zeebeElasticsearch.username=camunda-admin
+ * camunda.tasklist.zeebeElasticsearch.password=camunda123
+ * </pre>
+ *
+ * All of those properties can also be handed over via environment variables, e.g.
+ * `CAMUNDA_OPERATE_ELASTICSEARCH_INDEXPREFIX`
+ */
+public class StandaloneBackupManager implements CommandLineRunner {
+
+  private static final Logger LOG = LoggerFactory.getLogger(StandaloneBackupManager.class);
+  private final BrokerBasedProperties brokerProperties;
+  private final OperateUserDetailsService operateUserDetailsService;
+
+  public StandaloneBackupManager(
+      final BrokerBasedProperties brokerProperties,
+      final OperateUserDetailsService operateUserDetailsService) {
+    this.brokerProperties = brokerProperties;
+    this.operateUserDetailsService = operateUserDetailsService;
+  }
+
+  public static void main(final String[] args) throws Exception {
+    // To ensure that debug logging performed using java.util.logging is routed into Log4j 2
+    MainSupport.putSystemPropertyIfAbsent(
+        "java.util.logging.manager", "org.apache.logging.log4j.jul.LogManager");
+    // Workaround for https://github.com/spring-projects/spring-boot/issues/26627
+    MainSupport.putSystemPropertyIfAbsent(
+        "spring.config.location",
+        "optional:classpath:/,optional:classpath:/config/,optional:file:./,optional:file:./config/");
+
+    // show banner
+    MainSupport.putSystemPropertyIfAbsent(
+        "spring.banner.location", "classpath:/assets/camunda_banner.txt");
+
+    LOG.info("Creating/updating Elasticsearch schema for Camunda ...");
+
+    MainSupport.createDefaultApplicationBuilder()
+        .web(WebApplicationType.NONE)
+        .logStartupInfo(true)
+        .sources(
+            BackupManagerConfiguration.class,
+            StandaloneBackupManager.class,
+            io.camunda.tasklist.JacksonConfig.class,
+            io.camunda.operate.JacksonConfig.class)
+        .addCommandLineProperties(true)
+        .listeners(new ApplicationErrorListener())
+        .run(args);
+
+    // Explicit exit needed because there are daemon threads (at least from the ES client) that are
+    // blocking shutdown.
+    System.exit(0);
+  }
+
+  @Override
+  public void run(final String... args) throws Exception {
+    try {
+      final var elasticsearchConfig =
+          new ExporterConfiguration(
+                  "elasticsearch", brokerProperties.getExporters().get("elasticsearch").getArgs())
+              .instantiate(ElasticsearchExporterConfiguration.class);
+
+      // Not needed
+      //      new io.camunda.zeebe.exporter.SchemaManager(elasticsearchConfig).createSchema();
+      //      operateUserDetailsService.initializeUsers();
+    } catch (final Exception e) {
+      LOG.error("Failed to create/update schemas", e);
+      throw e;
+    }
+
+    LOG.info("... finished creating/updating Elasticsearch schema for Camunda");
+  }
+
+  @SpringBootConfiguration
+  @EnableConfigurationProperties(BrokerBasedProperties.class)
+  @ConfigurationPropertiesScan
+  @ComponentScan(
+      basePackageClasses = {
+        //        OperateUserDetailsService.class, - Not needed
+        //        io.camunda.tasklist.schema.SchemaStartup.class, - Not needed
+        //        io.camunda.operate.schema.SchemaStartup.class, - Not needed
+        OperateProperties.class,
+        TasklistProperties.class,
+        io.camunda.tasklist.es.RetryElasticsearchClient.class,
+        io.camunda.operate.store.elasticsearch.RetryElasticsearchClient.class,
+        DefaultObjectMapperConfiguration.class,
+      },
+      nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
+  public static class BackupManagerConfiguration {
+    @ConfigurationProperties("zeebe.broker")
+    public static final class BrokerBasedProperties extends BrokerCfg {}
+  }
+}

--- a/dist/src/main/java/io/camunda/application/StandaloneSchemaManager.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneSchemaManager.java
@@ -149,6 +149,7 @@ public class StandaloneSchemaManager implements CommandLineRunner {
         io.camunda.tasklist.es.RetryElasticsearchClient.class,
         io.camunda.operate.store.elasticsearch.RetryElasticsearchClient.class,
         DefaultObjectMapperConfiguration.class,
+        io.camunda.tasklist.connect.ElasticsearchConnector.class,
       },
       nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
   public static class SchemaManagerConfiguration {

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchDecisionStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchDecisionStore.java
@@ -13,7 +13,6 @@ import io.camunda.operate.conditions.ElasticsearchCondition;
 import io.camunda.operate.schema.indices.DecisionIndex;
 import io.camunda.operate.store.BatchRequest;
 import io.camunda.operate.store.DecisionStore;
-import io.camunda.operate.tenant.TenantAwareElasticsearchClient;
 import java.io.IOException;
 import java.util.Optional;
 import org.elasticsearch.action.search.SearchRequest;
@@ -46,10 +45,8 @@ public class ElasticsearchDecisionStore implements DecisionStore {
 
   @Autowired private RestHighLevelClient esClient;
 
-  @Autowired private TenantAwareElasticsearchClient tenantAwareClient;
-
   @Override
-  public Optional<Long> getDistinctCountFor(String fieldName) {
+  public Optional<Long> getDistinctCountFor(final String fieldName) {
     final String indexAlias = decisionIndex.getAlias();
     LOGGER.debug("Called distinct count for field {} in index alias {}.", fieldName, indexAlias);
     final SearchRequest searchRequest =
@@ -67,7 +64,7 @@ public class ElasticsearchDecisionStore implements DecisionStore {
       final Cardinality distinctFieldCounts =
           searchResponse.getAggregations().get(DISTINCT_FIELD_COUNTS);
       return Optional.of(distinctFieldCounts.getValue());
-    } catch (Exception e) {
+    } catch (final Exception e) {
       LOGGER.error(
           String.format(
               "Error in distinct count for field %s in index alias %s.", fieldName, indexAlias),
@@ -82,7 +79,8 @@ public class ElasticsearchDecisionStore implements DecisionStore {
   }
 
   @Override
-  public long deleteDocuments(String indexName, String idField, String id) throws IOException {
+  public long deleteDocuments(final String indexName, final String idField, final String id)
+      throws IOException {
     final DeleteByQueryRequest query =
         new DeleteByQueryRequest(indexName).setQuery(QueryBuilders.termsQuery(idField, id));
     final BulkByScrollResponse response = esClient.deleteByQuery(query, RequestOptions.DEFAULT);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/management/dto/GetBackupStateResponseDetailDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/management/dto/GetBackupStateResponseDetailDto.java
@@ -24,7 +24,7 @@ public class GetBackupStateResponseDetailDto {
     return snapshotName;
   }
 
-  public GetBackupStateResponseDetailDto setSnapshotName(String snapshotName) {
+  public GetBackupStateResponseDetailDto setSnapshotName(final String snapshotName) {
     this.snapshotName = snapshotName;
     return this;
   }
@@ -33,7 +33,7 @@ public class GetBackupStateResponseDetailDto {
     return state;
   }
 
-  public GetBackupStateResponseDetailDto setState(String state) {
+  public GetBackupStateResponseDetailDto setState(final String state) {
     this.state = state;
     return this;
   }
@@ -42,7 +42,7 @@ public class GetBackupStateResponseDetailDto {
     return startTime;
   }
 
-  public GetBackupStateResponseDetailDto setStartTime(OffsetDateTime startTime) {
+  public GetBackupStateResponseDetailDto setStartTime(final OffsetDateTime startTime) {
     this.startTime = startTime;
     return this;
   }
@@ -51,7 +51,7 @@ public class GetBackupStateResponseDetailDto {
     return failures;
   }
 
-  public GetBackupStateResponseDetailDto setFailures(String[] failures) {
+  public GetBackupStateResponseDetailDto setFailures(final String[] failures) {
     this.failures = failures;
     return this;
   }
@@ -64,7 +64,7 @@ public class GetBackupStateResponseDetailDto {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }
@@ -76,5 +76,21 @@ public class GetBackupStateResponseDetailDto {
         && Objects.equals(state, that.state)
         && Objects.equals(startTime, that.startTime)
         && Arrays.equals(failures, that.failures);
+  }
+
+  @Override
+  public String toString() {
+    return "GetBackupStateResponseDetailDto{"
+        + "snapshotName='"
+        + snapshotName
+        + '\''
+        + ", state='"
+        + state
+        + '\''
+        + ", startTime="
+        + startTime
+        + ", failures="
+        + Arrays.toString(failures)
+        + '}';
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/management/dto/GetBackupStateResponseDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/management/dto/GetBackupStateResponseDto.java
@@ -19,7 +19,7 @@ public class GetBackupStateResponseDto {
 
   public GetBackupStateResponseDto() {}
 
-  public GetBackupStateResponseDto(Long backupId) {
+  public GetBackupStateResponseDto(final Long backupId) {
     this.backupId = backupId;
   }
 
@@ -27,7 +27,7 @@ public class GetBackupStateResponseDto {
     return backupId;
   }
 
-  public GetBackupStateResponseDto setBackupId(Long backupId) {
+  public GetBackupStateResponseDto setBackupId(final Long backupId) {
     this.backupId = backupId;
     return this;
   }
@@ -36,7 +36,7 @@ public class GetBackupStateResponseDto {
     return state;
   }
 
-  public GetBackupStateResponseDto setState(BackupStateDto state) {
+  public GetBackupStateResponseDto setState(final BackupStateDto state) {
     this.state = state;
     return this;
   }
@@ -45,7 +45,7 @@ public class GetBackupStateResponseDto {
     return failureReason;
   }
 
-  public GetBackupStateResponseDto setFailureReason(String failureReason) {
+  public GetBackupStateResponseDto setFailureReason(final String failureReason) {
     this.failureReason = failureReason;
     return this;
   }
@@ -54,7 +54,7 @@ public class GetBackupStateResponseDto {
     return details;
   }
 
-  public GetBackupStateResponseDto setDetails(List<GetBackupStateResponseDetailDto> details) {
+  public GetBackupStateResponseDto setDetails(final List<GetBackupStateResponseDetailDto> details) {
     this.details = details;
     return this;
   }
@@ -65,7 +65,7 @@ public class GetBackupStateResponseDto {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }
@@ -77,5 +77,20 @@ public class GetBackupStateResponseDto {
         && state == that.state
         && Objects.equals(failureReason, that.failureReason)
         && Objects.equals(details, that.details);
+  }
+
+  @Override
+  public String toString() {
+    return "GetBackupStateResponseDto{"
+        + "backupId="
+        + backupId
+        + ", state="
+        + state
+        + ", failureReason='"
+        + failureReason
+        + '\''
+        + ", details="
+        + details
+        + '}';
   }
 }

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -194,6 +194,11 @@
       <artifactId>operate-common</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>tasklist-webapp</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/qa/integration-tests/src/test/java/io/camunda/it/StandaloneBackupManagerTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/StandaloneBackupManagerTest.java
@@ -1,0 +1,446 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it;
+
+import static java.time.Duration.ofSeconds;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import io.camunda.application.Profile;
+import io.camunda.operate.webapp.api.v1.entities.ProcessInstance;
+import io.camunda.operate.webapp.backup.Metadata;
+import io.camunda.qa.util.cluster.TestRestOperateClient.ProcessInstanceResult;
+import io.camunda.qa.util.cluster.TestStandaloneBackupManager;
+import io.camunda.qa.util.cluster.TestStandaloneCamunda;
+import io.camunda.qa.util.cluster.TestStandaloneSchemaManager;
+import io.camunda.search.clients.core.SearchQueryHit;
+import io.camunda.search.clients.query.SearchQueryBuilders;
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.search.connect.es.ElasticsearchConnector;
+import io.camunda.tasklist.entities.TaskEntity;
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import java.io.IOException;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+import org.awaitility.Awaitility;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@ZeebeIntegration
+@Testcontainers
+final class StandaloneBackupManagerTest {
+
+  public static final String ADMIN_USER = "camunda-admin";
+  public static final String ADMIN_PASSWORD = "admin123";
+  public static final String ADMIN_ROLE = "superuser";
+
+  public static final String APP_USER = "camunda-app";
+  public static final String APP_PASSWORD = "app123";
+  public static final String APP_ROLE = "camunda_app_role";
+  public static final String APP_ROLE_DEFINITION =
+      // language=yaml
+      """
+      camunda_app_role:
+        indices:
+          - names: ['zeebe-*', 'operate-*', 'tasklist-*']
+            privileges: ['manage', 'read', 'write']
+      """;
+
+  private static final String TEST_USER_NAME = "foo";
+  private static final String TEST_USER_PASSWORD = "bar";
+
+  private static final String REPOSITORY_NAME = "els-test";
+
+  private static final long BACKUP_ID = 12345L;
+  public static final String ZEEBE_SNAPSHOT_NAME = "camunda_zeebe_records_backup_" + BACKUP_ID;
+  public static final String TASKLIST_SNAPSHOT_NAME_PREFIX =
+      io.camunda.tasklist.webapp.es.backup.Metadata.buildSnapshotNamePrefix(BACKUP_ID);
+  public static final String OPERATE_SNAPSHOT_NAME_PREFIX =
+      Metadata.buildSnapshotNamePrefix(BACKUP_ID);
+
+  // Configure the backup manager for testing
+  @TestZeebe(autoStart = false)
+  final TestStandaloneBackupManager backupManager =
+      new TestStandaloneBackupManager()
+          .withProperty("camunda.operate.elasticsearch.username", ADMIN_USER)
+          .withProperty("camunda.operate.elasticsearch.password", ADMIN_PASSWORD)
+          .withProperty("camunda.operate.elasticsearch.healthCheckEnabled", "false")
+          .withProperty("camunda.operate.backup.repositoryName", "els-test")
+          .withProperty("camunda.tasklist.elasticsearch.username", ADMIN_USER)
+          .withProperty("camunda.tasklist.database", "elasticsearch")
+          .withProperty("camunda.tasklist.elasticsearch.username", ADMIN_USER)
+          .withProperty("camunda.tasklist.elasticsearch.password", ADMIN_PASSWORD)
+          .withProperty("camunda.tasklist.elasticsearch.healthCheckEnabled", "false")
+          .withProperty("camunda.tasklist.backup.repositoryName", "els-test");
+
+  // Configure the schema manager to create indices and templates in test setup
+  @TestZeebe(autoStart = false)
+  final TestStandaloneSchemaManager schemaManager =
+      new TestStandaloneSchemaManager()
+          .withProperty(
+              "zeebe.broker.exporters.elasticsearch.className",
+              "io.camunda.zeebe.exporter.ElasticsearchExporter")
+          .withProperty("zeebe.broker.exporters.elasticsearch.args.index.createTemplate", "true")
+          .withProperty("zeebe.broker.exporters.elasticsearch.args.retention.enabled", "true")
+          .withProperty(
+              "zeebe.broker.exporters.elasticsearch.args.authentication.username", ADMIN_USER)
+          .withProperty(
+              "zeebe.broker.exporters.elasticsearch.args.authentication.password", ADMIN_PASSWORD)
+          .withProperty("camunda.operate.elasticsearch.username", ADMIN_USER)
+          .withProperty("camunda.operate.elasticsearch.password", ADMIN_PASSWORD)
+          .withProperty("camunda.operate.elasticsearch.healthCheckEnabled", "false")
+          .withProperty("camunda.operate.archiver.ilmEnabled", "true")
+          .withProperty("camunda.tasklist.database", "elasticsearch")
+          .withProperty("camunda.tasklist.elasticsearch.username", ADMIN_USER)
+          .withProperty("camunda.tasklist.elasticsearch.password", ADMIN_PASSWORD)
+          .withProperty("camunda.tasklist.elasticsearch.healthCheckEnabled", "false")
+          .withProperty("camunda.tasklist.archiver.ilmEnabled", "true");
+
+  @Container
+  private final ElasticsearchContainer es =
+      new ElasticsearchContainer(
+              DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
+                  .withTag(RestClient.class.getPackage().getImplementationVersion()))
+          // Enable security features
+          .withEnv("xpack.security.enabled", "true")
+          // Ensure a fast and reliable startup
+          .withStartupTimeout(Duration.ofMinutes(5))
+          .withStartupAttempts(3)
+          .withEnv("xpack.security.enabled", "true")
+          .withEnv("xpack.watcher.enabled", "false")
+          .withEnv("xpack.ml.enabled", "false")
+          // Configure with allowed repository storage path
+          .withEnv("path.repo", "~/")
+          // to be able to delete indices with wildcards
+          .withEnv("action.destructive_requires_name", "false")
+          .withCopyToContainer(
+              Transferable.of(APP_ROLE_DEFINITION), "/usr/share/elasticsearch/config/roles.yml")
+          .withClasspathResourceMapping(
+              "elasticsearch-fast-startup.options",
+              "/usr/share/elasticsearch/config/jvm.options.d/elasticsearch-fast-startup.options",
+              BindMode.READ_ONLY);
+
+  // Configure the Camunda single application with restricted access to the Elasticsearch
+  @TestZeebe(autoStart = false)
+  final TestStandaloneCamunda camunda =
+      new TestStandaloneCamunda(es, false)
+          .withAdditionalProfile(Profile.DEFAULT_AUTH_PROFILE)
+          .withProperty("camunda.operate.migration.migrationEnabled", false)
+          .withProperty("camunda.tasklist.migration.migrationEnabled", false)
+          .withProperty("camunda.database.username", APP_USER)
+          .withProperty("camunda.database.password", APP_PASSWORD)
+          .withBrokerConfig(
+              cfg -> {
+                cfg.getExporters()
+                    .computeIfAbsent("elasticsearch", __ -> new ExporterCfg())
+                    .setArgs(
+                        Map.of(
+                            "index",
+                            Map.of("createTemplate", false),
+                            "retention",
+                            Map.of("enabled", false, "managePolicy", false),
+                            "authentication",
+                            Map.of("username", APP_USER, "password", APP_PASSWORD)));
+              })
+          .withOperateConfig(
+              cfg -> {
+                cfg.getElasticsearch().setCreateSchema(false);
+                cfg.getElasticsearch().setHealthCheckEnabled(false);
+                cfg.getElasticsearch().setUsername(APP_USER);
+                cfg.getElasticsearch().setPassword(APP_PASSWORD);
+                cfg.getZeebeElasticsearch().setUsername(APP_USER);
+                cfg.getZeebeElasticsearch().setPassword(APP_PASSWORD);
+                cfg.getArchiver().setIlmEnabled(true);
+              })
+          .withTasklistConfig(
+              cfg -> {
+                cfg.getElasticsearch().setCreateSchema(false);
+                cfg.getElasticsearch().setHealthCheckEnabled(false);
+                cfg.getElasticsearch().setUsername(APP_USER);
+                cfg.getElasticsearch().setPassword(APP_PASSWORD);
+                cfg.getZeebeElasticsearch().setUsername(APP_USER);
+                cfg.getZeebeElasticsearch().setPassword(APP_PASSWORD);
+                cfg.getArchiver().setIlmEnabled(true);
+                cfg.getArchiver().setIlmManagePolicy(false);
+              });
+
+  // Elasticsearch client with admin access to apply some manual operations
+  private ElasticsearchClient adminElasticsearchClient;
+
+  @BeforeEach
+  void setup() throws IOException, InterruptedException {
+    // setup ES users
+    es.execInContainer("elasticsearch-users", "useradd", APP_USER, "-p", APP_PASSWORD);
+    es.execInContainer("elasticsearch-users", "useradd", ADMIN_USER, "-p", ADMIN_PASSWORD);
+    es.execInContainer("elasticsearch-users", "roles", ADMIN_USER, "-a", ADMIN_ROLE);
+    es.execInContainer("elasticsearch-users", "roles", APP_USER, "-a", APP_ROLE);
+    // Connect to ES
+    schemaManager.withProperty(
+        "zeebe.broker.exporters.elasticsearch.args.url", "http://" + es.getHttpHostAddress());
+    schemaManager.withProperty(
+        "camunda.operate.elasticsearch.url", "http://" + es.getHttpHostAddress());
+    schemaManager.withProperty(
+        "camunda.tasklist.elasticsearch.url", "http://" + es.getHttpHostAddress());
+    backupManager.withProperty(
+        "camunda.operate.elasticsearch.url", "http://" + es.getHttpHostAddress());
+    backupManager.withProperty(
+        "camunda.tasklist.elasticsearch.url", "http://" + es.getHttpHostAddress());
+
+    adminElasticsearchClient = createAdminElasticsearchClient("http://" + es.getHttpHostAddress());
+  }
+
+  @Test
+  void canBackupRestore() throws Exception {
+    // GIVEN
+    // create the schema
+    schemaManager.start();
+    // Create a snapshot repository to store backups
+    createSnapshotRepository();
+    // Start the Camunda application
+    camunda.start();
+    // Generate test data
+    final long processInstanceKey = generateData();
+    // Assert that the data is created in Elasticsearch
+    final long userTaskKey =
+        assertThatDataIsPresent(processInstanceKey, isRunningProcessInstance());
+
+    // WHEN
+    // Start the backup process with a specific backup ID
+    backupManager.withBackupId(BACKUP_ID).start();
+    // manually backup zeebe indices
+    backupZeebeIndices();
+
+    final List<String> snapshots = new ArrayList<>();
+    // Wait for snapshots to be completed
+    snapshots.addAll(waitForSnapshotsToBeCompleted(OPERATE_SNAPSHOT_NAME_PREFIX, 6));
+    snapshots.addAll(waitForSnapshotsToBeCompleted(TASKLIST_SNAPSHOT_NAME_PREFIX, 6));
+    snapshots.addAll(waitForSnapshotsToBeCompleted(ZEEBE_SNAPSHOT_NAME, 1));
+    // Update the current state by completing the user task and the process instance
+    completeUserTask(userTaskKey);
+    // Assert that the state is updated: process instance is completed
+    assertThatDataIsPresent(processInstanceKey, isRunningProcessInstance().negate());
+
+    // Stop the Camunda application
+    camunda.stop();
+    // Delete indices to simulate a fresh start
+    deleteIndices();
+    // Restore the backup to recover deleted data
+    restoreBackup(snapshots);
+    // Restart Camunda after restoration
+    camunda.start();
+
+    // THEN
+    // Validate that the data is restored successfully at the state before the backup: process
+    // instance is running
+    assertThatDataIsPresent(processInstanceKey, isRunningProcessInstance());
+  }
+
+  /**
+   * As documented in
+   * https://docs.camunda.io/docs/self-managed/operational-guides/backup-restore/backup-and-restore/#backup-process
+   */
+  private void backupZeebeIndices() throws IOException {
+    adminElasticsearchClient
+        .snapshot()
+        .create(
+            r ->
+                r.repository(REPOSITORY_NAME)
+                    .snapshot(ZEEBE_SNAPSHOT_NAME)
+                    .indices("zeebe-record*")
+                    .featureStates("none"));
+  }
+
+  private long generateData() {
+    // creating a user for webapps authentication
+    try (final var operateClient = camunda.newOperateClient()) {
+      operateClient.createUser(TEST_USER_NAME, TEST_USER_PASSWORD);
+    }
+    // creating a process instance with user task
+    final long processInstanceKey;
+    try (final var zeebeClient = camunda.newClientBuilder().build()) {
+      // Deploy process with user task
+      zeebeClient
+          .newDeployResourceCommand()
+          .addProcessModel(
+              Bpmn.createExecutableProcess("process-with-user-task")
+                  .startEvent()
+                  .userTask("user-task")
+                  .zeebeUserTask()
+                  .zeebeAssignee(TEST_USER_NAME)
+                  .endEvent()
+                  .done(),
+              "process-with-user-task.bpmn")
+          .send()
+          .join();
+      processInstanceKey =
+          zeebeClient
+              .newCreateInstanceCommand()
+              .bpmnProcessId("process-with-user-task")
+              .latestVersion()
+              .send()
+              .join()
+              .getProcessInstanceKey();
+    }
+    return processInstanceKey;
+  }
+
+  private List<String> waitForSnapshotsToBeCompleted(
+      final String snapshotNamePrefix, final int count) {
+    final var snapshots = new ArrayList<String>();
+    Awaitility.await("should find all snapshots completed")
+        .atMost(ofSeconds(30))
+        .pollDelay(ofSeconds(2))
+        .untilAsserted(
+            () -> {
+              final var response =
+                  adminElasticsearchClient
+                      .snapshot()
+                      .get(r -> r.repository(REPOSITORY_NAME).snapshot(snapshotNamePrefix + "*"))
+                      .snapshots();
+              assertThat(response).hasSize(count);
+              assertThat(response.stream().map(snapshot -> snapshot.state()))
+                  .allMatch(state -> "SUCCESS".equals(state));
+              snapshots.addAll(response.stream().map(snapshot -> snapshot.snapshot()).toList());
+            });
+    return snapshots;
+  }
+
+  /**
+   * Asserts that the data is present in Operate and Tasklist.
+   *
+   * <ul>
+   *   <li>Asserts that the process instance is present in Operate and verifies the check.
+   *   <li>Asserts that one user task is present in Tasklist and returns its key.
+   * </ul>
+   */
+  private long assertThatDataIsPresent(
+      final long processInstanceKey, final Predicate<ProcessInstance> processInstanceCheck) {
+    try (final var operateClient = camunda.newOperateClient()) {
+      Awaitility.await("should find a process instance")
+          .atMost(ofSeconds(30))
+          .ignoreExceptions()
+          .untilAsserted(
+              () -> {
+                final var result =
+                    operateClient
+                        .withAuthentication(TEST_USER_NAME, TEST_USER_PASSWORD)
+                        .getProcessInstanceWith(processInstanceKey);
+                EitherAssert.assertThat(result)
+                    .right()
+                    .isNotNull()
+                    .extracting(ProcessInstanceResult::total)
+                    .isEqualTo(1L);
+                final var processInstance = result.get().processInstances().getFirst();
+                assertThat(processInstance).matches(processInstanceCheck);
+              });
+    }
+    final var userTaskKey = new AtomicReference<Long>();
+    try (final var tasklistClient = camunda.newTasklistClient()) {
+      Awaitility.await("should find a user task")
+          .atMost(ofSeconds(30))
+          .ignoreExceptions()
+          .untilAsserted(
+              () -> {
+                final List<SearchQueryHit<TaskEntity>> hits =
+                    tasklistClient
+                        .withAuthentication(TEST_USER_NAME, TEST_USER_PASSWORD)
+                        .searchUserTasks(SearchQueryBuilders.query().build())
+                        .hits();
+                assertThat(hits).hasSize(1);
+                userTaskKey.set(hits.get(0).source().getKey());
+              });
+    }
+    return userTaskKey.get();
+  }
+
+  private void deleteIndices() throws IOException {
+    adminElasticsearchClient
+        .indices()
+        .delete(r -> r.index("operate*", "tasklist*", "zeebe*").ignoreUnavailable(true));
+    Awaitility.await("should delete indices")
+        .atMost(ofSeconds(30))
+        .pollDelay(ofSeconds(2))
+        .untilAsserted(
+            () ->
+                assertThat(
+                        adminElasticsearchClient
+                            .indices()
+                            .exists(
+                                r ->
+                                    r.index("operate*", "tasklist*", "zeebe*")
+                                        .allowNoIndices(false))
+                            .value())
+                    .isFalse());
+  }
+
+  private void restoreBackup(final List<String> snapshots) {
+    snapshots.stream()
+        .forEach(
+            snapshot -> {
+              try {
+                adminElasticsearchClient
+                    .snapshot()
+                    .restore(
+                        r ->
+                            r.repository(REPOSITORY_NAME)
+                                .snapshot(snapshot)
+                                .waitForCompletion(true));
+              } catch (final IOException e) {
+                fail("Exception occurred while restoring the backup: " + e.getMessage(), e);
+              }
+            });
+  }
+
+  private void createSnapshotRepository() throws IOException {
+    adminElasticsearchClient
+        .snapshot()
+        .createRepository(
+            q ->
+                q.name(REPOSITORY_NAME)
+                    .repository(r -> r.fs(fs -> fs.settings(s -> s.location(REPOSITORY_NAME)))));
+  }
+
+  private void completeUserTask(final long userTaskKey) {
+    try (final var tasklistClient = camunda.newTasklistClient()) {
+      assertThat(
+              tasklistClient
+                  .withAuthentication(TEST_USER_NAME, TEST_USER_PASSWORD)
+                  .completeUserTask(userTaskKey))
+          .returns(200, HttpResponse::statusCode);
+    }
+  }
+
+  private ElasticsearchClient createAdminElasticsearchClient(final String elasticSearchUrl) {
+    final var connectConfiguration = new ConnectConfiguration();
+    connectConfiguration.setUrl(elasticSearchUrl);
+    connectConfiguration.setUsername(ADMIN_USER);
+    connectConfiguration.setPassword(ADMIN_PASSWORD);
+    return new ElasticsearchConnector(connectConfiguration).createClient();
+  }
+
+  private static Predicate<ProcessInstance> isRunningProcessInstance() {
+    return processInstance -> processInstance.getEndDate() == null;
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/StandaloneBackupManagerTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/StandaloneBackupManagerTest.java
@@ -108,9 +108,9 @@ final class StandaloneBackupManagerTest {
               "zeebe.broker.exporters.elasticsearch.args.authentication.username", ADMIN_USER)
           .withProperty(
               "zeebe.broker.exporters.elasticsearch.args.authentication.password", ADMIN_PASSWORD)
+          .withProperty("camunda.operate.elasticsearch.healthCheckEnabled", "false")
           .withProperty("camunda.operate.elasticsearch.username", ADMIN_USER)
           .withProperty("camunda.operate.elasticsearch.password", ADMIN_PASSWORD)
-          .withProperty("camunda.operate.elasticsearch.healthCheckEnabled", "false")
           .withProperty("camunda.operate.archiver.ilmEnabled", "true")
           .withProperty("camunda.tasklist.database", "elasticsearch")
           .withProperty("camunda.tasklist.elasticsearch.username", ADMIN_USER)
@@ -395,6 +395,10 @@ final class StandaloneBackupManagerTest {
                     .isFalse());
   }
 
+  /**
+   * As documented in
+   * https://docs.camunda.io/docs/self-managed/operational-guides/backup-restore/backup-and-restore/#restore
+   */
   private void restoreBackup(final List<String> snapshots) {
     snapshots.stream()
         .forEach(

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneBackupManager.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneBackupManager.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.cluster;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.application.StandaloneBackupManager;
+import io.camunda.application.StandaloneBackupManager.BackupManagerConfiguration;
+import io.camunda.zeebe.qa.util.actuator.HealthActuator;
+import io.camunda.zeebe.qa.util.actuator.HealthActuator.NoopHealthActuator;
+import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+
+public class TestStandaloneBackupManager
+    extends TestSpringApplication<TestStandaloneBackupManager> {
+
+  private Long backupId;
+
+  public TestStandaloneBackupManager() {
+    super(
+        BackupManagerConfiguration.class,
+        StandaloneBackupManager.class,
+        io.camunda.tasklist.JacksonConfig.class,
+        io.camunda.operate.JacksonConfig.class);
+  }
+
+  @Override
+  public TestStandaloneBackupManager self() {
+    return this;
+  }
+
+  @Override
+  public MemberId nodeId() {
+    return MemberId.from("backup");
+  }
+
+  @Override
+  public HealthActuator healthActuator() {
+    return new NoopHealthActuator();
+  }
+
+  @Override
+  public boolean isGateway() {
+    return false;
+  }
+
+  @Override
+  protected String[] commandLineArgs() {
+    return backupId == null ? super.commandLineArgs() : new String[] {String.valueOf(backupId)};
+  }
+
+  @Override
+  protected SpringApplicationBuilder createSpringBuilder() {
+    return super.createSpringBuilder().web(WebApplicationType.NONE);
+  }
+
+  public TestStandaloneBackupManager withBackupId(final Long backupId) {
+    this.backupId = backupId;
+    return this;
+  }
+}

--- a/tasklist/common/src/main/java/io/camunda/tasklist/CommonUtils.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/CommonUtils.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import io.camunda.tasklist.es.ElasticsearchConnector;
+import io.camunda.tasklist.connect.ElasticsearchConnector;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
@@ -56,11 +56,11 @@ public final class CommonUtils {
         .build();
   }
 
-  public static JsonObject getJsonObjectFromEntity(Object o) {
+  public static JsonObject getJsonObjectFromEntity(final Object o) {
     return Json.createObjectBuilder(OBJECT_MAPPER.convertValue(o, HashMap.class)).build();
   }
 
-  public static JsonObjectBuilder getJsonObjectBuilderForEntity(Object o) {
+  public static JsonObjectBuilder getJsonObjectBuilderForEntity(final Object o) {
     return Json.createObjectBuilder(OBJECT_MAPPER.convertValue(o, HashMap.class));
   }
 }

--- a/tasklist/common/src/main/java/io/camunda/tasklist/JacksonConfig.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/JacksonConfig.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import io.camunda.tasklist.es.ElasticsearchConnector;
+import io.camunda.tasklist.connect.ElasticsearchConnector;
 import io.camunda.tasklist.property.TasklistProperties;
 import java.time.Instant;
 import java.time.OffsetDateTime;

--- a/tasklist/common/src/main/java/io/camunda/tasklist/connect/ElasticsearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/connect/ElasticsearchConnector.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.tasklist.es;
+package io.camunda.tasklist.connect;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch.cluster.HealthResponse;

--- a/tasklist/common/src/test/java/io/camunda/tasklist/connect/ElasticsearchConnectorTest.java
+++ b/tasklist/common/src/test/java/io/camunda/tasklist/connect/ElasticsearchConnectorTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.tasklist.es;
+package io.camunda.tasklist.connect;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorIT.java
@@ -12,6 +12,7 @@ import com.github.tomakehurst.wiremock.client.CountMatchingStrategy;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import io.camunda.search.connect.plugin.PluginConfiguration;
+import io.camunda.tasklist.connect.ElasticsearchConnector;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.util.TestPlugin;
 import io.camunda.zeebe.util.FileUtil;

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorSSLAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorSSLAuthIT.java
@@ -10,6 +10,7 @@ package io.camunda.tasklist.es;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import io.camunda.tasklist.connect.ElasticsearchConnector;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.qa.util.TestUtil;
 import io.camunda.tasklist.util.TasklistIntegrationTest;
@@ -83,7 +84,7 @@ public class ElasticsearchConnectorSSLAuthIT extends TasklistIntegrationTest {
       implements ApplicationContextInitializer<ConfigurableApplicationContext> {
 
     @Override
-    public void initialize(ConfigurableApplicationContext applicationContext) {
+    public void initialize(final ConfigurableApplicationContext applicationContext) {
       elasticsearch.start();
 
       final String elsUrl =

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/management/HealthCheckAuthenticationIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/management/HealthCheckAuthenticationIT.java
@@ -14,7 +14,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
 
 import io.camunda.tasklist.JacksonConfig;
-import io.camunda.tasklist.es.ElasticsearchConnector;
+import io.camunda.tasklist.connect.ElasticsearchConnector;
 import io.camunda.tasklist.es.ElasticsearchInternalTask;
 import io.camunda.tasklist.es.RetryElasticsearchClient;
 import io.camunda.tasklist.property.TasklistProperties;

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/management/HealthCheckIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/management/HealthCheckIT.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import io.camunda.tasklist.JacksonConfig;
-import io.camunda.tasklist.es.ElasticsearchConnector;
+import io.camunda.tasklist.connect.ElasticsearchConnector;
 import io.camunda.tasklist.es.ElasticsearchInternalTask;
 import io.camunda.tasklist.es.RetryElasticsearchClient;
 import io.camunda.tasklist.property.TasklistProperties;

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/management/dto/GetBackupStateResponseDetailDto.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/management/dto/GetBackupStateResponseDetailDto.java
@@ -24,7 +24,7 @@ public class GetBackupStateResponseDetailDto {
     return snapshotName;
   }
 
-  public GetBackupStateResponseDetailDto setSnapshotName(String snapshotName) {
+  public GetBackupStateResponseDetailDto setSnapshotName(final String snapshotName) {
     this.snapshotName = snapshotName;
     return this;
   }
@@ -33,7 +33,7 @@ public class GetBackupStateResponseDetailDto {
     return state;
   }
 
-  public GetBackupStateResponseDetailDto setState(String state) {
+  public GetBackupStateResponseDetailDto setState(final String state) {
     this.state = state;
     return this;
   }
@@ -42,7 +42,7 @@ public class GetBackupStateResponseDetailDto {
     return startTime;
   }
 
-  public GetBackupStateResponseDetailDto setStartTime(OffsetDateTime startTime) {
+  public GetBackupStateResponseDetailDto setStartTime(final OffsetDateTime startTime) {
     this.startTime = startTime;
     return this;
   }
@@ -51,13 +51,20 @@ public class GetBackupStateResponseDetailDto {
     return failures;
   }
 
-  public GetBackupStateResponseDetailDto setFailures(String[] failures) {
+  public GetBackupStateResponseDetailDto setFailures(final String[] failures) {
     this.failures = failures;
     return this;
   }
 
   @Override
-  public boolean equals(Object o) {
+  public int hashCode() {
+    int result = Objects.hash(snapshotName, state, startTime);
+    result = 31 * result + Arrays.hashCode(failures);
+    return result;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }
@@ -72,9 +79,18 @@ public class GetBackupStateResponseDetailDto {
   }
 
   @Override
-  public int hashCode() {
-    int result = Objects.hash(snapshotName, state, startTime);
-    result = 31 * result + Arrays.hashCode(failures);
-    return result;
+  public String toString() {
+    return "GetBackupStateResponseDetailDto{"
+        + "snapshotName='"
+        + snapshotName
+        + '\''
+        + ", state='"
+        + state
+        + '\''
+        + ", startTime="
+        + startTime
+        + ", failures="
+        + Arrays.toString(failures)
+        + '}';
   }
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/management/dto/GetBackupStateResponseDto.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/management/dto/GetBackupStateResponseDto.java
@@ -19,7 +19,7 @@ public class GetBackupStateResponseDto {
 
   public GetBackupStateResponseDto() {}
 
-  public GetBackupStateResponseDto(Long backupId) {
+  public GetBackupStateResponseDto(final Long backupId) {
     this.backupId = backupId;
   }
 
@@ -27,7 +27,7 @@ public class GetBackupStateResponseDto {
     return backupId;
   }
 
-  public GetBackupStateResponseDto setBackupId(Long backupId) {
+  public GetBackupStateResponseDto setBackupId(final Long backupId) {
     this.backupId = backupId;
     return this;
   }
@@ -36,7 +36,7 @@ public class GetBackupStateResponseDto {
     return state;
   }
 
-  public GetBackupStateResponseDto setState(BackupStateDto state) {
+  public GetBackupStateResponseDto setState(final BackupStateDto state) {
     this.state = state;
     return this;
   }
@@ -45,7 +45,7 @@ public class GetBackupStateResponseDto {
     return failureReason;
   }
 
-  public GetBackupStateResponseDto setFailureReason(String failureReason) {
+  public GetBackupStateResponseDto setFailureReason(final String failureReason) {
     this.failureReason = failureReason;
     return this;
   }
@@ -54,13 +54,18 @@ public class GetBackupStateResponseDto {
     return details;
   }
 
-  public GetBackupStateResponseDto setDetails(List<GetBackupStateResponseDetailDto> details) {
+  public GetBackupStateResponseDto setDetails(final List<GetBackupStateResponseDetailDto> details) {
     this.details = details;
     return this;
   }
 
   @Override
-  public boolean equals(Object o) {
+  public int hashCode() {
+    return Objects.hash(backupId, state, failureReason, details);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }
@@ -75,7 +80,17 @@ public class GetBackupStateResponseDto {
   }
 
   @Override
-  public int hashCode() {
-    return Objects.hash(backupId, state, failureReason, details);
+  public String toString() {
+    return "GetBackupStateResponseDto{"
+        + "backupId="
+        + backupId
+        + ", state="
+        + state
+        + ", failureReason='"
+        + failureReason
+        + '\''
+        + ", details="
+        + details
+        + '}';
   }
 }

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/CommonUtils.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/CommonUtils.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import io.camunda.tasklist.es.ElasticsearchConnector;
+import io.camunda.tasklist.connect.ElasticsearchConnector;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;


### PR DESCRIPTION
## Description

We have the use case of creating backups (ES index snapshots) separate of our Camunda Platform, as taking snapshot in ES/OS requires separate and even higher permissions. 

There is the need of separating concerns here and to not have Camunda 8 application running all the time with such high permissions. 

As a POC we were building a SpringBoot application that:

- Accepts a backupId via command line argument
- That can be configured with similar properties we had before for the [StandaloneSchmemaManager](https://docs.camunda.io/docs/self-managed/concepts/elasticsearch-without-cluster-privileges/#11-configure-schema-manager)
    - Additionally, we would need to configure
        - `camunda.operate.backup.repositoryName:`
        - `camunda.tasklist.backup.repositoryName:`
- Bootstraps all necessary dependencies
- Schedules Operate and Tasklist indices snapshots on ES snapshot store
- Observes the process of the snapshots, until it is completed or in a failed state
- The application can be executed as: `SPRING_CONFIG_ADDITIONALLOCATION=backup-manager.yml ./dist/target/camunda-zeebe/bin/backup <backupID>`
  - Similar to what we have for the StandaloneSchemaManager

## Execution / Manual verification

1. Setup ES container: `$ podman run -p 9200:9200 -e "xpack.security.enabled=false" -e  "discovery.type=single-node" -e "action.destructive_requires_name=false" -e "indices.lifecycle.poll_interval=1s" -e "path.repo=~/" docker.io/library/elasticsearch:8.17.2
 `
   Be aware that `"path.repo=~/"` is necessary to setup the snapshot repository in ES
2. Create a snapshot repository via ElasticVue - in browser

![2025-03-06_13-47_1](https://github.com/user-attachments/assets/83a29f30-391f-45d5-bca0-559b93b5870b)
![2025-03-06_13-47](https://github.com/user-attachments/assets/f7130642-b528-4f21-aa7c-8ed0c9359a0a)

3. Run StandaloneCamunda to set up indices and some data

![2025-03-06_10-32](https://github.com/user-attachments/assets/998f8505-2adb-470b-a9ad-aad36dc28675)

4. Run the standalone backup manager
![2025-03-06_14-44_1](https://github.com/user-attachments/assets/65cf082e-9f66-4a48-a64a-9d0ea585720e)
![2025-03-06_14-44](https://github.com/user-attachments/assets/def982f8-8300-49af-953a-77d10c5a8e2f)


