### PR TITLE
fix: `camunda.client.auth` is never null

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CredentialsProviderConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CredentialsProviderConfiguration.java
@@ -98,9 +98,6 @@ public class CredentialsProviderConfiguration {
   private void maybeConfigureIdentityProviderSSLConfig(
       final OAuthCredentialsProviderBuilder builder,
       final CamundaClientProperties camundaClientProperties) {
-    if (camundaClientProperties.getAuth() == null) {
-      return;
-    }
     if (camundaClientProperties.getAuth().getKeystorePath() != null) {
       final Path keyStore = Paths.get(camundaClientProperties.getAuth().getKeystorePath());
       if (Files.exists(keyStore)) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The property `camunda.client.auth` can never be null: https://github.com/camunda/camunda/blob/main/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/properties/CamundaClientProperties.java#L49-L50

This null check can be removed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
