### PR TITLE
Convert remaining number keys to strings in C8 API

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateDocumentBatchCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateDocumentBatchCommandImpl.java
@@ -27,6 +27,7 @@ import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.DocumentReferenceBatchResponseImpl;
 import io.camunda.client.impl.util.DocumentBuilder;
+import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.DocumentCreationBatchResponse;
 import java.io.InputStream;
 import java.time.Duration;
@@ -91,7 +92,7 @@ public class CreateDocumentBatchCommandImpl implements CreateDocumentBatchComman
           document.getMetadata().setProcessDefinitionId(processDefinitionId);
         }
         if (processInstanceKey != null) {
-          document.getMetadata().setProcessInstanceKey(processInstanceKey);
+          document.getMetadata().setProcessInstanceKey(ParseUtil.keyToString(processInstanceKey));
         }
         final String metadataString = jsonMapper.toJson(document.getMetadata());
         final MultipartPart part =

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateDocumentCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateDocumentCommandImpl.java
@@ -27,6 +27,7 @@ import io.camunda.client.impl.http.HttpCamundaFuture;
 import io.camunda.client.impl.http.HttpClient;
 import io.camunda.client.impl.response.DocumentReferenceResponseImpl;
 import io.camunda.client.impl.util.DocumentBuilder;
+import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.DocumentReference;
 import java.io.InputStream;
 import java.time.Duration;
@@ -177,7 +178,7 @@ public class CreateDocumentCommandImpl extends DocumentBuilder
 
   @Override
   public CreateDocumentCommandStep2 processInstanceKey(final long processInstanceKey) {
-    super.getMetadata().setProcessInstanceKey(processInstanceKey);
+    super.getMetadata().setProcessInstanceKey(ParseUtil.keyToString(processInstanceKey));
     return this;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/response/DocumentMetadataImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/response/DocumentMetadataImpl.java
@@ -16,6 +16,7 @@
 package io.camunda.client.impl.response;
 
 import io.camunda.client.api.response.DocumentMetadata;
+import io.camunda.client.impl.util.ParseUtil;
 import java.time.OffsetDateTime;
 import java.util.Map;
 
@@ -63,7 +64,7 @@ public class DocumentMetadataImpl implements DocumentMetadata {
 
   @Override
   public Long getProcessInstanceKey() {
-    return response.getProcessInstanceKey();
+    return ParseUtil.parseLongOrNull(response.getProcessInstanceKey());
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateDocumentBatchCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateDocumentBatchCommandImpl.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.client.impl.command;
 
 import static io.camunda.zeebe.client.impl.command.ArgumentUtil.ensureNotNull;
 
+import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.DocumentCreationBatchResponse;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
@@ -91,7 +92,7 @@ public class CreateDocumentBatchCommandImpl implements CreateDocumentBatchComman
           document.getMetadata().setProcessDefinitionId(processDefinitionId);
         }
         if (processInstanceKey != null) {
-          document.getMetadata().setProcessInstanceKey(processInstanceKey);
+          document.getMetadata().setProcessInstanceKey(ParseUtil.keyToString(processInstanceKey));
         }
         final String metadataString = jsonMapper.toJson(document.getMetadata());
         final MultipartPart part =

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateDocumentCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateDocumentCommandImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.command;
 
+import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.client.protocol.rest.DocumentReference;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
@@ -175,7 +176,7 @@ public class CreateDocumentCommandImpl extends DocumentBuilder
 
   @Override
   public CreateDocumentCommandStep2 processInstanceKey(final long processInstanceKey) {
-    super.getMetadata().setProcessInstanceKey(processInstanceKey);
+    super.getMetadata().setProcessInstanceKey(ParseUtil.keyToString(processInstanceKey));
     return this;
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DocumentMetadataImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DocumentMetadataImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.response;
 
+import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.zeebe.client.api.response.DocumentMetadata;
 import java.time.OffsetDateTime;
 import java.util.Map;
@@ -63,7 +64,7 @@ public class DocumentMetadataImpl implements DocumentMetadata {
 
   @Override
   public Long getProcessInstanceKey() {
-    return response.getProcessInstanceKey();
+    return ParseUtil.parseLongOrNull(response.getProcessInstanceKey());
   }
 
   @Override

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -583,8 +583,7 @@ paths:
           required: true
           description: The unique identifier of the mapping rule.
           schema:
-            type: integer
-            format: int64
+            type: string
       responses:
         "202":
           description: The mapping rule was successfully assigned to the tenant.
@@ -619,8 +618,7 @@ paths:
           required: true
           description: The unique identifier of the mapping rule.
           schema:
-            type: integer
-            format: int64
+            type: string
       responses:
         "202":
           description: The mapping rule was successfully removed from the tenant.
@@ -656,8 +654,7 @@ paths:
           required: true
           description: The unique identifier of the group.
           schema:
-            type: integer
-            format: int64
+            type: string
       responses:
         "202":
           description: The group was successfully assigned to the tenant.
@@ -692,8 +689,7 @@ paths:
           required: true
           description: The unique identifier of the group.
           schema:
-            type: integer
-            format: int64
+            type: string
       responses:
         "202":
           description: The group was successfully removed from the tenant.
@@ -2024,8 +2020,7 @@ paths:
           required: true
           description: The key of the authorization to delete.
           schema:
-            type: integer
-            format: int64
+            type: string
       requestBody:
         content:
           application/json:
@@ -2057,8 +2052,7 @@ paths:
           required: true
           description: The key of the authorization to delete.
           schema:
-            type: integer
-            format: int64
+            type: string
       responses:
         "204":
           description: The authorization was deleted successfully.
@@ -2399,8 +2393,7 @@ paths:
           required: true
           description: The user key.
           schema:
-            type: integer
-            format: int64
+            type: string
       responses:
         "202":
           description: The user was assigned successfully to the group.
@@ -6550,8 +6543,7 @@ components:
           type: string
           description: The ID of the process definition that created the document.
         processInstanceKey:
-          type: integer
-          format: int64
+          type: string
           description: The key of the process instance that created the document.
         customProperties:
           type: object

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -652,7 +652,7 @@ public class RequestMapper {
         expiresAt,
         file.getSize(),
         metadata.getProcessDefinitionId(),
-        metadata.getProcessInstanceKey(),
+        KeyUtil.keyToLong(metadata.getProcessInstanceKey()),
         metadata.getCustomProperties());
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -281,7 +281,7 @@ public final class ResponseMapper {
             .size(internalMetadata.size())
             .contentType(internalMetadata.contentType())
             .processDefinitionId(internalMetadata.processDefinitionId())
-            .processInstanceKey(internalMetadata.processInstanceKey());
+            .processInstanceKey(KeyUtil.keyToString(internalMetadata.processInstanceKey()));
     Optional.ofNullable(internalMetadata.customProperties())
         .ifPresent(map -> map.forEach(externalMetadata::putCustomPropertiesItem));
     return new DocumentReference()


### PR DESCRIPTION
## Description

Convert remaining number keys to strings in the C8 API.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

n/a
