### PR TITLE
[C8 API] Add errorMessage field for filtering process instances

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilter.java
@@ -117,4 +117,10 @@ public interface ProcessInstanceFilter extends SearchRequestFilter {
 
   /** Filter by batchOperationId using {@link StringProperty} */
   ProcessInstanceFilter batchOperationId(final Consumer<StringProperty> fn);
+
+  /** Filter by error message */
+  ProcessInstanceFilter errorMessage(final String errorMessage);
+
+  /** Filter by error message using {@link StringProperty} consumer */
+  ProcessInstanceFilter errorMessage(final Consumer<StringProperty> fn);
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessInstanceFilterImpl.java
@@ -267,6 +267,20 @@ public class ProcessInstanceFilterImpl
   }
 
   @Override
+  public ProcessInstanceFilter errorMessage(final String errorMessage) {
+    errorMessage(b -> b.eq(errorMessage));
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceFilter errorMessage(final Consumer<StringProperty> fn) {
+    final StringProperty property = new StringPropertyImpl();
+    fn.accept(property);
+    filter.errorMessage(property.build());
+    return this;
+  }
+
+  @Override
   protected io.camunda.client.protocol.rest.ProcessInstanceFilter getSearchRequestProperty() {
     return filter;
   }

--- a/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
@@ -89,7 +89,9 @@ public class QueryProcessInstanceTest extends ClientRestTest {
                     .state(ACTIVE)
                     .hasIncident(true)
                     .tenantId("tenant")
-                    .variables(variablesMap))
+                    .variables(variablesMap)
+                    .variables(variables)
+                    .errorMessage("Error message"))
         .send()
         .join();
     // then
@@ -111,6 +113,7 @@ public class QueryProcessInstanceTest extends ClientRestTest {
     assertThat(filter.getHasIncident()).isEqualTo(true);
     assertThat(filter.getTenantId().get$Eq()).isEqualTo("tenant");
     assertThat(filter.getVariables()).isEqualTo(variables);
+    assertThat(filter.getErrorMessage().get$Eq()).isEqualTo("Error message");
   }
 
   @Test

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -166,6 +166,19 @@
         )
       </foreach>
     </if>
+
+    <!-- Error message filters -->
+    <if test="filter.errorMessageOperations != null and !filter.errorMessageOperations.isEmpty()">
+      AND EXISTS (
+      SELECT 1
+      FROM INCIDENT i
+      WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
+      <foreach collection="filter.errorMessageOperations" item="operation">
+        AND i.ERROR_MESSAGE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+      )
+    </if>
   </sql>
 
   <resultMap id="searchResultMap" type="io.camunda.search.entities.ProcessInstanceEntity">

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -170,32 +170,12 @@
     <!-- Error message filters -->
     <if test="filter.errorMessageOperations != null and !filter.errorMessageOperations.isEmpty()">
       <foreach collection="filter.errorMessageOperations" item="operation">
-        <choose>
-          <when test="operation.operator == @io.camunda.search.filter.Operator@NOT_EQUALS">
-            AND NOT EXISTS (
-            SELECT 1
-            FROM INCIDENT i
-            WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
-            AND i.ERROR_MESSAGE = #{operation.value}
-            )
-          </when>
-          <when test="operation.operator == @io.camunda.search.filter.Operator@NOT_EXISTS">
-            AND NOT EXISTS (
-            SELECT 1
-            FROM INCIDENT i
-            WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
-            AND i.ERROR_MESSAGE IS NOT NULL
-            )
-          </when>
-          <otherwise>
-            AND EXISTS (
-            SELECT 1
-            FROM INCIDENT i
-            WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
-            AND i.ERROR_MESSAGE <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-            )
-          </otherwise>
-        </choose>
+        AND EXISTS (
+        SELECT 1
+        FROM INCIDENT i
+        WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
+        AND i.ERROR_MESSAGE <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+        )
       </foreach>
     </if>
   </sql>

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -169,15 +169,34 @@
 
     <!-- Error message filters -->
     <if test="filter.errorMessageOperations != null and !filter.errorMessageOperations.isEmpty()">
