### PR TITLE
Implement tabs for tenant details page

### DIFF
--- a/identity/client/src/components/form/DropdownSearch.tsx
+++ b/identity/client/src/components/form/DropdownSearch.tsx
@@ -10,7 +10,7 @@ type DropdownSearchProps<Item> = {
   itemTitle: (item: Item) => string;
   itemSubTitle?: (item: Item) => string;
   placeholder: string;
-  onChange: (search: string) => unknown;
+  onChange?: (search: string) => unknown;
   onSelect: (item: Item) => unknown;
   autoFocus?: boolean;
 };
@@ -33,7 +33,7 @@ const MenuItemWrapper = styled.div<{ $isSelected: boolean }>`
 
 const DropdownSearch = <Item,>({
   placeholder,
-  onChange,
+  onChange = () => null,
   items,
   itemTitle,
   itemSubTitle,

--- a/identity/client/src/feature-flags.ts
+++ b/identity/client/src/feature-flags.ts
@@ -1,2 +1,3 @@
 export const IS_TENANT_GROUPS_SUPPORTED = false; // TODO: Remove when endpoints are available - https://github.com/camunda/camunda/issues/26961
 export const IS_TENANT_ROLES_SUPPORTED = false; // TODO: Remove when endpoints are available - https://github.com/camunda/camunda/issues/26961
+export const IS_TENANT_MAPPINGS_SUPPORTED = false; // TODO: Remove when endpoints are available - https://github.com/camunda/camunda/issues/26961

--- a/identity/client/src/feature-flags.ts
+++ b/identity/client/src/feature-flags.ts
@@ -1,0 +1,2 @@
+export const IS_TENANT_GROUPS_SUPPORTED = false; // TODO: Remove when endpoints are available - https://github.com/camunda/camunda/issues/26961
+export const IS_TENANT_ROLES_SUPPORTED = false; // TODO: Remove when endpoints are available - https://github.com/camunda/camunda/issues/26961

--- a/identity/client/src/pages/groups/detail/members/AssignMembersModal.tsx
+++ b/identity/client/src/pages/groups/detail/members/AssignMembersModal.tsx
@@ -106,17 +106,14 @@ const AssignMembersModal: FC<
           ))}
         </SelectedUsers>
       )}
-
       <DropdownSearch
         autoFocus
         items={unassignedUsers}
         itemTitle={({ username }) => username}
         itemSubTitle={({ email }) => email}
         placeholder={t("Search by full name or email address")}
-        onChange={() => null}
         onSelect={onSelectUser}
       />
-
       {!loading && error && (
         <TranslatedErrorInlineNotification
           title={t("Users could not be loaded.")}

--- a/identity/client/src/pages/tenants/detail/groups/AssignGroupsModal.tsx
+++ b/identity/client/src/pages/tenants/detail/groups/AssignGroupsModal.tsx
@@ -99,7 +99,9 @@ const AssignGroupsModal: FC<
       overflowVisible
     >
       <p>
-        <Translate>Search and assign group to tenant</Translate>
+        <Translate i18nKey="searchAndAssignGroupToTenant">
+          Search and assign group to tenant
+        </Translate>
       </p>
       {selectedGroups.length > 0 && (
         <SelectedGroups>
@@ -116,17 +118,14 @@ const AssignGroupsModal: FC<
           ))}
         </SelectedGroups>
       )}
-
       <DropdownSearch
         autoFocus
         items={unassignedGroups}
         itemTitle={({ groupKey }) => groupKey}
         itemSubTitle={({ name }) => name}
         placeholder={t("searchByGroupId")}
-        onChange={() => null}
         onSelect={onSelectGroup}
       />
-
       {!loading && error && (
         <TranslatedErrorInlineNotification
           title={t("groupsCouldNotLoad")}

--- a/identity/client/src/pages/tenants/detail/groups/AssignGroupsModal.tsx
+++ b/identity/client/src/pages/tenants/detail/groups/AssignGroupsModal.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, useEffect, useState } from "react";
+import { Tag } from "@carbon/react";
+import { UseEntityModalCustomProps } from "src/components/modal";
+import useTranslate from "src/utility/localization";
+import { useApi, useApiCall } from "src/utility/api/hooks";
+import { searchGroups, Group } from "src/utility/api/groups";
+import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
+import styled from "styled-components";
+import DropdownSearch from "src/components/form/DropdownSearch";
+import FormModal from "src/components/modal/FormModal";
+import { assignTenantGroup, Tenant } from "src/utility/api/tenants";
+
+const SelectedGroups = styled.div`
+  margin-top: 0;
+`;
+
+const AssignGroupsModal: FC<
+  UseEntityModalCustomProps<
+    { id: Tenant["tenantKey"] },
+    { assignedGroups: Group[] }
+  >
+> = ({ entity: tenant, assignedGroups, onSuccess, open, onClose }) => {
+  const { t, Translate } = useTranslate("tenants");
+  const [selectedGroups, setSelectedGroups] = useState<Group[]>([]);
+  const [loadingAssignGroup, setLoadingAssignGroup] = useState(false);
+
+  const {
+    data: groupSearchResults,
+    loading,
+    reload,
+    error,
+  } = useApi(searchGroups);
+
+  const [callAssignGroup] = useApiCall(assignTenantGroup);
+
+  const unassignedGroups =
+    groupSearchResults?.items.filter(
+      ({ groupKey }) =>
+        !assignedGroups.some((group) => group.groupKey === groupKey) &&
+        !selectedGroups.some((group) => group.groupKey === groupKey),
+    ) || [];
+
+  const onSelectGroup = (group: Group) => {
+    setSelectedGroups([...selectedGroups, group]);
+  };
+
+  const onUnselectGroup =
+    ({ groupKey }: Group) =>
+    () => {
+      setSelectedGroups(
+        selectedGroups.filter((group) => group.groupKey !== groupKey),
+      );
+    };
+
+  const canSubmit = tenant && selectedGroups.length;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+
+    setLoadingAssignGroup(true);
+
+    const results = await Promise.all(
+      selectedGroups.map(({ groupKey }) =>
+        callAssignGroup({ groupKey, tenantId: tenant.id }),
+      ),
+    );
+
+    setLoadingAssignGroup(false);
+
+    if (results.every(({ success }) => success)) {
+      onSuccess();
+    }
+  };
+
+  useEffect(() => {
+    if (open) {
+      setSelectedGroups([]);
+    }
+  }, [open]);
+
+  return (
+    <FormModal
+      headline={t("assignGroup")}
+      confirmLabel={t("assignGroup")}
+      loading={loadingAssignGroup}
+      loadingDescription={t("assigningGroup")}
+      open={open}
+      onSubmit={handleSubmit}
+      submitDisabled={!canSubmit}
+      onClose={onClose}
+      overflowVisible
+    >
+      <p>
+        <Translate>Search and assign group to tenant</Translate>
+      </p>
+      {selectedGroups.length > 0 && (
+        <SelectedGroups>
+          {selectedGroups.map((group) => (
+            <Tag
+              key={group.groupKey}
+              onClose={onUnselectGroup(group)}
+              size="md"
+              type="blue"
+              filter
+            >
+              {group.groupKey}
+            </Tag>
+          ))}
+        </SelectedGroups>
+      )}
+
+      <DropdownSearch
+        autoFocus
+        items={unassignedGroups}
+        itemTitle={({ groupKey }) => groupKey}
+        itemSubTitle={({ name }) => name}
+        placeholder={t("searchByGroupId")}
+        onChange={() => null}
+        onSelect={onSelectGroup}
+      />
+
+      {!loading && error && (
+        <TranslatedErrorInlineNotification
+          title={t("groupsCouldNotLoad")}
+          actionButton={{ label: t("retry"), onClick: reload }}
+        />
+      )}
+    </FormModal>
+  );
+};
+
+export default AssignGroupsModal;

--- a/identity/client/src/pages/tenants/detail/groups/DeleteModal.tsx
+++ b/identity/client/src/pages/tenants/detail/groups/DeleteModal.tsx
@@ -62,8 +62,13 @@ const DeleteModal: FC<RemoveTenantGroupModalProps> = ({
       confirmLabel={t("removeGroup")}
     >
       <p>
-        <Translate>Are you sure you want to remove</Translate>{" "}
-        <strong>{group.groupKey}</strong> from this tenant?
+        <Translate
+          i18nKey="removeGroupFromTenant"
+          values={{ groupKey: group.groupKey }}
+        >
+          Are you sure you want to remove <strong>{group.groupKey}</strong> from
+          this tenant?
+        </Translate>
       </p>
     </Modal>
   );

--- a/identity/client/src/pages/tenants/detail/groups/DeleteModal.tsx
+++ b/identity/client/src/pages/tenants/detail/groups/DeleteModal.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda
+ * Services GmbH under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file except in compliance with the Camunda License 1.0.
+ */
+import { FC } from "react";
+import { useApiCall } from "src/utility/api";
+import useTranslate from "src/utility/localization";
+import {
+  DeleteModal as Modal,
+  UseEntityModalCustomProps,
+} from "src/components/modal";
+import { useNotifications } from "src/components/notifications";
+import { Group } from "src/utility/api/groups";
+import { unassignTenantGroup } from "src/utility/api/tenants";
+
+type RemoveTenantGroupModalProps = UseEntityModalCustomProps<
+  Group,
+  {
+    tenant: string;
+  }
+>;
+
+const DeleteModal: FC<RemoveTenantGroupModalProps> = ({
+  entity: group,
+  open,
+  onClose,
+  onSuccess,
+  tenant,
+}) => {
+  const { t, Translate } = useTranslate("tenants");
+  const { enqueueNotification } = useNotifications();
+
+  const [callUnassignGroup, { loading }] = useApiCall(unassignTenantGroup);
+
+  const handleSubmit = async () => {
+    if (tenant && group) {
+      const { success } = await callUnassignGroup({
+        tenantId: tenant,
+        groupKey: group.groupKey,
+      });
+
+      if (success) {
+        enqueueNotification({
+          kind: "success",
+          title: t("tenantGroupRemoved"),
+        });
+        onSuccess();
+      }
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      headline={t("removeGroup")}
+      onSubmit={handleSubmit}
+      loading={loading}
+      loadingDescription={t("removingGroup")}
+      onClose={onClose}
+      confirmLabel={t("removeGroup")}
+    >
+      <p>
+        <Translate>Are you sure you want to remove</Translate>{" "}
+        <strong>{group.groupKey}</strong> from this tenant?
+      </p>
+    </Modal>
+  );
+};
+
+export default DeleteModal;

--- a/identity/client/src/pages/tenants/detail/groups/index.tsx
+++ b/identity/client/src/pages/tenants/detail/groups/index.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { C3EmptyState } from "@camunda/camunda-composite-components";
+import useTranslate from "src/utility/localization";
+import { useApi } from "src/utility/api/hooks";
+import { getGroupsByTenantId } from "src/utility/api/tenants";
+import EntityList from "src/components/entityList";
+import { useEntityModal } from "src/components/modal";
+import { TrashCan } from "@carbon/react/icons";
+import DeleteModal from "src/pages/tenants/detail/groups/DeleteModal";
+import AssignGroupsModal from "src/pages/tenants/detail/groups/AssignGroupsModal";
+
+type GroupsProps = {
+  tenantId: string;
+};
+
+const Groups: FC<GroupsProps> = ({ tenantId }) => {
+  const { t } = useTranslate("tenants");
+
+  const {
+    data: groups,
+    loading,
+    success,
+    reload,
+  } = useApi(getGroupsByTenantId, {
+    tenantId: tenantId,
+  });
+
+  const areNoGroupsAssigned = !groups || groups.items?.length === 0;
+
+  const [assignGroups, assignGroupsModal] = useEntityModal(
+    AssignGroupsModal,
+    reload,
+    {
+      assignedGroups: groups?.items || [],
+    },
+  );
+  const openAssignModal = () => assignGroups({ id: tenantId });
+  const [unassignGroup, unassignGroupModal] = useEntityModal(
+    DeleteModal,
+    reload,
+    {
+      tenant: tenantId,
+    },
+  );
+
+  if (!loading && !success)
+    return (
+      <C3EmptyState
+        heading={t("somethingsWrong")}
+        description={t("unableToLoadGroups")}
+        button={{ label: t("retry"), onClick: reload }}
+      />
+    );
+
+  if (success && areNoGroupsAssigned)
+    return (
+      <>
+        <C3EmptyState
+          heading={t("assignGroupsToTenant")}
+          description={t("tenantMemberAccessDisclaimer")}
+          button={{
+            label: t("assignGroup"),
+            onClick: openAssignModal,
+          }}
+          link={{
+            label: t("learnMoreAboutTenants"),
+            href: `/identity/concepts/access-control/tenants`,
+          }}
+        />
+        {assignGroupsModal}
+      </>
+    );
+
+  return (
+    <>
+      <EntityList
+        data={groups?.items}
+        headers={[
+          { header: t("groupId"), key: "groupKey" },
+          { header: t("groupName"), key: "name" },
+        ]}
+        sortProperty="groupKey"
+        loading={loading}
+        addEntityLabel={t("assignGroup")}
+        onAddEntity={openAssignModal}
+        searchPlaceholder={t("searchByGroupId")}
+        menuItems={[
+          {
+            label: t("remove"),
+            icon: TrashCan,
+            isDangerous: true,
+            onClick: unassignGroup,
+          },
+        ]}
+      />
+      {assignGroupsModal}
+      {unassignGroupModal}
+    </>
+  );
+};
+
+export default Groups;

--- a/identity/client/src/pages/tenants/detail/index.tsx
+++ b/identity/client/src/pages/tenants/detail/index.tsx
@@ -18,6 +18,7 @@ import { useEntityModal } from "src/components/modal";
 import DeleteModal from "src/pages/tenants/modals/DeleteModal";
 import { Description } from "src/pages/tenants/detail/components";
 import Members from "src/pages/tenants/detail/members";
+import Groups from "src/pages/tenants/detail/groups";
 
 const Details: FC = () => {
   const { t } = useTranslate("tenants");
@@ -78,6 +79,11 @@ const Details: FC = () => {
                   key: "users",
                   label: t("users"),
                   content: <Members tenantId={tenant.tenantId} />,
+                },
+                {
+                  key: "groups",
+                  label: t("groups"),
+                  content: <Groups tenantId={tenant.tenantId} />,
                 },
               ]}
               selectedTabKey={tab}

--- a/identity/client/src/pages/tenants/detail/index.tsx
+++ b/identity/client/src/pages/tenants/detail/index.tsx
@@ -20,9 +20,11 @@ import { Description } from "src/pages/tenants/detail/components";
 import Members from "src/pages/tenants/detail/members";
 import Groups from "src/pages/tenants/detail/groups";
 import Roles from "src/pages/tenants/detail/roles";
+import Mappings from "src/pages/tenants/detail/mappings";
 import {
   IS_TENANT_GROUPS_SUPPORTED,
   IS_TENANT_ROLES_SUPPORTED,
+  IS_TENANT_MAPPINGS_SUPPORTED,
 } from "src/feature-flags";
 
 const Details: FC = () => {
@@ -100,6 +102,15 @@ const Details: FC = () => {
                         key: "roles",
                         label: t("roles"),
                         content: <Roles tenantId={tenant.tenantId} />,
+                      },
+                    ]
+                  : []),
+                ...(IS_TENANT_MAPPINGS_SUPPORTED
+                  ? [
+                      {
+                        key: "mappings",
+                        label: t("mappings"),
+                        content: <Mappings tenantId={tenant.tenantId} />,
                       },
                     ]
                   : []),

--- a/identity/client/src/pages/tenants/detail/index.tsx
+++ b/identity/client/src/pages/tenants/detail/index.tsx
@@ -19,6 +19,11 @@ import DeleteModal from "src/pages/tenants/modals/DeleteModal";
 import { Description } from "src/pages/tenants/detail/components";
 import Members from "src/pages/tenants/detail/members";
 import Groups from "src/pages/tenants/detail/groups";
+import Roles from "src/pages/tenants/detail/roles";
+import {
+  IS_TENANT_GROUPS_SUPPORTED,
+  IS_TENANT_ROLES_SUPPORTED,
+} from "src/feature-flags";
 
 const Details: FC = () => {
   const { t } = useTranslate("tenants");
@@ -80,11 +85,24 @@ const Details: FC = () => {
                   label: t("users"),
                   content: <Members tenantId={tenant.tenantId} />,
                 },
-                {
-                  key: "groups",
-                  label: t("groups"),
-                  content: <Groups tenantId={tenant.tenantId} />,
-                },
+                ...(IS_TENANT_GROUPS_SUPPORTED
+                  ? [
+                      {
+                        key: "groups",
+                        label: t("groups"),
+                        content: <Groups tenantId={tenant.tenantId} />,
+                      },
+                    ]
+                  : []),
+                ...(IS_TENANT_ROLES_SUPPORTED
+                  ? [
+                      {
+                        key: "roles",
+                        label: t("roles"),
+                        content: <Roles tenantId={tenant.tenantId} />,
+                      },
+                    ]
+                  : []),
               ]}
               selectedTabKey={tab}
               path={`../${id}`}

--- a/identity/client/src/pages/tenants/detail/mappings/AssignMappingsModal.tsx
+++ b/identity/client/src/pages/tenants/detail/mappings/AssignMappingsModal.tsx
@@ -99,7 +99,9 @@ const AssignMappingsModal: FC<
       overflowVisible
     >
       <p>
-        <Translate>Search and assign mapping to tenant</Translate>
+        <Translate i18nKey="searchAndAssignMappingToTenant">
+          Search and assign mapping to tenant
+        </Translate>
       </p>
       {selectedMappings.length > 0 && (
         <SelectedMappings>
@@ -116,17 +118,14 @@ const AssignMappingsModal: FC<
           ))}
         </SelectedMappings>
       )}
-
       <DropdownSearch
         autoFocus
         items={unassignedMappings}
         itemTitle={({ id }) => id}
         itemSubTitle={({ name }) => name}
         placeholder={t("searchByMappingId")}
-        onChange={() => null}
         onSelect={onSelectMapping}
       />
-
       {!loading && error && (
         <TranslatedErrorInlineNotification
           title={t("mappingsCouldNotLoad")}

--- a/identity/client/src/pages/tenants/detail/mappings/AssignMappingsModal.tsx
+++ b/identity/client/src/pages/tenants/detail/mappings/AssignMappingsModal.tsx
@@ -1,0 +1,140 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, useEffect, useState } from "react";
+import { Tag } from "@carbon/react";
+import { UseEntityModalCustomProps } from "src/components/modal";
+import useTranslate from "src/utility/localization";
+import { useApi, useApiCall } from "src/utility/api/hooks";
+import { searchMapping, Mapping } from "src/utility/api/mappings";
+import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
+import styled from "styled-components";
+import DropdownSearch from "src/components/form/DropdownSearch";
+import FormModal from "src/components/modal/FormModal";
+import { assignTenantMapping, Tenant } from "src/utility/api/tenants";
+
+const SelectedMappings = styled.div`
+  margin-top: 0;
+`;
+
+const AssignMappingsModal: FC<
+  UseEntityModalCustomProps<
+    { id: Tenant["tenantKey"] },
+    { assignedMappings: Mapping[] }
+  >
+> = ({ entity: tenant, assignedMappings, onSuccess, open, onClose }) => {
+  const { t, Translate } = useTranslate("tenants");
+  const [selectedMappings, setSelectedMappings] = useState<Mapping[]>([]);
+  const [loadingAssignMapping, setLoadingAssignMapping] = useState(false);
+
+  const {
+    data: mappingSearchResults,
+    loading,
+    reload,
+    error,
+  } = useApi(searchMapping);
+
+  const [callAssignMapping] = useApiCall(assignTenantMapping);
+
+  const unassignedMappings =
+    mappingSearchResults?.items.filter(
+      ({ id }) =>
+        !assignedMappings.some((mapping) => mapping.id === id) &&
+        !selectedMappings.some((mapping) => mapping.id === id),
+    ) || [];
+
+  const onSelectMapping = (mapping: Mapping) => {
+    setSelectedMappings([...selectedMappings, mapping]);
+  };
+
+  const onUnselectMapping =
+    ({ id }: Mapping) =>
+    () => {
+      setSelectedMappings(
+        selectedMappings.filter((mapping) => mapping.id !== id),
+      );
+    };
+
+  const canSubmit = tenant && selectedMappings.length;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+
+    setLoadingAssignMapping(true);
+
+    const results = await Promise.all(
+      selectedMappings.map(({ id }) =>
+        callAssignMapping({ id, tenantId: tenant.id }),
+      ),
+    );
+
+    setLoadingAssignMapping(false);
+
+    if (results.every(({ success }) => success)) {
+      onSuccess();
+    }
+  };
+
+  useEffect(() => {
+    if (open) {
+      setSelectedMappings([]);
+    }
+  }, [open]);
+
+  return (
+    <FormModal
+      headline={t("assignMapping")}
+      confirmLabel={t("assignMapping")}
+      loading={loadingAssignMapping}
+      loadingDescription={t("assigningMapping")}
+      open={open}
+      onSubmit={handleSubmit}
+      submitDisabled={!canSubmit}
+      onClose={onClose}
+      overflowVisible
+    >
+      <p>
+        <Translate>Search and assign mapping to tenant</Translate>
+      </p>
+      {selectedMappings.length > 0 && (
+        <SelectedMappings>
+          {selectedMappings.map((mapping) => (
+            <Tag
+              key={mapping.id}
+              onClose={onUnselectMapping(mapping)}
+              size="md"
+              type="blue"
+              filter
+            >
+              {mapping.id}
+            </Tag>
+          ))}
+        </SelectedMappings>
+      )}
+
+      <DropdownSearch
+        autoFocus
+        items={unassignedMappings}
+        itemTitle={({ id }) => id}
+        itemSubTitle={({ name }) => name}
+        placeholder={t("searchByMappingId")}
+        onChange={() => null}
+        onSelect={onSelectMapping}
+      />
+
+      {!loading && error && (
+        <TranslatedErrorInlineNotification
+          title={t("mappingsCouldNotLoad")}
+          actionButton={{ label: t("retry"), onClick: reload }}
+        />
+      )}
+    </FormModal>
+  );
+};
+
+export default AssignMappingsModal;

--- a/identity/client/src/pages/tenants/detail/mappings/DeleteModal.tsx
+++ b/identity/client/src/pages/tenants/detail/mappings/DeleteModal.tsx
@@ -62,8 +62,13 @@ const DeleteModal: FC<RemoveTenantMappingModalProps> = ({
       confirmLabel={t("removeMapping")}
     >
       <p>
-        <Translate>Are you sure you want to remove</Translate>{" "}
-        <strong>{mapping.id}</strong> from this tenant?
+        <Translate
+          i18nKey="removeMappingFromTenant"
+          values={{ mappingId: mapping.id }}
+        >
+          Are you sure you want to remove <strong>{mapping.id}</strong> from
+          this tenant?
+        </Translate>
       </p>
     </Modal>
   );

--- a/identity/client/src/pages/tenants/detail/mappings/DeleteModal.tsx
+++ b/identity/client/src/pages/tenants/detail/mappings/DeleteModal.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda
+ * Services GmbH under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file except in compliance with the Camunda License 1.0.
+ */
+import { FC } from "react";
+import { useApiCall } from "src/utility/api";
+import useTranslate from "src/utility/localization";
+import {
+  DeleteModal as Modal,
+  UseEntityModalCustomProps,
+} from "src/components/modal";
+import { useNotifications } from "src/components/notifications";
+import { Mapping } from "src/utility/api/mappings";
+import { unassignTenantMapping } from "src/utility/api/tenants";
+
+type RemoveTenantMappingModalProps = UseEntityModalCustomProps<
+  Mapping,
+  {
+    tenant: string;
+  }
+>;
+
+const DeleteModal: FC<RemoveTenantMappingModalProps> = ({
+  entity: mapping,
+  open,
+  onClose,
+  onSuccess,
+  tenant,
+}) => {
+  const { t, Translate } = useTranslate("tenants");
+  const { enqueueNotification } = useNotifications();
+
+  const [callUnassignMapping, { loading }] = useApiCall(unassignTenantMapping);
+
+  const handleSubmit = async () => {
+    if (tenant && mapping) {
+      const { success } = await callUnassignMapping({
+        tenantId: tenant,
+        id: mapping.id,
+      });
+
+      if (success) {
+        enqueueNotification({
+          kind: "success",
+          title: t("tenantMappingRemoved"),
+        });
+        onSuccess();
+      }
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      headline={t("removeMapping")}
+      onSubmit={handleSubmit}
+      loading={loading}
+      loadingDescription={t("removingMapping")}
+      onClose={onClose}
+      confirmLabel={t("removeMapping")}
+    >
+      <p>
+        <Translate>Are you sure you want to remove</Translate>{" "}
+        <strong>{mapping.id}</strong> from this tenant?
+      </p>
+    </Modal>
+  );
+};
+
+export default DeleteModal;

--- a/identity/client/src/pages/tenants/detail/mappings/index.tsx
+++ b/identity/client/src/pages/tenants/detail/mappings/index.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { C3EmptyState } from "@camunda/camunda-composite-components";
+import { TrashCan } from "@carbon/react/icons";
+import useTranslate from "src/utility/localization";
+import { useApi } from "src/utility/api/hooks";
+import { getMappingsByTenantId } from "src/utility/api/tenants";
+import EntityList from "src/components/entityList";
+import { useEntityModal } from "src/components/modal";
+import DeleteModal from "src/pages/tenants/detail/mappings/DeleteModal";
+import AssignMappingsModal from "src/pages/tenants/detail/mappings/AssignMappingsModal";
+
+type MappingsProps = {
+  tenantId: string;
+};
+
+const Mappings: FC<MappingsProps> = ({ tenantId }) => {
+  const { t } = useTranslate("tenants");
+
+  const {
+    data: mappings,
+    loading,
+    success,
+    reload,
+  } = useApi(getMappingsByTenantId, {
+    tenantId: tenantId,
+  });
+
+  const areNoMappingsAssigned = !mappings || mappings.items?.length === 0;
+
+  const [assignMappings, assignMappingsModal] = useEntityModal(
+    AssignMappingsModal,
+    reload,
+    {
+      assignedMappings: mappings?.items || [],
+    },
+  );
+  const openAssignModal = () => assignMappings({ id: tenantId });
+  const [unassignMapping, unassignMappingModal] = useEntityModal(
+    DeleteModal,
+    reload,
+    {
+      tenant: tenantId,
+    },
+  );
+
+  if (!loading && !success)
+    return (
+      <C3EmptyState
+        heading={t("somethingsWrong")}
+        description={t("unableToLoadMappings")}
+        button={{ label: t("retry"), onClick: reload }}
+      />
+    );
+
+  if (success && areNoMappingsAssigned)
+    return (
+      <>
+        <C3EmptyState
+          heading={t("assignMappingsToTenant")}
+          description={t("tenantMemberAccessDisclaimer")}
+          button={{
+            label: t("assignMapping"),
+            onClick: openAssignModal,
+          }}
+          link={{
+            label: t("learnMoreAboutTenants"),
+            href: `/identity/concepts/access-control/tenants`,
+          }}
+        />
+        {assignMappingsModal}
+      </>
+    );
+
+  return (
+    <>
+      <EntityList
+        data={mappings?.items}
+        headers={[
+          { header: t("mappingId"), key: "id" },
+          { header: t("mappingName"), key: "name" },
+          { header: t("claimName"), key: "claimName" },
+          { header: t("claimValue"), key: "claimValue" },
+        ]}
+        sortProperty="id"
+        loading={loading}
+        addEntityLabel={t("assignMapping")}
+        onAddEntity={openAssignModal}
+        searchPlaceholder={t("searchByMappingId")}
+        menuItems={[
+          {
+            label: t("remove"),
+            icon: TrashCan,
+            isDangerous: true,
+            onClick: unassignMapping,
+          },
+        ]}
+      />
+      {assignMappingsModal}
+      {unassignMappingModal}
+    </>
+  );
+};
+
+export default Mappings;

--- a/identity/client/src/pages/tenants/detail/members/AssignMembersModal.tsx
+++ b/identity/client/src/pages/tenants/detail/members/AssignMembersModal.tsx
@@ -117,17 +117,14 @@ const AssignMembersModal: FC<
           ))}
         </SelectedUsers>
       )}
-
       <DropdownSearch
         autoFocus
         items={unassignedUsers}
         itemTitle={({ username }) => username}
         itemSubTitle={({ email }) => email}
         placeholder={t("searchByNameOrEmail")}
-        onChange={() => null}
         onSelect={onSelectUser}
       />
-
       {!loading && error && (
         <TranslatedErrorInlineNotification
           title={t("usersCouldNotLoad")}

--- a/identity/client/src/pages/tenants/detail/roles/AssignRolesModal.tsx
+++ b/identity/client/src/pages/tenants/detail/roles/AssignRolesModal.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC, useEffect, useState } from "react";
+import { Tag } from "@carbon/react";
+import { UseEntityModalCustomProps } from "src/components/modal";
+import useTranslate from "src/utility/localization";
+import { useApi, useApiCall } from "src/utility/api/hooks";
+import { searchRoles, Role } from "src/utility/api/roles";
+import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
+import styled from "styled-components";
+import DropdownSearch from "src/components/form/DropdownSearch";
+import FormModal from "src/components/modal/FormModal";
+import { assignTenantRole, Tenant } from "src/utility/api/tenants";
+
+const SelectedRoles = styled.div`
+  margin-top: 0;
+`;
+
+const AssignRolesModal: FC<
+  UseEntityModalCustomProps<
+    { id: Tenant["tenantKey"] },
+    { assignedRoles: Role[] }
+  >
+> = ({ entity: tenant, assignedRoles, onSuccess, open, onClose }) => {
+  const { t, Translate } = useTranslate("tenants");
+  const [selectedRoles, setSelectedRoles] = useState<Role[]>([]);
+  const [loadingAssignRole, setLoadingAssignRole] = useState(false);
+
+  const {
+    data: roleSearchResults,
+    loading,
+    reload,
+    error,
+  } = useApi(searchRoles);
+
+  const [callAssignRole] = useApiCall(assignTenantRole);
+
+  const unassignedRoles =
+    roleSearchResults?.items.filter(
+      ({ key }) =>
+        !assignedRoles.some((role) => role.key === key) &&
+        !selectedRoles.some((role) => role.key === key),
+    ) || [];
+
+  const onSelectRole = (role: Role) => {
+    setSelectedRoles([...selectedRoles, role]);
+  };
+
+  const onUnselectRole =
+    ({ key }: Role) =>
+    () => {
+      setSelectedRoles(selectedRoles.filter((role) => role.key !== key));
+    };
+
+  const canSubmit = tenant && selectedRoles.length;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+
+    setLoadingAssignRole(true);
+
+    const results = await Promise.all(
+      selectedRoles.map(({ key }) =>
+        callAssignRole({ key, tenantId: tenant.id }),
+      ),
+    );
+
+    setLoadingAssignRole(false);
+
+    if (results.every(({ success }) => success)) {
+      onSuccess();
+    }
+  };
+
+  useEffect(() => {
+    if (open) {
+      setSelectedRoles([]);
+    }
+  }, [open]);
+
+  return (
+    <FormModal
+      headline={t("assignRole")}
+      confirmLabel={t("assignRole")}
+      loading={loadingAssignRole}
+      loadingDescription={t("assigningRole")}
+      open={open}
+      onSubmit={handleSubmit}
+      submitDisabled={!canSubmit}
+      onClose={onClose}
+      overflowVisible
+    >
+      <p>
+        <Translate>Search and assign role to tenant</Translate>
+      </p>
+      {selectedRoles.length > 0 && (
+        <SelectedRoles>
+          {selectedRoles.map((role) => (
+            <Tag
+              key={role.key}
+              onClose={onUnselectRole(role)}
+              size="md"
+              type="blue"
+              filter
+            >
+              {role.key}
+            </Tag>
+          ))}
+        </SelectedRoles>
+      )}
+
+      <DropdownSearch
+        autoFocus
+        items={unassignedRoles}
+        itemTitle={({ key }) => String(key)}
+        itemSubTitle={({ name }) => name}
+        placeholder={t("searchByRoleId")}
+        onChange={() => null}
+        onSelect={onSelectRole}
+      />
+
+      {!loading && error && (
+        <TranslatedErrorInlineNotification
+          title={t("rolesCouldNotLoad")}
+          actionButton={{ label: t("retry"), onClick: reload }}
+        />
+      )}
+    </FormModal>
+  );
+};
+
+export default AssignRolesModal;

--- a/identity/client/src/pages/tenants/detail/roles/AssignRolesModal.tsx
+++ b/identity/client/src/pages/tenants/detail/roles/AssignRolesModal.tsx
@@ -114,17 +114,14 @@ const AssignRolesModal: FC<
           ))}
         </SelectedRoles>
       )}
-
       <DropdownSearch
         autoFocus
         items={unassignedRoles}
         itemTitle={({ key }) => String(key)}
         itemSubTitle={({ name }) => name}
         placeholder={t("searchByRoleId")}
-        onChange={() => null}
         onSelect={onSelectRole}
       />
-
       {!loading && error && (
         <TranslatedErrorInlineNotification
           title={t("rolesCouldNotLoad")}

--- a/identity/client/src/pages/tenants/detail/roles/DeleteModal.tsx
+++ b/identity/client/src/pages/tenants/detail/roles/DeleteModal.tsx
@@ -62,8 +62,13 @@ const DeleteModal: FC<RemoveTenantRoleModalProps> = ({
       confirmLabel={t("removeRole")}
     >
       <p>
-        <Translate>Are you sure you want to remove</Translate>{" "}
-        <strong>{role.key}</strong> from this tenant?
+        <Translate
+          i18nKey="removeRoleFromTenant"
+          values={{ roleKey: role.key }}
+        >
+          Are you sure you want to remove <strong>{role.key}</strong> from this
+          tenant?
+        </Translate>
       </p>
     </Modal>
   );

--- a/identity/client/src/pages/tenants/detail/roles/DeleteModal.tsx
+++ b/identity/client/src/pages/tenants/detail/roles/DeleteModal.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda
+ * Services GmbH under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file except in compliance with the Camunda License 1.0.
+ */
+import { FC } from "react";
+import { useApiCall } from "src/utility/api";
+import useTranslate from "src/utility/localization";
+import {
+  DeleteModal as Modal,
+  UseEntityModalCustomProps,
+} from "src/components/modal";
+import { useNotifications } from "src/components/notifications";
+import { Role } from "src/utility/api/roles";
+import { unassignTenantRole } from "src/utility/api/tenants";
+
+type RemoveTenantRoleModalProps = UseEntityModalCustomProps<
+  Role,
+  {
+    tenant: string;
+  }
+>;
+
+const DeleteModal: FC<RemoveTenantRoleModalProps> = ({
+  entity: role,
+  open,
+  onClose,
+  onSuccess,
+  tenant,
+}) => {
+  const { t, Translate } = useTranslate("tenants");
+  const { enqueueNotification } = useNotifications();
+
+  const [callUnassignRole, { loading }] = useApiCall(unassignTenantRole);
+
+  const handleSubmit = async () => {
+    if (tenant && role) {
+      const { success } = await callUnassignRole({
+        tenantId: tenant,
+        key: role.key,
+      });
+
+      if (success) {
+        enqueueNotification({
+          kind: "success",
+          title: t("tenantRoleRemoved"),
+        });
+        onSuccess();
+      }
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      headline={t("removeRole")}
+      onSubmit={handleSubmit}
+      loading={loading}
+      loadingDescription={t("removingRole")}
+      onClose={onClose}
+      confirmLabel={t("removeRole")}
+    >
+      <p>
+        <Translate>Are you sure you want to remove</Translate>{" "}
+        <strong>{role.key}</strong> from this tenant?
+      </p>
+    </Modal>
+  );
+};
+
+export default DeleteModal;

--- a/identity/client/src/pages/tenants/detail/roles/index.tsx
+++ b/identity/client/src/pages/tenants/detail/roles/index.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { C3EmptyState } from "@camunda/camunda-composite-components";
+import { TrashCan } from "@carbon/react/icons";
+import useTranslate from "src/utility/localization";
+import { useApi } from "src/utility/api/hooks";
+import { getRolesByTenantId } from "src/utility/api/tenants";
+import EntityList from "src/components/entityList";
+import { useEntityModal } from "src/components/modal";
+import DeleteModal from "src/pages/tenants/detail/roles/DeleteModal";
+import AssignRolesModal from "src/pages/tenants/detail/roles/AssignRolesModal";
+
+type RolesProps = {
+  tenantId: string;
+};
+
+const Roles: FC<RolesProps> = ({ tenantId }) => {
+  const { t } = useTranslate("tenants");
+
+  const {
+    data: roles,
+    loading,
+    success,
+    reload,
+  } = useApi(getRolesByTenantId, {
+    tenantId: tenantId,
+  });
+
+  const areNoRolesAssigned = !roles || roles.items?.length === 0;
+
+  const [assignRoles, assignRolesModal] = useEntityModal(
+    AssignRolesModal,
+    reload,
+    {
+      assignedRoles: roles?.items || [],
+    },
+  );
+  const openAssignModal = () => assignRoles({ id: tenantId });
+  const [unassignRole, unassignRoleModal] = useEntityModal(
+    DeleteModal,
+    reload,
+    {
+      tenant: tenantId,
+    },
+  );
+
+  if (!loading && !success)
+    return (
+      <C3EmptyState
+        heading={t("somethingsWrong")}
+        description={t("unableToLoadRoles")}
+        button={{ label: t("retry"), onClick: reload }}
+      />
+    );
+
+  if (success && areNoRolesAssigned)
+    return (
+      <>
+        <C3EmptyState
+          heading={t("assignRolesToTenant")}
+          description={t("tenantMemberAccessDisclaimer")}
+          button={{
+            label: t("assignRole"),
+            onClick: openAssignModal,
+          }}
+          link={{
+            label: t("learnMoreAboutTenants"),
+            href: `/identity/concepts/access-control/tenants`,
+          }}
+        />
+        {assignRolesModal}
+      </>
+    );
+
+  return (
+    <>
+      <EntityList
+        data={roles?.items}
+        headers={[
+          { header: t("roleId"), key: "key" },
+          { header: t("roleName"), key: "name" },
+        ]}
+        sortProperty="key"
+        loading={loading}
+        addEntityLabel={t("assignRole")}
+        onAddEntity={openAssignModal}
+        searchPlaceholder={t("searchByRoleId")}
+        menuItems={[
+          {
+            label: t("remove"),
+            icon: TrashCan,
+            isDangerous: true,
+            onClick: unassignRole,
+          },
+        ]}
+      />
+      {assignRolesModal}
+      {unassignRoleModal}
+    </>
+  );
+};
+
+export default Roles;

--- a/identity/client/src/pages/tenants/modals/DeleteModal.tsx
+++ b/identity/client/src/pages/tenants/modals/DeleteModal.tsx
@@ -50,9 +50,13 @@ const DeleteTenantModal: FC<UseEntityModalProps<DeleteTenantParams>> = ({
       confirmLabel={t("deleteTenant")}
     >
       <p>
-        <Translate>Are you sure you want to delete</Translate>{" "}
-        <strong>{tenantId}</strong>?{" "}
-        <Translate>This action cannot be undone.</Translate>
+        <Translate
+          i18nKey="deleteTenantConfirmation"
+          values={{ tenantId: tenantId }}
+        >
+          Are you sure you want to delete <strong>{tenantId}</strong>? This
+          action cannot be undone.
+        </Translate>
       </p>
     </Modal>
   );

--- a/identity/client/src/utility/api/tenants/index.ts
+++ b/identity/client/src/utility/api/tenants/index.ts
@@ -12,6 +12,7 @@ import { SearchResponse } from "src/utility/api";
 import { EntityData } from "src/components/entityList/EntityList";
 import { Group } from "src/utility/api/groups";
 import { Role } from "src/utility/api/roles";
+import { Mapping } from "src/utility/api/mappings";
 
 export const TENANTS_ENDPOINT = "/tenants";
 
@@ -108,3 +109,29 @@ export const unassignTenantRole: ApiDefinition<
   UnassignTenantRoleParams
 > = ({ tenantId, key }) =>
   apiDelete(`${TENANTS_ENDPOINT}/${tenantId}/roles/${key}`);
+
+// ----------------- Mappings within a Tenant -----------------
+
+export type GetTenantMappingsParams = {
+  tenantId: string;
+};
+export const getMappingsByTenantId: ApiDefinition<
+  SearchResponse<Mapping>,
+  GetTenantMappingsParams
+> = ({ tenantId }) =>
+  apiPost(`${TENANTS_ENDPOINT}/${tenantId}/mapping-rules/search`);
+
+type AssignTenantMappingParams = GetTenantMappingsParams & { id: string };
+export const assignTenantMapping: ApiDefinition<
+  undefined,
+  AssignTenantMappingParams
+> = ({ tenantId, id }) => {
+  return apiPut(`${TENANTS_ENDPOINT}/${tenantId}/mapping-rules/${id}`);
+};
+
+type UnassignTenantMappingParams = AssignTenantMappingParams;
+export const unassignTenantMapping: ApiDefinition<
+  undefined,
+  UnassignTenantMappingParams
+> = ({ tenantId, id }) =>
+  apiDelete(`${TENANTS_ENDPOINT}/${tenantId}/mapping-rules/${id}`);

--- a/identity/client/src/utility/api/tenants/index.ts
+++ b/identity/client/src/utility/api/tenants/index.ts
@@ -6,9 +6,11 @@ import {
   apiPost,
   apiPatch,
   apiDelete,
+  apiPut,
 } from "src/utility/api/request";
 import { SearchResponse } from "src/utility/api";
 import { EntityData } from "src/components/entityList/EntityList";
+import { Group } from "src/utility/api/groups";
 
 export const TENANTS_ENDPOINT = "/tenants";
 
@@ -59,3 +61,26 @@ export const updateTenant: ApiDefinition<undefined, UpdateTenantParams> = ({
 export const deleteTenant: ApiDefinition<undefined, { tenantId: string }> = ({
   tenantId,
 }) => apiDelete(`${TENANTS_ENDPOINT}/${tenantId}`);
+
+export type GetTenantGroupsParams = {
+  tenantId: string;
+};
+export const getGroupsByTenantId: ApiDefinition<
+  SearchResponse<Group>,
+  GetTenantGroupsParams
+> = ({ tenantId }) => apiPost(`${TENANTS_ENDPOINT}/${tenantId}/groups/search`);
+
+type AssignTenantGroupParams = GetTenantGroupsParams & { groupKey: string };
+export const assignTenantGroup: ApiDefinition<
+  undefined,
+  AssignTenantGroupParams
+> = ({ tenantId, groupKey }) => {
+  return apiPut(`${TENANTS_ENDPOINT}/${tenantId}/groups/${groupKey}`);
+};
+
+type UnassignTenantGroupParams = AssignTenantGroupParams;
+export const unassignTenantGroup: ApiDefinition<
+  undefined,
+  UnassignTenantGroupParams
+> = ({ tenantId, groupKey }) =>
+  apiDelete(`${TENANTS_ENDPOINT}/${tenantId}/groups/${groupKey}`);

--- a/identity/client/src/utility/api/tenants/index.ts
+++ b/identity/client/src/utility/api/tenants/index.ts
@@ -11,6 +11,7 @@ import {
 import { SearchResponse } from "src/utility/api";
 import { EntityData } from "src/components/entityList/EntityList";
 import { Group } from "src/utility/api/groups";
+import { Role } from "src/utility/api/roles";
 
 export const TENANTS_ENDPOINT = "/tenants";
 
@@ -29,7 +30,6 @@ type GetTenantParams = {
   name?: string;
   description?: string;
 };
-
 export const getTenantDetails: ApiDefinition<
   SearchResponse<Tenant>,
   GetTenantParams
@@ -39,7 +39,6 @@ export const getTenantDetails: ApiDefinition<
   });
 
 type CreateTenantParams = Omit<Tenant, "tenantKey">;
-
 export const createTenant: ApiDefinition<undefined, CreateTenantParams> = (
   tenant,
 ) => apiPost(TENANTS_ENDPOINT, tenant);
@@ -49,18 +48,18 @@ export type UpdateTenantParams = {
   name: string;
   description: string;
 };
-
-export type DeleteTenantParams = UpdateTenantParams;
-
 export const updateTenant: ApiDefinition<undefined, UpdateTenantParams> = ({
   tenantId,
   name,
   description,
 }) => apiPatch(`${TENANTS_ENDPOINT}/${tenantId}`, { name, description });
 
+export type DeleteTenantParams = UpdateTenantParams;
 export const deleteTenant: ApiDefinition<undefined, { tenantId: string }> = ({
   tenantId,
 }) => apiDelete(`${TENANTS_ENDPOINT}/${tenantId}`);
+
+// ----------------- Groups within a Tenant -----------------
 
 export type GetTenantGroupsParams = {
   tenantId: string;
@@ -84,3 +83,28 @@ export const unassignTenantGroup: ApiDefinition<
   UnassignTenantGroupParams
 > = ({ tenantId, groupKey }) =>
   apiDelete(`${TENANTS_ENDPOINT}/${tenantId}/groups/${groupKey}`);
+
+// ----------------- Roles within a Tenant -----------------
+
+export type GetTenantRolesParams = {
+  tenantId: string;
+};
+export const getRolesByTenantId: ApiDefinition<
+  SearchResponse<Role>,
+  GetTenantRolesParams
+> = ({ tenantId }) => apiPost(`${TENANTS_ENDPOINT}/${tenantId}/roles/search`);
+
+type AssignTenantRoleParams = GetTenantRolesParams & { key: number };
+export const assignTenantRole: ApiDefinition<
+  undefined,
+  AssignTenantRoleParams
+> = ({ tenantId, key }) => {
+  return apiPut(`${TENANTS_ENDPOINT}/${tenantId}/roles/${key}`);
+};
+
+type UnassignTenantRoleParams = AssignTenantRoleParams;
+export const unassignTenantRole: ApiDefinition<
+  undefined,
+  UnassignTenantRoleParams
+> = ({ tenantId, key }) =>
+  apiDelete(`${TENANTS_ENDPOINT}/${tenantId}/roles/${key}`);

--- a/identity/client/src/utility/localization/en/tenants.json
+++ b/identity/client/src/utility/localization/en/tenants.json
@@ -44,5 +44,16 @@
   "tenantIdPlaceholder": "Enter tenant ID",
   "tenantIdHelperText": "The tenant ID must be unique and cannot be modified.",
   "tenantNamePlaceholder": "Enter tenant name",
-  "tenantDescriptionPlaceholder": "Enter a tenant description (Max 255 characters)"
+  "tenantDescriptionPlaceholder": "Enter a tenant description (Max 255 characters)",
+  "removeGroup": "Remove group",
+  "removingGroup": "Removing group",
+  "tenantGroupRemoved": "Tenant member has been removed.",
+  "groupsCouldNotLoad": "Groups could not be loaded.",
+  "unableToLoadGroups": "We were unable to load the groups. Click \"Retry\" to try again.",
+  "searchByGroupId": "Search by group ID",
+  "assignGroupsToTenant": "Assign groups to this Tenant",
+  "assignGroup": "Assign group",
+  "assigningGroup": "Assigning group",
+  "groupId": "Group ID",
+  "groupName": "Group name"
 }

--- a/identity/client/src/utility/localization/en/tenants.json
+++ b/identity/client/src/utility/localization/en/tenants.json
@@ -79,5 +79,11 @@
   "mappingId": "Mapping ID",
   "mappingName": "Mapping name",
   "claimName": "Claim name",
-  "claimValue": "Claim value"
+  "claimValue": "Claim value",
+  "searchAndAssignMappingToTenant": "Search and assign mapping to tenant",
+  "deleteTenantConfirmation": "Are you sure you want to delete <strong>{{tenantId}}</strong>? This action cannot be undone.",
+  "removeGroupFromTenant": "Are you sure you want to remove <strong>{{groupKey}}</strong> from this tenant?",
+  "removeMappingFromTenant": "Are you sure you want to remove <strong>{{mappingId}}</strong> from this tenant?",
+  "removeRoleFromTenant": "Are you sure you want to remove <strong>{{roleKey}}</strong> from this tenant?",
+  "searchAndAssignGroupToTenant": "Search and assign group to tenant"
 }

--- a/identity/client/src/utility/localization/en/tenants.json
+++ b/identity/client/src/utility/localization/en/tenants.json
@@ -47,7 +47,7 @@
   "tenantDescriptionPlaceholder": "Enter a tenant description (Max 255 characters)",
   "removeGroup": "Remove group",
   "removingGroup": "Removing group",
-  "tenantGroupRemoved": "Tenant member has been removed.",
+  "tenantGroupRemoved": "Tenant group has been removed.",
   "groupsCouldNotLoad": "Groups could not be loaded.",
   "unableToLoadGroups": "We were unable to load the groups. Click \"Retry\" to try again.",
   "searchByGroupId": "Search by group ID",
@@ -55,5 +55,16 @@
   "assignGroup": "Assign group",
   "assigningGroup": "Assigning group",
   "groupId": "Group ID",
-  "groupName": "Group name"
+  "groupName": "Group name",
+  "assignRole": "Assign role",
+  "assigningRole": "Assigning role",
+  "searchByRoleId": "Search by role ID",
+  "rolesCouldNotLoad": "Roles could not be loaded.",
+  "tenantRoleRemoved": "Tenant role has been removed.",
+  "removeRole": "Remove role",
+  "removingRole": "Removing role",
+  "unableToLoadRoles": "We were unable to load the roles. Click \"Retry\" to try again.",
+  "assignRolesToTenant": "Assign roles to this Tenant",
+  "roleId": "Role ID",
+  "roleName": "Role name"
 }

--- a/identity/client/src/utility/localization/en/tenants.json
+++ b/identity/client/src/utility/localization/en/tenants.json
@@ -66,5 +66,18 @@
   "unableToLoadRoles": "We were unable to load the roles. Click \"Retry\" to try again.",
   "assignRolesToTenant": "Assign roles to this Tenant",
   "roleId": "Role ID",
-  "roleName": "Role name"
+  "roleName": "Role name",
+  "assignMapping": "Assign mapping",
+  "assigningMapping": "Assigning mapping",
+  "searchByMappingId": "Search by mapping ID",
+  "mappingsCouldNotLoad": "Mappings could not be loaded.",
+  "tenantMappingRemoved": "Tenant mapping has been removed.",
+  "removeMapping": "Remove mapping",
+  "removingMapping": "Removing mapping",
+  "unableToLoadMappings": "We were unable to load the mappings. Click \"Retry\" to try again.",
+  "assignMappingsToTenant": "Assign mappings to this Tenant",
+  "mappingId": "Mapping ID",
+  "mappingName": "Mapping name",
+  "claimName": "Claim name",
+  "claimValue": "Claim value"
 }


### PR DESCRIPTION
## Description

This PR introduces the addition of: a list structure, associated modals, and initial integration with API for the following tabs on the tenant details page:
- Groups
- Roles
- Mappings

Some of the [endpoints needed are not yet available](https://github.com/camunda/camunda/issues/26961), so this PR also introduces feature flags so we can hide these tabs while they can't be properly integrated with the backend. Once they are available we will need to come back and check what's working and fix what's not - dedicated issues have been created under the corresponding epics for that.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #28846
