### PR TITLE
feat: migrate PI statistics stores to v2

### DIFF
--- a/operate/client/src/modules/api/v2/processInstances/fetchProcessInstancesStatistics.ts
+++ b/operate/client/src/modules/api/v2/processInstances/fetchProcessInstancesStatistics.ts
@@ -63,4 +63,8 @@ const fetchProcessInstancesStatistics = async (
 };
 
 export {fetchProcessInstancesStatistics};
-export type {ProcessInstancesStatisticsDto, ProcessInstancesStatisticsRequest};
+export type {
+  ProcessInstancesStatisticsDto,
+  ProcessInstancesStatisticsRequest,
+  ProcessInstanceState,
+};

--- a/operate/client/src/modules/hooks/useProcessInstancesFilters.test.ts
+++ b/operate/client/src/modules/hooks/useProcessInstancesFilters.test.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {renderHook} from '@testing-library/react-hooks';
+import {useFilters} from 'modules/hooks/useFilters';
+import {ProcessInstanceFilters} from 'modules/utils/filter/shared';
+import {ProcessInstancesStatisticsRequest} from 'modules/api/v2/processInstances/fetchProcessInstancesStatistics';
+import {useProcessInstanceFilters} from './useProcessInstancesFilters';
+
+jest.mock('modules/hooks/useFilters');
+
+describe('useProcessInstanceFilters', () => {
+  it('should map filters to request correctly', () => {
+    const mockFilters: ProcessInstanceFilters = {
+      startDateAfter: '2023-01-01',
+      startDateBefore: '2023-01-31',
+      endDateAfter: '2023-02-01',
+      endDateBefore: '2023-02-28',
+      process: 'process1,process2',
+      ids: 'id1,id2',
+      active: true,
+      incidents: true,
+      completed: true,
+      canceled: true,
+      parentInstanceId: 'parent1',
+      tenant: 'tenant1',
+      retriesLeft: true,
+      operationId: 'operation1',
+    };
+
+    (useFilters as jest.Mock).mockReturnValue({
+      getFilters: () => mockFilters,
+    });
+
+    const expectedRequest: ProcessInstancesStatisticsRequest = {
+      startDate: {
+        $gt: '2023-01-01',
+        $lt: '2023-01-31',
+      },
+      endDate: {
+        $gt: '2023-02-01',
+        $lt: '2023-02-28',
+      },
+      processDefinitionKey: {
+        $in: ['process1', 'process2'],
+      },
+      processInstanceKey: {
+        $in: ['id1', 'id2'],
+      },
+      state: {
+        $in: ['RUNNING', 'INCIDENT', 'COMPLETED', 'CANCELED'],
+      },
+      parentProcessInstanceKey: 'parent1',
+      tenantId: 'tenant1',
+      hasRetriesLeft: true,
+      batchOperationKey: 'operation1',
+    };
+
+    const {result} = renderHook(() => useProcessInstanceFilters());
+    expect(result.current).toEqual(expectedRequest);
+  });
+
+  it('should handle empty filters', () => {
+    const mockFilters: ProcessInstanceFilters = {};
+
+    (useFilters as jest.Mock).mockReturnValue({
+      getFilters: () => mockFilters,
+    });
+
+    const expectedRequest: ProcessInstancesStatisticsRequest = {};
+
+    const {result} = renderHook(() => useProcessInstanceFilters());
+    expect(result.current).toEqual(expectedRequest);
+  });
+
+  it('should handle partial filters', () => {
+    const mockFilters: ProcessInstanceFilters = {
+      startDateAfter: '2023-01-01',
+      active: true,
+    };
+
+    (useFilters as jest.Mock).mockReturnValue({
+      getFilters: () => mockFilters,
+    });
+
+    const expectedRequest: ProcessInstancesStatisticsRequest = {
+      startDate: {
+        $gt: '2023-01-01',
+      },
+      state: {
+        $in: ['RUNNING'],
+      },
+    };
+
+    const {result} = renderHook(() => useProcessInstanceFilters());
+    expect(result.current).toEqual(expectedRequest);
+  });
+});

--- a/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
+++ b/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
@@ -12,6 +12,7 @@ import {
   ProcessInstanceState,
 } from 'modules/api/v2/processInstances/fetchProcessInstancesStatistics';
 import {useFilters} from 'modules/hooks/useFilters';