-      AND EXISTS (
-      SELECT 1
-      FROM INCIDENT i
-      WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
-      <foreach collection="filter.errorMessageOperations" item="operation">
-        AND i.ERROR_MESSAGE
-        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-      </foreach>
-      )
+      <choose>
+        <when test="filter.errorMessageOperations[0].operator == @io.camunda.search.filter.Operator@NOT_EQUALS">
+          AND NOT EXISTS (
+          SELECT 1
+          FROM INCIDENT i
+          WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
+          AND i.ERROR_MESSAGE = #{filter.errorMessageOperations[0].value}
+          )
+        </when>
+        <when test="filter.errorMessageOperations[0].operator == @io.camunda.search.filter.Operator@NOT_EXISTS">
+          AND NOT EXISTS (
+          SELECT 1
+          FROM INCIDENT i
+          WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
+          AND i.ERROR_MESSAGE IS NOT NULL
+          )
+        </when>
+        <otherwise>
+          AND EXISTS (
+          SELECT 1
+          FROM INCIDENT i
+          WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
+          <foreach collection="filter.errorMessageOperations" item="operation">
+            AND i.ERROR_MESSAGE <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+          </foreach>
+          )
+        </otherwise>
+      </choose>
     </if>
   </sql>
 

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -169,34 +169,34 @@
 
     <!-- Error message filters -->
     <if test="filter.errorMessageOperations != null and !filter.errorMessageOperations.isEmpty()">
-      <choose>
-        <when test="filter.errorMessageOperations[0].operator == @io.camunda.search.filter.Operator@NOT_EQUALS">
-          AND NOT EXISTS (
-          SELECT 1
-          FROM INCIDENT i
-          WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
-          AND i.ERROR_MESSAGE = #{filter.errorMessageOperations[0].value}
-          )
-        </when>
-        <when test="filter.errorMessageOperations[0].operator == @io.camunda.search.filter.Operator@NOT_EXISTS">
-          AND NOT EXISTS (
-          SELECT 1
-          FROM INCIDENT i
-          WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
-          AND i.ERROR_MESSAGE IS NOT NULL
-          )
-        </when>
-        <otherwise>
-          AND EXISTS (
-          SELECT 1
-          FROM INCIDENT i
-          WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
-          <foreach collection="filter.errorMessageOperations" item="operation">
+      <foreach collection="filter.errorMessageOperations" item="operation">
+        <choose>
+          <when test="operation.operator == @io.camunda.search.filter.Operator@NOT_EQUALS">
+            AND NOT EXISTS (
+            SELECT 1
+            FROM INCIDENT i
+            WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
+            AND i.ERROR_MESSAGE = #{operation.value}
+            )
+          </when>
+          <when test="operation.operator == @io.camunda.search.filter.Operator@NOT_EXISTS">
+            AND NOT EXISTS (
+            SELECT 1
+            FROM INCIDENT i
+            WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
+            AND i.ERROR_MESSAGE IS NOT NULL
+            )
+          </when>
+          <otherwise>
+            AND EXISTS (
+            SELECT 1
+            FROM INCIDENT i
+            WHERE i.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
             AND i.ERROR_MESSAGE <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
-          </foreach>
-          )
-        </otherwise>
-      </choose>
+            )
+          </otherwise>
+        </choose>
+      </foreach>
     </if>
   </sql>
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceSearchTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceSearchTest.java
@@ -30,8 +30,6 @@ import io.camunda.client.impl.search.filter.builder.StringPropertyImpl;
 import io.camunda.client.protocol.rest.ProcessInstanceStateEnum;
 import io.camunda.client.protocol.rest.ProcessInstanceVariableFilterRequest;
 import io.camunda.qa.util.multidb.MultiDbTest;
