### PR TITLE
Fix failing `DecisionIT`

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/DecisionIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/DecisionIT.java
@@ -42,7 +42,8 @@ import org.springframework.test.web.servlet.MvcResult;
       OperateProperties.PREFIX + ".importer.startLoadingDataOnStartup = false",
       OperateProperties.PREFIX + ".archiver.rolloverEnabled = false",
       "spring.mvc.pathmatch.matching-strategy=ANT_PATH_MATCHER",
-      "camunda.security.multiTenancy.enabled = true"
+      "camunda.security.multiTenancy.enabled = true",
+      "camunda.security.authentication.unprotected-api=false"
     })
 public class DecisionIT extends OperateAbstractIT {
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
It's not possible to enable multi-tenancy whilst having an unprotected api. Recently a feature was added to fail on startup when this is configured. This causes this test to fail. By adding the proper camunda.security.authentication .unprotected-api and setting it to false we can resolve this.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

N/A
