### PR TITLE
feat: change mapping delete api to use id

### DIFF
--- a/service/src/main/java/io/camunda/service/MappingServices.java
+++ b/service/src/main/java/io/camunda/service/MappingServices.java
@@ -114,8 +114,8 @@ public class MappingServices
         .findFirst();
   }
 
-  public CompletableFuture<MappingRecord> deleteMapping(final long mappingKey) {
-    return sendBrokerRequest(new BrokerMappingDeleteRequest().setMappingKey(mappingKey));
+  public CompletableFuture<MappingRecord> deleteMapping(final String mappingId) {
+    return sendBrokerRequest(new BrokerMappingDeleteRequest().setId(mappingId));
   }
 
   public List<MappingEntity> getMatchingMappings(final Map<String, Object> claims) {

--- a/service/src/test/java/io/camunda/service/MappingServicesTest.java
+++ b/service/src/test/java/io/camunda/service/MappingServicesTest.java
@@ -163,7 +163,7 @@ public class MappingServicesTest {
     // then
     verify(mockBrokerClient).sendRequest(mappingDeleteRequestArgumentCaptor.capture());
     final var request = mappingDeleteRequestArgumentCaptor.getValue();
-    assertThat(request.getRequestWriter().getMappingKey()).isEqualTo(1234L);
+    assertThat(request.getRequestWriter().getId()).isEqualTo("id");
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/MappingServicesTest.java
+++ b/service/src/test/java/io/camunda/service/MappingServicesTest.java
@@ -153,12 +153,12 @@ public class MappingServicesTest {
             mockBrokerClient, mock(SecurityContextProvider.class), client, testAuthentication);
 
     final var mappingRecord = new MappingRecord();
-    mappingRecord.setMappingKey(1234L);
+    mappingRecord.setId("id");
     when(mockBrokerClient.sendRequest(any()))
         .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(mappingRecord)));
 
     //  when
-    testMappingServices.deleteMapping(1234L);
+    testMappingServices.deleteMapping("id");
 
     // then
     verify(mockBrokerClient).sendRequest(mappingDeleteRequestArgumentCaptor.capture());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceFetchTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.resource;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.zeebe.engine.util.EngineRule;
@@ -21,6 +22,7 @@ import io.camunda.zeebe.protocol.record.value.deployment.ResourceAssert;
 import io.camunda.zeebe.stream.api.CommandResponseWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -69,10 +71,11 @@ public class ResourceFetchTest {
         .hasVersionTag("v1.0")
         .hasDeploymentKey(deployment.getKey())
         .hasChecksum(resourceMetadata.getChecksum());
-    verify(mockCommandResponseWriter).intent(ResourceIntent.FETCHED);
-    verify(mockCommandResponseWriter).valueType(ValueType.RESOURCE);
-    verify(mockCommandResponseWriter).key(resourceKey);
-    verify(mockCommandResponseWriter).tryWriteResponse(10, 123456789L);
+    final var timeout = timeout(Duration.ofSeconds(1).toMillis());
+    verify(mockCommandResponseWriter, timeout).intent(ResourceIntent.FETCHED);
+    verify(mockCommandResponseWriter, timeout).valueType(ValueType.RESOURCE);
+    verify(mockCommandResponseWriter, timeout).key(resourceKey);
+    verify(mockCommandResponseWriter, timeout).tryWriteResponse(10, 123456789L);
     ResourceAssert.assertThat(resourceResponse)
         .isNotNull()
         .hasResourceProp(new String(resourceBytes))

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -2642,7 +2642,7 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /mapping-rules/{id}:
+  /mapping-rules/{mappingId}:
     delete:
       tags:
         - Mapping rule
@@ -2654,7 +2654,7 @@ paths:
         This API is in a Work-in-Progress state and will undergo potential breaking changes until
         its release with an upcoming minor release.
       parameters:
-        - name: id
+        - name: mappingId
           in: path
           required: true
           description: The key of the mapping rule to delete.

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -2642,7 +2642,7 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /mapping-rules/{mappingKey}:
+  /mapping-rules/{id}:
     delete:
       tags:
         - Mapping rule
@@ -2654,7 +2654,7 @@ paths:
         This API is in a Work-in-Progress state and will undergo potential breaking changes until
         its release with an upcoming minor release.
       parameters:
-        - name: mappingKey
+        - name: id
           in: path
           required: true
           description: The key of the mapping rule to delete.

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingController.java
@@ -56,14 +56,14 @@ public class MappingController {
         ResponseMapper::toMappingCreateResponse);
   }
 
-  @CamundaDeleteMapping(path = "/{mappingKey}")
+  @CamundaDeleteMapping(path = "/{mappingId}")
   public CompletableFuture<ResponseEntity<Object>> deleteMapping(
-      @PathVariable final long mappingKey) {
+      @PathVariable final String mappingId) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             mappingServices
                 .withAuthentication(RequestMapper.getAuthentication())
-                .deleteMapping(mappingKey));
+                .deleteMapping(mappingId));
   }
 
   @CamundaGetMapping(path = "/{mappingKey}")

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
@@ -282,24 +282,24 @@ public class MappingControllerTest extends RestControllerTest {
   @Test
   void deleteMappingShouldReturnNoContent() {
     // given
-    final long mappingKey = 100L;
+    final String mappingId = "id";
 
-    final var mappingRecord = new MappingRecord().setMappingKey(mappingKey);
+    final var mappingRecord = new MappingRecord().setId(mappingId);
 
-    when(mappingServices.deleteMapping(mappingKey))
+    when(mappingServices.deleteMapping(mappingId))
         .thenReturn(CompletableFuture.completedFuture(mappingRecord));
 
     // when
     webClient
         .delete()
-        .uri("%s/%s".formatted(MAPPING_RULES_PATH, mappingKey))
+        .uri("%s/%s".formatted(MAPPING_RULES_PATH, mappingId))
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
         .isNoContent();
 
     // then
-    verify(mappingServices, times(1)).deleteMapping(mappingKey);
+    verify(mappingServices, times(1)).deleteMapping(mappingId);
   }
 
   private MappingDTO validCreateMappingRequest() {

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerMappingDeleteRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerMappingDeleteRequest.java
@@ -22,8 +22,8 @@ public class BrokerMappingDeleteRequest extends BrokerExecuteCommand<MappingReco
     setPartitionId(Protocol.DEPLOYMENT_PARTITION);
   }
 
-  public BrokerMappingDeleteRequest setMappingKey(final long mappingKey) {
-    requestDto.setMappingKey(mappingKey);
+  public BrokerMappingDeleteRequest setId(final String mappingId) {
+    requestDto.setId(mappingId);
     return this;
   }
 


### PR DESCRIPTION
## Description

Mapping delete api is using mapping key to lookup, but as we have introduced the mapping id and the key will be removed soon, api should change to use id instead of key.

## Related issues

closes #29432 
