### PR TITLE
Fix flaky MigrationRunnerIT(shouldMigrateSuccessfullyWithMultipleRounds(boolean)[2] isElasticsearch=false)

### DIFF
--- a/migration/process-migration/src/test/java/io/camunda/migration/process/it/MigrationRunnerIT.java
+++ b/migration/process-migration/src/test/java/io/camunda/migration/process/it/MigrationRunnerIT.java
@@ -168,7 +168,15 @@ public class MigrationRunnerIT extends AdapterTest {
     refreshIndices();
 
     // then
-    final var records = readRecords(ProcessEntity.class, processIndex.getFullQualifiedName());
+
+    final var records =
+        Awaitility.await()
+            .atMost(30, TimeUnit.SECONDS)
+            .pollInterval(2, TimeUnit.SECONDS)
+            .ignoreExceptions()
+            .until(
+                () -> readRecords(ProcessEntity.class, processIndex.getFullQualifiedName()),
+                res -> res.getFirst().getIsPublic() != null);
 
     // Since the key field is marked as a keyword in ES/OS the sorting is done lexicographically
     assertProcessorStepContentIsStored("9");


### PR DESCRIPTION
## Description

The error message was duplicated by retrieving the records before `runMigration` was called, this suggests that due to heavy load sometimes the migration changes are not visible when `readRecords` is initially called.

The flake should be fixed as now the record retrieval is retried until the migration changes are visible.

