### PR TITLE
build: keep optimize-commons in the single app

### DIFF
--- a/.github/workflows/tasklist-docker-tests.yml
+++ b/.github/workflows/tasklist-docker-tests.yml
@@ -30,7 +30,7 @@ jobs:
       - id: build-backend
         uses: ./.github/actions/build-zeebe
         with:
-          maven-extra-args: -D skip.fe.build -D skipOptimize
+          maven-extra-args: -D skip.fe.build
       - uses: ./.github/actions/build-platform-docker
         with:
           repository: localhost:5000/camunda/tasklist

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -698,19 +698,19 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <!-- optimize -->
     <!-- TODO: Remove Optimize dependencies once the backup system is reverted -->
 
     <dependency>
       <groupId>io.camunda.optimize</groupId>
       <artifactId>optimize-commons</artifactId>
-      <version>8.8.0-SNAPSHOT</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-junit-jupiter</artifactId>
-      <scope>test</scope>
+      <version>${project.version}</version>
     </dependency>
 
   </dependencies>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -699,23 +699,12 @@
     </dependency>
 
     <!-- optimize -->
+    <!-- TODO: Remove Optimize dependencies once the backup system is reverted -->
 
     <dependency>
       <groupId>io.camunda.optimize</groupId>
       <artifactId>optimize-commons</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda.optimize</groupId>
-      <artifactId>optimize-backend</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda.optimize</groupId>
-      <artifactId>optimize-webjar</artifactId>
-      <version>${project.version}</version>
+      <version>8.8.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -760,10 +749,6 @@
             <program>
               <id>operate</id>
               <mainClass>io.camunda.application.StandaloneOperate</mainClass>
-            </program>
-            <program>
-              <id>optimize</id>
-              <mainClass>io.camunda.application.StandaloneOptimize</mainClass>
             </program>
             <program>
               <id>migrate</id>
@@ -873,7 +858,6 @@
             <dep>io.camunda.migration:identity-migration</dep>
             <dep>io.camunda.migration:process-migration</dep>
             <dep>io.camunda.optimize:optimize-backend</dep>
-            <dep>io.camunda.optimize:optimize-webjar</dep>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/optimize-distro/pom.xml
+++ b/optimize-distro/pom.xml
@@ -41,6 +41,14 @@
     </dependency>
   </dependencies>
 
+  <repositories>
+    <repository>
+      <id>central</id>
+      <name>Maven Central</name>
+      <url>https://repo1.maven.org/maven2/</url>
+    </repository>
+  </repositories>
+
   <build>
     <finalName>camunda-optimize-${project.version}</finalName>
     <plugins>

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -685,6 +685,14 @@
     </dependency>
   </dependencies>
 
+  <repositories>
+    <repository>
+      <id>central</id>
+      <name>Maven Central</name>
+      <url>https://repo1.maven.org/maven2/</url>
+    </repository>
+  </repositories>
+
   <build>
     <finalName>optimize-backend-${project.version}</finalName>
     <resources>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -263,6 +263,9 @@
     </repository>
 
     <repository>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
       <id>central</id>
       <name>Maven Central</name>
       <url>https://repo1.maven.org/maven2/</url>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -264,8 +264,12 @@
     </repository>
 
     <repository>
-      <releases><enabled>true</enabled></releases>
-      <snapshots><enabled>true</enabled></snapshots>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
       <id>central</id>
       <name>Maven Central</name>
       <url>https://repo1.maven.org/maven2/</url>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -264,6 +264,8 @@
     </repository>
 
     <repository>
+      <releases><enabled>true</enabled></releases>
+      <snapshots><enabled>true</enabled></snapshots>
       <id>central</id>
       <name>Maven Central</name>
       <url>https://repo1.maven.org/maven2/</url>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -263,9 +263,6 @@
     </repository>
 
     <repository>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
       <id>central</id>
       <name>Maven Central</name>
       <url>https://repo1.maven.org/maven2/</url>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -47,6 +47,7 @@
       <id>camunda-nexus</id>
       <url>https://artifacts.camunda.com/artifactory/camunda-optimize/</url>
     </repository>
