### PR TITLE
build: remove Optimize dependencies from zeebe-parent

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -698,26 +698,6 @@
       <scope>test</scope>
     </dependency>
 
-    <!-- optimize -->
-
-    <dependency>
-      <groupId>io.camunda.optimize</groupId>
-      <artifactId>optimize-commons</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda.optimize</groupId>
-      <artifactId>optimize-backend</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda.optimize</groupId>
-      <artifactId>optimize-webjar</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Some Optimize dependencies are still imported by `dist` and they should not be, as building `dist` should not build Optimize.

Should fix release job failure caused by https://github.com/camunda/camunda/pull/29407 as discussed [here](https://camunda.slack.com/archives/C06UWQNCU7M/p1741743347390629).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
