### PR TITLE
fix: Return detail for unexpected batch upload failures

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -261,7 +261,7 @@ public final class ResponseMapper {
         status = HttpStatus.METHOD_NOT_ALLOWED;
       }
       default -> {
-        detail = null;
+        detail = "An error occurred: " + e.getClass().getName();
         status = HttpStatus.INTERNAL_SERVER_ERROR;
       }
     }


### PR DESCRIPTION
## Description

When the batch upload API is used to upload files and an unknown error occurs, the API response only contains the filename of the file that we failed to upload to the store.

```
{
    "createdDocuments": [],
    "failedDocuments": [
        {
            "fileName": "example.pdf"
        }
    ]
}
```
However, the API for a single file upload returns some more information.
```
{
    "type": "about:blank",
    "title": "io.camunda.document.api.DocumentError$UnknownDocumentError",
    "status": 500,
    "instance": "/v2/documents"
}
```
Given the above, I thought it would be good to at least return the information that an unknown error was recorded.
```
{
    "createdDocuments": [],
    "failedDocuments": [
        {
            "fileName": "example.pdf",
            "detail": "An error occurred: io.camunda.document.api.DocumentError$UnknownDocumentError"
        }
    ]
}
```
There are logs in place that should help us troubleshoot `UnknownDocumentError`s so this detail is just an indication of what went wrong.
