### PR TITLE
feat: validate token audience

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -137,6 +137,10 @@
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-oauth2-jose</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
@@ -144,11 +148,6 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-oauth2-jose</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/authentication/src/main/java/io/camunda/authentication/config/AudienceValidator.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/AudienceValidator.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+/**
+ * Validates the audience of a JWT token. A token can have multiple audiences, but at least one of
+ * the valid audiences must be present.
+ */
+final class AudienceValidator implements OAuth2TokenValidator<Jwt> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AudienceValidator.class);
+  private final Set<String> validAudiences;
+
+  /**
+   * Creates a new validator with the given valid audiences.
+   *
+   * @param validAudiences the valid audiences. Must not be empty.
+   */
+  AudienceValidator(final Set<String> validAudiences) {
+    if (validAudiences.isEmpty()) {
+      throw new IllegalArgumentException("At least one valid audience must be provided");
+    }
+    this.validAudiences = Set.copyOf(validAudiences);
+  }
+
+  @Override
+  public OAuth2TokenValidatorResult validate(final Jwt token) {
+    final var tokenAudiences = token.getAudience();
+
+    // Iterate over token audiences first, usually there is only one
+    for (final var tokenAudience : tokenAudiences) {
+      if (validAudiences.contains(tokenAudience)) {
+        return OAuth2TokenValidatorResult.success();
+      }
+    }
+
+    LOG.debug(
+        "Rejected token with audiences '{}', expected at least one of '{}'",
+        tokenAudiences,
+        validAudiences);
+    return OAuth2TokenValidatorResult.failure(
+        new OAuth2Error(
+            OAuth2ErrorCodes.INVALID_TOKEN,
+            "Token audiences are %s, expected at least one of %s"
+                .formatted(tokenAudiences, validAudiences),
+            null));
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -293,9 +293,9 @@ public class WebSecurityConfig {
               .getProviderDetails()
               .getJwkSetUri();
 
-      final var validAudiences = securityConfiguration.getAuthentication().getOidc().getAudience();
       final var decoder = NimbusJwtDecoder.withJwkSetUri(jwkSetUri).build();
 
+      final var validAudiences = securityConfiguration.getAuthentication().getOidc().getAudiences();
       if (validAudiences != null) {
         decoder.setJwtValidator(
             JwtValidators.createDefaultWithValidators(new AudienceValidator(validAudiences)));

--- a/authentication/src/test/java/io/camunda/authentication/config/AudienceValidatorTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/AudienceValidatorTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+final class AudienceValidatorTest {
+
+  @Test
+  void shouldThrowExceptionWhenNoValidAudiencesProvided() {
+    // when/then
+    assertThatThrownBy(() -> new AudienceValidator(Set.of()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("At least one valid audience must be provided");
+  }
+
+  @Test
+  void shouldValidateTokenWithMatchingAudience() {
+    // given
+    final var validAudiences = Set.of("valid-audience");
+    final var validator = new AudienceValidator(validAudiences);
+    final var token = createJwtWithAudiences(List.of("valid-audience"));
+
+    // when
+    final var result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isFalse();
+  }
+
+  @Test
+  void shouldValidateTokenWithOneMatchingAudienceAmongMany() {
+    // given
+    final var validAudiences = Set.of("valid-audience-1", "valid-audience-2");
+    final var validator = new AudienceValidator(validAudiences);
+    final var token = createJwtWithAudiences(List.of("invalid-audience", "valid-audience-2"));
+
+    // when
+    final var result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isFalse();
+  }
+
+  @Test
+  void shouldRejectTokenWithNoMatchingAudience() {
+    // given
+    final var validAudiences = Set.of("valid-audience");
+    final var validator = new AudienceValidator(validAudiences);
+    final var token = createJwtWithAudiences(List.of("invalid-audience"));
+
+    // when
+    final var result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isTrue();
+
+    final var errors = result.getErrors();
+    assertThat(errors).hasSize(1);
+
+    final var error = errors.iterator().next();
+    assertThat(error.getErrorCode()).isEqualTo(OAuth2ErrorCodes.INVALID_TOKEN);
+    assertThat(error.getDescription())
+        .isEqualTo(
+            "Token audiences are [invalid-audience], expected at least one of [valid-audience]");
+  }
+
+  @Test
+  void shouldValidateTokenWithMultipleValidAudiences() {
+    // given
+    final var validAudiences = Set.of("valid-audience-1", "valid-audience-2", "valid-audience-3");
+    final var validator = new AudienceValidator(validAudiences);
+    final var token = createJwtWithAudiences(List.of("valid-audience-2"));
+
+    // when
+    final var result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isFalse();
+  }
+
+  @Test
+  void shouldNotReflectChangesInOriginalAudiencesSet() {
+    // given
+    final var validAudiences = new HashSet<String>();
+    validAudiences.add("valid-audience");
+    final var validator = new AudienceValidator(validAudiences);
+
+    // when - modify the original set after creating the validator
+    validAudiences.clear();
+    validAudiences.add("new-audience");
+
+    // then - validator should NOT reflect changes in the original set
+    final var tokenWithOriginalAudience = createJwtWithAudiences(List.of("valid-audience"));
+    assertThat(validator.validate(tokenWithOriginalAudience).hasErrors()).isFalse();
+
+    // and - should NOT validate the new audience
+    final var tokenWithNewAudience = createJwtWithAudiences(List.of("new-audience"));
+    assertThat(validator.validate(tokenWithNewAudience).hasErrors()).isTrue();
+  }
+
+  private static Jwt createJwtWithAudiences(final List<String> audiences) {
+    return new Jwt(
+        "token-value",
+        Instant.now(),
+        Instant.now().plusSeconds(60),
+        Map.of("alg", "RS256"),
+        Map.of("aud", audiences));
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.security.configuration;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 public class OidcAuthenticationConfiguration {
   private String issuerUri;
@@ -19,6 +20,7 @@ public class OidcAuthenticationConfiguration {
   private List<String> scope = Arrays.asList("openid", "profile");
   private String jwkSetUri;
   private String authorizationUri;
+  private Set<String> audience;
 
   public String getIssuerUri() {
     return issuerUri;
@@ -82,5 +84,13 @@ public class OidcAuthenticationConfiguration {
 
   public void setAuthorizationUri(final String authorizationUri) {
     this.authorizationUri = authorizationUri;
+  }
+
+  public Set<String> getAudience() {
+    return audience;
+  }
+
+  public void setAudience(final Set<String> audience) {
+    this.audience = audience;
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -20,7 +20,7 @@ public class OidcAuthenticationConfiguration {
   private List<String> scope = Arrays.asList("openid", "profile");
   private String jwkSetUri;
   private String authorizationUri;
-  private Set<String> audience;
+  private Set<String> audiences;
 
   public String getIssuerUri() {
     return issuerUri;
@@ -86,11 +86,11 @@ public class OidcAuthenticationConfiguration {
     this.authorizationUri = authorizationUri;
   }
 
-  public Set<String> getAudience() {
-    return audience;
+  public Set<String> getAudiences() {
+    return audiences;
   }
 
-  public void setAudience(final Set<String> audience) {
-    this.audience = audience;
+  public void setAudiences(final Set<String> audiences) {
+    this.audiences = audiences;
   }
 }


### PR DESCRIPTION
This adds a new configuration parameter `camunda.security.authentication.oidc.audience` that takes one or more valid audience values.
If set, at least one of the token audiences must match the configured ones, otherwise the token is rejected.

Relates to https://github.com/camunda/camunda/issues/29422