### PR TITLE
deps: bump spring boot to fix Tomcat CVE

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -99,7 +99,7 @@
     <version.rest-assured>5.5.1</version.rest-assured>
     <version.spring>6.1.14</version.spring>
     <version.spring-security>6.3.4</version.spring-security>
-    <version.spring-boot>3.3.7</version.spring-boot>
+    <version.spring-boot>3.3.9</version.spring-boot>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.2</version.kryo>
     <version.failsafe>2.4.4</version.failsafe>


### PR DESCRIPTION
## Description

This PR bumps Spring Boot to 3.3.9, which also bumps Tomcat and fixes a high severity CVE: https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHETOMCATEMBED-9396739