### PR TITLE
feat: migrate BatchModificationNotification component to v2

### DIFF
--- a/operate/client/src/App/Processes/ListView/DiagramPanel/BatchModificationNotification/v2/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/BatchModificationNotification/v2/index.test.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen} from 'modules/testing-library';
+import {MemoryRouter} from 'react-router-dom';
+import {Paths} from 'modules/Routes';
+import {BatchModificationNotification} from '.';
+import {mockFetchProcessInstancesStatistics} from 'modules/mocks/api/v2/processInstances/fetchProcessInstancesStatistics';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {QueryClientProvider} from '@tanstack/react-query';
+import * as filterModule from 'modules/hooks/useProcessInstancesFilters';
+
+jest.mock('modules/hooks/useProcessInstancesFilters');
+
+const notificationText1 =
+  'Please select where you want to move the selected instances on the diagram.';
+
+const notificationText2 =
+  'Modification scheduled: Move 4 instances from “userTask” to “endEvent”. Press “Apply Modification” button to confirm.';
+
+function getWrapper(initialPath: string = Paths.dashboard()) {
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
+    return (
+      <MemoryRouter initialEntries={[initialPath]}>
+        <QueryClientProvider client={getMockQueryClient()}>
+          {children}
+        </QueryClientProvider>
+      </MemoryRouter>
+    );
+  };
+
+  return Wrapper;
+}
+
+describe('BatchModificationNotification', () => {
+  beforeEach(() => {
+    jest.spyOn(filterModule, 'useProcessInstanceFilters').mockReturnValue({});
+    mockFetchProcessInstancesStatistics().withSuccess([]);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should initially render batch modification notification', async () => {
+    mockFetchProcessInstancesStatistics().withSuccess([]);
+    render(<BatchModificationNotification />, {
+      wrapper: getWrapper(),
+    });
+
+    expect(screen.getByText(notificationText1)).toBeInTheDocument();
+  });
+
+  it('should render batch modification notification with instance count', async () => {
+    mockFetchProcessInstancesStatistics().withSuccess([
+      {
+        flowNodeId: 'userTask',
+        active: 4,
+        canceled: 0,
+        incidents: 0,
+        completed: 0,
+      },
+    ]);
+
+    render(
+      <BatchModificationNotification
+        sourceFlowNodeId="userTask"
+        targetFlowNodeId="endEvent"
+      />,
+      {
+        wrapper: getWrapper(),
+      },
+    );
+
+    expect(await screen.findByText(notificationText2)).toBeInTheDocument();
+    expect(screen.queryByText(notificationText1)).not.toBeInTheDocument();
+  });
+
+  it('should render Undo button if target is selected', async () => {
+    const undoMock = jest.fn();
+
+    mockFetchProcessInstancesStatistics().withSuccess([
+      {
+        flowNodeId: 'userTask',
+        active: 4,
+        canceled: 0,
+        incidents: 0,
+        completed: 0,
+      },
+    ]);
+
+    render(
+      <BatchModificationNotification
+        sourceFlowNodeId="userTask"
+        targetFlowNodeId="endEvent"
+        onUndoClick={undoMock}
+      />,
+      {
+        wrapper: getWrapper(),
+      },
+    );
+
+    expect(await screen.findByText(notificationText2)).toBeInTheDocument();
+    expect(screen.queryByText(notificationText1)).not.toBeInTheDocument();
+
+    const undoButton = screen.getByRole('button', {name: /undo/i});
+    expect(undoButton).toBeInTheDocument();
+
+    undoButton.click();
+    expect(undoMock).toHaveBeenCalled();
+  });
+
+  it('should not render Undo button if no target is selected', async () => {
+    mockFetchProcessInstancesStatistics().withSuccess([
+      {
+        flowNodeId: 'userTask',
+        active: 4,
+        canceled: 0,
+        incidents: 0,
+        completed: 0,
+      },
+    ]);
+
+    render(<BatchModificationNotification sourceFlowNodeId="userTask" />, {
+      wrapper: getWrapper(),
+    });
+
+    expect(screen.getByText(notificationText1)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /undo/i}),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/BatchModificationNotification/v2/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/BatchModificationNotification/v2/index.tsx
@@ -11,6 +11,7 @@ import {useInstancesCount} from 'modules/queries/processInstancesStatistics/useI
 import {processXmlStore} from 'modules/stores/processXml/processXml.list';
 import pluralSuffix from 'modules/utils/pluralSuffix';
 import {Container, InlineNotification, Button} from '../styled';
+import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
 
 type Props = {
   sourceFlowNodeId?: string;
@@ -20,7 +21,16 @@ type Props = {
 
 const BatchModificationNotification: React.FC<Props> = observer(
   ({sourceFlowNodeId, targetFlowNodeId, onUndoClick}) => {
-    const {data: instancesCount = 0} = useInstancesCount(sourceFlowNodeId);
+    const selectedProcessInstanceIds =
+      processInstancesSelectionStore.selectedProcessInstanceIds;
+    const {data: instancesCount = 0} = useInstancesCount(
+      {
+        processInstanceKey: {
+          $in: selectedProcessInstanceIds,
+        },
+      },
+      sourceFlowNodeId,
+    );
 
     const sourceFlowNodeName = sourceFlowNodeId
       ? processXmlStore.getFlowNodeName(sourceFlowNodeId)

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/BatchModificationNotification/v2/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/BatchModificationNotification/v2/index.tsx
@@ -20,9 +20,7 @@ type Props = {
 
 const BatchModificationNotification: React.FC<Props> = observer(
   ({sourceFlowNodeId, targetFlowNodeId, onUndoClick}) => {
-    const {data: instancesCount = 0} = useInstancesCount(
-      sourceFlowNodeId || '',
-    );
+    const {data: instancesCount = 0} = useInstancesCount(sourceFlowNodeId);
 
     const sourceFlowNodeName = sourceFlowNodeId
       ? processXmlStore.getFlowNodeName(sourceFlowNodeId)

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/BatchModificationNotification/v2/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/BatchModificationNotification/v2/index.tsx
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {observer} from 'mobx-react';
+import {useInstancesCount} from 'modules/queries/processInstancesStatistics/useInstancesCount';
+import {processXmlStore} from 'modules/stores/processXml/processXml.list';
+import pluralSuffix from 'modules/utils/pluralSuffix';
+import {Container, InlineNotification, Button} from '../styled';
+
+type Props = {
+  sourceFlowNodeId?: string;
+  targetFlowNodeId?: string;
+  onUndoClick?: () => void;
+};
+
+const BatchModificationNotification: React.FC<Props> = observer(
+  ({sourceFlowNodeId, targetFlowNodeId, onUndoClick}) => {
+    const {data: instancesCount = 0} = useInstancesCount(
+      sourceFlowNodeId || '',
+    );
+
+    const sourceFlowNodeName = sourceFlowNodeId
+      ? processXmlStore.getFlowNodeName(sourceFlowNodeId)
+      : undefined;
+    const targetFlowNodeName = targetFlowNodeId
+      ? processXmlStore.getFlowNodeName(targetFlowNodeId)
+      : undefined;
+
+    return (
+      <Container>
+        <InlineNotification
+          hideCloseButton
+          lowContrast
+          kind="info"
+          title=""
+          subtitle={
+            sourceFlowNodeName === undefined || targetFlowNodeName === undefined
+              ? 'Please select where you want to move the selected instances on the diagram.'
+              : `Modification scheduled: Move ${pluralSuffix(
+                  instancesCount,
+                  'instance',
+                )} from “${sourceFlowNodeName}” to “${targetFlowNodeName}”. Press “Apply Modification” button to confirm.`
+          }
+        />
+        {targetFlowNodeId && onUndoClick && (
+          <Button kind="ghost" size="sm" onClick={onUndoClick}>
+            Undo
+          </Button>
+        )}
+      </Container>
+    );
+  },
+);
+
+export {BatchModificationNotification};

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/index.tsx
@@ -27,7 +27,9 @@ import {isMoveModificationTarget} from 'modules/bpmn-js/utils/isMoveModification
 import {ModificationBadgeOverlay} from 'App/ProcessInstance/TopPanel/ModificationBadgeOverlay';
 import {processStatisticsBatchModificationStore} from 'modules/stores/processStatistics/processStatistics.batchModification';
 import {BatchModificationNotification} from './BatchModificationNotification';
+import {BatchModificationNotification as BatchModificationNotificationV2} from './BatchModificationNotification/v2';
 import {DiagramHeader} from './DiagramHeader';
+import {IS_PROCESS_INSTANCE_STATISTICS_V2_ENABLED} from 'modules/feature-flags';
 
 const OVERLAY_TYPE_BATCH_MODIFICATIONS_BADGE = 'batchModificationsBadge';
 
@@ -231,13 +233,24 @@ const DiagramPanel: React.FC = observer(() => {
           </Diagram>
         )}
       </DiagramShell>
-      {batchModificationStore.state.isEnabled && (
-        <BatchModificationNotification
-          sourceFlowNodeId={flowNodeId}
-          targetFlowNodeId={selectedTargetFlowNodeId || undefined}
-          onUndoClick={() => batchModificationStore.selectTargetFlowNode(null)}
-        />
-      )}
+      {batchModificationStore.state.isEnabled &&
+        (IS_PROCESS_INSTANCE_STATISTICS_V2_ENABLED ? (
+          <BatchModificationNotificationV2
+            sourceFlowNodeId={flowNodeId}
+            targetFlowNodeId={selectedTargetFlowNodeId || undefined}
+            onUndoClick={() =>
+              batchModificationStore.selectTargetFlowNode(null)
+            }
+          />
+        ) : (
+          <BatchModificationNotification
+            sourceFlowNodeId={flowNodeId}
+            targetFlowNodeId={selectedTargetFlowNodeId || undefined}
+            onUndoClick={() =>
+              batchModificationStore.selectTargetFlowNode(null)
+            }
+          />
+        ))}
     </Section>
   );
 });

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/v2/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/v2/index.tsx
@@ -27,6 +27,7 @@ import {BatchModificationNotification} from '../BatchModificationNotification/v2
 import {DiagramHeader} from '../DiagramHeader';
 import {useProcessInstancesOverlayData} from 'modules/queries/processInstancesStatistics/useOverlayData';
 import {useBatchModificationOverlayData} from 'modules/queries/processInstancesStatistics/useBatchModificationOverlayData';
+import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
 
 const OVERLAY_TYPE_BATCH_MODIFICATIONS_BADGE = 'batchModificationsBadge';
 
@@ -60,6 +61,9 @@ const DiagramPanel: React.FC = observer(() => {
 
   const processDetails = processesStore.getSelectedProcessDetails();
   const {processName} = processDetails;
+
+  const selectedProcessInstanceIds =
+    processInstancesSelectionStore.selectedProcessInstanceIds;
 
   const statisticsOverlays = diagramOverlaysStore.state.overlays.filter(
     ({type}) => type.match(/^statistics/) !== null,
@@ -108,7 +112,11 @@ const DiagramPanel: React.FC = observer(() => {
   );
 
   const {data: batchOverlayData} = useBatchModificationOverlayData(
-    {},
+    {
+      processInstanceKey: {
+        $in: selectedProcessInstanceIds,
+      },
+    },
     {
       sourceFlowNodeId: flowNodeId,
       targetFlowNodeId: selectedTargetFlowNodeId ?? undefined,

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/v2/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/v2/index.tsx
@@ -23,7 +23,7 @@ import {processXmlStore} from 'modules/stores/processXml/processXml.list';
 import {batchModificationStore} from 'modules/stores/batchModification';
 import {isMoveModificationTarget} from 'modules/bpmn-js/utils/isMoveModificationTarget';
 import {ModificationBadgeOverlay} from 'App/ProcessInstance/TopPanel/ModificationBadgeOverlay';
-import {BatchModificationNotification} from '../BatchModificationNotification';
+import {BatchModificationNotification} from '../BatchModificationNotification/v2';
 import {DiagramHeader} from '../DiagramHeader';
 import {useProcessInstancesOverlayData} from 'modules/queries/processInstancesStatistics/useOverlayData';
 import {useBatchModificationOverlayData} from 'modules/queries/processInstancesStatistics/useBatchModificationOverlayData';

--- a/operate/client/src/modules/queries/processInstancesStatistics/useBatchModificationOverlayData.ts
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useBatchModificationOverlayData.ts
@@ -13,6 +13,7 @@ import {
 import {MODIFICATIONS} from 'modules/bpmn-js/badgePositions';
 import {useProcessInstancesStatistics} from './useProcessInstancesStatistics';
 import {OverlayData} from 'modules/bpmn-js/BpmnJS';
+import {getInstancesCount} from './useInstancesCount';
 
 function batchModificationOverlayParser(params: {
   sourceFlowNodeId?: string;
@@ -28,27 +29,17 @@ function batchModificationOverlayParser(params: {
       return [];
     }
 
-    function getInstancesCount(flowNodeId?: string) {
-      const flowNodeStatistics = data.find(
-        (statistics) => statistics.flowNodeId === flowNodeId,
-      );
-
-      if (flowNodeStatistics === undefined) {
-        return 0;
-      }
-
-      return flowNodeStatistics.active + flowNodeStatistics.incidents;
-    }
-
     return [
       {
-        payload: {cancelledTokenCount: getInstancesCount(sourceFlowNodeId)},
+        payload: {
+          cancelledTokenCount: getInstancesCount(data, sourceFlowNodeId),
+        },
         type: 'batchModificationsBadge',
         flowNodeId: sourceFlowNodeId,
         position: MODIFICATIONS,
       },
       {
-        payload: {newTokenCount: getInstancesCount(sourceFlowNodeId)},
+        payload: {newTokenCount: getInstancesCount(data, sourceFlowNodeId)},
         type: 'batchModificationsBadge',
         flowNodeId: targetFlowNodeId,
         position: MODIFICATIONS,

--- a/operate/client/src/modules/queries/processInstancesStatistics/useBatchModificationOverlayData.ts
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useBatchModificationOverlayData.ts
@@ -13,7 +13,7 @@ import {
 import {MODIFICATIONS} from 'modules/bpmn-js/badgePositions';
 import {useProcessInstancesStatistics} from './useProcessInstancesStatistics';
 import {OverlayData} from 'modules/bpmn-js/BpmnJS';
-import {getInstancesCount} from './useInstancesCount';
+import {getInstancesCount} from 'modules/utils/statistics/processInstances';
 
 function batchModificationOverlayParser(params: {
   sourceFlowNodeId?: string;

--- a/operate/client/src/modules/queries/processInstancesStatistics/useInstancesCount.ts
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useInstancesCount.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {ProcessInstancesStatisticsDto} from 'modules/api/v2/processInstances/fetchProcessInstancesStatistics';
+import {useProcessInstancesStatistics} from './useProcessInstancesStatistics';
+
+function getInstancesCount(
+  data: ProcessInstancesStatisticsDto[],
+  flowNodeId: string,
+) {
+  const flowNodeStatistics = data.find(
+    (statistics) => statistics.flowNodeId === flowNodeId,
+  );
+
+  if (flowNodeStatistics === undefined) {
+    return 0;
+  }
+
+  return flowNodeStatistics.active + flowNodeStatistics.incidents;
+}
+
+function instancesCountParser(
+  flowNodeId: string,
+): (data: ProcessInstancesStatisticsDto[]) => number {
+  return (data: ProcessInstancesStatisticsDto[]) => {
+    return getInstancesCount(data, flowNodeId);
+  };
+}
+
+function useInstancesCount(flowNodeId: string) {
+  return useProcessInstancesStatistics<number>(
+    {flowNodeId: flowNodeId},
+    instancesCountParser(flowNodeId),
+    flowNodeId !== '',
+  );
+}
+
+export {getInstancesCount, useInstancesCount};

--- a/operate/client/src/modules/queries/processInstancesStatistics/useInstancesCount.ts
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useInstancesCount.ts
@@ -6,7 +6,10 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {ProcessInstancesStatisticsDto} from 'modules/api/v2/processInstances/fetchProcessInstancesStatistics';
+import {
+  ProcessInstancesStatisticsDto,
+  ProcessInstancesStatisticsRequest,
+} from 'modules/api/v2/processInstances/fetchProcessInstancesStatistics';
 import {useProcessInstancesStatistics} from './useProcessInstancesStatistics';
 import {getInstancesCount} from 'modules/utils/statistics/processInstances';
 
@@ -18,9 +21,12 @@ function instancesCountParser(
   };
 }
 
-function useInstancesCount(flowNodeId?: string) {
+function useInstancesCount(
+  payload: ProcessInstancesStatisticsRequest,
+  flowNodeId?: string,
+) {
   return useProcessInstancesStatistics<number>(
-    {flowNodeId: flowNodeId},
+    payload,
     instancesCountParser(flowNodeId),
     !!flowNodeId,
   );

--- a/operate/client/src/modules/queries/processInstancesStatistics/useInstancesCount.ts
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useInstancesCount.ts
@@ -8,36 +8,22 @@
 
 import {ProcessInstancesStatisticsDto} from 'modules/api/v2/processInstances/fetchProcessInstancesStatistics';
 import {useProcessInstancesStatistics} from './useProcessInstancesStatistics';
-
-function getInstancesCount(
-  data: ProcessInstancesStatisticsDto[],
-  flowNodeId: string,
-) {
-  const flowNodeStatistics = data.find(
-    (statistics) => statistics.flowNodeId === flowNodeId,
-  );
-
-  if (flowNodeStatistics === undefined) {
-    return 0;
-  }
-
-  return flowNodeStatistics.active + flowNodeStatistics.incidents;
-}
+import {getInstancesCount} from 'modules/utils/statistics/processInstances';
 
 function instancesCountParser(
-  flowNodeId: string,
+  flowNodeId?: string,
 ): (data: ProcessInstancesStatisticsDto[]) => number {
   return (data: ProcessInstancesStatisticsDto[]) => {
     return getInstancesCount(data, flowNodeId);
   };
 }
 
-function useInstancesCount(flowNodeId: string) {
+function useInstancesCount(flowNodeId?: string) {
   return useProcessInstancesStatistics<number>(
     {flowNodeId: flowNodeId},
     instancesCountParser(flowNodeId),
-    flowNodeId !== '',
+    !!flowNodeId,
   );
 }
 
-export {getInstancesCount, useInstancesCount};
+export {useInstancesCount};

--- a/operate/client/src/modules/utils/statistics/processInstances.test.ts
+++ b/operate/client/src/modules/utils/statistics/processInstances.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {getInstancesCount} from './processInstances';
+import {ProcessInstancesStatisticsDto} from 'modules/api/v2/processInstances/fetchProcessInstancesStatistics';
+
+describe('getInstancesCount', () => {
+  it('should return the correct count of active and incident instances for a given flowNodeId', () => {
+    const data: ProcessInstancesStatisticsDto[] = [
+      {
+        flowNodeId: 'node1',
+        active: 5,
+        incidents: 2,
+        canceled: 0,
+        completed: 0,
+      },
+      {
+        flowNodeId: 'node2',
+        active: 3,
+        incidents: 1,
+        canceled: 0,
+        completed: 0,
+      },
+    ];
+
+    expect(getInstancesCount(data, 'node1')).toBe(7);
+    expect(getInstancesCount(data, 'node2')).toBe(4);
+  });
+
+  it('should return 0 if the flowNodeId is not found in the data', () => {
+    const data: ProcessInstancesStatisticsDto[] = [
+      {
+        flowNodeId: 'node1',
+        active: 5,
+        incidents: 2,
+        canceled: 0,
+        completed: 0,
+      },
+    ];
+
+    expect(getInstancesCount(data, 'node2')).toBe(0);
+  });
+
+  it('should return 0 if the data is empty', () => {
+    const data: ProcessInstancesStatisticsDto[] = [];
+
+    expect(getInstancesCount(data, 'node1')).toBe(0);
+  });
+});

--- a/operate/client/src/modules/utils/statistics/processInstances.ts
+++ b/operate/client/src/modules/utils/statistics/processInstances.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {ProcessInstancesStatisticsDto} from 'modules/api/v2/processInstances/fetchProcessInstancesStatistics';
+
+function getInstancesCount(
+  data: ProcessInstancesStatisticsDto[],
+  flowNodeId: string | undefined,
+) {
+  const flowNodeStatistics = data.find(
+    (statistics) => statistics.flowNodeId === flowNodeId,
+  );
+
+  if (flowNodeStatistics === undefined) {
+    return 0;
+  }
+
+  return flowNodeStatistics.active + flowNodeStatistics.incidents;
+}
+
+export {getInstancesCount};

--- a/operate/client/yarn.lock
+++ b/operate/client/yarn.lock
@@ -2689,6 +2689,11 @@
   dependencies:
     "@typescript-eslint/utils" "^8.18.1"
 
+"@tanstack/query-core@5.67.2":
+  version "5.67.2"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.67.2.tgz#3d59a7dd3613321465925975510c0bb8e603a064"
+  integrity sha512-+iaFJ/pt8TaApCk6LuZ0WHS/ECVfTzrxDOEL9HH9Dayyb5OVuomLzDXeSaI2GlGT/8HN7bDGiRXDts3LV+u6ww==
+
 "@tanstack/query-devtools@5.65.0":
   version "5.65.0"
   resolved "https://registry.yarnpkg.com/@tanstack/query-devtools/-/query-devtools-5.65.0.tgz#37da5e911543b4f6d98b9a04369eab0de6044ba1"


### PR DESCRIPTION
## Description

This PR creates a v2 component to display PI statistics data on the `BatchModificationNotification`.
Most of the component and tests logic is similar to V1, the main differences are the introduction of TanStack Query.

Here's a screen recording showing the app with V2 diagram panel

https://github.com/user-attachments/assets/28b9d98d-592c-4d36-a88c-9457739f4ccb

It's worth noting the mocked data returns 20 active instances which is why the message currently displays "Move 20 instance".

## Related issues

closes #29284