### PR TITLE
Restore E2E integration tests that ensure tenant membership is enforced on relevant endpoints

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -129,22 +129,19 @@ public final class DeploymentCreateProcessor
 
   @Override
   public void processNewCommand(final TypedRecord<DeploymentRecord> command) {
+    final var newResourceAuthorization = true;
     final var authorizationRequest =
         new AuthorizationRequest(
             command,
             AuthorizationResourceType.RESOURCE,
             PermissionType.CREATE,
-            command.getValue().getTenantId());
+            command.getValue().getTenantId(),
+            newResourceAuthorization);
     final var isAuthorized = authCheckBehavior.isAuthorized(authorizationRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();
-      final String errorMessage =
-          RejectionType.NOT_FOUND.equals(rejection.type())
-              ? "Expected to create a deployment for tenant '%s', but no such tenant was found"
-                  .formatted(command.getValue().getTenantId())
-              : rejection.reason();
-      rejectionWriter.appendRejection(command, rejection.type(), errorMessage);
-      responseWriter.writeRejectionOnCommand(command, rejection.type(), errorMessage);
+      rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -347,6 +347,20 @@ public final class AuthorizationCheckBehavior {
     }
   }
 
+  /**
+   * Checks if a user is assigned to a specific tenant.
+   *
+   * @param command The command send by the user
+   * @param tenantId The tenant we want to check assignment for
+   * @return true if assigned, false otherwise
+   */
+  public boolean isAssignedToTenant(final TypedRecord<?> command, final String tenantId) {
+    if (!securityConfig.getMultiTenancy().isEnabled()) {
+      return true;
+    }
+    return getAuthorizedTenantIds(command).isAuthorizedForTenantId(tenantId);
+  }
+
   public AuthorizedTenants getAuthorizedTenantIds(final TypedRecord<?> command) {
     if (isAuthorizedAnonymousUser(command)) {
       return AuthorizedTenants.ANONYMOUS;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -120,7 +120,7 @@ public final class AuthorizationCheckBehavior {
     if (securityConfig.getMultiTenancy().isEnabled()) {
       if (!isUserAuthorizedForTenant(request, userOptional.get())) {
         final var rejectionType =
-            request.isNewResource() ? RejectionType.UNAUTHORIZED : RejectionType.NOT_FOUND;
+            request.isNewResource() ? RejectionType.FORBIDDEN : RejectionType.NOT_FOUND;
         return Either.left(new Rejection(rejectionType, request.getTenantErrorMessage()));
       }
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -89,8 +89,7 @@ public final class MessageCorrelationCorrelateProcessor
   public void processRecord(final TypedRecord<MessageCorrelationRecord> command) {
     final var messageCorrelationRecord = command.getValue();
 
-    final var authorizedTenantIds = authCheckBehavior.getAuthorizedTenantIds(command);
-    if (!authorizedTenantIds.isAuthorizedForTenantId(messageCorrelationRecord.getTenantId())) {
+    if (!authCheckBehavior.isAssignedToTenant(command, messageCorrelationRecord.getTenantId())) {
       final var message =
           "Expected to correlate message for tenant '%s', but user is not assigned to this tenant."
               .formatted(messageCorrelationRecord.getTenantId());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -93,7 +93,8 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
             command,
             AuthorizationResourceType.MESSAGE,
             PermissionType.CREATE,
-            command.getValue().getTenantId());
+            command.getValue().getTenantId(),
+            true);
     final var isAuthorized = authCheckBehavior.isAuthorized(authRequest);
     if (isAuthorized.isLeft()) {
       final var rejection = isAuthorized.getLeft();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
@@ -173,14 +173,21 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
   @Override
   public ProcessingError tryHandleError(
       final TypedRecord<SignalRecord> command, final Throwable error) {
-    if (error instanceof final ForbiddenException exception) {
-      rejectionWriter.appendRejection(
-          command, exception.getRejectionType(), exception.getMessage());
-      responseWriter.writeRejectionOnCommand(
-          command, exception.getRejectionType(), exception.getMessage());
-      return ProcessingError.EXPECTED_ERROR;
-    }
 
-    return ProcessingError.UNEXPECTED_ERROR;
+    switch (error) {
+      case final NotFoundException exception:
+        rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, exception.getMessage());
+        responseWriter.writeRejectionOnCommand(
+            command, RejectionType.NOT_FOUND, exception.getMessage());
+        return ProcessingError.EXPECTED_ERROR;
+      case final ForbiddenException exception:
+        rejectionWriter.appendRejection(
+            command, exception.getRejectionType(), exception.getMessage());
+        responseWriter.writeRejectionOnCommand(
+            command, exception.getRejectionType(), exception.getMessage());
+        return ProcessingError.EXPECTED_ERROR;
+      default:
+        return ProcessingError.UNEXPECTED_ERROR;
+    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
@@ -79,8 +79,7 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
     final long eventKey = keyGenerator.nextKey();
     final var signalRecord = command.getValue();
 
-    final var authorizedTenantIds = authCheckBehavior.getAuthorizedTenantIds(command);
-    if (!authorizedTenantIds.isAuthorizedForTenantId(signalRecord.getTenantId())) {
+    if (!authCheckBehavior.isAssignedToTenant(command, signalRecord.getTenantId())) {
       final var message =
           "Expected to broadcast signal for tenant '%s', but user is not assigned to this tenant."
               .formatted(signalRecord.getTenantId());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.configuration.AuthorizationsConfiguration;
+import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
@@ -50,6 +51,9 @@ public class AuthorizationCheckBehaviorTest {
     final var authConfig = new AuthorizationsConfiguration();
     authConfig.setEnabled(true);
     securityConfig.setAuthorizations(authConfig);
+    final var multiTenancyConfig = new MultiTenancyConfiguration();
+    multiTenancyConfig.setEnabled(true);
+    securityConfig.setMultiTenancy(multiTenancyConfig);
     authorizationCheckBehavior = new AuthorizationCheckBehavior(processingState, securityConfig);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/StandaloneDecisionEvaluationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/dmn/StandaloneDecisionEvaluationTest.java
@@ -159,7 +159,7 @@ public class StandaloneDecisionEvaluationTest {
         ENGINE.decision().ofDecisionId(falseDecisionId).expectRejection().evaluate();
 
     // then
-    assertThat(record.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(record.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
     assertThat(record.getIntent()).isEqualTo(DecisionEvaluationIntent.EVALUATE);
     assertThat(record.getRejectionReason())
         .isEqualTo(
@@ -181,7 +181,7 @@ public class StandaloneDecisionEvaluationTest {
         ENGINE.decision().ofDecisionKey(falseDecisionKey).expectRejection().evaluate();
 
     // then
-    assertThat(record.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(record.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
     assertThat(record.getIntent()).isEqualTo(DecisionEvaluationIntent.EVALUATE);
     assertThat(record.getRejectionReason())
         .isEqualTo(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/ErrorEventIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/ErrorEventIncidentTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
@@ -158,6 +159,15 @@ public final class ErrorEventIncidentTest {
   public void shouldCreateIncidentWithCustomTenant() {
     // given
     final String tenantId = "acme";
+    final String username = "username";
+    ENGINE.tenant().newTenant().withTenantId(tenantId).create();
+    ENGINE.user().newUser(username).create();
+    ENGINE
+        .tenant()
+        .addEntity(tenantId)
+        .withEntityId(username)
+        .withEntityType(EntityType.USER)
+        .add();
     ENGINE.deployment().withXmlResource(BOUNDARY_EVENT_PROCESS).withTenantId(tenantId).deploy();
 
     final long processInstanceKey =
@@ -170,7 +180,7 @@ public final class ErrorEventIncidentTest {
         .withType(JOB_TYPE)
         .withErrorCode("other-error")
         .withAuthorizedTenantIds(tenantId)
-        .throwError();
+        .throwError(username);
 
     // then
     final Record<IncidentRecordValue> incidentEvent =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
@@ -389,11 +389,7 @@ public final class CompleteJobTest {
 
     // when
     final Record<JobRecordValue> jobCompletedRecord =
-        ENGINE
-            .job()
-            .withKey(batchRecord.getValue().getJobKeys().get(0))
-            .withAuthorizedTenantIds(tenantId)
-            .complete();
+        ENGINE.job().withKey(batchRecord.getValue().getJobKeys().get(0)).complete(username);
 
     // then
     final JobRecordValue recordValue = jobCompletedRecord.getValue();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
@@ -450,8 +450,7 @@ public final class FailJobTest {
             .withKey(jobKey)
             .ofInstance(job.getProcessInstanceKey())
             .withRetries(retries)
-            .withAuthorizedTenantIds(tenantId)
-            .fail();
+            .fail(username);
 
     // then
     Assertions.assertThat(failRecord).hasRecordType(RecordType.EVENT).hasIntent(FAILED);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorTest.java
@@ -478,7 +478,6 @@ public final class JobThrowErrorTest {
   @Test
   public void shouldThrowErrorForCustomTenant() {
     // given
-    final String tenantId = "acme";
     final var job = ENGINE.createJob(jobType, PROCESS_ID, Collections.emptyMap(), tenantId);
 
     // when
@@ -488,8 +487,7 @@ public final class JobThrowErrorTest {
             .withKey(job.getKey())
             .withErrorCode("error")
             .withErrorMessage("error-message")
-            .withAuthorizedTenantIds(tenantId)
-            .throwError();
+            .throwError(username);
 
     // then
     Assertions.assertThat(result).hasRecordType(RecordType.EVENT).hasIntent(ERROR_THROWN);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesTest.java
@@ -204,12 +204,7 @@ public final class JobUpdateRetriesTest {
 
     // when
     final Record<JobRecordValue> updatedRecord =
-        ENGINE
-            .job()
-            .withKey(jobKey)
-            .withRetries(NEW_RETRIES)
-            .withAuthorizedTenantIds(tenantId)
-            .updateRetries();
+        ENGINE.job().withKey(jobKey).withRetries(NEW_RETRIES).updateRetries(username);
 
     // then
     Assertions.assertThat(updatedRecord.getValue()).hasTenantId(tenantId);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutTest.java
@@ -259,12 +259,7 @@ public class JobUpdateTimeoutTest {
 
     // when
     final Record<JobRecordValue> updatedRecord =
-        ENGINE
-            .job()
-            .withKey(jobKey)
-            .withTimeout(timeout)
-            .withAuthorizedTenantIds(tenantId)
-            .updateTimeout();
+        ENGINE.job().withKey(jobKey).withTimeout(timeout).updateTimeout(username);
 
     // then
     Assertions.assertThat(updatedRecord.getValue()).hasTenantId(tenantId);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareActivateJobBatchTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareActivateJobBatchTest.java
@@ -25,7 +25,7 @@ public class TenantAwareActivateJobBatchTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.getAuthorizations().setEnabled(true));
+          .withSecurityConfig(config -> config.getMultiTenancy().setEnabled(true));
 
   @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareBusinessRuleTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareBusinessRuleTaskTest.java
@@ -36,7 +36,10 @@ import org.junit.Test;
 
 public class TenantAwareBusinessRuleTaskTest {
 
-  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          .withSecurityConfig(config -> config.getMultiTenancy().setEnabled(true));
 
   private static final String DMN_DECISION_TABLE = "/dmn/decision-table.dmn";
   private static final String DMN_DECISION_TABLE_WITH_ASSERTION =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareCallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareCallActivityTest.java
@@ -30,7 +30,10 @@ import org.junit.Test;
 
 public class TenantAwareCallActivityTest {
 
-  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          .withSecurityConfig(config -> config.getMultiTenancy().setEnabled(true));
 
   private static final String PROCESS_ID_PARENT = "wf-parent";
   private static final String PROCESS_ID_CHILD = "wf-child";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareCancelProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareCancelProcessInstanceTest.java
@@ -26,7 +26,7 @@ public class TenantAwareCancelProcessInstanceTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.getAuthorizations().setEnabled(true));
+          .withSecurityConfig(config -> config.getMultiTenancy().setEnabled(true));
 
   @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
 
@@ -71,7 +71,7 @@ public class TenantAwareCancelProcessInstanceTest {
     final var tenantId = "another-tenant";
     final var username = "username";
     final var user = ENGINE.user().newUser(username).create().getValue();
-    ENGINE.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
+    ENGINE.tenant().newTenant().withTenantId(tenantId).create();
     ENGINE
         .tenant()
         .addEntity(tenantId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareFormLinkingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareFormLinkingTest.java
@@ -24,7 +24,12 @@ public class TenantAwareFormLinkingTest {
   private static final String FORM_ID = "Form_0w7r08e";
   private static final String TEST_FORM = "/form/test-form-1.form";
   private static final String TENANT = "tenant";
-  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withSecurityConfig(config -> config.getMultiTenancy().setEnabled(true));
+
   @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareModifyProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareModifyProcessInstanceTest.java
@@ -28,7 +28,7 @@ public class TenantAwareModifyProcessInstanceTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.getAuthorizations().setEnabled(true));
+          .withSecurityConfig(config -> config.getMultiTenancy().setEnabled(true));
 
   @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareProcessInstanceVariableTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareProcessInstanceVariableTest.java
@@ -24,7 +24,10 @@ import org.junit.Test;
 
 public class TenantAwareProcessInstanceVariableTest {
 
-  @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
+  @ClassRule
+  public static final EngineRule ENGINE_RULE =
+      EngineRule.singlePartition()
+          .withSecurityConfig(config -> config.getMultiTenancy().setEnabled(true));
 
   public static final String PROCESS_ID = "process";
   private static final String TENANT_ID = "foo";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareResourceDeletionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareResourceDeletionTest.java
@@ -29,7 +29,11 @@ import org.junit.Test;
 
 public class TenantAwareResourceDeletionTest {
 
-  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          .withSecurityConfig(config -> config.getMultiTenancy().setEnabled(true));
+
   private static final String DRG_SINGLE_DECISION = "/dmn/decision-table.dmn";
   private static final String TEST_FORM_1 = "/form/test-form-1.form";
   private static final BpmnModelInstance PROCESS =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareResourceDeletionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareResourceDeletionTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.multitenancy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
+import io.camunda.security.configuration.ConfiguredUser;
 import io.camunda.zeebe.auth.Authorization;
 import io.camunda.zeebe.engine.util.AuthorizationUtil;
 import io.camunda.zeebe.engine.util.EngineRule;
@@ -20,19 +21,33 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordAssert;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.List;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class TenantAwareResourceDeletionTest {
 
+  public static final String USERNAME = "username";
+  public static final String TENANT_ID_A = "tenant-a";
+  public static final String TENANT_ID_B = "tenant-b";
+
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.getMultiTenancy().setEnabled(true));
+          .withIdentitySetup()
+          .withSecurityConfig(config -> config.getMultiTenancy().setEnabled(true))
+          .withSecurityConfig(
+              config ->
+                  config
+                      .getInitialization()
+                      .setUsers(
+                          List.of(new ConfiguredUser(USERNAME, "password", "name", "email"))));
 
   private static final String DRG_SINGLE_DECISION = "/dmn/decision-table.dmn";
   private static final String TEST_FORM_1 = "/form/test-form-1.form";
@@ -41,14 +56,23 @@ public class TenantAwareResourceDeletionTest {
 
   @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
 
-  private final String tenantIdA = "tenant-a";
-  private final String tenantIdB = "tenant-b";
+  @BeforeClass
+  public static void beforeClass() {
+    ENGINE.tenant().newTenant().withTenantId(TENANT_ID_A).create();
+    ENGINE.tenant().newTenant().withTenantId(TENANT_ID_B).create();
+    ENGINE
+        .tenant()
+        .addEntity(TENANT_ID_A)
+        .withEntityId(USERNAME)
+        .withEntityType(EntityType.USER)
+        .add();
+  }
 
   @Test
   public void shouldDeleteProcessForAuthorizedTenant() {
     // given
     final var deployment =
-        ENGINE.deployment().withXmlResource(PROCESS).withTenantId(tenantIdA).deploy();
+        ENGINE.deployment().withXmlResource(PROCESS).withTenantId(TENANT_ID_A).deploy();
     final var resourceKey =
         deployment.getValue().getProcessesMetadata().get(0).getProcessDefinitionKey();
 
@@ -57,11 +81,11 @@ public class TenantAwareResourceDeletionTest {
         ENGINE
             .resourceDeletion()
             .withResourceKey(resourceKey)
-            .withAuthorizedTenantIds(tenantIdA)
-            .delete();
+            .withAuthorizedTenantIds(TENANT_ID_A)
+            .delete(USERNAME);
 
     // then
-    Assertions.assertThat(deleted.getValue()).hasTenantId(tenantIdA);
+    Assertions.assertThat(deleted.getValue()).hasTenantId(TENANT_ID_A);
     verifyResourceIsDeleted(resourceKey);
   }
 
@@ -72,7 +96,7 @@ public class TenantAwareResourceDeletionTest {
         ENGINE
             .deployment()
             .withXmlClasspathResource(DRG_SINGLE_DECISION)
-            .withTenantId(tenantIdA)
+            .withTenantId(TENANT_ID_A)
             .deploy();
     final var resourceKey =
         deployment.getValue().getDecisionRequirementsMetadata().get(0).getDecisionRequirementsKey();
@@ -82,11 +106,11 @@ public class TenantAwareResourceDeletionTest {
         ENGINE
             .resourceDeletion()
             .withResourceKey(resourceKey)
-            .withAuthorizedTenantIds(tenantIdA)
-            .delete();
+            .withAuthorizedTenantIds(TENANT_ID_A)
+            .delete(USERNAME);
 
     // then
-    Assertions.assertThat(deleted.getValue()).hasTenantId(tenantIdA);
+    Assertions.assertThat(deleted.getValue()).hasTenantId(TENANT_ID_A);
     verifyResourceIsDeleted(resourceKey);
   }
 
@@ -94,7 +118,11 @@ public class TenantAwareResourceDeletionTest {
   public void shouldDeleteFormForAuthorizedTenant() {
     // given
     final var deployment =
-        ENGINE.deployment().withXmlClasspathResource(TEST_FORM_1).withTenantId(tenantIdA).deploy();
+        ENGINE
+            .deployment()
+            .withXmlClasspathResource(TEST_FORM_1)
+            .withTenantId(TENANT_ID_A)
+            .deploy();
     final var resourceKey = deployment.getValue().getFormMetadata().get(0).getFormKey();
 
     // when
@@ -102,11 +130,11 @@ public class TenantAwareResourceDeletionTest {
         ENGINE
             .resourceDeletion()
             .withResourceKey(resourceKey)
-            .withAuthorizedTenantIds(tenantIdA)
-            .delete();
+            .withAuthorizedTenantIds(TENANT_ID_A)
+            .delete(USERNAME);
 
     // then
-    Assertions.assertThat(deleted.getValue()).hasTenantId(tenantIdA);
+    Assertions.assertThat(deleted.getValue()).hasTenantId(TENANT_ID_A);
     verifyResourceIsDeleted(resourceKey);
   }
 
@@ -114,7 +142,7 @@ public class TenantAwareResourceDeletionTest {
   public void shouldNotDeleteResourceForUnauthorizedTenant() {
     // given
     final var deployment =
-        ENGINE.deployment().withXmlResource(PROCESS).withTenantId(tenantIdA).deploy();
+        ENGINE.deployment().withXmlResource(PROCESS).withTenantId(TENANT_ID_A).deploy();
     final var resourceKey =
         deployment.getValue().getProcessesMetadata().get(0).getProcessDefinitionKey();
 
@@ -123,7 +151,7 @@ public class TenantAwareResourceDeletionTest {
         ENGINE
             .resourceDeletion()
             .withResourceKey(resourceKey)
-            .withAuthorizedTenantIds(tenantIdB)
+            .withAuthorizedTenantIds(TENANT_ID_B)
             .expectRejection()
             .delete();
 
@@ -144,11 +172,8 @@ public class TenantAwareResourceDeletionTest {
   @Test
   public void shouldDeleteResourceAssignedToDefaultTenantWithAnonymousUser() {
     // given
-    ENGINE.tenant().newTenant().withTenantId(tenantIdA).create();
-    ENGINE.tenant().newTenant().withTenantId(tenantIdB).create();
-
     final var deployment =
-        ENGINE.deployment().withXmlResource(PROCESS).withTenantId(tenantIdA).deploy();
+        ENGINE.deployment().withXmlResource(PROCESS).withTenantId(TENANT_ID_A).deploy();
     final var resourceKey =
         deployment.getValue().getProcessesMetadata().getFirst().getProcessDefinitionKey();
 
@@ -159,7 +184,7 @@ public class TenantAwareResourceDeletionTest {
     final var deleted = ENGINE.resourceDeletion().withResourceKey(resourceKey).delete(anonymous);
 
     // then
-    Assertions.assertThat(deleted.getValue()).hasTenantId(tenantIdA);
+    Assertions.assertThat(deleted.getValue()).hasTenantId(TENANT_ID_A);
     verifyResourceIsDeleted(resourceKey);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareSignalEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareSignalEventTest.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.value.EntityType;
-import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -64,37 +63,6 @@ public class TenantAwareSignalEventTest {
   public void setup() {
     processId = Strings.newRandomValidBpmnId();
     signalName = "signal-%s".formatted(processId);
-  }
-
-  @Test
-  public void shouldBroadcastSignalForDefaultTenant() {
-    // given
-    ENGINE
-        .deployment()
-        .withXmlResource(
-            Bpmn.createExecutableProcess(processId)
-                .startEvent("signal-start")
-                .signal(signalName)
-                .endEvent()
-                .done())
-        .withTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
-        .deploy();
-
-    // when
-    final var broadcasted = ENGINE.signal().withSignalName(signalName).broadcast(USERNAME);
-
-    // then
-    assertThat(broadcasted)
-        .describedAs("Expect that signal was broadcast successfully")
-        .hasIntent(SignalIntent.BROADCASTED);
-
-    assertThat(
-            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-                .withBpmnProcessId(processId)
-                .withElementId("signal-start")
-                .getFirst())
-        .describedAs("Expect that process instance was created")
-        .isNotNull();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareSignalEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareSignalEventTest.java
@@ -26,7 +26,10 @@ import org.junit.rules.TestWatcher;
 
 public class TenantAwareSignalEventTest {
 
-  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          .withSecurityConfig(config -> config.getMultiTenancy().setEnabled(true));
 
   @Rule public final TestWatcher testWatcher = new RecordingExporterTestWatcher();
   private String processId;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareStandaloneDecisionEvaluationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareStandaloneDecisionEvaluationTest.java
@@ -27,7 +27,10 @@ import org.junit.Test;
 
 public class TenantAwareStandaloneDecisionEvaluationTest {
 
-  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          .withSecurityConfig(config -> config.getMultiTenancy().setEnabled(true));
 
   private static final String DMN_DECISION_TABLE = "/dmn/decision-table.dmn";
   private static final String DMN_DECISION_TABLE_WITH_ASSERTIONS =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareStandaloneDecisionEvaluationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareStandaloneDecisionEvaluationTest.java
@@ -135,7 +135,7 @@ public class TenantAwareStandaloneDecisionEvaluationTest {
             .evaluate();
 
     // then
-    assertThat(record.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(record.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
     assertThat(record.getIntent()).isEqualTo(DecisionEvaluationIntent.EVALUATE);
     assertThat(record.getRejectionReason())
         .isEqualTo(
@@ -162,7 +162,7 @@ public class TenantAwareStandaloneDecisionEvaluationTest {
             .evaluate();
 
     // then
-    assertThat(record.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(record.getRejectionType()).isEqualTo(RejectionType.NOT_FOUND);
     assertThat(record.getIntent()).isEqualTo(DecisionEvaluationIntent.EVALUATE);
     assertThat(record.getRejectionReason())
         .isEqualTo(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerCatchEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerCatchEventTest.java
@@ -32,7 +32,10 @@ public class TenantAwareTimerCatchEventTest {
   private static final String TIMER_ID = "timer";
   private static final String TENANT = "tenant-a";
 
-  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withSecurityConfig(config -> config.getMultiTenancy().setEnabled(true));
 
   private static BpmnModelInstance processWithTimer(
       final Consumer<IntermediateCatchEventBuilder> consumer) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerEventTest.java
@@ -26,7 +26,10 @@ import org.junit.rules.TestWatcher;
 
 public class TenantAwareTimerEventTest {
 
-  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          .withSecurityConfig(config -> config.getMultiTenancy().setEnabled(true));
 
   @Rule public final TestWatcher testWatcher = new RecordingExporterTestWatcher();
   private String processId;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerStartEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerStartEventTest.java
@@ -32,7 +32,11 @@ public class TenantAwareTimerStartEventTest {
   private static final String PROCESS_ID = "process";
   private static final String TENANT = "tenant-a";
 
-  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition()
+          .withSecurityConfig(config -> config.getMultiTenancy().setEnabled(true));
+
   private long processDefinitionKey;
 
   private static BpmnModelInstance processWithTimerStartEvent(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerStartEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerStartEventTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.multitenancy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
+import io.camunda.security.configuration.ConfiguredUser;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -20,22 +21,31 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
+import java.util.List;
 import java.util.function.Consumer;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
 public class TenantAwareTimerStartEventTest {
-
+  public static final String USERNAME = "username";
   private static final String PROCESS_ID = "process";
   private static final String TENANT = "tenant-a";
 
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.getMultiTenancy().setEnabled(true));
+          .withIdentitySetup()
+          .withSecurityConfig(config -> config.getMultiTenancy().setEnabled(true))
+          .withSecurityConfig(
+              config ->
+                  config
+                      .getInitialization()
+                      .setUsers(
+                          List.of(new ConfiguredUser(USERNAME, "password", "name", "email"))));
 
   private long processDefinitionKey;
 
@@ -48,6 +58,8 @@ public class TenantAwareTimerStartEventTest {
 
   @Before
   public void init() {
+    engine.tenant().newTenant().withTenantId(TENANT).create();
+    engine.tenant().addEntity(TENANT).withEntityId(USERNAME).withEntityType(EntityType.USER).add();
     final var process = processWithTimerStartEvent(c -> c.timerWithCycle("R2/PT1M"));
     final var deployment =
         engine.deployment().withXmlResource(process).withTenantId(TENANT).deploy();
@@ -181,7 +193,7 @@ public class TenantAwareTimerStartEventTest {
         .resourceDeletion()
         .withResourceKey(processDefinitionKey)
         .withAuthorizedTenantIds(TENANT)
-        .delete();
+        .delete(USERNAME);
 
     // then
     final var canceledEvent =
@@ -211,7 +223,7 @@ public class TenantAwareTimerStartEventTest {
         .resourceDeletion()
         .withResourceKey(latestProcessDefinitionKey)
         .withAuthorizedTenantIds(TENANT)
-        .delete();
+        .delete(USERNAME);
 
     // then
     final var canceledEvent =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareUpdateVariablesTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareUpdateVariablesTest.java
@@ -27,7 +27,7 @@ public class TenantAwareUpdateVariablesTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withSecurityConfig(config -> config.getAuthorizations().setEnabled(true));
+          .withSecurityConfig(config -> config.getMultiTenancy().setEnabled(true));
 
   @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/CompleteUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/CompleteUserTaskTest.java
@@ -20,8 +20,10 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -220,18 +222,23 @@ public final class CompleteUserTaskTest {
   @Test
   public void shouldCompleteUserTaskForCustomTenant() {
     // given
-    final String tenantId = "acme";
+    final String tenantId = Strings.newRandomValidIdentityId();
+    final String username = Strings.newRandomValidIdentityId();
+    ENGINE.tenant().newTenant().withTenantId(tenantId).create();
+    ENGINE.user().newUser(username).create();
+    ENGINE
+        .tenant()
+        .addEntity(tenantId)
+        .withEntityId(username)
+        .withEntityType(EntityType.USER)
+        .add();
     ENGINE.deployment().withXmlResource(process()).withTenantId(tenantId).deploy();
     final long processInstanceKey =
         ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(tenantId).create();
 
     // when
     final Record<UserTaskRecordValue> completedRecord =
-        ENGINE
-            .userTask()
-            .ofInstance(processInstanceKey)
-            .withAuthorizedTenantIds(tenantId)
-            .complete();
+        ENGINE.userTask().ofInstance(processInstanceKey).complete(username);
 
     // then
     final UserTaskRecordValue recordValue = completedRecord.getValue();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobClient.java
@@ -230,6 +230,18 @@ public final class JobClient {
     return expectation.apply(position);
   }
 
+  public Record<JobRecordValue> updateTimeout(final String username) {
+    final long jobKey = findJobKey();
+    final long position =
+        writer.writeCommand(
+            jobKey,
+            JobIntent.UPDATE_TIMEOUT,
+            username,
+            jobRecord,
+            authorizedTenantIds.toArray(new String[0]));
+    return expectation.apply(position);
+  }
+
   public Record<JobRecordValue> update() {
     final long jobKey = findJobKey();
     final long position =
@@ -244,6 +256,18 @@ public final class JobClient {
         writer.writeCommand(
             jobKey, JobIntent.THROW_ERROR, jobRecord, authorizedTenantIds.toArray(new String[0]));
 
+    return expectation.apply(position);
+  }
+
+  public Record<JobRecordValue> throwError(final String username) {
+    final long jobKey = findJobKey();
+    final long position =
+        writer.writeCommand(
+            jobKey,
+            JobIntent.THROW_ERROR,
+            username,
+            jobRecord,
+            authorizedTenantIds.toArray(new String[0]));
     return expectation.apply(position);
   }
 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -224,8 +224,6 @@ public final class GrpcErrorMapper {
         builder.setCode(Code.INTERNAL_VALUE);
         break;
       case UNAUTHORIZED:
-        builder.setCode(Code.UNAUTHENTICATED_VALUE);
-        break;
       case FORBIDDEN:
         builder.setCode(Code.PERMISSION_DENIED_VALUE);
         break;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyIT.java
@@ -67,7 +67,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 @ZeebeIntegration
-public class MultiTenancyOverIdentityIT {
+public class MultiTenancyIT {
 
   @Container
   private static final ElasticsearchContainer CONTAINER =

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -223,10 +223,10 @@ public class MultiTenancyOverIdentityIT {
       assertThat(result)
           .failsWithin(Duration.ofSeconds(10))
           .withThrowableThat()
-          .withMessageContaining("PERMISSION_DENIED")
+          .withMessageContaining("UNAUTHORIZED")
           .withMessageContaining(
-              "Expected to handle gRPC request DeployResource with tenant identifier 'tenant-b'")
-          .withMessageContaining("but tenant is not authorized to perform this request");
+              "Insufficient permissions to perform operation 'CREATE' on resource 'RESOURCE' for tenant '%s'"
+                  .formatted(TENANT_B));
     }
   }
 
@@ -622,10 +622,10 @@ public class MultiTenancyOverIdentityIT {
       assertThat(result)
           .failsWithin(Duration.ofSeconds(10))
           .withThrowableThat()
-          .withMessageContaining("PERMISSION_DENIED")
+          .withMessageContaining("NOT_FOUND")
           .withMessageContaining(
-              "Expected to handle gRPC request PublishMessage with tenant identifier 'tenant-b'")
-          .withMessageContaining("but tenant is not authorized to perform this request");
+              "Expected to perform operation 'CREATE' on resource 'MESSAGE', but no resource was found for tenant '%s'"
+                  .formatted(TENANT_B));
     }
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -142,1375 +142,1375 @@ public class MultiTenancyOverIdentityIT {
     }
   }
 
-  //
-  //  @ParameterizedTest
-  //  @MethodSource("provideTopologyCases")
-  //  void shouldAuthorizeTopologyRequestWithoutTenantAccess(
-  //      final UnaryOperator<TopologyRequestStep1> apiPicker) {
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
-  //      // when
-  //      final var topology = apiPicker.apply(client.newTopologyRequest()).send().join();
-  //
-  //      // then
-  //      assertThat(topology.getBrokers()).hasSize(1);
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldAuthorizeDeployProcess() {
-  //    // given
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      // when
-  //      final Future<DeploymentEvent> response =
-  //          client
-  //              .newDeployResourceCommand()
-  //              .addProcessModel(process, "process.bpmn")
-  //              .tenantId(TENANT_A)
-  //              .send();
-  //
-  //      // then
-  //      assertThat(response)
-  //          .describedAs("Expect that process can be deployed for tenant-a")
-  //          .succeedsWithin(Duration.ofSeconds(10));
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldDenyDeployResourceWhenUnauthorized() {
-  //    // given
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      // when
-  //      final Future<DeploymentEvent> result =
-  //          client
-  //              .newDeployResourceCommand()
-  //              .addProcessModel(process, "process.bpmn")
-  //              .tenantId(TENANT_B)
-  //              .send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .failsWithin(Duration.ofSeconds(10))
-  //          .withThrowableThat()
-  //          .withMessageContaining("PERMISSION_DENIED")
-  //          .withMessageContaining(
-  //              "Expected to handle gRPC request DeployResource with tenant identifier
-  // 'tenant-b'")
-  //          .withMessageContaining("but tenant is not authorized to perform this request");
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldDenyDeployResourceWhenUnauthorizedForDefaultTenant() {
-  //    // given
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_WITHOUT_DEFAULT_TENANT))
-  // {
-  //      // when
-  //      final Future<DeploymentEvent> result =
-  //          client
-  //              .newDeployResourceCommand()
-  //              .addProcessModel(process, "process.bpmn")
-  //              .tenantId(DEFAULT_TENANT)
-  //              .send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .failsWithin(Duration.ofSeconds(10))
-  //          .withThrowableThat()
-  //          .withMessageContaining("PERMISSION_DENIED")
-  //          .withMessageContaining(
-  //              "Expected to handle gRPC request DeployResource with tenant identifier
-  // '<default>'")
-  //          .withMessageContaining("but tenant is not authorized to perform this request");
-  //    }
-  //  }
-  //
-  //  @SuppressWarnings("deprecation")
-  //  @Test
-  //  void shouldDenyDeployProcessWhenUnauthorizedForDefaultTenant() {
-  //    // given
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_WITHOUT_DEFAULT_TENANT))
-  // {
-  //      // when
-  //      // note that deploy process command is always only for the default tenant
-  //      final Future<DeploymentEvent> result =
-  //          client.newDeployCommand().addProcessModel(process, "process.bpmn").send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .failsWithin(Duration.ofSeconds(10))
-  //          .withThrowableThat()
-  //          .withMessageContaining("PERMISSION_DENIED")
-  //          .withMessageContaining(
-  //              "Expected to handle gRPC request DeployProcess with tenant identifier
-  // '<default>'")
-  //          .withMessageContaining("but tenant is not authorized to perform this request");
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldAuthorizeDeleteResource() throws ExecutionException, InterruptedException {
-  //    // given
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      final Future<DeploymentEvent> deploymentResponse =
-  //          client
-  //              .newDeployResourceCommand()
-  //              .addProcessModel(process, "process.bpmn")
-  //              .tenantId(TENANT_A)
-  //              .send();
-  //      assertThat(deploymentResponse)
-  //          .describedAs("Expect that process was deployed for tenant-a")
-  //          .succeedsWithin(Duration.ofSeconds(10));
-  //      final long resourceKey =
-  //          deploymentResponse.get().getProcesses().get(0).getProcessDefinitionKey();
-  //
-  //      // when
-  //      final Future<DeleteResourceResponse> response =
-  //          client.newDeleteResourceCommand(resourceKey).send();
-  //
-  //      // then
-  //      assertThat(response)
-  //          .describedAs("Expect that process can be deleted for tenant-a")
-  //          .succeedsWithin(Duration.ofSeconds(10));
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldDenyDeleteResourceWhenUnauthorized() throws ExecutionException,
-  // InterruptedException {
-  //    // given
-  //    final long resourceKey;
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      final Future<DeploymentEvent> deploymentResponse =
-  //          client
-  //              .newDeployResourceCommand()
-  //              .addProcessModel(process, "process.bpmn")
-  //              .tenantId(TENANT_A)
-  //              .send();
-  //      assertThat(deploymentResponse)
-  //          .describedAs("Expect that process was deployed for tenant-a")
-  //          .succeedsWithin(Duration.ofSeconds(10));
-  //      resourceKey = deploymentResponse.get().getProcesses().get(0).getProcessDefinitionKey();
-  //    }
-  //
-  //    // when
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-  //      final Future<DeleteResourceResponse> response =
-  //          client.newDeleteResourceCommand(resourceKey).send();
-  //
-  //      // then
-  //      assertThat(response)
-  //          .failsWithin(Duration.ofSeconds(10))
-  //          .withThrowableThat()
-  //          .withMessageContaining("NOT_FOUND");
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldIncrementProcessVersionPerTenant() {
-  //    // given
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addProcessModel(process, "process.bpmn")
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //    }
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addProcessModel(process, "process.bpmn")
-  //          .tenantId(TENANT_B)
-  //          .send()
-  //          .join();
-  //    }
-  //
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-  //      // when
-  //      final var processV2 = Bpmn.createExecutableProcess(processId).startEvent().done();
-  //      final Future<DeploymentEvent> result =
-  //          client
-  //              .newDeployResourceCommand()
-  //              .addProcessModel(processV2, "process.bpmn")
-  //              .tenantId(TENANT_B)
-  //              .send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .succeedsWithin(Duration.ofSeconds(10))
-  //          .describedAs("Process version is incremented for tenant-b but not for tenant-a")
-  //          .extracting(deploymentEvent -> deploymentEvent.getProcesses().get(0))
-  //          .extracting(Process::getVersion, Process::getTenantId)
-  //          .containsExactly(2, TENANT_B);
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldAuthorizeCreateProcessInstance() {
-  //    // given
-  //    final long processDefinitionKey;
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
-  //      processDefinitionKey =
-  //          client
-  //              .newDeployResourceCommand()
-  //              .addProcessModel(process, "process.bpmn")
-  //              .tenantId(TENANT_A)
-  //              .send()
-  //              .join()
-  //              .getProcesses()
-  //              .stream()
-  //              .map(Process::getProcessDefinitionKey)
-  //              .findFirst()
-  //              .orElseThrow();
-  //
-  //      // when
-  //      final Future<ProcessInstanceEvent> result =
-  //          client
-  //              .newCreateInstanceCommand()
-  //              .processDefinitionKey(processDefinitionKey)
-  //              .tenantId(TENANT_A)
-  //              .send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .describedAs(
-  //              "Expect that process instance can be created as the client has access process of
-  // tenant-a")
-  //          .succeedsWithin(Duration.ofSeconds(10));
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldNotFindOtherTenantsProcessById() {
-  //    // given
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addProcessModel(process, "process.bpmn")
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //    }
-  //
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-  //      // when
-  //      final Future<ProcessInstanceEvent> result =
-  //          client
-  //              .newCreateInstanceCommand()
-  //              .bpmnProcessId(processId)
-  //              .latestVersion()
-  //              .tenantId(TENANT_B)
-  //              .send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .failsWithin(Duration.ofSeconds(10))
-  //          .withThrowableThat()
-  //          .describedAs("Process definition should exist for tenant-a but not for tenant-b")
-  //          .withMessageContaining("NOT_FOUND")
-  //          .withMessageContaining("Expected to find process definition with process ID")
-  //          .withMessageContaining("but none found");
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldNotFindOtherTenantsProcessByKey() {
-  //    // given
-  //    final long processDefinitionKey;
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      processDefinitionKey =
-  //          client
-  //              .newDeployResourceCommand()
-  //              .addProcessModel(process, "process.bpmn")
-  //              .tenantId(TENANT_A)
-  //              .send()
-  //              .join()
-  //              .getProcesses()
-  //              .stream()
-  //              .map(Process::getProcessDefinitionKey)
-  //              .findFirst()
-  //              .orElseThrow();
-  //    }
-  //
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-  //      // when
-  //      final Future<ProcessInstanceEvent> result =
-  //          client
-  //              .newCreateInstanceCommand()
-  //              .processDefinitionKey(processDefinitionKey)
-  //              .tenantId(TENANT_B)
-  //              .send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .failsWithin(Duration.ofSeconds(10))
-  //          .withThrowableThat()
-  //          .describedAs("Process definition should exist for tenant-a but not for tenant-b")
-  //          .withMessageContaining("NOT_FOUND")
-  //          .withMessageContaining("Expected to find process definition with key")
-  //          .withMessageContaining("but none found");
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldNotFindOtherTenantsProcessInCallActivity() {
-  //    // given
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addProcessModel(process, "process.bpmn")
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //    }
-  //
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addProcessModel(
-  //              Bpmn.createExecutableProcess("parent")
-  //                  .startEvent()
-  //                  .callActivity("call", c -> c.zeebeProcessId(processId))
-  //                  .endEvent()
-  //                  .done(),
-  //              "parent.bpmn")
-  //          .tenantId(TENANT_B)
-  //          .send()
-  //          .join();
-  //    }
-  //
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-  //      // when
-  //      client
-  //          .newCreateInstanceCommand()
-  //          .bpmnProcessId("parent")
-  //          .latestVersion()
-  //          .tenantId(TENANT_B)
-  //          .send();
-  //
-  //      // then
-  //      Assertions.assertThat(
-  //
-  // RecordingExporter.incidentRecords().withBpmnProcessId("parent").getFirst().getValue())
-  //          .hasErrorMessage(
-  //              "Expected process with BPMN process id '%s' to be deployed, but not found."
-  //                  .formatted(processId));
-  //    }
-  //  }
-  //
-  //  /**
-  //   * This test case may become obsolete when we allow shared processes definitions across
-  // tenants.
-  //   */
-  //  @Test
-  //  void shouldNotFindOtherTenantsProcessEvenWhenClientIsAuthorizedForTenant() {
-  //    // given
-  //    final long processDefinitionKey;
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
-  //      processDefinitionKey =
-  //          client
-  //              .newDeployResourceCommand()
-  //              .addProcessModel(process, "process.bpmn")
-  //              .tenantId(TENANT_A)
-  //              .send()
-  //              .join()
-  //              .getProcesses()
-  //              .stream()
-  //              .map(Process::getProcessDefinitionKey)
-  //              .findFirst()
-  //              .orElseThrow();
-  //    }
-  //
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
-  //      // when
-  //      final Future<ProcessInstanceEvent> result =
-  //          client
-  //              .newCreateInstanceCommand()
-  //              .processDefinitionKey(processDefinitionKey)
-  //              .tenantId(TENANT_B)
-  //              .send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .failsWithin(Duration.ofSeconds(10))
-  //          .withThrowableThat()
-  //          .describedAs("Process definition should exist for tenant-a but not for tenant-b")
-  //          .withMessageContaining("NOT_FOUND")
-  //          .withMessageContaining("Expected to find process definition with key")
-  //          .withMessageContaining("but none found");
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldStartProcessWhenPublishingMessageForTenant() {
-  //    // given
-  //    final String messageName = "message";
-  //    process =
-  //
-  // Bpmn.createExecutableProcess(processId).startEvent().message(messageName).endEvent().done();
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addProcessModel(process, "process.bpmn")
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //
-  //      // when
-  //      final Future<PublishMessageResponse> result =
-  //          client
-  //              .newPublishMessageCommand()
-  //              .messageName(messageName)
-  //              .withoutCorrelationKey()
-  //              .tenantId(TENANT_A)
-  //              .send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .describedAs(
-  //              "Expect that message can be published as the client has access process of
-  // tenant-a")
-  //          .succeedsWithin(Duration.ofSeconds(10));
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldDenyPublishMessageWhenUnauthorized() {
-  //    // given
-  //    final String messageName = "message";
-  //    process =
-  //
-  // Bpmn.createExecutableProcess(processId).startEvent().message(messageName).endEvent().done();
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addProcessModel(process, "process.bpmn")
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //
-  //      // when
-  //      final Future<PublishMessageResponse> result =
-  //          client
-  //              .newPublishMessageCommand()
-  //              .messageName(messageName)
-  //              .withoutCorrelationKey()
-  //              .tenantId(TENANT_B)
-  //              .send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .failsWithin(Duration.ofSeconds(10))
-  //          .withThrowableThat()
-  //          .withMessageContaining("PERMISSION_DENIED")
-  //          .withMessageContaining(
-  //              "Expected to handle gRPC request PublishMessage with tenant identifier
-  // 'tenant-b'")
-  //          .withMessageContaining("but tenant is not authorized to perform this request");
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldActivateJobForTenant() {
-  //    // given
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addProcessModel(process, "process.bpmn")
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //      client
-  //          .newCreateInstanceCommand()
-  //          .bpmnProcessId(processId)
-  //          .latestVersion()
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //
-  //      // when
-  //      final Future<ActivateJobsResponse> result =
-  //          client
-  //              .newActivateJobsCommand()
-  //              .jobType("type")
-  //              .maxJobsToActivate(1)
-  //              .tenantId(TENANT_A)
-  //              .send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .describedAs(
-  //              "Expect that job can be activated as the client has access process of tenant-a")
-  //          .succeedsWithin(Duration.ofSeconds(10));
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldDenyActivateJobWhenUnauthorized() {
-  //    // given
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addProcessModel(process, "process.bpmn")
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //      client
-  //          .newCreateInstanceCommand()
-  //          .bpmnProcessId(processId)
-  //          .latestVersion()
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //    }
-  //
-  //    // when
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-  //      final Future<ActivateJobsResponse> result =
-  //          client
-  //              .newActivateJobsCommand()
-  //              .jobType("type")
-  //              .maxJobsToActivate(1)
-  //              .tenantId(TENANT_A)
-  //              .send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .failsWithin(Duration.ofSeconds(10))
-  //          .withThrowableThat()
-  //          .withMessageContaining("PERMISSION_DENIED")
-  //          .withMessageContaining(
-  //              "Expected to handle gRPC request ActivateJobs with tenant identifier 'tenant-a'")
-  //          .withMessageContaining("but tenant is not authorized to perform this request");
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldCompleteJobForTenant() {
-  //    // given
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addProcessModel(process, "process.bpmn")
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //      client
-  //          .newCreateInstanceCommand()
-  //          .bpmnProcessId(processId)
-  //          .latestVersion()
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //
-  //      final var activatedJob =
-  //          client
-  //              .newActivateJobsCommand()
-  //              .jobType("type")
-  //              .maxJobsToActivate(1)
-  //              .tenantId(TENANT_A)
-  //              .send()
-  //              .join()
-  //              .getJobs()
-  //              .get(0);
-  //
-  //      // when
-  //      final Future<CompleteJobResponse> result = client.newCompleteCommand(activatedJob).send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .describedAs(
-  //              "Expect that job can be competed as the client has access process of tenant-a")
-  //          .succeedsWithin(Duration.ofSeconds(10));
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldCompleteUserTaskForTenant() {
-  //    // given
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addProcessModel(process, "process.bpmn")
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //      client
-  //          .newCreateInstanceCommand()
-  //          .bpmnProcessId(processId)
-  //          .latestVersion()
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //
-  //      final var activatedJob =
-  //          client
-  //              .newActivateJobsCommand()
-  //              .jobType("type")
-  //              .maxJobsToActivate(1)
-  //              .tenantId(TENANT_A)
-  //              .send()
-  //              .join()
-  //              .getJobs()
-  //              .get(0);
-  //
-  //      // when
-  //      final Future<CompleteJobResponse> result = client.newCompleteCommand(activatedJob).send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .describedAs(
-  //              "Expect that job can be competed as the client has access process of tenant-a")
-  //          .succeedsWithin(Duration.ofSeconds(10));
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldUpdateJobTimeoutForTenant() {
-  //    // given
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addProcessModel(process, "process.bpmn")
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //      client
-  //          .newCreateInstanceCommand()
-  //          .bpmnProcessId(processId)
-  //          .latestVersion()
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //
-  //      final var activatedJob =
-  //          client
-  //              .newActivateJobsCommand()
-  //              .jobType("type")
-  //              .maxJobsToActivate(1)
-  //              .tenantId(TENANT_A)
-  //              .timeout(Duration.ofMinutes(10))
-  //              .send()
-  //              .join()
-  //              .getJobs()
-  //              .get(0);
-  //
-  //      // when
-  //      final Future<UpdateTimeoutJobResponse> result =
-  //          client.newUpdateTimeoutCommand(activatedJob).timeout(Duration.ofMinutes(11)).send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .describedAs(
-  //              "Expect that job timeout can be updated as the client has access process of
-  // tenant-a")
-  //          .succeedsWithin(Duration.ofSeconds(10));
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldNotUpdateJobTimeoutWhenUnauthorized() {
-  //    // given
-  //    final ActivatedJob activatedJob;
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addProcessModel(process, "process.bpmn")
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //      client
-  //          .newCreateInstanceCommand()
-  //          .bpmnProcessId(processId)
-  //          .latestVersion()
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //      activatedJob =
-  //          client
-  //              .newActivateJobsCommand()
-  //              .jobType("type")
-  //              .maxJobsToActivate(1)
-  //              .tenantId(TENANT_A)
-  //              .timeout(Duration.ofMinutes(10))
-  //              .send()
-  //              .join()
-  //              .getJobs()
-  //              .get(0);
-  //    }
-  //
-  //    // when
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-  //      final Future<UpdateTimeoutJobResponse> result =
-  //          client.newUpdateTimeoutCommand(activatedJob).timeout(Duration.ofMinutes(11)).send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .failsWithin(Duration.ofSeconds(10))
-  //          .withThrowableThat()
-  //          .withMessageContaining("NOT_FOUND")
-  //          .withMessageContaining(
-  //              "Command 'UPDATE_TIMEOUT' rejected with code 'NOT_FOUND': Expected to update job
-  // with key '%d', but no such job was found"
-  //                  .formatted(activatedJob.getKey()));
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldNotFindJobWhenUnauthorized() {
-  //    // given
-  //    final ActivatedJob activatedJob;
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addProcessModel(process, "process.bpmn")
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //      client
-  //          .newCreateInstanceCommand()
-  //          .bpmnProcessId(processId)
-  //          .latestVersion()
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //      activatedJob =
-  //          client
-  //              .newActivateJobsCommand()
-  //              .jobType("type")
-  //              .maxJobsToActivate(1)
-  //              .tenantId(TENANT_A)
-  //              .send()
-  //              .join()
-  //              .getJobs()
-  //              .get(0);
-  //    }
-  //
-  //    // when
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-  //      final Future<CompleteJobResponse> result = client.newCompleteCommand(activatedJob).send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .failsWithin(Duration.ofSeconds(10))
-  //          .withThrowableThat()
-  //          .withMessageContaining("NOT_FOUND")
-  //          .withMessageContaining(
-  //              "Command 'COMPLETE' rejected with code 'NOT_FOUND': Expected to update retries for
-  // job with key '%d', but no such job was found"
-  //                  .formatted(activatedJob.getKey()));
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldResolveIncidentForTenant() {
-  //    // given
-  //    process =
-  //        Bpmn.createExecutableProcess(processId)
-  //            .startEvent()
-  //            .zeebeOutputExpression("assert(foo, foo != null)", "target")
-  //            .endEvent()
-  //            .done();
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addProcessModel(process, "process.bpmn")
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //      client
-  //          .newCreateInstanceCommand()
-  //          .bpmnProcessId(processId)
-  //          .latestVersion()
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //
-  //      final var incidentKey =
-  //          RecordingExporter.incidentRecords().withBpmnProcessId(processId).getFirst().getKey();
-  //
-  //      // when
-  //      final Future<ResolveIncidentResponse> result =
-  //          client.newResolveIncidentCommand(incidentKey).send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .describedAs(
-  //              "Expect that incident can be resolved as the client has access process of
-  // tenant-a")
-  //          .succeedsWithin(Duration.ofSeconds(10));
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldNotFindIncidentForTenantWhenUnauthorized() {
-  //    // given
-  //    process =
-  //        Bpmn.createExecutableProcess(processId)
-  //            .startEvent()
-  //            .zeebeOutputExpression("assert(foo, foo != null)", "target")
-  //            .endEvent()
-  //            .done();
-  //    final long incidentKey;
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addProcessModel(process, "process.bpmn")
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //      client
-  //          .newCreateInstanceCommand()
-  //          .bpmnProcessId(processId)
-  //          .latestVersion()
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //
-  //      incidentKey =
-  //          RecordingExporter.incidentRecords().withBpmnProcessId(processId).getFirst().getKey();
-  //    }
-  //
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-  //      // when
-  //      final Future<ResolveIncidentResponse> result =
-  //          client.newResolveIncidentCommand(incidentKey).send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .failsWithin(Duration.ofSeconds(10))
-  //          .withThrowableThat()
-  //          .withMessageContaining("NOT_FOUND")
-  //          .withMessageContaining(
-  //              "Command 'RESOLVE' rejected with code 'NOT_FOUND': Expected to resolve incident
-  // with key '%d', but no such incident was found"
-  //                  .formatted(incidentKey));
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldAllowModifyProcessInstanceForDefaultTenant() {
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
-  //      // given
-  //      client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
-  //
-  //      final long processInstanceKey =
-  //          client
-  //              .newCreateInstanceCommand()
-  //              .bpmnProcessId(processId)
-  //              .latestVersion()
-  //              .send()
-  //              .join()
-  //              .getProcessInstanceKey();
-  //
-  //      // when
-  //      final Future<ModifyProcessInstanceResponse> response =
-  //
-  // client.newModifyProcessInstanceCommand(processInstanceKey).activateElement("task").send();
-  //
-  //      // then
-  //      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldAllowModifyProcessInstanceForOtherTenant() {
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      // given
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addProcessModel(process, "process.bpmn")
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //
-  //      final long processInstanceKey =
-  //          client
-  //              .newCreateInstanceCommand()
-  //              .bpmnProcessId(processId)
-  //              .latestVersion()
-  //              .tenantId(TENANT_A)
-  //              .send()
-  //              .join()
-  //              .getProcessInstanceKey();
-  //
-  //      // when
-  //      final Future<ModifyProcessInstanceResponse> response =
-  //
-  // client.newModifyProcessInstanceCommand(processInstanceKey).activateElement("task").send();
-  //
-  //      // then
-  //      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldRejectModifyProcessInstanceForUnauthorizedTenant() {
-  //    final long processInstanceKey;
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      // given
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addProcessModel(process, "process.bpmn")
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //
-  //      processInstanceKey =
-  //          client
-  //              .newCreateInstanceCommand()
-  //              .bpmnProcessId(processId)
-  //              .latestVersion()
-  //              .tenantId(TENANT_A)
-  //              .send()
-  //              .join()
-  //              .getProcessInstanceKey();
-  //    }
-  //
-  //    // when
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-  //      final Future<ModifyProcessInstanceResponse> response =
-  //
-  // client.newModifyProcessInstanceCommand(processInstanceKey).activateElement("task").send();
-  //
-  //      // then
-  //      assertThat(response)
-  //          .failsWithin(Duration.ofSeconds(10))
-  //          .withThrowableThat()
-  //          .withMessageContaining("NOT_FOUND")
-  //          .withMessageContaining(
-  //              "Expected to modify process instance but no process instance found with key");
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldAllowMigrateProcessInstanceForDefaultTenant() {
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
-  //      // given
-  //      client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
-  //      final var deploymentResponse =
-  //          client
-  //              .newDeployResourceCommand()
-  //              .addProcessModel(migratedProcess, "migrated-process.bpmn")
-  //              .send()
-  //              .join();
-  //      final long targetProcessDefinitionKey =
-  //          deploymentResponse.getProcesses().get(0).getProcessDefinitionKey();
-  //
-  //      final long processInstanceKey =
-  //          client
-  //              .newCreateInstanceCommand()
-  //              .bpmnProcessId(processId)
-  //              .latestVersion()
-  //              .send()
-  //              .join()
-  //              .getProcessInstanceKey();
-  //
-  //      // when
-  //      final Future<MigrateProcessInstanceResponse> response =
-  //          client
-  //              .newMigrateProcessInstanceCommand(processInstanceKey)
-  //              .migrationPlan(targetProcessDefinitionKey)
-  //              .addMappingInstruction("task", "migrated-task")
-  //              .send();
-  //
-  //      // then
-  //      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldAllowMigrateProcessInstanceForOtherTenant() {
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      // given
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addProcessModel(process, "process.bpmn")
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //      final var deploymentResponse =
-  //          client
-  //              .newDeployResourceCommand()
-  //              .addProcessModel(migratedProcess, "migrated-process.bpmn")
-  //              .tenantId(TENANT_A)
-  //              .send()
-  //              .join();
-  //      final long targetProcessDefinitionKey =
-  //          deploymentResponse.getProcesses().get(0).getProcessDefinitionKey();
-  //
-  //      final long processInstanceKey =
-  //          client
-  //              .newCreateInstanceCommand()
-  //              .bpmnProcessId(processId)
-  //              .latestVersion()
-  //              .tenantId(TENANT_A)
-  //              .send()
-  //              .join()
-  //              .getProcessInstanceKey();
-  //
-  //      // when
-  //      final Future<MigrateProcessInstanceResponse> response =
-  //          client
-  //              .newMigrateProcessInstanceCommand(processInstanceKey)
-  //              .migrationPlan(targetProcessDefinitionKey)
-  //              .addMappingInstruction("task", "migrated-task")
-  //              .send();
-  //
-  //      // then
-  //      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldRejectMigrateProcessInstanceForUnauthorizedTenant() {
-  //    final long processInstanceKey;
-  //    final long targetProcessDefinitionKey;
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      // given
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addProcessModel(process, "process.bpmn")
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //      final var deploymentResponse =
-  //          client
-  //              .newDeployResourceCommand()
-  //              .addProcessModel(migratedProcess, "process.bpmn")
-  //              .tenantId(TENANT_A)
-  //              .send()
-  //              .join();
-  //      targetProcessDefinitionKey =
-  //          deploymentResponse.getProcesses().get(0).getProcessDefinitionKey();
-  //
-  //      processInstanceKey =
-  //          client
-  //              .newCreateInstanceCommand()
-  //              .bpmnProcessId(processId)
-  //              .latestVersion()
-  //              .tenantId(TENANT_A)
-  //              .send()
-  //              .join()
-  //              .getProcessInstanceKey();
-  //    }
-  //
-  //    // when
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-  //      final Future<MigrateProcessInstanceResponse> response =
-  //          client
-  //              .newMigrateProcessInstanceCommand(processInstanceKey)
-  //              .migrationPlan(targetProcessDefinitionKey)
-  //              .addMappingInstruction("task", "migrated-task")
-  //              .send();
-  //
-  //      // then
-  //      assertThat(response)
-  //          .failsWithin(Duration.ofSeconds(10))
-  //          .withThrowableThat()
-  //          .withMessageContaining("NOT_FOUND")
-  //          .withMessageContaining(
-  //              String.format(
-  //                  "Expected to migrate process instance but no process instance found with key
-  // '%s'",
-  //                  processInstanceKey));
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldAllowEvaluateDecisionForDefaultTenant() {
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
-  //      // given
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addResourceFromClasspath("dmn/decision-table.dmn")
-  //          .send()
-  //          .join();
-  //
-  //      // when
-  //      final Future<EvaluateDecisionResponse> response =
-  //          client
-  //              .newEvaluateDecisionCommand()
-  //              .decisionId("jedi_or_sith")
-  //              .variable("lightsaberColor", "blue")
-  //              .send();
-  //      // then
-  //      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldAllowEvaluateDecisionForCustomTenant() {
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
-  //      // given
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addResourceFromClasspath("dmn/decision-table.dmn")
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //
-  //      // when
-  //      final Future<EvaluateDecisionResponse> response =
-  //          client
-  //              .newEvaluateDecisionCommand()
-  //              .decisionId("jedi_or_sith")
-  //              .variable("lightsaberColor", "blue")
-  //              .tenantId(TENANT_A)
-  //              .send();
-  //      // then
-  //      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldDenyEvaluateDecisionForCustomTenant() {
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
-  //      // given
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addResourceFromClasspath("dmn/decision-table.dmn")
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //
-  //      // when
-  //      final Future<EvaluateDecisionResponse> response =
-  //          client
-  //              .newEvaluateDecisionCommand()
-  //              .decisionId("jedi_or_sith")
-  //              .variable("lightsaberColor", "blue")
-  //              .tenantId(TENANT_B)
-  //              .send();
-  //      // then
-  //      assertThat(response)
-  //          .failsWithin(Duration.ofSeconds(10))
-  //          .withThrowableThat()
-  //          .withMessageContaining("PERMISSION_DENIED")
-  //          .withMessageContaining(
-  //              "Expected to handle gRPC request EvaluateDecision with tenant identifier
-  // 'tenant-b'")
-  //          .withMessageContaining("but tenant is not authorized to perform this request");
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldStartInstanceWhenBroadcastSignalForTenant() {
-  //    final String signalName = "signal";
-  //    process =
-  //
-  // Bpmn.createExecutableProcess(processId).startEvent().signal(signalName).endEvent().done();
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      // given
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addProcessModel(process, "process.bpmn")
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //
-  //      // when
-  //      final Future<BroadcastSignalResponse> result =
-  //          client.newBroadcastSignalCommand().signalName(signalName).tenantId(TENANT_A).send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .describedAs(
-  //              "Expect that signal can be broadcast as the client has access to the process of
-  // 'tenant-a'")
-  //          .succeedsWithin(Duration.ofSeconds(20));
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldDenyBroadcastSignalWhenUnauthorized() {
-  //    final String signalName = "signal";
-  //    process =
-  //
-  // Bpmn.createExecutableProcess(processId).startEvent().signal(signalName).endEvent().done();
-  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-  //      // given
-  //      client
-  //          .newDeployResourceCommand()
-  //          .addProcessModel(process, "process.bpmn")
-  //          .tenantId(TENANT_A)
-  //          .send()
-  //          .join();
-  //
-  //      // when
-  //      final Future<BroadcastSignalResponse> result =
-  //          client.newBroadcastSignalCommand().signalName(signalName).tenantId(TENANT_B).send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .failsWithin(Duration.ofSeconds(10))
-  //          .withThrowableThat()
-  //          .withMessageContaining("PERMISSION_DENIED")
-  //          .withMessageContaining(
-  //              "Expected to handle gRPC request BroadcastSignal with tenant identifier
-  // 'tenant-b'")
-  //          .withMessageContaining("but tenant is not authorized to perform this request");
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldAllowAssignUserTaskForTenant() {
-  //    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
-  //        final var clientTenantB = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
-  //      // given
-  //      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
-  //      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
-  //
-  //      // when
-  //      final Future<AssignUserTaskResponse> result =
-  //          clientTenantB.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send();
-  //
-  //      // then
-  //      assertThat(result).succeedsWithin(Duration.ofSeconds(10));
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldRejectAssignUserTaskForTenant() {
-  //    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
-  //        final var skeletorClient = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
-  //      // given
-  //      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
-  //      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
-  //
-  //      // when
-  //      final Future<AssignUserTaskResponse> result =
-  //          skeletorClient.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .failsWithin(Duration.ofSeconds(10))
-  //          .withThrowableThat()
-  //          .havingCause()
-  //          .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
-  //          .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldAllowCompleteUserTaskForTenant() {
-  //    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
-  //        final var clientTenantB = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
-  //      // given
-  //      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
-  //      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
-  //
-  //      // when
-  //      final Future<CompleteUserTaskResponse> result =
-  //          clientTenantB.newUserTaskCompleteCommand(userTaskKey).send();
-  //
-  //      // then
-  //      assertThat(result).succeedsWithin(Duration.ofSeconds(10));
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldRejectCompleteUserTaskForTenant() {
-  //    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
-  //        final var invalidClient = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
-  //      // given
-  //      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
-  //      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
-  //
-  //      // when
-  //      final Future<CompleteUserTaskResponse> result =
-  //          invalidClient.newUserTaskCompleteCommand(userTaskKey).send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .failsWithin(Duration.ofSeconds(10))
-  //          .withThrowableThat()
-  //          .havingCause()
-  //          .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
-  //          .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldAllowUnassignUserTaskForTenant() {
-  //    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
-  //        final var clientTenantB = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
-  //      // given
-  //      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
-  //      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
-  //      clientTenantA.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send().join();
-  //
-  //      // when
-  //      final Future<UnassignUserTaskResponse> result =
-  //          clientTenantB.newUserTaskUnassignCommand(userTaskKey).send();
-  //
-  //      // then
-  //      assertThat(result).succeedsWithin(Duration.ofSeconds(10));
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldRejectUnassignUserTaskForTenant() {
-  //    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
-  //        final var invalidClient = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
-  //      // given
-  //      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
-  //      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
-  //      clientTenantA.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send().join();
-  //
-  //      // when
-  //      final Future<UnassignUserTaskResponse> result =
-  //          invalidClient.newUserTaskUnassignCommand(userTaskKey).send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .failsWithin(Duration.ofSeconds(10))
-  //          .withThrowableThat()
-  //          .havingCause()
-  //          .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
-  //          .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldAllowUpdateUserTaskForTenant() {
-  //    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
-  //        final var clientTenantB = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
-  //      // given
-  //      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
-  //      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
-  //
-  //      // when
-  //      final Future<UpdateUserTaskResponse> result =
-  //          clientTenantB.newUserTaskUpdateCommand(userTaskKey).candidateUsers("Skeletor").send();
-  //
-  //      // then
-  //      assertThat(result).succeedsWithin(Duration.ofSeconds(10));
-  //    }
-  //  }
-  //
-  //  @Test
-  //  void shouldRejectUpdateUserTaskForTenant() {
-  //    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
-  //        final var invalidClient = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
-  //      // given
-  //      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
-  //      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
-  //
-  //      // when
-  //      final Future<UpdateUserTaskResponse> result =
-  //          invalidClient.newUserTaskUpdateCommand(userTaskKey).candidateUsers("Skeletor").send();
-  //
-  //      // then
-  //      assertThat(result)
-  //          .failsWithin(Duration.ofSeconds(10))
-  //          .withThrowableThat()
-  //          .havingCause()
-  //          .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
-  //          .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
-  //    }
-  //  }
-  //
+
+    @ParameterizedTest
+    @MethodSource("provideTopologyCases")
+    void shouldAuthorizeTopologyRequestWithoutTenantAccess(
+        final UnaryOperator<TopologyRequestStep1> apiPicker) {
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
+        // when
+        final var topology = apiPicker.apply(client.newTopologyRequest()).send().join();
+
+        // then
+        assertThat(topology.getBrokers()).hasSize(1);
+      }
+    }
+
+    @Test
+    void shouldAuthorizeDeployProcess() {
+      // given
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        // when
+        final Future<DeploymentEvent> response =
+            client
+                .newDeployResourceCommand()
+                .addProcessModel(process, "process.bpmn")
+                .tenantId(TENANT_A)
+                .send();
+
+        // then
+        assertThat(response)
+            .describedAs("Expect that process can be deployed for tenant-a")
+            .succeedsWithin(Duration.ofSeconds(10));
+      }
+    }
+
+    @Test
+    void shouldDenyDeployResourceWhenUnauthorized() {
+      // given
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        // when
+        final Future<DeploymentEvent> result =
+            client
+                .newDeployResourceCommand()
+                .addProcessModel(process, "process.bpmn")
+                .tenantId(TENANT_B)
+                .send();
+
+        // then
+        assertThat(result)
+            .failsWithin(Duration.ofSeconds(10))
+            .withThrowableThat()
+            .withMessageContaining("PERMISSION_DENIED")
+            .withMessageContaining(
+                "Expected to handle gRPC request DeployResource with tenant identifier
+   'tenant-b'")
+            .withMessageContaining("but tenant is not authorized to perform this request");
+      }
+    }
+
+    @Test
+    void shouldDenyDeployResourceWhenUnauthorizedForDefaultTenant() {
+      // given
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_WITHOUT_DEFAULT_TENANT))
+   {
+        // when
+        final Future<DeploymentEvent> result =
+            client
+                .newDeployResourceCommand()
+                .addProcessModel(process, "process.bpmn")
+                .tenantId(DEFAULT_TENANT)
+                .send();
+
+        // then
+        assertThat(result)
+            .failsWithin(Duration.ofSeconds(10))
+            .withThrowableThat()
+            .withMessageContaining("PERMISSION_DENIED")
+            .withMessageContaining(
+                "Expected to handle gRPC request DeployResource with tenant identifier
+   '<default>'")
+            .withMessageContaining("but tenant is not authorized to perform this request");
+      }
+    }
+
+    @SuppressWarnings("deprecation")
+    @Test
+    void shouldDenyDeployProcessWhenUnauthorizedForDefaultTenant() {
+      // given
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_WITHOUT_DEFAULT_TENANT))
+   {
+        // when
+        // note that deploy process command is always only for the default tenant
+        final Future<DeploymentEvent> result =
+            client.newDeployCommand().addProcessModel(process, "process.bpmn").send();
+
+        // then
+        assertThat(result)
+            .failsWithin(Duration.ofSeconds(10))
+            .withThrowableThat()
+            .withMessageContaining("PERMISSION_DENIED")
+            .withMessageContaining(
+                "Expected to handle gRPC request DeployProcess with tenant identifier
+   '<default>'")
+            .withMessageContaining("but tenant is not authorized to perform this request");
+      }
+    }
+
+    @Test
+    void shouldAuthorizeDeleteResource() throws ExecutionException, InterruptedException {
+      // given
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        final Future<DeploymentEvent> deploymentResponse =
+            client
+                .newDeployResourceCommand()
+                .addProcessModel(process, "process.bpmn")
+                .tenantId(TENANT_A)
+                .send();
+        assertThat(deploymentResponse)
+            .describedAs("Expect that process was deployed for tenant-a")
+            .succeedsWithin(Duration.ofSeconds(10));
+        final long resourceKey =
+            deploymentResponse.get().getProcesses().get(0).getProcessDefinitionKey();
+
+        // when
+        final Future<DeleteResourceResponse> response =
+            client.newDeleteResourceCommand(resourceKey).send();
+
+        // then
+        assertThat(response)
+            .describedAs("Expect that process can be deleted for tenant-a")
+            .succeedsWithin(Duration.ofSeconds(10));
+      }
+    }
+
+    @Test
+    void shouldDenyDeleteResourceWhenUnauthorized() throws ExecutionException,
+   InterruptedException {
+      // given
+      final long resourceKey;
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        final Future<DeploymentEvent> deploymentResponse =
+            client
+                .newDeployResourceCommand()
+                .addProcessModel(process, "process.bpmn")
+                .tenantId(TENANT_A)
+                .send();
+        assertThat(deploymentResponse)
+            .describedAs("Expect that process was deployed for tenant-a")
+            .succeedsWithin(Duration.ofSeconds(10));
+        resourceKey = deploymentResponse.get().getProcesses().get(0).getProcessDefinitionKey();
+      }
+
+      // when
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+        final Future<DeleteResourceResponse> response =
+            client.newDeleteResourceCommand(resourceKey).send();
+
+        // then
+        assertThat(response)
+            .failsWithin(Duration.ofSeconds(10))
+            .withThrowableThat()
+            .withMessageContaining("NOT_FOUND");
+      }
+    }
+
+    @Test
+    void shouldIncrementProcessVersionPerTenant() {
+      // given
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(process, "process.bpmn")
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+      }
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(process, "process.bpmn")
+            .tenantId(TENANT_B)
+            .send()
+            .join();
+      }
+
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+        // when
+        final var processV2 = Bpmn.createExecutableProcess(processId).startEvent().done();
+        final Future<DeploymentEvent> result =
+            client
+                .newDeployResourceCommand()
+                .addProcessModel(processV2, "process.bpmn")
+                .tenantId(TENANT_B)
+                .send();
+
+        // then
+        assertThat(result)
+            .succeedsWithin(Duration.ofSeconds(10))
+            .describedAs("Process version is incremented for tenant-b but not for tenant-a")
+            .extracting(deploymentEvent -> deploymentEvent.getProcesses().get(0))
+            .extracting(Process::getVersion, Process::getTenantId)
+            .containsExactly(2, TENANT_B);
+      }
+    }
+
+    @Test
+    void shouldAuthorizeCreateProcessInstance() {
+      // given
+      final long processDefinitionKey;
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
+        processDefinitionKey =
+            client
+                .newDeployResourceCommand()
+                .addProcessModel(process, "process.bpmn")
+                .tenantId(TENANT_A)
+                .send()
+                .join()
+                .getProcesses()
+                .stream()
+                .map(Process::getProcessDefinitionKey)
+                .findFirst()
+                .orElseThrow();
+
+        // when
+        final Future<ProcessInstanceEvent> result =
+            client
+                .newCreateInstanceCommand()
+                .processDefinitionKey(processDefinitionKey)
+                .tenantId(TENANT_A)
+                .send();
+
+        // then
+        assertThat(result)
+            .describedAs(
+                "Expect that process instance can be created as the client has access process of
+   tenant-a")
+            .succeedsWithin(Duration.ofSeconds(10));
+      }
+    }
+
+    @Test
+    void shouldNotFindOtherTenantsProcessById() {
+      // given
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(process, "process.bpmn")
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+      }
+
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+        // when
+        final Future<ProcessInstanceEvent> result =
+            client
+                .newCreateInstanceCommand()
+                .bpmnProcessId(processId)
+                .latestVersion()
+                .tenantId(TENANT_B)
+                .send();
+
+        // then
+        assertThat(result)
+            .failsWithin(Duration.ofSeconds(10))
+            .withThrowableThat()
+            .describedAs("Process definition should exist for tenant-a but not for tenant-b")
+            .withMessageContaining("NOT_FOUND")
+            .withMessageContaining("Expected to find process definition with process ID")
+            .withMessageContaining("but none found");
+      }
+    }
+
+    @Test
+    void shouldNotFindOtherTenantsProcessByKey() {
+      // given
+      final long processDefinitionKey;
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        processDefinitionKey =
+            client
+                .newDeployResourceCommand()
+                .addProcessModel(process, "process.bpmn")
+                .tenantId(TENANT_A)
+                .send()
+                .join()
+                .getProcesses()
+                .stream()
+                .map(Process::getProcessDefinitionKey)
+                .findFirst()
+                .orElseThrow();
+      }
+
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+        // when
+        final Future<ProcessInstanceEvent> result =
+            client
+                .newCreateInstanceCommand()
+                .processDefinitionKey(processDefinitionKey)
+                .tenantId(TENANT_B)
+                .send();
+
+        // then
+        assertThat(result)
+            .failsWithin(Duration.ofSeconds(10))
+            .withThrowableThat()
+            .describedAs("Process definition should exist for tenant-a but not for tenant-b")
+            .withMessageContaining("NOT_FOUND")
+            .withMessageContaining("Expected to find process definition with key")
+            .withMessageContaining("but none found");
+      }
+    }
+
+    @Test
+    void shouldNotFindOtherTenantsProcessInCallActivity() {
+      // given
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(process, "process.bpmn")
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+      }
+
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(
+                Bpmn.createExecutableProcess("parent")
+                    .startEvent()
+                    .callActivity("call", c -> c.zeebeProcessId(processId))
+                    .endEvent()
+                    .done(),
+                "parent.bpmn")
+            .tenantId(TENANT_B)
+            .send()
+            .join();
+      }
+
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+        // when
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId("parent")
+            .latestVersion()
+            .tenantId(TENANT_B)
+            .send();
+
+        // then
+        Assertions.assertThat(
+
+   RecordingExporter.incidentRecords().withBpmnProcessId("parent").getFirst().getValue())
+            .hasErrorMessage(
+                "Expected process with BPMN process id '%s' to be deployed, but not found."
+                    .formatted(processId));
+      }
+    }
+
+    /**
+     * This test case may become obsolete when we allow shared processes definitions across
+   tenants.
+     */
+    @Test
+    void shouldNotFindOtherTenantsProcessEvenWhenClientIsAuthorizedForTenant() {
+      // given
+      final long processDefinitionKey;
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
+        processDefinitionKey =
+            client
+                .newDeployResourceCommand()
+                .addProcessModel(process, "process.bpmn")
+                .tenantId(TENANT_A)
+                .send()
+                .join()
+                .getProcesses()
+                .stream()
+                .map(Process::getProcessDefinitionKey)
+                .findFirst()
+                .orElseThrow();
+      }
+
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
+        // when
+        final Future<ProcessInstanceEvent> result =
+            client
+                .newCreateInstanceCommand()
+                .processDefinitionKey(processDefinitionKey)
+                .tenantId(TENANT_B)
+                .send();
+
+        // then
+        assertThat(result)
+            .failsWithin(Duration.ofSeconds(10))
+            .withThrowableThat()
+            .describedAs("Process definition should exist for tenant-a but not for tenant-b")
+            .withMessageContaining("NOT_FOUND")
+            .withMessageContaining("Expected to find process definition with key")
+            .withMessageContaining("but none found");
+      }
+    }
+
+    @Test
+    void shouldStartProcessWhenPublishingMessageForTenant() {
+      // given
+      final String messageName = "message";
+      process =
+
+   Bpmn.createExecutableProcess(processId).startEvent().message(messageName).endEvent().done();
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(process, "process.bpmn")
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+
+        // when
+        final Future<PublishMessageResponse> result =
+            client
+                .newPublishMessageCommand()
+                .messageName(messageName)
+                .withoutCorrelationKey()
+                .tenantId(TENANT_A)
+                .send();
+
+        // then
+        assertThat(result)
+            .describedAs(
+                "Expect that message can be published as the client has access process of
+   tenant-a")
+            .succeedsWithin(Duration.ofSeconds(10));
+      }
+    }
+
+    @Test
+    void shouldDenyPublishMessageWhenUnauthorized() {
+      // given
+      final String messageName = "message";
+      process =
+
+   Bpmn.createExecutableProcess(processId).startEvent().message(messageName).endEvent().done();
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(process, "process.bpmn")
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+
+        // when
+        final Future<PublishMessageResponse> result =
+            client
+                .newPublishMessageCommand()
+                .messageName(messageName)
+                .withoutCorrelationKey()
+                .tenantId(TENANT_B)
+                .send();
+
+        // then
+        assertThat(result)
+            .failsWithin(Duration.ofSeconds(10))
+            .withThrowableThat()
+            .withMessageContaining("PERMISSION_DENIED")
+            .withMessageContaining(
+                "Expected to handle gRPC request PublishMessage with tenant identifier
+   'tenant-b'")
+            .withMessageContaining("but tenant is not authorized to perform this request");
+      }
+    }
+
+    @Test
+    void shouldActivateJobForTenant() {
+      // given
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(process, "process.bpmn")
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+
+        // when
+        final Future<ActivateJobsResponse> result =
+            client
+                .newActivateJobsCommand()
+                .jobType("type")
+                .maxJobsToActivate(1)
+                .tenantId(TENANT_A)
+                .send();
+
+        // then
+        assertThat(result)
+            .describedAs(
+                "Expect that job can be activated as the client has access process of tenant-a")
+            .succeedsWithin(Duration.ofSeconds(10));
+      }
+    }
+
+    @Test
+    void shouldDenyActivateJobWhenUnauthorized() {
+      // given
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(process, "process.bpmn")
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+      }
+
+      // when
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+        final Future<ActivateJobsResponse> result =
+            client
+                .newActivateJobsCommand()
+                .jobType("type")
+                .maxJobsToActivate(1)
+                .tenantId(TENANT_A)
+                .send();
+
+        // then
+        assertThat(result)
+            .failsWithin(Duration.ofSeconds(10))
+            .withThrowableThat()
+            .withMessageContaining("PERMISSION_DENIED")
+            .withMessageContaining(
+                "Expected to handle gRPC request ActivateJobs with tenant identifier 'tenant-a'")
+            .withMessageContaining("but tenant is not authorized to perform this request");
+      }
+    }
+
+    @Test
+    void shouldCompleteJobForTenant() {
+      // given
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(process, "process.bpmn")
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+
+        final var activatedJob =
+            client
+                .newActivateJobsCommand()
+                .jobType("type")
+                .maxJobsToActivate(1)
+                .tenantId(TENANT_A)
+                .send()
+                .join()
+                .getJobs()
+                .get(0);
+
+        // when
+        final Future<CompleteJobResponse> result = client.newCompleteCommand(activatedJob).send();
+
+        // then
+        assertThat(result)
+            .describedAs(
+                "Expect that job can be competed as the client has access process of tenant-a")
+            .succeedsWithin(Duration.ofSeconds(10));
+      }
+    }
+
+    @Test
+    void shouldCompleteUserTaskForTenant() {
+      // given
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(process, "process.bpmn")
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+
+        final var activatedJob =
+            client
+                .newActivateJobsCommand()
+                .jobType("type")
+                .maxJobsToActivate(1)
+                .tenantId(TENANT_A)
+                .send()
+                .join()
+                .getJobs()
+                .get(0);
+
+        // when
+        final Future<CompleteJobResponse> result = client.newCompleteCommand(activatedJob).send();
+
+        // then
+        assertThat(result)
+            .describedAs(
+                "Expect that job can be competed as the client has access process of tenant-a")
+            .succeedsWithin(Duration.ofSeconds(10));
+      }
+    }
+
+    @Test
+    void shouldUpdateJobTimeoutForTenant() {
+      // given
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(process, "process.bpmn")
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+
+        final var activatedJob =
+            client
+                .newActivateJobsCommand()
+                .jobType("type")
+                .maxJobsToActivate(1)
+                .tenantId(TENANT_A)
+                .timeout(Duration.ofMinutes(10))
+                .send()
+                .join()
+                .getJobs()
+                .get(0);
+
+        // when
+        final Future<UpdateTimeoutJobResponse> result =
+            client.newUpdateTimeoutCommand(activatedJob).timeout(Duration.ofMinutes(11)).send();
+
+        // then
+        assertThat(result)
+            .describedAs(
+                "Expect that job timeout can be updated as the client has access process of
+   tenant-a")
+            .succeedsWithin(Duration.ofSeconds(10));
+      }
+    }
+
+    @Test
+    void shouldNotUpdateJobTimeoutWhenUnauthorized() {
+      // given
+      final ActivatedJob activatedJob;
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(process, "process.bpmn")
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+        activatedJob =
+            client
+                .newActivateJobsCommand()
+                .jobType("type")
+                .maxJobsToActivate(1)
+                .tenantId(TENANT_A)
+                .timeout(Duration.ofMinutes(10))
+                .send()
+                .join()
+                .getJobs()
+                .get(0);
+      }
+
+      // when
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+        final Future<UpdateTimeoutJobResponse> result =
+            client.newUpdateTimeoutCommand(activatedJob).timeout(Duration.ofMinutes(11)).send();
+
+        // then
+        assertThat(result)
+            .failsWithin(Duration.ofSeconds(10))
+            .withThrowableThat()
+            .withMessageContaining("NOT_FOUND")
+            .withMessageContaining(
+                "Command 'UPDATE_TIMEOUT' rejected with code 'NOT_FOUND': Expected to update job
+   with key '%d', but no such job was found"
+                    .formatted(activatedJob.getKey()));
+      }
+    }
+
+    @Test
+    void shouldNotFindJobWhenUnauthorized() {
+      // given
+      final ActivatedJob activatedJob;
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(process, "process.bpmn")
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+        activatedJob =
+            client
+                .newActivateJobsCommand()
+                .jobType("type")
+                .maxJobsToActivate(1)
+                .tenantId(TENANT_A)
+                .send()
+                .join()
+                .getJobs()
+                .get(0);
+      }
+
+      // when
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+        final Future<CompleteJobResponse> result = client.newCompleteCommand(activatedJob).send();
+
+        // then
+        assertThat(result)
+            .failsWithin(Duration.ofSeconds(10))
+            .withThrowableThat()
+            .withMessageContaining("NOT_FOUND")
+            .withMessageContaining(
+                "Command 'COMPLETE' rejected with code 'NOT_FOUND': Expected to update retries for
+   job with key '%d', but no such job was found"
+                    .formatted(activatedJob.getKey()));
+      }
+    }
+
+    @Test
+    void shouldResolveIncidentForTenant() {
+      // given
+      process =
+          Bpmn.createExecutableProcess(processId)
+              .startEvent()
+              .zeebeOutputExpression("assert(foo, foo != null)", "target")
+              .endEvent()
+              .done();
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(process, "process.bpmn")
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+
+        final var incidentKey =
+            RecordingExporter.incidentRecords().withBpmnProcessId(processId).getFirst().getKey();
+
+        // when
+        final Future<ResolveIncidentResponse> result =
+            client.newResolveIncidentCommand(incidentKey).send();
+
+        // then
+        assertThat(result)
+            .describedAs(
+                "Expect that incident can be resolved as the client has access process of
+   tenant-a")
+            .succeedsWithin(Duration.ofSeconds(10));
+      }
+    }
+
+    @Test
+    void shouldNotFindIncidentForTenantWhenUnauthorized() {
+      // given
+      process =
+          Bpmn.createExecutableProcess(processId)
+              .startEvent()
+              .zeebeOutputExpression("assert(foo, foo != null)", "target")
+              .endEvent()
+              .done();
+      final long incidentKey;
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(process, "process.bpmn")
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+
+        incidentKey =
+            RecordingExporter.incidentRecords().withBpmnProcessId(processId).getFirst().getKey();
+      }
+
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+        // when
+        final Future<ResolveIncidentResponse> result =
+            client.newResolveIncidentCommand(incidentKey).send();
+
+        // then
+        assertThat(result)
+            .failsWithin(Duration.ofSeconds(10))
+            .withThrowableThat()
+            .withMessageContaining("NOT_FOUND")
+            .withMessageContaining(
+                "Command 'RESOLVE' rejected with code 'NOT_FOUND': Expected to resolve incident
+   with key '%d', but no such incident was found"
+                    .formatted(incidentKey));
+      }
+    }
+
+    @Test
+    void shouldAllowModifyProcessInstanceForDefaultTenant() {
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
+        // given
+        client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
+
+        final long processInstanceKey =
+            client
+                .newCreateInstanceCommand()
+                .bpmnProcessId(processId)
+                .latestVersion()
+                .send()
+                .join()
+                .getProcessInstanceKey();
+
+        // when
+        final Future<ModifyProcessInstanceResponse> response =
+
+   client.newModifyProcessInstanceCommand(processInstanceKey).activateElement("task").send();
+
+        // then
+        assertThat(response).succeedsWithin(Duration.ofSeconds(10));
+      }
+    }
+
+    @Test
+    void shouldAllowModifyProcessInstanceForOtherTenant() {
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        // given
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(process, "process.bpmn")
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+
+        final long processInstanceKey =
+            client
+                .newCreateInstanceCommand()
+                .bpmnProcessId(processId)
+                .latestVersion()
+                .tenantId(TENANT_A)
+                .send()
+                .join()
+                .getProcessInstanceKey();
+
+        // when
+        final Future<ModifyProcessInstanceResponse> response =
+
+   client.newModifyProcessInstanceCommand(processInstanceKey).activateElement("task").send();
+
+        // then
+        assertThat(response).succeedsWithin(Duration.ofSeconds(10));
+      }
+    }
+
+    @Test
+    void shouldRejectModifyProcessInstanceForUnauthorizedTenant() {
+      final long processInstanceKey;
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        // given
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(process, "process.bpmn")
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+
+        processInstanceKey =
+            client
+                .newCreateInstanceCommand()
+                .bpmnProcessId(processId)
+                .latestVersion()
+                .tenantId(TENANT_A)
+                .send()
+                .join()
+                .getProcessInstanceKey();
+      }
+
+      // when
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+        final Future<ModifyProcessInstanceResponse> response =
+
+   client.newModifyProcessInstanceCommand(processInstanceKey).activateElement("task").send();
+
+        // then
+        assertThat(response)
+            .failsWithin(Duration.ofSeconds(10))
+            .withThrowableThat()
+            .withMessageContaining("NOT_FOUND")
+            .withMessageContaining(
+                "Expected to modify process instance but no process instance found with key");
+      }
+    }
+
+    @Test
+    void shouldAllowMigrateProcessInstanceForDefaultTenant() {
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
+        // given
+        client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
+        final var deploymentResponse =
+            client
+                .newDeployResourceCommand()
+                .addProcessModel(migratedProcess, "migrated-process.bpmn")
+                .send()
+                .join();
+        final long targetProcessDefinitionKey =
+            deploymentResponse.getProcesses().get(0).getProcessDefinitionKey();
+
+        final long processInstanceKey =
+            client
+                .newCreateInstanceCommand()
+                .bpmnProcessId(processId)
+                .latestVersion()
+                .send()
+                .join()
+                .getProcessInstanceKey();
+
+        // when
+        final Future<MigrateProcessInstanceResponse> response =
+            client
+                .newMigrateProcessInstanceCommand(processInstanceKey)
+                .migrationPlan(targetProcessDefinitionKey)
+                .addMappingInstruction("task", "migrated-task")
+                .send();
+
+        // then
+        assertThat(response).succeedsWithin(Duration.ofSeconds(10));
+      }
+    }
+
+    @Test
+    void shouldAllowMigrateProcessInstanceForOtherTenant() {
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        // given
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(process, "process.bpmn")
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+        final var deploymentResponse =
+            client
+                .newDeployResourceCommand()
+                .addProcessModel(migratedProcess, "migrated-process.bpmn")
+                .tenantId(TENANT_A)
+                .send()
+                .join();
+        final long targetProcessDefinitionKey =
+            deploymentResponse.getProcesses().get(0).getProcessDefinitionKey();
+
+        final long processInstanceKey =
+            client
+                .newCreateInstanceCommand()
+                .bpmnProcessId(processId)
+                .latestVersion()
+                .tenantId(TENANT_A)
+                .send()
+                .join()
+                .getProcessInstanceKey();
+
+        // when
+        final Future<MigrateProcessInstanceResponse> response =
+            client
+                .newMigrateProcessInstanceCommand(processInstanceKey)
+                .migrationPlan(targetProcessDefinitionKey)
+                .addMappingInstruction("task", "migrated-task")
+                .send();
+
+        // then
+        assertThat(response).succeedsWithin(Duration.ofSeconds(10));
+      }
+    }
+
+    @Test
+    void shouldRejectMigrateProcessInstanceForUnauthorizedTenant() {
+      final long processInstanceKey;
+      final long targetProcessDefinitionKey;
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        // given
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(process, "process.bpmn")
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+        final var deploymentResponse =
+            client
+                .newDeployResourceCommand()
+                .addProcessModel(migratedProcess, "process.bpmn")
+                .tenantId(TENANT_A)
+                .send()
+                .join();
+        targetProcessDefinitionKey =
+            deploymentResponse.getProcesses().get(0).getProcessDefinitionKey();
+
+        processInstanceKey =
+            client
+                .newCreateInstanceCommand()
+                .bpmnProcessId(processId)
+                .latestVersion()
+                .tenantId(TENANT_A)
+                .send()
+                .join()
+                .getProcessInstanceKey();
+      }
+
+      // when
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+        final Future<MigrateProcessInstanceResponse> response =
+            client
+                .newMigrateProcessInstanceCommand(processInstanceKey)
+                .migrationPlan(targetProcessDefinitionKey)
+                .addMappingInstruction("task", "migrated-task")
+                .send();
+
+        // then
+        assertThat(response)
+            .failsWithin(Duration.ofSeconds(10))
+            .withThrowableThat()
+            .withMessageContaining("NOT_FOUND")
+            .withMessageContaining(
+                String.format(
+                    "Expected to migrate process instance but no process instance found with key
+   '%s'",
+                    processInstanceKey));
+      }
+    }
+
+    @Test
+    void shouldAllowEvaluateDecisionForDefaultTenant() {
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
+        // given
+        client
+            .newDeployResourceCommand()
+            .addResourceFromClasspath("dmn/decision-table.dmn")
+            .send()
+            .join();
+
+        // when
+        final Future<EvaluateDecisionResponse> response =
+            client
+                .newEvaluateDecisionCommand()
+                .decisionId("jedi_or_sith")
+                .variable("lightsaberColor", "blue")
+                .send();
+        // then
+        assertThat(response).succeedsWithin(Duration.ofSeconds(10));
+      }
+    }
+
+    @Test
+    void shouldAllowEvaluateDecisionForCustomTenant() {
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
+        // given
+        client
+            .newDeployResourceCommand()
+            .addResourceFromClasspath("dmn/decision-table.dmn")
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+
+        // when
+        final Future<EvaluateDecisionResponse> response =
+            client
+                .newEvaluateDecisionCommand()
+                .decisionId("jedi_or_sith")
+                .variable("lightsaberColor", "blue")
+                .tenantId(TENANT_A)
+                .send();
+        // then
+        assertThat(response).succeedsWithin(Duration.ofSeconds(10));
+      }
+    }
+
+    @Test
+    void shouldDenyEvaluateDecisionForCustomTenant() {
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
+        // given
+        client
+            .newDeployResourceCommand()
+            .addResourceFromClasspath("dmn/decision-table.dmn")
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+
+        // when
+        final Future<EvaluateDecisionResponse> response =
+            client
+                .newEvaluateDecisionCommand()
+                .decisionId("jedi_or_sith")
+                .variable("lightsaberColor", "blue")
+                .tenantId(TENANT_B)
+                .send();
+        // then
+        assertThat(response)
+            .failsWithin(Duration.ofSeconds(10))
+            .withThrowableThat()
+            .withMessageContaining("PERMISSION_DENIED")
+            .withMessageContaining(
+                "Expected to handle gRPC request EvaluateDecision with tenant identifier
+   'tenant-b'")
+            .withMessageContaining("but tenant is not authorized to perform this request");
+      }
+    }
+
+    @Test
+    void shouldStartInstanceWhenBroadcastSignalForTenant() {
+      final String signalName = "signal";
+      process =
+
+   Bpmn.createExecutableProcess(processId).startEvent().signal(signalName).endEvent().done();
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        // given
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(process, "process.bpmn")
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+
+        // when
+        final Future<BroadcastSignalResponse> result =
+            client.newBroadcastSignalCommand().signalName(signalName).tenantId(TENANT_A).send();
+
+        // then
+        assertThat(result)
+            .describedAs(
+                "Expect that signal can be broadcast as the client has access to the process of
+   'tenant-a'")
+            .succeedsWithin(Duration.ofSeconds(20));
+      }
+    }
+
+    @Test
+    void shouldDenyBroadcastSignalWhenUnauthorized() {
+      final String signalName = "signal";
+      process =
+
+   Bpmn.createExecutableProcess(processId).startEvent().signal(signalName).endEvent().done();
+      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+        // given
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(process, "process.bpmn")
+            .tenantId(TENANT_A)
+            .send()
+            .join();
+
+        // when
+        final Future<BroadcastSignalResponse> result =
+            client.newBroadcastSignalCommand().signalName(signalName).tenantId(TENANT_B).send();
+
+        // then
+        assertThat(result)
+            .failsWithin(Duration.ofSeconds(10))
+            .withThrowableThat()
+            .withMessageContaining("PERMISSION_DENIED")
+            .withMessageContaining(
+                "Expected to handle gRPC request BroadcastSignal with tenant identifier
+   'tenant-b'")
+            .withMessageContaining("but tenant is not authorized to perform this request");
+      }
+    }
+
+    @Test
+    void shouldAllowAssignUserTaskForTenant() {
+      try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
+          final var clientTenantB = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
+        // given
+        final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+        final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+
+        // when
+        final Future<AssignUserTaskResponse> result =
+            clientTenantB.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send();
+
+        // then
+        assertThat(result).succeedsWithin(Duration.ofSeconds(10));
+      }
+    }
+
+    @Test
+    void shouldRejectAssignUserTaskForTenant() {
+      try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
+          final var skeletorClient = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
+        // given
+        final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+        final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+
+        // when
+        final Future<AssignUserTaskResponse> result =
+            skeletorClient.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send();
+
+        // then
+        assertThat(result)
+            .failsWithin(Duration.ofSeconds(10))
+            .withThrowableThat()
+            .havingCause()
+            .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
+            .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
+      }
+    }
+
+    @Test
+    void shouldAllowCompleteUserTaskForTenant() {
+      try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
+          final var clientTenantB = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
+        // given
+        final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+        final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+
+        // when
+        final Future<CompleteUserTaskResponse> result =
+            clientTenantB.newUserTaskCompleteCommand(userTaskKey).send();
+
+        // then
+        assertThat(result).succeedsWithin(Duration.ofSeconds(10));
+      }
+    }
+
+    @Test
+    void shouldRejectCompleteUserTaskForTenant() {
+      try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
+          final var invalidClient = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
+        // given
+        final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+        final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+
+        // when
+        final Future<CompleteUserTaskResponse> result =
+            invalidClient.newUserTaskCompleteCommand(userTaskKey).send();
+
+        // then
+        assertThat(result)
+            .failsWithin(Duration.ofSeconds(10))
+            .withThrowableThat()
+            .havingCause()
+            .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
+            .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
+      }
+    }
+
+    @Test
+    void shouldAllowUnassignUserTaskForTenant() {
+      try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
+          final var clientTenantB = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
+        // given
+        final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+        final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+        clientTenantA.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send().join();
+
+        // when
+        final Future<UnassignUserTaskResponse> result =
+            clientTenantB.newUserTaskUnassignCommand(userTaskKey).send();
+
+        // then
+        assertThat(result).succeedsWithin(Duration.ofSeconds(10));
+      }
+    }
+
+    @Test
+    void shouldRejectUnassignUserTaskForTenant() {
+      try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
+          final var invalidClient = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
+        // given
+        final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+        final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+        clientTenantA.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send().join();
+
+        // when
+        final Future<UnassignUserTaskResponse> result =
+            invalidClient.newUserTaskUnassignCommand(userTaskKey).send();
+
+        // then
+        assertThat(result)
+            .failsWithin(Duration.ofSeconds(10))
+            .withThrowableThat()
+            .havingCause()
+            .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
+            .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
+      }
+    }
+
+    @Test
+    void shouldAllowUpdateUserTaskForTenant() {
+      try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
+          final var clientTenantB = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
+        // given
+        final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+        final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+
+        // when
+        final Future<UpdateUserTaskResponse> result =
+            clientTenantB.newUserTaskUpdateCommand(userTaskKey).candidateUsers("Skeletor").send();
+
+        // then
+        assertThat(result).succeedsWithin(Duration.ofSeconds(10));
+      }
+    }
+
+    @Test
+    void shouldRejectUpdateUserTaskForTenant() {
+      try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
+          final var invalidClient = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
+        // given
+        final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+        final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+
+        // when
+        final Future<UpdateUserTaskResponse> result =
+            invalidClient.newUserTaskUpdateCommand(userTaskKey).candidateUsers("Skeletor").send();
+
+        // then
+        assertThat(result)
+            .failsWithin(Duration.ofSeconds(10))
+            .withThrowableThat()
+            .havingCause()
+            .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
+            .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
+      }
+    }
+
   private static Stream<Named<UnaryOperator<TopologyRequestStep1>>> provideTopologyCases() {
     return Stream.of(
         Named.of("grpc", TopologyRequestStep1::useGrpc),

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -10,12 +10,33 @@ package io.camunda.zeebe.it.multitenancy;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.command.TopologyRequestStep1;
+import io.camunda.client.api.response.ActivateJobsResponse;
+import io.camunda.client.api.response.ActivatedJob;
+import io.camunda.client.api.response.AssignUserTaskResponse;
+import io.camunda.client.api.response.BroadcastSignalResponse;
+import io.camunda.client.api.response.CompleteJobResponse;
+import io.camunda.client.api.response.CompleteUserTaskResponse;
+import io.camunda.client.api.response.DeleteResourceResponse;
+import io.camunda.client.api.response.DeploymentEvent;
+import io.camunda.client.api.response.EvaluateDecisionResponse;
+import io.camunda.client.api.response.MigrateProcessInstanceResponse;
+import io.camunda.client.api.response.ModifyProcessInstanceResponse;
+import io.camunda.client.api.response.Process;
+import io.camunda.client.api.response.ProcessInstanceEvent;
+import io.camunda.client.api.response.PublishMessageResponse;
+import io.camunda.client.api.response.ResolveIncidentResponse;
+import io.camunda.client.api.response.UnassignUserTaskResponse;
+import io.camunda.client.api.response.UpdateTimeoutJobResponse;
+import io.camunda.client.api.response.UpdateUserTaskResponse;
 import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
 import io.camunda.security.configuration.ConfiguredUser;
 import io.camunda.zeebe.it.util.AuthorizationsUtil;
+import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
@@ -26,11 +47,16 @@ import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
+import org.apache.http.HttpStatus;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
@@ -52,6 +78,7 @@ public class MultiTenancyOverIdentityIT {
   private static final String USER_TENANT_B = "userTenantB";
   private static final String USER_TENANT_A_AND_B = "userTenantAB";
   private static final String USER_TENANT_A_WITHOUT_DEFAULT_TENANT = "userTenantANoDefault";
+  private static final String USER_WITHOUT_TENANT = "userNoTenant";
 
   @TestZeebe(autoStart = false)
   private static final TestStandaloneBroker BROKER =
@@ -78,6 +105,11 @@ public class MultiTenancyOverIdentityIT {
                                   USER_TENANT_A_WITHOUT_DEFAULT_TENANT,
                                   USER_TENANT_A_WITHOUT_DEFAULT_TENANT,
                                   USER_TENANT_A_WITHOUT_DEFAULT_TENANT,
+                                  "test@camunda.com"),
+                              new ConfiguredUser(
+                                  USER_WITHOUT_TENANT,
+                                  USER_WITHOUT_TENANT,
+                                  USER_WITHOUT_TENANT,
                                   "test@camunda.com"))));
 
   private String processId;
@@ -96,6 +128,7 @@ public class MultiTenancyOverIdentityIT {
       authUtil.awaitUserExistsInElasticsearch(USER_TENANT_B);
       authUtil.awaitUserExistsInElasticsearch(USER_TENANT_A_AND_B);
       authUtil.awaitUserExistsInElasticsearch(USER_TENANT_A_WITHOUT_DEFAULT_TENANT);
+      authUtil.awaitUserExistsInElasticsearch(USER_WITHOUT_TENANT);
 
       assignUsersToTenant(
           client, DEFAULT_TENANT, USER_TENANT_A, USER_TENANT_B, USER_TENANT_A_AND_B);
@@ -142,1374 +175,1346 @@ public class MultiTenancyOverIdentityIT {
     }
   }
 
+  @ParameterizedTest
+  @MethodSource("provideTopologyCases")
+  void shouldAuthorizeTopologyRequestWithoutTenantAccess(
+      final UnaryOperator<TopologyRequestStep1> apiPicker) {
+    try (final var client = createCamundaClient(USER_TENANT_A_WITHOUT_DEFAULT_TENANT)) {
+      // when
+      final var topology = apiPicker.apply(client.newTopologyRequest()).send().join();
 
-    @ParameterizedTest
-    @MethodSource("provideTopologyCases")
-    void shouldAuthorizeTopologyRequestWithoutTenantAccess(
-        final UnaryOperator<TopologyRequestStep1> apiPicker) {
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
-        // when
-        final var topology = apiPicker.apply(client.newTopologyRequest()).send().join();
-
-        // then
-        assertThat(topology.getBrokers()).hasSize(1);
-      }
+      // then
+      assertThat(topology.getBrokers()).hasSize(1);
     }
+  }
 
-    @Test
-    void shouldAuthorizeDeployProcess() {
-      // given
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        // when
-        final Future<DeploymentEvent> response =
-            client
-                .newDeployResourceCommand()
-                .addProcessModel(process, "process.bpmn")
-                .tenantId(TENANT_A)
-                .send();
+  @Test
+  void shouldAuthorizeDeployProcess() {
+    // given
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      // when
+      final Future<DeploymentEvent> response =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(process, "process.bpmn")
+              .tenantId(TENANT_A)
+              .send();
 
-        // then
-        assertThat(response)
-            .describedAs("Expect that process can be deployed for tenant-a")
-            .succeedsWithin(Duration.ofSeconds(10));
-      }
+      // then
+      assertThat(response)
+          .describedAs("Expect that process can be deployed for tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
     }
+  }
 
-    @Test
-    void shouldDenyDeployResourceWhenUnauthorized() {
-      // given
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        // when
-        final Future<DeploymentEvent> result =
-            client
-                .newDeployResourceCommand()
-                .addProcessModel(process, "process.bpmn")
-                .tenantId(TENANT_B)
-                .send();
+  @Test
+  void shouldDenyDeployResourceWhenUnauthorized() {
+    // given
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      // when
+      final Future<DeploymentEvent> result =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(process, "process.bpmn")
+              .tenantId(TENANT_B)
+              .send();
 
-        // then
-        assertThat(result)
-            .failsWithin(Duration.ofSeconds(10))
-            .withThrowableThat()
-            .withMessageContaining("PERMISSION_DENIED")
-            .withMessageContaining(
-                "Expected to handle gRPC request DeployResource with tenant identifier
-   'tenant-b'")
-            .withMessageContaining("but tenant is not authorized to perform this request");
-      }
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("PERMISSION_DENIED")
+          .withMessageContaining(
+              "Expected to handle gRPC request DeployResource with tenant identifier 'tenant-b'")
+          .withMessageContaining("but tenant is not authorized to perform this request");
     }
+  }
 
-    @Test
-    void shouldDenyDeployResourceWhenUnauthorizedForDefaultTenant() {
-      // given
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_WITHOUT_DEFAULT_TENANT))
-   {
-        // when
-        final Future<DeploymentEvent> result =
-            client
-                .newDeployResourceCommand()
-                .addProcessModel(process, "process.bpmn")
-                .tenantId(DEFAULT_TENANT)
-                .send();
+  @Test
+  void shouldDenyDeployResourceWhenUnauthorizedForDefaultTenant() {
+    // given
+    try (final var client = createCamundaClient(USER_TENANT_A_WITHOUT_DEFAULT_TENANT)) {
+      // when
+      final Future<DeploymentEvent> result =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(process, "process.bpmn")
+              .tenantId(DEFAULT_TENANT)
+              .send();
 
-        // then
-        assertThat(result)
-            .failsWithin(Duration.ofSeconds(10))
-            .withThrowableThat()
-            .withMessageContaining("PERMISSION_DENIED")
-            .withMessageContaining(
-                "Expected to handle gRPC request DeployResource with tenant identifier
-   '<default>'")
-            .withMessageContaining("but tenant is not authorized to perform this request");
-      }
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("PERMISSION_DENIED")
+          .withMessageContaining(
+              "Expected to handle gRPC request DeployResource with tenant identifier '<default>'")
+          .withMessageContaining("but tenant is not authorized to perform this request");
     }
+  }
 
-    @SuppressWarnings("deprecation")
-    @Test
-    void shouldDenyDeployProcessWhenUnauthorizedForDefaultTenant() {
-      // given
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_WITHOUT_DEFAULT_TENANT))
-   {
-        // when
-        // note that deploy process command is always only for the default tenant
-        final Future<DeploymentEvent> result =
-            client.newDeployCommand().addProcessModel(process, "process.bpmn").send();
+  @SuppressWarnings("deprecation")
+  @Test
+  void shouldDenyDeployProcessWhenUnauthorizedForDefaultTenant() {
+    // given
+    try (final var client = createCamundaClient(USER_TENANT_A_WITHOUT_DEFAULT_TENANT)) {
+      // when
+      // note that deploy process command is always only for the default tenant
+      final Future<DeploymentEvent> result =
+          client.newDeployCommand().addProcessModel(process, "process.bpmn").send();
 
-        // then
-        assertThat(result)
-            .failsWithin(Duration.ofSeconds(10))
-            .withThrowableThat()
-            .withMessageContaining("PERMISSION_DENIED")
-            .withMessageContaining(
-                "Expected to handle gRPC request DeployProcess with tenant identifier
-   '<default>'")
-            .withMessageContaining("but tenant is not authorized to perform this request");
-      }
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("PERMISSION_DENIED")
+          .withMessageContaining(
+              "Expected to handle gRPC request DeployProcess with tenant identifier '<default>'")
+          .withMessageContaining("but tenant is not authorized to perform this request");
     }
+  }
 
-    @Test
-    void shouldAuthorizeDeleteResource() throws ExecutionException, InterruptedException {
-      // given
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        final Future<DeploymentEvent> deploymentResponse =
-            client
-                .newDeployResourceCommand()
-                .addProcessModel(process, "process.bpmn")
-                .tenantId(TENANT_A)
-                .send();
-        assertThat(deploymentResponse)
-            .describedAs("Expect that process was deployed for tenant-a")
-            .succeedsWithin(Duration.ofSeconds(10));
-        final long resourceKey =
-            deploymentResponse.get().getProcesses().get(0).getProcessDefinitionKey();
-
-        // when
-        final Future<DeleteResourceResponse> response =
-            client.newDeleteResourceCommand(resourceKey).send();
-
-        // then
-        assertThat(response)
-            .describedAs("Expect that process can be deleted for tenant-a")
-            .succeedsWithin(Duration.ofSeconds(10));
-      }
-    }
-
-    @Test
-    void shouldDenyDeleteResourceWhenUnauthorized() throws ExecutionException,
-   InterruptedException {
-      // given
-      final long resourceKey;
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        final Future<DeploymentEvent> deploymentResponse =
-            client
-                .newDeployResourceCommand()
-                .addProcessModel(process, "process.bpmn")
-                .tenantId(TENANT_A)
-                .send();
-        assertThat(deploymentResponse)
-            .describedAs("Expect that process was deployed for tenant-a")
-            .succeedsWithin(Duration.ofSeconds(10));
-        resourceKey = deploymentResponse.get().getProcesses().get(0).getProcessDefinitionKey();
-      }
+  @Test
+  void shouldAuthorizeDeleteResource() throws ExecutionException, InterruptedException {
+    // given
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      final Future<DeploymentEvent> deploymentResponse =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(process, "process.bpmn")
+              .tenantId(TENANT_A)
+              .send();
+      assertThat(deploymentResponse)
+          .describedAs("Expect that process was deployed for tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
+      final long resourceKey =
+          deploymentResponse.get().getProcesses().get(0).getProcessDefinitionKey();
 
       // when
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-        final Future<DeleteResourceResponse> response =
-            client.newDeleteResourceCommand(resourceKey).send();
+      final Future<DeleteResourceResponse> response =
+          client.newDeleteResourceCommand(resourceKey).send();
 
-        // then
-        assertThat(response)
-            .failsWithin(Duration.ofSeconds(10))
-            .withThrowableThat()
-            .withMessageContaining("NOT_FOUND");
-      }
+      // then
+      assertThat(response)
+          .describedAs("Expect that process can be deleted for tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldDenyDeleteResourceWhenUnauthorized() throws ExecutionException, InterruptedException {
+    // given
+    final long resourceKey;
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      final Future<DeploymentEvent> deploymentResponse =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(process, "process.bpmn")
+              .tenantId(TENANT_A)
+              .send();
+      assertThat(deploymentResponse)
+          .describedAs("Expect that process was deployed for tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
+      resourceKey = deploymentResponse.get().getProcesses().get(0).getProcessDefinitionKey();
     }
 
-    @Test
-    void shouldIncrementProcessVersionPerTenant() {
-      // given
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        client
-            .newDeployResourceCommand()
-            .addProcessModel(process, "process.bpmn")
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-      }
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-        client
-            .newDeployResourceCommand()
-            .addProcessModel(process, "process.bpmn")
-            .tenantId(TENANT_B)
-            .send()
-            .join();
-      }
+    // when
+    try (final var client = createCamundaClient(USER_TENANT_B)) {
+      final Future<DeleteResourceResponse> response =
+          client.newDeleteResourceCommand(resourceKey).send();
 
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-        // when
-        final var processV2 = Bpmn.createExecutableProcess(processId).startEvent().done();
-        final Future<DeploymentEvent> result =
-            client
-                .newDeployResourceCommand()
-                .addProcessModel(processV2, "process.bpmn")
-                .tenantId(TENANT_B)
-                .send();
+      // then
+      assertThat(response)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("NOT_FOUND");
+    }
+  }
 
-        // then
-        assertThat(result)
-            .succeedsWithin(Duration.ofSeconds(10))
-            .describedAs("Process version is incremented for tenant-b but not for tenant-a")
-            .extracting(deploymentEvent -> deploymentEvent.getProcesses().get(0))
-            .extracting(Process::getVersion, Process::getTenantId)
-            .containsExactly(2, TENANT_B);
-      }
+  @Test
+  void shouldIncrementProcessVersionPerTenant() {
+    // given
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+    }
+    try (final var client = createCamundaClient(USER_TENANT_B)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_B)
+          .send()
+          .join();
     }
 
-    @Test
-    void shouldAuthorizeCreateProcessInstance() {
-      // given
-      final long processDefinitionKey;
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
-        processDefinitionKey =
-            client
-                .newDeployResourceCommand()
-                .addProcessModel(process, "process.bpmn")
-                .tenantId(TENANT_A)
-                .send()
-                .join()
-                .getProcesses()
-                .stream()
-                .map(Process::getProcessDefinitionKey)
-                .findFirst()
-                .orElseThrow();
+    try (final var client = createCamundaClient(USER_TENANT_B)) {
+      // when
+      final var processV2 = Bpmn.createExecutableProcess(processId).startEvent().done();
+      final Future<DeploymentEvent> result =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(processV2, "process.bpmn")
+              .tenantId(TENANT_B)
+              .send();
 
-        // when
-        final Future<ProcessInstanceEvent> result =
-            client
-                .newCreateInstanceCommand()
-                .processDefinitionKey(processDefinitionKey)
-                .tenantId(TENANT_A)
-                .send();
-
-        // then
-        assertThat(result)
-            .describedAs(
-                "Expect that process instance can be created as the client has access process of
-   tenant-a")
-            .succeedsWithin(Duration.ofSeconds(10));
-      }
+      // then
+      assertThat(result)
+          .succeedsWithin(Duration.ofSeconds(10))
+          .describedAs("Process version is incremented for tenant-b but not for tenant-a")
+          .extracting(deploymentEvent -> deploymentEvent.getProcesses().get(0))
+          .extracting(Process::getVersion, Process::getTenantId)
+          .containsExactly(2, TENANT_B);
     }
+  }
 
-    @Test
-    void shouldNotFindOtherTenantsProcessById() {
-      // given
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        client
-            .newDeployResourceCommand()
-            .addProcessModel(process, "process.bpmn")
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-      }
-
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-        // when
-        final Future<ProcessInstanceEvent> result =
-            client
-                .newCreateInstanceCommand()
-                .bpmnProcessId(processId)
-                .latestVersion()
-                .tenantId(TENANT_B)
-                .send();
-
-        // then
-        assertThat(result)
-            .failsWithin(Duration.ofSeconds(10))
-            .withThrowableThat()
-            .describedAs("Process definition should exist for tenant-a but not for tenant-b")
-            .withMessageContaining("NOT_FOUND")
-            .withMessageContaining("Expected to find process definition with process ID")
-            .withMessageContaining("but none found");
-      }
-    }
-
-    @Test
-    void shouldNotFindOtherTenantsProcessByKey() {
-      // given
-      final long processDefinitionKey;
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        processDefinitionKey =
-            client
-                .newDeployResourceCommand()
-                .addProcessModel(process, "process.bpmn")
-                .tenantId(TENANT_A)
-                .send()
-                .join()
-                .getProcesses()
-                .stream()
-                .map(Process::getProcessDefinitionKey)
-                .findFirst()
-                .orElseThrow();
-      }
-
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-        // when
-        final Future<ProcessInstanceEvent> result =
-            client
-                .newCreateInstanceCommand()
-                .processDefinitionKey(processDefinitionKey)
-                .tenantId(TENANT_B)
-                .send();
-
-        // then
-        assertThat(result)
-            .failsWithin(Duration.ofSeconds(10))
-            .withThrowableThat()
-            .describedAs("Process definition should exist for tenant-a but not for tenant-b")
-            .withMessageContaining("NOT_FOUND")
-            .withMessageContaining("Expected to find process definition with key")
-            .withMessageContaining("but none found");
-      }
-    }
-
-    @Test
-    void shouldNotFindOtherTenantsProcessInCallActivity() {
-      // given
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        client
-            .newDeployResourceCommand()
-            .addProcessModel(process, "process.bpmn")
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-      }
-
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-        client
-            .newDeployResourceCommand()
-            .addProcessModel(
-                Bpmn.createExecutableProcess("parent")
-                    .startEvent()
-                    .callActivity("call", c -> c.zeebeProcessId(processId))
-                    .endEvent()
-                    .done(),
-                "parent.bpmn")
-            .tenantId(TENANT_B)
-            .send()
-            .join();
-      }
-
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-        // when
-        client
-            .newCreateInstanceCommand()
-            .bpmnProcessId("parent")
-            .latestVersion()
-            .tenantId(TENANT_B)
-            .send();
-
-        // then
-        Assertions.assertThat(
-
-   RecordingExporter.incidentRecords().withBpmnProcessId("parent").getFirst().getValue())
-            .hasErrorMessage(
-                "Expected process with BPMN process id '%s' to be deployed, but not found."
-                    .formatted(processId));
-      }
-    }
-
-    /**
-     * This test case may become obsolete when we allow shared processes definitions across
-   tenants.
-     */
-    @Test
-    void shouldNotFindOtherTenantsProcessEvenWhenClientIsAuthorizedForTenant() {
-      // given
-      final long processDefinitionKey;
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
-        processDefinitionKey =
-            client
-                .newDeployResourceCommand()
-                .addProcessModel(process, "process.bpmn")
-                .tenantId(TENANT_A)
-                .send()
-                .join()
-                .getProcesses()
-                .stream()
-                .map(Process::getProcessDefinitionKey)
-                .findFirst()
-                .orElseThrow();
-      }
-
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
-        // when
-        final Future<ProcessInstanceEvent> result =
-            client
-                .newCreateInstanceCommand()
-                .processDefinitionKey(processDefinitionKey)
-                .tenantId(TENANT_B)
-                .send();
-
-        // then
-        assertThat(result)
-            .failsWithin(Duration.ofSeconds(10))
-            .withThrowableThat()
-            .describedAs("Process definition should exist for tenant-a but not for tenant-b")
-            .withMessageContaining("NOT_FOUND")
-            .withMessageContaining("Expected to find process definition with key")
-            .withMessageContaining("but none found");
-      }
-    }
-
-    @Test
-    void shouldStartProcessWhenPublishingMessageForTenant() {
-      // given
-      final String messageName = "message";
-      process =
-
-   Bpmn.createExecutableProcess(processId).startEvent().message(messageName).endEvent().done();
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        client
-            .newDeployResourceCommand()
-            .addProcessModel(process, "process.bpmn")
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-
-        // when
-        final Future<PublishMessageResponse> result =
-            client
-                .newPublishMessageCommand()
-                .messageName(messageName)
-                .withoutCorrelationKey()
-                .tenantId(TENANT_A)
-                .send();
-
-        // then
-        assertThat(result)
-            .describedAs(
-                "Expect that message can be published as the client has access process of
-   tenant-a")
-            .succeedsWithin(Duration.ofSeconds(10));
-      }
-    }
-
-    @Test
-    void shouldDenyPublishMessageWhenUnauthorized() {
-      // given
-      final String messageName = "message";
-      process =
-
-   Bpmn.createExecutableProcess(processId).startEvent().message(messageName).endEvent().done();
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        client
-            .newDeployResourceCommand()
-            .addProcessModel(process, "process.bpmn")
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-
-        // when
-        final Future<PublishMessageResponse> result =
-            client
-                .newPublishMessageCommand()
-                .messageName(messageName)
-                .withoutCorrelationKey()
-                .tenantId(TENANT_B)
-                .send();
-
-        // then
-        assertThat(result)
-            .failsWithin(Duration.ofSeconds(10))
-            .withThrowableThat()
-            .withMessageContaining("PERMISSION_DENIED")
-            .withMessageContaining(
-                "Expected to handle gRPC request PublishMessage with tenant identifier
-   'tenant-b'")
-            .withMessageContaining("but tenant is not authorized to perform this request");
-      }
-    }
-
-    @Test
-    void shouldActivateJobForTenant() {
-      // given
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        client
-            .newDeployResourceCommand()
-            .addProcessModel(process, "process.bpmn")
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-        client
-            .newCreateInstanceCommand()
-            .bpmnProcessId(processId)
-            .latestVersion()
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-
-        // when
-        final Future<ActivateJobsResponse> result =
-            client
-                .newActivateJobsCommand()
-                .jobType("type")
-                .maxJobsToActivate(1)
-                .tenantId(TENANT_A)
-                .send();
-
-        // then
-        assertThat(result)
-            .describedAs(
-                "Expect that job can be activated as the client has access process of tenant-a")
-            .succeedsWithin(Duration.ofSeconds(10));
-      }
-    }
-
-    @Test
-    void shouldDenyActivateJobWhenUnauthorized() {
-      // given
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        client
-            .newDeployResourceCommand()
-            .addProcessModel(process, "process.bpmn")
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-        client
-            .newCreateInstanceCommand()
-            .bpmnProcessId(processId)
-            .latestVersion()
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-      }
+  @Test
+  void shouldAuthorizeCreateProcessInstance() {
+    // given
+    final long processDefinitionKey;
+    try (final var client = createCamundaClient(USER_TENANT_A_AND_B)) {
+      processDefinitionKey =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(process, "process.bpmn")
+              .tenantId(TENANT_A)
+              .send()
+              .join()
+              .getProcesses()
+              .stream()
+              .map(Process::getProcessDefinitionKey)
+              .findFirst()
+              .orElseThrow();
 
       // when
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-        final Future<ActivateJobsResponse> result =
-            client
-                .newActivateJobsCommand()
-                .jobType("type")
-                .maxJobsToActivate(1)
-                .tenantId(TENANT_A)
-                .send();
+      final Future<ProcessInstanceEvent> result =
+          client
+              .newCreateInstanceCommand()
+              .processDefinitionKey(processDefinitionKey)
+              .tenantId(TENANT_A)
+              .send();
 
-        // then
-        assertThat(result)
-            .failsWithin(Duration.ofSeconds(10))
-            .withThrowableThat()
-            .withMessageContaining("PERMISSION_DENIED")
-            .withMessageContaining(
-                "Expected to handle gRPC request ActivateJobs with tenant identifier 'tenant-a'")
-            .withMessageContaining("but tenant is not authorized to perform this request");
-      }
+      // then
+      assertThat(result)
+          .describedAs(
+              "Expect that process instance can be created as the client has access process of tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldNotFindOtherTenantsProcessById() {
+    // given
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
     }
 
-    @Test
-    void shouldCompleteJobForTenant() {
-      // given
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        client
-            .newDeployResourceCommand()
-            .addProcessModel(process, "process.bpmn")
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-        client
-            .newCreateInstanceCommand()
-            .bpmnProcessId(processId)
-            .latestVersion()
-            .tenantId(TENANT_A)
-            .send()
-            .join();
+    try (final var client = createCamundaClient(USER_TENANT_B)) {
+      // when
+      final Future<ProcessInstanceEvent> result =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId(processId)
+              .latestVersion()
+              .tenantId(TENANT_B)
+              .send();
 
-        final var activatedJob =
-            client
-                .newActivateJobsCommand()
-                .jobType("type")
-                .maxJobsToActivate(1)
-                .tenantId(TENANT_A)
-                .send()
-                .join()
-                .getJobs()
-                .get(0);
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .describedAs("Process definition should exist for tenant-a but not for tenant-b")
+          .withMessageContaining("NOT_FOUND")
+          .withMessageContaining("Expected to find process definition with process ID")
+          .withMessageContaining("but none found");
+    }
+  }
 
-        // when
-        final Future<CompleteJobResponse> result = client.newCompleteCommand(activatedJob).send();
-
-        // then
-        assertThat(result)
-            .describedAs(
-                "Expect that job can be competed as the client has access process of tenant-a")
-            .succeedsWithin(Duration.ofSeconds(10));
-      }
+  @Test
+  void shouldNotFindOtherTenantsProcessByKey() {
+    // given
+    final long processDefinitionKey;
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      processDefinitionKey =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(process, "process.bpmn")
+              .tenantId(TENANT_A)
+              .send()
+              .join()
+              .getProcesses()
+              .stream()
+              .map(Process::getProcessDefinitionKey)
+              .findFirst()
+              .orElseThrow();
     }
 
-    @Test
-    void shouldCompleteUserTaskForTenant() {
-      // given
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        client
-            .newDeployResourceCommand()
-            .addProcessModel(process, "process.bpmn")
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-        client
-            .newCreateInstanceCommand()
-            .bpmnProcessId(processId)
-            .latestVersion()
-            .tenantId(TENANT_A)
-            .send()
-            .join();
+    try (final var client = createCamundaClient(USER_TENANT_B)) {
+      // when
+      final Future<ProcessInstanceEvent> result =
+          client
+              .newCreateInstanceCommand()
+              .processDefinitionKey(processDefinitionKey)
+              .tenantId(TENANT_B)
+              .send();
 
-        final var activatedJob =
-            client
-                .newActivateJobsCommand()
-                .jobType("type")
-                .maxJobsToActivate(1)
-                .tenantId(TENANT_A)
-                .send()
-                .join()
-                .getJobs()
-                .get(0);
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .describedAs("Process definition should exist for tenant-a but not for tenant-b")
+          .withMessageContaining("NOT_FOUND")
+          .withMessageContaining("Expected to find process definition with key")
+          .withMessageContaining("but none found");
+    }
+  }
 
-        // when
-        final Future<CompleteJobResponse> result = client.newCompleteCommand(activatedJob).send();
-
-        // then
-        assertThat(result)
-            .describedAs(
-                "Expect that job can be competed as the client has access process of tenant-a")
-            .succeedsWithin(Duration.ofSeconds(10));
-      }
+  @Test
+  void shouldNotFindOtherTenantsProcessInCallActivity() {
+    // given
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
     }
 
-    @Test
-    void shouldUpdateJobTimeoutForTenant() {
-      // given
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        client
-            .newDeployResourceCommand()
-            .addProcessModel(process, "process.bpmn")
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-        client
-            .newCreateInstanceCommand()
-            .bpmnProcessId(processId)
-            .latestVersion()
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-
-        final var activatedJob =
-            client
-                .newActivateJobsCommand()
-                .jobType("type")
-                .maxJobsToActivate(1)
-                .tenantId(TENANT_A)
-                .timeout(Duration.ofMinutes(10))
-                .send()
-                .join()
-                .getJobs()
-                .get(0);
-
-        // when
-        final Future<UpdateTimeoutJobResponse> result =
-            client.newUpdateTimeoutCommand(activatedJob).timeout(Duration.ofMinutes(11)).send();
-
-        // then
-        assertThat(result)
-            .describedAs(
-                "Expect that job timeout can be updated as the client has access process of
-   tenant-a")
-            .succeedsWithin(Duration.ofSeconds(10));
-      }
+    try (final var client = createCamundaClient(USER_TENANT_B)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(
+              Bpmn.createExecutableProcess("parent")
+                  .startEvent()
+                  .callActivity("call", c -> c.zeebeProcessId(processId))
+                  .endEvent()
+                  .done(),
+              "parent.bpmn")
+          .tenantId(TENANT_B)
+          .send()
+          .join();
     }
 
-    @Test
-    void shouldNotUpdateJobTimeoutWhenUnauthorized() {
-      // given
-      final ActivatedJob activatedJob;
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        client
-            .newDeployResourceCommand()
-            .addProcessModel(process, "process.bpmn")
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-        client
-            .newCreateInstanceCommand()
-            .bpmnProcessId(processId)
-            .latestVersion()
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-        activatedJob =
-            client
-                .newActivateJobsCommand()
-                .jobType("type")
-                .maxJobsToActivate(1)
-                .tenantId(TENANT_A)
-                .timeout(Duration.ofMinutes(10))
-                .send()
-                .join()
-                .getJobs()
-                .get(0);
-      }
+    try (final var client = createCamundaClient(USER_TENANT_B)) {
+      // when
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId("parent")
+          .latestVersion()
+          .tenantId(TENANT_B)
+          .send();
+
+      // then
+      Assertions.assertThat(
+              RecordingExporter.incidentRecords().withBpmnProcessId("parent").getFirst().getValue())
+          .hasErrorMessage(
+              "Expected process with BPMN process id '%s' to be deployed, but not found."
+                  .formatted(processId));
+    }
+  }
+
+  /**
+   * This test case may become obsolete when we allow shared processes definitions across tenants.
+   */
+  @Test
+  void shouldNotFindOtherTenantsProcessEvenWhenClientIsAuthorizedForTenant() {
+    // given
+    final long processDefinitionKey;
+    try (final var client = createCamundaClient(USER_TENANT_A_AND_B)) {
+      processDefinitionKey =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(process, "process.bpmn")
+              .tenantId(TENANT_A)
+              .send()
+              .join()
+              .getProcesses()
+              .stream()
+              .map(Process::getProcessDefinitionKey)
+              .findFirst()
+              .orElseThrow();
+    }
+
+    try (final var client = createCamundaClient(USER_TENANT_A_AND_B)) {
+      // when
+      final Future<ProcessInstanceEvent> result =
+          client
+              .newCreateInstanceCommand()
+              .processDefinitionKey(processDefinitionKey)
+              .tenantId(TENANT_B)
+              .send();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .describedAs("Process definition should exist for tenant-a but not for tenant-b")
+          .withMessageContaining("NOT_FOUND")
+          .withMessageContaining("Expected to find process definition with key")
+          .withMessageContaining("but none found");
+    }
+  }
+
+  @Test
+  void shouldStartProcessWhenPublishingMessageForTenant() {
+    // given
+    final String messageName = "message";
+    process =
+        Bpmn.createExecutableProcess(processId).startEvent().message(messageName).endEvent().done();
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
 
       // when
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-        final Future<UpdateTimeoutJobResponse> result =
-            client.newUpdateTimeoutCommand(activatedJob).timeout(Duration.ofMinutes(11)).send();
+      final Future<PublishMessageResponse> result =
+          client
+              .newPublishMessageCommand()
+              .messageName(messageName)
+              .withoutCorrelationKey()
+              .tenantId(TENANT_A)
+              .send();
 
-        // then
-        assertThat(result)
-            .failsWithin(Duration.ofSeconds(10))
-            .withThrowableThat()
-            .withMessageContaining("NOT_FOUND")
-            .withMessageContaining(
-                "Command 'UPDATE_TIMEOUT' rejected with code 'NOT_FOUND': Expected to update job
-   with key '%d', but no such job was found"
-                    .formatted(activatedJob.getKey()));
-      }
+      // then
+      assertThat(result)
+          .describedAs(
+              "Expect that message can be published as the client has access process of tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
     }
+  }
 
-    @Test
-    void shouldNotFindJobWhenUnauthorized() {
-      // given
-      final ActivatedJob activatedJob;
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        client
-            .newDeployResourceCommand()
-            .addProcessModel(process, "process.bpmn")
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-        client
-            .newCreateInstanceCommand()
-            .bpmnProcessId(processId)
-            .latestVersion()
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-        activatedJob =
-            client
-                .newActivateJobsCommand()
-                .jobType("type")
-                .maxJobsToActivate(1)
-                .tenantId(TENANT_A)
-                .send()
-                .join()
-                .getJobs()
-                .get(0);
-      }
+  @Test
+  void shouldDenyPublishMessageWhenUnauthorized() {
+    // given
+    final String messageName = "message";
+    process =
+        Bpmn.createExecutableProcess(processId).startEvent().message(messageName).endEvent().done();
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
 
       // when
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-        final Future<CompleteJobResponse> result = client.newCompleteCommand(activatedJob).send();
+      final Future<PublishMessageResponse> result =
+          client
+              .newPublishMessageCommand()
+              .messageName(messageName)
+              .withoutCorrelationKey()
+              .tenantId(TENANT_B)
+              .send();
 
-        // then
-        assertThat(result)
-            .failsWithin(Duration.ofSeconds(10))
-            .withThrowableThat()
-            .withMessageContaining("NOT_FOUND")
-            .withMessageContaining(
-                "Command 'COMPLETE' rejected with code 'NOT_FOUND': Expected to update retries for
-   job with key '%d', but no such job was found"
-                    .formatted(activatedJob.getKey()));
-      }
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("PERMISSION_DENIED")
+          .withMessageContaining(
+              "Expected to handle gRPC request PublishMessage with tenant identifier 'tenant-b'")
+          .withMessageContaining("but tenant is not authorized to perform this request");
     }
+  }
 
-    @Test
-    void shouldResolveIncidentForTenant() {
-      // given
-      process =
-          Bpmn.createExecutableProcess(processId)
-              .startEvent()
-              .zeebeOutputExpression("assert(foo, foo != null)", "target")
-              .endEvent()
-              .done();
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        client
-            .newDeployResourceCommand()
-            .addProcessModel(process, "process.bpmn")
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-        client
-            .newCreateInstanceCommand()
-            .bpmnProcessId(processId)
-            .latestVersion()
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-
-        final var incidentKey =
-            RecordingExporter.incidentRecords().withBpmnProcessId(processId).getFirst().getKey();
-
-        // when
-        final Future<ResolveIncidentResponse> result =
-            client.newResolveIncidentCommand(incidentKey).send();
-
-        // then
-        assertThat(result)
-            .describedAs(
-                "Expect that incident can be resolved as the client has access process of
-   tenant-a")
-            .succeedsWithin(Duration.ofSeconds(10));
-      }
-    }
-
-    @Test
-    void shouldNotFindIncidentForTenantWhenUnauthorized() {
-      // given
-      process =
-          Bpmn.createExecutableProcess(processId)
-              .startEvent()
-              .zeebeOutputExpression("assert(foo, foo != null)", "target")
-              .endEvent()
-              .done();
-      final long incidentKey;
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        client
-            .newDeployResourceCommand()
-            .addProcessModel(process, "process.bpmn")
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-        client
-            .newCreateInstanceCommand()
-            .bpmnProcessId(processId)
-            .latestVersion()
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-
-        incidentKey =
-            RecordingExporter.incidentRecords().withBpmnProcessId(processId).getFirst().getKey();
-      }
-
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-        // when
-        final Future<ResolveIncidentResponse> result =
-            client.newResolveIncidentCommand(incidentKey).send();
-
-        // then
-        assertThat(result)
-            .failsWithin(Duration.ofSeconds(10))
-            .withThrowableThat()
-            .withMessageContaining("NOT_FOUND")
-            .withMessageContaining(
-                "Command 'RESOLVE' rejected with code 'NOT_FOUND': Expected to resolve incident
-   with key '%d', but no such incident was found"
-                    .formatted(incidentKey));
-      }
-    }
-
-    @Test
-    void shouldAllowModifyProcessInstanceForDefaultTenant() {
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
-        // given
-        client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
-
-        final long processInstanceKey =
-            client
-                .newCreateInstanceCommand()
-                .bpmnProcessId(processId)
-                .latestVersion()
-                .send()
-                .join()
-                .getProcessInstanceKey();
-
-        // when
-        final Future<ModifyProcessInstanceResponse> response =
-
-   client.newModifyProcessInstanceCommand(processInstanceKey).activateElement("task").send();
-
-        // then
-        assertThat(response).succeedsWithin(Duration.ofSeconds(10));
-      }
-    }
-
-    @Test
-    void shouldAllowModifyProcessInstanceForOtherTenant() {
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        // given
-        client
-            .newDeployResourceCommand()
-            .addProcessModel(process, "process.bpmn")
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-
-        final long processInstanceKey =
-            client
-                .newCreateInstanceCommand()
-                .bpmnProcessId(processId)
-                .latestVersion()
-                .tenantId(TENANT_A)
-                .send()
-                .join()
-                .getProcessInstanceKey();
-
-        // when
-        final Future<ModifyProcessInstanceResponse> response =
-
-   client.newModifyProcessInstanceCommand(processInstanceKey).activateElement("task").send();
-
-        // then
-        assertThat(response).succeedsWithin(Duration.ofSeconds(10));
-      }
-    }
-
-    @Test
-    void shouldRejectModifyProcessInstanceForUnauthorizedTenant() {
-      final long processInstanceKey;
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        // given
-        client
-            .newDeployResourceCommand()
-            .addProcessModel(process, "process.bpmn")
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-
-        processInstanceKey =
-            client
-                .newCreateInstanceCommand()
-                .bpmnProcessId(processId)
-                .latestVersion()
-                .tenantId(TENANT_A)
-                .send()
-                .join()
-                .getProcessInstanceKey();
-      }
+  @Test
+  void shouldActivateJobForTenant() {
+    // given
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId(processId)
+          .latestVersion()
+          .tenantId(TENANT_A)
+          .send()
+          .join();
 
       // when
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-        final Future<ModifyProcessInstanceResponse> response =
+      final Future<ActivateJobsResponse> result =
+          client
+              .newActivateJobsCommand()
+              .jobType("type")
+              .maxJobsToActivate(1)
+              .tenantId(TENANT_A)
+              .send();
 
-   client.newModifyProcessInstanceCommand(processInstanceKey).activateElement("task").send();
+      // then
+      assertThat(result)
+          .describedAs(
+              "Expect that job can be activated as the client has access process of tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
 
-        // then
-        assertThat(response)
-            .failsWithin(Duration.ofSeconds(10))
-            .withThrowableThat()
-            .withMessageContaining("NOT_FOUND")
-            .withMessageContaining(
-                "Expected to modify process instance but no process instance found with key");
-      }
+  @Test
+  void shouldDenyActivateJobWhenUnauthorized() {
+    // given
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId(processId)
+          .latestVersion()
+          .tenantId(TENANT_A)
+          .send()
+          .join();
     }
 
-    @Test
-    void shouldAllowMigrateProcessInstanceForDefaultTenant() {
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
-        // given
-        client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
-        final var deploymentResponse =
-            client
-                .newDeployResourceCommand()
-                .addProcessModel(migratedProcess, "migrated-process.bpmn")
-                .send()
-                .join();
-        final long targetProcessDefinitionKey =
-            deploymentResponse.getProcesses().get(0).getProcessDefinitionKey();
+    // when
+    try (final var client = createCamundaClient(USER_TENANT_B)) {
+      final Future<ActivateJobsResponse> result =
+          client
+              .newActivateJobsCommand()
+              .jobType("type")
+              .maxJobsToActivate(1)
+              .tenantId(TENANT_A)
+              .send();
 
-        final long processInstanceKey =
-            client
-                .newCreateInstanceCommand()
-                .bpmnProcessId(processId)
-                .latestVersion()
-                .send()
-                .join()
-                .getProcessInstanceKey();
-
-        // when
-        final Future<MigrateProcessInstanceResponse> response =
-            client
-                .newMigrateProcessInstanceCommand(processInstanceKey)
-                .migrationPlan(targetProcessDefinitionKey)
-                .addMappingInstruction("task", "migrated-task")
-                .send();
-
-        // then
-        assertThat(response).succeedsWithin(Duration.ofSeconds(10));
-      }
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("PERMISSION_DENIED")
+          .withMessageContaining(
+              "Expected to handle gRPC request ActivateJobs with tenant identifier 'tenant-a'")
+          .withMessageContaining("but tenant is not authorized to perform this request");
     }
+  }
 
-    @Test
-    void shouldAllowMigrateProcessInstanceForOtherTenant() {
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        // given
-        client
-            .newDeployResourceCommand()
-            .addProcessModel(process, "process.bpmn")
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-        final var deploymentResponse =
-            client
-                .newDeployResourceCommand()
-                .addProcessModel(migratedProcess, "migrated-process.bpmn")
-                .tenantId(TENANT_A)
-                .send()
-                .join();
-        final long targetProcessDefinitionKey =
-            deploymentResponse.getProcesses().get(0).getProcessDefinitionKey();
+  @Test
+  void shouldCompleteJobForTenant() {
+    // given
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId(processId)
+          .latestVersion()
+          .tenantId(TENANT_A)
+          .send()
+          .join();
 
-        final long processInstanceKey =
-            client
-                .newCreateInstanceCommand()
-                .bpmnProcessId(processId)
-                .latestVersion()
-                .tenantId(TENANT_A)
-                .send()
-                .join()
-                .getProcessInstanceKey();
-
-        // when
-        final Future<MigrateProcessInstanceResponse> response =
-            client
-                .newMigrateProcessInstanceCommand(processInstanceKey)
-                .migrationPlan(targetProcessDefinitionKey)
-                .addMappingInstruction("task", "migrated-task")
-                .send();
-
-        // then
-        assertThat(response).succeedsWithin(Duration.ofSeconds(10));
-      }
-    }
-
-    @Test
-    void shouldRejectMigrateProcessInstanceForUnauthorizedTenant() {
-      final long processInstanceKey;
-      final long targetProcessDefinitionKey;
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        // given
-        client
-            .newDeployResourceCommand()
-            .addProcessModel(process, "process.bpmn")
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-        final var deploymentResponse =
-            client
-                .newDeployResourceCommand()
-                .addProcessModel(migratedProcess, "process.bpmn")
-                .tenantId(TENANT_A)
-                .send()
-                .join();
-        targetProcessDefinitionKey =
-            deploymentResponse.getProcesses().get(0).getProcessDefinitionKey();
-
-        processInstanceKey =
-            client
-                .newCreateInstanceCommand()
-                .bpmnProcessId(processId)
-                .latestVersion()
-                .tenantId(TENANT_A)
-                .send()
-                .join()
-                .getProcessInstanceKey();
-      }
+      final var activatedJob =
+          client
+              .newActivateJobsCommand()
+              .jobType("type")
+              .maxJobsToActivate(1)
+              .tenantId(TENANT_A)
+              .send()
+              .join()
+              .getJobs()
+              .get(0);
 
       // when
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-        final Future<MigrateProcessInstanceResponse> response =
-            client
-                .newMigrateProcessInstanceCommand(processInstanceKey)
-                .migrationPlan(targetProcessDefinitionKey)
-                .addMappingInstruction("task", "migrated-task")
-                .send();
+      final Future<CompleteJobResponse> result = client.newCompleteCommand(activatedJob).send();
 
-        // then
-        assertThat(response)
-            .failsWithin(Duration.ofSeconds(10))
-            .withThrowableThat()
-            .withMessageContaining("NOT_FOUND")
-            .withMessageContaining(
-                String.format(
-                    "Expected to migrate process instance but no process instance found with key
-   '%s'",
-                    processInstanceKey));
-      }
+      // then
+      assertThat(result)
+          .describedAs(
+              "Expect that job can be competed as the client has access process of tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldCompleteUserTaskForTenant() {
+    // given
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId(processId)
+          .latestVersion()
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+
+      final var activatedJob =
+          client
+              .newActivateJobsCommand()
+              .jobType("type")
+              .maxJobsToActivate(1)
+              .tenantId(TENANT_A)
+              .send()
+              .join()
+              .getJobs()
+              .get(0);
+
+      // when
+      final Future<CompleteJobResponse> result = client.newCompleteCommand(activatedJob).send();
+
+      // then
+      assertThat(result)
+          .describedAs(
+              "Expect that job can be competed as the client has access process of tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldUpdateJobTimeoutForTenant() {
+    // given
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId(processId)
+          .latestVersion()
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+
+      final var activatedJob =
+          client
+              .newActivateJobsCommand()
+              .jobType("type")
+              .maxJobsToActivate(1)
+              .tenantId(TENANT_A)
+              .timeout(Duration.ofMinutes(10))
+              .send()
+              .join()
+              .getJobs()
+              .get(0);
+
+      // when
+      final Future<UpdateTimeoutJobResponse> result =
+          client.newUpdateTimeoutCommand(activatedJob).timeout(Duration.ofMinutes(11)).send();
+
+      // then
+      assertThat(result)
+          .describedAs(
+              "Expect that job timeout can be updated as the client has access process of tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldNotUpdateJobTimeoutWhenUnauthorized() {
+    // given
+    final ActivatedJob activatedJob;
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId(processId)
+          .latestVersion()
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      activatedJob =
+          client
+              .newActivateJobsCommand()
+              .jobType("type")
+              .maxJobsToActivate(1)
+              .tenantId(TENANT_A)
+              .timeout(Duration.ofMinutes(10))
+              .send()
+              .join()
+              .getJobs()
+              .get(0);
     }
 
-    @Test
-    void shouldAllowEvaluateDecisionForDefaultTenant() {
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
-        // given
-        client
-            .newDeployResourceCommand()
-            .addResourceFromClasspath("dmn/decision-table.dmn")
-            .send()
-            .join();
+    // when
+    try (final var client = createCamundaClient(USER_TENANT_B)) {
+      final Future<UpdateTimeoutJobResponse> result =
+          client.newUpdateTimeoutCommand(activatedJob).timeout(Duration.ofMinutes(11)).send();
 
-        // when
-        final Future<EvaluateDecisionResponse> response =
-            client
-                .newEvaluateDecisionCommand()
-                .decisionId("jedi_or_sith")
-                .variable("lightsaberColor", "blue")
-                .send();
-        // then
-        assertThat(response).succeedsWithin(Duration.ofSeconds(10));
-      }
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("NOT_FOUND")
+          .withMessageContaining(
+              "Command 'UPDATE_TIMEOUT' rejected with code 'NOT_FOUND': Expected to update job with key '%d', but no such job was found"
+                  .formatted(activatedJob.getKey()));
+    }
+  }
+
+  @Test
+  void shouldNotFindJobWhenUnauthorized() {
+    // given
+    final ActivatedJob activatedJob;
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId(processId)
+          .latestVersion()
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      activatedJob =
+          client
+              .newActivateJobsCommand()
+              .jobType("type")
+              .maxJobsToActivate(1)
+              .tenantId(TENANT_A)
+              .send()
+              .join()
+              .getJobs()
+              .get(0);
     }
 
-    @Test
-    void shouldAllowEvaluateDecisionForCustomTenant() {
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
-        // given
-        client
-            .newDeployResourceCommand()
-            .addResourceFromClasspath("dmn/decision-table.dmn")
-            .tenantId(TENANT_A)
-            .send()
-            .join();
+    // when
+    try (final var client = createCamundaClient(USER_TENANT_B)) {
+      final Future<CompleteJobResponse> result = client.newCompleteCommand(activatedJob).send();
 
-        // when
-        final Future<EvaluateDecisionResponse> response =
-            client
-                .newEvaluateDecisionCommand()
-                .decisionId("jedi_or_sith")
-                .variable("lightsaberColor", "blue")
-                .tenantId(TENANT_A)
-                .send();
-        // then
-        assertThat(response).succeedsWithin(Duration.ofSeconds(10));
-      }
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("NOT_FOUND")
+          .withMessageContaining(
+              "Command 'COMPLETE' rejected with code 'NOT_FOUND': Expected to update retries for job with key '%d', but no such job was found"
+                  .formatted(activatedJob.getKey()));
+    }
+  }
+
+  @Test
+  void shouldResolveIncidentForTenant() {
+    // given
+    process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .zeebeOutputExpression("assert(foo, foo != null)", "target")
+            .endEvent()
+            .done();
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId(processId)
+          .latestVersion()
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+
+      final var incidentKey =
+          RecordingExporter.incidentRecords().withBpmnProcessId(processId).getFirst().getKey();
+
+      // when
+      final Future<ResolveIncidentResponse> result =
+          client.newResolveIncidentCommand(incidentKey).send();
+
+      // then
+      assertThat(result)
+          .describedAs(
+              "Expect that incident can be resolved as the client has access process of tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldNotFindIncidentForTenantWhenUnauthorized() {
+    // given
+    process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .zeebeOutputExpression("assert(foo, foo != null)", "target")
+            .endEvent()
+            .done();
+    final long incidentKey;
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId(processId)
+          .latestVersion()
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+
+      incidentKey =
+          RecordingExporter.incidentRecords().withBpmnProcessId(processId).getFirst().getKey();
     }
 
-    @Test
-    void shouldDenyEvaluateDecisionForCustomTenant() {
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
-        // given
-        client
-            .newDeployResourceCommand()
-            .addResourceFromClasspath("dmn/decision-table.dmn")
-            .tenantId(TENANT_A)
-            .send()
-            .join();
+    try (final var client = createCamundaClient(USER_TENANT_B)) {
+      // when
+      final Future<ResolveIncidentResponse> result =
+          client.newResolveIncidentCommand(incidentKey).send();
 
-        // when
-        final Future<EvaluateDecisionResponse> response =
-            client
-                .newEvaluateDecisionCommand()
-                .decisionId("jedi_or_sith")
-                .variable("lightsaberColor", "blue")
-                .tenantId(TENANT_B)
-                .send();
-        // then
-        assertThat(response)
-            .failsWithin(Duration.ofSeconds(10))
-            .withThrowableThat()
-            .withMessageContaining("PERMISSION_DENIED")
-            .withMessageContaining(
-                "Expected to handle gRPC request EvaluateDecision with tenant identifier
-   'tenant-b'")
-            .withMessageContaining("but tenant is not authorized to perform this request");
-      }
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("NOT_FOUND")
+          .withMessageContaining(
+              "Command 'RESOLVE' rejected with code 'NOT_FOUND': Expected to resolve incident with key '%d', but no such incident was found"
+                  .formatted(incidentKey));
+    }
+  }
+
+  @Test
+  void shouldAllowModifyProcessInstanceForDefaultTenant() {
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      // given
+      client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
+
+      final long processInstanceKey =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId(processId)
+              .latestVersion()
+              .send()
+              .join()
+              .getProcessInstanceKey();
+
+      // when
+      final Future<ModifyProcessInstanceResponse> response =
+          client.newModifyProcessInstanceCommand(processInstanceKey).activateElement("task").send();
+
+      // then
+      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldAllowModifyProcessInstanceForOtherTenant() {
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      // given
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+
+      final long processInstanceKey =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId(processId)
+              .latestVersion()
+              .tenantId(TENANT_A)
+              .send()
+              .join()
+              .getProcessInstanceKey();
+
+      // when
+      final Future<ModifyProcessInstanceResponse> response =
+          client.newModifyProcessInstanceCommand(processInstanceKey).activateElement("task").send();
+
+      // then
+      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldRejectModifyProcessInstanceForUnauthorizedTenant() {
+    final long processInstanceKey;
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      // given
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+
+      processInstanceKey =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId(processId)
+              .latestVersion()
+              .tenantId(TENANT_A)
+              .send()
+              .join()
+              .getProcessInstanceKey();
     }
 
-    @Test
-    void shouldStartInstanceWhenBroadcastSignalForTenant() {
-      final String signalName = "signal";
-      process =
+    // when
+    try (final var client = createCamundaClient(USER_TENANT_B)) {
+      final Future<ModifyProcessInstanceResponse> response =
+          client.newModifyProcessInstanceCommand(processInstanceKey).activateElement("task").send();
 
-   Bpmn.createExecutableProcess(processId).startEvent().signal(signalName).endEvent().done();
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        // given
-        client
-            .newDeployResourceCommand()
-            .addProcessModel(process, "process.bpmn")
-            .tenantId(TENANT_A)
-            .send()
-            .join();
+      // then
+      assertThat(response)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("NOT_FOUND")
+          .withMessageContaining(
+              "Expected to modify process instance but no process instance found with key");
+    }
+  }
 
-        // when
-        final Future<BroadcastSignalResponse> result =
-            client.newBroadcastSignalCommand().signalName(signalName).tenantId(TENANT_A).send();
+  @Test
+  void shouldAllowMigrateProcessInstanceForDefaultTenant() {
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      // given
+      client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
+      final var deploymentResponse =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(migratedProcess, "migrated-process.bpmn")
+              .send()
+              .join();
+      final long targetProcessDefinitionKey =
+          deploymentResponse.getProcesses().get(0).getProcessDefinitionKey();
 
-        // then
-        assertThat(result)
-            .describedAs(
-                "Expect that signal can be broadcast as the client has access to the process of
-   'tenant-a'")
-            .succeedsWithin(Duration.ofSeconds(20));
-      }
+      final long processInstanceKey =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId(processId)
+              .latestVersion()
+              .send()
+              .join()
+              .getProcessInstanceKey();
+
+      // when
+      final Future<MigrateProcessInstanceResponse> response =
+          client
+              .newMigrateProcessInstanceCommand(processInstanceKey)
+              .migrationPlan(targetProcessDefinitionKey)
+              .addMappingInstruction("task", "migrated-task")
+              .send();
+
+      // then
+      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldAllowMigrateProcessInstanceForOtherTenant() {
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      // given
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      final var deploymentResponse =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(migratedProcess, "migrated-process.bpmn")
+              .tenantId(TENANT_A)
+              .send()
+              .join();
+      final long targetProcessDefinitionKey =
+          deploymentResponse.getProcesses().get(0).getProcessDefinitionKey();
+
+      final long processInstanceKey =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId(processId)
+              .latestVersion()
+              .tenantId(TENANT_A)
+              .send()
+              .join()
+              .getProcessInstanceKey();
+
+      // when
+      final Future<MigrateProcessInstanceResponse> response =
+          client
+              .newMigrateProcessInstanceCommand(processInstanceKey)
+              .migrationPlan(targetProcessDefinitionKey)
+              .addMappingInstruction("task", "migrated-task")
+              .send();
+
+      // then
+      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldRejectMigrateProcessInstanceForUnauthorizedTenant() {
+    final long processInstanceKey;
+    final long targetProcessDefinitionKey;
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      // given
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      final var deploymentResponse =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(migratedProcess, "process.bpmn")
+              .tenantId(TENANT_A)
+              .send()
+              .join();
+      targetProcessDefinitionKey =
+          deploymentResponse.getProcesses().get(0).getProcessDefinitionKey();
+
+      processInstanceKey =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId(processId)
+              .latestVersion()
+              .tenantId(TENANT_A)
+              .send()
+              .join()
+              .getProcessInstanceKey();
     }
 
-    @Test
-    void shouldDenyBroadcastSignalWhenUnauthorized() {
-      final String signalName = "signal";
-      process =
+    // when
+    try (final var client = createCamundaClient(USER_TENANT_B)) {
+      final Future<MigrateProcessInstanceResponse> response =
+          client
+              .newMigrateProcessInstanceCommand(processInstanceKey)
+              .migrationPlan(targetProcessDefinitionKey)
+              .addMappingInstruction("task", "migrated-task")
+              .send();
 
-   Bpmn.createExecutableProcess(processId).startEvent().signal(signalName).endEvent().done();
-      try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-        // given
-        client
-            .newDeployResourceCommand()
-            .addProcessModel(process, "process.bpmn")
-            .tenantId(TENANT_A)
-            .send()
-            .join();
-
-        // when
-        final Future<BroadcastSignalResponse> result =
-            client.newBroadcastSignalCommand().signalName(signalName).tenantId(TENANT_B).send();
-
-        // then
-        assertThat(result)
-            .failsWithin(Duration.ofSeconds(10))
-            .withThrowableThat()
-            .withMessageContaining("PERMISSION_DENIED")
-            .withMessageContaining(
-                "Expected to handle gRPC request BroadcastSignal with tenant identifier
-   'tenant-b'")
-            .withMessageContaining("but tenant is not authorized to perform this request");
-      }
+      // then
+      assertThat(response)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("NOT_FOUND")
+          .withMessageContaining(
+              String.format(
+                  "Expected to migrate process instance but no process instance found with key '%s'",
+                  processInstanceKey));
     }
+  }
 
-    @Test
-    void shouldAllowAssignUserTaskForTenant() {
-      try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
-          final var clientTenantB = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
-        // given
-        final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
-        final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+  @Test
+  void shouldAllowEvaluateDecisionForDefaultTenant() {
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      // given
+      client
+          .newDeployResourceCommand()
+          .addResourceFromClasspath("dmn/decision-table.dmn")
+          .send()
+          .join();
 
-        // when
-        final Future<AssignUserTaskResponse> result =
-            clientTenantB.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send();
-
-        // then
-        assertThat(result).succeedsWithin(Duration.ofSeconds(10));
-      }
+      // when
+      final Future<EvaluateDecisionResponse> response =
+          client
+              .newEvaluateDecisionCommand()
+              .decisionId("jedi_or_sith")
+              .variable("lightsaberColor", "blue")
+              .send();
+      // then
+      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
     }
+  }
 
-    @Test
-    void shouldRejectAssignUserTaskForTenant() {
-      try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
-          final var skeletorClient = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
-        // given
-        final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
-        final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+  @Test
+  void shouldAllowEvaluateDecisionForCustomTenant() {
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      // given
+      client
+          .newDeployResourceCommand()
+          .addResourceFromClasspath("dmn/decision-table.dmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
 
-        // when
-        final Future<AssignUserTaskResponse> result =
-            skeletorClient.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send();
-
-        // then
-        assertThat(result)
-            .failsWithin(Duration.ofSeconds(10))
-            .withThrowableThat()
-            .havingCause()
-            .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
-            .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
-      }
+      // when
+      final Future<EvaluateDecisionResponse> response =
+          client
+              .newEvaluateDecisionCommand()
+              .decisionId("jedi_or_sith")
+              .variable("lightsaberColor", "blue")
+              .tenantId(TENANT_A)
+              .send();
+      // then
+      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
     }
+  }
 
-    @Test
-    void shouldAllowCompleteUserTaskForTenant() {
-      try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
-          final var clientTenantB = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
-        // given
-        final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
-        final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+  @Test
+  void shouldDenyEvaluateDecisionForCustomTenant() {
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      // given
+      client
+          .newDeployResourceCommand()
+          .addResourceFromClasspath("dmn/decision-table.dmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
 
-        // when
-        final Future<CompleteUserTaskResponse> result =
-            clientTenantB.newUserTaskCompleteCommand(userTaskKey).send();
-
-        // then
-        assertThat(result).succeedsWithin(Duration.ofSeconds(10));
-      }
+      // when
+      final Future<EvaluateDecisionResponse> response =
+          client
+              .newEvaluateDecisionCommand()
+              .decisionId("jedi_or_sith")
+              .variable("lightsaberColor", "blue")
+              .tenantId(TENANT_B)
+              .send();
+      // then
+      assertThat(response)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("PERMISSION_DENIED")
+          .withMessageContaining(
+              "Expected to handle gRPC request EvaluateDecision with tenant identifier 'tenant-b'")
+          .withMessageContaining("but tenant is not authorized to perform this request");
     }
+  }
 
-    @Test
-    void shouldRejectCompleteUserTaskForTenant() {
-      try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
-          final var invalidClient = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
-        // given
-        final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
-        final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+  @Test
+  void shouldStartInstanceWhenBroadcastSignalForTenant() {
+    final String signalName = "signal";
+    process =
+        Bpmn.createExecutableProcess(processId).startEvent().signal(signalName).endEvent().done();
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      // given
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
 
-        // when
-        final Future<CompleteUserTaskResponse> result =
-            invalidClient.newUserTaskCompleteCommand(userTaskKey).send();
+      // when
+      final Future<BroadcastSignalResponse> result =
+          client.newBroadcastSignalCommand().signalName(signalName).tenantId(TENANT_A).send();
 
-        // then
-        assertThat(result)
-            .failsWithin(Duration.ofSeconds(10))
-            .withThrowableThat()
-            .havingCause()
-            .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
-            .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
-      }
+      // then
+      assertThat(result)
+          .describedAs(
+              "Expect that signal can be broadcast as the client has access to the process of 'tenant-a'")
+          .succeedsWithin(Duration.ofSeconds(20));
     }
+  }
 
-    @Test
-    void shouldAllowUnassignUserTaskForTenant() {
-      try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
-          final var clientTenantB = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
-        // given
-        final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
-        final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
-        clientTenantA.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send().join();
+  @Test
+  void shouldDenyBroadcastSignalWhenUnauthorized() {
+    final String signalName = "signal";
+    process =
+        Bpmn.createExecutableProcess(processId).startEvent().signal(signalName).endEvent().done();
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      // given
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
 
-        // when
-        final Future<UnassignUserTaskResponse> result =
-            clientTenantB.newUserTaskUnassignCommand(userTaskKey).send();
+      // when
+      final Future<BroadcastSignalResponse> result =
+          client.newBroadcastSignalCommand().signalName(signalName).tenantId(TENANT_B).send();
 
-        // then
-        assertThat(result).succeedsWithin(Duration.ofSeconds(10));
-      }
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("PERMISSION_DENIED")
+          .withMessageContaining(
+              "Expected to handle gRPC request BroadcastSignal with tenant identifier 'tenant-b'")
+          .withMessageContaining("but tenant is not authorized to perform this request");
     }
+  }
 
-    @Test
-    void shouldRejectUnassignUserTaskForTenant() {
-      try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
-          final var invalidClient = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
-        // given
-        final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
-        final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
-        clientTenantA.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send().join();
+  @Test
+  void shouldAllowAssignUserTaskForTenant() {
+    try (final var clientTenantA = createCamundaClient(USER_TENANT_A);
+        final var clientTenantB = createCamundaClient(USER_TENANT_A_AND_B)) {
+      // given
+      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
 
-        // when
-        final Future<UnassignUserTaskResponse> result =
-            invalidClient.newUserTaskUnassignCommand(userTaskKey).send();
+      // when
+      final Future<AssignUserTaskResponse> result =
+          clientTenantB.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send();
 
-        // then
-        assertThat(result)
-            .failsWithin(Duration.ofSeconds(10))
-            .withThrowableThat()
-            .havingCause()
-            .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
-            .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
-      }
+      // then
+      assertThat(result).succeedsWithin(Duration.ofSeconds(10));
     }
+  }
 
-    @Test
-    void shouldAllowUpdateUserTaskForTenant() {
-      try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
-          final var clientTenantB = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
-        // given
-        final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
-        final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+  @Test
+  void shouldRejectAssignUserTaskForTenant() {
+    try (final var clientTenantA = createCamundaClient(USER_TENANT_A);
+        final var skeletorClient = createCamundaClient(USER_WITHOUT_TENANT)) {
+      // given
+      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
 
-        // when
-        final Future<UpdateUserTaskResponse> result =
-            clientTenantB.newUserTaskUpdateCommand(userTaskKey).candidateUsers("Skeletor").send();
+      // when
+      final Future<AssignUserTaskResponse> result =
+          skeletorClient.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send();
 
-        // then
-        assertThat(result).succeedsWithin(Duration.ofSeconds(10));
-      }
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .havingCause()
+          .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
+          .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
     }
+  }
 
-    @Test
-    void shouldRejectUpdateUserTaskForTenant() {
-      try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
-          final var invalidClient = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
-        // given
-        final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
-        final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+  @Test
+  void shouldAllowCompleteUserTaskForTenant() {
+    try (final var clientTenantA = createCamundaClient(USER_TENANT_A);
+        final var clientTenantB = createCamundaClient(USER_TENANT_A_AND_B)) {
+      // given
+      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
 
-        // when
-        final Future<UpdateUserTaskResponse> result =
-            invalidClient.newUserTaskUpdateCommand(userTaskKey).candidateUsers("Skeletor").send();
+      // when
+      final Future<CompleteUserTaskResponse> result =
+          clientTenantB.newUserTaskCompleteCommand(userTaskKey).send();
 
-        // then
-        assertThat(result)
-            .failsWithin(Duration.ofSeconds(10))
-            .withThrowableThat()
-            .havingCause()
-            .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
-            .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
-      }
+      // then
+      assertThat(result).succeedsWithin(Duration.ofSeconds(10));
     }
+  }
+
+  @Test
+  void shouldRejectCompleteUserTaskForTenant() {
+    try (final var clientTenantA = createCamundaClient(USER_TENANT_A);
+        final var invalidClient = createCamundaClient(USER_WITHOUT_TENANT)) {
+      // given
+      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+
+      // when
+      final Future<CompleteUserTaskResponse> result =
+          invalidClient.newUserTaskCompleteCommand(userTaskKey).send();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .havingCause()
+          .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
+          .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
+    }
+  }
+
+  @Test
+  void shouldAllowUnassignUserTaskForTenant() {
+    try (final var clientTenantA = createCamundaClient(USER_TENANT_A);
+        final var clientTenantB = createCamundaClient(USER_TENANT_A_AND_B)) {
+      // given
+      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+      clientTenantA.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send().join();
+
+      // when
+      final Future<UnassignUserTaskResponse> result =
+          clientTenantB.newUserTaskUnassignCommand(userTaskKey).send();
+
+      // then
+      assertThat(result).succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldRejectUnassignUserTaskForTenant() {
+    try (final var clientTenantA = createCamundaClient(USER_TENANT_A);
+        final var invalidClient = createCamundaClient(USER_WITHOUT_TENANT)) {
+      // given
+      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+      clientTenantA.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send().join();
+
+      // when
+      final Future<UnassignUserTaskResponse> result =
+          invalidClient.newUserTaskUnassignCommand(userTaskKey).send();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .havingCause()
+          .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
+          .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
+    }
+  }
+
+  @Test
+  void shouldAllowUpdateUserTaskForTenant() {
+    try (final var clientTenantA = createCamundaClient(USER_TENANT_A);
+        final var clientTenantB = createCamundaClient(USER_TENANT_A_AND_B)) {
+      // given
+      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+
+      // when
+      final Future<UpdateUserTaskResponse> result =
+          clientTenantB.newUserTaskUpdateCommand(userTaskKey).candidateUsers("Skeletor").send();
+
+      // then
+      assertThat(result).succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldRejectUpdateUserTaskForTenant() {
+    try (final var clientTenantA = createCamundaClient(USER_TENANT_A);
+        final var invalidClient = createCamundaClient(USER_WITHOUT_TENANT)) {
+      // given
+      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+
+      // when
+      final Future<UpdateUserTaskResponse> result =
+          invalidClient.newUserTaskUpdateCommand(userTaskKey).candidateUsers("Skeletor").send();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .havingCause()
+          .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
+          .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
+    }
+  }
 
   private static Stream<Named<UnaryOperator<TopologyRequestStep1>>> provideTopologyCases() {
     return Stream.of(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -1341,16 +1341,18 @@ public class MultiTenancyOverIdentityIT {
           .tenantId(TENANT_A)
           .send()
           .join();
+    }
 
-      // when
+    // when
+    try (final var client = createCamundaClient(USER_TENANT_B)) {
       final Future<BroadcastSignalResponse> result =
-          client.newBroadcastSignalCommand().signalName(signalName).tenantId(TENANT_B).send();
+          client.newBroadcastSignalCommand().signalName(signalName).tenantId(TENANT_A).send();
 
       // then
       assertThat(result)
           .failsWithin(Duration.ofSeconds(10))
           .withThrowableThat()
-          .withMessageContaining("PERMISSION_DENIED")
+          .withMessageContaining("NOT_FOUND")
           .withMessageContaining(
               "Expected to handle gRPC request BroadcastSignal with tenant identifier 'tenant-b'")
           .withMessageContaining("but tenant is not authorized to perform this request");

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -294,1334 +294,1375 @@ public class MultiTenancyOverIdentityIT {
     }
   }
 
-  @Test
-  void shouldAuthorizeDeployProcess() {
-    // given
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      // when
-      final Future<DeploymentEvent> response =
-          client
-              .newDeployResourceCommand()
-              .addProcessModel(process, "process.bpmn")
-              .tenantId(TENANT_A)
-              .send();
-
-      // then
-      assertThat(response)
-          .describedAs("Expect that process can be deployed for tenant-a")
-          .succeedsWithin(Duration.ofSeconds(10));
-    }
-  }
-
-  @Test
-  void shouldDenyDeployResourceWhenUnauthorized() {
-    // given
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      // when
-      final Future<DeploymentEvent> result =
-          client
-              .newDeployResourceCommand()
-              .addProcessModel(process, "process.bpmn")
-              .tenantId(TENANT_B)
-              .send();
-
-      // then
-      assertThat(result)
-          .failsWithin(Duration.ofSeconds(10))
-          .withThrowableThat()
-          .withMessageContaining("PERMISSION_DENIED")
-          .withMessageContaining(
-              "Expected to handle gRPC request DeployResource with tenant identifier 'tenant-b'")
-          .withMessageContaining("but tenant is not authorized to perform this request");
-    }
-  }
-
-  @Test
-  void shouldDenyDeployResourceWhenUnauthorizedForDefaultTenant() {
-    // given
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_WITHOUT_DEFAULT_TENANT)) {
-      // when
-      final Future<DeploymentEvent> result =
-          client
-              .newDeployResourceCommand()
-              .addProcessModel(process, "process.bpmn")
-              .tenantId(DEFAULT_TENANT)
-              .send();
-
-      // then
-      assertThat(result)
-          .failsWithin(Duration.ofSeconds(10))
-          .withThrowableThat()
-          .withMessageContaining("PERMISSION_DENIED")
-          .withMessageContaining(
-              "Expected to handle gRPC request DeployResource with tenant identifier '<default>'")
-          .withMessageContaining("but tenant is not authorized to perform this request");
-    }
-  }
-
-  @SuppressWarnings("deprecation")
-  @Test
-  void shouldDenyDeployProcessWhenUnauthorizedForDefaultTenant() {
-    // given
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_WITHOUT_DEFAULT_TENANT)) {
-      // when
-      // note that deploy process command is always only for the default tenant
-      final Future<DeploymentEvent> result =
-          client.newDeployCommand().addProcessModel(process, "process.bpmn").send();
-
-      // then
-      assertThat(result)
-          .failsWithin(Duration.ofSeconds(10))
-          .withThrowableThat()
-          .withMessageContaining("PERMISSION_DENIED")
-          .withMessageContaining(
-              "Expected to handle gRPC request DeployProcess with tenant identifier '<default>'")
-          .withMessageContaining("but tenant is not authorized to perform this request");
-    }
-  }
-
-  @Test
-  void shouldAuthorizeDeleteResource() throws ExecutionException, InterruptedException {
-    // given
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      final Future<DeploymentEvent> deploymentResponse =
-          client
-              .newDeployResourceCommand()
-              .addProcessModel(process, "process.bpmn")
-              .tenantId(TENANT_A)
-              .send();
-      assertThat(deploymentResponse)
-          .describedAs("Expect that process was deployed for tenant-a")
-          .succeedsWithin(Duration.ofSeconds(10));
-      final long resourceKey =
-          deploymentResponse.get().getProcesses().get(0).getProcessDefinitionKey();
-
-      // when
-      final Future<DeleteResourceResponse> response =
-          client.newDeleteResourceCommand(resourceKey).send();
-
-      // then
-      assertThat(response)
-          .describedAs("Expect that process can be deleted for tenant-a")
-          .succeedsWithin(Duration.ofSeconds(10));
-    }
-  }
-
-  @Test
-  void shouldDenyDeleteResourceWhenUnauthorized() throws ExecutionException, InterruptedException {
-    // given
-    final long resourceKey;
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      final Future<DeploymentEvent> deploymentResponse =
-          client
-              .newDeployResourceCommand()
-              .addProcessModel(process, "process.bpmn")
-              .tenantId(TENANT_A)
-              .send();
-      assertThat(deploymentResponse)
-          .describedAs("Expect that process was deployed for tenant-a")
-          .succeedsWithin(Duration.ofSeconds(10));
-      resourceKey = deploymentResponse.get().getProcesses().get(0).getProcessDefinitionKey();
-    }
-
-    // when
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-      final Future<DeleteResourceResponse> response =
-          client.newDeleteResourceCommand(resourceKey).send();
-
-      // then
-      assertThat(response)
-          .failsWithin(Duration.ofSeconds(10))
-          .withThrowableThat()
-          .withMessageContaining("NOT_FOUND");
-    }
-  }
-
-  @Test
-  void shouldIncrementProcessVersionPerTenant() {
-    // given
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      client
-          .newDeployResourceCommand()
-          .addProcessModel(process, "process.bpmn")
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-    }
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-      client
-          .newDeployResourceCommand()
-          .addProcessModel(process, "process.bpmn")
-          .tenantId(TENANT_B)
-          .send()
-          .join();
-    }
-
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-      // when
-      final var processV2 = Bpmn.createExecutableProcess(processId).startEvent().done();
-      final Future<DeploymentEvent> result =
-          client
-              .newDeployResourceCommand()
-              .addProcessModel(processV2, "process.bpmn")
-              .tenantId(TENANT_B)
-              .send();
-
-      // then
-      assertThat(result)
-          .succeedsWithin(Duration.ofSeconds(10))
-          .describedAs("Process version is incremented for tenant-b but not for tenant-a")
-          .extracting(deploymentEvent -> deploymentEvent.getProcesses().get(0))
-          .extracting(Process::getVersion, Process::getTenantId)
-          .containsExactly(2, TENANT_B);
-    }
-  }
-
-  @Test
-  void shouldAuthorizeCreateProcessInstance() {
-    // given
-    final long processDefinitionKey;
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
-      processDefinitionKey =
-          client
-              .newDeployResourceCommand()
-              .addProcessModel(process, "process.bpmn")
-              .tenantId(TENANT_A)
-              .send()
-              .join()
-              .getProcesses()
-              .stream()
-              .map(Process::getProcessDefinitionKey)
-              .findFirst()
-              .orElseThrow();
-
-      // when
-      final Future<ProcessInstanceEvent> result =
-          client
-              .newCreateInstanceCommand()
-              .processDefinitionKey(processDefinitionKey)
-              .tenantId(TENANT_A)
-              .send();
-
-      // then
-      assertThat(result)
-          .describedAs(
-              "Expect that process instance can be created as the client has access process of tenant-a")
-          .succeedsWithin(Duration.ofSeconds(10));
-    }
-  }
-
-  @Test
-  void shouldNotFindOtherTenantsProcessById() {
-    // given
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      client
-          .newDeployResourceCommand()
-          .addProcessModel(process, "process.bpmn")
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-    }
-
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-      // when
-      final Future<ProcessInstanceEvent> result =
-          client
-              .newCreateInstanceCommand()
-              .bpmnProcessId(processId)
-              .latestVersion()
-              .tenantId(TENANT_B)
-              .send();
-
-      // then
-      assertThat(result)
-          .failsWithin(Duration.ofSeconds(10))
-          .withThrowableThat()
-          .describedAs("Process definition should exist for tenant-a but not for tenant-b")
-          .withMessageContaining("NOT_FOUND")
-          .withMessageContaining("Expected to find process definition with process ID")
-          .withMessageContaining("but none found");
-    }
-  }
-
-  @Test
-  void shouldNotFindOtherTenantsProcessByKey() {
-    // given
-    final long processDefinitionKey;
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      processDefinitionKey =
-          client
-              .newDeployResourceCommand()
-              .addProcessModel(process, "process.bpmn")
-              .tenantId(TENANT_A)
-              .send()
-              .join()
-              .getProcesses()
-              .stream()
-              .map(Process::getProcessDefinitionKey)
-              .findFirst()
-              .orElseThrow();
-    }
-
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-      // when
-      final Future<ProcessInstanceEvent> result =
-          client
-              .newCreateInstanceCommand()
-              .processDefinitionKey(processDefinitionKey)
-              .tenantId(TENANT_B)
-              .send();
-
-      // then
-      assertThat(result)
-          .failsWithin(Duration.ofSeconds(10))
-          .withThrowableThat()
-          .describedAs("Process definition should exist for tenant-a but not for tenant-b")
-          .withMessageContaining("NOT_FOUND")
-          .withMessageContaining("Expected to find process definition with key")
-          .withMessageContaining("but none found");
-    }
-  }
-
-  @Test
-  void shouldNotFindOtherTenantsProcessInCallActivity() {
-    // given
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      client
-          .newDeployResourceCommand()
-          .addProcessModel(process, "process.bpmn")
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-    }
-
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-      client
-          .newDeployResourceCommand()
-          .addProcessModel(
-              Bpmn.createExecutableProcess("parent")
-                  .startEvent()
-                  .callActivity("call", c -> c.zeebeProcessId(processId))
-                  .endEvent()
-                  .done(),
-              "parent.bpmn")
-          .tenantId(TENANT_B)
-          .send()
-          .join();
-    }
-
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-      // when
-      client
-          .newCreateInstanceCommand()
-          .bpmnProcessId("parent")
-          .latestVersion()
-          .tenantId(TENANT_B)
-          .send();
-
-      // then
-      Assertions.assertThat(
-              RecordingExporter.incidentRecords().withBpmnProcessId("parent").getFirst().getValue())
-          .hasErrorMessage(
-              "Expected process with BPMN process id '%s' to be deployed, but not found."
-                  .formatted(processId));
-    }
-  }
-
-  /**
-   * This test case may become obsolete when we allow shared processes definitions across tenants.
-   */
-  @Test
-  void shouldNotFindOtherTenantsProcessEvenWhenClientIsAuthorizedForTenant() {
-    // given
-    final long processDefinitionKey;
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
-      processDefinitionKey =
-          client
-              .newDeployResourceCommand()
-              .addProcessModel(process, "process.bpmn")
-              .tenantId(TENANT_A)
-              .send()
-              .join()
-              .getProcesses()
-              .stream()
-              .map(Process::getProcessDefinitionKey)
-              .findFirst()
-              .orElseThrow();
-    }
-
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
-      // when
-      final Future<ProcessInstanceEvent> result =
-          client
-              .newCreateInstanceCommand()
-              .processDefinitionKey(processDefinitionKey)
-              .tenantId(TENANT_B)
-              .send();
-
-      // then
-      assertThat(result)
-          .failsWithin(Duration.ofSeconds(10))
-          .withThrowableThat()
-          .describedAs("Process definition should exist for tenant-a but not for tenant-b")
-          .withMessageContaining("NOT_FOUND")
-          .withMessageContaining("Expected to find process definition with key")
-          .withMessageContaining("but none found");
-    }
-  }
-
-  @Test
-  void shouldStartProcessWhenPublishingMessageForTenant() {
-    // given
-    final String messageName = "message";
-    process =
-        Bpmn.createExecutableProcess(processId).startEvent().message(messageName).endEvent().done();
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      client
-          .newDeployResourceCommand()
-          .addProcessModel(process, "process.bpmn")
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-
-      // when
-      final Future<PublishMessageResponse> result =
-          client
-              .newPublishMessageCommand()
-              .messageName(messageName)
-              .withoutCorrelationKey()
-              .tenantId(TENANT_A)
-              .send();
-
-      // then
-      assertThat(result)
-          .describedAs(
-              "Expect that message can be published as the client has access process of tenant-a")
-          .succeedsWithin(Duration.ofSeconds(10));
-    }
-  }
-
-  @Test
-  void shouldDenyPublishMessageWhenUnauthorized() {
-    // given
-    final String messageName = "message";
-    process =
-        Bpmn.createExecutableProcess(processId).startEvent().message(messageName).endEvent().done();
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      client
-          .newDeployResourceCommand()
-          .addProcessModel(process, "process.bpmn")
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-
-      // when
-      final Future<PublishMessageResponse> result =
-          client
-              .newPublishMessageCommand()
-              .messageName(messageName)
-              .withoutCorrelationKey()
-              .tenantId(TENANT_B)
-              .send();
-
-      // then
-      assertThat(result)
-          .failsWithin(Duration.ofSeconds(10))
-          .withThrowableThat()
-          .withMessageContaining("PERMISSION_DENIED")
-          .withMessageContaining(
-              "Expected to handle gRPC request PublishMessage with tenant identifier 'tenant-b'")
-          .withMessageContaining("but tenant is not authorized to perform this request");
-    }
-  }
-
-  @Test
-  void shouldActivateJobForTenant() {
-    // given
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      client
-          .newDeployResourceCommand()
-          .addProcessModel(process, "process.bpmn")
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-      client
-          .newCreateInstanceCommand()
-          .bpmnProcessId(processId)
-          .latestVersion()
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-
-      // when
-      final Future<ActivateJobsResponse> result =
-          client
-              .newActivateJobsCommand()
-              .jobType("type")
-              .maxJobsToActivate(1)
-              .tenantId(TENANT_A)
-              .send();
-
-      // then
-      assertThat(result)
-          .describedAs(
-              "Expect that job can be activated as the client has access process of tenant-a")
-          .succeedsWithin(Duration.ofSeconds(10));
-    }
-  }
-
-  @Test
-  void shouldDenyActivateJobWhenUnauthorized() {
-    // given
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      client
-          .newDeployResourceCommand()
-          .addProcessModel(process, "process.bpmn")
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-      client
-          .newCreateInstanceCommand()
-          .bpmnProcessId(processId)
-          .latestVersion()
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-    }
-
-    // when
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-      final Future<ActivateJobsResponse> result =
-          client
-              .newActivateJobsCommand()
-              .jobType("type")
-              .maxJobsToActivate(1)
-              .tenantId(TENANT_A)
-              .send();
-
-      // then
-      assertThat(result)
-          .failsWithin(Duration.ofSeconds(10))
-          .withThrowableThat()
-          .withMessageContaining("PERMISSION_DENIED")
-          .withMessageContaining(
-              "Expected to handle gRPC request ActivateJobs with tenant identifier 'tenant-a'")
-          .withMessageContaining("but tenant is not authorized to perform this request");
-    }
-  }
-
-  @Test
-  void shouldCompleteJobForTenant() {
-    // given
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      client
-          .newDeployResourceCommand()
-          .addProcessModel(process, "process.bpmn")
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-      client
-          .newCreateInstanceCommand()
-          .bpmnProcessId(processId)
-          .latestVersion()
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-
-      final var activatedJob =
-          client
-              .newActivateJobsCommand()
-              .jobType("type")
-              .maxJobsToActivate(1)
-              .tenantId(TENANT_A)
-              .send()
-              .join()
-              .getJobs()
-              .get(0);
-
-      // when
-      final Future<CompleteJobResponse> result = client.newCompleteCommand(activatedJob).send();
-
-      // then
-      assertThat(result)
-          .describedAs(
-              "Expect that job can be competed as the client has access process of tenant-a")
-          .succeedsWithin(Duration.ofSeconds(10));
-    }
-  }
-
-  @Test
-  void shouldCompleteUserTaskForTenant() {
-    // given
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      client
-          .newDeployResourceCommand()
-          .addProcessModel(process, "process.bpmn")
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-      client
-          .newCreateInstanceCommand()
-          .bpmnProcessId(processId)
-          .latestVersion()
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-
-      final var activatedJob =
-          client
-              .newActivateJobsCommand()
-              .jobType("type")
-              .maxJobsToActivate(1)
-              .tenantId(TENANT_A)
-              .send()
-              .join()
-              .getJobs()
-              .get(0);
-
-      // when
-      final Future<CompleteJobResponse> result = client.newCompleteCommand(activatedJob).send();
-
-      // then
-      assertThat(result)
-          .describedAs(
-              "Expect that job can be competed as the client has access process of tenant-a")
-          .succeedsWithin(Duration.ofSeconds(10));
-    }
-  }
-
-  @Test
-  void shouldUpdateJobTimeoutForTenant() {
-    // given
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      client
-          .newDeployResourceCommand()
-          .addProcessModel(process, "process.bpmn")
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-      client
-          .newCreateInstanceCommand()
-          .bpmnProcessId(processId)
-          .latestVersion()
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-
-      final var activatedJob =
-          client
-              .newActivateJobsCommand()
-              .jobType("type")
-              .maxJobsToActivate(1)
-              .tenantId(TENANT_A)
-              .timeout(Duration.ofMinutes(10))
-              .send()
-              .join()
-              .getJobs()
-              .get(0);
-
-      // when
-      final Future<UpdateTimeoutJobResponse> result =
-          client.newUpdateTimeoutCommand(activatedJob).timeout(Duration.ofMinutes(11)).send();
-
-      // then
-      assertThat(result)
-          .describedAs(
-              "Expect that job timeout can be updated as the client has access process of tenant-a")
-          .succeedsWithin(Duration.ofSeconds(10));
-    }
-  }
-
-  @Test
-  void shouldNotUpdateJobTimeoutWhenUnauthorized() {
-    // given
-    final ActivatedJob activatedJob;
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      client
-          .newDeployResourceCommand()
-          .addProcessModel(process, "process.bpmn")
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-      client
-          .newCreateInstanceCommand()
-          .bpmnProcessId(processId)
-          .latestVersion()
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-      activatedJob =
-          client
-              .newActivateJobsCommand()
-              .jobType("type")
-              .maxJobsToActivate(1)
-              .tenantId(TENANT_A)
-              .timeout(Duration.ofMinutes(10))
-              .send()
-              .join()
-              .getJobs()
-              .get(0);
-    }
-
-    // when
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-      final Future<UpdateTimeoutJobResponse> result =
-          client.newUpdateTimeoutCommand(activatedJob).timeout(Duration.ofMinutes(11)).send();
-
-      // then
-      assertThat(result)
-          .failsWithin(Duration.ofSeconds(10))
-          .withThrowableThat()
-          .withMessageContaining("NOT_FOUND")
-          .withMessageContaining(
-              "Command 'UPDATE_TIMEOUT' rejected with code 'NOT_FOUND': Expected to update job with key '%d', but no such job was found"
-                  .formatted(activatedJob.getKey()));
-    }
-  }
-
-  @Test
-  void shouldNotFindJobWhenUnauthorized() {
-    // given
-    final ActivatedJob activatedJob;
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      client
-          .newDeployResourceCommand()
-          .addProcessModel(process, "process.bpmn")
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-      client
-          .newCreateInstanceCommand()
-          .bpmnProcessId(processId)
-          .latestVersion()
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-      activatedJob =
-          client
-              .newActivateJobsCommand()
-              .jobType("type")
-              .maxJobsToActivate(1)
-              .tenantId(TENANT_A)
-              .send()
-              .join()
-              .getJobs()
-              .get(0);
-    }
-
-    // when
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-      final Future<CompleteJobResponse> result = client.newCompleteCommand(activatedJob).send();
-
-      // then
-      assertThat(result)
-          .failsWithin(Duration.ofSeconds(10))
-          .withThrowableThat()
-          .withMessageContaining("NOT_FOUND")
-          .withMessageContaining(
-              "Command 'COMPLETE' rejected with code 'NOT_FOUND': Expected to update retries for job with key '%d', but no such job was found"
-                  .formatted(activatedJob.getKey()));
-    }
-  }
-
-  @Test
-  void shouldResolveIncidentForTenant() {
-    // given
-    process =
-        Bpmn.createExecutableProcess(processId)
-            .startEvent()
-            .zeebeOutputExpression("assert(foo, foo != null)", "target")
-            .endEvent()
-            .done();
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      client
-          .newDeployResourceCommand()
-          .addProcessModel(process, "process.bpmn")
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-      client
-          .newCreateInstanceCommand()
-          .bpmnProcessId(processId)
-          .latestVersion()
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-
-      final var incidentKey =
-          RecordingExporter.incidentRecords().withBpmnProcessId(processId).getFirst().getKey();
-
-      // when
-      final Future<ResolveIncidentResponse> result =
-          client.newResolveIncidentCommand(incidentKey).send();
-
-      // then
-      assertThat(result)
-          .describedAs(
-              "Expect that incident can be resolved as the client has access process of tenant-a")
-          .succeedsWithin(Duration.ofSeconds(10));
-    }
-  }
-
-  @Test
-  void shouldNotFindIncidentForTenantWhenUnauthorized() {
-    // given
-    process =
-        Bpmn.createExecutableProcess(processId)
-            .startEvent()
-            .zeebeOutputExpression("assert(foo, foo != null)", "target")
-            .endEvent()
-            .done();
-    final long incidentKey;
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      client
-          .newDeployResourceCommand()
-          .addProcessModel(process, "process.bpmn")
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-      client
-          .newCreateInstanceCommand()
-          .bpmnProcessId(processId)
-          .latestVersion()
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-
-      incidentKey =
-          RecordingExporter.incidentRecords().withBpmnProcessId(processId).getFirst().getKey();
-    }
-
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-      // when
-      final Future<ResolveIncidentResponse> result =
-          client.newResolveIncidentCommand(incidentKey).send();
-
-      // then
-      assertThat(result)
-          .failsWithin(Duration.ofSeconds(10))
-          .withThrowableThat()
-          .withMessageContaining("NOT_FOUND")
-          .withMessageContaining(
-              "Command 'RESOLVE' rejected with code 'NOT_FOUND': Expected to resolve incident with key '%d', but no such incident was found"
-                  .formatted(incidentKey));
-    }
-  }
-
-  @Test
-  void shouldAllowModifyProcessInstanceForDefaultTenant() {
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
-      // given
-      client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
-
-      final long processInstanceKey =
-          client
-              .newCreateInstanceCommand()
-              .bpmnProcessId(processId)
-              .latestVersion()
-              .send()
-              .join()
-              .getProcessInstanceKey();
-
-      // when
-      final Future<ModifyProcessInstanceResponse> response =
-          client.newModifyProcessInstanceCommand(processInstanceKey).activateElement("task").send();
-
-      // then
-      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
-    }
-  }
-
-  @Test
-  void shouldAllowModifyProcessInstanceForOtherTenant() {
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      // given
-      client
-          .newDeployResourceCommand()
-          .addProcessModel(process, "process.bpmn")
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-
-      final long processInstanceKey =
-          client
-              .newCreateInstanceCommand()
-              .bpmnProcessId(processId)
-              .latestVersion()
-              .tenantId(TENANT_A)
-              .send()
-              .join()
-              .getProcessInstanceKey();
-
-      // when
-      final Future<ModifyProcessInstanceResponse> response =
-          client.newModifyProcessInstanceCommand(processInstanceKey).activateElement("task").send();
-
-      // then
-      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
-    }
-  }
-
-  @Test
-  void shouldRejectModifyProcessInstanceForUnauthorizedTenant() {
-    final long processInstanceKey;
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      // given
-      client
-          .newDeployResourceCommand()
-          .addProcessModel(process, "process.bpmn")
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-
-      processInstanceKey =
-          client
-              .newCreateInstanceCommand()
-              .bpmnProcessId(processId)
-              .latestVersion()
-              .tenantId(TENANT_A)
-              .send()
-              .join()
-              .getProcessInstanceKey();
-    }
-
-    // when
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-      final Future<ModifyProcessInstanceResponse> response =
-          client.newModifyProcessInstanceCommand(processInstanceKey).activateElement("task").send();
-
-      // then
-      assertThat(response)
-          .failsWithin(Duration.ofSeconds(10))
-          .withThrowableThat()
-          .withMessageContaining("NOT_FOUND")
-          .withMessageContaining(
-              "Expected to modify process instance but no process instance found with key");
-    }
-  }
-
-  @Test
-  void shouldAllowMigrateProcessInstanceForDefaultTenant() {
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
-      // given
-      client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
-      final var deploymentResponse =
-          client
-              .newDeployResourceCommand()
-              .addProcessModel(migratedProcess, "migrated-process.bpmn")
-              .send()
-              .join();
-      final long targetProcessDefinitionKey =
-          deploymentResponse.getProcesses().get(0).getProcessDefinitionKey();
-
-      final long processInstanceKey =
-          client
-              .newCreateInstanceCommand()
-              .bpmnProcessId(processId)
-              .latestVersion()
-              .send()
-              .join()
-              .getProcessInstanceKey();
-
-      // when
-      final Future<MigrateProcessInstanceResponse> response =
-          client
-              .newMigrateProcessInstanceCommand(processInstanceKey)
-              .migrationPlan(targetProcessDefinitionKey)
-              .addMappingInstruction("task", "migrated-task")
-              .send();
-
-      // then
-      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
-    }
-  }
-
-  @Test
-  void shouldAllowMigrateProcessInstanceForOtherTenant() {
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      // given
-      client
-          .newDeployResourceCommand()
-          .addProcessModel(process, "process.bpmn")
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-      final var deploymentResponse =
-          client
-              .newDeployResourceCommand()
-              .addProcessModel(migratedProcess, "migrated-process.bpmn")
-              .tenantId(TENANT_A)
-              .send()
-              .join();
-      final long targetProcessDefinitionKey =
-          deploymentResponse.getProcesses().get(0).getProcessDefinitionKey();
-
-      final long processInstanceKey =
-          client
-              .newCreateInstanceCommand()
-              .bpmnProcessId(processId)
-              .latestVersion()
-              .tenantId(TENANT_A)
-              .send()
-              .join()
-              .getProcessInstanceKey();
-
-      // when
-      final Future<MigrateProcessInstanceResponse> response =
-          client
-              .newMigrateProcessInstanceCommand(processInstanceKey)
-              .migrationPlan(targetProcessDefinitionKey)
-              .addMappingInstruction("task", "migrated-task")
-              .send();
-
-      // then
-      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
-    }
-  }
-
-  @Test
-  void shouldRejectMigrateProcessInstanceForUnauthorizedTenant() {
-    final long processInstanceKey;
-    final long targetProcessDefinitionKey;
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      // given
-      client
-          .newDeployResourceCommand()
-          .addProcessModel(process, "process.bpmn")
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-      final var deploymentResponse =
-          client
-              .newDeployResourceCommand()
-              .addProcessModel(migratedProcess, "process.bpmn")
-              .tenantId(TENANT_A)
-              .send()
-              .join();
-      targetProcessDefinitionKey =
-          deploymentResponse.getProcesses().get(0).getProcessDefinitionKey();
-
-      processInstanceKey =
-          client
-              .newCreateInstanceCommand()
-              .bpmnProcessId(processId)
-              .latestVersion()
-              .tenantId(TENANT_A)
-              .send()
-              .join()
-              .getProcessInstanceKey();
-    }
-
-    // when
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
-      final Future<MigrateProcessInstanceResponse> response =
-          client
-              .newMigrateProcessInstanceCommand(processInstanceKey)
-              .migrationPlan(targetProcessDefinitionKey)
-              .addMappingInstruction("task", "migrated-task")
-              .send();
-
-      // then
-      assertThat(response)
-          .failsWithin(Duration.ofSeconds(10))
-          .withThrowableThat()
-          .withMessageContaining("NOT_FOUND")
-          .withMessageContaining(
-              String.format(
-                  "Expected to migrate process instance but no process instance found with key '%s'",
-                  processInstanceKey));
-    }
-  }
-
-  @Test
-  void shouldAllowEvaluateDecisionForDefaultTenant() {
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
-      // given
-      client
-          .newDeployResourceCommand()
-          .addResourceFromClasspath("dmn/decision-table.dmn")
-          .send()
-          .join();
-
-      // when
-      final Future<EvaluateDecisionResponse> response =
-          client
-              .newEvaluateDecisionCommand()
-              .decisionId("jedi_or_sith")
-              .variable("lightsaberColor", "blue")
-              .send();
-      // then
-      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
-    }
-  }
-
-  @Test
-  void shouldAllowEvaluateDecisionForCustomTenant() {
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
-      // given
-      client
-          .newDeployResourceCommand()
-          .addResourceFromClasspath("dmn/decision-table.dmn")
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-
-      // when
-      final Future<EvaluateDecisionResponse> response =
-          client
-              .newEvaluateDecisionCommand()
-              .decisionId("jedi_or_sith")
-              .variable("lightsaberColor", "blue")
-              .tenantId(TENANT_A)
-              .send();
-      // then
-      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
-    }
-  }
-
-  @Test
-  void shouldDenyEvaluateDecisionForCustomTenant() {
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
-      // given
-      client
-          .newDeployResourceCommand()
-          .addResourceFromClasspath("dmn/decision-table.dmn")
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-
-      // when
-      final Future<EvaluateDecisionResponse> response =
-          client
-              .newEvaluateDecisionCommand()
-              .decisionId("jedi_or_sith")
-              .variable("lightsaberColor", "blue")
-              .tenantId(TENANT_B)
-              .send();
-      // then
-      assertThat(response)
-          .failsWithin(Duration.ofSeconds(10))
-          .withThrowableThat()
-          .withMessageContaining("PERMISSION_DENIED")
-          .withMessageContaining(
-              "Expected to handle gRPC request EvaluateDecision with tenant identifier 'tenant-b'")
-          .withMessageContaining("but tenant is not authorized to perform this request");
-    }
-  }
-
-  @Test
-  void shouldStartInstanceWhenBroadcastSignalForTenant() {
-    final String signalName = "signal";
-    process =
-        Bpmn.createExecutableProcess(processId).startEvent().signal(signalName).endEvent().done();
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      // given
-      client
-          .newDeployResourceCommand()
-          .addProcessModel(process, "process.bpmn")
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-
-      // when
-      final Future<BroadcastSignalResponse> result =
-          client.newBroadcastSignalCommand().signalName(signalName).tenantId(TENANT_A).send();
-
-      // then
-      assertThat(result)
-          .describedAs(
-              "Expect that signal can be broadcast as the client has access to the process of 'tenant-a'")
-          .succeedsWithin(Duration.ofSeconds(20));
-    }
-  }
-
-  @Test
-  void shouldDenyBroadcastSignalWhenUnauthorized() {
-    final String signalName = "signal";
-    process =
-        Bpmn.createExecutableProcess(processId).startEvent().signal(signalName).endEvent().done();
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      // given
-      client
-          .newDeployResourceCommand()
-          .addProcessModel(process, "process.bpmn")
-          .tenantId(TENANT_A)
-          .send()
-          .join();
-
-      // when
-      final Future<BroadcastSignalResponse> result =
-          client.newBroadcastSignalCommand().signalName(signalName).tenantId(TENANT_B).send();
-
-      // then
-      assertThat(result)
-          .failsWithin(Duration.ofSeconds(10))
-          .withThrowableThat()
-          .withMessageContaining("PERMISSION_DENIED")
-          .withMessageContaining(
-              "Expected to handle gRPC request BroadcastSignal with tenant identifier 'tenant-b'")
-          .withMessageContaining("but tenant is not authorized to perform this request");
-    }
-  }
-
-  @Test
-  void shouldAllowAssignUserTaskForTenant() {
-    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
-        final var clientTenantB = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
-      // given
-      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
-      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
-
-      // when
-      final Future<AssignUserTaskResponse> result =
-          clientTenantB.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send();
-
-      // then
-      assertThat(result).succeedsWithin(Duration.ofSeconds(10));
-    }
-  }
-
-  @Test
-  void shouldRejectAssignUserTaskForTenant() {
-    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
-        final var skeletorClient = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
-      // given
-      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
-      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
-
-      // when
-      final Future<AssignUserTaskResponse> result =
-          skeletorClient.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send();
-
-      // then
-      assertThat(result)
-          .failsWithin(Duration.ofSeconds(10))
-          .withThrowableThat()
-          .havingCause()
-          .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
-          .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
-    }
-  }
-
-  @Test
-  void shouldAllowCompleteUserTaskForTenant() {
-    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
-        final var clientTenantB = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
-      // given
-      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
-      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
-
-      // when
-      final Future<CompleteUserTaskResponse> result =
-          clientTenantB.newUserTaskCompleteCommand(userTaskKey).send();
-
-      // then
-      assertThat(result).succeedsWithin(Duration.ofSeconds(10));
-    }
-  }
-
-  @Test
-  void shouldRejectCompleteUserTaskForTenant() {
-    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
-        final var invalidClient = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
-      // given
-      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
-      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
-
-      // when
-      final Future<CompleteUserTaskResponse> result =
-          invalidClient.newUserTaskCompleteCommand(userTaskKey).send();
-
-      // then
-      assertThat(result)
-          .failsWithin(Duration.ofSeconds(10))
-          .withThrowableThat()
-          .havingCause()
-          .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
-          .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
-    }
-  }
-
-  @Test
-  void shouldAllowUnassignUserTaskForTenant() {
-    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
-        final var clientTenantB = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
-      // given
-      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
-      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
-      clientTenantA.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send().join();
-
-      // when
-      final Future<UnassignUserTaskResponse> result =
-          clientTenantB.newUserTaskUnassignCommand(userTaskKey).send();
-
-      // then
-      assertThat(result).succeedsWithin(Duration.ofSeconds(10));
-    }
-  }
-
-  @Test
-  void shouldRejectUnassignUserTaskForTenant() {
-    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
-        final var invalidClient = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
-      // given
-      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
-      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
-      clientTenantA.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send().join();
-
-      // when
-      final Future<UnassignUserTaskResponse> result =
-          invalidClient.newUserTaskUnassignCommand(userTaskKey).send();
-
-      // then
-      assertThat(result)
-          .failsWithin(Duration.ofSeconds(10))
-          .withThrowableThat()
-          .havingCause()
-          .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
-          .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
-    }
-  }
-
-  @Test
-  void shouldAllowUpdateUserTaskForTenant() {
-    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
-        final var clientTenantB = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
-      // given
-      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
-      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
-
-      // when
-      final Future<UpdateUserTaskResponse> result =
-          clientTenantB.newUserTaskUpdateCommand(userTaskKey).candidateUsers("Skeletor").send();
-
-      // then
-      assertThat(result).succeedsWithin(Duration.ofSeconds(10));
-    }
-  }
-
-  @Test
-  void shouldRejectUpdateUserTaskForTenant() {
-    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
-        final var invalidClient = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
-      // given
-      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
-      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
-
-      // when
-      final Future<UpdateUserTaskResponse> result =
-          invalidClient.newUserTaskUpdateCommand(userTaskKey).candidateUsers("Skeletor").send();
-
-      // then
-      assertThat(result)
-          .failsWithin(Duration.ofSeconds(10))
-          .withThrowableThat()
-          .havingCause()
-          .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
-          .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
-    }
-  }
-
+  //
+  //  @ParameterizedTest
+  //  @MethodSource("provideTopologyCases")
+  //  void shouldAuthorizeTopologyRequestWithoutTenantAccess(
+  //      final UnaryOperator<TopologyRequestStep1> apiPicker) {
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
+  //      // when
+  //      final var topology = apiPicker.apply(client.newTopologyRequest()).send().join();
+  //
+  //      // then
+  //      assertThat(topology.getBrokers()).hasSize(1);
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldAuthorizeDeployProcess() {
+  //    // given
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      // when
+  //      final Future<DeploymentEvent> response =
+  //          client
+  //              .newDeployResourceCommand()
+  //              .addProcessModel(process, "process.bpmn")
+  //              .tenantId(TENANT_A)
+  //              .send();
+  //
+  //      // then
+  //      assertThat(response)
+  //          .describedAs("Expect that process can be deployed for tenant-a")
+  //          .succeedsWithin(Duration.ofSeconds(10));
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldDenyDeployResourceWhenUnauthorized() {
+  //    // given
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      // when
+  //      final Future<DeploymentEvent> result =
+  //          client
+  //              .newDeployResourceCommand()
+  //              .addProcessModel(process, "process.bpmn")
+  //              .tenantId(TENANT_B)
+  //              .send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .failsWithin(Duration.ofSeconds(10))
+  //          .withThrowableThat()
+  //          .withMessageContaining("PERMISSION_DENIED")
+  //          .withMessageContaining(
+  //              "Expected to handle gRPC request DeployResource with tenant identifier
+  // 'tenant-b'")
+  //          .withMessageContaining("but tenant is not authorized to perform this request");
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldDenyDeployResourceWhenUnauthorizedForDefaultTenant() {
+  //    // given
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_WITHOUT_DEFAULT_TENANT))
+  // {
+  //      // when
+  //      final Future<DeploymentEvent> result =
+  //          client
+  //              .newDeployResourceCommand()
+  //              .addProcessModel(process, "process.bpmn")
+  //              .tenantId(DEFAULT_TENANT)
+  //              .send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .failsWithin(Duration.ofSeconds(10))
+  //          .withThrowableThat()
+  //          .withMessageContaining("PERMISSION_DENIED")
+  //          .withMessageContaining(
+  //              "Expected to handle gRPC request DeployResource with tenant identifier
+  // '<default>'")
+  //          .withMessageContaining("but tenant is not authorized to perform this request");
+  //    }
+  //  }
+  //
+  //  @SuppressWarnings("deprecation")
+  //  @Test
+  //  void shouldDenyDeployProcessWhenUnauthorizedForDefaultTenant() {
+  //    // given
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_WITHOUT_DEFAULT_TENANT))
+  // {
+  //      // when
+  //      // note that deploy process command is always only for the default tenant
+  //      final Future<DeploymentEvent> result =
+  //          client.newDeployCommand().addProcessModel(process, "process.bpmn").send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .failsWithin(Duration.ofSeconds(10))
+  //          .withThrowableThat()
+  //          .withMessageContaining("PERMISSION_DENIED")
+  //          .withMessageContaining(
+  //              "Expected to handle gRPC request DeployProcess with tenant identifier
+  // '<default>'")
+  //          .withMessageContaining("but tenant is not authorized to perform this request");
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldAuthorizeDeleteResource() throws ExecutionException, InterruptedException {
+  //    // given
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      final Future<DeploymentEvent> deploymentResponse =
+  //          client
+  //              .newDeployResourceCommand()
+  //              .addProcessModel(process, "process.bpmn")
+  //              .tenantId(TENANT_A)
+  //              .send();
+  //      assertThat(deploymentResponse)
+  //          .describedAs("Expect that process was deployed for tenant-a")
+  //          .succeedsWithin(Duration.ofSeconds(10));
+  //      final long resourceKey =
+  //          deploymentResponse.get().getProcesses().get(0).getProcessDefinitionKey();
+  //
+  //      // when
+  //      final Future<DeleteResourceResponse> response =
+  //          client.newDeleteResourceCommand(resourceKey).send();
+  //
+  //      // then
+  //      assertThat(response)
+  //          .describedAs("Expect that process can be deleted for tenant-a")
+  //          .succeedsWithin(Duration.ofSeconds(10));
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldDenyDeleteResourceWhenUnauthorized() throws ExecutionException,
+  // InterruptedException {
+  //    // given
+  //    final long resourceKey;
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      final Future<DeploymentEvent> deploymentResponse =
+  //          client
+  //              .newDeployResourceCommand()
+  //              .addProcessModel(process, "process.bpmn")
+  //              .tenantId(TENANT_A)
+  //              .send();
+  //      assertThat(deploymentResponse)
+  //          .describedAs("Expect that process was deployed for tenant-a")
+  //          .succeedsWithin(Duration.ofSeconds(10));
+  //      resourceKey = deploymentResponse.get().getProcesses().get(0).getProcessDefinitionKey();
+  //    }
+  //
+  //    // when
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+  //      final Future<DeleteResourceResponse> response =
+  //          client.newDeleteResourceCommand(resourceKey).send();
+  //
+  //      // then
+  //      assertThat(response)
+  //          .failsWithin(Duration.ofSeconds(10))
+  //          .withThrowableThat()
+  //          .withMessageContaining("NOT_FOUND");
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldIncrementProcessVersionPerTenant() {
+  //    // given
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addProcessModel(process, "process.bpmn")
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //    }
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addProcessModel(process, "process.bpmn")
+  //          .tenantId(TENANT_B)
+  //          .send()
+  //          .join();
+  //    }
+  //
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+  //      // when
+  //      final var processV2 = Bpmn.createExecutableProcess(processId).startEvent().done();
+  //      final Future<DeploymentEvent> result =
+  //          client
+  //              .newDeployResourceCommand()
+  //              .addProcessModel(processV2, "process.bpmn")
+  //              .tenantId(TENANT_B)
+  //              .send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .succeedsWithin(Duration.ofSeconds(10))
+  //          .describedAs("Process version is incremented for tenant-b but not for tenant-a")
+  //          .extracting(deploymentEvent -> deploymentEvent.getProcesses().get(0))
+  //          .extracting(Process::getVersion, Process::getTenantId)
+  //          .containsExactly(2, TENANT_B);
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldAuthorizeCreateProcessInstance() {
+  //    // given
+  //    final long processDefinitionKey;
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
+  //      processDefinitionKey =
+  //          client
+  //              .newDeployResourceCommand()
+  //              .addProcessModel(process, "process.bpmn")
+  //              .tenantId(TENANT_A)
+  //              .send()
+  //              .join()
+  //              .getProcesses()
+  //              .stream()
+  //              .map(Process::getProcessDefinitionKey)
+  //              .findFirst()
+  //              .orElseThrow();
+  //
+  //      // when
+  //      final Future<ProcessInstanceEvent> result =
+  //          client
+  //              .newCreateInstanceCommand()
+  //              .processDefinitionKey(processDefinitionKey)
+  //              .tenantId(TENANT_A)
+  //              .send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .describedAs(
+  //              "Expect that process instance can be created as the client has access process of
+  // tenant-a")
+  //          .succeedsWithin(Duration.ofSeconds(10));
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldNotFindOtherTenantsProcessById() {
+  //    // given
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addProcessModel(process, "process.bpmn")
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //    }
+  //
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+  //      // when
+  //      final Future<ProcessInstanceEvent> result =
+  //          client
+  //              .newCreateInstanceCommand()
+  //              .bpmnProcessId(processId)
+  //              .latestVersion()
+  //              .tenantId(TENANT_B)
+  //              .send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .failsWithin(Duration.ofSeconds(10))
+  //          .withThrowableThat()
+  //          .describedAs("Process definition should exist for tenant-a but not for tenant-b")
+  //          .withMessageContaining("NOT_FOUND")
+  //          .withMessageContaining("Expected to find process definition with process ID")
+  //          .withMessageContaining("but none found");
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldNotFindOtherTenantsProcessByKey() {
+  //    // given
+  //    final long processDefinitionKey;
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      processDefinitionKey =
+  //          client
+  //              .newDeployResourceCommand()
+  //              .addProcessModel(process, "process.bpmn")
+  //              .tenantId(TENANT_A)
+  //              .send()
+  //              .join()
+  //              .getProcesses()
+  //              .stream()
+  //              .map(Process::getProcessDefinitionKey)
+  //              .findFirst()
+  //              .orElseThrow();
+  //    }
+  //
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+  //      // when
+  //      final Future<ProcessInstanceEvent> result =
+  //          client
+  //              .newCreateInstanceCommand()
+  //              .processDefinitionKey(processDefinitionKey)
+  //              .tenantId(TENANT_B)
+  //              .send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .failsWithin(Duration.ofSeconds(10))
+  //          .withThrowableThat()
+  //          .describedAs("Process definition should exist for tenant-a but not for tenant-b")
+  //          .withMessageContaining("NOT_FOUND")
+  //          .withMessageContaining("Expected to find process definition with key")
+  //          .withMessageContaining("but none found");
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldNotFindOtherTenantsProcessInCallActivity() {
+  //    // given
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addProcessModel(process, "process.bpmn")
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //    }
+  //
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addProcessModel(
+  //              Bpmn.createExecutableProcess("parent")
+  //                  .startEvent()
+  //                  .callActivity("call", c -> c.zeebeProcessId(processId))
+  //                  .endEvent()
+  //                  .done(),
+  //              "parent.bpmn")
+  //          .tenantId(TENANT_B)
+  //          .send()
+  //          .join();
+  //    }
+  //
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+  //      // when
+  //      client
+  //          .newCreateInstanceCommand()
+  //          .bpmnProcessId("parent")
+  //          .latestVersion()
+  //          .tenantId(TENANT_B)
+  //          .send();
+  //
+  //      // then
+  //      Assertions.assertThat(
+  //
+  // RecordingExporter.incidentRecords().withBpmnProcessId("parent").getFirst().getValue())
+  //          .hasErrorMessage(
+  //              "Expected process with BPMN process id '%s' to be deployed, but not found."
+  //                  .formatted(processId));
+  //    }
+  //  }
+  //
+  //  /**
+  //   * This test case may become obsolete when we allow shared processes definitions across
+  // tenants.
+  //   */
+  //  @Test
+  //  void shouldNotFindOtherTenantsProcessEvenWhenClientIsAuthorizedForTenant() {
+  //    // given
+  //    final long processDefinitionKey;
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
+  //      processDefinitionKey =
+  //          client
+  //              .newDeployResourceCommand()
+  //              .addProcessModel(process, "process.bpmn")
+  //              .tenantId(TENANT_A)
+  //              .send()
+  //              .join()
+  //              .getProcesses()
+  //              .stream()
+  //              .map(Process::getProcessDefinitionKey)
+  //              .findFirst()
+  //              .orElseThrow();
+  //    }
+  //
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
+  //      // when
+  //      final Future<ProcessInstanceEvent> result =
+  //          client
+  //              .newCreateInstanceCommand()
+  //              .processDefinitionKey(processDefinitionKey)
+  //              .tenantId(TENANT_B)
+  //              .send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .failsWithin(Duration.ofSeconds(10))
+  //          .withThrowableThat()
+  //          .describedAs("Process definition should exist for tenant-a but not for tenant-b")
+  //          .withMessageContaining("NOT_FOUND")
+  //          .withMessageContaining("Expected to find process definition with key")
+  //          .withMessageContaining("but none found");
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldStartProcessWhenPublishingMessageForTenant() {
+  //    // given
+  //    final String messageName = "message";
+  //    process =
+  //
+  // Bpmn.createExecutableProcess(processId).startEvent().message(messageName).endEvent().done();
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addProcessModel(process, "process.bpmn")
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //
+  //      // when
+  //      final Future<PublishMessageResponse> result =
+  //          client
+  //              .newPublishMessageCommand()
+  //              .messageName(messageName)
+  //              .withoutCorrelationKey()
+  //              .tenantId(TENANT_A)
+  //              .send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .describedAs(
+  //              "Expect that message can be published as the client has access process of
+  // tenant-a")
+  //          .succeedsWithin(Duration.ofSeconds(10));
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldDenyPublishMessageWhenUnauthorized() {
+  //    // given
+  //    final String messageName = "message";
+  //    process =
+  //
+  // Bpmn.createExecutableProcess(processId).startEvent().message(messageName).endEvent().done();
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addProcessModel(process, "process.bpmn")
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //
+  //      // when
+  //      final Future<PublishMessageResponse> result =
+  //          client
+  //              .newPublishMessageCommand()
+  //              .messageName(messageName)
+  //              .withoutCorrelationKey()
+  //              .tenantId(TENANT_B)
+  //              .send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .failsWithin(Duration.ofSeconds(10))
+  //          .withThrowableThat()
+  //          .withMessageContaining("PERMISSION_DENIED")
+  //          .withMessageContaining(
+  //              "Expected to handle gRPC request PublishMessage with tenant identifier
+  // 'tenant-b'")
+  //          .withMessageContaining("but tenant is not authorized to perform this request");
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldActivateJobForTenant() {
+  //    // given
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addProcessModel(process, "process.bpmn")
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //      client
+  //          .newCreateInstanceCommand()
+  //          .bpmnProcessId(processId)
+  //          .latestVersion()
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //
+  //      // when
+  //      final Future<ActivateJobsResponse> result =
+  //          client
+  //              .newActivateJobsCommand()
+  //              .jobType("type")
+  //              .maxJobsToActivate(1)
+  //              .tenantId(TENANT_A)
+  //              .send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .describedAs(
+  //              "Expect that job can be activated as the client has access process of tenant-a")
+  //          .succeedsWithin(Duration.ofSeconds(10));
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldDenyActivateJobWhenUnauthorized() {
+  //    // given
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addProcessModel(process, "process.bpmn")
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //      client
+  //          .newCreateInstanceCommand()
+  //          .bpmnProcessId(processId)
+  //          .latestVersion()
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //    }
+  //
+  //    // when
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+  //      final Future<ActivateJobsResponse> result =
+  //          client
+  //              .newActivateJobsCommand()
+  //              .jobType("type")
+  //              .maxJobsToActivate(1)
+  //              .tenantId(TENANT_A)
+  //              .send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .failsWithin(Duration.ofSeconds(10))
+  //          .withThrowableThat()
+  //          .withMessageContaining("PERMISSION_DENIED")
+  //          .withMessageContaining(
+  //              "Expected to handle gRPC request ActivateJobs with tenant identifier 'tenant-a'")
+  //          .withMessageContaining("but tenant is not authorized to perform this request");
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldCompleteJobForTenant() {
+  //    // given
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addProcessModel(process, "process.bpmn")
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //      client
+  //          .newCreateInstanceCommand()
+  //          .bpmnProcessId(processId)
+  //          .latestVersion()
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //
+  //      final var activatedJob =
+  //          client
+  //              .newActivateJobsCommand()
+  //              .jobType("type")
+  //              .maxJobsToActivate(1)
+  //              .tenantId(TENANT_A)
+  //              .send()
+  //              .join()
+  //              .getJobs()
+  //              .get(0);
+  //
+  //      // when
+  //      final Future<CompleteJobResponse> result = client.newCompleteCommand(activatedJob).send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .describedAs(
+  //              "Expect that job can be competed as the client has access process of tenant-a")
+  //          .succeedsWithin(Duration.ofSeconds(10));
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldCompleteUserTaskForTenant() {
+  //    // given
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addProcessModel(process, "process.bpmn")
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //      client
+  //          .newCreateInstanceCommand()
+  //          .bpmnProcessId(processId)
+  //          .latestVersion()
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //
+  //      final var activatedJob =
+  //          client
+  //              .newActivateJobsCommand()
+  //              .jobType("type")
+  //              .maxJobsToActivate(1)
+  //              .tenantId(TENANT_A)
+  //              .send()
+  //              .join()
+  //              .getJobs()
+  //              .get(0);
+  //
+  //      // when
+  //      final Future<CompleteJobResponse> result = client.newCompleteCommand(activatedJob).send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .describedAs(
+  //              "Expect that job can be competed as the client has access process of tenant-a")
+  //          .succeedsWithin(Duration.ofSeconds(10));
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldUpdateJobTimeoutForTenant() {
+  //    // given
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addProcessModel(process, "process.bpmn")
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //      client
+  //          .newCreateInstanceCommand()
+  //          .bpmnProcessId(processId)
+  //          .latestVersion()
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //
+  //      final var activatedJob =
+  //          client
+  //              .newActivateJobsCommand()
+  //              .jobType("type")
+  //              .maxJobsToActivate(1)
+  //              .tenantId(TENANT_A)
+  //              .timeout(Duration.ofMinutes(10))
+  //              .send()
+  //              .join()
+  //              .getJobs()
+  //              .get(0);
+  //
+  //      // when
+  //      final Future<UpdateTimeoutJobResponse> result =
+  //          client.newUpdateTimeoutCommand(activatedJob).timeout(Duration.ofMinutes(11)).send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .describedAs(
+  //              "Expect that job timeout can be updated as the client has access process of
+  // tenant-a")
+  //          .succeedsWithin(Duration.ofSeconds(10));
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldNotUpdateJobTimeoutWhenUnauthorized() {
+  //    // given
+  //    final ActivatedJob activatedJob;
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addProcessModel(process, "process.bpmn")
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //      client
+  //          .newCreateInstanceCommand()
+  //          .bpmnProcessId(processId)
+  //          .latestVersion()
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //      activatedJob =
+  //          client
+  //              .newActivateJobsCommand()
+  //              .jobType("type")
+  //              .maxJobsToActivate(1)
+  //              .tenantId(TENANT_A)
+  //              .timeout(Duration.ofMinutes(10))
+  //              .send()
+  //              .join()
+  //              .getJobs()
+  //              .get(0);
+  //    }
+  //
+  //    // when
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+  //      final Future<UpdateTimeoutJobResponse> result =
+  //          client.newUpdateTimeoutCommand(activatedJob).timeout(Duration.ofMinutes(11)).send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .failsWithin(Duration.ofSeconds(10))
+  //          .withThrowableThat()
+  //          .withMessageContaining("NOT_FOUND")
+  //          .withMessageContaining(
+  //              "Command 'UPDATE_TIMEOUT' rejected with code 'NOT_FOUND': Expected to update job
+  // with key '%d', but no such job was found"
+  //                  .formatted(activatedJob.getKey()));
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldNotFindJobWhenUnauthorized() {
+  //    // given
+  //    final ActivatedJob activatedJob;
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addProcessModel(process, "process.bpmn")
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //      client
+  //          .newCreateInstanceCommand()
+  //          .bpmnProcessId(processId)
+  //          .latestVersion()
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //      activatedJob =
+  //          client
+  //              .newActivateJobsCommand()
+  //              .jobType("type")
+  //              .maxJobsToActivate(1)
+  //              .tenantId(TENANT_A)
+  //              .send()
+  //              .join()
+  //              .getJobs()
+  //              .get(0);
+  //    }
+  //
+  //    // when
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+  //      final Future<CompleteJobResponse> result = client.newCompleteCommand(activatedJob).send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .failsWithin(Duration.ofSeconds(10))
+  //          .withThrowableThat()
+  //          .withMessageContaining("NOT_FOUND")
+  //          .withMessageContaining(
+  //              "Command 'COMPLETE' rejected with code 'NOT_FOUND': Expected to update retries for
+  // job with key '%d', but no such job was found"
+  //                  .formatted(activatedJob.getKey()));
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldResolveIncidentForTenant() {
+  //    // given
+  //    process =
+  //        Bpmn.createExecutableProcess(processId)
+  //            .startEvent()
+  //            .zeebeOutputExpression("assert(foo, foo != null)", "target")
+  //            .endEvent()
+  //            .done();
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addProcessModel(process, "process.bpmn")
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //      client
+  //          .newCreateInstanceCommand()
+  //          .bpmnProcessId(processId)
+  //          .latestVersion()
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //
+  //      final var incidentKey =
+  //          RecordingExporter.incidentRecords().withBpmnProcessId(processId).getFirst().getKey();
+  //
+  //      // when
+  //      final Future<ResolveIncidentResponse> result =
+  //          client.newResolveIncidentCommand(incidentKey).send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .describedAs(
+  //              "Expect that incident can be resolved as the client has access process of
+  // tenant-a")
+  //          .succeedsWithin(Duration.ofSeconds(10));
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldNotFindIncidentForTenantWhenUnauthorized() {
+  //    // given
+  //    process =
+  //        Bpmn.createExecutableProcess(processId)
+  //            .startEvent()
+  //            .zeebeOutputExpression("assert(foo, foo != null)", "target")
+  //            .endEvent()
+  //            .done();
+  //    final long incidentKey;
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addProcessModel(process, "process.bpmn")
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //      client
+  //          .newCreateInstanceCommand()
+  //          .bpmnProcessId(processId)
+  //          .latestVersion()
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //
+  //      incidentKey =
+  //          RecordingExporter.incidentRecords().withBpmnProcessId(processId).getFirst().getKey();
+  //    }
+  //
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+  //      // when
+  //      final Future<ResolveIncidentResponse> result =
+  //          client.newResolveIncidentCommand(incidentKey).send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .failsWithin(Duration.ofSeconds(10))
+  //          .withThrowableThat()
+  //          .withMessageContaining("NOT_FOUND")
+  //          .withMessageContaining(
+  //              "Command 'RESOLVE' rejected with code 'NOT_FOUND': Expected to resolve incident
+  // with key '%d', but no such incident was found"
+  //                  .formatted(incidentKey));
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldAllowModifyProcessInstanceForDefaultTenant() {
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
+  //      // given
+  //      client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
+  //
+  //      final long processInstanceKey =
+  //          client
+  //              .newCreateInstanceCommand()
+  //              .bpmnProcessId(processId)
+  //              .latestVersion()
+  //              .send()
+  //              .join()
+  //              .getProcessInstanceKey();
+  //
+  //      // when
+  //      final Future<ModifyProcessInstanceResponse> response =
+  //
+  // client.newModifyProcessInstanceCommand(processInstanceKey).activateElement("task").send();
+  //
+  //      // then
+  //      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldAllowModifyProcessInstanceForOtherTenant() {
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      // given
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addProcessModel(process, "process.bpmn")
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //
+  //      final long processInstanceKey =
+  //          client
+  //              .newCreateInstanceCommand()
+  //              .bpmnProcessId(processId)
+  //              .latestVersion()
+  //              .tenantId(TENANT_A)
+  //              .send()
+  //              .join()
+  //              .getProcessInstanceKey();
+  //
+  //      // when
+  //      final Future<ModifyProcessInstanceResponse> response =
+  //
+  // client.newModifyProcessInstanceCommand(processInstanceKey).activateElement("task").send();
+  //
+  //      // then
+  //      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldRejectModifyProcessInstanceForUnauthorizedTenant() {
+  //    final long processInstanceKey;
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      // given
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addProcessModel(process, "process.bpmn")
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //
+  //      processInstanceKey =
+  //          client
+  //              .newCreateInstanceCommand()
+  //              .bpmnProcessId(processId)
+  //              .latestVersion()
+  //              .tenantId(TENANT_A)
+  //              .send()
+  //              .join()
+  //              .getProcessInstanceKey();
+  //    }
+  //
+  //    // when
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+  //      final Future<ModifyProcessInstanceResponse> response =
+  //
+  // client.newModifyProcessInstanceCommand(processInstanceKey).activateElement("task").send();
+  //
+  //      // then
+  //      assertThat(response)
+  //          .failsWithin(Duration.ofSeconds(10))
+  //          .withThrowableThat()
+  //          .withMessageContaining("NOT_FOUND")
+  //          .withMessageContaining(
+  //              "Expected to modify process instance but no process instance found with key");
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldAllowMigrateProcessInstanceForDefaultTenant() {
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
+  //      // given
+  //      client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
+  //      final var deploymentResponse =
+  //          client
+  //              .newDeployResourceCommand()
+  //              .addProcessModel(migratedProcess, "migrated-process.bpmn")
+  //              .send()
+  //              .join();
+  //      final long targetProcessDefinitionKey =
+  //          deploymentResponse.getProcesses().get(0).getProcessDefinitionKey();
+  //
+  //      final long processInstanceKey =
+  //          client
+  //              .newCreateInstanceCommand()
+  //              .bpmnProcessId(processId)
+  //              .latestVersion()
+  //              .send()
+  //              .join()
+  //              .getProcessInstanceKey();
+  //
+  //      // when
+  //      final Future<MigrateProcessInstanceResponse> response =
+  //          client
+  //              .newMigrateProcessInstanceCommand(processInstanceKey)
+  //              .migrationPlan(targetProcessDefinitionKey)
+  //              .addMappingInstruction("task", "migrated-task")
+  //              .send();
+  //
+  //      // then
+  //      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldAllowMigrateProcessInstanceForOtherTenant() {
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      // given
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addProcessModel(process, "process.bpmn")
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //      final var deploymentResponse =
+  //          client
+  //              .newDeployResourceCommand()
+  //              .addProcessModel(migratedProcess, "migrated-process.bpmn")
+  //              .tenantId(TENANT_A)
+  //              .send()
+  //              .join();
+  //      final long targetProcessDefinitionKey =
+  //          deploymentResponse.getProcesses().get(0).getProcessDefinitionKey();
+  //
+  //      final long processInstanceKey =
+  //          client
+  //              .newCreateInstanceCommand()
+  //              .bpmnProcessId(processId)
+  //              .latestVersion()
+  //              .tenantId(TENANT_A)
+  //              .send()
+  //              .join()
+  //              .getProcessInstanceKey();
+  //
+  //      // when
+  //      final Future<MigrateProcessInstanceResponse> response =
+  //          client
+  //              .newMigrateProcessInstanceCommand(processInstanceKey)
+  //              .migrationPlan(targetProcessDefinitionKey)
+  //              .addMappingInstruction("task", "migrated-task")
+  //              .send();
+  //
+  //      // then
+  //      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldRejectMigrateProcessInstanceForUnauthorizedTenant() {
+  //    final long processInstanceKey;
+  //    final long targetProcessDefinitionKey;
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      // given
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addProcessModel(process, "process.bpmn")
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //      final var deploymentResponse =
+  //          client
+  //              .newDeployResourceCommand()
+  //              .addProcessModel(migratedProcess, "process.bpmn")
+  //              .tenantId(TENANT_A)
+  //              .send()
+  //              .join();
+  //      targetProcessDefinitionKey =
+  //          deploymentResponse.getProcesses().get(0).getProcessDefinitionKey();
+  //
+  //      processInstanceKey =
+  //          client
+  //              .newCreateInstanceCommand()
+  //              .bpmnProcessId(processId)
+  //              .latestVersion()
+  //              .tenantId(TENANT_A)
+  //              .send()
+  //              .join()
+  //              .getProcessInstanceKey();
+  //    }
+  //
+  //    // when
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+  //      final Future<MigrateProcessInstanceResponse> response =
+  //          client
+  //              .newMigrateProcessInstanceCommand(processInstanceKey)
+  //              .migrationPlan(targetProcessDefinitionKey)
+  //              .addMappingInstruction("task", "migrated-task")
+  //              .send();
+  //
+  //      // then
+  //      assertThat(response)
+  //          .failsWithin(Duration.ofSeconds(10))
+  //          .withThrowableThat()
+  //          .withMessageContaining("NOT_FOUND")
+  //          .withMessageContaining(
+  //              String.format(
+  //                  "Expected to migrate process instance but no process instance found with key
+  // '%s'",
+  //                  processInstanceKey));
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldAllowEvaluateDecisionForDefaultTenant() {
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
+  //      // given
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addResourceFromClasspath("dmn/decision-table.dmn")
+  //          .send()
+  //          .join();
+  //
+  //      // when
+  //      final Future<EvaluateDecisionResponse> response =
+  //          client
+  //              .newEvaluateDecisionCommand()
+  //              .decisionId("jedi_or_sith")
+  //              .variable("lightsaberColor", "blue")
+  //              .send();
+  //      // then
+  //      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldAllowEvaluateDecisionForCustomTenant() {
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
+  //      // given
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addResourceFromClasspath("dmn/decision-table.dmn")
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //
+  //      // when
+  //      final Future<EvaluateDecisionResponse> response =
+  //          client
+  //              .newEvaluateDecisionCommand()
+  //              .decisionId("jedi_or_sith")
+  //              .variable("lightsaberColor", "blue")
+  //              .tenantId(TENANT_A)
+  //              .send();
+  //      // then
+  //      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldDenyEvaluateDecisionForCustomTenant() {
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
+  //      // given
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addResourceFromClasspath("dmn/decision-table.dmn")
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //
+  //      // when
+  //      final Future<EvaluateDecisionResponse> response =
+  //          client
+  //              .newEvaluateDecisionCommand()
+  //              .decisionId("jedi_or_sith")
+  //              .variable("lightsaberColor", "blue")
+  //              .tenantId(TENANT_B)
+  //              .send();
+  //      // then
+  //      assertThat(response)
+  //          .failsWithin(Duration.ofSeconds(10))
+  //          .withThrowableThat()
+  //          .withMessageContaining("PERMISSION_DENIED")
+  //          .withMessageContaining(
+  //              "Expected to handle gRPC request EvaluateDecision with tenant identifier
+  // 'tenant-b'")
+  //          .withMessageContaining("but tenant is not authorized to perform this request");
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldStartInstanceWhenBroadcastSignalForTenant() {
+  //    final String signalName = "signal";
+  //    process =
+  //
+  // Bpmn.createExecutableProcess(processId).startEvent().signal(signalName).endEvent().done();
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      // given
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addProcessModel(process, "process.bpmn")
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //
+  //      // when
+  //      final Future<BroadcastSignalResponse> result =
+  //          client.newBroadcastSignalCommand().signalName(signalName).tenantId(TENANT_A).send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .describedAs(
+  //              "Expect that signal can be broadcast as the client has access to the process of
+  // 'tenant-a'")
+  //          .succeedsWithin(Duration.ofSeconds(20));
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldDenyBroadcastSignalWhenUnauthorized() {
+  //    final String signalName = "signal";
+  //    process =
+  //
+  // Bpmn.createExecutableProcess(processId).startEvent().signal(signalName).endEvent().done();
+  //    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+  //      // given
+  //      client
+  //          .newDeployResourceCommand()
+  //          .addProcessModel(process, "process.bpmn")
+  //          .tenantId(TENANT_A)
+  //          .send()
+  //          .join();
+  //
+  //      // when
+  //      final Future<BroadcastSignalResponse> result =
+  //          client.newBroadcastSignalCommand().signalName(signalName).tenantId(TENANT_B).send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .failsWithin(Duration.ofSeconds(10))
+  //          .withThrowableThat()
+  //          .withMessageContaining("PERMISSION_DENIED")
+  //          .withMessageContaining(
+  //              "Expected to handle gRPC request BroadcastSignal with tenant identifier
+  // 'tenant-b'")
+  //          .withMessageContaining("but tenant is not authorized to perform this request");
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldAllowAssignUserTaskForTenant() {
+  //    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
+  //        final var clientTenantB = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
+  //      // given
+  //      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+  //      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+  //
+  //      // when
+  //      final Future<AssignUserTaskResponse> result =
+  //          clientTenantB.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send();
+  //
+  //      // then
+  //      assertThat(result).succeedsWithin(Duration.ofSeconds(10));
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldRejectAssignUserTaskForTenant() {
+  //    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
+  //        final var skeletorClient = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
+  //      // given
+  //      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+  //      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+  //
+  //      // when
+  //      final Future<AssignUserTaskResponse> result =
+  //          skeletorClient.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .failsWithin(Duration.ofSeconds(10))
+  //          .withThrowableThat()
+  //          .havingCause()
+  //          .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
+  //          .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldAllowCompleteUserTaskForTenant() {
+  //    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
+  //        final var clientTenantB = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
+  //      // given
+  //      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+  //      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+  //
+  //      // when
+  //      final Future<CompleteUserTaskResponse> result =
+  //          clientTenantB.newUserTaskCompleteCommand(userTaskKey).send();
+  //
+  //      // then
+  //      assertThat(result).succeedsWithin(Duration.ofSeconds(10));
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldRejectCompleteUserTaskForTenant() {
+  //    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
+  //        final var invalidClient = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
+  //      // given
+  //      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+  //      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+  //
+  //      // when
+  //      final Future<CompleteUserTaskResponse> result =
+  //          invalidClient.newUserTaskCompleteCommand(userTaskKey).send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .failsWithin(Duration.ofSeconds(10))
+  //          .withThrowableThat()
+  //          .havingCause()
+  //          .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
+  //          .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldAllowUnassignUserTaskForTenant() {
+  //    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
+  //        final var clientTenantB = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
+  //      // given
+  //      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+  //      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+  //      clientTenantA.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send().join();
+  //
+  //      // when
+  //      final Future<UnassignUserTaskResponse> result =
+  //          clientTenantB.newUserTaskUnassignCommand(userTaskKey).send();
+  //
+  //      // then
+  //      assertThat(result).succeedsWithin(Duration.ofSeconds(10));
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldRejectUnassignUserTaskForTenant() {
+  //    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
+  //        final var invalidClient = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
+  //      // given
+  //      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+  //      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+  //      clientTenantA.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send().join();
+  //
+  //      // when
+  //      final Future<UnassignUserTaskResponse> result =
+  //          invalidClient.newUserTaskUnassignCommand(userTaskKey).send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .failsWithin(Duration.ofSeconds(10))
+  //          .withThrowableThat()
+  //          .havingCause()
+  //          .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
+  //          .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldAllowUpdateUserTaskForTenant() {
+  //    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
+  //        final var clientTenantB = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
+  //      // given
+  //      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+  //      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+  //
+  //      // when
+  //      final Future<UpdateUserTaskResponse> result =
+  //          clientTenantB.newUserTaskUpdateCommand(userTaskKey).candidateUsers("Skeletor").send();
+  //
+  //      // then
+  //      assertThat(result).succeedsWithin(Duration.ofSeconds(10));
+  //    }
+  //  }
+  //
+  //  @Test
+  //  void shouldRejectUpdateUserTaskForTenant() {
+  //    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
+  //        final var invalidClient = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
+  //      // given
+  //      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+  //      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+  //
+  //      // when
+  //      final Future<UpdateUserTaskResponse> result =
+  //          invalidClient.newUserTaskUpdateCommand(userTaskKey).candidateUsers("Skeletor").send();
+  //
+  //      // then
+  //      assertThat(result)
+  //          .failsWithin(Duration.ofSeconds(10))
+  //          .withThrowableThat()
+  //          .havingCause()
+  //          .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
+  //          .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
+  //    }
+  //  }
+  //
   private static Stream<Named<UnaryOperator<TopologyRequestStep1>>> provideTopologyCases() {
     return Stream.of(
         Named.of("grpc", TopologyRequestStep1::useGrpc),

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -51,7 +51,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
-import org.apache.http.HttpStatus;
+import org.apache.hc.core5.http.HttpStatus;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -72,7 +72,7 @@ public class MultiTenancyOverIdentityIT {
       TestSearchContainers.createDefeaultElasticsearchContainer();
 
   private static final String DEFAULT_TENANT = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
-  private static final String TENANT_A = "tenanA";
+  private static final String TENANT_A = "tenantA";
   private static final String TENANT_B = "tenantB";
   private static final String USER_TENANT_A = "userTenantA";
   private static final String USER_TENANT_B = "userTenantB";

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -9,211 +9,76 @@ package io.camunda.zeebe.it.multitenancy;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import dasniko.testcontainers.keycloak.KeycloakContainer;
-import io.camunda.application.Profile;
-import io.camunda.identity.sdk.Identity;
-import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.command.ProblemException;
-import io.camunda.zeebe.client.api.command.TopologyRequestStep1;
-import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
-import io.camunda.zeebe.client.api.response.ActivatedJob;
-import io.camunda.zeebe.client.api.response.AssignUserTaskResponse;
-import io.camunda.zeebe.client.api.response.BroadcastSignalResponse;
-import io.camunda.zeebe.client.api.response.CompleteJobResponse;
-import io.camunda.zeebe.client.api.response.CompleteUserTaskResponse;
-import io.camunda.zeebe.client.api.response.DeleteResourceResponse;
-import io.camunda.zeebe.client.api.response.DeploymentEvent;
-import io.camunda.zeebe.client.api.response.EvaluateDecisionResponse;
-import io.camunda.zeebe.client.api.response.MigrateProcessInstanceResponse;
-import io.camunda.zeebe.client.api.response.ModifyProcessInstanceResponse;
-import io.camunda.zeebe.client.api.response.Process;
-import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
-import io.camunda.zeebe.client.api.response.PublishMessageResponse;
-import io.camunda.zeebe.client.api.response.ResolveIncidentResponse;
-import io.camunda.zeebe.client.api.response.UnassignUserTaskResponse;
-import io.camunda.zeebe.client.api.response.UpdateTimeoutJobResponse;
-import io.camunda.zeebe.client.api.response.UpdateUserTaskResponse;
-import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder;
-import io.camunda.zeebe.gateway.impl.configuration.AuthenticationCfg.AuthMode;
-import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.TopologyRequestStep1;
+import io.camunda.client.impl.basicauth.BasicAuthCredentialsProviderBuilder;
+import io.camunda.security.configuration.ConfiguredUser;
+import io.camunda.zeebe.it.util.AuthorizationsUtil;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
-import io.camunda.zeebe.qa.util.cluster.TestHealthProbe;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import io.camunda.zeebe.qa.util.testcontainers.DefaultTestContainers;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.Strings;
-import io.camunda.zeebe.test.util.junit.AutoCloseResources;
-import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
-import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
-import java.nio.file.Path;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
-import org.apache.hc.core5.http.HttpStatus;
-import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Named;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.Network;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
-import org.testcontainers.images.PullPolicy;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
 
-/** Verifies that data can be isolated per tenant using Identity as the tenant provider. */
 @Testcontainers
-@AutoCloseResources
+@ZeebeIntegration
 public class MultiTenancyOverIdentityIT {
 
-  private static final String IDENTITY_SNAPSHOT_TAG = "SNAPSHOT";
-  @TempDir private static Path credentialsCacheDir;
+  @Container
+  private static final ElasticsearchContainer CONTAINER =
+      TestSearchContainers.createDefeaultElasticsearchContainer();
+
   private static final String DEFAULT_TENANT = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
-  private static final String DATABASE_HOST = "postgres";
-  private static final int DATABASE_PORT = 5432;
-  private static final String DATABASE_USER = "postgres";
-  private static final String DATABASE_PASSWORD = "zecret";
-  private static final String DATABASE_NAME = "postgres";
+  private static final String TENANT_A = "tenanA";
+  private static final String TENANT_B = "tenantB";
+  private static final String USER_TENANT_A = "userTenantA";
+  private static final String USER_TENANT_B = "userTenantB";
+  private static final String USER_TENANT_A_AND_B = "userTenantAB";
+  private static final String USER_TENANT_A_WITHOUT_DEFAULT_TENANT = "userTenantANoDefault";
 
-  private static final String KEYCLOAK_USER = "admin";
-  private static final String KEYCLOAK_PASSWORD = "admin";
-  private static final String KEYCLOAK_PATH_CAMUNDA_REALM = "/realms/camunda-platform";
-  private static final String ZEEBE_CLIENT_ID_TENANT_A = "zeebe-tenant-a-and-default";
-  private static final String ZEEBE_CLIENT_ID_TENANT_A_WITHOUT_DEFAULT_TENANT =
-      "zeebe-tenant-a-without-default";
-  private static final String ZEEBE_CLIENT_ID_TENANT_B = "zeebe-tenant-b-and-default";
-  private static final String ZEEBE_CLIENT_ID_TENANT_A_AND_B = "zeebe-tenant-a-and-b-and-default";
-  private static final String ZEEBE_CLIENT_ID_TENANT_DEFAULT = ZEEBE_CLIENT_ID_TENANT_A;
-  private static final String ZEEBE_CLIENT_ID_WITHOUT_TENANT = "zeebe-without-tenant";
-  private static final String ZEEBE_CLIENT_AUDIENCE = "zeebe-api";
-  private static final String ZEEBE_CLIENT_SECRET = "zecret";
-
-  private static final Network NETWORK = Network.newNetwork();
-
-  @Container
-  @SuppressWarnings("resource")
-  private static final PostgreSQLContainer<?> POSTGRES =
-      new PostgreSQLContainer<>("postgres:15.0-alpine")
-          .withExposedPorts(DATABASE_PORT)
-          .withDatabaseName(DATABASE_NAME)
-          .withUsername(DATABASE_USER)
-          .withPassword(DATABASE_PASSWORD)
-          .withNetwork(NETWORK)
-          .withNetworkAliases(DATABASE_HOST);
-
-  @Container
-  private static final KeycloakContainer KEYCLOAK =
-      DefaultTestContainers.createDefaultKeycloak()
-          .withEnv("KEYCLOAK_ADMIN_USER", KEYCLOAK_USER)
-          .withEnv("KEYCLOAK_ADMIN_PASSWORD", KEYCLOAK_PASSWORD)
-          .withEnv("KEYCLOAK_DATABASE_VENDOR", "dev-mem")
-          .withNetwork(NETWORK)
-          .withNetworkAliases("keycloak")
-          .withExposedPorts(8080);
-
-  @Container
-  @SuppressWarnings("resource")
-  private static final GenericContainer<?> IDENTITY =
-      new GenericContainer<>(
-              DockerImageName.parse("camunda/identity").withTag(getIdentityImageTag()))
-          .withImagePullPolicy(
-              System.getProperty("identity.docker.image.version", "SNAPSHOT").equals("SNAPSHOT")
-                  ? PullPolicy.alwaysPull()
-                  : PullPolicy.defaultPolicy())
-          .dependsOn(POSTGRES, KEYCLOAK)
-          .withEnv("MULTITENANCY_ENABLED", "true")
-          .withEnv("RESOURCE_AUTHORIZATIONS_ENABLED", "true")
-          .withEnv("IDENTITY_LOG_LEVEL", "TRACE")
-          .withEnv("logging_level_org_springframework_security", "DEBUG")
-          .withEnv("LOGGING_LEVEL_org.springframework", "DEBUG")
-          .withEnv("KEYCLOAK_URL", "http://keycloak:8080")
-          .withEnv(
-              "IDENTITY_AUTH_PROVIDER_BACKEND_URL",
-              "http://keycloak:8080" + KEYCLOAK_PATH_CAMUNDA_REALM)
-          .withEnv("KEYCLOAK_SETUP_USER", KEYCLOAK_USER)
-          .withEnv("KEYCLOAK_SETUP_PASSWORD", KEYCLOAK_PASSWORD)
-          .withEnv("KEYCLOAK_INIT_ZEEBE_SECRET", ZEEBE_CLIENT_SECRET)
-          .withEnv("KEYCLOAK_CLIENTS_0_NAME", ZEEBE_CLIENT_ID_TENANT_A)
-          .withEnv("KEYCLOAK_CLIENTS_0_ID", ZEEBE_CLIENT_ID_TENANT_A)
-          .withEnv("KEYCLOAK_CLIENTS_0_SECRET", ZEEBE_CLIENT_SECRET)
-          .withEnv("KEYCLOAK_CLIENTS_0_TYPE", "m2m")
-          .withEnv("KEYCLOAK_CLIENTS_0_PERMISSIONS_0_RESOURCE_SERVER_ID", ZEEBE_CLIENT_AUDIENCE)
-          .withEnv("KEYCLOAK_CLIENTS_0_PERMISSIONS_0_DEFINITION", "write:*")
-          .withEnv("KEYCLOAK_CLIENTS_4_NAME", ZEEBE_CLIENT_ID_TENANT_A_WITHOUT_DEFAULT_TENANT)
-          .withEnv("KEYCLOAK_CLIENTS_4_ID", ZEEBE_CLIENT_ID_TENANT_A_WITHOUT_DEFAULT_TENANT)
-          .withEnv("KEYCLOAK_CLIENTS_4_SECRET", ZEEBE_CLIENT_SECRET)
-          .withEnv("KEYCLOAK_CLIENTS_4_TYPE", "m2m")
-          .withEnv("KEYCLOAK_CLIENTS_4_PERMISSIONS_0_RESOURCE_SERVER_ID", ZEEBE_CLIENT_AUDIENCE)
-          .withEnv("KEYCLOAK_CLIENTS_4_PERMISSIONS_0_DEFINITION", "write:*")
-          .withEnv("KEYCLOAK_CLIENTS_1_NAME", ZEEBE_CLIENT_ID_TENANT_B)
-          .withEnv("KEYCLOAK_CLIENTS_1_ID", ZEEBE_CLIENT_ID_TENANT_B)
-          .withEnv("KEYCLOAK_CLIENTS_1_SECRET", ZEEBE_CLIENT_SECRET)
-          .withEnv("KEYCLOAK_CLIENTS_1_TYPE", "m2m")
-          .withEnv("KEYCLOAK_CLIENTS_1_PERMISSIONS_0_RESOURCE_SERVER_ID", ZEEBE_CLIENT_AUDIENCE)
-          .withEnv("KEYCLOAK_CLIENTS_1_PERMISSIONS_0_DEFINITION", "write:*")
-          .withEnv("KEYCLOAK_CLIENTS_2_NAME", ZEEBE_CLIENT_ID_TENANT_A_AND_B)
-          .withEnv("KEYCLOAK_CLIENTS_2_ID", ZEEBE_CLIENT_ID_TENANT_A_AND_B)
-          .withEnv("KEYCLOAK_CLIENTS_2_SECRET", ZEEBE_CLIENT_SECRET)
-          .withEnv("KEYCLOAK_CLIENTS_2_TYPE", "m2m")
-          .withEnv("KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID", ZEEBE_CLIENT_AUDIENCE)
-          .withEnv("KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION", "write:*")
-          .withEnv("KEYCLOAK_CLIENTS_3_NAME", ZEEBE_CLIENT_ID_WITHOUT_TENANT)
-          .withEnv("KEYCLOAK_CLIENTS_3_ID", ZEEBE_CLIENT_ID_WITHOUT_TENANT)
-          .withEnv("KEYCLOAK_CLIENTS_3_SECRET", ZEEBE_CLIENT_SECRET)
-          .withEnv("KEYCLOAK_CLIENTS_3_TYPE", "m2m")
-          .withEnv("KEYCLOAK_CLIENTS_3_PERMISSIONS_0_RESOURCE_SERVER_ID", ZEEBE_CLIENT_AUDIENCE)
-          .withEnv("KEYCLOAK_CLIENTS_3_PERMISSIONS_0_DEFINITION", "write:*")
-          .withEnv("IDENTITY_RETRY_ATTEMPTS", "90")
-          .withEnv("IDENTITY_RETRY_DELAY_SECONDS", "1")
-          .withEnv("IDENTITY_DATABASE_HOST", DATABASE_HOST)
-          .withEnv("IDENTITY_DATABASE_PORT", String.valueOf(DATABASE_PORT))
-          .withEnv("IDENTITY_DATABASE_NAME", DATABASE_NAME)
-          .withEnv("IDENTITY_DATABASE_USERNAME", DATABASE_USER)
-          .withEnv("IDENTITY_DATABASE_PASSWORD", DATABASE_PASSWORD)
-          // this will enable readiness checks by spring to await ApplicationRunner completion
-          .withEnv("MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED", "true")
-          .withEnv("MANAGEMENT_HEALTH_READINESSSTATE_ENABLED", "true")
-          .withNetwork(NETWORK)
-          .withExposedPorts(8080, 8082)
-          .waitingFor(
-              new HttpWaitStrategy()
-                  .forPort(8082)
-                  .forPath("/actuator/health/readiness")
-                  .allowInsecure()
-                  .forStatusCode(200))
-          .withNetworkAliases("identity");
-
-  @AutoCloseResource
-  private static final TestStandaloneBroker ZEEBE =
-      new TestStandaloneBroker().withAdditionalProfile(Profile.IDENTITY_AUTH);
-
-  private static final String TENANT_A = "tenant-a";
-  private static final String TENANT_B = "tenant-b";
-
-  @SuppressWarnings("unused")
-  @RegisterExtension
-  final ContainerLogsDumper logsWatcher =
-      new ContainerLogsDumper(
-          () -> Map.of("postgres", POSTGRES, "keycloak", KEYCLOAK, "identity", IDENTITY));
+  @TestZeebe(autoStart = false)
+  private static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withRecordingExporter(true)
+          .withBasicAuth()
+          .withMultiTenancyEnabled()
+          .withAuthenticatedAccess()
+          .withSecurityConfig(
+              cfg ->
+                  cfg.getInitialization()
+                      .setUsers(
+                          List.of(
+                              new ConfiguredUser(
+                                  USER_TENANT_A, USER_TENANT_A, USER_TENANT_A, "test@camunda.com"),
+                              new ConfiguredUser(
+                                  USER_TENANT_B, USER_TENANT_B, USER_TENANT_B, "test@camunda.com"),
+                              new ConfiguredUser(
+                                  USER_TENANT_A_AND_B,
+                                  USER_TENANT_A_AND_B,
+                                  USER_TENANT_A_AND_B,
+                                  "test@camunda.com"),
+                              new ConfiguredUser(
+                                  USER_TENANT_A_WITHOUT_DEFAULT_TENANT,
+                                  USER_TENANT_A_WITHOUT_DEFAULT_TENANT,
+                                  USER_TENANT_A_WITHOUT_DEFAULT_TENANT,
+                                  "test@camunda.com"))));
 
   private String processId;
   private String migratedProcessId;
@@ -221,31 +86,27 @@ public class MultiTenancyOverIdentityIT {
   private BpmnModelInstance migratedProcess;
 
   @BeforeAll
-  static void init() throws Exception {
-    ZEEBE
-        .withGatewayConfig(
-            gateway -> {
-              gateway.getMultiTenancy().setEnabled(true);
-              gateway.getSecurity().getAuthentication().setMode(AuthMode.IDENTITY);
-            })
-        .withProperty(
-            "camunda.identity.baseUrl",
-            "http://%s:%d".formatted(IDENTITY.getHost(), IDENTITY.getMappedPort(8080)))
-        .withProperty(
-            "camunda.identity.issuerBackendUrl",
-            "http://%s:%d%s"
-                .formatted(
-                    KEYCLOAK.getHost(), KEYCLOAK.getMappedPort(8080), KEYCLOAK_PATH_CAMUNDA_REALM))
-        .withProperty("camunda.identity.audience", ZEEBE_CLIENT_AUDIENCE)
-        .withRecordingExporter(true)
-        .start()
-        .await(TestHealthProbe.READY);
+  static void init() {
+    BROKER.withCamundaExporter("http://" + CONTAINER.getHttpHostAddress()).start();
 
-    associateTenantsWithClient(List.of(DEFAULT_TENANT, TENANT_A), ZEEBE_CLIENT_ID_TENANT_A);
-    associateTenantsWithClient(List.of(TENANT_A), ZEEBE_CLIENT_ID_TENANT_A_WITHOUT_DEFAULT_TENANT);
-    associateTenantsWithClient(List.of(DEFAULT_TENANT, TENANT_B), ZEEBE_CLIENT_ID_TENANT_B);
-    associateTenantsWithClient(
-        List.of(DEFAULT_TENANT, TENANT_A, TENANT_B), ZEEBE_CLIENT_ID_TENANT_A_AND_B);
+    // We can do the setup with any user. We pick user A for convenience.
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
+      final var authUtil = new AuthorizationsUtil(BROKER, client, CONTAINER.getHttpHostAddress());
+      authUtil.awaitUserExistsInElasticsearch(USER_TENANT_A);
+      authUtil.awaitUserExistsInElasticsearch(USER_TENANT_B);
+      authUtil.awaitUserExistsInElasticsearch(USER_TENANT_A_AND_B);
+      authUtil.awaitUserExistsInElasticsearch(USER_TENANT_A_WITHOUT_DEFAULT_TENANT);
+
+      assignUsersToTenant(
+          client, DEFAULT_TENANT, USER_TENANT_A, USER_TENANT_B, USER_TENANT_A_AND_B);
+      createTenantAndAssignUsers(
+          client,
+          TENANT_A,
+          USER_TENANT_A,
+          USER_TENANT_A_AND_B,
+          USER_TENANT_A_WITHOUT_DEFAULT_TENANT);
+      createTenantAndAssignUsers(client, TENANT_B, USER_TENANT_B, USER_TENANT_A_AND_B);
+    }
   }
 
   @BeforeEach
@@ -272,20 +133,7 @@ public class MultiTenancyOverIdentityIT {
   @MethodSource("provideTopologyCases")
   void shouldAuthorizeTopologyRequestWithTenantAccess(
       final UnaryOperator<TopologyRequestStep1> apiPicker) {
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
-      // when
-      final var topology = apiPicker.apply(client.newTopologyRequest()).send().join();
-
-      // then
-      assertThat(topology.getBrokers()).hasSize(1);
-    }
-  }
-
-  @ParameterizedTest
-  @MethodSource("provideTopologyCases")
-  void shouldAuthorizeTopologyRequestWithoutTenantAccess(
-      final UnaryOperator<TopologyRequestStep1> apiPicker) {
-    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
+    try (final var client = createCamundaClient(USER_TENANT_A)) {
       // when
       final var topology = apiPicker.apply(client.newTopologyRequest()).send().join();
 
@@ -1669,151 +1517,44 @@ public class MultiTenancyOverIdentityIT {
         Named.of("rest", TopologyRequestStep1::useRest));
   }
 
+  //
   /**
-   * Creates a new Zeebe Client with the given client ID such that Identity can provide the
-   * associated tenant IDs. The credentials are cached separately for each test case.
-   *
-   * @param clientId The client ID to use for the new Zeebe Client
-   * @return A new Zeebe Client to use in these tests
+   * Creates a new Camunda Client with the given user. Note that the username and password are equal
    */
-  private static ZeebeClient createZeebeClient(final String clientId) {
-    return ZEEBE
+  private static CamundaClient createCamundaClient(final String user) {
+    return BROKER
         .newClientBuilder()
         .credentialsProvider(
-            new OAuthCredentialsProviderBuilder()
-                .clientId(clientId)
-                .clientSecret(ZEEBE_CLIENT_SECRET)
-                .audience(ZEEBE_CLIENT_AUDIENCE)
-                .authorizationServerUrl(
-                    "http://localhost:%d%s/protocol/openid-connect/token"
-                        .formatted(KEYCLOAK.getFirstMappedPort(), KEYCLOAK_PATH_CAMUNDA_REALM))
-                .credentialsCachePath(credentialsCacheDir.resolve(clientId).toString())
-                .build())
+            new BasicAuthCredentialsProviderBuilder().username(user).password(user).build())
         .defaultRequestTimeout(Duration.ofSeconds(10))
         .build();
   }
 
   /**
-   * Sets up the association between the given tenant IDs and the given client ID in Keycloak and
-   * Identity.
+   * Creates a tenant and assigns the provided users
    *
-   * @param tenantIds The tenant ids to associate with the client
-   * @param clientId The client id to associate the tenants with
-   * @throws Exception If an error occurs while performing the database operations
+   * @param client The camunda client to create the association with
+   * @param tenantId The id of the tenant to create
+   * @param usernames The usernames of the users to associate the tenant with
    */
-  private static void associateTenantsWithClient(
-      final List<String> tenantIds, final String clientId) throws Exception {
-
-    try (final PostgresHelper postgres = new PostgresHelper()) {
-      final String accessRuleId;
-      // Create access rule for service account
-      try (final var resultSet =
-          postgres.executeQuery(
-              """
-                  INSERT INTO access_rules \
-                    (member_id, member_type, global) \
-                  VALUES ('%s', 'APPLICATION', false) \
-                  ON CONFLICT DO NOTHING \
-                  RETURNING id"""
-                  .formatted(clientId))) {
-        if (!resultSet.next()) {
-          throw new IllegalStateException(
-              "Expected to find access rule associated to service account.");
-        }
-        accessRuleId = resultSet.getString(1);
-      }
-
-      // Create tenant(s) if not already existing,
-      // using tenantId for both id and name
-      tenantIds.forEach(
-          (tenantId) ->
-              postgres.execute(
-                  """
-                      INSERT INTO tenants \
-                        (name, tenant_id) \
-                      VALUES ('%s', '%s') \
-                      ON CONFLICT DO NOTHING"""
-                      .formatted(tenantId, tenantId)));
-
-      // Connect tenants to access rule
-      tenantIds.forEach(
-          tenantId ->
-              postgres.execute(
-                  """
-                      INSERT INTO access_rules_tenants \
-                        (tenant_id, access_rule_id) \
-                      VALUES ('%s', '%s') \
-                      ON CONFLICT DO NOTHING"""
-                      .formatted(tenantId, accessRuleId)));
-    }
+  private static void createTenantAndAssignUsers(
+      final CamundaClient client, final String tenantId, final String... usernames) {
+    client.newCreateTenantCommand().tenantId(tenantId).name(tenantId).send().join();
+    assignUsersToTenant(client, tenantId, usernames);
   }
 
   /**
-   * Helper method to determine the Docker image tag for the Camunda Identity version used in Zeebe.
-   * If a SNAPSHOT version of Identity is used, the method will return 'SNAPSHOT' instead of the
-   * format '8.X.Y-SNAPSHOT', as Identity doesn't provide versioned snapshots of their Docker
-   * images.
+   * Assigns the provided users to a given tenant
    *
-   * @return a String specifying the Identity Docker image tag
+   * @param client The camunda client to create the association with
+   * @param tenantId The id of the tenant to create
+   * @param usernames The usernames of the users to associate the tenant with
    */
-  private static String getIdentityImageTag() {
-    final String identityVersion = Identity.class.getPackage().getImplementationVersion();
-    final String dockerImageTag =
-        System.getProperty("identity.docker.image.version", identityVersion);
-
-    return dockerImageTag.contains("SNAPSHOT") ? IDENTITY_SNAPSHOT_TAG : dockerImageTag;
-  }
-
-  /**
-   * Helper class to perform queries against the Postgres database. It will automatically create and
-   * close the connection. To be used within a try-with-resources block.
-   */
-  private static final class PostgresHelper implements AutoCloseable {
-    private final Supplier<Connection> connector;
-    private Connection connection;
-
-    private PostgresHelper() {
-      final String jdbcUrl = POSTGRES.getJdbcUrl();
-      final String username = POSTGRES.getUsername();
-      final String password = POSTGRES.getPassword();
-      connector =
-          () -> {
-            try {
-              return DriverManager.getConnection(jdbcUrl, username, password);
-            } catch (final SQLException e) {
-              throw new RuntimeException(e);
-            }
-          };
-    }
-
-    private ResultSet executeQuery(final String query) {
-      if (connection == null) {
-        connection = connector.get();
-      }
-      try {
-        final var statement = connection.createStatement();
-        return statement.executeQuery(query);
-      } catch (final SQLException e) {
-        throw new RuntimeException(e);
-      }
-    }
-
-    private void execute(final String query) {
-      if (connection == null) {
-        connection = connector.get();
-      }
-      try (final var statement = connection.createStatement()) {
-        statement.execute(query);
-      } catch (final SQLException e) {
-        throw new RuntimeException(e);
-      }
-    }
-
-    @Override
-    public void close() throws Exception {
-      if (connection != null) {
-        connection.close();
-      }
-    }
+  private static void assignUsersToTenant(
+      final CamundaClient client, final String tenantId, final String... usernames) {
+    Arrays.stream(usernames)
+        .forEach(
+            username ->
+                client.newAssignUserToTenantCommand(tenantId).username(username).send().join());
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -1,0 +1,1778 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.multitenancy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dasniko.testcontainers.keycloak.KeycloakContainer;
+import io.camunda.application.Profile;
+import io.camunda.identity.sdk.Identity;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.api.command.TopologyRequestStep1;
+import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.response.AssignUserTaskResponse;
+import io.camunda.zeebe.client.api.response.BroadcastSignalResponse;
+import io.camunda.zeebe.client.api.response.CompleteJobResponse;
+import io.camunda.zeebe.client.api.response.CompleteUserTaskResponse;
+import io.camunda.zeebe.client.api.response.DeleteResourceResponse;
+import io.camunda.zeebe.client.api.response.DeploymentEvent;
+import io.camunda.zeebe.client.api.response.EvaluateDecisionResponse;
+import io.camunda.zeebe.client.api.response.MigrateProcessInstanceResponse;
+import io.camunda.zeebe.client.api.response.ModifyProcessInstanceResponse;
+import io.camunda.zeebe.client.api.response.Process;
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.client.api.response.PublishMessageResponse;
+import io.camunda.zeebe.client.api.response.ResolveIncidentResponse;
+import io.camunda.zeebe.client.api.response.UnassignUserTaskResponse;
+import io.camunda.zeebe.client.api.response.UpdateTimeoutJobResponse;
+import io.camunda.zeebe.client.api.response.UpdateUserTaskResponse;
+import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder;
+import io.camunda.zeebe.gateway.impl.configuration.AuthenticationCfg.AuthMode;
+import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.qa.util.cluster.TestHealthProbe;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.testcontainers.DefaultTestContainers;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+import org.apache.hc.core5.http.HttpStatus;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.images.PullPolicy;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+/** Verifies that data can be isolated per tenant using Identity as the tenant provider. */
+@Testcontainers
+@AutoCloseResources
+public class MultiTenancyOverIdentityIT {
+
+  private static final String IDENTITY_SNAPSHOT_TAG = "SNAPSHOT";
+  @TempDir private static Path credentialsCacheDir;
+  private static final String DEFAULT_TENANT = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
+  private static final String DATABASE_HOST = "postgres";
+  private static final int DATABASE_PORT = 5432;
+  private static final String DATABASE_USER = "postgres";
+  private static final String DATABASE_PASSWORD = "zecret";
+  private static final String DATABASE_NAME = "postgres";
+
+  private static final String KEYCLOAK_USER = "admin";
+  private static final String KEYCLOAK_PASSWORD = "admin";
+  private static final String KEYCLOAK_PATH_CAMUNDA_REALM = "/realms/camunda-platform";
+  private static final String ZEEBE_CLIENT_ID_TENANT_A = "zeebe-tenant-a-and-default";
+  private static final String ZEEBE_CLIENT_ID_TENANT_A_WITHOUT_DEFAULT_TENANT =
+      "zeebe-tenant-a-without-default";
+  private static final String ZEEBE_CLIENT_ID_TENANT_B = "zeebe-tenant-b-and-default";
+  private static final String ZEEBE_CLIENT_ID_TENANT_A_AND_B = "zeebe-tenant-a-and-b-and-default";
+  private static final String ZEEBE_CLIENT_ID_TENANT_DEFAULT = ZEEBE_CLIENT_ID_TENANT_A;
+  private static final String ZEEBE_CLIENT_ID_WITHOUT_TENANT = "zeebe-without-tenant";
+  private static final String ZEEBE_CLIENT_AUDIENCE = "zeebe-api";
+  private static final String ZEEBE_CLIENT_SECRET = "zecret";
+
+  private static final Network NETWORK = Network.newNetwork();
+
+  @Container
+  @SuppressWarnings("resource")
+  private static final PostgreSQLContainer<?> POSTGRES =
+      new PostgreSQLContainer<>("postgres:15.0-alpine")
+          .withExposedPorts(DATABASE_PORT)
+          .withDatabaseName(DATABASE_NAME)
+          .withUsername(DATABASE_USER)
+          .withPassword(DATABASE_PASSWORD)
+          .withNetwork(NETWORK)
+          .withNetworkAliases(DATABASE_HOST);
+
+  @Container
+  private static final KeycloakContainer KEYCLOAK =
+      DefaultTestContainers.createDefaultKeycloak()
+          .withEnv("KEYCLOAK_ADMIN_USER", KEYCLOAK_USER)
+          .withEnv("KEYCLOAK_ADMIN_PASSWORD", KEYCLOAK_PASSWORD)
+          .withEnv("KEYCLOAK_DATABASE_VENDOR", "dev-mem")
+          .withNetwork(NETWORK)
+          .withNetworkAliases("keycloak")
+          .withExposedPorts(8080);
+
+  @Container
+  @SuppressWarnings("resource")
+  private static final GenericContainer<?> IDENTITY =
+      new GenericContainer<>(
+              DockerImageName.parse("camunda/identity").withTag(getIdentityImageTag()))
+          .withImagePullPolicy(
+              System.getProperty("identity.docker.image.version", "SNAPSHOT").equals("SNAPSHOT")
+                  ? PullPolicy.alwaysPull()
+                  : PullPolicy.defaultPolicy())
+          .dependsOn(POSTGRES, KEYCLOAK)
+          .withEnv("MULTITENANCY_ENABLED", "true")
+          .withEnv("RESOURCE_AUTHORIZATIONS_ENABLED", "true")
+          .withEnv("IDENTITY_LOG_LEVEL", "TRACE")
+          .withEnv("logging_level_org_springframework_security", "DEBUG")
+          .withEnv("LOGGING_LEVEL_org.springframework", "DEBUG")
+          .withEnv("KEYCLOAK_URL", "http://keycloak:8080")
+          .withEnv(
+              "IDENTITY_AUTH_PROVIDER_BACKEND_URL",
+              "http://keycloak:8080" + KEYCLOAK_PATH_CAMUNDA_REALM)
+          .withEnv("KEYCLOAK_SETUP_USER", KEYCLOAK_USER)
+          .withEnv("KEYCLOAK_SETUP_PASSWORD", KEYCLOAK_PASSWORD)
+          .withEnv("KEYCLOAK_INIT_ZEEBE_SECRET", ZEEBE_CLIENT_SECRET)
+          .withEnv("KEYCLOAK_CLIENTS_0_NAME", ZEEBE_CLIENT_ID_TENANT_A)
+          .withEnv("KEYCLOAK_CLIENTS_0_ID", ZEEBE_CLIENT_ID_TENANT_A)
+          .withEnv("KEYCLOAK_CLIENTS_0_SECRET", ZEEBE_CLIENT_SECRET)
+          .withEnv("KEYCLOAK_CLIENTS_0_TYPE", "m2m")
+          .withEnv("KEYCLOAK_CLIENTS_0_PERMISSIONS_0_RESOURCE_SERVER_ID", ZEEBE_CLIENT_AUDIENCE)
+          .withEnv("KEYCLOAK_CLIENTS_0_PERMISSIONS_0_DEFINITION", "write:*")
+          .withEnv("KEYCLOAK_CLIENTS_4_NAME", ZEEBE_CLIENT_ID_TENANT_A_WITHOUT_DEFAULT_TENANT)
+          .withEnv("KEYCLOAK_CLIENTS_4_ID", ZEEBE_CLIENT_ID_TENANT_A_WITHOUT_DEFAULT_TENANT)
+          .withEnv("KEYCLOAK_CLIENTS_4_SECRET", ZEEBE_CLIENT_SECRET)
+          .withEnv("KEYCLOAK_CLIENTS_4_TYPE", "m2m")
+          .withEnv("KEYCLOAK_CLIENTS_4_PERMISSIONS_0_RESOURCE_SERVER_ID", ZEEBE_CLIENT_AUDIENCE)
+          .withEnv("KEYCLOAK_CLIENTS_4_PERMISSIONS_0_DEFINITION", "write:*")
+          .withEnv("KEYCLOAK_CLIENTS_1_NAME", ZEEBE_CLIENT_ID_TENANT_B)
+          .withEnv("KEYCLOAK_CLIENTS_1_ID", ZEEBE_CLIENT_ID_TENANT_B)
+          .withEnv("KEYCLOAK_CLIENTS_1_SECRET", ZEEBE_CLIENT_SECRET)
+          .withEnv("KEYCLOAK_CLIENTS_1_TYPE", "m2m")
+          .withEnv("KEYCLOAK_CLIENTS_1_PERMISSIONS_0_RESOURCE_SERVER_ID", ZEEBE_CLIENT_AUDIENCE)
+          .withEnv("KEYCLOAK_CLIENTS_1_PERMISSIONS_0_DEFINITION", "write:*")
+          .withEnv("KEYCLOAK_CLIENTS_2_NAME", ZEEBE_CLIENT_ID_TENANT_A_AND_B)
+          .withEnv("KEYCLOAK_CLIENTS_2_ID", ZEEBE_CLIENT_ID_TENANT_A_AND_B)
+          .withEnv("KEYCLOAK_CLIENTS_2_SECRET", ZEEBE_CLIENT_SECRET)
+          .withEnv("KEYCLOAK_CLIENTS_2_TYPE", "m2m")
+          .withEnv("KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID", ZEEBE_CLIENT_AUDIENCE)
+          .withEnv("KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION", "write:*")
+          .withEnv("KEYCLOAK_CLIENTS_3_NAME", ZEEBE_CLIENT_ID_WITHOUT_TENANT)
+          .withEnv("KEYCLOAK_CLIENTS_3_ID", ZEEBE_CLIENT_ID_WITHOUT_TENANT)
+          .withEnv("KEYCLOAK_CLIENTS_3_SECRET", ZEEBE_CLIENT_SECRET)
+          .withEnv("KEYCLOAK_CLIENTS_3_TYPE", "m2m")
+          .withEnv("KEYCLOAK_CLIENTS_3_PERMISSIONS_0_RESOURCE_SERVER_ID", ZEEBE_CLIENT_AUDIENCE)
+          .withEnv("KEYCLOAK_CLIENTS_3_PERMISSIONS_0_DEFINITION", "write:*")
+          .withEnv("IDENTITY_RETRY_ATTEMPTS", "90")
+          .withEnv("IDENTITY_RETRY_DELAY_SECONDS", "1")
+          .withEnv("IDENTITY_DATABASE_HOST", DATABASE_HOST)
+          .withEnv("IDENTITY_DATABASE_PORT", String.valueOf(DATABASE_PORT))
+          .withEnv("IDENTITY_DATABASE_NAME", DATABASE_NAME)
+          .withEnv("IDENTITY_DATABASE_USERNAME", DATABASE_USER)
+          .withEnv("IDENTITY_DATABASE_PASSWORD", DATABASE_PASSWORD)
+          // this will enable readiness checks by spring to await ApplicationRunner completion
+          .withEnv("MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED", "true")
+          .withEnv("MANAGEMENT_HEALTH_READINESSSTATE_ENABLED", "true")
+          .withNetwork(NETWORK)
+          .withExposedPorts(8080, 8082)
+          .waitingFor(
+              new HttpWaitStrategy()
+                  .forPort(8082)
+                  .forPath("/actuator/health/readiness")
+                  .allowInsecure()
+                  .forStatusCode(200))
+          .withNetworkAliases("identity");
+
+  @AutoCloseResource
+  private static final TestStandaloneBroker ZEEBE =
+      new TestStandaloneBroker().withAdditionalProfile(Profile.IDENTITY_AUTH);
+
+  private static final String TENANT_A = "tenant-a";
+  private static final String TENANT_B = "tenant-b";
+
+  @SuppressWarnings("unused")
+  @RegisterExtension
+  final ContainerLogsDumper logsWatcher =
+      new ContainerLogsDumper(
+          () -> Map.of("postgres", POSTGRES, "keycloak", KEYCLOAK, "identity", IDENTITY));
+
+  private String processId;
+  private String migratedProcessId;
+  private BpmnModelInstance process;
+  private BpmnModelInstance migratedProcess;
+
+  @BeforeAll
+  static void init() throws Exception {
+    ZEEBE
+        .withGatewayConfig(
+            gateway -> {
+              gateway.getMultiTenancy().setEnabled(true);
+              gateway.getSecurity().getAuthentication().setMode(AuthMode.IDENTITY);
+            })
+        .withProperty(
+            "camunda.identity.baseUrl",
+            "http://%s:%d".formatted(IDENTITY.getHost(), IDENTITY.getMappedPort(8080)))
+        .withProperty(
+            "camunda.identity.issuerBackendUrl",
+            "http://%s:%d%s"
+                .formatted(
+                    KEYCLOAK.getHost(), KEYCLOAK.getMappedPort(8080), KEYCLOAK_PATH_CAMUNDA_REALM))
+        .withProperty("camunda.identity.audience", ZEEBE_CLIENT_AUDIENCE)
+        .withRecordingExporter(true)
+        .start()
+        .await(TestHealthProbe.READY);
+
+    associateTenantsWithClient(List.of(DEFAULT_TENANT, TENANT_A), ZEEBE_CLIENT_ID_TENANT_A);
+    associateTenantsWithClient(List.of(TENANT_A), ZEEBE_CLIENT_ID_TENANT_A_WITHOUT_DEFAULT_TENANT);
+    associateTenantsWithClient(List.of(DEFAULT_TENANT, TENANT_B), ZEEBE_CLIENT_ID_TENANT_B);
+    associateTenantsWithClient(
+        List.of(DEFAULT_TENANT, TENANT_A, TENANT_B), ZEEBE_CLIENT_ID_TENANT_A_AND_B);
+  }
+
+  @BeforeEach
+  void setup() {
+    RecordingExporter.reset();
+    processId = Strings.newRandomValidBpmnId();
+    process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .serviceTask("task", b -> b.zeebeJobType("type"))
+            .endEvent()
+            .done();
+
+    migratedProcessId = Strings.newRandomValidBpmnId();
+    migratedProcess =
+        Bpmn.createExecutableProcess(migratedProcessId)
+            .startEvent()
+            .serviceTask("migrated-task", b -> b.zeebeJobType("type"))
+            .endEvent()
+            .done();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTopologyCases")
+  void shouldAuthorizeTopologyRequestWithTenantAccess(
+      final UnaryOperator<TopologyRequestStep1> apiPicker) {
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      // when
+      final var topology = apiPicker.apply(client.newTopologyRequest()).send().join();
+
+      // then
+      assertThat(topology.getBrokers()).hasSize(1);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTopologyCases")
+  void shouldAuthorizeTopologyRequestWithoutTenantAccess(
+      final UnaryOperator<TopologyRequestStep1> apiPicker) {
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
+      // when
+      final var topology = apiPicker.apply(client.newTopologyRequest()).send().join();
+
+      // then
+      assertThat(topology.getBrokers()).hasSize(1);
+    }
+  }
+
+  @Test
+  void shouldAuthorizeDeployProcess() {
+    // given
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      // when
+      final Future<DeploymentEvent> response =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(process, "process.bpmn")
+              .tenantId(TENANT_A)
+              .send();
+
+      // then
+      assertThat(response)
+          .describedAs("Expect that process can be deployed for tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldDenyDeployResourceWhenUnauthorized() {
+    // given
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      // when
+      final Future<DeploymentEvent> result =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(process, "process.bpmn")
+              .tenantId(TENANT_B)
+              .send();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("PERMISSION_DENIED")
+          .withMessageContaining(
+              "Expected to handle gRPC request DeployResource with tenant identifier 'tenant-b'")
+          .withMessageContaining("but tenant is not authorized to perform this request");
+    }
+  }
+
+  @Test
+  void shouldDenyDeployResourceWhenUnauthorizedForDefaultTenant() {
+    // given
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_WITHOUT_DEFAULT_TENANT)) {
+      // when
+      final Future<DeploymentEvent> result =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(process, "process.bpmn")
+              .tenantId(DEFAULT_TENANT)
+              .send();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("PERMISSION_DENIED")
+          .withMessageContaining(
+              "Expected to handle gRPC request DeployResource with tenant identifier '<default>'")
+          .withMessageContaining("but tenant is not authorized to perform this request");
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  void shouldDenyDeployProcessWhenUnauthorizedForDefaultTenant() {
+    // given
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_WITHOUT_DEFAULT_TENANT)) {
+      // when
+      // note that deploy process command is always only for the default tenant
+      final Future<DeploymentEvent> result =
+          client.newDeployCommand().addProcessModel(process, "process.bpmn").send();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("PERMISSION_DENIED")
+          .withMessageContaining(
+              "Expected to handle gRPC request DeployProcess with tenant identifier '<default>'")
+          .withMessageContaining("but tenant is not authorized to perform this request");
+    }
+  }
+
+  @Test
+  void shouldAuthorizeDeleteResource() throws ExecutionException, InterruptedException {
+    // given
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      final Future<DeploymentEvent> deploymentResponse =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(process, "process.bpmn")
+              .tenantId(TENANT_A)
+              .send();
+      assertThat(deploymentResponse)
+          .describedAs("Expect that process was deployed for tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
+      final long resourceKey =
+          deploymentResponse.get().getProcesses().get(0).getProcessDefinitionKey();
+
+      // when
+      final Future<DeleteResourceResponse> response =
+          client.newDeleteResourceCommand(resourceKey).send();
+
+      // then
+      assertThat(response)
+          .describedAs("Expect that process can be deleted for tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldDenyDeleteResourceWhenUnauthorized() throws ExecutionException, InterruptedException {
+    // given
+    final long resourceKey;
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      final Future<DeploymentEvent> deploymentResponse =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(process, "process.bpmn")
+              .tenantId(TENANT_A)
+              .send();
+      assertThat(deploymentResponse)
+          .describedAs("Expect that process was deployed for tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
+      resourceKey = deploymentResponse.get().getProcesses().get(0).getProcessDefinitionKey();
+    }
+
+    // when
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+      final Future<DeleteResourceResponse> response =
+          client.newDeleteResourceCommand(resourceKey).send();
+
+      // then
+      assertThat(response)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("NOT_FOUND");
+    }
+  }
+
+  @Test
+  void shouldIncrementProcessVersionPerTenant() {
+    // given
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+    }
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_B)
+          .send()
+          .join();
+    }
+
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+      // when
+      final var processV2 = Bpmn.createExecutableProcess(processId).startEvent().done();
+      final Future<DeploymentEvent> result =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(processV2, "process.bpmn")
+              .tenantId(TENANT_B)
+              .send();
+
+      // then
+      assertThat(result)
+          .succeedsWithin(Duration.ofSeconds(10))
+          .describedAs("Process version is incremented for tenant-b but not for tenant-a")
+          .extracting(deploymentEvent -> deploymentEvent.getProcesses().get(0))
+          .extracting(Process::getVersion, Process::getTenantId)
+          .containsExactly(2, TENANT_B);
+    }
+  }
+
+  @Test
+  void shouldAuthorizeCreateProcessInstance() {
+    // given
+    final long processDefinitionKey;
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
+      processDefinitionKey =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(process, "process.bpmn")
+              .tenantId(TENANT_A)
+              .send()
+              .join()
+              .getProcesses()
+              .stream()
+              .map(Process::getProcessDefinitionKey)
+              .findFirst()
+              .orElseThrow();
+
+      // when
+      final Future<ProcessInstanceEvent> result =
+          client
+              .newCreateInstanceCommand()
+              .processDefinitionKey(processDefinitionKey)
+              .tenantId(TENANT_A)
+              .send();
+
+      // then
+      assertThat(result)
+          .describedAs(
+              "Expect that process instance can be created as the client has access process of tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldNotFindOtherTenantsProcessById() {
+    // given
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+    }
+
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+      // when
+      final Future<ProcessInstanceEvent> result =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId(processId)
+              .latestVersion()
+              .tenantId(TENANT_B)
+              .send();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .describedAs("Process definition should exist for tenant-a but not for tenant-b")
+          .withMessageContaining("NOT_FOUND")
+          .withMessageContaining("Expected to find process definition with process ID")
+          .withMessageContaining("but none found");
+    }
+  }
+
+  @Test
+  void shouldNotFindOtherTenantsProcessByKey() {
+    // given
+    final long processDefinitionKey;
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      processDefinitionKey =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(process, "process.bpmn")
+              .tenantId(TENANT_A)
+              .send()
+              .join()
+              .getProcesses()
+              .stream()
+              .map(Process::getProcessDefinitionKey)
+              .findFirst()
+              .orElseThrow();
+    }
+
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+      // when
+      final Future<ProcessInstanceEvent> result =
+          client
+              .newCreateInstanceCommand()
+              .processDefinitionKey(processDefinitionKey)
+              .tenantId(TENANT_B)
+              .send();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .describedAs("Process definition should exist for tenant-a but not for tenant-b")
+          .withMessageContaining("NOT_FOUND")
+          .withMessageContaining("Expected to find process definition with key")
+          .withMessageContaining("but none found");
+    }
+  }
+
+  @Test
+  void shouldNotFindOtherTenantsProcessInCallActivity() {
+    // given
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+    }
+
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(
+              Bpmn.createExecutableProcess("parent")
+                  .startEvent()
+                  .callActivity("call", c -> c.zeebeProcessId(processId))
+                  .endEvent()
+                  .done(),
+              "parent.bpmn")
+          .tenantId(TENANT_B)
+          .send()
+          .join();
+    }
+
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+      // when
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId("parent")
+          .latestVersion()
+          .tenantId(TENANT_B)
+          .send();
+
+      // then
+      Assertions.assertThat(
+              RecordingExporter.incidentRecords().withBpmnProcessId("parent").getFirst().getValue())
+          .hasErrorMessage(
+              "Expected process with BPMN process id '%s' to be deployed, but not found."
+                  .formatted(processId));
+    }
+  }
+
+  /**
+   * This test case may become obsolete when we allow shared processes definitions across tenants.
+   */
+  @Test
+  void shouldNotFindOtherTenantsProcessEvenWhenClientIsAuthorizedForTenant() {
+    // given
+    final long processDefinitionKey;
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
+      processDefinitionKey =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(process, "process.bpmn")
+              .tenantId(TENANT_A)
+              .send()
+              .join()
+              .getProcesses()
+              .stream()
+              .map(Process::getProcessDefinitionKey)
+              .findFirst()
+              .orElseThrow();
+    }
+
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
+      // when
+      final Future<ProcessInstanceEvent> result =
+          client
+              .newCreateInstanceCommand()
+              .processDefinitionKey(processDefinitionKey)
+              .tenantId(TENANT_B)
+              .send();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .describedAs("Process definition should exist for tenant-a but not for tenant-b")
+          .withMessageContaining("NOT_FOUND")
+          .withMessageContaining("Expected to find process definition with key")
+          .withMessageContaining("but none found");
+    }
+  }
+
+  @Test
+  void shouldStartProcessWhenPublishingMessageForTenant() {
+    // given
+    final String messageName = "message";
+    process =
+        Bpmn.createExecutableProcess(processId).startEvent().message(messageName).endEvent().done();
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+
+      // when
+      final Future<PublishMessageResponse> result =
+          client
+              .newPublishMessageCommand()
+              .messageName(messageName)
+              .withoutCorrelationKey()
+              .tenantId(TENANT_A)
+              .send();
+
+      // then
+      assertThat(result)
+          .describedAs(
+              "Expect that message can be published as the client has access process of tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldDenyPublishMessageWhenUnauthorized() {
+    // given
+    final String messageName = "message";
+    process =
+        Bpmn.createExecutableProcess(processId).startEvent().message(messageName).endEvent().done();
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+
+      // when
+      final Future<PublishMessageResponse> result =
+          client
+              .newPublishMessageCommand()
+              .messageName(messageName)
+              .withoutCorrelationKey()
+              .tenantId(TENANT_B)
+              .send();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("PERMISSION_DENIED")
+          .withMessageContaining(
+              "Expected to handle gRPC request PublishMessage with tenant identifier 'tenant-b'")
+          .withMessageContaining("but tenant is not authorized to perform this request");
+    }
+  }
+
+  @Test
+  void shouldActivateJobForTenant() {
+    // given
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId(processId)
+          .latestVersion()
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+
+      // when
+      final Future<ActivateJobsResponse> result =
+          client
+              .newActivateJobsCommand()
+              .jobType("type")
+              .maxJobsToActivate(1)
+              .tenantId(TENANT_A)
+              .send();
+
+      // then
+      assertThat(result)
+          .describedAs(
+              "Expect that job can be activated as the client has access process of tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldDenyActivateJobWhenUnauthorized() {
+    // given
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId(processId)
+          .latestVersion()
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+    }
+
+    // when
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+      final Future<ActivateJobsResponse> result =
+          client
+              .newActivateJobsCommand()
+              .jobType("type")
+              .maxJobsToActivate(1)
+              .tenantId(TENANT_A)
+              .send();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("PERMISSION_DENIED")
+          .withMessageContaining(
+              "Expected to handle gRPC request ActivateJobs with tenant identifier 'tenant-a'")
+          .withMessageContaining("but tenant is not authorized to perform this request");
+    }
+  }
+
+  @Test
+  void shouldCompleteJobForTenant() {
+    // given
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId(processId)
+          .latestVersion()
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+
+      final var activatedJob =
+          client
+              .newActivateJobsCommand()
+              .jobType("type")
+              .maxJobsToActivate(1)
+              .tenantId(TENANT_A)
+              .send()
+              .join()
+              .getJobs()
+              .get(0);
+
+      // when
+      final Future<CompleteJobResponse> result = client.newCompleteCommand(activatedJob).send();
+
+      // then
+      assertThat(result)
+          .describedAs(
+              "Expect that job can be competed as the client has access process of tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldCompleteUserTaskForTenant() {
+    // given
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId(processId)
+          .latestVersion()
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+
+      final var activatedJob =
+          client
+              .newActivateJobsCommand()
+              .jobType("type")
+              .maxJobsToActivate(1)
+              .tenantId(TENANT_A)
+              .send()
+              .join()
+              .getJobs()
+              .get(0);
+
+      // when
+      final Future<CompleteJobResponse> result = client.newCompleteCommand(activatedJob).send();
+
+      // then
+      assertThat(result)
+          .describedAs(
+              "Expect that job can be competed as the client has access process of tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldUpdateJobTimeoutForTenant() {
+    // given
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId(processId)
+          .latestVersion()
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+
+      final var activatedJob =
+          client
+              .newActivateJobsCommand()
+              .jobType("type")
+              .maxJobsToActivate(1)
+              .tenantId(TENANT_A)
+              .timeout(Duration.ofMinutes(10))
+              .send()
+              .join()
+              .getJobs()
+              .get(0);
+
+      // when
+      final Future<UpdateTimeoutJobResponse> result =
+          client.newUpdateTimeoutCommand(activatedJob).timeout(Duration.ofMinutes(11)).send();
+
+      // then
+      assertThat(result)
+          .describedAs(
+              "Expect that job timeout can be updated as the client has access process of tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldNotUpdateJobTimeoutWhenUnauthorized() {
+    // given
+    final ActivatedJob activatedJob;
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId(processId)
+          .latestVersion()
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      activatedJob =
+          client
+              .newActivateJobsCommand()
+              .jobType("type")
+              .maxJobsToActivate(1)
+              .tenantId(TENANT_A)
+              .timeout(Duration.ofMinutes(10))
+              .send()
+              .join()
+              .getJobs()
+              .get(0);
+    }
+
+    // when
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+      final Future<UpdateTimeoutJobResponse> result =
+          client.newUpdateTimeoutCommand(activatedJob).timeout(Duration.ofMinutes(11)).send();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("NOT_FOUND")
+          .withMessageContaining(
+              "Command 'UPDATE_TIMEOUT' rejected with code 'NOT_FOUND': Expected to update job with key '%d', but no such job was found"
+                  .formatted(activatedJob.getKey()));
+    }
+  }
+
+  @Test
+  void shouldNotFindJobWhenUnauthorized() {
+    // given
+    final ActivatedJob activatedJob;
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId(processId)
+          .latestVersion()
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      activatedJob =
+          client
+              .newActivateJobsCommand()
+              .jobType("type")
+              .maxJobsToActivate(1)
+              .tenantId(TENANT_A)
+              .send()
+              .join()
+              .getJobs()
+              .get(0);
+    }
+
+    // when
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+      final Future<CompleteJobResponse> result = client.newCompleteCommand(activatedJob).send();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("NOT_FOUND")
+          .withMessageContaining(
+              "Command 'COMPLETE' rejected with code 'NOT_FOUND': Expected to update retries for job with key '%d', but no such job was found"
+                  .formatted(activatedJob.getKey()));
+    }
+  }
+
+  @Test
+  void shouldResolveIncidentForTenant() {
+    // given
+    process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .zeebeOutputExpression("assert(foo, foo != null)", "target")
+            .endEvent()
+            .done();
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId(processId)
+          .latestVersion()
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+
+      final var incidentKey =
+          RecordingExporter.incidentRecords().withBpmnProcessId(processId).getFirst().getKey();
+
+      // when
+      final Future<ResolveIncidentResponse> result =
+          client.newResolveIncidentCommand(incidentKey).send();
+
+      // then
+      assertThat(result)
+          .describedAs(
+              "Expect that incident can be resolved as the client has access process of tenant-a")
+          .succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldNotFindIncidentForTenantWhenUnauthorized() {
+    // given
+    process =
+        Bpmn.createExecutableProcess(processId)
+            .startEvent()
+            .zeebeOutputExpression("assert(foo, foo != null)", "target")
+            .endEvent()
+            .done();
+    final long incidentKey;
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      client
+          .newCreateInstanceCommand()
+          .bpmnProcessId(processId)
+          .latestVersion()
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+
+      incidentKey =
+          RecordingExporter.incidentRecords().withBpmnProcessId(processId).getFirst().getKey();
+    }
+
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+      // when
+      final Future<ResolveIncidentResponse> result =
+          client.newResolveIncidentCommand(incidentKey).send();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("NOT_FOUND")
+          .withMessageContaining(
+              "Command 'RESOLVE' rejected with code 'NOT_FOUND': Expected to resolve incident with key '%d', but no such incident was found"
+                  .formatted(incidentKey));
+    }
+  }
+
+  @Test
+  void shouldAllowModifyProcessInstanceForDefaultTenant() {
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
+      // given
+      client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
+
+      final long processInstanceKey =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId(processId)
+              .latestVersion()
+              .send()
+              .join()
+              .getProcessInstanceKey();
+
+      // when
+      final Future<ModifyProcessInstanceResponse> response =
+          client.newModifyProcessInstanceCommand(processInstanceKey).activateElement("task").send();
+
+      // then
+      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldAllowModifyProcessInstanceForOtherTenant() {
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      // given
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+
+      final long processInstanceKey =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId(processId)
+              .latestVersion()
+              .tenantId(TENANT_A)
+              .send()
+              .join()
+              .getProcessInstanceKey();
+
+      // when
+      final Future<ModifyProcessInstanceResponse> response =
+          client.newModifyProcessInstanceCommand(processInstanceKey).activateElement("task").send();
+
+      // then
+      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldRejectModifyProcessInstanceForUnauthorizedTenant() {
+    final long processInstanceKey;
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      // given
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+
+      processInstanceKey =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId(processId)
+              .latestVersion()
+              .tenantId(TENANT_A)
+              .send()
+              .join()
+              .getProcessInstanceKey();
+    }
+
+    // when
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+      final Future<ModifyProcessInstanceResponse> response =
+          client.newModifyProcessInstanceCommand(processInstanceKey).activateElement("task").send();
+
+      // then
+      assertThat(response)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("NOT_FOUND")
+          .withMessageContaining(
+              "Expected to modify process instance but no process instance found with key");
+    }
+  }
+
+  @Test
+  void shouldAllowMigrateProcessInstanceForDefaultTenant() {
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
+      // given
+      client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
+      final var deploymentResponse =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(migratedProcess, "migrated-process.bpmn")
+              .send()
+              .join();
+      final long targetProcessDefinitionKey =
+          deploymentResponse.getProcesses().get(0).getProcessDefinitionKey();
+
+      final long processInstanceKey =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId(processId)
+              .latestVersion()
+              .send()
+              .join()
+              .getProcessInstanceKey();
+
+      // when
+      final Future<MigrateProcessInstanceResponse> response =
+          client
+              .newMigrateProcessInstanceCommand(processInstanceKey)
+              .migrationPlan(targetProcessDefinitionKey)
+              .addMappingInstruction("task", "migrated-task")
+              .send();
+
+      // then
+      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldAllowMigrateProcessInstanceForOtherTenant() {
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      // given
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      final var deploymentResponse =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(migratedProcess, "migrated-process.bpmn")
+              .tenantId(TENANT_A)
+              .send()
+              .join();
+      final long targetProcessDefinitionKey =
+          deploymentResponse.getProcesses().get(0).getProcessDefinitionKey();
+
+      final long processInstanceKey =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId(processId)
+              .latestVersion()
+              .tenantId(TENANT_A)
+              .send()
+              .join()
+              .getProcessInstanceKey();
+
+      // when
+      final Future<MigrateProcessInstanceResponse> response =
+          client
+              .newMigrateProcessInstanceCommand(processInstanceKey)
+              .migrationPlan(targetProcessDefinitionKey)
+              .addMappingInstruction("task", "migrated-task")
+              .send();
+
+      // then
+      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldRejectMigrateProcessInstanceForUnauthorizedTenant() {
+    final long processInstanceKey;
+    final long targetProcessDefinitionKey;
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      // given
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+      final var deploymentResponse =
+          client
+              .newDeployResourceCommand()
+              .addProcessModel(migratedProcess, "process.bpmn")
+              .tenantId(TENANT_A)
+              .send()
+              .join();
+      targetProcessDefinitionKey =
+          deploymentResponse.getProcesses().get(0).getProcessDefinitionKey();
+
+      processInstanceKey =
+          client
+              .newCreateInstanceCommand()
+              .bpmnProcessId(processId)
+              .latestVersion()
+              .tenantId(TENANT_A)
+              .send()
+              .join()
+              .getProcessInstanceKey();
+    }
+
+    // when
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_B)) {
+      final Future<MigrateProcessInstanceResponse> response =
+          client
+              .newMigrateProcessInstanceCommand(processInstanceKey)
+              .migrationPlan(targetProcessDefinitionKey)
+              .addMappingInstruction("task", "migrated-task")
+              .send();
+
+      // then
+      assertThat(response)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("NOT_FOUND")
+          .withMessageContaining(
+              String.format(
+                  "Expected to migrate process instance but no process instance found with key '%s'",
+                  processInstanceKey));
+    }
+  }
+
+  @Test
+  void shouldAllowEvaluateDecisionForDefaultTenant() {
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
+      // given
+      client
+          .newDeployResourceCommand()
+          .addResourceFromClasspath("dmn/decision-table.dmn")
+          .send()
+          .join();
+
+      // when
+      final Future<EvaluateDecisionResponse> response =
+          client
+              .newEvaluateDecisionCommand()
+              .decisionId("jedi_or_sith")
+              .variable("lightsaberColor", "blue")
+              .send();
+      // then
+      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldAllowEvaluateDecisionForCustomTenant() {
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
+      // given
+      client
+          .newDeployResourceCommand()
+          .addResourceFromClasspath("dmn/decision-table.dmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+
+      // when
+      final Future<EvaluateDecisionResponse> response =
+          client
+              .newEvaluateDecisionCommand()
+              .decisionId("jedi_or_sith")
+              .variable("lightsaberColor", "blue")
+              .tenantId(TENANT_A)
+              .send();
+      // then
+      assertThat(response).succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldDenyEvaluateDecisionForCustomTenant() {
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_DEFAULT)) {
+      // given
+      client
+          .newDeployResourceCommand()
+          .addResourceFromClasspath("dmn/decision-table.dmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+
+      // when
+      final Future<EvaluateDecisionResponse> response =
+          client
+              .newEvaluateDecisionCommand()
+              .decisionId("jedi_or_sith")
+              .variable("lightsaberColor", "blue")
+              .tenantId(TENANT_B)
+              .send();
+      // then
+      assertThat(response)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("PERMISSION_DENIED")
+          .withMessageContaining(
+              "Expected to handle gRPC request EvaluateDecision with tenant identifier 'tenant-b'")
+          .withMessageContaining("but tenant is not authorized to perform this request");
+    }
+  }
+
+  @Test
+  void shouldStartInstanceWhenBroadcastSignalForTenant() {
+    final String signalName = "signal";
+    process =
+        Bpmn.createExecutableProcess(processId).startEvent().signal(signalName).endEvent().done();
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      // given
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+
+      // when
+      final Future<BroadcastSignalResponse> result =
+          client.newBroadcastSignalCommand().signalName(signalName).tenantId(TENANT_A).send();
+
+      // then
+      assertThat(result)
+          .describedAs(
+              "Expect that signal can be broadcast as the client has access to the process of 'tenant-a'")
+          .succeedsWithin(Duration.ofSeconds(20));
+    }
+  }
+
+  @Test
+  void shouldDenyBroadcastSignalWhenUnauthorized() {
+    final String signalName = "signal";
+    process =
+        Bpmn.createExecutableProcess(processId).startEvent().signal(signalName).endEvent().done();
+    try (final var client = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A)) {
+      // given
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(process, "process.bpmn")
+          .tenantId(TENANT_A)
+          .send()
+          .join();
+
+      // when
+      final Future<BroadcastSignalResponse> result =
+          client.newBroadcastSignalCommand().signalName(signalName).tenantId(TENANT_B).send();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .withMessageContaining("PERMISSION_DENIED")
+          .withMessageContaining(
+              "Expected to handle gRPC request BroadcastSignal with tenant identifier 'tenant-b'")
+          .withMessageContaining("but tenant is not authorized to perform this request");
+    }
+  }
+
+  @Test
+  void shouldAllowAssignUserTaskForTenant() {
+    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
+        final var clientTenantB = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
+      // given
+      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+
+      // when
+      final Future<AssignUserTaskResponse> result =
+          clientTenantB.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send();
+
+      // then
+      assertThat(result).succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldRejectAssignUserTaskForTenant() {
+    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
+        final var skeletorClient = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
+      // given
+      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+
+      // when
+      final Future<AssignUserTaskResponse> result =
+          skeletorClient.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .havingCause()
+          .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
+          .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
+    }
+  }
+
+  @Test
+  void shouldAllowCompleteUserTaskForTenant() {
+    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
+        final var clientTenantB = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
+      // given
+      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+
+      // when
+      final Future<CompleteUserTaskResponse> result =
+          clientTenantB.newUserTaskCompleteCommand(userTaskKey).send();
+
+      // then
+      assertThat(result).succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldRejectCompleteUserTaskForTenant() {
+    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
+        final var invalidClient = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
+      // given
+      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+
+      // when
+      final Future<CompleteUserTaskResponse> result =
+          invalidClient.newUserTaskCompleteCommand(userTaskKey).send();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .havingCause()
+          .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
+          .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
+    }
+  }
+
+  @Test
+  void shouldAllowUnassignUserTaskForTenant() {
+    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
+        final var clientTenantB = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
+      // given
+      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+      clientTenantA.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send().join();
+
+      // when
+      final Future<UnassignUserTaskResponse> result =
+          clientTenantB.newUserTaskUnassignCommand(userTaskKey).send();
+
+      // then
+      assertThat(result).succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldRejectUnassignUserTaskForTenant() {
+    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
+        final var invalidClient = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
+      // given
+      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+      clientTenantA.newUserTaskAssignCommand(userTaskKey).assignee("Skeletor").send().join();
+
+      // when
+      final Future<UnassignUserTaskResponse> result =
+          invalidClient.newUserTaskUnassignCommand(userTaskKey).send();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .havingCause()
+          .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
+          .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
+    }
+  }
+
+  @Test
+  void shouldAllowUpdateUserTaskForTenant() {
+    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
+        final var clientTenantB = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A_AND_B)) {
+      // given
+      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+
+      // when
+      final Future<UpdateUserTaskResponse> result =
+          clientTenantB.newUserTaskUpdateCommand(userTaskKey).candidateUsers("Skeletor").send();
+
+      // then
+      assertThat(result).succeedsWithin(Duration.ofSeconds(10));
+    }
+  }
+
+  @Test
+  void shouldRejectUpdateUserTaskForTenant() {
+    try (final var clientTenantA = createZeebeClient(ZEEBE_CLIENT_ID_TENANT_A);
+        final var invalidClient = createZeebeClient(ZEEBE_CLIENT_ID_WITHOUT_TENANT)) {
+      // given
+      final var resourceHelper = new ZeebeResourcesHelper(clientTenantA);
+      final var userTaskKey = resourceHelper.createSingleUserTask(TENANT_A);
+
+      // when
+      final Future<UpdateUserTaskResponse> result =
+          invalidClient.newUserTaskUpdateCommand(userTaskKey).candidateUsers("Skeletor").send();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ofSeconds(10))
+          .withThrowableThat()
+          .havingCause()
+          .asInstanceOf(InstanceOfAssertFactories.throwable(ProblemException.class))
+          .returns(HttpStatus.SC_NOT_FOUND, ProblemException::code);
+    }
+  }
+
+  private static Stream<Named<UnaryOperator<TopologyRequestStep1>>> provideTopologyCases() {
+    return Stream.of(
+        Named.of("grpc", TopologyRequestStep1::useGrpc),
+        Named.of("rest", TopologyRequestStep1::useRest));
+  }
+
+  /**
+   * Creates a new Zeebe Client with the given client ID such that Identity can provide the
+   * associated tenant IDs. The credentials are cached separately for each test case.
+   *
+   * @param clientId The client ID to use for the new Zeebe Client
+   * @return A new Zeebe Client to use in these tests
+   */
+  private static ZeebeClient createZeebeClient(final String clientId) {
+    return ZEEBE
+        .newClientBuilder()
+        .credentialsProvider(
+            new OAuthCredentialsProviderBuilder()
+                .clientId(clientId)
+                .clientSecret(ZEEBE_CLIENT_SECRET)
+                .audience(ZEEBE_CLIENT_AUDIENCE)
+                .authorizationServerUrl(
+                    "http://localhost:%d%s/protocol/openid-connect/token"
+                        .formatted(KEYCLOAK.getFirstMappedPort(), KEYCLOAK_PATH_CAMUNDA_REALM))
+                .credentialsCachePath(credentialsCacheDir.resolve(clientId).toString())
+                .build())
+        .defaultRequestTimeout(Duration.ofSeconds(10))
+        .build();
+  }
+
+  /**
+   * Sets up the association between the given tenant IDs and the given client ID in Keycloak and
+   * Identity.
+   *
+   * @param tenantIds The tenant ids to associate with the client
+   * @param clientId The client id to associate the tenants with
+   * @throws Exception If an error occurs while performing the database operations
+   */
+  private static void associateTenantsWithClient(
+      final List<String> tenantIds, final String clientId) throws Exception {
+
+    try (final PostgresHelper postgres = new PostgresHelper()) {
+      final String accessRuleId;
+      // Create access rule for service account
+      try (final var resultSet =
+          postgres.executeQuery(
+              """
+                  INSERT INTO access_rules \
+                    (member_id, member_type, global) \
+                  VALUES ('%s', 'APPLICATION', false) \
+                  ON CONFLICT DO NOTHING \
+                  RETURNING id"""
+                  .formatted(clientId))) {
+        if (!resultSet.next()) {
+          throw new IllegalStateException(
+              "Expected to find access rule associated to service account.");
+        }
+        accessRuleId = resultSet.getString(1);
+      }
+
+      // Create tenant(s) if not already existing,
+      // using tenantId for both id and name
+      tenantIds.forEach(
+          (tenantId) ->
+              postgres.execute(
+                  """
+                      INSERT INTO tenants \
+                        (name, tenant_id) \
+                      VALUES ('%s', '%s') \
+                      ON CONFLICT DO NOTHING"""
+                      .formatted(tenantId, tenantId)));
+
+      // Connect tenants to access rule
+      tenantIds.forEach(
+          tenantId ->
+              postgres.execute(
+                  """
+                      INSERT INTO access_rules_tenants \
+                        (tenant_id, access_rule_id) \
+                      VALUES ('%s', '%s') \
+                      ON CONFLICT DO NOTHING"""
+                      .formatted(tenantId, accessRuleId)));
+    }
+  }
+
+  /**
+   * Helper method to determine the Docker image tag for the Camunda Identity version used in Zeebe.
+   * If a SNAPSHOT version of Identity is used, the method will return 'SNAPSHOT' instead of the
+   * format '8.X.Y-SNAPSHOT', as Identity doesn't provide versioned snapshots of their Docker
+   * images.
+   *
+   * @return a String specifying the Identity Docker image tag
+   */
+  private static String getIdentityImageTag() {
+    final String identityVersion = Identity.class.getPackage().getImplementationVersion();
+    final String dockerImageTag =
+        System.getProperty("identity.docker.image.version", identityVersion);
+
+    return dockerImageTag.contains("SNAPSHOT") ? IDENTITY_SNAPSHOT_TAG : dockerImageTag;
+  }
+
+  /**
+   * Helper class to perform queries against the Postgres database. It will automatically create and
+   * close the connection. To be used within a try-with-resources block.
+   */
+  private static final class PostgresHelper implements AutoCloseable {
+    private final Supplier<Connection> connector;
+    private Connection connection;
+
+    private PostgresHelper() {
+      final String jdbcUrl = POSTGRES.getJdbcUrl();
+      final String username = POSTGRES.getUsername();
+      final String password = POSTGRES.getPassword();
+      connector =
+          () -> {
+            try {
+              return DriverManager.getConnection(jdbcUrl, username, password);
+            } catch (final SQLException e) {
+              throw new RuntimeException(e);
+            }
+          };
+    }
+
+    private ResultSet executeQuery(final String query) {
+      if (connection == null) {
+        connection = connector.get();
+      }
+      try {
+        final var statement = connection.createStatement();
+        return statement.executeQuery(query);
+      } catch (final SQLException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    private void execute(final String query) {
+      if (connection == null) {
+        connection = connector.get();
+      }
+      try (final var statement = connection.createStatement()) {
+        statement.execute(query);
+      } catch (final SQLException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    public void close() throws Exception {
+      if (connection != null) {
+        connection.close();
+      }
+    }
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -626,9 +626,9 @@ public class MultiTenancyOverIdentityIT {
       assertThat(result)
           .failsWithin(Duration.ofSeconds(10))
           .withThrowableThat()
-          .withMessageContaining("NOT_FOUND")
+          .withMessageContaining("FORBIDDEN")
           .withMessageContaining(
-              "Expected to perform operation 'CREATE' on resource 'MESSAGE', but no resource was found for tenant '%s'"
+              "Insufficient permissions to perform operation 'CREATE' on resource 'MESSAGE' for tenant '%s'"
                   .formatted(TENANT_B));
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -936,7 +936,7 @@ public class MultiTenancyOverIdentityIT {
           .withThrowableThat()
           .withMessageContaining("NOT_FOUND")
           .withMessageContaining(
-              "Command 'UPDATE' rejected with code 'NOT_FOUND': Expected to update job with key '2251799813685327', but no such job was found"
+              "Command 'UPDATE' rejected with code 'NOT_FOUND': Expected to update job with key '%d', but no such job was found"
                   .formatted(activatedJob.getKey()));
     }
   }
@@ -981,7 +981,7 @@ public class MultiTenancyOverIdentityIT {
           .withThrowableThat()
           .withMessageContaining("NOT_FOUND")
           .withMessageContaining(
-              "Command 'COMPLETE' rejected with code 'NOT_FOUND': Expected to complete job with key '2251799813685288', but no such job was found"
+              "Command 'COMPLETE' rejected with code 'NOT_FOUND': Expected to complete job with key '%d', but no such job was found"
                   .formatted(activatedJob.getKey()));
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -1354,8 +1354,8 @@ public class MultiTenancyOverIdentityIT {
           .withThrowableThat()
           .withMessageContaining("NOT_FOUND")
           .withMessageContaining(
-              "Expected to handle gRPC request BroadcastSignal with tenant identifier 'tenant-b'")
-          .withMessageContaining("but tenant is not authorized to perform this request");
+              "Expected to broadcast signal with name '%s', but no such signal was found"
+                  .formatted(signalName));
     }
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -224,7 +224,7 @@ public class MultiTenancyOverIdentityIT {
       assertThat(result)
           .failsWithin(Duration.ofSeconds(10))
           .withThrowableThat()
-          .withMessageContaining("UNAUTHORIZED")
+          .withMessageContaining("FORBIDDEN")
           .withMessageContaining(
               "Insufficient permissions to perform operation 'CREATE' on resource 'RESOURCE' for tenant '%s'"
                   .formatted(TENANT_B));

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -1355,10 +1355,10 @@ public class MultiTenancyOverIdentityIT {
       assertThat(result)
           .failsWithin(Duration.ofSeconds(10))
           .withThrowableThat()
-          .withMessageContaining("NOT_FOUND")
+          .withMessageContaining("FORBIDDEN")
           .withMessageContaining(
-              "Expected to broadcast signal with name '%s', but no such signal was found"
-                  .formatted(signalName));
+              "Expected to broadcast signal for tenant '%s', but user is not assigned to this tenant."
+                  .formatted(TENANT_A));
     }
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -55,6 +55,7 @@ import org.apache.http.HttpStatus;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -230,6 +231,7 @@ public class MultiTenancyOverIdentityIT {
     }
   }
 
+  @Disabled("https://github.com/camunda/camunda/issues/29518")
   @Test
   void shouldDenyDeployResourceWhenUnauthorizedForDefaultTenant() {
     // given
@@ -253,6 +255,7 @@ public class MultiTenancyOverIdentityIT {
     }
   }
 
+  @Disabled("https://github.com/camunda/camunda/issues/29518")
   @SuppressWarnings("deprecation")
   @Test
   void shouldDenyDeployProcessWhenUnauthorizedForDefaultTenant() {

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -173,6 +173,11 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     return this;
   }
 
+  /** Enables multi-tenancy in the security configuration. */
+  public TestStandaloneBroker withMultiTenancyEnabled() {
+    return withSecurityConfig(cfg -> cfg.getMultiTenancy().setEnabled(true));
+  }
+
   /**
    * Returns the health actuator for this broker. You can use this to check for liveness, readiness,
    * and startup.


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Restore the `MultiTenancyOverIdentityIT` test class that ensures tenant membership is enforced on relevant endpoints.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29233 