-import io.camunda.search.filter.FilterBuilders;
-import io.camunda.search.filter.Operation;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
@@ -44,9 +42,10 @@ import org.junit.jupiter.api.Test;
 @MultiDbTest
 public class ProcessInstanceAndFlowNodeInstanceSearchTest {
 
+  public static final String EXPECTED_ERROR =
+      "Expected result of the expression 'retriesA' to be 'NUMBER', but was 'STRING'.";
   static final List<Process> DEPLOYED_PROCESSES = new ArrayList<>();
   static final List<ProcessInstanceEvent> PROCESS_INSTANCES = new ArrayList<>();
-
   private static FlowNodeInstance flowNodeInstance;
   private static FlowNodeInstance flowNodeInstanceWithIncident;
   private static CamundaClient camundaClient;
@@ -1204,25 +1203,137 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
 
   @Test
   void shouldQueryProcessInstancesByErrorMessageEqual() {
-    // given: we expect that the incident process instance has this error message.
-    final String expectedError =
-        "Expected at least one condition to evaluate to true, or to have a default flow";
-    // using the builder helper, set errorMessage filter with equality operator
-    final var filter =
-        FilterBuilders.processInstance(
-            f -> f.errorMessageOperations(List.of(Operation.eq(expectedError))));
+    // given: we expect that the incident process instance has an error message.
+    // when: query process instances by errorMessage not equal
 
     // when: query process instances by errorMessage equal
     final var result =
         camundaClient
             .newProcessInstanceQuery()
-            .filter(f -> f.errorMessage(b -> b.eq(expectedError)))
+            .filter(b -> b.errorMessage(f -> f.eq(EXPECTED_ERROR)))
             .send()
             .join();
 
-    // then: we expect to find only the incident process instance (assumed to have this error
-    // message)
+    // then: we expect to find all the process instance without the error.
     assertThat(result.items().size()).isEqualTo(1);
     assertThat(result.items().getFirst().getProcessDefinitionId()).isEqualTo("incident_process_v1");
+  }
+
+  @Test
+  void shouldQueryProcessInstancesByErrorMessageNotEqual() {
+    // given: we expect that the incident process instance has an error message.
+    // when: query process instances by errorMessage not equal
+    final var result =
+        camundaClient
+            .newProcessInstanceQuery()
+            .filter(b -> b.errorMessage(f -> f.neq(EXPECTED_ERROR)))
+            .send()
+            .join();
+
+    // then: we expect to find all the process instance without the error.
+    assertThat(result.items().size()).isEqualTo(5);
+    assertThat(result.items())
+        .extracting("processDefinitionId")
+        .doesNotContain("incident_process_v1");
+  }
+
+  @Test
+  void shouldQueryProcessInstancesByErrorMessageExists() {
+    // given: we expect that the incident process instance has an error message.
+    // when: query process instances by errorMessage exists
+    final var result =
+        camundaClient
+            .newProcessInstanceQuery()
+            .filter(b -> b.errorMessage(f -> f.exists(true)))
+            .send()
+            .join();
+
+    // then: we expect to find only the process instance with the error.
+    assertThat(result.items().size()).isEqualTo(1);
+    assertThat(result.items()).extracting("processDefinitionId").contains("incident_process_v1");
+  }
+
+  @Test
+  void shouldQueryProcessInstancesByErrorMessageNotExists() {
+    // given: we expect that the incident process instance has an error message.
+    // when: query process instances by errorMessage not exists
+    final var result =
+        camundaClient
+            .newProcessInstanceQuery()
+            .filter(b -> b.errorMessage(f -> f.exists(false)))
+            .send()
+            .join();
+
+    // then: we expect to find all the process instances without error message
+    assertThat(result.items().size()).isEqualTo(5);
+    assertThat(result.items())
+        .extracting("processDefinitionId")
+        .doesNotContain("incident_process_v1");
+  }
+
+  @Test
+  void shouldQueryProcessInstancesByErrorMessageIn() {
+    // given: we expect that the incident process instance has an error message.
+    // when: query process instances by errorMessage in
+    final var result =
+        camundaClient
+            .newProcessInstanceQuery()
+            .filter(b -> b.errorMessage(f -> f.in(EXPECTED_ERROR, "foo")))
+            .send()
+            .join();
+
+    // then: we expect to find only the process instance with the error.
+    assertThat(result.items().size()).isEqualTo(1);
+    assertThat(result.items()).extracting("processDefinitionId").contains("incident_process_v1");
+  }
+
+  @Test
+  void shouldQueryProcessInstancesByErrorMessageNotIn() {
+    // given: we expect that the incident process instance has an error message.
+    // when: query process instances by errorMessage not in
+    final var result =
+        camundaClient
+            .newProcessInstanceQuery()
+            .filter(b -> b.errorMessage(f -> f.in("foo", "bar")))
+            .send()
+            .join();
+
+    // then: we expect to find no process instances.
+    assertThat(result.items().size()).isEqualTo(0);
+  }
+
+  @Test
+  void shouldQueryProcessInstancesByErrorMessageExistsLike() {
+    // given: we expect that the incident process instance has this error message.
+    final String expectedError = "Expect*";
+
+    // when: query process instances by errorMessage like
+    final var result =
+        camundaClient
+            .newProcessInstanceQuery()
+            .filter(b -> b.errorMessage(f -> f.like(expectedError)))
+            .send()
+            .join();
+
+    // then: we expect to find only the incident process instance
+    assertThat(result.items().size()).isEqualTo(1);
+    assertThat(result.items()).extracting("processDefinitionId").contains("incident_process_v1");
+  }
+
+  @Test
+  void shouldQueryProcessInstancesByErrorMessageLikeAndIn() {
+    // given: we expect that the incident process instance has this error message.
+    final String expectedError = "Expect*";
+
+    // when: query process instances by errorMessage like and in
+    final var result =
+        camundaClient
+            .newProcessInstanceQuery()
+            .filter(b -> b.errorMessage(f -> f.like(expectedError).in("foo", "bar")))
+            .send()
+            .join();
+
+    // then: we expect to find no process instances.
+    assertThat(result.items().size()).isEqualTo(0);
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceSearchTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceSearchTest.java
@@ -1206,7 +1206,7 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
     // when:
     final var result =
         camundaClient
-            .newProcessInstanceQuery()
+            .newProcessInstanceSearchRequest()
             .filter(b -> b.errorMessage(f -> f.eq(EXPECTED_ERROR)))
             .send()
             .join();
@@ -1221,7 +1221,7 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
     // when:
     final var result =
         camundaClient
-            .newProcessInstanceQuery()
+            .newProcessInstanceSearchRequest()
             .filter(b -> b.errorMessage(f -> f.neq(EXPECTED_ERROR)))
             .send()
             .join();
@@ -1235,7 +1235,7 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
     // when:
     final var result =
         camundaClient
-            .newProcessInstanceQuery()
+            .newProcessInstanceSearchRequest()
             .filter(b -> b.errorMessage(f -> f.exists(true)))
             .send()
             .join();
@@ -1250,7 +1250,7 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
     // when:
     final var result =
         camundaClient
-            .newProcessInstanceQuery()
+            .newProcessInstanceSearchRequest()
             .filter(b -> b.errorMessage(f -> f.exists(false)))
             .send()
             .join();
@@ -1264,7 +1264,7 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
     // when:
     final var result =
         camundaClient
-            .newProcessInstanceQuery()
+            .newProcessInstanceSearchRequest()
             .filter(b -> b.errorMessage(f -> f.in(EXPECTED_ERROR, "foo")))
             .send()
             .join();
@@ -1279,7 +1279,7 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
     // when:
     final var result =
         camundaClient
-            .newProcessInstanceQuery()
+            .newProcessInstanceSearchRequest()
             .filter(b -> b.errorMessage(f -> f.in("foo", "bar")))
             .send()
             .join();
@@ -1296,7 +1296,7 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
     // when:
     final var result =
         camundaClient
-            .newProcessInstanceQuery()
+            .newProcessInstanceSearchRequest()
             .filter(b -> b.errorMessage(f -> f.like(expectedError)))
             .send()
             .join();
@@ -1314,7 +1314,7 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
     // when:
     final var result =
         camundaClient
-            .newProcessInstanceQuery()
+            .newProcessInstanceSearchRequest()
             .filter(b -> b.errorMessage(f -> f.like(expectedError).in("foo", "bar")))
             .send()
             .join();

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceSearchTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceSearchTest.java
@@ -1203,10 +1203,7 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
 
   @Test
   void shouldQueryProcessInstancesByErrorMessageEqual() {
-    // given: we expect that the incident process instance has an error message.
-    // when: query process instances by errorMessage not equal
-
-    // when: query process instances by errorMessage equal
+    // when:
     final var result =
         camundaClient
             .newProcessInstanceQuery()
@@ -1214,15 +1211,14 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
             .send()
             .join();
 
-    // then: we expect to find all the process instance without the error.
+    // then:
     assertThat(result.items().size()).isEqualTo(1);
     assertThat(result.items().getFirst().getProcessDefinitionId()).isEqualTo("incident_process_v1");
   }
 
   @Test
   void shouldQueryProcessInstancesByErrorMessageNotEqual() {
-    // given: we expect that the incident process instance has an error message.
-    // when: query process instances by errorMessage not equal
+    // when:
     final var result =
         camundaClient
             .newProcessInstanceQuery()
@@ -1230,17 +1226,13 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
             .send()
             .join();
 
-    // then: we expect to find all the process instance without the error.
-    assertThat(result.items().size()).isEqualTo(6);
-    assertThat(result.items())
-        .extracting("processDefinitionId")
-        .doesNotContain("incident_process_v1");
+    // then:
+    assertThat(result.items().size()).isEqualTo(0);
   }
 
   @Test
   void shouldQueryProcessInstancesByErrorMessageExists() {
-    // given: we expect that the incident process instance has an error message.
-    // when: query process instances by errorMessage exists
+    // when:
     final var result =
         camundaClient
             .newProcessInstanceQuery()
@@ -1248,15 +1240,14 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
             .send()
             .join();
 
-    // then: we expect to find only the process instance with the error.
+    // then:
     assertThat(result.items().size()).isEqualTo(1);
     assertThat(result.items()).extracting("processDefinitionId").contains("incident_process_v1");
   }
 
   @Test
   void shouldQueryProcessInstancesByErrorMessageNotExists() {
-    // given: we expect that the incident process instance has an error message.
-    // when: query process instances by errorMessage not exists
+    // when:
     final var result =
         camundaClient
             .newProcessInstanceQuery()
@@ -1264,17 +1255,13 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
             .send()
             .join();
 
-    // then: we expect to find all the process instances without error message
-    assertThat(result.items().size()).isEqualTo(6);
-    assertThat(result.items())
-        .extracting("processDefinitionId")
-        .doesNotContain("incident_process_v1");
+    // then:
+    assertThat(result.items().size()).isEqualTo(0);
   }
 
   @Test
   void shouldQueryProcessInstancesByErrorMessageIn() {
-    // given: we expect that the incident process instance has an error message.
-    // when: query process instances by errorMessage in
+    // when:
     final var result =
         camundaClient
             .newProcessInstanceQuery()
@@ -1282,15 +1269,14 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
             .send()
             .join();
 
-    // then: we expect to find only the process instance with the error.
+    // then:
     assertThat(result.items().size()).isEqualTo(1);
     assertThat(result.items()).extracting("processDefinitionId").contains("incident_process_v1");
   }
 
   @Test
   void shouldQueryProcessInstancesByErrorMessageNotIn() {
-    // given: we expect that the incident process instance has an error message.
-    // when: query process instances by errorMessage not in
+    // when:
     final var result =
         camundaClient
             .newProcessInstanceQuery()
@@ -1298,16 +1284,16 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
             .send()
             .join();
 
-    // then: we expect to find no process instances.
+    // then:
     assertThat(result.items().size()).isEqualTo(0);
   }
 
   @Test
   void shouldQueryProcessInstancesByErrorMessageExistsLike() {
-    // given: we expect that the incident process instance has this error message.
+    // given:
     final String expectedError = "Expect*";
 
-    // when: query process instances by errorMessage like
+    // when:
     final var result =
         camundaClient
             .newProcessInstanceQuery()
@@ -1315,17 +1301,17 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
             .send()
             .join();
 
-    // then: we expect to find only the incident process instance
+    // then:
     assertThat(result.items().size()).isEqualTo(1);
     assertThat(result.items()).extracting("processDefinitionId").contains("incident_process_v1");
   }
 
   @Test
   void shouldQueryProcessInstancesByErrorMessageLikeAndIn() {
-    // given: we expect that the incident process instance has this error message.
+    // given:
     final String expectedError = "Expect*";
 
-    // when: query process instances by errorMessage like and in
+    // when:
     final var result =
         camundaClient
             .newProcessInstanceQuery()
@@ -1333,7 +1319,7 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
             .send()
             .join();
 
-    // then: we expect to find no process instances.
+    // then:
     assertThat(result.items().size()).isEqualTo(0);
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceSearchTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceSearchTest.java
@@ -1231,7 +1231,7 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
             .join();
 
     // then: we expect to find all the process instance without the error.
-    assertThat(result.items().size()).isEqualTo(5);
+    assertThat(result.items().size()).isEqualTo(6);
     assertThat(result.items())
         .extracting("processDefinitionId")
         .doesNotContain("incident_process_v1");
@@ -1265,7 +1265,7 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
             .join();
 
     // then: we expect to find all the process instances without error message
-    assertThat(result.items().size()).isEqualTo(5);
+    assertThat(result.items().size()).isEqualTo(6);
     assertThat(result.items())
         .extracting("processDefinitionId")
         .doesNotContain("incident_process_v1");

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
@@ -428,42 +428,59 @@ public final class SearchQueryBuilders {
     }
   }
 
-  public static <C extends List<Operation<String>>> List<SearchQuery> stringMatchHasChildOperations(
-      final String field,
-      final C operations,
-      final String childType,
-      final SearchMatchQueryOperator matchQueryOperator) {
+  public static <C extends List<Operation<String>>>
+      List<SearchQuery> stringMatchWithHasChildOperations(
+          final String field,
+          final C operations,
+          final String childType,
+          final SearchMatchQueryOperator matchQueryOperator) {
+
     if (operations == null || operations.isEmpty()) {
       return null;
-    } else {
-      final var searchQueries = new ArrayList<SearchQuery>();
-      operations.forEach(
-          op -> {
-            searchQueries.add(
+    }
+
+    return operations.stream()
+        .map(
+            op ->
                 switch (op.operator()) {
                   case EQUALS ->
                       hasChildQuery(childType, match(field, op.value(), matchQueryOperator));
+
                   case NOT_EQUALS ->
-                      mustNot(
-                          hasChildQuery(childType, match(field, op.value(), matchQueryOperator)));
-                  case EXISTS -> hasChildQuery(childType, exists(field));
-                  case NOT_EXISTS -> mustNot(hasChildQuery(childType, exists(field)));
+                      hasChildQuery(
+                          childType,
+                          bool(b ->
+                                  b.must(List.of(exists(field)))
+                                      .mustNot(
+                                          List.of(match(field, op.value(), matchQueryOperator))))
+                              .toSearchQuery());
+
+                  case EXISTS ->
+                      hasChildQuery(
+                          childType, bool(b -> b.must(List.of(exists(field)))).toSearchQuery());
+
+                  case NOT_EXISTS ->
+                      hasChildQuery(
+                          childType,
+                          bool(b -> b.must(List.of(exists(field))).mustNot(List.of(exists(field))))
+                              .toSearchQuery());
+
                   case IN ->
                       hasChildQuery(
                           childType,
                           or(
                               op.values().stream()
                                   .map(value -> match(field, value, matchQueryOperator))
-                                  .collect(Collectors.toList())));
+                                  .toList()));
+
                   case LIKE ->
                       hasChildQuery(
                           childType,
                           wildcardQuery(field, Objects.requireNonNull(op.value()).toLowerCase()));
+
                   default -> throw unexpectedOperation("String", op.operator());
-                });
-          });
-      return searchQueries;
-    }
+                })
+        .toList();
   }
 
   private static String formatDate(final OffsetDateTime dateTime) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
