### PR TITLE
feat: migrate BatchModificationSummaryModal component to v2

### DIFF
--- a/operate/client/src/App/Processes/ListView/DiagramPanel/BatchModificationNotification/v2/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/BatchModificationNotification/v2/index.tsx
@@ -11,7 +11,6 @@ import {useInstancesCount} from 'modules/queries/processInstancesStatistics/useI
 import {processXmlStore} from 'modules/stores/processXml/processXml.list';
 import pluralSuffix from 'modules/utils/pluralSuffix';
 import {Container, InlineNotification, Button} from '../styled';
-import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
 
 type Props = {
   sourceFlowNodeId?: string;
@@ -21,16 +20,7 @@ type Props = {
 
 const BatchModificationNotification: React.FC<Props> = observer(
   ({sourceFlowNodeId, targetFlowNodeId, onUndoClick}) => {
-    const selectedProcessInstanceIds =
-      processInstancesSelectionStore.selectedProcessInstanceIds;
-    const {data: instancesCount = 0} = useInstancesCount(
-      {
-        processInstanceKey: {
-          $in: selectedProcessInstanceIds,
-        },
-      },
-      sourceFlowNodeId,
-    );
+    const {data: instancesCount = 0} = useInstancesCount({}, sourceFlowNodeId);
 
     const sourceFlowNodeName = sourceFlowNodeId
       ? processXmlStore.getFlowNodeName(sourceFlowNodeId)

--- a/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/v2/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/v2/index.test.tsx
@@ -1,0 +1,162 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useEffect} from 'react';
+import {observer} from 'mobx-react';
+import {render, screen, waitFor} from 'modules/testing-library';
+import {processesStore} from 'modules/stores/processes/processes.list';
+import {processXmlStore} from 'modules/stores/processXml/processXml.list';
+import {batchModificationStore} from 'modules/stores/batchModification';
+import {BatchModificationSummaryModal} from '.';
+import {MemoryRouter} from 'react-router-dom';
+import {Paths} from 'modules/Routes';
+import {
+  groupedProcessesMock,
+  mockProcessStatisticsV2,
+  mockProcessXML,
+} from 'modules/testUtils';
+import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
+import {mockFetchGroupedProcesses} from 'modules/mocks/api/processes/fetchGroupedProcesses';
+import {mockFetchProcessInstancesStatistics} from 'modules/mocks/api/v2/processInstances/fetchProcessInstancesStatistics';
+import * as hooks from 'App/Processes/ListView/InstancesTable/useOperationApply';
+import {tracking} from 'modules/tracking';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+
+jest.mock('App/Processes/ListView/InstancesTable/useOperationApply');
+
+const Wrapper: React.FC<{children?: React.ReactNode}> = observer(
+  ({children}) => {
+    useEffect(() => {
+      return () => {
+        processesStore.reset();
+        processXmlStore.reset();
+        batchModificationStore.reset();
+      };
+    });
+
+    return (
+      <QueryClientProvider client={getMockQueryClient()}>
+        <MemoryRouter
+          initialEntries={[
+            `${Paths.processes()}?process=bigVarProcess&version=1&flowNodeId=ServiceTask_0kt6c5i`,
+          ]}
+        >
+          {children}
+          <button
+            onClick={async () => {
+              await processesStore.fetchProcesses();
+              await processXmlStore.fetchProcessXml();
+              batchModificationStore.enable();
+              batchModificationStore.selectTargetFlowNode('StartEvent_1');
+            }}
+          >
+            init
+          </button>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  },
+);
+
+describe('BatchModificationSummaryModal', () => {
+  beforeEach(() => {
+    mockFetchGroupedProcesses().withSuccess(groupedProcessesMock);
+    mockFetchProcessXML().withSuccess(mockProcessXML);
+    mockFetchProcessInstancesStatistics().withSuccess(mockProcessStatisticsV2);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render batch modification summary', async () => {
+    const applyBatchOperationMock = jest.fn();
+    jest.spyOn(hooks, 'default').mockImplementation(() => ({
+      applyBatchOperation: applyBatchOperationMock,
+    }));
+    mockFetchProcessInstancesStatistics().withSuccess(mockProcessStatisticsV2);
+
+    const {user} = render(
+      <BatchModificationSummaryModal setOpen={() => {}} open={true} />,
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    await user.click(screen.getByRole('button', {name: /init/i}));
+
+    expect(
+      await screen.findByText(
+        /Planned modifications for "Big variable process". Click "Apply" to proceed./i,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: /batch move/i})).toBeInTheDocument();
+    expect(await screen.findByRole('cell', {name: /^1$/})).toBeInTheDocument();
+    expect(
+      await screen.findByRole('cell', {
+        name: /Service Task 1 --> Start Event 1/i,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('should apply batch operation', async () => {
+    const trackSpy = jest.spyOn(tracking, 'track');
+    const applyBatchOperationMock = jest.fn();
+    jest.spyOn(hooks, 'default').mockImplementation(() => ({
+      applyBatchOperation: applyBatchOperationMock,
+    }));
+
+    const {user} = render(
+      <BatchModificationSummaryModal setOpen={() => {}} open={true} />,
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    expect(screen.getByRole('button', {name: /apply/i})).toBeDisabled();
+
+    await user.click(screen.getByRole('button', {name: /init/i}));
+    await waitFor(() =>
+      expect(screen.getByRole('button', {name: /apply/i})).toBeEnabled(),
+    );
+    await user.click(screen.getByRole('button', {name: /apply/i}));
+
+    expect(batchModificationStore.state.isEnabled).toBe(false);
+    expect(applyBatchOperationMock).toHaveBeenCalledTimes(1);
+    expect(applyBatchOperationMock).toHaveBeenCalledWith({
+      modifications: [
+        {
+          fromFlowNodeId: 'ServiceTask_0kt6c5i',
+          modification: 'MOVE_TOKEN',
+          toFlowNodeId: 'StartEvent_1',
+        },
+      ],
+      onSuccess: expect.any(Function),
+      operationType: 'MODIFY_PROCESS_INSTANCE',
+    });
+    expect(trackSpy).toHaveBeenCalledWith({
+      eventName: 'batch-move-modification-apply-button-clicked',
+    });
+  });
+
+  it('should close the modal when cancel button is clicked', async () => {
+    const setOpenMock = jest.fn();
+
+    const {user} = render(
+      <BatchModificationSummaryModal setOpen={setOpenMock} open={true} />,
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    await user.click(screen.getByRole('button', {name: /cancel/i}));
+
+    expect(setOpenMock).toHaveBeenCalledWith(false);
+  });
+});

--- a/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/v2/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/v2/index.tsx
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import React from 'react';
+import {observer} from 'mobx-react';
+import {Modal} from '@carbon/react';
+import {useLocation} from 'react-router-dom';
+import {StateProps} from 'modules/components/ModalStateManager';
+import {getProcessInstanceFilters} from 'modules/utils/filter';
+import {processesStore} from 'modules/stores/processes/processes.list';
+import {processXmlStore} from 'modules/stores/processXml/processXml.list';
+import {batchModificationStore} from 'modules/stores/batchModification';
+import {Title, DataTable} from '../styled';
+import useOperationApply from '../../../useOperationApply';
+import {panelStatesStore} from 'modules/stores/panelStates';
+import {tracking} from 'modules/tracking';
+import {useInstancesCount} from 'modules/queries/processInstancesStatistics/useInstancesCount';
+import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
+
+const BatchModificationSummaryModal: React.FC<StateProps> = observer(
+  ({open, setOpen}) => {
+    const location = useLocation();
+
+    const {applyBatchOperation} = useOperationApply();
+    const processInstancesFilters = getProcessInstanceFilters(location.search);
+    const {flowNodeId: sourceFlowNodeId, process: bpmnProcessId} =
+      processInstancesFilters;
+    const process = processesStore.getProcess({bpmnProcessId});
+    const processName = process?.name ?? process?.bpmnProcessId ?? 'Process';
+    const {selectedTargetFlowNodeId: targetFlowNodeId} =
+      batchModificationStore.state;
+    const sourceFlowNodeName = sourceFlowNodeId
+      ? processXmlStore.getFlowNodeName(sourceFlowNodeId)
+      : undefined;
+    const targetFlowNodeName = targetFlowNodeId
+      ? processXmlStore.getFlowNodeName(targetFlowNodeId)
+      : undefined;
+    const selectedProcessInstanceIds =
+      processInstancesSelectionStore.selectedProcessInstanceIds;
+    const {data: instancesCount} = useInstancesCount(
+      {
+        processInstanceKey: {
+          $in: selectedProcessInstanceIds,
+        },
+      },
+      sourceFlowNodeId,
+    );
+    const isPrimaryButtonDisabled =
+      sourceFlowNodeId === undefined || targetFlowNodeId === null;
+    const headers = [
+      {
+        header: 'Operation',
+        key: 'operation',
+        width: '30%',
+      },
+      {
+        header: 'Flow Node',
+        key: 'flowNode',
+        width: '40%',
+      },
+      {
+        header: 'Affected instances',
+        key: 'affectedInstances',
+        width: '30%',
+      },
+    ];
+    const rows = [
+      {
+        id: 'batchMove',
+        operation: 'Batch move',
+        flowNode: `${sourceFlowNodeName} --> ${targetFlowNodeName}`,
+        affectedInstances: instancesCount,
+      },
+    ];
+
+    return (
+      <Modal
+        primaryButtonDisabled={isPrimaryButtonDisabled}
+        modalHeading="Apply Modifications"
+        size="lg"
+        primaryButtonText="Apply"
+        secondaryButtonText="Cancel"
+        open={open}
+        onRequestClose={() => setOpen(false)}
+        preventCloseOnClickOutside
+        onRequestSubmit={() => {
+          if (isPrimaryButtonDisabled) {
+            return;
+          }
+          tracking.track({
+            eventName: 'batch-move-modification-apply-button-clicked',
+          });
+          setOpen(false);
+          batchModificationStore.reset();
+          applyBatchOperation({
+            operationType: 'MODIFY_PROCESS_INSTANCE',
+            modifications: [
+              {
+                modification: 'MOVE_TOKEN',
+                fromFlowNodeId: sourceFlowNodeId,
+                toFlowNodeId: targetFlowNodeId,
+              },
+            ],
+            onSuccess: panelStatesStore.expandOperationsPanel,
+          });
+        }}
+      >
+        <p>
+          {`Planned modifications for "${processName}". Click "Apply" to proceed.`}
+        </p>
+        <Title>Flow Node Modifications</Title>
+        <DataTable headers={headers} rows={rows} />
+      </Modal>
+    );
+  },
+);
+
+export {BatchModificationSummaryModal};

--- a/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/v2/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/v2/index.tsx
@@ -20,7 +20,6 @@ import useOperationApply from '../../../useOperationApply';
 import {panelStatesStore} from 'modules/stores/panelStates';
 import {tracking} from 'modules/tracking';
 import {useInstancesCount} from 'modules/queries/processInstancesStatistics/useInstancesCount';
-import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
 
 const BatchModificationSummaryModal: React.FC<StateProps> = observer(
   ({open, setOpen}) => {
@@ -40,16 +39,7 @@ const BatchModificationSummaryModal: React.FC<StateProps> = observer(
     const targetFlowNodeName = targetFlowNodeId
       ? processXmlStore.getFlowNodeName(targetFlowNodeId)
       : undefined;
-    const selectedProcessInstanceIds =
-      processInstancesSelectionStore.selectedProcessInstanceIds;
-    const {data: instancesCount} = useInstancesCount(
-      {
-        processInstanceKey: {
-          $in: selectedProcessInstanceIds,
-        },
-      },
-      sourceFlowNodeId,
-    );
+    const {data: instancesCount} = useInstancesCount({}, sourceFlowNodeId);
     const isPrimaryButtonDisabled =
       sourceFlowNodeId === undefined || targetFlowNodeId === null;
     const headers = [

--- a/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/index.tsx
@@ -11,12 +11,14 @@ import {observer} from 'mobx-react';
 import {batchModificationStore} from 'modules/stores/batchModification';
 import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
 import {ModalStateManager} from 'modules/components/ModalStateManager';
+import {BatchModificationSummaryModal as BatchModificationSummaryModalV2} from './BatchModificationSummaryModal/v2';
 import {BatchModificationSummaryModal} from './BatchModificationSummaryModal';
 import {Stack} from './styled';
 import {tracking} from 'modules/tracking';
 import {useCallbackPrompt} from 'modules/hooks/useCallbackPrompt';
 import {Location, Transition} from 'history';
 import {useState} from 'react';
+import {IS_PROCESS_INSTANCE_STATISTICS_V2_ENABLED} from 'modules/feature-flags';
 
 /**
  * This callback function is provided to useCallbackPrompt.
@@ -83,9 +85,13 @@ const BatchModificationFooter: React.FC = observer(() => {
             </Button>
           )}
         >
-          {({open, setOpen}) => (
-            <BatchModificationSummaryModal open={open} setOpen={setOpen} />
-          )}
+          {({open, setOpen}) =>
+            IS_PROCESS_INSTANCE_STATISTICS_V2_ENABLED ? (
+              <BatchModificationSummaryModalV2 open={open} setOpen={setOpen} />
+            ) : (
+              <BatchModificationSummaryModal open={open} setOpen={setOpen} />
+            )
+          }
         </ModalStateManager>
       </Stack>
       {(isNavigationInterrupted || isModalVisible) && (

--- a/operate/client/src/modules/queries/processInstancesStatistics/useBatchModificationOverlayData.ts
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useBatchModificationOverlayData.ts
@@ -13,9 +13,11 @@ import {
 import {MODIFICATIONS} from 'modules/bpmn-js/badgePositions';
 import {useProcessInstancesStatisticsOptions} from './useProcessInstancesStatistics';
 import {OverlayData} from 'modules/bpmn-js/BpmnJS';
-import {getInstancesCount} from 'modules/utils/statistics/processInstances';
+import {
+  getInstancesCount,
+  getProcessInstanceKey,
+} from 'modules/utils/statistics/processInstances';
 import {useQuery} from '@tanstack/react-query';
-import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
 
 function batchModificationOverlayParser(params: {
   sourceFlowNodeId?: string;
@@ -55,22 +57,7 @@ function useBatchModificationOverlayData(
   params: {sourceFlowNodeId?: string; targetFlowNodeId?: string},
   enabled?: boolean,
 ) {
-  const {
-    selectedProcessInstanceIds,
-    excludedProcessInstanceIds,
-    state: {selectionMode},
-  } = processInstancesSelectionStore;
-
-  const ids = ['EXCLUDE', 'ALL'].includes(selectionMode)
-    ? []
-    : selectedProcessInstanceIds;
-
-  const processInstanceKey = {
-    $in: ids,
-    ...(excludedProcessInstanceIds.length > 0 && {
-      $nin: excludedProcessInstanceIds,
-    }),
-  };
+  const processInstanceKey = getProcessInstanceKey();
 
   return useQuery(
     useProcessInstancesStatisticsOptions<OverlayData[]>(

--- a/operate/client/src/modules/queries/processInstancesStatistics/useInstancesCount.ts
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useInstancesCount.ts
@@ -12,7 +12,10 @@ import {
 } from 'modules/api/v2/processInstances/fetchProcessInstancesStatistics';
 import {useProcessInstancesStatisticsOptions} from './useProcessInstancesStatistics';
 import {useQuery} from '@tanstack/react-query';
-import {getInstancesCount} from 'modules/utils/statistics/processInstances';
+import {
+  getInstancesCount,
+  getProcessInstanceKey,
+} from 'modules/utils/statistics/processInstances';
 
 function instancesCountParser(
   flowNodeId?: string,
@@ -26,9 +29,14 @@ function useInstancesCount(
   payload: ProcessInstancesStatisticsRequest,
   flowNodeId?: string,
 ) {
+  const processInstanceKey = getProcessInstanceKey();
+
   return useQuery(
     useProcessInstancesStatisticsOptions<number>(
-      payload,
+      {
+        ...payload,
+        processInstanceKey,
+      },
       instancesCountParser(flowNodeId),
       !!flowNodeId,
     ),

--- a/operate/client/src/modules/utils/statistics/processInstances.ts
+++ b/operate/client/src/modules/utils/statistics/processInstances.ts
@@ -7,6 +7,7 @@
  */
 
 import {ProcessInstancesStatisticsDto} from 'modules/api/v2/processInstances/fetchProcessInstancesStatistics';
+import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
 
 function getInstancesCount(
   data: ProcessInstancesStatisticsDto[],
@@ -23,4 +24,23 @@ function getInstancesCount(
   return flowNodeStatistics.active + flowNodeStatistics.incidents;
 }
 
-export {getInstancesCount};
+const getProcessInstanceKey = () => {
+  const {
+    selectedProcessInstanceIds,
+    excludedProcessInstanceIds,
+    state: {selectionMode},
+  } = processInstancesSelectionStore;
+
+  const ids = ['EXCLUDE', 'ALL'].includes(selectionMode)
+    ? []
+    : selectedProcessInstanceIds;
+
+  return {
+    $in: ids,
+    ...(excludedProcessInstanceIds.length > 0 && {
+      $nin: excludedProcessInstanceIds,
+    }),
+  };
+};
+
+export {getInstancesCount, getProcessInstanceKey};


### PR DESCRIPTION
## Description

This PR creates a v2 component that fetches PI instance count data in the `BatchModificationSummaryModal`.
Most of the component and tests logic is similar to V1, the main differences are the introduction of TanStack Query.

Here's a screen recording showing the app with V2 Instances Table

https://github.com/user-attachments/assets/c58ed9b2-0883-4c5e-b905-292aea9975c3

As you can see, the instance count data appears in the "Apply Modification" modal. If we look at TanStack dev tools, the same query as #29284 is repeated

## Related issues

closes #29286