### PR TITLE
ci: remove unneeded Operate Slack notification

### DIFF
--- a/.github/workflows/operate-ci-test-reusable.yml
+++ b/.github/workflows/operate-ci-test-reusable.yml
@@ -123,18 +123,6 @@ jobs:
         uses: ./.github/actions/collect-test-artifacts
         with:
           name: "Operate ${{ inputs.test-type }}"
-      - name: Send Slack notification on failure
-        if: failure()
-        uses: slackapi/slack-github-action@v2.0.0
-        with:
-          webhook: ${{ steps.secrets.outputs.OPERATE_CI_ALERT_WEBHOOK_URL }}
-          webhook-type: incoming-webhook
-          payload: |
-            {
-              "workflow_name": "${{ github.workflow }}",
-              "github_run_url": "https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}",
-              "branch": "${{ github.head_ref || github.ref_name }}"
-            }
 
       - name: Observe build status
         if: always()


### PR DESCRIPTION
## Description

This workflow posts Slack notifications on every failure including branches/PRs from Renovate etc which is very noise and brings no value → confirmed by no reactions [to the Slack messages](https://camunda.slack.com/archives/C014HSVN5EY).

![image](https://github.com/user-attachments/assets/6c564817-16ff-480c-99f2-960e17ef4e2d)

I propose to remove this notification altogether.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Related #28873 
