### PR TITLE
[Backport stable/optimize-8.7] ci: switch e2e tests to run on chrome

### DIFF
--- a/.github/workflows/optimize-e2e-tests-sm.yml
+++ b/.github/workflows/optimize-e2e-tests-sm.yml
@@ -38,7 +38,7 @@ permissions:
 jobs:
   e2e-tests-sm:
     name: E2E tests sm
-    runs-on: gcp-core-4-default
+    runs-on: ubuntu-latest
     timeout-minutes: 120
 
     steps:
@@ -61,40 +61,10 @@ jobs:
         with:
           secrets: ${{ toJSON(secrets) }}
 
-      - name: Install firefox deps
-        run: |
-          sudo apt-get update && sudo apt-get install
-          sudo apt-get install -y xvfb bzip2 packagekit-gtk3-module libasound2
-
-      - name: Install firefox
-        uses: browser-actions/setup-firefox@v1
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ steps.pom_info.outputs.x_version_node }}
-
-      - name: Setup yarn
-        run: npm install -g yarn
-
-      - name: Setup NodeJS
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
-        with:
-          node-version: ${{ steps.pom_info.outputs.x_version_node }}
-
-      - uses: camunda/infra-global-github-actions/setup-yarn-cache@main
-        with:
-          directory: optimize/client
-
-      - name: Install node dependencies
-        working-directory: ./optimize/client
-        shell: bash
-        run: yarn
-
       - name: Build frontend
-        working-directory: ./optimize/client
-        run: yarn build
-        shell: bash
+        uses: ./.github/actions/build-frontend
+        with:
+          directory: ./optimize/client
 
       - name: Start frontend
         working-directory: ./optimize/client

--- a/optimize/client/package.json
+++ b/optimize/client/package.json
@@ -44,7 +44,7 @@
     "e2e": "testcafe -c 3 chrome e2e/sm-tests/*.js --disable-screenshots",
     "e2e:ci:headless": "testcafe -c 3 chrome:headless e2e/sm-tests/*.js -e --disable-screenshots --assertion-timeout 40000 -q attemptLimit=3,successThreshold=1",
     "e2e:ci:cloud:headless": "testcafe chrome:headless e2e/cloud-tests/smokeTest.js -e",
-    "e2e:ci:sm:headless": "testcafe -c 3 firefox:headless e2e/sm-tests/*.js -e --disable-screenshots --assertion-timeout 40000 -q attemptLimit=3,successThreshold=1",
+    "e2e:ci:sm:headless": "testcafe -c 3 chrome:headless e2e/sm-tests/*.js -e --disable-screenshots --assertion-timeout 40000 -q attemptLimit=3,successThreshold=1",
     "e2e:cloud": "testcafe chrome e2e/cloud-tests/smokeTest.js",
     "eject": "react-scripts eject",
     "postinstall": "node scripts/wireModules && patch-package",


### PR DESCRIPTION
# Description
Backport of #24656 to `stable/optimize-8.7`.

relates to 