### PR TITLE
Camunda exporter ignores 8.8 zeebe indice for brownfield detection

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -335,7 +335,7 @@ public class CamundaExporter implements Exporter {
         zeebeIndicesVersion87Exist =
             !searchEngineClient
                 .getMappings(
-                    configuration.getIndex().getZeebeIndexPrefix() + "*8.7*", MappingSource.INDEX)
+                    configuration.getIndex().getZeebeIndexPrefix() + "*8.7.*_", MappingSource.INDEX)
                 .isEmpty();
       }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -72,7 +72,7 @@ public class CamundaExporter implements Exporter {
   private BackgroundTaskManager taskManager;
   private ExporterMetadata metadata;
   private boolean exporterCanFlush = false;
-  private boolean zeebeIndicesExist = false;
+  private boolean zeebeIndicesVersion87Exist = false;
   private SearchEngineClient searchEngineClient;
   private int partitionId;
 
@@ -331,16 +331,16 @@ public class CamundaExporter implements Exporter {
                   d -> d instanceof ImportPositionIndex || d instanceof TasklistImportPositionIndex)
               .toList();
 
-      if (!zeebeIndicesExist) {
-        zeebeIndicesExist =
+      if (!zeebeIndicesVersion87Exist) {
+        zeebeIndicesVersion87Exist =
             !searchEngineClient
                 .getMappings(
-                    configuration.getIndex().getZeebeIndexPrefix() + "*", MappingSource.INDEX)
+                    configuration.getIndex().getZeebeIndexPrefix() + "*8.7*", MappingSource.INDEX)
                 .isEmpty();
       }
 
       exporterCanFlush =
-          !zeebeIndicesExist
+          !zeebeIndicesVersion87Exist
               || searchEngineClient.importersCompleted(partitionId, importPositionIndices);
     } catch (final Exception e) {
       LOG.warn("Unexpected exception occurred checking importers completed, will retry later.", e);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -760,14 +760,14 @@ final class CamundaExporterIT {
     }
 
     @TestTemplate
-    void shouldNotFlushIfImportersAreNotCompletedAndThereAreVersion87ZeebeIndices(
+    void shouldNotFlushIf87IndicesExistToBeImported(
         final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
         throws IOException {
       // given
       final String zeebeIndexPrefix = CUSTOM_PREFIX + "-zeebe-record";
       config.getIndex().setZeebeIndexPrefix(zeebeIndexPrefix);
       createSchemas(config, clientAdapter);
-      clientAdapter.index("1", zeebeIndexPrefix + "-decision_8.7.0", Map.of("key", "12345"));
+      clientAdapter.index("1", zeebeIndexPrefix + "-decision_8.7.0_", Map.of("key", "12345"));
 
       // adds a not complete position index document so exporter sees importing as not yet completed
       indexImportPositionEntity("decision", false, clientAdapter);
@@ -912,7 +912,7 @@ final class CamundaExporterIT {
       config.getIndex().setZeebeIndexPrefix(zeebeIndexPrefix);
 
       // Simulate existing zeebe index so it will not skip the wait for importers
-      clientAdapter.index("1", zeebeIndexPrefix + "-decision_8.7.0", Map.of("key", "12345"));
+      clientAdapter.index("1", zeebeIndexPrefix + "-decision_8.7.0_", Map.of("key", "12345"));
 
       // if schemas are never created then import position indices do not exist and all checks about
       // whether the importers are completed will return false.

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -680,6 +680,41 @@ final class CamundaExporterIT {
     }
 
     @TestTemplate
+    void shouldMarkImportersAsCompletedEvenIfVersion88ZeebeIndicesExist(
+        final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
+        throws IOException {
+      final String zeebeIndexPrefix = CUSTOM_PREFIX + "-zeebe-record";
+      config.getIndex().setZeebeIndexPrefix(zeebeIndexPrefix);
+      createSchemas(config, clientAdapter);
+      clientAdapter.index("1", zeebeIndexPrefix + "-decision_8.8.0", Map.of("key", "12345"));
+
+      // adds a not complete position index document so exporter sees importing as not yet completed
+      indexImportPositionEntity("decision", false, clientAdapter);
+      clientAdapter.refresh();
+
+      final var context = spy(getContextFromConfig(config));
+      doReturn(partitionId).when(context).getPartitionId();
+      camundaExporter.configure(context);
+      camundaExporter.open(controller);
+
+      controller.runScheduledTasks(Duration.ofMinutes(1));
+
+      // when
+      final var record =
+          factory.generateRecord(
+              ValueType.USER,
+              r -> r.withBrokerVersion("8.8.0").withTimestamp(System.currentTimeMillis()),
+              UserIntent.CREATED);
+
+      camundaExporter.export(record);
+
+      // then
+      assertThat(controller.getPosition()).isEqualTo(record.getPosition());
+      verify(controller, times(1))
+          .updateLastExportedRecordPosition(eq(record.getPosition()), any());
+    }
+
+    @TestTemplate
     void shouldFlushIfImporterNotCompletedButNoZeebeIndices(
         final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
         throws IOException {
@@ -725,14 +760,14 @@ final class CamundaExporterIT {
     }
 
     @TestTemplate
-    void shouldNotFlushIfImportersAreNotCompletedAndThereAreZeebeIndices(
+    void shouldNotFlushIfImportersAreNotCompletedAndThereAreVersion87ZeebeIndices(
         final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
         throws IOException {
       // given
       final String zeebeIndexPrefix = CUSTOM_PREFIX + "-zeebe-record";
       config.getIndex().setZeebeIndexPrefix(zeebeIndexPrefix);
       createSchemas(config, clientAdapter);
-      clientAdapter.index("1", zeebeIndexPrefix + "-decision", Map.of("key", "12345"));
+      clientAdapter.index("1", zeebeIndexPrefix + "-decision_8.7.0", Map.of("key", "12345"));
 
       // adds a not complete position index document so exporter sees importing as not yet completed
       indexImportPositionEntity("decision", false, clientAdapter);
@@ -877,7 +912,7 @@ final class CamundaExporterIT {
       config.getIndex().setZeebeIndexPrefix(zeebeIndexPrefix);
 
       // Simulate existing zeebe index so it will not skip the wait for importers
-      clientAdapter.index("1", zeebeIndexPrefix + "-decision", Map.of("key", "12345"));
+      clientAdapter.index("1", zeebeIndexPrefix + "-decision_8.7.0", Map.of("key", "12345"));
 
       // if schemas are never created then import position indices do not exist and all checks about
       // whether the importers are completed will return false.


### PR DESCRIPTION
## Description

Currently, if any zeebe indices are detected it is assumed to be an update. However this is not always the case, for a fresh install of 8.8 optimize still requires the ES exporter which will result in 8.8 zeebe indices. This could result in a race condition where the exporter never gets to flush on a fresh install if optimize is enabled. 

This fix involves specifically checking for the existence of 8.7 zeebe indices, which if exist mean it is definitely an update, while ignoring any 8.8 zeebe indices.

## Related issues

closes #28833
