### PR TITLE
Migrate standalone camunda test

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/StandaloneCamundaTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/StandaloneCamundaTest.java
@@ -19,17 +19,19 @@ import java.time.Duration;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 @Tag("multi-db-test")
+@DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 public class StandaloneCamundaTest {
 
-  private static final TestSimpleCamundaApplication testStandaloneCamunda =
+  private static final TestSimpleCamundaApplication CAMUNDA_APPLICATION =
       new TestSimpleCamundaApplication().withUnauthenticatedAccess();
 
   @RegisterExtension
   private static final CamundaMultiDBExtension EXTENSION =
-      new CamundaMultiDBExtension(testStandaloneCamunda);
+      new CamundaMultiDBExtension(CAMUNDA_APPLICATION);
 
   private static CamundaClient camundaClient;
 
@@ -60,7 +62,7 @@ public class StandaloneCamundaTest {
             .join();
 
     // then
-    final var operateClient = testStandaloneCamunda.newOperateClient();
+    final var operateClient = CAMUNDA_APPLICATION.newOperateClient();
     Awaitility.await("should receive data from ES")
         .timeout(Duration.ofMinutes(1))
         .untilAsserted(

--- a/qa/integration-tests/src/test/java/io/camunda/it/StandaloneCamundaTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/StandaloneCamundaTest.java
@@ -9,27 +9,33 @@ package io.camunda.it;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.client.CamundaClient;
 import io.camunda.qa.util.cluster.TestRestOperateClient.ProcessInstanceResult;
-import io.camunda.qa.util.cluster.TestStandaloneCamunda;
+import io.camunda.qa.util.cluster.TestSimpleCamundaApplication;
+import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.util.Either;
 import java.time.Duration;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-@ZeebeIntegration
+@Tag("multi-db-test")
 public class StandaloneCamundaTest {
 
-  @TestZeebe
-  final TestStandaloneCamunda testStandaloneCamunda =
-      new TestStandaloneCamunda().withUnauthenticatedAccess();
+  private static final TestSimpleCamundaApplication testStandaloneCamunda =
+      new TestSimpleCamundaApplication().withUnauthenticatedAccess();
+
+  @RegisterExtension
+  private static final CamundaMultiDBExtension EXTENSION =
+      new CamundaMultiDBExtension(testStandaloneCamunda);
+
+  private static CamundaClient camundaClient;
 
   @Test
   public void shouldCreateAndRetrieveInstance() {
     // given
-    final var camundaClient = testStandaloneCamunda.newClientBuilder().build();
 
     // when
     camundaClient

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestSimpleCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestSimpleCamundaApplication.java
@@ -246,4 +246,8 @@ public final class TestSimpleCamundaApplication
   public Optional<AuthenticationMethod> clientAuthenticationMethod() {
     return apiAuthenticationMethod();
   }
+
+  public TestRestOperateClient newOperateClient() {
+    return new TestRestOperateClient(restAddress());
+  }
 }


### PR DESCRIPTION
## Description


1. Adds missing functionality to util class, to create operate client
2. Migrate StandaloneCamundaTest to multi db support, so we can validate behavior not only for ES but also for OS, AWS OS and RDBMS

## Related issues

related https://github.com/camunda/camunda/issues/28161
