### PR TITLE
fix: reintroduce the /oauth/authorization path to the config to allow…

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -72,13 +72,14 @@ public class WebSecurityConfig {
           "/v1/external/process/**");
   private static final Set<String> WEBAPP_PATHS =
       Set.of(
-          "/sso-callback/**",
           "/login/**",
           "/logout",
           "/identity/**",
           "/operate/**",
           "/tasklist/**",
-          "/");
+          "/",
+          "/sso-callback/**",
+          "/oauth2/authorization/**");
   private static final Set<String> UNPROTECTED_PATHS =
       Set.of(
           // endpoint for failure forwarding


### PR DESCRIPTION
… the auth flow to function

## Description

I incorrectly removed a path from the WebSecurityConfig that allows the OIDC auth flow to function (at this point in the auth flow we don't have authentication so need to allow the path so that we can get authentication.
