### PR TITLE
feat: Migrate MigrateAction component to v2

### DIFF
--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MigrateAction/v2/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MigrateAction/v2/index.test.tsx
@@ -1,0 +1,367 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {act} from '@testing-library/react';
+import {render, screen, waitFor} from 'modules/testing-library';
+import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
+import {mockFetchProcessInstances} from 'modules/mocks/api/processInstances/fetchProcessInstances';
+import {
+  mockCalledProcessInstances,
+  mockProcessInstances,
+  mockProcessStatistics,
+} from 'modules/testUtils';
+import {MigrateAction} from '.';
+import {processInstanceMigrationStore} from 'modules/stores/processInstanceMigration';
+import {processXmlStore} from 'modules/stores/processXml/processXml.list';
+import {mockFetchProcessInstancesStatistics} from 'modules/mocks/api/processInstances/fetchProcessInstancesStatistics';
+import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
+import {tracking} from 'modules/tracking';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {MemoryRouter} from 'react-router-dom';
+import {fetchProcessInstances, getProcessInstance} from '../../mocks';
+import {processInstancesStore} from 'modules/stores/processInstances';
+import {useEffect} from 'react';
+import {batchModificationStore} from 'modules/stores/batchModification';
+
+const PROCESS_DEFINITION_ID = '2251799813685249';
+const PROCESS_ID = 'eventBasedGatewayProcess';
+
+jest.mock('modules/stores/processes/processes.list', () => ({
+  processesStore: {
+    getPermissions: jest.fn(),
+    state: {processes: []},
+    versionsByProcessAndTenant: {
+      [`{${PROCESS_ID}}-{<default>}`]: [
+        {id: PROCESS_DEFINITION_ID, version: 1},
+      ],
+    },
+  },
+}));
+
+function getWrapper(initialPath: string = '') {
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
+    useEffect(() => {
+      return () => {
+        processInstancesSelectionStore.reset();
+        processInstancesStore.reset();
+        processInstanceMigrationStore.reset();
+        processXmlStore.reset();
+        batchModificationStore.reset();
+      };
+    }, []);
+
+    return (
+      <MemoryRouter initialEntries={[initialPath]}>
+        {children}
+        <button
+          onClick={processInstancesSelectionStore.selectAllProcessInstances}
+        >
+          Select all instances
+        </button>
+        <button
+          onClick={() =>
+            processInstancesStore.fetchInstances({
+              fetchType: 'initial',
+              payload: {query: {}},
+            })
+          }
+        >
+          Fetch process instances
+        </button>
+        <button
+          onClick={() => {
+            processXmlStore.fetchProcessXml('1');
+          }}
+        >
+          Fetch process xml
+        </button>
+        <button onClick={batchModificationStore.enable}>
+          Enter batch modification mode
+        </button>
+        <button onClick={batchModificationStore.reset}>
+          Exit batch modification mode
+        </button>
+      </MemoryRouter>
+    );
+  };
+
+  return Wrapper;
+}
+
+function getWrapperWithQueryClient(initialPath: string = '') {
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
+    return (
+      <QueryClientProvider client={getMockQueryClient()}>
+        {getWrapper(initialPath)({children})}
+      </QueryClientProvider>
+    );
+  };
+
+  return Wrapper;
+}
+
+describe('<MigrateAction />', () => {
+  it('should disable migrate button, when no process version is selected', () => {
+    render(<MigrateAction />, {wrapper: getWrapperWithQueryClient()});
+
+    expect(screen.getByRole('button', {name: /migrate/i})).toBeDisabled();
+  });
+
+  it('should disable migrate button, when no active or incident instances are selected', () => {
+    render(<MigrateAction />, {
+      wrapper: getWrapperWithQueryClient(
+        `/processes?process=eventBasedGatewayProcess&version=1`,
+      ),
+    });
+
+    expect(screen.getByRole('button', {name: /migrate/i})).toBeDisabled();
+  });
+
+  it('should enable migrate button, when active or incident instances are selected', async () => {
+    mockFetchProcessInstances().withSuccess(mockProcessInstances);
+
+    const {user} = render(<MigrateAction />, {
+      wrapper: getWrapperWithQueryClient(
+        `/processes?process=eventBasedGatewayProcess&version=1`,
+      ),
+    });
+
+    await fetchProcessInstances(screen, user);
+
+    const instance = getProcessInstance('ACTIVE', mockProcessInstances);
+
+    expect(screen.getByRole('button', {name: /migrate/i})).toBeDisabled();
+
+    act(() => {
+      processInstancesSelectionStore.selectProcessInstance(instance.id);
+    });
+
+    expect(screen.getByRole('button', {name: /migrate/i})).toBeEnabled();
+  });
+
+  it('should enable migrate button when selected instances are called by parent', async () => {
+    mockFetchProcessInstances().withSuccess(mockCalledProcessInstances);
+
+    const {user} = render(<MigrateAction />, {
+      wrapper: getWrapperWithQueryClient(
+        `/processes?process=eventBasedGatewayProcess&version=1`,
+      ),
+    });
+
+    await fetchProcessInstances(screen, user);
+
+    const instance = getProcessInstance('ACTIVE', mockCalledProcessInstances);
+
+    act(() => {
+      processInstancesSelectionStore.selectProcessInstance(instance.id);
+    });
+
+    expect(screen.getByRole('button', {name: /migrate/i})).toBeEnabled();
+  });
+
+  it('should disable migrate button, when process XML could not be loaded', async () => {
+    mockFetchProcessInstances().withSuccess(mockCalledProcessInstances);
+
+    const {user} = render(<MigrateAction />, {
+      wrapper: getWrapperWithQueryClient(
+        `/processes?process=eventBasedGatewayProcess&version=1`,
+      ),
+    });
+
+    mockFetchProcessXML().withServerError();
+    await waitFor(() => processXmlStore.fetchProcessXml('1'));
+    expect(processXmlStore.state.status).toBe('error');
+
+    await fetchProcessInstances(screen, user);
+
+    const instance = getProcessInstance('ACTIVE', mockProcessInstances);
+
+    act(() => {
+      processInstancesSelectionStore.selectProcessInstance(instance.id);
+    });
+
+    expect(screen.getByRole('button', {name: /migrate/i})).toBeDisabled();
+  });
+
+  it('should disable migrate button, when only finished instances are selected', async () => {
+    mockFetchProcessInstances().withSuccess(mockProcessInstances);
+
+    const {user} = render(<MigrateAction />, {
+      wrapper: getWrapperWithQueryClient(
+        `/processes?process=eventBasedGatewayProcess&version=1`,
+      ),
+    });
+
+    await fetchProcessInstances(screen, user);
+
+    const instance = getProcessInstance('CANCELED', mockProcessInstances);
+
+    act(() => {
+      processInstancesSelectionStore.selectProcessInstance(instance.id);
+    });
+
+    expect(screen.getByRole('button', {name: /migrate/i})).toBeDisabled();
+  });
+
+  it('should enable migrate button, when all instances are selected', async () => {
+    mockFetchProcessInstances().withSuccess(mockProcessInstances);
+
+    const {user} = render(<MigrateAction />, {
+      wrapper: getWrapperWithQueryClient(
+        `/processes?process=eventBasedGatewayProcess&version=1`,
+      ),
+    });
+
+    expect(screen.getByRole('button', {name: /migrate/i})).toBeDisabled();
+
+    await fetchProcessInstances(screen, user);
+
+    await user.click(
+      screen.getByRole('button', {name: /select all instances/i}),
+    );
+
+    expect(screen.getByRole('button', {name: /migrate/i})).toBeEnabled();
+  });
+
+  it('should display migration helper modal on button click', async () => {
+    mockFetchProcessInstances().withSuccess(mockProcessInstances);
+
+    const {user} = render(<MigrateAction />, {
+      wrapper: getWrapperWithQueryClient(
+        `/processes?process=eventBasedGatewayProcess&version=1`,
+      ),
+    });
+
+    await fetchProcessInstances(screen, user);
+
+    const instance = getProcessInstance('ACTIVE', mockProcessInstances);
+
+    act(() => {
+      processInstancesSelectionStore.selectProcessInstance(instance.id);
+    });
+
+    await user.click(screen.getByRole('button', {name: /migrate/i}));
+
+    expect(
+      screen.getByText(
+        'Migrate is used to migrate running process instances to a different process definition.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'When the migration steps are executed, all selected process instances will be affected. This can lead to interruptions, delays or changes.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'To minimize interruptions or delays, plan the migration at times when the system load is low.',
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', {name: 'migration documentation'}),
+    ).toBeInTheDocument();
+  });
+
+  it('should set correct store states after migrate click', async () => {
+    const SEARCH_STRING = `?process=${PROCESS_ID}&version=1&active=true&incidents=false`;
+
+    const originalWindow = {...window};
+    const locationSpy = jest.spyOn(window, 'location', 'get');
+    locationSpy.mockImplementation(() => ({
+      ...originalWindow.location,
+      search: SEARCH_STRING,
+    }));
+
+    const {user} = render(<MigrateAction />, {
+      wrapper: getWrapperWithQueryClient(`/processes${SEARCH_STRING}`),
+    });
+
+    mockFetchProcessInstances().withSuccess(mockProcessInstances);
+    await fetchProcessInstances(screen, user);
+
+    const instance = getProcessInstance('ACTIVE', mockProcessInstances);
+    act(() => {
+      processInstancesSelectionStore.selectProcessInstance(instance.id);
+    });
+    await user.click(screen.getByRole('button', {name: /migrate/i}));
+
+    mockFetchProcessInstancesStatistics().withSuccess(mockProcessStatistics);
+    await user.click(screen.getByRole('button', {name: /continue/i}));
+
+    expect(processInstanceMigrationStore.state.currentStep).toBe(
+      'elementMapping',
+    );
+    expect(processInstanceMigrationStore.state.batchOperationQuery).toEqual({
+      active: true,
+      excludeIds: [],
+      ids: [instance.id],
+      incidents: false,
+      processIds: [PROCESS_DEFINITION_ID],
+      running: true,
+    });
+
+    locationSpy.mockRestore();
+  });
+
+  it('should track migrate click', async () => {
+    const trackSpy = jest.spyOn(tracking, 'track');
+
+    const {user} = render(<MigrateAction />, {
+      wrapper: getWrapperWithQueryClient(
+        `/processes?process=eventBasedGatewayProcess&version=1`,
+      ),
+    });
+
+    mockFetchProcessInstances().withSuccess(mockProcessInstances);
+    await fetchProcessInstances(screen, user);
+
+    const instance = getProcessInstance('ACTIVE', mockProcessInstances);
+    act(() => {
+      processInstancesSelectionStore.selectProcessInstance(instance.id);
+    });
+    await user.click(screen.getByRole('button', {name: /migrate/i}));
+
+    expect(trackSpy).toHaveBeenCalledWith({
+      eventName: 'process-instance-migration-button-clicked',
+    });
+
+    mockFetchProcessInstancesStatistics().withSuccess(mockProcessStatistics);
+    await user.click(screen.getByRole('button', {name: /continue/i}));
+
+    expect(trackSpy).toHaveBeenCalledWith({
+      eventName: 'process-instance-migration-mode-entered',
+    });
+
+    trackSpy.mockRestore();
+  });
+
+  it('should disable migrate action in batch modification mode', async () => {
+    mockFetchProcessInstances().withSuccess(mockProcessInstances);
+
+    const {user} = render(<MigrateAction />, {
+      wrapper: getWrapperWithQueryClient(
+        `/processes?process=eventBasedGatewayProcess&version=1`,
+      ),
+    });
+
+    await fetchProcessInstances(screen, user);
+
+    await user.click(
+      screen.getByRole('button', {name: /select all instances/i}),
+    );
+
+    expect(screen.getByRole('button', {name: /migrate/i})).toBeEnabled();
+
+    await user.click(
+      screen.getByRole('button', {name: /enter batch modification mode/i}),
+    );
+
+    expect(screen.getByRole('button', {name: /migrate/i})).toBeDisabled();
+  });
+});

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MigrateAction/v2/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MigrateAction/v2/index.tsx
@@ -1,0 +1,158 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {observer} from 'mobx-react';
+import {useLocation} from 'react-router-dom';
+import {Link, OrderedList, Stack, TableBatchAction} from '@carbon/react';
+import {MigrateAlt} from '@carbon/react/icons';
+import {Restricted} from 'modules/components/Restricted';
+import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
+import {getProcessInstanceFilters} from 'modules/utils/filter/getProcessInstanceFilters';
+import {processInstanceMigrationStore} from 'modules/stores/processInstanceMigration';
+import {processXmlStore as processXmlMigrationSourceStore} from 'modules/stores/processXml/processXml.migration.source';
+import {processXmlStore} from 'modules/stores/processXml/processXml.list';
+import {processesStore} from 'modules/stores/processes/processes.list';
+import {ModalStateManager} from 'modules/components/ModalStateManager';
+import {getProcessInstancesRequestFilters} from 'modules/utils/filter';
+import {ListItem} from '../styled';
+import {tracking} from 'modules/tracking';
+import {batchModificationStore} from 'modules/stores/batchModification';
+import {HelperModal} from 'modules/components/HelperModal';
+import {getStateLocally} from 'modules/utils/localStorage';
+
+const localStorageKey = 'hideMigrationHelperModal';
+
+const MigrateAction: React.FC = observer(() => {
+  const location = useLocation();
+  const {version, process, tenant} = getProcessInstanceFilters(location.search);
+  const {
+    selectedProcessInstanceIds,
+    hasSelectedRunningInstances,
+    state: {isAllChecked},
+  } = processInstancesSelectionStore;
+
+  const isVersionSelected = version !== undefined && version !== 'all';
+
+  const hasXmlError = processXmlStore.state.status === 'error';
+
+  const isDisabled =
+    batchModificationStore.state.isEnabled ||
+    !isVersionSelected ||
+    !hasSelectedRunningInstances ||
+    hasXmlError;
+
+  const getTooltipText = () => {
+    if (!isVersionSelected) {
+      return 'To start the migration process, choose a process and version first.';
+    }
+
+    if (hasXmlError) {
+      return 'Issue fetching diagram, contact admin if problem persists.';
+    }
+
+    if (!hasSelectedRunningInstances) {
+      return 'You can only migrate instances in active or incident state.';
+    }
+  };
+
+  const handleSubmit = () => {
+    processXmlMigrationSourceStore.setProcessXml(processXmlStore.state.xml);
+
+    const requestFilterParameters = {
+      ...getProcessInstancesRequestFilters(),
+      ids: isAllChecked ? [] : selectedProcessInstanceIds,
+      excludeIds: isAllChecked ? selectedProcessInstanceIds : [],
+    };
+
+    processInstanceMigrationStore.setSelectedInstancesCount(
+      processInstancesSelectionStore.selectedProcessInstanceCount,
+    );
+    processInstanceMigrationStore.setBatchOperationQuery(
+      requestFilterParameters,
+    );
+    processInstanceMigrationStore.enable();
+
+    tracking.track({
+      eventName: 'process-instance-migration-mode-entered',
+    });
+  };
+
+  return (
+    <Restricted
+      resourceBasedRestrictions={{
+        scopes: ['UPDATE_PROCESS_INSTANCE'],
+        permissions: processesStore.getPermissions(process, tenant),
+      }}
+    >
+      <ModalStateManager
+        renderLauncher={({setOpen}) => (
+          <TableBatchAction
+            renderIcon={MigrateAlt}
+            onClick={() => {
+              if (getStateLocally()?.[localStorageKey]) {
+                handleSubmit();
+              } else {
+                setOpen(true);
+              }
+              tracking.track({
+                eventName: 'process-instance-migration-button-clicked',
+              });
+            }}
+            disabled={isDisabled}
+            title={
+              batchModificationStore.state.isEnabled
+                ? 'Not available in batch modification mode'
+                : getTooltipText()
+            }
+          >
+            Migrate
+          </TableBatchAction>
+        )}
+      >
+        {({open, setOpen}) => (
+          <HelperModal
+            title="Migrate process instance versions"
+            open={open}
+            onClose={() => setOpen(false)}
+            localStorageKey={localStorageKey}
+            onSubmit={handleSubmit}
+          >
+            <Stack as={OrderedList} nested gap={5}>
+              <ListItem>
+                Migrate is used to migrate running process instances to a
+                different process definition.
+              </ListItem>
+              <ListItem>
+                When the migration steps are executed, all selected process
+                instances will be affected. This can lead to interruptions,
+                delays or changes.
+              </ListItem>
+              <ListItem>
+                To minimize interruptions or delays, plan the migration at times
+                when the system load is low.
+              </ListItem>
+            </Stack>
+            <p>
+              Questions or concerns? Check our{' '}
+              <Link
+                href="https://docs.camunda.io/docs/components/operate/userguide/process-instance-migration/"
+                target="_blank"
+                inline
+              >
+                migration documentation
+              </Link>{' '}
+              for guidance and best practices.
+            </p>
+          </HelperModal>
+        )}
+      </ModalStateManager>
+    </Restricted>
+  );
+});
+
+export {MigrateAction};

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/index.tsx
@@ -14,10 +14,12 @@ import useOperationApply from '../useOperationApply';
 import {panelStatesStore} from 'modules/stores/panelStates';
 import {RetryFailed, Error} from '@carbon/react/icons';
 import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
+import {MigrateAction as MigrateActionV2} from './MigrateAction/v2';
 import {MigrateAction} from './MigrateAction';
 import {MoveAction} from './MoveAction';
 import {batchModificationStore} from 'modules/stores/batchModification';
 import {observer} from 'mobx-react';
+import {IS_PROCESS_INSTANCE_STATISTICS_V2_ENABLED} from 'modules/feature-flags';
 
 type Props = {
   selectedInstancesCount: number;
@@ -90,7 +92,11 @@ const Toolbar: React.FC<Props> = observer(({selectedInstancesCount}) => {
           }}
         >
           <MoveAction />
-          <MigrateAction />
+          {IS_PROCESS_INSTANCE_STATISTICS_V2_ENABLED ? (
+            <MigrateActionV2 />
+          ) : (
+            <MigrateAction />
+          )}
           <TableBatchAction
             renderIcon={Error}
             onClick={() => setModalMode('CANCEL_PROCESS_INSTANCE')}


### PR DESCRIPTION
## Description

The v1 behavior of the `MigrateAction` component was to prefetch PI statistics data to the mobx store. For the same reasons as [mentioned here](https://github.com/camunda/camunda/pull/29435#discussion_r2000401895), I believe we can remove this prefetch logic. The consumers of statistics data should all be using query hooks in v2 which refreshes the data if needed, so we don't need to prefetch anything. The v2 component in this PR is a copy of v1 with the prefetch removed.

## Related issues

closes #29287