@@ -9,9 +9,14 @@ package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.*;
 import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
+<<<<<<< HEAD
 import static io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate.BATCH_OPERATION_IDS;
+=======
+import static io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate.ACTIVITIES_JOIN_RELATION;
+>>>>>>> d43b84479da (feat: add filter field for process instance in ES)
 import static io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate.BPMN_PROCESS_ID;
 import static io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate.END_DATE;
+import static io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate.ERROR_MSG;
 import static io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate.INCIDENT;
 import static io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate.JOIN_RELATION;
 import static io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate.KEY;
@@ -26,6 +31,7 @@ import static io.camunda.webapps.schema.descriptors.operate.template.ListViewTem
 import static io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate.STATE;
 import static java.util.Optional.ofNullable;
 
+import io.camunda.search.clients.query.SearchMatchQuery.SearchMatchQueryOperator;
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.clients.transformers.ServiceTransformers;
 import io.camunda.search.filter.ProcessInstanceFilter;
@@ -77,6 +83,13 @@ public final class ProcessInstanceFilterTransformer
     ofNullable(stringOperations(STATE, filter.stateOperations())).ifPresent(queries::addAll);
     ofNullable(getIncidentQuery(filter.hasIncident())).ifPresent(queries::add);
     ofNullable(stringOperations(TENANT_ID, filter.tenantIdOperations())).ifPresent(queries::addAll);
