### PR TITLE
feat: Migrate SourceDiagram component to v2

### DIFF
--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MigrateAction/v2/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MigrateAction/v2/index.tsx
@@ -37,6 +37,7 @@ const MigrateAction: React.FC = observer(() => {
   } = processInstancesSelectionStore;
 
   const isVersionSelected = version !== undefined && version !== 'all';
+
   const hasXmlError = processXmlStore.state.status === 'error';
 
   const isDisabled =

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MigrateAction/v2/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MigrateAction/v2/index.tsx
@@ -37,7 +37,6 @@ const MigrateAction: React.FC = observer(() => {
   } = processInstancesSelectionStore;
 
   const isVersionSelected = version !== undefined && version !== 'all';
-
   const hasXmlError = processXmlStore.state.status === 'error';
 
   const isDisabled =

--- a/operate/client/src/App/Processes/ListView/index.tsx
+++ b/operate/client/src/App/Processes/ListView/index.tsx
@@ -63,7 +63,6 @@ const ListView: React.FC = observer(() => {
     document.title = PAGE_TITLE.INSTANCES;
 
     return () => {
-      processInstancesSelectionStore.reset();
       processInstancesStore.reset();
       processesStore.reset();
     };

--- a/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/index.tsx
+++ b/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/index.tsx
@@ -10,8 +10,10 @@ import {useEffect, useRef, useState} from 'react';
 import {SplitDirection} from '@devbookhq/splitter';
 import {ResizablePanel} from 'modules/components/ResizablePanel';
 import {DiagramContainer} from './styled';
+import {SourceDiagram as SourceDiagramV2} from './v2/SourceDiagram';
 import {SourceDiagram} from './SourceDiagram';
 import {TargetDiagram} from './TargetDiagram';
+import {IS_PROCESS_INSTANCE_STATISTICS_V2_ENABLED} from 'modules/feature-flags';
 
 const Diagrams: React.FC = () => {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -31,7 +33,11 @@ const Diagrams: React.FC = () => {
         direction={SplitDirection.Horizontal}
         minWidths={[panelMinWidth, panelMinWidth]}
       >
-        <SourceDiagram />
+        {IS_PROCESS_INSTANCE_STATISTICS_V2_ENABLED ? (
+          <SourceDiagramV2 />
+        ) : (
+          <SourceDiagram />
+        )}
         <TargetDiagram />
       </ResizablePanel>
     </DiagramContainer>

--- a/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/v2/SourceDiagram.test.tsx
+++ b/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/v2/SourceDiagram.test.tsx
@@ -15,8 +15,7 @@ import {
 } from 'modules/testUtils';
 import {processesStore} from 'modules/stores/processes/processes.migration';
 import {SourceDiagram} from './SourceDiagram';
-import {processXmlStore as processXmlSourceStore} from 'modules/stores/processXml/processXml.migration.source';
-import {processXmlStore as processXmlTargetStore} from 'modules/stores/processXml/processXml.migration.target';
+import {processXmlStore} from 'modules/stores/processXml/processXml.migration.source';
 import {mockFetchProcessInstancesStatistics} from 'modules/mocks/api/v2/processInstances/fetchProcessInstancesStatistics';
 import {QueryClientProvider} from '@tanstack/react-query';
 import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
@@ -32,8 +31,7 @@ const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
       processesStore.reset();
       processInstanceMigrationStore.reset();
       processInstancesSelectionStore.reset();
-      processXmlSourceStore.reset();
-      processXmlTargetStore.reset();
+      processXmlStore.reset();
     };
   });
 
@@ -90,7 +88,7 @@ describe('Source Diagram', () => {
   });
 
   it('should render xml', async () => {
-    processXmlSourceStore.setProcessXml(mockProcessXML);
+    processXmlStore.setProcessXml(mockProcessXML);
 
     render(<SourceDiagram />, {wrapper: Wrapper});
 
@@ -101,7 +99,7 @@ describe('Source Diagram', () => {
   });
 
   it('should render statistics overlays', async () => {
-    processXmlSourceStore.setProcessXml(mockProcessXML);
+    processXmlStore.setProcessXml(mockProcessXML);
     processInstancesSelectionStore.setselectedProcessInstanceIds([
       'processInstance1',
     ]);

--- a/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/v2/SourceDiagram.test.tsx
+++ b/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/v2/SourceDiagram.test.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen} from 'modules/testing-library';
+import {mockFetchGroupedProcesses} from 'modules/mocks/api/processes/fetchGroupedProcesses';
+import {
+  groupedProcessesMock,
+  mockProcessStatisticsV2,
+  mockProcessXML,
+} from 'modules/testUtils';
+import {processesStore} from 'modules/stores/processes/processes.migration';
+import {SourceDiagram} from './SourceDiagram';
+import {processXmlStore as processXmlSourceStore} from 'modules/stores/processXml/processXml.migration.source';
+import {processXmlStore as processXmlTargetStore} from 'modules/stores/processXml/processXml.migration.target';
+import {mockFetchProcessInstancesStatistics} from 'modules/mocks/api/v2/processInstances/fetchProcessInstancesStatistics';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import {processInstanceMigrationStore} from 'modules/stores/processInstanceMigration';
+import {useEffect} from 'react';
+import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
+
+jest.mock('modules/hooks/useProcessInstancesFilters');
+
+const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
+  useEffect(() => {
+    return () => {
+      processesStore.reset();
+      processInstanceMigrationStore.reset();
+      processInstancesSelectionStore.reset();
+      processXmlSourceStore.reset();
+      processXmlTargetStore.reset();
+    };
+  });
+
+  return (
+    <QueryClientProvider client={getMockQueryClient()}>
+      {children}
+      <button
+        onClick={() => processInstanceMigrationStore.setCurrentStep('summary')}
+      >
+        Summary
+      </button>
+      <button
+        onClick={() =>
+          processInstanceMigrationStore.setCurrentStep('elementMapping')
+        }
+      >
+        Element Mapping
+      </button>
+      <button
+        onClick={() => {
+          processInstanceMigrationStore.updateFlowNodeMapping({
+            sourceId: 'ServiceTask_0kt6c5i',
+            targetId: 'ServiceTask_0kt6c5i',
+          });
+        }}
+      >
+        map elements
+      </button>
+    </QueryClientProvider>
+  );
+};
+
+describe('Source Diagram', () => {
+  it('should render process name and version', async () => {
+    mockFetchGroupedProcesses().withSuccess(groupedProcessesMock);
+
+    const originalWindow = {...window};
+    const locationSpy = jest.spyOn(window, 'location', 'get');
+
+    locationSpy.mockImplementation(() => ({
+      ...originalWindow.location,
+      search: '?active=true&incidents=true&process=demoProcess&version=3',
+    }));
+
+    processesStore.fetchProcesses();
+    render(<SourceDiagram />, {wrapper: Wrapper});
+
+    expect(await screen.findByText('New demo process')).toBeInTheDocument();
+    expect(screen.getByText('Source')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('Version')).toBeInTheDocument();
+
+    locationSpy.mockRestore();
+  });
+
+  it('should render xml', async () => {
+    processXmlSourceStore.setProcessXml(mockProcessXML);
+
+    render(<SourceDiagram />, {wrapper: Wrapper});
+
+    expect(await screen.findByTestId('diagram')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /reset diagram zoom/i}));
+    expect(screen.getByRole('button', {name: /zoom in diagram/i}));
+    expect(screen.getByRole('button', {name: /zoom out diagram/i}));
+  });
+
+  it('should render statistics overlays', async () => {
+    processXmlSourceStore.setProcessXml(mockProcessXML);
+    processInstancesSelectionStore.setselectedProcessInstanceIds([
+      'processInstance1',
+    ]);
+    mockFetchProcessInstancesStatistics().withSuccess(mockProcessStatisticsV2);
+
+    const {user} = render(<SourceDiagram />, {wrapper: Wrapper});
+
+    await user.click(screen.getByRole('button', {name: /summary/i}));
+
+    expect(await screen.findByText(/diagram mock/i)).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('state-overlay-active'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('state-overlay-active')).toHaveTextContent('1');
+
+    await user.click(screen.getByRole('button', {name: /element mapping/i}));
+
+    expect(await screen.findByText(/diagram mock/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('state-overlay')).not.toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/v2/SourceDiagram.tsx
+++ b/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/v2/SourceDiagram.tsx
@@ -19,6 +19,7 @@ import {StateOverlay} from 'modules/components/StateOverlay';
 import {useProcessInstancesOverlayData} from 'modules/queries/processInstancesStatistics/useOverlayData';
 import {useProcessInstanceFilters} from 'modules/hooks/useProcessInstancesFilters';
 import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
+import {getProcessInstanceKey} from 'modules/utils/statistics/processInstances';
 
 const SourceDiagram: React.FC = observer(() => {
   const {processName, version} = processesStore.getSelectedProcessDetails();
@@ -33,9 +34,7 @@ const SourceDiagram: React.FC = observer(() => {
   const {data: overlayData} = useProcessInstancesOverlayData(
     {
       ...processInstanceFilters,
-      processInstanceKey: {
-        $in: processInstancesSelectionStore.selectedProcessInstanceIds,
-      },
+      processInstanceKey: getProcessInstanceKey(),
     },
     processInstancesSelectionStore.selectedProcessInstanceIds.length > 0,
   );

--- a/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/v2/SourceDiagram.tsx
+++ b/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/v2/SourceDiagram.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {processesStore} from 'modules/stores/processes/processes.migration';
+import {processXmlStore} from 'modules/stores/processXml/processXml.migration.source';
+import {Header} from '../Header';
+import {DiagramWrapper} from '../styled';
+import {observer} from 'mobx-react';
+import {DiagramShell} from 'modules/components/DiagramShell';
+import {Diagram} from 'modules/components/Diagram';
+import {processInstanceMigrationStore} from 'modules/stores/processInstanceMigration';
+import {diagramOverlaysStore} from 'modules/stores/diagramOverlays';
+import {StateOverlay} from 'modules/components/StateOverlay';
+import {useProcessInstancesOverlayData} from 'modules/queries/processInstancesStatistics/useOverlayData';
+import {useProcessInstanceFilters} from 'modules/hooks/useProcessInstancesFilters';
+import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
+
+const SourceDiagram: React.FC = observer(() => {
+  const {processName, version} = processesStore.getSelectedProcessDetails();
+  const {selectedSourceFlowNodeIds} = processInstanceMigrationStore;
+
+  const statisticsOverlays = diagramOverlaysStore.state.overlays.filter(
+    ({type}) => type.match(/^statistics/) !== null,
+  );
+
+  const processInstanceFilters = useProcessInstanceFilters();
+
+  const {data: overlayData} = useProcessInstancesOverlayData(
+    {
+      ...processInstanceFilters,
+      processInstanceKey: {
+        $in: processInstancesSelectionStore.selectedProcessInstanceIds,
+      },
+    },
+    processInstancesSelectionStore.selectedProcessInstanceIds.length > 0,
+  );
+
+  return (
+    <DiagramWrapper>
+      {!processInstanceMigrationStore.isSummaryStep && (
+        <Header
+          mode="view"
+          label="Source"
+          processName={processName}
+          processVersion={version ?? ''}
+        />
+      )}
+      <DiagramShell status="content">
+        {processXmlStore.state.xml !== null && (
+          <Diagram
+            xml={processXmlStore.state.xml}
+            selectableFlowNodes={processXmlStore.selectableIds}
+            selectedFlowNodeIds={selectedSourceFlowNodeIds}
+            onFlowNodeSelection={(flowNodeId) => {
+              processInstanceMigrationStore.selectSourceFlowNode(flowNodeId);
+            }}
+            overlaysData={
+              processInstanceMigrationStore.isSummaryStep ? overlayData : []
+            }
+          >
+            {processInstanceMigrationStore.isSummaryStep &&
+              statisticsOverlays.map((overlay) => {
+                const payload = overlay.payload as {
+                  flowNodeState: FlowNodeState;
+                  count: number;
+                };
+
+                return (
+                  <StateOverlay
+                    key={`${overlay.flowNodeId}-${payload.flowNodeState}`}
+                    state={payload.flowNodeState}
+                    count={payload.count}
+                    container={overlay.container}
+                  />
+                );
+              })}
+          </Diagram>
+        )}
+      </DiagramShell>
+    </DiagramWrapper>
+  );
+});
+
+export {SourceDiagram};


### PR DESCRIPTION
## Description

This PR creates a v2 component that fetches overlay PI statistics data in the `SourceDiagram`.
Most of the component and tests logic is similar to V1, the main difference is the introduction of TanStack Query.

Here's a screen recording showing the app with V2 SourceDiagram

https://github.com/user-attachments/assets/e931a412-e39c-43d6-a89a-ea923d2404d4

## Related issues

closes #29288
