### PR TITLE
[CPT] feat: Assert that a process instance has not activated the given elements

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
@@ -202,6 +202,29 @@ public interface ProcessInstanceAssert {
   ProcessInstanceAssert hasTerminatedElement(ElementSelector elementSelector, int times);
 
   /**
+   * Verifies that the given BPMN elements are not activated (i.e. not entered). The verification
+   * fails if at least one element is active, completed, or terminated.
+   *
+   * <p>The assertion doesn't wait for the given activities.
+   *
+   * @param elementIds the BPMN element IDs
+   * @return the assertion object
+   */
+  ProcessInstanceAssert hasNotActivatedElements(String... elementIds);
+
+  /**
+   * Verifies that the given BPMN elements are not activated (i.e. not entered). The verification
+   * fails if at least one element is active, completed, or terminated.
+   *
+   * <p>The assertion doesn't wait for the given activities.
+   *
+   * @param elementSelectors the selectors for the BPMN elements
+   * @return the assertion object
+   * @see ElementSelectors
+   */
+  ProcessInstanceAssert hasNotActivatedElements(ElementSelector... elementSelectors);
+
+  /**
    * Verifies that the process instance has the given variables. The verification fails if at least
    * one variable doesn't exist.
    *

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ElementAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ElementAssertj.java
@@ -299,19 +299,19 @@ public class ElementAssertj extends AbstractAssert<ElementAssertj, String> {
         dataSource.findFlowNodeInstances(
             flowNodeInstanceFilter(processInstanceKey, elementSelectors));
 
-    final List<ElementSelector> activatedFlowNodeInstances =
+    final List<ElementSelector> activatedElements =
         elementSelectors.stream()
             .filter(elementSelector -> flowNodeInstances.stream().anyMatch(elementSelector::test))
             .collect(Collectors.toList());
 
-    assertThat(activatedFlowNodeInstances)
+    assertThat(activatedElements)
         .withFailMessage(
             () ->
                 String.format(
                     "%s should have not activated elements %s but the following elements were activated:\n%s",
                     actual,
                     formatElementSelectors(elementSelectors),
-                    formatFlowNodeInstanceStates(activatedFlowNodeInstances, flowNodeInstances)))
+                    formatFlowNodeInstanceStates(activatedElements, flowNodeInstances)))
         .isEmpty();
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -175,6 +175,18 @@ public class ProcessInstanceAssertj
   }
 
   @Override
+  public ProcessInstanceAssert hasNotActivatedElements(final String... elementIds) {
+    elementAssertj.hasNotActivatedElements(getProcessInstanceKey(), elementIds);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert hasNotActivatedElements(final ElementSelector... elementSelectors) {
+    elementAssertj.hasNotActivatedElements(getProcessInstanceKey(), elementSelectors);
+    return this;
+  }
+
+  @Override
   public ProcessInstanceAssert hasVariableNames(final String... variableNames) {
     variableAssertj.hasVariableNames(getProcessInstanceKey(), variableNames);
     return this;


### PR DESCRIPTION
## Description

Add a new assertion: `hasNotActivatedElements()`. 

This assertion is an equivalent of:
- C7: [hasNotPassed](https://docs.camunda.org/manual/7.21/user-guide/testing/assert-examples/#instance-hasnotpassed)
- ZPT: [hasNotPassedElement](https://github.com/camunda/zeebe-process-test/blob/ae9b96c848ca1bf3d8efdbf43bf6b1003ac1536a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/ProcessInstanceAssert.java#L198)

## Related issues

closes #23240 
