### PR TITLE
fix: Disable X-Frame-Options to allow PDF previews in <embed> tags [Firefox]

### DIFF
--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/BaseWebConfigurer.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/BaseWebConfigurer.java
@@ -68,6 +68,8 @@ public abstract class BaseWebConfigurer {
 
   protected void applySecurityHeadersSettings(final HttpSecurity http) throws Exception {
     http.headers()
+        .frameOptions()
+        .disable()
         .contentSecurityPolicy(
             tasklistProperties.getSecurityProperties().getContentSecurityPolicy());
   }


### PR DESCRIPTION
## Description

This PR disables the use of the response header `X-Frame-Options` because:
* The updated Config class is already providing a Content Security Policy (CSP). The [defined CSP](https://github.com/camunda/camunda/blob/f69621825e7b0121cab5c15e9cf28ae712fde7f2/tasklist/common/src/main/java/io/camunda/tasklist/property/SecurityProperties.java) contains `frame-ancestors 'self'` which clashes with  `X-Frame-Options: DENY`. Having both with conflicting values can cause unexpected behaviours on different browsers.
* Firefox doesn't like that `X-Frame-Options` was set to DENY and it was not displaying PDF previews in `<embed>` HTML tags even though CSP was allowing that behaviour.

**Sources**
* [Clickjacking protection with CSP](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP#clickjacking_protection)
* [How to use frame-ancestors](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors)


Before these changes


![Screenshot 2025-03-12 at 11 54 36](https://github.com/user-attachments/assets/4a36312d-9b69-4ed9-b37c-beb2ed429a83)

After these changes

![Screenshot 2025-03-12 at 12 37 30](https://github.com/user-attachments/assets/90b79313-18d6-42c9-af13-fc49a98d5b88)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Relates to https://github.com/camunda/camunda/issues/28498