+    ofNullable(
+            stringMatchHasChildOperations(
+                ERROR_MSG,
+                filter.errorMessageOperations(),
+                ACTIVITIES_JOIN_RELATION,
+                SearchMatchQueryOperator.AND))
+        .ifPresent(queries::addAll);
 
     if (filter.variableFilters() != null && !filter.variableFilters().isEmpty()) {
       final var processVariableQuery = getProcessVariablesQuery(filter.variableFilters());

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
@@ -9,11 +9,8 @@ package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.*;
 import static io.camunda.webapps.schema.descriptors.IndexDescriptor.TENANT_ID;
-<<<<<<< HEAD
-import static io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate.BATCH_OPERATION_IDS;
-=======
 import static io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate.ACTIVITIES_JOIN_RELATION;
->>>>>>> d43b84479da (feat: add filter field for process instance in ES)
+import static io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate.BATCH_OPERATION_IDS;
 import static io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate.BPMN_PROCESS_ID;
 import static io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate.END_DATE;
 import static io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate.ERROR_MSG;
@@ -83,17 +80,20 @@ public final class ProcessInstanceFilterTransformer
     ofNullable(stringOperations(STATE, filter.stateOperations())).ifPresent(queries::addAll);
     ofNullable(getIncidentQuery(filter.hasIncident())).ifPresent(queries::add);
     ofNullable(stringOperations(TENANT_ID, filter.tenantIdOperations())).ifPresent(queries::addAll);
-    ofNullable(
-            stringMatchHasChildOperations(
-                ERROR_MSG,
-                filter.errorMessageOperations(),
-                ACTIVITIES_JOIN_RELATION,
-                SearchMatchQueryOperator.AND))
-        .ifPresent(queries::addAll);
 
     if (filter.variableFilters() != null && !filter.variableFilters().isEmpty()) {
       final var processVariableQuery = getProcessVariablesQuery(filter.variableFilters());
       queries.add(processVariableQuery);
+    }
+
+    if (filter.errorMessageOperations() != null && !filter.errorMessageOperations().isEmpty()) {
+      ofNullable(
+              stringMatchWithHasChildOperations(
+                  ERROR_MSG,
+                  filter.errorMessageOperations(),
+                  ACTIVITIES_JOIN_RELATION,
+                  SearchMatchQueryOperator.AND))
+          .ifPresent(queries::addAll);
     }
 
     ofNullable(stringOperations(BATCH_OPERATION_IDS, filter.batchOperationIdOperations()))

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ProcessInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ProcessInstanceFilter.java
@@ -32,7 +32,8 @@ public record ProcessInstanceFilter(
     Boolean hasIncident,
     List<Operation<String>> tenantIdOperations,
     List<VariableValueFilter> variableFilters,
-    List<Operation<String>> batchOperationIdOperations)
+    List<Operation<String>> batchOperationIdOperations,
+    List<Operation<String>> errorMessageOperations)
     implements FilterBase {
 
   public Builder toBuilder() {
@@ -71,6 +72,7 @@ public record ProcessInstanceFilter(
     private List<Operation<String>> tenantIdOperations;
     private List<VariableValueFilter> variableFilters;
     private List<Operation<String>> batchOperationIdOperations;
+    private List<Operation<String>> errorMessageOperations;
 
     public Builder processInstanceKeyOperations(final List<Operation<Long>> operations) {
       processInstanceKeyOperations = addValuesToList(processInstanceKeyOperations, operations);
@@ -275,6 +277,21 @@ public record ProcessInstanceFilter(
       return batchOperationIdOperations(collectValues(operation, operations));
     }
 
+    public Builder errorMessages(final String value, final String... values) {
+      return errorMessageOperations(FilterUtil.mapDefaultToOperation(value, values));
+    }
+
+    @SafeVarargs
+    public final Builder errorMessageOperations(
+        final Operation<String> operation, final Operation<String>... operations) {
+      return errorMessageOperations(collectValues(operation, operations));
+    }
+
+    public Builder errorMessageOperations(final List<Operation<String>> operations) {
+      errorMessageOperations = addValuesToList(errorMessageOperations, operations);
+      return this;
+    }
+
     @Override
     public ProcessInstanceFilter build() {
       return new ProcessInstanceFilter(
@@ -293,7 +310,8 @@ public record ProcessInstanceFilter(
           hasIncident,
           Objects.requireNonNullElse(tenantIdOperations, Collections.emptyList()),
           Objects.requireNonNullElse(variableFilters, Collections.emptyList()),
-          Objects.requireNonNullElse(batchOperationIdOperations, Collections.emptyList()));
+          Objects.requireNonNullElse(batchOperationIdOperations, Collections.emptyList()),
+          Objects.requireNonNullElse(errorMessageOperations, Collections.emptyList()));
     }
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4537,6 +4537,10 @@ components:
           description: The batch operation ID.
           allOf:
             - $ref: "#/components/schemas/StringFilterProperty"
+        errorMessage:
+          description: The error message related to the process.
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
     ProcessInstanceVariableFilterRequest:
       description: Process instance variable filter.
       type: object

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -648,9 +648,6 @@ public final class SearchQueryRequestMapper {
           builder.variables(either.get());
         }
       }
-      ofNullable(filter.getVariables())
-          .filter(variables -> !variables.isEmpty())
-          .ifPresent(vars -> builder.variables(toVariableValueFiltersForProcessInstance(vars)));
       ofNullable(filter.getErrorMessage())
           .map(mapToOperations(String.class))
           .ifPresent(builder::errorMessageOperations);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -648,6 +648,12 @@ public final class SearchQueryRequestMapper {
           builder.variables(either.get());
         }
       }
+      ofNullable(filter.getVariables())
+          .filter(variables -> !variables.isEmpty())
+          .ifPresent(vars -> builder.variables(toVariableValueFiltersForProcessInstance(vars)));
+      ofNullable(filter.getErrorMessage())
+          .map(mapToOperations(String.class))
+          .ifPresent(builder::errorMessageOperations);
     }
     return validationErrors.isEmpty()
         ? Either.right(builder.build())

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -502,7 +502,10 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         streamBuilder,
         "endDate",
         ops -> new ProcessInstanceFilter.Builder().endDateOperations(ops).build());
-
+    stringOperationTestCases(
+        streamBuilder,
+        "errorMessage",
+        ops -> new ProcessInstanceFilter.Builder().errorMessageOperations(ops).build());
     return streamBuilder.build();
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR extends the v2/process-instances/search endpoint by adding errorMessage as a filter field. This allows users to filter process instances associated with a specific error message. This has also been implemented for Java client, ES/OS and RDBMS.

This is done as part of migrating Operate UI to C8 V2 API

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
