### PR TITLE
feat: migrate InstancesTable component to v2

### DIFF
--- a/operate/client/src/App/Processes/ListView/DiagramPanel/v2/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/v2/index.tsx
@@ -27,7 +27,6 @@ import {BatchModificationNotification} from '../BatchModificationNotification/v2
 import {DiagramHeader} from '../DiagramHeader';
 import {useProcessInstancesOverlayData} from 'modules/queries/processInstancesStatistics/useOverlayData';
 import {useBatchModificationOverlayData} from 'modules/queries/processInstancesStatistics/useBatchModificationOverlayData';
-import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
 
 const OVERLAY_TYPE_BATCH_MODIFICATIONS_BADGE = 'batchModificationsBadge';
 
@@ -61,9 +60,6 @@ const DiagramPanel: React.FC = observer(() => {
 
   const processDetails = processesStore.getSelectedProcessDetails();
   const {processName} = processDetails;
-
-  const selectedProcessInstanceIds =
-    processInstancesSelectionStore.selectedProcessInstanceIds;
 
   const statisticsOverlays = diagramOverlaysStore.state.overlays.filter(
     ({type}) => type.match(/^statistics/) !== null,
@@ -112,11 +108,7 @@ const DiagramPanel: React.FC = observer(() => {
   );
 
   const {data: batchOverlayData} = useBatchModificationOverlayData(
-    {
-      processInstanceKey: {
-        $in: selectedProcessInstanceIds,
-      },
-    },
+    {},
     {
       sourceFlowNodeId: flowNodeId,
       targetFlowNodeId: selectedTargetFlowNodeId ?? undefined,

--- a/operate/client/src/App/Processes/ListView/InstancesTable/v2/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/v2/index.test.tsx
@@ -1,0 +1,169 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen, within} from 'modules/testing-library';
+import {InstancesTable} from '.';
+import {unstable_HistoryRouter as HistoryRouter} from 'react-router-dom';
+import {Paths} from 'modules/Routes';
+import {batchModificationStore} from 'modules/stores/batchModification';
+import {useEffect} from 'react';
+import {createMemoryHistory} from 'history';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {processInstancesStore} from 'modules/stores/processInstances';
+import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
+import {processesStore} from 'modules/stores/processes/processes.list';
+import {mockFetchProcessInstancesStatistics} from 'modules/mocks/api/v2/processInstances/fetchProcessInstancesStatistics';
+import {mockFetchProcessInstances} from 'modules/mocks/api/processInstances/fetchProcessInstances';
+import {mockFetchGroupedProcesses} from 'modules/mocks/api/processes/fetchGroupedProcesses';
+import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
+import {
+  groupedProcessesMock,
+  mockProcessInstances,
+  mockProcessStatisticsV2 as mockProcessStatistics,
+} from 'modules/testUtils';
+
+jest.mock('modules/utils/bpmn');
+
+function getWrapper(initialPath: string = Paths.processes()) {
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
+    useEffect(() => {
+      return () => {
+        processInstancesStore.reset();
+        processInstancesSelectionStore.reset();
+        processesStore.reset();
+        batchModificationStore.reset();
+      };
+    }, []);
+
+    return (
+      <QueryClientProvider client={getMockQueryClient()}>
+        <HistoryRouter
+          history={createMemoryHistory({
+            initialEntries: [initialPath],
+          })}
+        >
+          {children}
+          <button onClick={batchModificationStore.enable}>
+            Enable batch modification mode
+          </button>
+        </HistoryRouter>
+      </QueryClientProvider>
+    );
+  };
+
+  return Wrapper;
+}
+
+describe('<InstancesTable />', () => {
+  const locationSpy = jest.spyOn(window, 'location', 'get');
+
+  beforeEach(() => {
+    mockFetchProcessInstances().withSuccess(mockProcessInstances);
+    mockFetchGroupedProcesses().withSuccess(groupedProcessesMock);
+    mockFetchProcessInstancesStatistics().withSuccess(mockProcessStatistics);
+    mockFetchProcessXML().withSuccess('');
+
+    processesStore.fetchProcesses();
+  });
+
+  afterEach(() => {
+    locationSpy.mockClear();
+  });
+
+  it.each(['all', undefined])(
+    'should show tenant column when multi tenancy is enabled and tenant filter is %p',
+    async (tenant) => {
+      window.clientConfig = {
+        multiTenancyEnabled: true,
+      };
+
+      render(<InstancesTable />, {
+        wrapper: getWrapper(
+          `${Paths.processes()}?${new URLSearchParams(
+            tenant === undefined ? undefined : {tenant},
+          )}`,
+        ),
+      });
+
+      expect(
+        screen.getByRole('columnheader', {name: 'Tenant'}),
+      ).toBeInTheDocument();
+
+      window.clientConfig = undefined;
+    },
+  );
+
+  it('should hide tenant column when multi tenancy is enabled and tenant filter is a specific tenant', async () => {
+    window.clientConfig = {
+      multiTenancyEnabled: true,
+    };
+
+    render(<InstancesTable />, {
+      wrapper: getWrapper(
+        `${Paths.processes()}?${new URLSearchParams({tenant: 'tenant-a'})}`,
+      ),
+    });
+
+    expect(
+      screen.queryByRole('columnheader', {name: 'Tenant'}),
+    ).not.toBeInTheDocument();
+
+    window.clientConfig = undefined;
+  });
+
+  it('should hide tenant column when multi tenancy is disabled', async () => {
+    render(<InstancesTable />, {
+      wrapper: getWrapper(
+        `${Paths.processes()}?${new URLSearchParams({tenant: 'all'})}`,
+      ),
+    });
+
+    expect(
+      screen.queryByRole('columnheader', {name: 'Tenant'}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should render batch modification footer', async () => {
+    const {user} = render(<InstancesTable />, {wrapper: getWrapper()});
+
+    await user.click(
+      screen.getByRole('button', {name: /enable batch modification mode/i}),
+    );
+
+    expect(batchModificationStore.state.isEnabled).toBe(true);
+    expect(
+      screen.getByRole('button', {name: /apply modification/i}),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', {name: /exit/i}));
+
+    await user.click(
+      within(screen.getByRole('dialog')).getByRole('button', {name: /exit/i}),
+    );
+
+    expect(batchModificationStore.state.isEnabled).toBe(false);
+    expect(
+      screen.queryByRole('button', {name: /apply modification/i}),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /exit/i}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should display empty state message when there are no process instances', async () => {
+    processInstancesStore.state.processInstances = [];
+    processInstancesStore.state.status = 'fetched';
+
+    render(<InstancesTable />, {wrapper: getWrapper()});
+
+    expect(
+      screen.getByText('There are no Instances matching this filter set'),
+    ).toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/Processes/ListView/InstancesTable/v2/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/v2/index.test.tsx
@@ -18,15 +18,10 @@ import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
 import {processInstancesStore} from 'modules/stores/processInstances';
 import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
 import {processesStore} from 'modules/stores/processes/processes.list';
-import {mockFetchProcessInstancesStatistics} from 'modules/mocks/api/v2/processInstances/fetchProcessInstancesStatistics';
 import {mockFetchProcessInstances} from 'modules/mocks/api/processInstances/fetchProcessInstances';
 import {mockFetchGroupedProcesses} from 'modules/mocks/api/processes/fetchGroupedProcesses';
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
-import {
-  groupedProcessesMock,
-  mockProcessInstances,
-  mockProcessStatisticsV2 as mockProcessStatistics,
-} from 'modules/testUtils';
+import {groupedProcessesMock, mockProcessInstances} from 'modules/testUtils';
 
 jest.mock('modules/utils/bpmn');
 
@@ -66,7 +61,6 @@ describe('<InstancesTable />', () => {
   beforeEach(() => {
     mockFetchProcessInstances().withSuccess(mockProcessInstances);
     mockFetchGroupedProcesses().withSuccess(groupedProcessesMock);
-    mockFetchProcessInstancesStatistics().withSuccess(mockProcessStatistics);
     mockFetchProcessXML().withSuccess('');
 
     processesStore.fetchProcesses();

--- a/operate/client/src/App/Processes/ListView/InstancesTable/v2/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/v2/index.tsx
@@ -34,10 +34,6 @@ import {useLocation} from 'react-router-dom';
 import {Operations} from 'modules/components/Operations';
 import {BatchModificationFooter} from '../BatchModificationFooter';
 import {getProcessInstancesRequestFilters} from 'modules/utils/filter';
-import {usePrefetchProcessInstancesStatistics} from 'modules/queries/processInstancesStatistics/useProcessInstancesStatistics';
-import {useProcessInstanceFilters} from 'modules/hooks/useProcessInstancesFilters';
-import {ProcessInstanceState} from 'modules/api/v2/processInstances/fetchProcessInstancesStatistics';
-import {useMemo} from 'react';
 
 const ROW_HEIGHT = 34;
 
@@ -46,7 +42,6 @@ const InstancesTable: React.FC = observer(() => {
     areProcessInstancesEmpty,
     state: {status, filteredProcessInstancesCount, processInstances},
   } = processInstancesStore;
-  const processInstanceFilters = useProcessInstanceFilters();
 
   /**
    * Is true if at least one process instances from the store has a version tag.
@@ -87,48 +82,6 @@ const InstancesTable: React.FC = observer(() => {
 
     return 'content';
   };
-
-  const {
-    selectedProcessInstanceIds,
-    excludedProcessInstanceIds,
-    state: {selectionMode},
-  } = processInstancesSelectionStore;
-
-  const isBatchModificationEnabled = batchModificationStore.state.isEnabled;
-
-  const requestFilterParameters = useMemo(() => {
-    if (!isBatchModificationEnabled) {
-      return null;
-    }
-
-    const filteredIds = processInstanceFilters.processInstanceKey?.$in;
-    const ids = ['EXCLUDE', 'ALL'].includes(selectionMode)
-      ? (filteredIds ?? [])
-      : selectedProcessInstanceIds;
-    const stateFilters: ProcessInstanceState[] = [
-      ProcessInstanceState.RUNNING,
-      ProcessInstanceState.INCIDENT,
-    ].filter((state) => processInstanceFilters.state?.$in?.includes(state));
-
-    return {
-      ...processInstanceFilters,
-      processInstanceKey: {
-        $in: ids,
-        $nin: excludedProcessInstanceIds,
-      },
-      state: {
-        $in: stateFilters,
-      },
-    };
-  }, [
-    selectedProcessInstanceIds,
-    excludedProcessInstanceIds,
-    isBatchModificationEnabled,
-    selectionMode,
-    processInstanceFilters,
-  ]);
-
-  usePrefetchProcessInstancesStatistics(requestFilterParameters ?? {}, true);
 
   const getEmptyListMessage = () => {
     return {

--- a/operate/client/src/App/Processes/ListView/InstancesTable/v2/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/v2/index.tsx
@@ -1,0 +1,376 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {PanelHeader} from 'modules/components/PanelHeader';
+import {SortableTable} from 'modules/components/SortableTable';
+import {StateIcon} from 'modules/components/StateIcon';
+import {formatDate} from 'modules/utils/date';
+import {Container, ProcessName} from '../styled';
+import {observer} from 'mobx-react';
+import {Paths} from 'modules/Routes';
+import {tracking} from 'modules/tracking';
+import {Link} from 'modules/components/Link';
+import {useFilters} from 'modules/hooks/useFilters';
+
+/** Stores */
+import {
+  MAX_PROCESS_INSTANCES_STORED,
+  processInstancesStore,
+} from 'modules/stores/processInstances';
+import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
+import {processesStore} from 'modules/stores/processes/processes.list';
+import {notificationsStore} from 'modules/stores/notifications';
+import {batchModificationStore} from 'modules/stores/batchModification';
+
+import {getProcessName} from 'modules/utils/instance';
+import {Toolbar} from '../Toolbar';
+import {getProcessInstanceFilters} from 'modules/utils/filter/getProcessInstanceFilters';
+import {useLocation} from 'react-router-dom';
+import {Operations} from 'modules/components/Operations';
+import {BatchModificationFooter} from '../BatchModificationFooter';
+import {getProcessInstancesRequestFilters} from 'modules/utils/filter';
+import {usePrefetchProcessInstancesStatistics} from 'modules/queries/processInstancesStatistics/useProcessInstancesStatistics';
+import {useProcessInstanceFilters} from 'modules/hooks/useProcessInstancesFilters';
+import {ProcessInstanceState} from 'modules/api/v2/processInstances/fetchProcessInstancesStatistics';
+import {useMemo} from 'react';
+
+const ROW_HEIGHT = 34;
+
+const InstancesTable: React.FC = observer(() => {
+  const {
+    areProcessInstancesEmpty,
+    state: {status, filteredProcessInstancesCount, processInstances},
+  } = processInstancesStore;
+  const processInstanceFilters = useProcessInstanceFilters();
+
+  /**
+   * Is true if at least one process instances from the store has a version tag.
+   */
+  const hasVersionTags = processInstances.some(({processId}) => {
+    return processesStore.getVersionTag(processId);
+  });
+
+  const filters = useFilters();
+  const location = useLocation();
+
+  const {canceled, completed, tenant} = getProcessInstanceFilters(
+    location.search,
+  );
+  const listHasFinishedInstances = canceled || completed;
+
+  const isTenantColumnVisible =
+    window.clientConfig?.multiTenancyEnabled &&
+    (tenant === undefined || tenant === 'all');
+
+  const {batchOperationId} = getProcessInstancesRequestFilters();
+
+  const isOperationStateColumnVisible = !!batchOperationId;
+
+  const getTableState = () => {
+    if (['initial', 'first-fetch'].includes(status)) {
+      return 'skeleton';
+    }
+    if (status === 'fetching') {
+      return 'loading';
+    }
+    if (status === 'error') {
+      return 'error';
+    }
+    if (status === 'fetched' && areProcessInstancesEmpty) {
+      return 'empty';
+    }
+
+    return 'content';
+  };
+
+  const {
+    selectedProcessInstanceIds,
+    excludedProcessInstanceIds,
+    state: {selectionMode},
+  } = processInstancesSelectionStore;
+
+  const isBatchModificationEnabled = batchModificationStore.state.isEnabled;
+
+  const requestFilterParameters = useMemo(() => {
+    if (!isBatchModificationEnabled) {
+      return null;
+    }
+
+    const filteredIds = processInstanceFilters.processInstanceKey?.$in;
+    const ids = ['EXCLUDE', 'ALL'].includes(selectionMode)
+      ? (filteredIds ?? [])
+      : selectedProcessInstanceIds;
+    const stateFilters: ProcessInstanceState[] = [
+      ProcessInstanceState.RUNNING,
+      ProcessInstanceState.INCIDENT,
+    ].filter((state) => processInstanceFilters.state?.$in?.includes(state));
+
+    return {
+      ...processInstanceFilters,
+      processInstanceKey: {
+        $in: ids,
+        $nin: excludedProcessInstanceIds,
+      },
+      state: {
+        $in: stateFilters,
+      },
+    };
+  }, [
+    selectedProcessInstanceIds,
+    excludedProcessInstanceIds,
+    isBatchModificationEnabled,
+    selectionMode,
+    processInstanceFilters,
+  ]);
+
+  usePrefetchProcessInstancesStatistics(requestFilterParameters ?? {}, true);
+
+  const getEmptyListMessage = () => {
+    return {
+      message: 'There are no Instances matching this filter set',
+      additionalInfo: filters.areProcessInstanceStatesApplied()
+        ? undefined
+        : 'To see some results, select at least one Instance state',
+    };
+  };
+
+  return (
+    <Container aria-label="Process Instances Panel">
+      <PanelHeader
+        title="Process Instances"
+        count={filteredProcessInstancesCount}
+      />
+
+      <Toolbar
+        selectedInstancesCount={
+          processInstancesSelectionStore.selectedProcessInstanceCount
+        }
+      />
+      <SortableTable
+        state={getTableState()}
+        columnsWithNoContentPadding={['operations']}
+        selectionType="checkbox"
+        onSelectAll={processInstancesSelectionStore.selectAllProcessInstances}
+        onSelect={(rowId) => {
+          processInstancesSelectionStore.selectProcessInstance(rowId);
+        }}
+        checkIsAllSelected={() =>
+          processInstancesSelectionStore.state.isAllChecked
+        }
+        checkIsIndeterminate={() =>
+          !processInstancesSelectionStore.state.isAllChecked &&
+          processInstancesSelectionStore.selectedProcessInstanceCount > 0
+        }
+        checkIsRowSelected={(rowId) => {
+          return processInstancesSelectionStore.isProcessInstanceChecked(rowId);
+        }}
+        rowOperationError={(rowId) => {
+          return processInstancesStore.getProcessInstanceOperationError(rowId);
+        }}
+        emptyMessage={getEmptyListMessage()}
+        onVerticalScrollStartReach={async (scrollDown) => {
+          if (processInstancesStore.shouldFetchPreviousInstances() === false) {
+            return;
+          }
+
+          await processInstancesStore.fetchPreviousInstances();
+
+          if (
+            processInstancesStore.state.processInstances.length ===
+              MAX_PROCESS_INSTANCES_STORED &&
+            processInstancesStore.state.latestFetch?.processInstancesCount !==
+              0 &&
+            processInstancesStore.state.latestFetch !== null
+          ) {
+            scrollDown(
+              processInstancesStore.state.latestFetch.processInstancesCount *
+                ROW_HEIGHT,
+            );
+          }
+        }}
+        onVerticalScrollEndReach={() => {
+          if (processInstancesStore.shouldFetchNextInstances() === false) {
+            return;
+          }
+
+          processInstancesStore.fetchNextInstances();
+        }}
+        rows={processInstances.map((instance) => {
+          const versionTag = processesStore.getVersionTag(instance.processId);
+
+          return {
+            id: instance.id,
+            processName: (
+              <ProcessName>
+                <StateIcon
+                  state={instance.state}
+                  data-testid={`${instance.state}-icon-${instance.id}`}
+                  size={20}
+                />
+
+                {getProcessName(instance)}
+              </ProcessName>
+            ),
+            instanceOperationState: isOperationStateColumnVisible
+              ? instance.operations?.find(
+                  (operation) =>
+                    operation.batchOperationId === batchOperationId,
+                )?.state || '--'
+              : undefined,
+            processInstanceKey: (
+              <Link
+                to={Paths.processInstance(instance.id)}
+                title={`View instance ${instance.id}`}
+                aria-label={`View instance ${instance.id}`}
+                onClick={() => {
+                  tracking.track({
+                    eventName: 'navigation',
+                    link: 'processes-instance-details',
+                  });
+                }}
+              >
+                {instance.id}
+              </Link>
+            ),
+            processVersion: instance.processVersion,
+            versionTag: versionTag ?? '--',
+            tenant: isTenantColumnVisible ? instance.tenantId : undefined,
+            startDate: formatDate(instance.startDate),
+            endDate: formatDate(instance.endDate),
+            parentInstanceId: (
+              <>
+                {instance.parentInstanceId !== null ? (
+                  <Link
+                    to={Paths.processInstance(instance.parentInstanceId)}
+                    title={`View parent instance ${instance.parentInstanceId}`}
+                    aria-label={`View parent instance ${instance.parentInstanceId}`}
+                    onClick={() => {
+                      tracking.track({
+                        eventName: 'navigation',
+                        link: 'processes-parent-instance-details',
+                      });
+                    }}
+                  >
+                    {instance.parentInstanceId}
+                  </Link>
+                ) : (
+                  'None'
+                )}
+              </>
+            ),
+            operations: (
+              <Operations
+                instance={instance}
+                onOperation={(operationType) =>
+                  processInstancesStore.markProcessInstancesWithActiveOperations(
+                    {
+                      ids: [instance.id],
+                      operationType,
+                    },
+                  )
+                }
+                onError={({operationType, statusCode}) => {
+                  processInstancesStore.unmarkProcessInstancesWithActiveOperations(
+                    {
+                      instanceIds: [instance.id],
+                      operationType,
+                    },
+                  );
+                  notificationsStore.displayNotification({
+                    kind: 'error',
+                    title: 'Operation could not be created',
+                    subtitle:
+                      statusCode === 403
+                        ? 'You do not have permission'
+                        : undefined,
+                    isDismissable: true,
+                  });
+                }}
+                onSuccess={(operationType) => {
+                  tracking.track({
+                    eventName: 'single-operation',
+                    operationType,
+                    source: 'instances-list',
+                  });
+                }}
+                permissions={processesStore.getPermissions(
+                  instance.bpmnProcessId,
+                  instance.tenantId,
+                )}
+              />
+            ),
+          };
+        })}
+        headerColumns={[
+          {
+            header: 'Name',
+            key: 'processName',
+          },
+          ...(isOperationStateColumnVisible
+            ? [
+                {
+                  header: 'Operation State',
+                  key: 'instanceOperationState',
+                },
+              ]
+            : []),
+          {
+            header: 'Process Instance Key',
+            key: 'processInstanceKey',
+            sortKey: 'id',
+          },
+          {
+            header: 'Version',
+            key: 'processVersion',
+          },
+          ...(hasVersionTags
+            ? [
+                {
+                  header: 'Version Tag',
+                  key: 'versionTag',
+                  isDisabled: true,
+                },
+              ]
+            : []),
+          ...(isTenantColumnVisible
+            ? [
+                {
+                  header: 'Tenant',
+                  key: 'tenant',
+                },
+              ]
+            : []),
+          {
+            header: 'Start Date',
+            key: 'startDate',
+            isDefault: true,
+          },
+          {
+            header: 'End Date',
+            key: 'endDate',
+            isDisabled: !listHasFinishedInstances,
+          },
+          {
+            header: 'Parent Process Instance Key',
+            key: 'parentInstanceId',
+          },
+
+          {
+            header: 'Operations',
+            key: 'operations',
+            isDisabled: true,
+          },
+        ]}
+        batchOperationId={batchOperationId}
+      />
+      {batchModificationStore.state.isEnabled && <BatchModificationFooter />}
+    </Container>
+  );
+});
+
+export {InstancesTable};

--- a/operate/client/src/App/Processes/ListView/index.tsx
+++ b/operate/client/src/App/Processes/ListView/index.tsx
@@ -9,6 +9,7 @@
 import {InstancesList} from '../../Layout/InstancesList';
 import {VisuallyHiddenH1} from 'modules/components/VisuallyHiddenH1';
 import {Filters} from './Filters';
+import {InstancesTable as InstancesTableV2} from './InstancesTable/v2';
 import {InstancesTable} from './InstancesTable';
 import {DiagramPanel as DiagramPanelV2} from './DiagramPanel/v2';
 import {DiagramPanel} from './DiagramPanel';
@@ -134,7 +135,13 @@ const ListView: React.FC = observer(() => {
             <DiagramPanel />
           )
         }
-        bottomPanel={<InstancesTable />}
+        bottomPanel={
+          IS_PROCESS_INSTANCE_STATISTICS_V2_ENABLED ? (
+            <InstancesTableV2 />
+          ) : (
+            <InstancesTable />
+          )
+        }
         rightPanel={<OperationsPanel />}
         frame={{
           isVisible: batchModificationStore.state.isEnabled,

--- a/operate/client/src/modules/api/v2/processInstances/fetchProcessInstancesStatistics.ts
+++ b/operate/client/src/modules/api/v2/processInstances/fetchProcessInstancesStatistics.ts
@@ -16,7 +16,12 @@ type ProcessInstancesStatisticsDto = {
   completed: number;
 };
 
-type ProcessInstanceState = 'RUNNING' | 'COMPLETED' | 'CANCELED' | 'INCIDENT';
+enum ProcessInstanceState {
+  RUNNING = 'RUNNING',
+  COMPLETED = 'COMPLETED',
+  CANCELED = 'CANCELED',
+  INCIDENT = 'INCIDENT',
+}
 
 type ProcessInstancesStatisticsRequest = {
   groupBy?: string;
@@ -62,9 +67,5 @@ const fetchProcessInstancesStatistics = async (
   });
 };
 
-export {fetchProcessInstancesStatistics};
-export type {
-  ProcessInstancesStatisticsDto,
-  ProcessInstancesStatisticsRequest,
-  ProcessInstanceState,
-};
+export {fetchProcessInstancesStatistics, ProcessInstanceState};
+export type {ProcessInstancesStatisticsDto, ProcessInstancesStatisticsRequest};

--- a/operate/client/src/modules/hooks/useProcessInstancesFilters.test.ts
+++ b/operate/client/src/modules/hooks/useProcessInstancesFilters.test.ts
@@ -9,7 +9,10 @@
 import {renderHook} from '@testing-library/react-hooks';
 import {useFilters} from 'modules/hooks/useFilters';
 import {ProcessInstanceFilters} from 'modules/utils/filter/shared';
-import {ProcessInstancesStatisticsRequest} from 'modules/api/v2/processInstances/fetchProcessInstancesStatistics';
+import {
+  ProcessInstancesStatisticsRequest,
+  ProcessInstanceState,
+} from 'modules/api/v2/processInstances/fetchProcessInstancesStatistics';
 import {useProcessInstanceFilters} from './useProcessInstancesFilters';
 import {processesStore} from 'modules/stores/processes/processes.list';
 
@@ -67,7 +70,12 @@ describe('useProcessInstanceFilters', () => {
         $in: ['id1', 'id2'],
       },
       state: {
-        $in: ['RUNNING', 'INCIDENT', 'COMPLETED', 'CANCELED'],
+        $in: [
+          ProcessInstanceState.RUNNING,
+          ProcessInstanceState.INCIDENT,
+          ProcessInstanceState.COMPLETED,
+          ProcessInstanceState.CANCELED,
+        ],
       },
       parentProcessInstanceKey: 'parent1',
       tenantId: 'tenant1',
@@ -109,7 +117,7 @@ describe('useProcessInstanceFilters', () => {
         $gt: '2023-01-01',
       },
       state: {
-        $in: ['RUNNING'],
+        $in: [ProcessInstanceState.RUNNING],
       },
     };
 

--- a/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
+++ b/operate/client/src/modules/hooks/useProcessInstancesFilters.ts
@@ -91,10 +91,10 @@ function mapFiltersToRequest(
   }
 
   const state: ProcessInstanceState[] = [];
-  if (active) state.push('RUNNING');
-  if (incidents) state.push('INCIDENT');
-  if (completed) state.push('COMPLETED');
-  if (canceled) state.push('CANCELED');
+  if (active) state.push(ProcessInstanceState.RUNNING);
+  if (incidents) state.push(ProcessInstanceState.INCIDENT);
+  if (completed) state.push(ProcessInstanceState.COMPLETED);
+  if (canceled) state.push(ProcessInstanceState.CANCELED);
 
   if (state.length > 0) {
     request.state = {

--- a/operate/client/src/modules/queries/genericQuery.ts
+++ b/operate/client/src/modules/queries/genericQuery.ts
@@ -6,15 +6,15 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useQuery, UseQueryOptions, UseQueryResult} from '@tanstack/react-query';
+import {UseQueryOptions} from '@tanstack/react-query';
 import {RequestError, RequestResult} from 'modules/request';
 
-function useGenericQuery<T, TSelect = T>(
+function genericQueryOptions<T, TSelect = T>(
   queryKey: unknown[],
   fetchFunction: () => RequestResult<T>,
   options?: UseQueryOptions<T, RequestError, TSelect>,
-): UseQueryResult<TSelect, RequestError> {
-  return useQuery<T, RequestError, TSelect>({
+): UseQueryOptions<T, RequestError, TSelect> {
+  return {
     queryKey,
     queryFn: async () => {
       const {response, error} = await fetchFunction();
@@ -26,7 +26,7 @@ function useGenericQuery<T, TSelect = T>(
       throw error;
     },
     ...options,
-  });
+  };
 }
 
-export {useGenericQuery};
+export {genericQueryOptions};

--- a/operate/client/src/modules/queries/processInstancesStatistics/useBatchModificationOverlayData.ts
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useBatchModificationOverlayData.ts
@@ -15,6 +15,7 @@ import {useProcessInstancesStatisticsOptions} from './useProcessInstancesStatist
 import {OverlayData} from 'modules/bpmn-js/BpmnJS';
 import {getInstancesCount} from 'modules/utils/statistics/processInstances';
 import {useQuery} from '@tanstack/react-query';
+import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
 
 function batchModificationOverlayParser(params: {
   sourceFlowNodeId?: string;
@@ -54,9 +55,29 @@ function useBatchModificationOverlayData(
   params: {sourceFlowNodeId?: string; targetFlowNodeId?: string},
   enabled?: boolean,
 ) {
+  const {
+    selectedProcessInstanceIds,
+    excludedProcessInstanceIds,
+    state: {selectionMode},
+  } = processInstancesSelectionStore;
+
+  const ids = ['EXCLUDE', 'ALL'].includes(selectionMode)
+    ? []
+    : selectedProcessInstanceIds;
+
+  const processInstanceKey = {
+    $in: ids,
+    ...(excludedProcessInstanceIds.length > 0 && {
+      $nin: excludedProcessInstanceIds,
+    }),
+  };
+
   return useQuery(
     useProcessInstancesStatisticsOptions<OverlayData[]>(
-      payload,
+      {
+        ...payload,
+        processInstanceKey,
+      },
       batchModificationOverlayParser(params),
       enabled,
     ),

--- a/operate/client/src/modules/queries/processInstancesStatistics/useBatchModificationOverlayData.ts
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useBatchModificationOverlayData.ts
@@ -11,9 +11,10 @@ import {
   ProcessInstancesStatisticsRequest,
 } from 'modules/api/v2/processInstances/fetchProcessInstancesStatistics';
 import {MODIFICATIONS} from 'modules/bpmn-js/badgePositions';
-import {useProcessInstancesStatistics} from './useProcessInstancesStatistics';
+import {useProcessInstancesStatisticsOptions} from './useProcessInstancesStatistics';
 import {OverlayData} from 'modules/bpmn-js/BpmnJS';
 import {getInstancesCount} from 'modules/utils/statistics/processInstances';
+import {useQuery} from '@tanstack/react-query';
 
 function batchModificationOverlayParser(params: {
   sourceFlowNodeId?: string;
@@ -53,10 +54,12 @@ function useBatchModificationOverlayData(
   params: {sourceFlowNodeId?: string; targetFlowNodeId?: string},
   enabled?: boolean,
 ) {
-  return useProcessInstancesStatistics<OverlayData[]>(
-    payload,
-    batchModificationOverlayParser(params),
-    enabled,
+  return useQuery(
+    useProcessInstancesStatisticsOptions<OverlayData[]>(
+      payload,
+      batchModificationOverlayParser(params),
+      enabled,
+    ),
   );
 }
 

--- a/operate/client/src/modules/queries/processInstancesStatistics/useInstancesCount.ts
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useInstancesCount.ts
@@ -10,7 +10,8 @@ import {
   ProcessInstancesStatisticsDto,
   ProcessInstancesStatisticsRequest,
 } from 'modules/api/v2/processInstances/fetchProcessInstancesStatistics';
-import {useProcessInstancesStatistics} from './useProcessInstancesStatistics';
+import {useProcessInstancesStatisticsOptions} from './useProcessInstancesStatistics';
+import {useQuery} from '@tanstack/react-query';
 import {getInstancesCount} from 'modules/utils/statistics/processInstances';
 
 function instancesCountParser(
@@ -25,10 +26,12 @@ function useInstancesCount(
   payload: ProcessInstancesStatisticsRequest,
   flowNodeId?: string,
 ) {
-  return useProcessInstancesStatistics<number>(
-    payload,
-    instancesCountParser(flowNodeId),
-    !!flowNodeId,
+  return useQuery(
+    useProcessInstancesStatisticsOptions<number>(
+      payload,
+      instancesCountParser(flowNodeId),
+      !!flowNodeId,
+    ),
   );
 }
 

--- a/operate/client/src/modules/queries/processInstancesStatistics/useOverlayData.ts
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useOverlayData.ts
@@ -18,7 +18,8 @@ import {
   COMPLETED_END_EVENT_BADGE,
   INCIDENTS_BADGE,
 } from 'modules/bpmn-js/badgePositions';
-import {useProcessInstancesStatistics} from './useProcessInstancesStatistics';
+import {useProcessInstancesStatisticsOptions} from './useProcessInstancesStatistics';
+import {useQuery} from '@tanstack/react-query';
 
 type FlowNodeState =
   | 'active'
@@ -85,10 +86,12 @@ function useProcessInstancesOverlayData(
   payload: ProcessInstancesStatisticsRequest,
   enabled?: boolean,
 ) {
-  return useProcessInstancesStatistics<OverlayData[]>(
-    payload,
-    overlayParser,
-    enabled,
+  return useQuery(
+    useProcessInstancesStatisticsOptions<OverlayData[]>(
+      payload,
+      overlayParser,
+      enabled,
+    ),
   );
 }
 

--- a/operate/client/src/modules/queries/processInstancesStatistics/useProcessInstancesStatistics.tsx
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useProcessInstancesStatistics.tsx
@@ -6,28 +6,30 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {useGenericQuery} from 'modules/queries/useGenericQuery';
+import {genericQueryOptions} from 'modules/queries/genericQuery';
 import {
   fetchProcessInstancesStatistics,
   ProcessInstancesStatisticsDto,
   ProcessInstancesStatisticsRequest,
 } from 'modules/api/v2/processInstances/fetchProcessInstancesStatistics';
 import {useProcessInstanceFilters} from 'modules/hooks/useProcessInstancesFilters';
-import {UseQueryResult} from '@tanstack/react-query';
+import {usePrefetchQuery, UseQueryOptions} from '@tanstack/react-query';
 import {RequestError} from 'modules/request';
 
 function getQueryKey(payload: ProcessInstancesStatisticsRequest) {
   return ['processInstancesStatistics', ...Object.values(payload)];
 }
 
-function useProcessInstancesStatistics<T = ProcessInstancesStatisticsDto[]>(
+function useProcessInstancesStatisticsOptions<
+  T = ProcessInstancesStatisticsDto[],
+>(
   payload: ProcessInstancesStatisticsRequest,
   select?: (data: ProcessInstancesStatisticsDto[]) => T,
   enabled?: boolean,
-): UseQueryResult<T, RequestError> {
+): UseQueryOptions<ProcessInstancesStatisticsDto[], RequestError, T> {
   const filters = useProcessInstanceFilters();
 
-  return useGenericQuery<ProcessInstancesStatisticsDto[], T>(
+  return genericQueryOptions<ProcessInstancesStatisticsDto[], T>(
     getQueryKey(payload),
     () =>
       fetchProcessInstancesStatistics({
@@ -45,4 +47,16 @@ function useProcessInstancesStatistics<T = ProcessInstancesStatisticsDto[]>(
   );
 }
 
-export {useProcessInstancesStatistics};
+function usePrefetchProcessInstancesStatistics(
+  payload: ProcessInstancesStatisticsRequest,
+  enabled?: boolean,
+) {
+  return usePrefetchQuery(
+    useProcessInstancesStatisticsOptions(payload, (data) => data, enabled),
+  );
+}
+
+export {
+  usePrefetchProcessInstancesStatistics,
+  useProcessInstancesStatisticsOptions,
+};

--- a/operate/client/src/modules/queries/processInstancesStatistics/useProcessInstancesStatistics.tsx
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useProcessInstancesStatistics.tsx
@@ -13,7 +13,7 @@ import {
   ProcessInstancesStatisticsRequest,
 } from 'modules/api/v2/processInstances/fetchProcessInstancesStatistics';
 import {useProcessInstanceFilters} from 'modules/hooks/useProcessInstancesFilters';
-import {usePrefetchQuery, UseQueryOptions} from '@tanstack/react-query';
+import {UseQueryOptions} from '@tanstack/react-query';
 import {RequestError} from 'modules/request';
 
 function getQueryKey(payload: ProcessInstancesStatisticsRequest) {
@@ -47,16 +47,4 @@ function useProcessInstancesStatisticsOptions<
   );
 }
 
-function usePrefetchProcessInstancesStatistics(
-  payload: ProcessInstancesStatisticsRequest,
-  enabled?: boolean,
-) {
-  return usePrefetchQuery(
-    useProcessInstancesStatisticsOptions(payload, (data) => data, enabled),
-  );
-}
-
-export {
-  usePrefetchProcessInstancesStatistics,
-  useProcessInstancesStatisticsOptions,
-};
+export {useProcessInstancesStatisticsOptions};


### PR DESCRIPTION
## Description

This PR creates a v2 component that prefetches PI statistics data in the `InstancesTable`.
Most of the component and tests logic is similar to V1, the main differences are the introduction of TanStack Query.

Here's a screen recording showing the app with V2 Instances Table

https://github.com/user-attachments/assets/e2a74e9d-fd4b-4dd0-a9f8-7a019e5db885

As you can see, the data is prefetched but marked as `inactive` because it is not consumed by any components (see [comment](https://github.com/TanStack/query/discussions/1913#discussioncomment-435842))

## Related issues

closes #29285