+
     <snapshotRepository>
       <id>camunda-nexus</id>
       <url>https://artifacts.camunda.com/artifactory/camunda-optimize-snapshots/</url>

--- a/optimize/qa/schema-integrity-tests/pom.xml
+++ b/optimize/qa/schema-integrity-tests/pom.xml
@@ -164,6 +164,14 @@
     </dependency>
   </dependencies>
 
+  <repositories>
+    <repository>
+      <id>central</id>
+      <name>Maven Central</name>
+      <url>https://repo1.maven.org/maven2/</url>
+    </repository>
+  </repositories>
+
   <build>
     <testResources>
       <testResource>

--- a/optimize/upgrade/pom.xml
+++ b/optimize/upgrade/pom.xml
@@ -181,7 +181,7 @@
       <version>${version.guava}</version>
       <scope>provided</scope>
     </dependency>
-
+    r
     <dependency>
       <groupId>org.opensearch.client</groupId>
       <artifactId>opensearch-rest-client</artifactId>

--- a/optimize/upgrade/pom.xml
+++ b/optimize/upgrade/pom.xml
@@ -190,6 +190,14 @@
     </dependency>
   </dependencies>
 
+  <repositories>
+    <repository>
+      <id>central</id>
+      <name>Maven Central</name>
+      <url>https://repo1.maven.org/maven2/</url>
+    </repository>
+  </repositories>
+
   <build>
     <finalName>upgrade-optimize-from-${project.previousVersion}-to-${project.version}</finalName>
     <plugins>

--- a/optimize/upgrade/pom.xml
+++ b/optimize/upgrade/pom.xml
@@ -181,7 +181,7 @@
       <version>${version.guava}</version>
       <scope>provided</scope>
     </dependency>
-    r
+
     <dependency>
       <groupId>org.opensearch.client</groupId>
       <artifactId>opensearch-rest-client</artifactId>

--- a/optimize/util/optimize-commons/pom.xml
+++ b/optimize/util/optimize-commons/pom.xml
@@ -322,7 +322,6 @@
     </dependency>
   </dependencies>
 
-  <!-- this fixes some artifacts download when building from within the single application -->
   <repositories>
     <repository>
       <id>central</id>

--- a/optimize/util/optimize-commons/pom.xml
+++ b/optimize/util/optimize-commons/pom.xml
@@ -322,15 +322,6 @@
     </dependency>
   </dependencies>
 
-  <!-- this fixes some artifacts download when building from within the single application -->
-  <repositories>
-    <repository>
-      <id>central</id>
-      <name>Maven Central</name>
-      <url>https://repo1.maven.org/maven2/</url>
-    </repository>
-  </repositories>
-
   <build>
     <plugins>
       <plugin>

--- a/optimize/util/optimize-commons/pom.xml
+++ b/optimize/util/optimize-commons/pom.xml
@@ -322,6 +322,15 @@
     </dependency>
   </dependencies>
 
+  <!-- this fixes some artifacts download when building from within the single application -->
+  <repositories>
+    <repository>
+      <id>central</id>
+      <name>Maven Central</name>
+      <url>https://repo1.maven.org/maven2/</url>
+    </repository>
+  </repositories>
+
   <build>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <module>migration</module>
 
     <!-- TODO: Remove optimize once the backup system is reverted -->
-    <module>optimize/util/optimize-commons</module>
+    <module>optimize</module>
   </modules>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,9 @@
     <module>document</module>
     <module>security</module>
     <module>migration</module>
+
+    <!-- TODO: Remove optimize once the backup system is reverted -->
+    <module>optimize/util/optimize-commons</module>
   </modules>
 
   <scm>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

As the backup system is still using Optimize classes, we can't disconnect Optimize entirely from the single app yet. We need to keep building `optimize-commons` to let `dist` build correctly.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
