### PR TITLE
Pass task headers to listeners

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -312,7 +312,8 @@ public final class BpmnJobBehavior {
                     listenerJobProperties,
                     JobKind.TASK_LISTENER,
                     fromTaskListenerEventType(listener.getEventType()),
-                    extractUserTaskHeaders(taskRecordValue, changedAttributes)))
+                    extractUserTaskHeaders(
+                        taskRecordValue, changedAttributes, listener.getJobWorkerProperties())))
         .ifLeft(failure -> incidentBehavior.createIncident(failure, context));
   }
 
@@ -475,8 +476,11 @@ public final class BpmnJobBehavior {
   }
 
   private Map<String, String> extractUserTaskHeaders(
-      final UserTaskRecord userTaskRecord, final List<String> changedAttributes) {
-    final var headers = new HashMap<String, String>();
+      final UserTaskRecord userTaskRecord,
+      final List<String> changedAttributes,
+      final JobWorkerProperties jobWorkerProperties) {
+    final var taskHeaders = jobWorkerProperties.getTaskHeaders();
+    final var headers = new HashMap<>(taskHeaders);
 
     if (StringUtils.isNotEmpty(userTaskRecord.getAction())) {
       headers.put(Protocol.USER_TASK_ACTION_HEADER_NAME, userTaskRecord.getAction());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.model.bpmn.builder.UserTaskBuilder;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
 import java.time.InstantSource;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
@@ -311,6 +312,26 @@ class UserTaskTransformerTest {
                 assertThat(listener.getEventType()).isEqualTo(expected.eventType);
                 assertThat(type(listener)).isEqualTo(expected.type);
                 assertThat(retries(listener)).isEqualTo(expected.retries);
+              });
+    }
+
+    @Test
+    void shouldTransformWithTaskHeaders() {
+      final var userTask =
+          transformZeebeUserTask(
+              processWithUserTask(
+                  b ->
+                      b.zeebeTaskHeader("key", "value")
+                          .zeebeTaskListener(l -> l.canceling().type("myType"))
+                          .zeebeUserTask()));
+
+      assertThat(userTask.getTaskListeners())
+          .hasSize(1)
+          .first()
+          .satisfies(
+              listener -> {
+                assertThat(listener.getJobWorkerProperties().getTaskHeaders())
+                    .isEqualTo(Map.of("key", "value"));
               });
     }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerDataAccessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerDataAccessTest.java
@@ -11,7 +11,6 @@ import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
-import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -241,29 +240,5 @@ public class TaskListenerDataAccessTest {
             entry(Protocol.USER_TASK_ACTION_HEADER_NAME, "unassign"),
             // `assignee` was cleared during unassignment, marking it as a changed attribute.
             entry(Protocol.USER_TASK_CHANGED_ATTRIBUTES_HEADER_NAME, "[\"assignee\"]"));
