### PR TITLE
test: avoid concurrent modification error

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/observability/MetricsConfigurationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/observability/MetricsConfigurationIT.java
@@ -18,8 +18,8 @@ import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import io.micrometer.registry.otlp.OtlpMeterRegistry;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -59,7 +59,7 @@ final class MetricsConfigurationIT {
   @SuppressWarnings("resource")
   @Nested
   final class OtlpIT {
-    private final List<String> logLines = new ArrayList<>();
+    private final List<String> logLines = new CopyOnWriteArrayList<>();
 
     @Container
     private final GenericContainer<?> otelCollector =


### PR DESCRIPTION
## Description

This PR fixes a flaky test due to using an array to collect data that gets modified across thread boundaries. The fix is just to use a `CopyOnWriteArrayList`.
