### PR TITLE
fix: small fixes to resolve OIDC issues

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -313,7 +313,14 @@ public class WebSecurityConfig {
                                   .findByRegistrationId(OidcClientRegistration.REGISTRATION_ID)
                                   .getProviderDetails()
                                   .getJwkSetUri())))
-          .oauth2Login(oauthLoginConfigurer -> {})
+          .oauth2Login(
+              oauthLoginConfigurer -> {
+                oauthLoginConfigurer
+                    .clientRegistrationRepository(clientRegistrationRepository)
+                    .redirectionEndpoint(
+                        redirectionEndpointConfig ->
+                            redirectionEndpointConfig.baseUri("/sso-callback"));
+              })
           .oidcLogout(httpSecurityOidcLogoutConfigurer -> {})
           .logout(
               (logout) ->

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -72,6 +72,7 @@ public class WebSecurityConfig {
           "/v1/external/process/**");
   private static final Set<String> WEBAPP_PATHS =
       Set.of(
+          "/sso-callback/**",
           "/login/**",
           "/logout",
           "/oauth2/authorization/**",

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -75,11 +75,9 @@ public class WebSecurityConfig {
           "/sso-callback/**",
           "/login/**",
           "/logout",
-          "/oauth2/authorization/**",
           "/identity/**",
           "/operate/**",
           "/tasklist/**",
-          "/favicon.ico",
           "/");
   private static final Set<String> UNPROTECTED_PATHS =
       Set.of(
@@ -92,7 +90,8 @@ public class WebSecurityConfig {
           "/health",
           "/startup",
           // deprecated Tasklist v1 Public Endpoints
-          "/new/**");
+          "/new/**",
+          "/favicon.ico");
 
   @Bean
   @ConditionalOnMissingBean(MethodSecurityExpressionHandler.class)

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -71,7 +71,15 @@ public class WebSecurityConfig {
           // deprecated Tasklist v1 Public Endpoints
           "/v1/external/process/**");
   private static final Set<String> WEBAPP_PATHS =
-      Set.of("/login", "/logout", "/identity/**", "/operate/**", "/tasklist/**");
+      Set.of(
+          "/login/**",
+          "/logout",
+          "/oauth2/authorization/**",
+          "/identity/**",
+          "/operate/**",
+          "/tasklist/**",
+          "/favicon.ico",
+          "/");
   private static final Set<String> UNPROTECTED_PATHS =
       Set.of(
           // endpoint for failure forwarding

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaOidcUser.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaOidcUser.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.authentication.entity;
 
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -15,7 +16,7 @@ import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 
-public class CamundaOidcUser implements OidcUser, CamundaPrincipal {
+public class CamundaOidcUser implements OidcUser, CamundaPrincipal, Serializable {
   private final OidcUser user;
   private final AuthenticationContext authentication;
   private final Set<Long> mappingKeys;

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.authentication.entity.AuthenticationContext;
 import io.camunda.authentication.entity.CamundaOidcUser;
 import io.camunda.search.entities.MappingEntity;
+import io.camunda.search.entities.RoleEntity;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.GroupServices;
 import io.camunda.service.MappingServices;
@@ -72,6 +73,11 @@ public class CamundaOidcUserServiceTest {
                 new MappingEntity(5L, "role", "R1", "role-r1"),
                 new MappingEntity(7L, "group", "G1", "group-g1")));
 
+    final var roleR1 = new RoleEntity(8L, "Role R1");
+    when(roleServices.getRolesByMemberKeys(Set.of(5L, 7L))).thenReturn(List.of(roleR1));
+    when(authorizationServices.getAuthorizedApplications(Set.of("5", "7", "8")))
+        .thenReturn(List.of("*"));
+
     // when
     final OidcUser oidcUser = camundaOidcUserService.loadUser(createOidcUserRequest(claims));
 
@@ -82,10 +88,10 @@ public class CamundaOidcUserServiceTest {
     assertThat(camundaUser.getEmail()).isEqualTo("foo@camunda.test");
     assertThat(camundaUser.getMappingKeys()).isEqualTo(Set.of(5L, 7L));
     final AuthenticationContext authenticationContext = camundaUser.getAuthenticationContext();
-    assertThat(authenticationContext.roles()).isEmpty();
+    assertThat(authenticationContext.roles()).containsAll(Set.of(roleR1));
     assertThat(authenticationContext.groups()).isEmpty();
     assertThat(authenticationContext.tenants()).isEmpty();
-    assertThat(authenticationContext.authorizedApplications()).isEmpty();
+    assertThat(authenticationContext.authorizedApplications()).containsAll(Set.of("*"));
   }
 
   private static OidcUserRequest createOidcUserRequest(final Map<String, Object> claims) {

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -7,13 +7,16 @@
  */
 package io.camunda.security.configuration;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class OidcAuthenticationConfiguration {
   private String issuerUri;
   private String clientId;
   private String clientSecret;
   private String grantType = "authorization_code";
   private String redirectUri;
-  private String scope = "openid,profile";
+  private List<String> scope = Arrays.asList("openid", "profile");
   private String jwkSetUri;
   private String authorizationUri;
 
@@ -57,11 +60,11 @@ public class OidcAuthenticationConfiguration {
     this.redirectUri = redirectUri;
   }
 
-  public String getScope() {
+  public List<String> getScope() {
     return scope;
   }
 
-  public void setScope(final String scope) {
+  public void setScope(final List<String> scope) {
     this.scope = scope;
   }
 

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.gateway.impl.broker.request.tenant.BrokerTenantDeleteReq
 import io.camunda.zeebe.gateway.impl.broker.request.tenant.BrokerTenantUpdateRequest;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -163,7 +164,8 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
     return tenantEntity;
   }
 
-  public record TenantDTO(Long key, String tenantId, String name, String description) {
+  public record TenantDTO(Long key, String tenantId, String name, String description)
+      implements Serializable {
     public static TenantDTO fromEntity(final TenantEntity entity) {
       return new TenantDTO(entity.key(), entity.tenantId(), entity.name(), entity.description());
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR is the result of testing against a development cluster in SaaS to ensure that OIDC works in that setting (and by extension, self-managed).

I would like to highlight the following changes to give some extra context:
1. We have set the redirect URI to be `/sso-callback` - this is largely defined by the SaaS deployments using this structure so its a simple integration. We could allow this to be configurable in the longer term so self-managed customers could tailor the callback to match internal policies, however its not in the scope of my PR here.
2. I had to make two classes serializable due to the shared web session storage work - without this, Spring cannot ser/deser the object to be placed into the session storage index.
