### PR TITLE
Document Backup E2E

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
@@ -60,6 +60,18 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+/**
+ * This test is on purpose no {@link io.camunda.qa.util.multidb.MultiDbTest}, as we have special
+ * requirements on ES and OS, and need direct access.
+ *
+ * <ul>
+ *   <li>We need to configure ES/OS to allow local repositories.
+ *   <li>We need to create snapshot repositories with specific ES/OS clients.
+ *   <li>We need to create snapshots of the Zeebe exporter indices
+ * </ul>
+ *
+ * Furthermore, this test will not apply to RDBMS.
+ */
 @Testcontainers
 @ZeebeIntegration
 public class BackupRestoreIT {


### PR DESCRIPTION
## Description

 Reason about why Backup E2E is no multi db test
<!-- Describe the goal and purpose of this PR. -->


## Related issues

related https://github.com/camunda/camunda/issues/28161