-  }
-
-  @Test
-  public void shouldIncludeUserTaskHeadersInJobCustomHeaders() {
-    final BpmnModelInstance processWithZeebeUserTask =
-        helper.createProcessWithZeebeUserTask(
-            taskBuilder -> {
-              taskBuilder
-                  .zeebeTaskHeader("key", "value")
-                  .zeebeTaskListener(listener -> listener.completing().type(listenerType));
-              return taskBuilder;
-            });
-
-    // given
-    final long processInstanceKey = helper.createProcessInstance(processWithZeebeUserTask);
-
-    // when
-    ENGINE.userTask().ofInstance(processInstanceKey).complete();
-
-    // then
-    final var activatedListenerJob = helper.activateJob(processInstanceKey, listenerType);
-
-    assertThat(activatedListenerJob.getCustomHeaders()).contains(entry("key", "value"));
-    helper.completeJobs(processInstanceKey, listenerType);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerDataAccessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerDataAccessTest.java
@@ -11,6 +11,7 @@ import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -240,5 +241,29 @@ public class TaskListenerDataAccessTest {
             entry(Protocol.USER_TASK_ACTION_HEADER_NAME, "unassign"),
             // `assignee` was cleared during unassignment, marking it as a changed attribute.
             entry(Protocol.USER_TASK_CHANGED_ATTRIBUTES_HEADER_NAME, "[\"assignee\"]"));
+  }
+
+  @Test
+  public void shouldIncludeUserTaskHeadersInJobCustomHeaders() {
+    final BpmnModelInstance processWithZeebeUserTask =
+        helper.createProcessWithZeebeUserTask(
+            taskBuilder -> {
+              taskBuilder
+                  .zeebeTaskHeader("key", "value")
+                  .zeebeTaskListener(listener -> listener.completing().type(listenerType));
+              return taskBuilder;
+            });
+
+    // given
+    final long processInstanceKey = helper.createProcessInstance(processWithZeebeUserTask);
+
+    // when
+    ENGINE.userTask().ofInstance(processInstanceKey).complete();
+
+    // then
+    final var activatedListenerJob = helper.activateJob(processInstanceKey, listenerType);
+
+    assertThat(activatedListenerJob.getCustomHeaders()).contains(entry("key", "value"));
+    helper.completeJobs(processInstanceKey, listenerType);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTaskHeadersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTaskHeadersTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.activity.listeners.task;
+
+import static java.util.Map.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.client.UserTaskClient;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.UUID;
+import java.util.function.Consumer;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+/** Tests verifying that a task listener may access user task headers via custom headers. */
+public class TaskListenerTaskHeadersTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+  private final TaskListenerTestHelper helper = new TaskListenerTestHelper(ENGINE);
+
+  private String listenerType;
+
+  @Before
+  public void setup() {
+    listenerType = "my_listener_" + UUID.randomUUID();
+  }
+
+  @Test
+  public void shouldIncludeUserTaskHeadersInJobCustomHeadersForAssigningTaskListener() {
+    shouldIncludeUserTaskHeadersInJobCustomHeaders(
+        ZeebeTaskListenerEventType.assigning,
+        userTask -> userTask.withAssignee("initial_assignee").claim());
+  }
+
+  @Test
+  public void shouldIncludeUserTaskHeadersInJobCustomHeadersForCompletingTaskListener() {
+    shouldIncludeUserTaskHeadersInJobCustomHeaders(
+        ZeebeTaskListenerEventType.completing, UserTaskClient::complete);
+  }
+
+  @Test
+  public void shouldIncludeUserTaskHeadersInJobCustomHeadersForUpdatingTaskListener() {
+    shouldIncludeUserTaskHeadersInJobCustomHeaders(
+        ZeebeTaskListenerEventType.updating, UserTaskClient::update);
+  }
+
+  private void shouldIncludeUserTaskHeadersInJobCustomHeaders(
+      final ZeebeTaskListenerEventType eventType, final Consumer<UserTaskClient> userTaskAction) {
+    final BpmnModelInstance processWithZeebeUserTask =
+        helper.createProcessWithZeebeUserTask(
+            taskBuilder -> {
+              taskBuilder
+                  .zeebeTaskHeader("key", "value")
+                  .zeebeTaskListener(l -> l.eventType(eventType).type(listenerType));
+              return taskBuilder;
+            });
+
+    // given
+    final long processInstanceKey = helper.createProcessInstance(processWithZeebeUserTask);
+
+    // when
+    userTaskAction.accept(ENGINE.userTask().ofInstance(processInstanceKey));
+
+    // then
+    final var activatedListenerJob = helper.activateJob(processInstanceKey, listenerType);
+
+    assertThat(activatedListenerJob.getCustomHeaders()).contains(entry("key", "value"));
+    helper.completeJobs(processInstanceKey, listenerType);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTaskHeadersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTaskHeadersTest.java
@@ -60,12 +60,10 @@ public class TaskListenerTaskHeadersTest {
       final ZeebeTaskListenerEventType eventType, final Consumer<UserTaskClient> userTaskAction) {
     final BpmnModelInstance processWithZeebeUserTask =
         helper.createProcessWithZeebeUserTask(
-            taskBuilder -> {
-              taskBuilder
-                  .zeebeTaskHeader("key", "value")
-                  .zeebeTaskListener(l -> l.eventType(eventType).type(listenerType));
-              return taskBuilder;
-            });
+            taskBuilder ->
+                taskBuilder
+                    .zeebeTaskHeader("key", "value")
+                    .zeebeTaskListener(l -> l.eventType(eventType).type(listenerType)));
 
     // given
     final long processInstanceKey = helper.createProcessInstance(processWithZeebeUserTask);


### PR DESCRIPTION
## Description

A user can define task headers on a user task.
This PR adds the possibility to access statically defined headers from the listener jobs custom headers . 
This PR only covers User Task Listeners.

The same functionality for Execution Listeners will be covered in another PR for[ this issue.](https://github.com/camunda/camunda/issues/29460)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29461
