### PR TITLE
feat: add purgeCluster method to CamundaManagementClient

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/clock/CamundaAddClockRequestDto.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/clock/CamundaAddClockRequestDto.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.client.clock;
+
+public class CamundaAddClockRequestDto {
+
+  private long offsetMilli;
+
+  public long getOffsetMilli() {
+    return offsetMilli;
+  }
+
+  public void setOffsetMilli(final long offsetMilli) {
+    this.offsetMilli = offsetMilli;
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/clock/CamundaClockResponseDto.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/clock/CamundaClockResponseDto.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.client.clock;
+
+public class CamundaClockResponseDto {
+
+  private long epochMilli;
+  private String instant;
+
+  public long getEpochMilli() {
+    return epochMilli;
+  }
+
+  public void setEpochMilli(final long epochMilli) {
+    this.epochMilli = epochMilli;
+  }
+
+  public String getInstant() {
+    return instant;
+  }
+
+  public void setInstant(final String instant) {
+    this.instant = instant;
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/purge/MinimalLastChangeDto.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/purge/MinimalLastChangeDto.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.client.purge;
+
+public class MinimalLastChangeDto {
+  private long id;
+  private String status;
+
+  public long getId() {
+    return id;
+  }
+
+  public void setId(final long id) {
+    this.id = id;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(final String status) {
+    this.status = status;
+  }
+
+  public boolean isStatusCompleted() {
+    return "COMPLETED".equalsIgnoreCase(status);
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/purge/MinimalPlannedOperationsResponseDto.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/purge/MinimalPlannedOperationsResponseDto.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.client.purge;
+
+public class MinimalPlannedOperationsResponseDto {
+
+  private long changeId;
+
+  public long getChangeId() {
+    return changeId;
+  }
+
+  public void setChangeId(final long changeId) {
+    this.changeId = changeId;
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/purge/MinimalTopologyResponseDto.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/purge/MinimalTopologyResponseDto.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.client.purge;
+
+public class MinimalTopologyResponseDto {
+  private MinimalLastChangeDto lastChange;
+
+  public boolean isTopologyChangeCompleted(final long changeId) {
+    if (lastChange == null) {
+      return false;
+    }
+
+    if (changeId == lastChange.getId()) {
+      return lastChange.isStatusCompleted();
+    }
+
+    return changeId < lastChange.getId();
+  }
+
+  public MinimalLastChangeDto getLastChange() {
+    return lastChange;
+  }
+
+  public void setLastChange(final MinimalLastChangeDto lastChange) {
+    this.lastChange = lastChange;
+  }
+}


### PR DESCRIPTION
## Description

Create a new endpoint in the CamundaManagementClient to purge the cluster inside a test environment. Added the endpoint to the CamundaProcessTestContext.

closes #29147 