### PR TITLE
fix: on authorizations disabled, return wildcard app authorizations

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -239,9 +239,14 @@ public class CamundaServicesConfiguration {
   public AuthorizationServices authorizationServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
-      final AuthorizationSearchClient authorizationSearchClient) {
+      final AuthorizationSearchClient authorizationSearchClient,
+      final SecurityConfiguration securityConfiguration) {
     return new AuthorizationServices(
-        brokerClient, securityContextProvider, authorizationSearchClient, null);
+        brokerClient,
+        securityContextProvider,
+        authorizationSearchClient,
+        null,
+        securityConfiguration);
   }
 
   @Bean

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/ApplicationAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/ApplicationAuthorizationIT.java
@@ -11,6 +11,8 @@ import static io.camunda.client.protocol.rest.PermissionTypeEnum.ACCESS;
 import static io.camunda.client.protocol.rest.ResourceTypeEnum.APPLICATION;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.client.CamundaClient;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
@@ -53,6 +55,9 @@ class ApplicationAuthorizationIT {
   private static final String RESTRICTED = "restricted";
   private static final String ADMIN = "admin";
   private static final String DEFAULT_PASSWORD = "password";
+
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
   @UserDefinition
   private static final User ADMIN_USER =
@@ -172,6 +177,24 @@ class ApplicationAuthorizationIT {
     assertAccessAllowed(response);
   }
 
+  @Test
+  void meContainsAppUserSpecificAuthorizations(
+      @Authenticated(RESTRICTED) final CamundaClient restrictedClient)
+      throws IOException, URISyntaxException, InterruptedException {
+    // when
+    final HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(createUri(restrictedClient, "v2/authentication/me"))
+            .header("Authorization", basicAuthentication(RESTRICTED))
+            .build();
+    final HttpResponse<String> response =
+        HTTP_CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+
+    // then
+    final MeResponse meResponse = OBJECT_MAPPER.readValue(response.body(), MeResponse.class);
+    assertThat(meResponse.authorizedApplications).containsExactly("tasklist");
+  }
+
   private static void assertRedirectToForbidden(
       final String appName, final HttpResponse<String> response) {
     assertThat(response.statusCode()).isEqualTo(HttpURLConnection.HTTP_MOVED_TEMP);
@@ -198,4 +221,6 @@ class ApplicationAuthorizationIT {
             HttpURLConnection.HTTP_FORBIDDEN,
             HttpURLConnection.HTTP_MOVED_TEMP);
   }
+
+  private record MeResponse(List<String> authorizedApplications) {}
 }

--- a/service/src/main/java/io/camunda/service/AuthorizationServices.java
+++ b/service/src/main/java/io/camunda/service/AuthorizationServices.java
@@ -14,6 +14,7 @@ import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -33,20 +34,27 @@ public class AuthorizationServices
     extends SearchQueryService<AuthorizationServices, AuthorizationQuery, AuthorizationEntity> {
 
   private final AuthorizationSearchClient authorizationSearchClient;
+  private final SecurityConfiguration securityConfiguration;
 
   public AuthorizationServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final AuthorizationSearchClient authorizationSearchClient,
-      final Authentication authentication) {
+      final Authentication authentication,
+      final SecurityConfiguration securityConfiguration) {
     super(brokerClient, securityContextProvider, authentication);
     this.authorizationSearchClient = authorizationSearchClient;
+    this.securityConfiguration = securityConfiguration;
   }
 
   @Override
   public AuthorizationServices withAuthentication(final Authentication authentication) {
     return new AuthorizationServices(
-        brokerClient, securityContextProvider, authorizationSearchClient, authentication);
+        brokerClient,
+        securityContextProvider,
+        authorizationSearchClient,
+        authentication,
+        securityConfiguration);
   }
 
   @Override
@@ -82,6 +90,11 @@ public class AuthorizationServices
   }
 
   public List<String> getAuthorizedApplications(final Set<String> ownerIds) {
+    if (!securityConfiguration.getAuthorizations().isEnabled()) {
+      // if authorizations are not enabled, we default to a wildcard authorization which is
+      // needed for frontend side checks
+      return List.of("*");
+    }
     return getAuthorizedResources(
         ownerIds, PermissionType.ACCESS, AuthorizationResourceType.APPLICATION);
   }


### PR DESCRIPTION
## Description

This serves as a backend/frontend integration fix. As the frontends are not aware of authorizations being enabled or not, we return wildcard access to applications when authorizations are disabled.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29355
