### PR TITLE
build: adjust Optimize sharing feature to new SaaS context path

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/tomcat/CCSaasRequestAdjustmentFilter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/tomcat/CCSaasRequestAdjustmentFilter.java
@@ -48,6 +48,13 @@ public class CCSaasRequestAdjustmentFilter implements Filter {
       return;
     }
 
+    /* serve static external resource (Optimize only) */
+    if (ExternalResourcesUtil.shouldServeStaticResource(httpRequest, clusterId)) {
+      ExternalResourcesUtil.serveStaticResource(
+          httpRequest, httpResponse, servletContext, clusterId);
+      return;
+    }
+
     /* Strip cluster ID subpath */
     if (!clusterId.isEmpty() && requestURI.startsWith(clusterIdPath())) {
       requestURI = requestURI.substring(clusterIdPath().length());
@@ -58,12 +65,6 @@ public class CCSaasRequestAdjustmentFilter implements Filter {
     if (requestURI.startsWith("/external/api/")) {
       requestURI = requestURI.replaceFirst("/external/api/", "/api/external/");
       shallForward = true;
-    }
-
-    /* serve static external resource (Optimize only) */
-    if (ExternalResourcesUtil.shouldServeStaticResource(httpRequest)) {
-      ExternalResourcesUtil.serveStaticResource(httpRequest, httpResponse, servletContext);
-      shallForward = false;
     }
 
     if (shallForward) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Now that Optimize no longer uses StandaloneOptimize to start, the context path /optimize in SaaS is no longer present. This PR adjusts the external resource server to work well with the new setup in SaaS.

It also adds few things:
* it fixes a small bug where a return statement was missing, after serving an external resource.
* it throws a more debuggable exception in case something goes wrong when serving an external resource.

It can be tried with the following cluster:
https://lpp-1.optimize.dev.ultrawombat.com/c8086c50-79bc-4802-aba7-c1ab787086f2/#/

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
