### PR TITLE
docs: flag identity APIs still to be refactored

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -2107,9 +2107,12 @@ paths:
       tags:
         - Role
       operationId: createRole
-      summary: Create role
+      summary: Create role (Work-in-Progress)
       description: |
         Create a new role.
+
+        This API is in a Work-in-Progress state and will undergo potential breaking changes till
+        its release with an upcoming minor release.
       requestBody:
         content:
           application/json:
@@ -2136,9 +2139,12 @@ paths:
       tags:
         - Role
       operationId: getRole
-      summary: Get role
+      summary: Get role (Work-in-Progress)
       description: |
         Get a role by its key.
+
+        This API is in a Work-in-Progress state and will undergo potential breaking changes till
+        its release with an upcoming minor release.
       parameters:
         - name: roleKey
           in: path
@@ -2169,8 +2175,12 @@ paths:
       tags:
         - Role
       operationId: updateRole
-      summary: Update role
-      description: Update a role with the given key.
+      summary: Update role (Work-in-Progress)
+      description: |
+        Update a role with the given key.
+
+        This API is in a Work-in-Progress state and will undergo potential breaking changes till
+        its release with an upcoming minor release.
       parameters:
         - name: roleKey
           in: path
@@ -2203,8 +2213,12 @@ paths:
       tags:
         - Role
       operationId: deleteRole
-      summary: Delete role
-      description: Deletes the role with the given key.
+      summary: Delete role (Work-in-Progress)
+      description: |
+        Deletes the role with the given key.
+
+        This API is in a Work-in-Progress state and will undergo potential breaking changes till
+        its release with an upcoming minor release.
       parameters:
         - name: roleKey
           in: path
@@ -2230,9 +2244,12 @@ paths:
       tags:
         - Role
       operationId: searchRoles
-      summary: Query roles
+      summary: Query roles (Work-in-Progress)
       description: |
         Search for roles based on given criteria.
+
+        This API is in a Work-in-Progress state and will undergo potential breaking changes till
+        its release with an upcoming minor release.
       requestBody:
         required: false
         content:
@@ -2264,7 +2281,12 @@ paths:
       tags:
         - Group
       operationId: createGroup
-      summary: Create group
+      summary: Create group (Work-in-Progress)
+      description: |
+        Create a new group.
+
+        This API is in a Work-in-Progress state and will undergo potential breaking changes till
+        its release with an upcoming minor release.
       requestBody:
         content:
           application/json:
@@ -2290,9 +2312,12 @@ paths:
       tags:
         - Group
       operationId: getGroup
-      summary: Get group
+      summary: Get group (Work-in-Progress)
       description: |
         Get a group by its key.
+
+        This API is in a Work-in-Progress state and will undergo potential breaking changes till
+        its release with an upcoming minor release.
       parameters:
         - name: groupKey
           in: path
@@ -2323,8 +2348,12 @@ paths:
       tags:
         - Group
       operationId: updateGroup
-      summary: Update group
-      description: Update a group with the given key.
+      summary: Update group (Work-in-Progress)
+      description: |
+        Update a group with the given key.
+
+        This API is in a Work-in-Progress state and will undergo potential breaking changes till
+        its release with an upcoming minor release.
       parameters:
         - name: groupKey
           in: path
@@ -2357,8 +2386,12 @@ paths:
       tags:
         - Group
       operationId: deleteGroup
-      summary: Delete group
-      description: Deletes the group with the given key.
+      summary: Delete group (Work-in-Progress)
+      description: |
+        Deletes the group with the given key.
+
+        This API is in a Work-in-Progress state and will undergo potential breaking changes till
+        its release with an upcoming minor release.
       parameters:
         - name: groupKey
           in: path
@@ -2384,9 +2417,12 @@ paths:
       tags:
         - Group
       operationId: addUserToGroup
-      summary: Assign a user to a group
+      summary: Assign a user to a group (Work-in-Progress)
       description: |
         Assigns a user to a group.
+
+        This API is in a Work-in-Progress state and will undergo potential breaking changes till
+        its release with an upcoming minor release.
       parameters:
         - name: groupKey
           in: path
@@ -2426,9 +2462,12 @@ paths:
       tags:
         - Group
       operationId: unassignUserFromGroup
-      summary: Unassign a user from a group
+      summary: Unassign a user from a group (Work-in-Progress)
       description: |
         Unassigns a user from a group.
+
+        This API is in a Work-in-Progress state and will undergo potential breaking changes till
+        its release with an upcoming minor release.
       parameters:
         - name: groupKey
           in: path
@@ -2462,9 +2501,12 @@ paths:
       tags:
         - Group
       operationId: searchGroups
-      summary: Query groups
+      summary: Query groups (Work-in-Progress)
       description: |
         Search for groups based on given criteria.
+
+        This API is in a Work-in-Progress state and will undergo potential breaking changes till
+        its release with an upcoming minor release.
       requestBody:
         required: false
         content:
@@ -2534,8 +2576,12 @@ paths:
       tags:
         - Mapping rule
       operationId: deleteMappingRule
-      summary: Delete a mapping rule
-      description: Deletes the mapping rule with the given key.
+      summary: Delete a mapping rule (Work-in-Progress)
+      description: |
+        Deletes the mapping rule with the given key.
+
+        This API is in a Work-in-Progress state and will undergo potential breaking changes till
+        its release with an upcoming minor release.
       parameters:
         - name: mappingKey
           in: path
@@ -2562,9 +2608,12 @@ paths:
       tags:
         - Mapping rule
       operationId: findMappings
-      summary: Query mappings
+      summary: Query mappings (Work-in-Progress)
       description: |
         Search for mapping rules based on given criteria.
+
+        This API is in a Work-in-Progress state and will undergo potential breaking changes till
+        its release with an upcoming minor release.
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
## Description

The identity API is not yet in the state intended to be released. This change makes transparent which APIs are still subject to change.

It's mainly:
* [Groups & Roles API](https://github.com/camunda/camunda/issues/26961)
* [Mapping Rule API](https://github.com/camunda/camunda/issues/26981) - except [Create Mapping Rule](https://github.com/camunda/camunda/issues/27373) which was refactored already

Context: https://camunda.slack.com/archives/C06UYJMMETZ/p1741330563661189?thread_ts=1741295012.417169&cid=C06UYJMMETZ

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)
