### PR TITLE
fix: removed unused properties from sdk

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/common/AuthProperties.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/common/AuthProperties.java
@@ -21,10 +21,6 @@ import org.springframework.boot.context.properties.DeprecatedConfigurationProper
 
 public class AuthProperties {
 
-  // simple
-  private String username;
-  private String password;
-
   // self-managed and saas
   private String clientId;
   private String clientSecret;
@@ -79,22 +75,6 @@ public class AuthProperties {
     this.issuer = issuer;
   }
 
-  public String getUsername() {
-    return username;
-  }
-
-  public void setUsername(final String username) {
-    this.username = username;
-  }
-
-  public String getPassword() {
-    return password;
-  }
-
-  public void setPassword(final String password) {
-    this.password = password;
-  }
-
   public String getClientId() {
     return clientId;
   }
@@ -114,13 +94,7 @@ public class AuthProperties {
   @Override
   public String toString() {
     return "AuthProperties{"
-        + "username='"
-        + username
-        + '\''
-        + ", password='"
-        + (password != null ? "***" : null)
-        + '\''
-        + ", clientId='"
+        + "clientId='"
         + (clientId != null ? "***" : null)
         + '\''
         + ", clientSecret='"

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientPropertiesPostProcessorTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientPropertiesPostProcessorTest.java
@@ -575,27 +575,6 @@ public class ZeebeClientPropertiesPostProcessorTest {
       }
 
       @Nested
-      @SpringBootTest(
-          properties = {
-            "camunda.client.mode=self-managed",
-            "camunda.client.auth.username=jonny",
-            "camunda.client.auth.password=prosciutto"
-          })
-      class BasicAuthCredentials {
-        @Autowired CamundaClientProperties camundaClientProperties;
-
-        @Test
-        void shouldReadUsername() {
-          assertThat(camundaClientProperties.getAuth().getUsername()).isEqualTo("jonny");
-        }
-
-        @Test
-        void shouldReadPassword() {
-          assertThat(camundaClientProperties.getAuth().getPassword()).isEqualTo("prosciutto");
-        }
-      }
-
-      @Nested
       @SpringBootTest(properties = {"camunda.client.zeebe.execution-threads=5"})
       class ExecutionThreads {
         @Autowired CamundaClientProperties camundaClientProperties;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR removes properties from the Spring SDK that are unused. 

The configuration option will also be removed from the docs: https://github.com/camunda/camunda-docs/pull/5198

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
