### PR TITLE
[CPT] feat: Optimize collector

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
@@ -18,6 +18,7 @@ package io.camunda.process.test.impl.assertions;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.SearchRequestPage;
 import io.camunda.client.api.search.filter.FlownodeInstanceFilter;
+import io.camunda.client.api.search.filter.IncidentFilter;
 import io.camunda.client.api.search.filter.ProcessInstanceFilter;
 import io.camunda.client.api.search.response.FlowNodeInstance;
 import io.camunda.client.api.search.response.Incident;
@@ -78,10 +79,10 @@ public class CamundaDataSource {
         .items();
   }
 
-  public List<Incident> findIncidentsByProcessInstanceKey(final long processInstanceKey) {
+  public List<Incident> findIncidents(final Consumer<IncidentFilter> filter) {
     return client
         .newIncidentQuery()
-        .filter(filter -> filter.processInstanceKey(processInstanceKey))
+        .filter(filter)
         .sort(sort -> sort.creationTime().asc())
         .page(DEFAULT_PAGE_REQUEST)
         .send()

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultCollector.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultCollector.java
@@ -77,15 +77,13 @@ public class CamundaProcessTestResultCollector {
   }
 
   private List<Incident> collectOpenIncidents(final long processInstanceKey) {
-    return dataSource.findIncidentsByProcessInstanceKey(processInstanceKey).stream()
-        .filter(incident -> incident.getState().equals(IncidentState.ACTIVE))
-        .collect(Collectors.toList());
+    return dataSource.findIncidents(
+        filter -> filter.processInstanceKey(processInstanceKey).state(IncidentState.ACTIVE));
   }
 
   private List<FlowNodeInstance> collectActiveFlowNodeInstances(final long processInstanceKey) {
-    return dataSource.findFlowNodeInstancesByProcessInstanceKey(processInstanceKey).stream()
-        .filter(
-            flowNodeInstance -> flowNodeInstance.getState().equals(FlowNodeInstanceState.ACTIVE))
-        .collect(Collectors.toList());
+    return dataSource.findFlowNodeInstances(
+        filter ->
+            filter.processInstanceKey(processInstanceKey).state(FlowNodeInstanceState.ACTIVE));
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultCollector.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultCollector.java
@@ -62,8 +62,7 @@ public class CamundaProcessTestResultCollector {
 
     final long processInstanceKey = processInstance.getProcessInstanceKey();
 
-    result.setProcessInstanceKey(processInstanceKey);
-    result.setProcessId(processInstance.getProcessDefinitionId());
+    result.setProcessInstance(processInstance);
     result.setVariables(collectVariables(processInstanceKey));
     result.setOpenIncidents(collectOpenIncidents(processInstanceKey));
     result.setActiveFlowNodeInstances(collectActiveFlowNodeInstances(processInstanceKey));

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultPrinter.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultPrinter.java
@@ -61,8 +61,10 @@ public class CamundaProcessTestResultPrinter {
 
     final String formattedProcessInstance =
         String.format(
-            "Process instance: %d [process-id: '%s']",
-            processInstance.getProcessInstanceKey(), processInstance.getProcessDefinitionId());
+            "Process instance: %d [process-id: '%s', state: %s]",
+            processInstance.getProcessInstanceKey(),
+            processInstance.getProcessDefinitionId(),
+            processInstance.getState().name().toLowerCase());
 
     return formattedProcessInstance
         + "\n\n"

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultPrinter.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultPrinter.java
@@ -17,6 +17,7 @@ package io.camunda.process.test.impl.testresult;
 
 import io.camunda.client.api.search.response.FlowNodeInstance;
 import io.camunda.client.api.search.response.Incident;
+import io.camunda.client.api.search.response.ProcessInstance;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -56,10 +57,12 @@ public class CamundaProcessTestResultPrinter {
   }
 
   private static String formatProcessInstance(final ProcessInstanceResult result) {
+    final ProcessInstance processInstance = result.getProcessInstance();
+
     final String formattedProcessInstance =
         String.format(
             "Process instance: %d [process-id: '%s']",
-            result.getProcessInstanceKey(), result.getProcessId());
+            processInstance.getProcessInstanceKey(), processInstance.getProcessDefinitionId());
 
     return formattedProcessInstance
         + "\n\n"

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/ProcessInstanceResult.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/ProcessInstanceResult.java
@@ -17,6 +17,7 @@ package io.camunda.process.test.impl.testresult;
 
 import io.camunda.client.api.search.response.FlowNodeInstance;
 import io.camunda.client.api.search.response.Incident;
+import io.camunda.client.api.search.response.ProcessInstance;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -24,8 +25,7 @@ import java.util.Map;
 
 public class ProcessInstanceResult {
 
-  private long processInstanceKey;
-  private String processId;
+  private ProcessInstance processInstance;
 
   private Map<String, String> variables = new HashMap<>();
 
@@ -33,20 +33,12 @@ public class ProcessInstanceResult {
 
   private List<FlowNodeInstance> activeFlowNodeInstances = new ArrayList<>();
 
-  public long getProcessInstanceKey() {
-    return processInstanceKey;
+  public ProcessInstance getProcessInstance() {
+    return processInstance;
   }
 
-  public void setProcessInstanceKey(final long processInstanceKey) {
-    this.processInstanceKey = processInstanceKey;
-  }
-
-  public String getProcessId() {
-    return processId;
-  }
-
-  public void setProcessId(final String processId) {
-    this.processId = processId;
+  public void setProcessInstance(final ProcessInstance processInstance) {
+    this.processInstance = processInstance;
   }
 
   public Map<String, String> getVariables() {

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultCollectorTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultCollectorTest.java
@@ -99,8 +99,8 @@ public class CamundaProcessResultCollectorTest {
     // then
     assertThat(result.getProcessInstanceTestResults())
         .hasSize(2)
-        .extracting(
-            ProcessInstanceResult::getProcessInstanceKey, ProcessInstanceResult::getProcessId)
+        .extracting(ProcessInstanceResult::getProcessInstance)
+        .extracting(ProcessInstance::getProcessInstanceKey, ProcessInstance::getProcessDefinitionId)
         .contains(tuple(1L, "process-a"), tuple(2L, "process-b"));
 
     assertThat(result.getProcessInstanceTestResults())

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultCollectorTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultCollectorTest.java
@@ -17,6 +17,7 @@ package io.camunda.process.test.impl.testresult;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
@@ -160,23 +161,6 @@ public class CamundaProcessResultCollectorTest {
             .setIncidentKey(11L)
             .build();
 
-    when(camundaDataSource.findFlowNodeInstancesByProcessInstanceKey(
-            PROCESS_INSTANCE_1.getProcessInstanceKey()))
-        .thenReturn(Arrays.asList(flowNodeInstance1, flowNodeInstance2));
-
-    when(camundaDataSource.findIncidentsByProcessInstanceKey(
-            PROCESS_INSTANCE_1.getProcessInstanceKey()))
-        .thenReturn(
-            Arrays.asList(
-                IncidentBuilder.newActiveIncident(
-                        IncidentErrorType.JOB_NO_RETRIES, "No retries left.")
-                    .setFlowNodeId("A")
-                    .build(),
-                IncidentBuilder.newActiveIncident(
-                        IncidentErrorType.EXTRACT_VALUE_ERROR, "Failed to evaluate expression.")
-                    .setFlowNodeId("B")
-                    .build()));
-
     final FlowNodeInstance flowNodeInstance3 =
         FlowNodeInstanceBuilder.newActiveFlowNodeInstance(
                 "C", PROCESS_INSTANCE_2.getProcessInstanceKey())
@@ -190,12 +174,21 @@ public class CamundaProcessResultCollectorTest {
             .setIncident(false)
             .build();
 
-    when(camundaDataSource.findFlowNodeInstancesByProcessInstanceKey(
-            PROCESS_INSTANCE_2.getProcessInstanceKey()))
+    when(camundaDataSource.findFlowNodeInstances(any()))
+        .thenReturn(Arrays.asList(flowNodeInstance1, flowNodeInstance2))
         .thenReturn(Arrays.asList(flowNodeInstance3, flowNodeInstance4));
 
-    when(camundaDataSource.findIncidentsByProcessInstanceKey(
-            PROCESS_INSTANCE_2.getProcessInstanceKey()))
+    when(camundaDataSource.findIncidents(any()))
+        .thenReturn(
+            Arrays.asList(
+                IncidentBuilder.newActiveIncident(
+                        IncidentErrorType.JOB_NO_RETRIES, "No retries left.")
+                    .setFlowNodeId("A")
+                    .build(),
+                IncidentBuilder.newActiveIncident(
+                        IncidentErrorType.EXTRACT_VALUE_ERROR, "Failed to evaluate expression.")
+                    .setFlowNodeId("B")
+                    .build()))
         .thenReturn(
             Collections.singletonList(
                 IncidentBuilder.newActiveIncident(
@@ -229,8 +222,7 @@ public class CamundaProcessResultCollectorTest {
     when(camundaDataSource.findProcessInstances())
         .thenReturn(Arrays.asList(PROCESS_INSTANCE_1, PROCESS_INSTANCE_2));
 
-    when(camundaDataSource.findFlowNodeInstancesByProcessInstanceKey(
-            PROCESS_INSTANCE_1.getProcessInstanceKey()))
+    when(camundaDataSource.findFlowNodeInstances(any()))
         .thenReturn(
             Arrays.asList(
                 FlowNodeInstanceBuilder.newActiveFlowNodeInstance(
@@ -238,16 +230,13 @@ public class CamundaProcessResultCollectorTest {
                     .build(),
                 FlowNodeInstanceBuilder.newActiveFlowNodeInstance(
                         "B", PROCESS_INSTANCE_1.getProcessInstanceKey())
-                    .build()));
-
-    when(camundaDataSource.findFlowNodeInstancesByProcessInstanceKey(
-            PROCESS_INSTANCE_2.getProcessInstanceKey()))
+                    .build()))
         .thenReturn(
             Arrays.asList(
                 FlowNodeInstanceBuilder.newActiveFlowNodeInstance(
                         "C", PROCESS_INSTANCE_2.getProcessInstanceKey())
                     .build(),
-                FlowNodeInstanceBuilder.newCompletedFlowNodeInstance(
+                FlowNodeInstanceBuilder.newActiveFlowNodeInstance(
                         "D", PROCESS_INSTANCE_2.getProcessInstanceKey())
                     .build()));
 
@@ -263,8 +252,8 @@ public class CamundaProcessResultCollectorTest {
         .contains(tuple("A", "element_A"), tuple("B", "element_B"));
 
     assertThat(result.getProcessInstanceTestResults().get(1).getActiveFlowNodeInstances())
-        .hasSize(1)
+        .hasSize(2)
         .extracting(FlowNodeInstance::getFlowNodeId, FlowNodeInstance::getFlowNodeName)
-        .contains(tuple("C", "element_C"));
+        .contains(tuple("C", "element_C"), tuple("D", "element_D"));
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultPrinterTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultPrinterTest.java
@@ -56,8 +56,18 @@ public class CamundaProcessResultPrinterTest {
   void shouldPrintProcessInstances() {
     // given
     final ProcessTestResult processTestResult = new ProcessTestResult();
-    final ProcessInstanceResult processInstance1 = newProcessInstance(1L, "process-a");
-    final ProcessInstanceResult processInstance2 = newProcessInstance(2L, "process-b");
+
+    final ProcessInstanceResult processInstance1 = new ProcessInstanceResult();
+    processInstance1.setProcessInstance(
+        ProcessInstanceBuilder.newActiveProcessInstance(1L)
+            .setProcessDefinitionId("process-a")
+            .build());
+
+    final ProcessInstanceResult processInstance2 = new ProcessInstanceResult();
+    processInstance2.setProcessInstance(
+        ProcessInstanceBuilder.newCompletedProcessInstance(2L)
+            .setProcessDefinitionId("process-b")
+            .build());
 
     processTestResult.setProcessInstanceTestResults(
         Arrays.asList(processInstance1, processInstance2));
@@ -75,7 +85,7 @@ public class CamundaProcessResultPrinterTest {
             "Process test results:\n"
                 + "=====================\n"
                 + "\n"
-                + "Process instance: 1 [process-id: 'process-a']\n"
+                + "Process instance: 1 [process-id: 'process-a', state: active]\n"
                 + "\n"
                 + "Active elements:\n"
                 + "<None>\n"
@@ -87,7 +97,7 @@ public class CamundaProcessResultPrinterTest {
                 + "<None>\n"
                 + "---------------------\n"
                 + "\n"
-                + "Process instance: 2 [process-id: 'process-b']\n"
+                + "Process instance: 2 [process-id: 'process-b', state: completed]\n"
                 + "\n"
                 + "Active elements:\n"
                 + "<None>\n"
@@ -128,10 +138,10 @@ public class CamundaProcessResultPrinterTest {
     // then
     assertThat(outputBuilder.toString())
         .containsSubsequence(
-            "Process instance: 1 [process-id: 'process-a']\n",
+            "Process instance: 1 [process-id: 'process-a', state: active]\n",
             "Variables:\n",
             "- 'var-1': 1\n",
-            "Process instance: 2 [process-id: 'process-b']\n",
+            "Process instance: 2 [process-id: 'process-b', state: active]\n",
             "Variables:\n",
             "- 'var-2': 2\n");
   }
@@ -173,11 +183,11 @@ public class CamundaProcessResultPrinterTest {
     // then
     assertThat(outputBuilder.toString())
         .containsSubsequence(
-            "Process instance: 1 [process-id: 'process-a']\n",
+            "Process instance: 1 [process-id: 'process-a', state: active]\n",
             "Open incidents:\n",
             "- 'task-a' [type: JOB_NO_RETRIES] \"No retries left.\"\n",
             "- 'task-b' [type: EXTRACT_VALUE_ERROR] \"Failed to evaluate expression.\"\n",
-            "Process instance: 2 [process-id: 'process-b']\n",
+            "Process instance: 2 [process-id: 'process-b', state: active]\n",
             "Open incidents:\n",
             "- 'task-c' [type: UNHANDLED_ERROR_EVENT] \"No error catch event found.\"\n");
   }
@@ -214,11 +224,11 @@ public class CamundaProcessResultPrinterTest {
     // then
     assertThat(outputBuilder.toString())
         .containsSubsequence(
-            "Process instance: 1 [process-id: 'process-a']\n",
+            "Process instance: 1 [process-id: 'process-a', state: active]\n",
             "Active elements:\n",
             "- 'A' [name: 'element_A']\n",
             "- 'B' [name: 'element_B']\n",
-            "Process instance: 2 [process-id: 'process-b']\n",
+            "Process instance: 2 [process-id: 'process-b', state: active]\n",
             "Active elements:\n",
             "- 'C' [name: 'element_C']\n",
             "- 'D' [name: '']\n");

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultPrinterTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultPrinterTest.java
@@ -18,8 +18,10 @@ package io.camunda.process.test.impl.testresult;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.api.search.response.IncidentErrorType;
+import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.process.test.utils.FlowNodeInstanceBuilder;
 import io.camunda.process.test.utils.IncidentBuilder;
+import io.camunda.process.test.utils.ProcessInstanceBuilder;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -278,9 +280,12 @@ public class CamundaProcessResultPrinterTest {
 
   private static ProcessInstanceResult newProcessInstance(
       final long processInstanceKey, final String processId) {
-    final ProcessInstanceResult processInstance = new ProcessInstanceResult();
-    processInstance.setProcessInstanceKey(processInstanceKey);
-    processInstance.setProcessId(processId);
-    return processInstance;
+    final ProcessInstanceResult processInstanceResult = new ProcessInstanceResult();
+    final ProcessInstance processInstance =
+        ProcessInstanceBuilder.newActiveProcessInstance(processInstanceKey)
+            .setProcessDefinitionId(processId)
+            .build();
+    processInstanceResult.setProcessInstance(processInstance);
+    return processInstanceResult;
   }
 }


### PR DESCRIPTION
## Description

- feat: Limit the flow node instances and incidents search queries in the result collector
- feat: Print the process instance state with the result
- refactoring: Add the process instance DTO to the result object to bundle process instance data

## Related issues

follow-up of https://github.com/camunda/camunda/pull/28822

related to https://github.com/camunda/camunda/issues/19263