+import {getProcessIds} from 'modules/utils/filter';
 
 function mapFiltersToRequest(
   filters: ProcessInstanceFilters,
@@ -22,6 +23,7 @@ function mapFiltersToRequest(
     endDateAfter,
     endDateBefore,
     process,
+    version,
     ids,
     active,
     incidents,
@@ -52,10 +54,18 @@ function mapFiltersToRequest(
     };
   }
 
-  if (process) {
-    request.processDefinitionKey = {
-      $in: process.split(','),
-    };
+  if (process && version) {
+    const processIds = getProcessIds({
+      process,
+      processVersion: version,
+      tenant,
+    });
+
+    if (processIds.length > 0) {
+      request.processDefinitionKey = {
+        $in: processIds,
+      };
+    }
   }
 
   if (ids) {

--- a/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
+++ b/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {ProcessInstanceFilters} from 'modules/utils/filter/shared';
+import {
+  ProcessInstancesStatisticsRequest,
+  ProcessInstanceState,
+} from 'modules/api/v2/processInstances/fetchProcessInstancesStatistics';
+import {useFilters} from 'modules/hooks/useFilters';
+
+function mapFiltersToRequest(
+  filters: ProcessInstanceFilters,
+): ProcessInstancesStatisticsRequest {
+  const {
+    startDateAfter,
+    startDateBefore,
+    endDateAfter,
+    endDateBefore,
+    process,
+    ids,
+    active,
+    incidents,
+    completed,
+    canceled,
+    parentInstanceId,
+    tenant,
+    retriesLeft,
+    operationId,
+    ...rest
+  } = filters;
+
+  const request: ProcessInstancesStatisticsRequest = {
+    ...rest,
+  };
+
+  if (startDateAfter || startDateBefore) {
+    request.startDate = {
+      ...(startDateAfter && {$gt: startDateAfter}),
+      ...(startDateBefore && {$lt: startDateBefore}),
+    };
+  }
+
+  if (endDateAfter || endDateBefore) {
+    request.endDate = {
+      ...(endDateAfter && {$gt: endDateAfter}),
+      ...(endDateBefore && {$lt: endDateBefore}),
+    };
+  }
+
+  if (process) {
+    request.processDefinitionKey = {
+      $in: process.split(','),
+    };
+  }
+
+  if (ids) {
+    request.processInstanceKey = {
+      $in: ids.split(','),
+    };
+  }
+
+  if (parentInstanceId) {
+    request.parentProcessInstanceKey = parentInstanceId;
+  }
+
+  if (tenant) {
+    request.tenantId = tenant;
+  }
+
+  if (retriesLeft !== undefined) {
+    request.hasRetriesLeft = retriesLeft;
+  }
+
+  if (operationId) {
+    request.batchOperationKey = operationId;
+  }
+
+  const state: ProcessInstanceState[] = [];
+  if (active) state.push('RUNNING');
+  if (incidents) state.push('INCIDENT');
+  if (completed) state.push('COMPLETED');
+  if (canceled) state.push('CANCELED');
+
+  if (state.length > 0) {
+    request.state = {
+      $in: state,
+    };
+  }
+
+  return request;
+}
+
+function useProcessInstanceFilters(): ProcessInstancesStatisticsRequest {
+  const {getFilters} = useFilters();
+  const filters = getFilters();
+
+  return mapFiltersToRequest(filters);
+}
+
+export {useProcessInstanceFilters};

--- a/operate/client/src/modules/queries/processInstancesStatistics/useBatchModificationOverlay.test.tsx
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useBatchModificationOverlay.test.tsx
@@ -1,0 +1,178 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {renderHook, waitFor} from '@testing-library/react';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {useBatchModificationOverlayData} from './useBatchModificationOverlayData';
+import {mockFetchProcessInstancesStatistics} from 'modules/mocks/api/v2/processInstances/fetchProcessInstancesStatistics';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {MODIFICATIONS} from 'modules/bpmn-js/badgePositions';
+import * as filterModule from 'modules/hooks/useProcessInstancesFilters';
+
+jest.mock('modules/hooks/useProcessInstancesFilters');
+
+describe('useBatchModificationOverlayData', () => {
+  const wrapper = ({children}: {children: React.ReactNode}) => (
+    <QueryClientProvider client={getMockQueryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    jest.spyOn(filterModule, 'useProcessInstanceFilters').mockReturnValue({});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch batch modification overlay data successfully', async () => {
+    const mockData = [
+      {
+        flowNodeId: 'messageCatchEvent',
+        active: 2,
+        canceled: 1,
+        incidents: 3,
+        completed: 4,
+      },
+    ];
+    const mockOverlayData = [
+      {
+        payload: {cancelledTokenCount: 5},
+        type: 'batchModificationsBadge',
+        flowNodeId: 'messageCatchEvent',
+        position: MODIFICATIONS,
+      },
+      {
+        payload: {newTokenCount: 5},
+        type: 'batchModificationsBadge',
+        flowNodeId: 'targetNode',
+        position: MODIFICATIONS,
+      },
+    ];
+
+    mockFetchProcessInstancesStatistics().withSuccess(mockData);
+
+    const {result} = renderHook(
+      () =>
+        useBatchModificationOverlayData(
+          {},
+          {
+            sourceFlowNodeId: 'messageCatchEvent',
+            targetFlowNodeId: 'targetNode',
+          },
+          true,
+        ),
+      {
+        wrapper,
+      },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockOverlayData);
+  });
+
+  it('should handle server error while fetching batch modification overlay data', async () => {
+    mockFetchProcessInstancesStatistics().withServerError();
+
+    const {result} = renderHook(
+      () =>
+        useBatchModificationOverlayData(
+          {},
+          {sourceFlowNodeId: 'sourceNode', targetFlowNodeId: 'targetNode'},
+          true,
+        ),
+      {
+        wrapper,
+      },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.error?.variant).toBe('failed-response');
+    expect(result.current.error?.response).toBeDefined();
+  });
+
+  it('should handle network error while fetching batch modification overlay data', async () => {
+    mockFetchProcessInstancesStatistics().withNetworkError();
+
+    const {result} = renderHook(
+      () =>
+        useBatchModificationOverlayData(
+          {},
+          {sourceFlowNodeId: 'sourceNode', targetFlowNodeId: 'targetNode'},
+          true,
+        ),
+      {
+        wrapper,
+      },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.error?.variant).toBe('network-error');
+    expect(result.current.error?.response).toBeNull();
+  });
+
+  it('should handle empty data', async () => {
+    mockFetchProcessInstancesStatistics().withSuccess([]);
+
+    const {result} = renderHook(
+      () =>
+        useBatchModificationOverlayData(
+          {},
+          {sourceFlowNodeId: 'sourceNode', targetFlowNodeId: 'targetNode'},
+          true,
+        ),
+      {
+        wrapper,
+      },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('should handle loading state', async () => {
+    const {result} = renderHook(
+      () =>
+        useBatchModificationOverlayData(
+          {},
+          {sourceFlowNodeId: 'sourceNode', targetFlowNodeId: 'targetNode'},
+          true,
+        ),
+      {
+        wrapper,
+      },
+    );
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('should not fetch data when enabled is false', async () => {
+    const {result} = renderHook(
+      () =>
+        useBatchModificationOverlayData(
+          {},
+          {sourceFlowNodeId: 'sourceNode', targetFlowNodeId: 'targetNode'},
+          false,
+        ),
+      {
+        wrapper,
+      },
+    );
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isFetched).toBe(false);
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/operate/client/src/modules/queries/processInstancesStatistics/useBatchModificationOverlayData.ts
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useBatchModificationOverlayData.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  ProcessInstancesStatisticsDto,
+  ProcessInstancesStatisticsRequest,
+} from 'modules/api/v2/processInstances/fetchProcessInstancesStatistics';
+import {MODIFICATIONS} from 'modules/bpmn-js/badgePositions';
+import {useProcessInstancesStatistics} from './useProcessInstancesStatistics';
+import {OverlayData} from 'modules/bpmn-js/BpmnJS';
+
+function batchModificationOverlayParser(params: {
+  sourceFlowNodeId?: string;
+  targetFlowNodeId?: string;
+}): (data: ProcessInstancesStatisticsDto[]) => OverlayData[] {
+  return (data: ProcessInstancesStatisticsDto[]): OverlayData[] => {
+    const {sourceFlowNodeId, targetFlowNodeId} = params;
+    if (
+      data.length === 0 ||
+      targetFlowNodeId === undefined ||
+      sourceFlowNodeId === undefined
+    ) {
+      return [];
+    }
+
+    function getInstancesCount(flowNodeId?: string) {
+      const flowNodeStatistics = data.find(
+        (statistics) => statistics.flowNodeId === flowNodeId,
+      );
+
+      if (flowNodeStatistics === undefined) {
+        return 0;
+      }
+
+      return flowNodeStatistics.active + flowNodeStatistics.incidents;
+    }
+
+    return [
+      {
+        payload: {cancelledTokenCount: getInstancesCount(sourceFlowNodeId)},
+        type: 'batchModificationsBadge',
+        flowNodeId: sourceFlowNodeId,
+        position: MODIFICATIONS,
+      },
+      {
+        payload: {newTokenCount: getInstancesCount(sourceFlowNodeId)},
+        type: 'batchModificationsBadge',
+        flowNodeId: targetFlowNodeId,
+        position: MODIFICATIONS,
+      },
+    ];
+  };
+}
+
+function useBatchModificationOverlayData(
+  payload: ProcessInstancesStatisticsRequest,
+  params: {sourceFlowNodeId?: string; targetFlowNodeId?: string},
+  enabled?: boolean,
+) {
+  return useProcessInstancesStatistics<OverlayData[]>(
+    payload,
+    batchModificationOverlayParser(params),
+    enabled,
+  );
+}
+
+export {useBatchModificationOverlayData};

--- a/operate/client/src/modules/queries/processInstancesStatistics/useOverlayData.test.tsx
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useOverlayData.test.tsx
@@ -1,0 +1,165 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {renderHook, waitFor} from '@testing-library/react';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {useProcessInstancesOverlayData} from './useOverlayData';
+import {mockFetchProcessInstancesStatistics} from 'modules/mocks/api/v2/processInstances/fetchProcessInstancesStatistics';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import * as filterModule from 'modules/hooks/useProcessInstancesFilters';
+
+jest.mock('modules/hooks/useProcessInstancesFilters');
+
+describe('useProcessInstancesOverlayStatistics', () => {
+  const wrapper = ({children}: {children: React.ReactNode}) => (
+    <QueryClientProvider client={getMockQueryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    jest.spyOn(filterModule, 'useProcessInstanceFilters').mockReturnValue({});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch process instances overlay statistics successfully', async () => {
+    const mockData = [
+      {
+        flowNodeId: 'messageCatchEvent',
+        active: 2,
+        canceled: 1,
+        incidents: 3,
+        completed: 4,
+      },
+    ];
+    const mockOverlayData = [
+      {
+        flowNodeId: 'messageCatchEvent',
+        payload: {
+          count: 2,
+          flowNodeState: 'active',
+        },
+        position: {
+          bottom: 9,
+          left: 0,
+        },
+        type: 'statistics-active',
+      },
+      {
+        flowNodeId: 'messageCatchEvent',
+        payload: {
+          count: 3,
+          flowNodeState: 'incidents',
+        },
+        position: {
+          bottom: 9,
+          right: 0,
+        },
+        type: 'statistics-incidents',
+      },
+      {
+        flowNodeId: 'messageCatchEvent',
+        payload: {
+          count: 1,
+          flowNodeState: 'canceled',
+        },
+        position: {
+          top: -16,
+          left: 0,
+        },
+        type: 'statistics-canceled',
+      },
+      {
+        flowNodeId: 'messageCatchEvent',
+        payload: {
+          count: 4,
+          flowNodeState: 'completedEndEvents',
+        },
+        position: {
+          bottom: 1,
+          left: 17,
+        },
+        type: 'statistics-completedEndEvents',
+      },
+    ];
+
+    mockFetchProcessInstancesStatistics().withSuccess(mockData);
+
+    const {result} = renderHook(() => useProcessInstancesOverlayData({}), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockOverlayData);
+  });
+
+  it('should handle server error while fetching process instances overlay statistics', async () => {
+    mockFetchProcessInstancesStatistics().withServerError();
+
+    const {result} = renderHook(() => useProcessInstancesOverlayData({}), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.error?.variant).toBe('failed-response');
+    expect(result.current.error?.response).toBeDefined();
+  });
+
+  it('should handle network error while fetching process instances overlay statistics', async () => {
+    mockFetchProcessInstancesStatistics().withNetworkError();
+
+    const {result} = renderHook(() => useProcessInstancesOverlayData({}), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.error?.variant).toBe('network-error');
+    expect(result.current.error?.response).toBeNull();
+  });
+
+  it('should handle empty data', async () => {
+    mockFetchProcessInstancesStatistics().withSuccess([]);
+
+    const {result} = renderHook(() => useProcessInstancesOverlayData({}), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('should handle loading state', async () => {
+    const {result} = renderHook(() => useProcessInstancesOverlayData({}), {
+      wrapper,
+    });
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('should not fetch data when enabled is false', async () => {
+    const {result} = renderHook(
+      () => useProcessInstancesOverlayData({}, false),
+      {
+        wrapper,
+      },
+    );
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isFetched).toBe(false);
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/operate/client/src/modules/queries/processInstancesStatistics/useOverlayData.ts
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useOverlayData.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  ProcessInstancesStatisticsDto,
+  ProcessInstancesStatisticsRequest,
+} from 'modules/api/v2/processInstances/fetchProcessInstancesStatistics';
+import {OverlayData} from 'modules/bpmn-js/BpmnJS';
+import {
+  ACTIVE_BADGE,
+  CANCELED_BADGE,
+  COMPLETED_BADGE,
+  COMPLETED_END_EVENT_BADGE,
+  INCIDENTS_BADGE,
+} from 'modules/bpmn-js/badgePositions';
+import {useProcessInstancesStatistics} from './useProcessInstancesStatistics';
+
+type FlowNodeState =
+  | 'active'
+  | 'incidents'
+  | 'canceled'
+  | 'completed'
+  | 'completedEndEvents';
+
+const overlayPositions = {
+  active: ACTIVE_BADGE,
+  incidents: INCIDENTS_BADGE,
+  canceled: CANCELED_BADGE,
+  completed: COMPLETED_BADGE,
+  completedEndEvents: COMPLETED_END_EVENT_BADGE,
+};
+
+export function overlayParser(
+  data: ProcessInstancesStatisticsDto[],
+): OverlayData[] {
+  const flowNodeStates = data.flatMap((statistics) => {
+    const types: FlowNodeState[] = [
+      'active',
+      'incidents',
+      'canceled',
+      'completed',
+    ];
+    return types.reduce<
+      {
+        flowNodeId: string;
+        count: number;
+        flowNodeState: FlowNodeState;
+      }[]
+    >((states, flowNodeState) => {
+      const count = Number(
+        statistics[flowNodeState as keyof ProcessInstancesStatisticsDto],
+      );
+      if (count > 0) {
+        return [
+          ...states,
+          {
+            flowNodeId: statistics.flowNodeId,
+            count,
+            flowNodeState:
+              flowNodeState === 'completed'
+                ? 'completedEndEvents'
+                : flowNodeState,
+          },
+        ];
+      } else {
+        return states;
+      }
+    }, []);
+  });
+
+  return flowNodeStates.map(({flowNodeState, count, flowNodeId}) => ({
+    payload: {flowNodeState, count},
+    type: `statistics-${flowNodeState}`,
+    flowNodeId,
+    position: overlayPositions[flowNodeState],
+  }));
+}
+
+function useProcessInstancesOverlayData(
+  payload: ProcessInstancesStatisticsRequest,
+  enabled?: boolean,
+) {
+  return useProcessInstancesStatistics<OverlayData[]>(
+    payload,
+    overlayParser,
+    enabled,
+  );
+}
+
+export {useProcessInstancesOverlayData};

--- a/operate/client/src/modules/queries/useGenericQuery.ts
+++ b/operate/client/src/modules/queries/useGenericQuery.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useQuery, UseQueryOptions, UseQueryResult} from '@tanstack/react-query';
+import {RequestError, RequestResult} from 'modules/request';
+
+function useGenericQuery<RawDataT, ParsedDataT>(
+  queryKey: unknown[],
+  fetchFunction: () => RequestResult<RawDataT>,
+  parser: (data: RawDataT) => ParsedDataT,
+  options?: UseQueryOptions<ParsedDataT, RequestError>,
+): UseQueryResult<ParsedDataT, RequestError> {
+  return useQuery<ParsedDataT, RequestError>({
+    queryKey,
+    queryFn: async () => {
+      const {response, error} = await fetchFunction();
+
+      if (response !== null) {
+        return parser(response);
+      }
+
+      throw error;
+    },
+    ...options,
+  });
+}
+
+export {useGenericQuery};

--- a/operate/client/src/modules/utils/filter/index.ts
+++ b/operate/client/src/modules/utils/filter/index.ts
@@ -512,6 +512,7 @@ function getSortParams(search?: string): {
 }
 
 export {
+  getProcessIds,
   getProcessInstanceFilters,
   parseIds,
   parseFilterTime,


### PR DESCRIPTION
## Description

This PR migrates 2 of the PI statistics store methods (`overlayData` and `batchModification`. See [1](https://github.com/camunda/camunda/blob/f65196630a008ef39900a2cee9cffe10083abb18/operate/client/src/modules/stores/processStatistics/processStatistics.base.ts#L108-L124) and [2](https://github.com/camunda/camunda/blob/f65196630a008ef39900a2cee9cffe10083abb18/operate/client/src/modules/stores/processStatistics/processStatistics.batchModification.ts#L25-L65) for the old logic. I've also added tests using a mock query client to cover different cases.

## Related issues

related to #29283
