### PR TITLE
feat: extend the `StreamProcessor` to use a dedicated `Actor` for each `AsyncTaskGroup` tasks

### DIFF
--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/AsyncSchedulePool.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/AsyncSchedulePool.java
@@ -10,8 +10,7 @@ package io.camunda.zeebe.stream.api.scheduling;
 import io.camunda.zeebe.scheduler.SchedulingHints;
 
 public enum AsyncSchedulePool {
-  ASYNC_PROCESSING("AsyncProcessingScheduleActor", SchedulingHints.ioBound()),
-  ;
+  ASYNC_PROCESSING("AsyncProcessingScheduleActor", SchedulingHints.ioBound());
   private final String name;
   private final SchedulingHints schedulingHints;
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/AsyncSchedulePool.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/AsyncSchedulePool.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.api.scheduling;
+
+import io.camunda.zeebe.scheduler.SchedulingHints;
+
+public enum AsyncSchedulePool {
+  ASYNC_PROCESSING("AsyncProcessingScheduleActor", SchedulingHints.ioBound()),
+  ;
+  private final String name;
+  private final SchedulingHints schedulingHints;
+
+  AsyncSchedulePool(final String name, final SchedulingHints schedulingHints) {
+    this.name = name;
+    this.schedulingHints = schedulingHints;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public SchedulingHints getSchedulingHints() {
+    return schedulingHints;
+  }
+}

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/AsyncTaskGroup.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/AsyncTaskGroup.java
@@ -9,12 +9,26 @@ package io.camunda.zeebe.stream.api.scheduling;
 
 import io.camunda.zeebe.scheduler.SchedulingHints;
 
-public enum AsyncSchedulePool {
-  ASYNC_PROCESSING("AsyncProcessingScheduleActor", SchedulingHints.ioBound());
+/**
+ * Enum to define the different task groups for the {@link
+ * io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService}. The task groups are used to
+ * specify the actor in which the tasks are executed. *
+ *
+ * <p>Adding an extra value to the enum guarantees creating a new actor for this group.
+ *
+ * <p>Each task group has a name and a {@link SchedulingHints} to define the scheduling hints for
+ * the group.
+ *
+ * <p>For example, the {@link #ASYNC_PROCESSING} task group is used for CPU-bound tasks.
+ *
+ * @see SchedulingHints
+ */
+public enum AsyncTaskGroup {
+  ASYNC_PROCESSING("AsyncProcessingScheduleActor", SchedulingHints.cpuBound());
   private final String name;
   private final SchedulingHints schedulingHints;
 
-  AsyncSchedulePool(final String name, final SchedulingHints schedulingHints) {
+  AsyncTaskGroup(final String name, final SchedulingHints schedulingHints) {
     this.name = name;
     this.schedulingHints = schedulingHints;
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ProcessingScheduleService.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ProcessingScheduleService.java
@@ -20,8 +20,9 @@ public interface ProcessingScheduleService extends SimpleProcessingScheduleServi
    * scheduled tasks and always execute scheduled tasks on the same thread, this method does not
    * guarantee this.
    *
-   * <p>Uses {@link AsyncSchedulePool#ASYNC_PROCESSING} as the pool to execute the task. If you wish
-   * to use a different pool, use {@link #runAtFixedRateAsync(Duration, Task, AsyncSchedulePool)}
+   * <p>Uses {@link AsyncTaskGroup#ASYNC_PROCESSING} as the default task group to execute the task.
+   * To use a different task group, use {@link #runAtFixedRateAsync(Duration, Task,
+   * AsyncTaskGroup)}.
    *
    * <p>Note that time-traveling in tests only affects the delay of the currently scheduled next
    * task and not any of the iterations after. This is because the next task is scheduled with the
@@ -41,8 +42,8 @@ public interface ProcessingScheduleService extends SimpleProcessingScheduleServi
    * scheduled tasks and always execute scheduled tasks on the same thread, this method does not
    * guarantee this.
    *
-   * <p>Uses {@link AsyncSchedulePool#ASYNC_PROCESSING} as the pool to execute the task. If you wish
-   * to use a different pool, use {@link #runDelayedAsync(Duration, Task, AsyncSchedulePool)}
+   * <p>Uses {@link AsyncTaskGroup#ASYNC_PROCESSING} as the default task group to execute the task.
+   * To use a different task group, use {@link #runDelayedAsync(Duration, Task, AsyncTaskGroup)}.
    *
    * @param delay The delay to wait before executing the task
    * @param task The task to execute after the delay
@@ -61,8 +62,8 @@ public interface ProcessingScheduleService extends SimpleProcessingScheduleServi
    * scheduled tasks and always execute scheduled tasks on the same thread, this method does not
    * guarantee this.
    *
-   * <p>Uses {@link AsyncSchedulePool#ASYNC_PROCESSING} as the pool to execute the task. If you wish
-   * to use a different pool, use {@link #runAtAsync(long, Task, AsyncSchedulePool)}
+   * <p>Uses {@link AsyncTaskGroup#ASYNC_PROCESSING} as the default task group to execute the task.
+   * To use a different task group, use {@link #runAtAsync(long, Task, AsyncTaskGroup)}.
    *
    * @param timestamp Unix epoch timestamp in milliseconds
    * @param task The task to execute at or after the timestamp
@@ -87,9 +88,9 @@ public interface ProcessingScheduleService extends SimpleProcessingScheduleServi
    *
    * @param delay The delay to wait initially and between each run
    * @param task The task to execute at the fixed rate
-   * @param pool The pool to execute the task on
+   * @param taskGroup The {@link AsyncTaskGroup} to execute the task on
    */
-  void runAtFixedRateAsync(Duration delay, Task task, AsyncSchedulePool pool);
+  void runAtFixedRateAsync(Duration delay, Task task, AsyncTaskGroup taskGroup);
 
   /**
    * Schedule a task to execute with a specific delay. After that delay, the task is executed.
@@ -101,11 +102,11 @@ public interface ProcessingScheduleService extends SimpleProcessingScheduleServi
    *
    * @param delay The delay to wait before executing the task
    * @param task The task to execute after the delay
-   * @param pool The pool to execute the task on
+   * @param taskGroup The {@link AsyncTaskGroup} to execute the task on
    * @implNote If the delay is short, cancellation via {@link ScheduledTask} may happen after
    *     execution and have no effect.
    */
-  ScheduledTask runDelayedAsync(Duration delay, Task task, AsyncSchedulePool pool);
+  ScheduledTask runDelayedAsync(Duration delay, Task task, AsyncTaskGroup taskGroup);
 
   /**
    * Schedule a task to execute at or after a specific timestamp. The task is executed after the
@@ -119,9 +120,9 @@ public interface ProcessingScheduleService extends SimpleProcessingScheduleServi
    *
    * @param timestamp Unix epoch timestamp in milliseconds
    * @param task The task to execute at or after the timestamp
-   * @param pool The pool to execute the task on
+   * @param taskGroup The {@link AsyncTaskGroup} to execute the task on
    * @implNote If the delay is short, cancellation via {@link ScheduledTask} may happen after
    *     execution and have no effect.
    */
-  ScheduledTask runAtAsync(long timestamp, Task task, AsyncSchedulePool pool);
+  ScheduledTask runAtAsync(long timestamp, Task task, AsyncTaskGroup taskGroup);
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ProcessingScheduleService.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ProcessingScheduleService.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.stream.api.scheduling;
 
+import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.time.Duration;
 
 public interface ProcessingScheduleService extends SimpleProcessingScheduleService {
@@ -61,4 +62,10 @@ public interface ProcessingScheduleService extends SimpleProcessingScheduleServi
    *     execution and have no effect.
    */
   ScheduledTask runAtAsync(final long timestamp, final Task task);
+
+  ActorFuture<Void> open();
+
+  ActorFuture<Void> closeActorsAsync();
+
+  void closeSchedulers();
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ProcessingScheduleService.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ProcessingScheduleService.java
@@ -63,6 +63,35 @@ public interface ProcessingScheduleService extends SimpleProcessingScheduleServi
    */
   ScheduledTask runAtAsync(final long timestamp, final Task task);
 
+  /**
+   * Same as @{@link #runAtFixedRate(Duration, Task)}, but the task is executed on a specific pool
+   * (actor).
+   *
+   * @param delay The delay to wait initially and between each run
+   * @param task The task to execute at the fixed rate
+   * @param poolName The name of the pool to execute the task on
+   */
+  void runAtFixedRateOnPool(Duration delay, Task task, String poolName);
+
+  /**
+   * Same as @{@link #runDelayed(Duration, Task)}, but the task is executed on a specific pool
+   * (actor).
+   *
+   * @param delay The delay to wait before executing the task
+   * @param task The task to execute after the delay
+   * @param poolName The name of the pool to execute the task on
+   */
+  ScheduledTask runDelayedOnPool(Duration delay, Task task, String poolName);
+
+  /**
+   * Same as @{@link #runAt(long, Task)}, but the task is executed on a specific pool (actor).
+   *
+   * @param timestamp Unix epoch timestamp in milliseconds
+   * @param task The task to execute at or after the timestamp
+   * @param poolName The name of the pool to execute the task on
+   */
+  ScheduledTask runAtOnPool(long timestamp, Task task, String poolName);
+
   ActorFuture<Void> open();
 
   ActorFuture<Void> closeActorsAsync();

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ProcessingScheduleService.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ProcessingScheduleService.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.stream.api.scheduling;
 
-import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.time.Duration;
 
 public interface ProcessingScheduleService extends SimpleProcessingScheduleService {
@@ -91,10 +90,4 @@ public interface ProcessingScheduleService extends SimpleProcessingScheduleServi
    * @param pool The pool to execute the task on
    */
   ScheduledTask runAtOnPool(long timestamp, Task task, AsyncSchedulePool pool);
-
-  ActorFuture<Void> open();
-
-  ActorFuture<Void> closeActorsAsync();
-
-  void closeSchedulers();
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ProcessingScheduleService.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ProcessingScheduleService.java
@@ -69,9 +69,9 @@ public interface ProcessingScheduleService extends SimpleProcessingScheduleServi
    *
    * @param delay The delay to wait initially and between each run
    * @param task The task to execute at the fixed rate
-   * @param poolName The name of the pool to execute the task on
+   * @param pool The pool to execute the task on
    */
-  void runAtFixedRateOnPool(Duration delay, Task task, String poolName);
+  void runAtFixedRateOnPool(Duration delay, Task task, AsyncSchedulePool pool);
 
   /**
    * Same as @{@link #runDelayed(Duration, Task)}, but the task is executed on a specific pool
@@ -79,18 +79,18 @@ public interface ProcessingScheduleService extends SimpleProcessingScheduleServi
    *
    * @param delay The delay to wait before executing the task
    * @param task The task to execute after the delay
-   * @param poolName The name of the pool to execute the task on
+   * @param pool The pool to execute the task on
    */
-  ScheduledTask runDelayedOnPool(Duration delay, Task task, String poolName);
+  ScheduledTask runDelayedOnPool(Duration delay, Task task, AsyncSchedulePool pool);
 
   /**
    * Same as @{@link #runAt(long, Task)}, but the task is executed on a specific pool (actor).
    *
    * @param timestamp Unix epoch timestamp in milliseconds
    * @param task The task to execute at or after the timestamp
-   * @param poolName The name of the pool to execute the task on
+   * @param pool The pool to execute the task on
    */
-  ScheduledTask runAtOnPool(long timestamp, Task task, String poolName);
+  ScheduledTask runAtOnPool(long timestamp, Task task, AsyncSchedulePool pool);
 
   ActorFuture<Void> open();
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncProcessingScheduleServiceActor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncProcessingScheduleServiceActor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.stream.impl;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService;
 import java.util.Map;
 
 final class AsyncProcessingScheduleServiceActor extends Actor {
@@ -73,5 +74,9 @@ final class AsyncProcessingScheduleServiceActor extends Actor {
   public void onActorFailed() {
     scheduleService.close();
     closeFuture.complete(null);
+  }
+
+  public SimpleProcessingScheduleService getScheduleService() {
+    return scheduleService;
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncProcessingScheduleServiceActor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncProcessingScheduleServiceActor.java
@@ -13,7 +13,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.util.Map;
 
-final class AsyncProcessingScheduleServiceActor extends Actor {
+public final class AsyncProcessingScheduleServiceActor extends Actor {
 
   private final ProcessingScheduleServiceImpl scheduleService;
   private CompletableActorFuture<Void> closeFuture = CompletableActorFuture.completed(null);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncProcessingScheduleServiceActor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncProcessingScheduleServiceActor.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.stream.impl;
 
 import io.camunda.zeebe.scheduler.Actor;
-import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.util.Map;
@@ -68,9 +67,5 @@ public final class AsyncProcessingScheduleServiceActor extends Actor {
   @Override
   public void onActorFailed() {
     closeFuture.complete(null);
-  }
-
-  public ActorControl getActorControl() {
-    return actor;
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncProcessingScheduleServiceActor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncProcessingScheduleServiceActor.java
@@ -54,6 +54,11 @@ final class AsyncProcessingScheduleServiceActor extends Actor {
   }
 
   @Override
+  protected void onActorClosing() {
+    scheduleService.close();
+  }
+
+  @Override
   protected void onActorClosed() {
     closeFuture.complete(null);
   }
@@ -66,6 +71,7 @@ final class AsyncProcessingScheduleServiceActor extends Actor {
 
   @Override
   public void onActorFailed() {
+    scheduleService.close();
     closeFuture.complete(null);
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncProcessingScheduleServiceActor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncProcessingScheduleServiceActor.java
@@ -22,9 +22,9 @@ final class AsyncProcessingScheduleServiceActor extends Actor {
 
   public AsyncProcessingScheduleServiceActor(
       final String name,
-      final ProcessingScheduleServiceImpl scheduleService,
+      final ProcessingScheduleServiceFactory scheduleServiceFactory,
       final int partitionId) {
-    this.scheduleService = scheduleService;
+    scheduleService = scheduleServiceFactory.create();
     asyncScheduleActorName = buildActorName(name, partitionId);
     this.partitionId = partitionId;
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncProcessingScheduleServiceActor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncProcessingScheduleServiceActor.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import io.camunda.zeebe.scheduler.Actor;
+import io.camunda.zeebe.scheduler.ActorControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.util.Map;
+
+final class AsyncProcessingScheduleServiceActor extends Actor {
+
+  private final ProcessingScheduleServiceImpl scheduleService;
+  private CompletableActorFuture<Void> closeFuture = CompletableActorFuture.completed(null);
+  private final String asyncScheduleActorName;
+  private final int partitionId;
+
+  public AsyncProcessingScheduleServiceActor(
+      final ProcessingScheduleServiceImpl scheduleService, final int partitionId) {
+    this.scheduleService = scheduleService;
+    asyncScheduleActorName = buildActorName("AsyncProcessingScheduleActor", partitionId);
+    this.partitionId = partitionId;
+  }
+
+  @Override
+  protected Map<String, String> createContext() {
+    final var context = super.createContext();
+    context.put(ACTOR_PROP_PARTITION_ID, Integer.toString(partitionId));
+    return context;
+  }
+
+  @Override
+  public String getName() {
+    return asyncScheduleActorName;
+  }
+
+  @Override
+  protected void onActorStarting() {
+    final ActorFuture<Void> actorFuture = scheduleService.open(actor);
+    actor.runOnCompletionBlockingCurrentPhase(
+        actorFuture,
+        (v, t) -> {
+          if (t != null) {
+            actor.fail(t);
+          }
+        });
+    closeFuture = new CompletableActorFuture<>();
+  }
+
+  @Override
+  protected void onActorClosed() {
+    closeFuture.complete(null);
+  }
+
+  @Override
+  public CompletableActorFuture<Void> closeAsync() {
+    actor.close();
+    return closeFuture;
+  }
+
+  @Override
+  public void onActorFailed() {
+    closeFuture.complete(null);
+  }
+
+  public ActorControl getActorControl() {
+    return actor;
+  }
+}

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncProcessingScheduleServiceActor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncProcessingScheduleServiceActor.java
@@ -21,9 +21,11 @@ final class AsyncProcessingScheduleServiceActor extends Actor {
   private final int partitionId;
 
   public AsyncProcessingScheduleServiceActor(
-      final ProcessingScheduleServiceImpl scheduleService, final int partitionId) {
+      final String name,
+      final ProcessingScheduleServiceImpl scheduleService,
+      final int partitionId) {
     this.scheduleService = scheduleService;
-    asyncScheduleActorName = buildActorName("AsyncProcessingScheduleActor", partitionId);
+    asyncScheduleActorName = buildActorName(name, partitionId);
     this.partitionId = partitionId;
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncProcessingScheduleServiceActor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncProcessingScheduleServiceActor.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.util.Map;
 
-public final class AsyncProcessingScheduleServiceActor extends Actor {
+final class AsyncProcessingScheduleServiceActor extends Actor {
 
   private final ProcessingScheduleServiceImpl scheduleService;
   private CompletableActorFuture<Void> closeFuture = CompletableActorFuture.completed(null);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncScheduleServiceContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncScheduleServiceContext.java
@@ -69,6 +69,6 @@ class AsyncScheduleServiceContext implements AsyncClosable {
                 Function.identity(),
                 taskGroup ->
                     new AsyncProcessingScheduleServiceActor(
-                        taskGroup.getName(), actorServiceFactory.create(), partitionId)));
+                        taskGroup.getName(), actorServiceFactory, partitionId)));
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncScheduleServiceContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncScheduleServiceContext.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.stream.api.scheduling.AsyncSchedulePool;
 import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.StageableScheduledCommandCache;
+import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService;
 import io.camunda.zeebe.stream.impl.AsyncUtil.Step;
 import io.camunda.zeebe.stream.impl.StreamProcessor.Phase;
 import io.camunda.zeebe.stream.impl.metrics.ScheduledTaskMetrics;
@@ -79,7 +80,7 @@ public class AsyncScheduleServiceContext {
     return asyncActors.get(pool);
   }
 
-  public ProcessingScheduleServiceImpl getAsyncActorService(final AsyncSchedulePool pool) {
+  public SimpleProcessingScheduleService getAsyncActorService(final AsyncSchedulePool pool) {
     return asyncActorServices.get(pool);
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncScheduleServiceContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncScheduleServiceContext.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import io.camunda.zeebe.logstreams.log.LogStreamWriter;
+import io.camunda.zeebe.scheduler.ActorSchedulingService;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.stream.api.scheduling.AsyncSchedulePool;
+import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.StageableScheduledCommandCache;
+import io.camunda.zeebe.stream.impl.AsyncUtil.Step;
+import io.camunda.zeebe.stream.impl.StreamProcessor.Phase;
+import io.camunda.zeebe.stream.impl.metrics.ScheduledTaskMetrics;
+import java.time.Duration;
+import java.time.InstantSource;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
+public class AsyncScheduleServiceContext {
+  private final ActorSchedulingService actorSchedulingService;
+  private final Supplier<Phase> streamProcessorPhaseSupplier;
+  private final BooleanSupplier abortCondition;
+  private final Supplier<LogStreamWriter> writerSupplier;
+  private final StageableScheduledCommandCache commandCache;
+  private final InstantSource clock;
+  private final Duration interval;
+  private final ScheduledTaskMetrics metrics;
+  private final int partitionId;
+
+  private final HashMap<AsyncSchedulePool, AsyncProcessingScheduleServiceActor> asyncActors;
+  private final HashMap<AsyncSchedulePool, ProcessingScheduleServiceImpl> asyncActorServices;
+
+  public AsyncScheduleServiceContext(
+      final ActorSchedulingService actorSchedulingService,
+      final Supplier<Phase> streamProcessorPhaseSupplier,
+      final BooleanSupplier abortCondition,
+      final Supplier<LogStreamWriter> writerSupplier,
+      final StageableScheduledCommandCache commandCache,
+      final InstantSource clock,
+      final Duration interval,
+      final ScheduledTaskMetrics metrics,
+      final int partitionId) {
+    this.actorSchedulingService = actorSchedulingService;
+    this.streamProcessorPhaseSupplier = streamProcessorPhaseSupplier;
+    this.abortCondition = abortCondition;
+    this.writerSupplier = writerSupplier;
+    this.commandCache = commandCache;
+    this.clock = clock;
+    this.interval = interval;
+    this.metrics = metrics;
+    this.partitionId = partitionId;
+
+    asyncActors = new LinkedHashMap<>();
+    asyncActorServices = new LinkedHashMap<>();
+  }
+
+  public ProcessingScheduleServiceImpl createActorService() {
+    return new ProcessingScheduleServiceImpl(
+        streamProcessorPhaseSupplier, // this is volatile
+        abortCondition,
+        writerSupplier,
+        commandCache,
+        clock,
+        interval,
+        metrics);
+  }
+
+  public AsyncProcessingScheduleServiceActor getOrCreateAsyncActor(final AsyncSchedulePool pool) {
+    return geAsyncActor(pool, true);
+  }
+
+  public AsyncProcessingScheduleServiceActor geAsyncActor(
+      final AsyncSchedulePool pool, final boolean create) {
+    if (!create) {
+      return asyncActors.get(pool);
+    }
+    return asyncActors.computeIfAbsent(pool, this::createAndSubmitAsyncActor);
+  }
+
+  public ProcessingScheduleServiceImpl getAsyncActorService(final AsyncSchedulePool pool) {
+    return asyncActorServices.get(pool);
+  }
+
+  public AsyncProcessingScheduleServiceActor createAsyncActor(final AsyncSchedulePool pool) {
+    final var actorService = createActorService();
+    final var actor =
+        new AsyncProcessingScheduleServiceActor(pool.getName(), actorService, partitionId);
+
+    asyncActorServices.put(pool, actorService);
+    asyncActors.put(pool, actor);
+    return actor;
+  }
+
+  public ActorFuture<Void> submitActor(final AsyncProcessingScheduleServiceActor actor) {
+    return actorSchedulingService.submitActor(actor);
+  }
+
+  public ActorFuture<Void> closeActorsAsync() {
+    final Step[] array =
+        asyncActors.values().stream().map(a -> (Step) a::closeAsync).toArray(Step[]::new);
+    return AsyncUtil.chainSteps(0, array);
+  }
+
+  public void closeActorServices() {
+    asyncActorServices.values().forEach(ProcessingScheduleServiceImpl::close);
+  }
+
+  private AsyncProcessingScheduleServiceActor createAndSubmitAsyncActor(
+      final AsyncSchedulePool pool) {
+    final var actor = createAsyncActor(pool);
+
+    submitActor(pool, actor).join();
+    return actor;
+  }
+
+  private ActorFuture<Void> submitActor(
+      final AsyncSchedulePool pool, final AsyncProcessingScheduleServiceActor actor) {
+    return actorSchedulingService.submitActor(actor, pool.getSchedulingHints());
+  }
+}

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncScheduleServiceContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncScheduleServiceContext.java
@@ -49,10 +49,6 @@ class AsyncScheduleServiceContext implements AsyncClosable {
     return asyncActorServices.get(taskGroup);
   }
 
-  public void closeActorServices() {
-    asyncActorServices.values().forEach(ProcessingScheduleServiceImpl::close);
-  }
-
   public ActorFuture<Void> submitActors() {
     final Step[] submitActorSteps =
         asyncActors.entrySet().stream()

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncScheduleServiceContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncScheduleServiceContext.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
-public class AsyncScheduleServiceContext {
+class AsyncScheduleServiceContext {
   private final ActorSchedulingService actorSchedulingService;
   private final Supplier<Phase> streamProcessorPhaseSupplier;
   private final BooleanSupplier abortCondition;

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncUtil.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncUtil.java
@@ -14,7 +14,7 @@ import java.util.function.Consumer;
 public class AsyncUtil {
   public static ActorFuture<Void> chainSteps(final int index, final Step[] steps) {
     if (index >= steps.length) {
-      return new CompletableActorFuture<>();
+      return CompletableActorFuture.completed(null);
     }
 
     final Step step = steps[index];

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncUtil.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/AsyncUtil.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.util.function.Consumer;
+
+public class AsyncUtil {
+  public static ActorFuture<Void> chainSteps(final int index, final Step[] steps) {
+    if (index >= steps.length) {
+      return new CompletableActorFuture<>();
+    }
+
+    final Step step = steps[index];
+    final ActorFuture<Void> future = step.run();
+
+    final int nextIndex = index + 1;
+    if (nextIndex < steps.length) {
+      future.onComplete(
+          (v, t) -> {
+            if (t == null) {
+              chainSteps(nextIndex, steps);
+            } else {
+              future.completeExceptionally(t);
+            }
+          });
+    }
+    return future;
+  }
+
+  public static void chainSteps(
+      final int index,
+      final Step[] steps,
+      final Runnable last,
+      final Consumer<Throwable> onFailure) {
+    if (index == steps.length) {
+      last.run();
+      return;
+    }
+
+    final Step step = steps[index];
+    step.run()
+        .onComplete(
+            (v, t) -> {
+              if (t == null) {
+                chainSteps(index + 1, steps, last, onFailure);
+              } else {
+                onFailure.accept(t);
+              }
+            });
+  }
+
+  public interface Step {
+    ActorFuture<Void> run();
+  }
+}

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.Task;
 import java.time.Duration;
 
-public class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService {
+class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService {
   private final AsyncScheduleServiceContext context;
   private final SimpleProcessingScheduleService processorActorService;
   private final boolean alwaysAsync;

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
@@ -47,7 +47,7 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
   @Override
   public void runAtFixedRateOnPool(
       final Duration delay, final Task task, final AsyncSchedulePool pool) {
-    final var actor = context.getOrCreateAsyncActor(pool);
+    final var actor = context.geAsyncActor(pool);
     final var actorService = context.getAsyncActorService(pool);
     actor.run(
         () -> {
@@ -59,7 +59,7 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
   @Override
   public ScheduledTask runDelayedOnPool(
       final Duration delay, final Task task, final AsyncSchedulePool pool) {
-    final var actor = context.getOrCreateAsyncActor(pool);
+    final var actor = context.geAsyncActor(pool);
     final var actorService = context.getAsyncActorService(pool);
 
     final var futureScheduledTask = actor.<ScheduledTask>createFuture();
@@ -75,7 +75,7 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
   @Override
   public ScheduledTask runAtOnPool(
       final long timestamp, final Task task, final AsyncSchedulePool pool) {
-    final var actor = context.getOrCreateAsyncActor(pool);
+    final var actor = context.geAsyncActor(pool);
     final var actorService = context.getAsyncActorService(pool);
     final var futureScheduledTask = actor.<ScheduledTask>createFuture();
     actor.run(
@@ -90,7 +90,7 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
   @Override
   public ScheduledTask runDelayed(final Duration delay, final Runnable task) {
     if (alwaysAsync) {
-      final var actor = context.getOrCreateAsyncActor(ASYNC_PROCESSING);
+      final var actor = context.geAsyncActor(ASYNC_PROCESSING);
       final var actorService = context.getAsyncActorService(ASYNC_PROCESSING);
       final var futureScheduledTask = actor.<ScheduledTask>createFuture();
       actor.run(
@@ -126,7 +126,7 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
   @Override
   public ScheduledTask runAt(final long timestamp, final Runnable task) {
     if (alwaysAsync) {
-      final var actor = context.getOrCreateAsyncActor(ASYNC_PROCESSING);
+      final var actor = context.geAsyncActor(ASYNC_PROCESSING);
       final var actorService = context.getAsyncActorService(ASYNC_PROCESSING);
       final var futureScheduledTask = actor.<ScheduledTask>createFuture();
       actor.run(
@@ -171,7 +171,7 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
      */
     @Override
     public void cancel() {
-      final var actor = context.geAsyncActor(pool, false);
+      final var actor = context.geAsyncActor(pool);
       if (actor == null) {
         return;
       }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
@@ -32,21 +32,21 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
 
   @Override
   public void runAtFixedRateAsync(final Duration delay, final Task task) {
-    runAtFixedRateOnPool(delay, task, ASYNC_PROCESSING);
+    runAtFixedRateAsync(delay, task, ASYNC_PROCESSING);
   }
 
   @Override
   public ScheduledTask runDelayedAsync(final Duration delay, final Task task) {
-    return runDelayedOnPool(delay, task, ASYNC_PROCESSING);
+    return runDelayedAsync(delay, task, ASYNC_PROCESSING);
   }
 
   @Override
   public ScheduledTask runAtAsync(final long timestamp, final Task task) {
-    return runAtOnPool(timestamp, task, ASYNC_PROCESSING);
+    return runAtAsync(timestamp, task, ASYNC_PROCESSING);
   }
 
   @Override
-  public void runAtFixedRateOnPool(
+  public void runAtFixedRateAsync(
       final Duration delay, final Task task, final AsyncSchedulePool pool) {
     final var actor = context.geAsyncActor(pool);
     final var actorService = context.getAsyncActorService(pool);
@@ -58,7 +58,7 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
   }
 
   @Override
-  public ScheduledTask runDelayedOnPool(
+  public ScheduledTask runDelayedAsync(
       final Duration delay, final Task task, final AsyncSchedulePool pool) {
     final var actor = context.geAsyncActor(pool);
     final var actorService = context.getAsyncActorService(pool);
@@ -74,7 +74,7 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
   }
 
   @Override
-  public ScheduledTask runAtOnPool(
+  public ScheduledTask runAtAsync(
       final long timestamp, final Task task, final AsyncSchedulePool pool) {
     final var actor = context.geAsyncActor(pool);
     final var actorService = context.getAsyncActorService(pool);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
@@ -9,109 +9,33 @@ package io.camunda.zeebe.stream.impl;
 
 import static io.camunda.zeebe.stream.api.scheduling.AsyncSchedulePool.ASYNC_PROCESSING;
 
-import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.scheduler.ActorControl;
-import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.stream.api.scheduling.AsyncSchedulePool;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
-import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.StageableScheduledCommandCache;
 import io.camunda.zeebe.stream.api.scheduling.Task;
-import io.camunda.zeebe.stream.impl.StreamProcessor.Phase;
-import io.camunda.zeebe.stream.impl.metrics.ScheduledTaskMetrics;
-import io.camunda.zeebe.util.VisibleForTesting;
+import io.camunda.zeebe.stream.impl.AsyncUtil.Step;
 import java.time.Duration;
-import java.time.InstantSource;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.function.BooleanSupplier;
-import java.util.function.Supplier;
 
 public class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService {
 
-  private final ActorSchedulingService actorSchedulingService;
+  private final AsyncScheduleServiceContext context;
   private final ActorControl streamProcessorActorControl;
   private final ProcessingScheduleServiceImpl processorActorService;
 
-  private final StageableScheduledCommandCache commandCache;
-  private final InstantSource clock;
-  private final Duration interval;
-  private final ScheduledTaskMetrics metrics;
   private final boolean alwaysAsync;
-  private final int partitionId;
 
-  private final HashMap<AsyncSchedulePool, AsyncProcessingScheduleServiceActor> asyncActors;
-  private final HashMap<AsyncSchedulePool, ProcessingScheduleServiceImpl> asyncActorServices;
-  private final Supplier<Phase> streamProcessorPhaseSupplier;
-  private final BooleanSupplier abortCondition;
-  private final Supplier<LogStreamWriter> writerSupplier;
   private final AsyncProcessingScheduleServiceActor asyncActor;
 
   public ExtendedProcessingScheduleServiceImpl(
-      final ActorSchedulingService actorSchedulingService,
+      final AsyncScheduleServiceContext asyncScheduleServiceContext,
       final ActorControl streamProcessorActorControl,
-      final Supplier<Phase> streamProcessorPhaseSupplier,
-      final BooleanSupplier abortCondition,
-      final Supplier<LogStreamWriter> writerSupplier,
-      final StageableScheduledCommandCache commandCache,
-      final InstantSource clock,
-      final Duration interval,
-      final ScheduledTaskMetrics metrics,
-      final boolean alwaysAsync,
-      final int partitionId) {
-    this.actorSchedulingService = actorSchedulingService;
-    this.streamProcessorActorControl = streamProcessorActorControl;
-    this.streamProcessorPhaseSupplier = streamProcessorPhaseSupplier;
-    this.abortCondition = abortCondition;
-    this.writerSupplier = writerSupplier;
-    this.commandCache = commandCache;
-    this.clock = clock;
-    this.interval = interval;
-    this.metrics = metrics;
-    this.alwaysAsync = alwaysAsync;
-    this.partitionId = partitionId;
-
-    asyncActors = new LinkedHashMap<>();
-    asyncActorServices = new LinkedHashMap<>();
-
-    processorActorService =
-        new ProcessingScheduleServiceImpl(
-            streamProcessorPhaseSupplier, // this is volatile
-            abortCondition,
-            writerSupplier,
-            commandCache,
-            clock,
-            interval,
-            metrics);
-    asyncActor = createAsyncActor(ASYNC_PROCESSING);
-  }
-
-  @VisibleForTesting
-  public ExtendedProcessingScheduleServiceImpl(
-      final ProcessingScheduleServiceImpl sync,
-      final ProcessingScheduleServiceImpl async,
-      final AsyncProcessingScheduleServiceActor asyncConcurrencyControl,
       final boolean alwaysAsync) {
+    context = asyncScheduleServiceContext;
+    this.streamProcessorActorControl = streamProcessorActorControl;
     this.alwaysAsync = alwaysAsync;
-    actorSchedulingService = null;
-    streamProcessorActorControl = null;
-    streamProcessorPhaseSupplier = null;
-    abortCondition = null;
-    writerSupplier = null;
-    commandCache = null;
-    clock = null;
-    interval = null;
-    metrics = null;
-
-    processorActorService = sync;
-    partitionId = 0;
-    asyncActor = null;
-
-    asyncActors = new LinkedHashMap<>();
-    asyncActors.put(ASYNC_PROCESSING, asyncConcurrencyControl);
-    asyncActorServices = new LinkedHashMap<>();
-    asyncActorServices.put(ASYNC_PROCESSING, async);
+    processorActorService = context.createActorService();
+    asyncActor = context.createAsyncActor(ASYNC_PROCESSING);
   }
 
   @Override
@@ -132,8 +56,8 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
   @Override
   public void runAtFixedRateOnPool(
       final Duration delay, final Task task, final AsyncSchedulePool pool) {
-    final var actor = asyncActors.computeIfAbsent(pool, this::createAndSubmitAsyncActor);
-    final var actorService = asyncActorServices.get(pool);
+    final var actor = context.getOrCreateAsyncActor(pool);
+    final var actorService = context.getAsyncActorService(pool);
     actor.run(
         () -> {
           // we must run in different actor in order to schedule task
@@ -144,8 +68,8 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
   @Override
   public ScheduledTask runDelayedOnPool(
       final Duration delay, final Task task, final AsyncSchedulePool pool) {
-    final var actor = asyncActors.computeIfAbsent(pool, this::createAndSubmitAsyncActor);
-    final var actorService = asyncActorServices.get(pool);
+    final var actor = context.getOrCreateAsyncActor(pool);
+    final var actorService = context.getAsyncActorService(pool);
 
     final var futureScheduledTask = actor.<ScheduledTask>createFuture();
     actor.run(
@@ -160,8 +84,8 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
   @Override
   public ScheduledTask runAtOnPool(
       final long timestamp, final Task task, final AsyncSchedulePool pool) {
-    final var actor = asyncActors.computeIfAbsent(pool, this::createAndSubmitAsyncActor);
-    final var actorService = asyncActorServices.get(pool.getName());
+    final var actor = context.getOrCreateAsyncActor(pool);
+    final var actorService = context.getAsyncActorService(pool);
     final var futureScheduledTask = actor.<ScheduledTask>createFuture();
     actor.run(
         () -> {
@@ -174,33 +98,30 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
 
   @Override
   public ActorFuture<Void> open() {
-    return chainSteps(
+    return AsyncUtil.chainSteps(
         0,
         new Step[] {
           () -> processorActorService.open(streamProcessorActorControl),
-          () -> actorSchedulingService.submitActor(asyncActor)
+          () -> context.submitActor(asyncActor)
         });
   }
 
   @Override
   public ActorFuture<Void> closeActorsAsync() {
-    final Step[] array =
-        asyncActors.values().stream().map(a -> (Step) a::closeAsync).toArray(Step[]::new);
-    return chainSteps(0, array);
+    return context.closeActorsAsync();
   }
 
   @Override
   public void closeSchedulers() {
     processorActorService.close();
-    asyncActorServices.values().forEach(ProcessingScheduleServiceImpl::close);
+    context.closeActorServices();
   }
 
   @Override
   public ScheduledTask runDelayed(final Duration delay, final Runnable task) {
     if (alwaysAsync) {
-      final var actor =
-          asyncActors.computeIfAbsent(ASYNC_PROCESSING, this::createAndSubmitAsyncActor);
-      final var actorService = asyncActorServices.get(ASYNC_PROCESSING);
+      final var actor = context.getOrCreateAsyncActor(ASYNC_PROCESSING);
+      final var actorService = context.getAsyncActorService(ASYNC_PROCESSING);
       final var futureScheduledTask = actor.<ScheduledTask>createFuture();
       actor.run(
           () -> {
@@ -235,9 +156,8 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
   @Override
   public ScheduledTask runAt(final long timestamp, final Runnable task) {
     if (alwaysAsync) {
-      final var actor =
-          asyncActors.computeIfAbsent(ASYNC_PROCESSING, this::createAndSubmitAsyncActor);
-      final var actorService = asyncActorServices.get(ASYNC_PROCESSING);
+      final var actor = context.getOrCreateAsyncActor(ASYNC_PROCESSING);
+      final var actorService = context.getAsyncActorService(ASYNC_PROCESSING);
       final var futureScheduledTask = actor.<ScheduledTask>createFuture();
       actor.run(
           () -> {
@@ -258,58 +178,6 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
     } else {
       processorActorService.runAtFixedRate(delay, task);
     }
-  }
-
-  private AsyncProcessingScheduleServiceActor createAndSubmitAsyncActor(
-      final AsyncSchedulePool pool) {
-    final var actor = createAsyncActor(pool);
-
-    actorSchedulingService.submitActor(actor, pool.getSchedulingHints()).join();
-    return actor;
-  }
-
-  private AsyncProcessingScheduleServiceActor createAsyncActor(final AsyncSchedulePool pool) {
-    final var actorService =
-        new ProcessingScheduleServiceImpl(
-            streamProcessorPhaseSupplier, // this is volatile
-            abortCondition,
-            writerSupplier,
-            commandCache,
-            clock,
-            interval,
-            metrics);
-    final var actor =
-        new AsyncProcessingScheduleServiceActor(pool.getName(), actorService, partitionId);
-
-    asyncActorServices.put(pool, actorService);
-    asyncActors.put(pool, actor);
-    return actor;
-  }
-
-  private ActorFuture<Void> chainSteps(final int index, final Step[] steps) {
-    if (index >= steps.length) {
-      return new CompletableActorFuture<>();
-    }
-
-    final Step step = steps[index];
-    final ActorFuture<Void> future = step.run();
-
-    final int nextIndex = index + 1;
-    if (nextIndex < steps.length) {
-      future.onComplete(
-          (v, t) -> {
-            if (t == null) {
-              chainSteps(nextIndex, steps);
-            } else {
-              future.completeExceptionally(t);
-            }
-          });
-    }
-    return future;
-  }
-
-  private interface Step {
-    ActorFuture<Void> run();
   }
 
   /**
@@ -333,7 +201,7 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
      */
     @Override
     public void cancel() {
-      final var actor = asyncActors.get(pool);
+      final var actor = context.geAsyncActor(pool, false);
       if (actor == null) {
         return;
       }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
@@ -49,7 +49,7 @@ class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService
   public void runAtFixedRateAsync(
       final Duration delay, final Task task, final AsyncTaskGroup taskGroup) {
     final var actor = context.geAsyncActor(taskGroup);
-    final var actorService = context.getAsyncActorService(taskGroup);
+    final var actorService = actor.getScheduleService();
     actor.run(
         () -> {
           // we must run in different actor in order to schedule task
@@ -61,7 +61,7 @@ class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService
   public ScheduledTask runDelayedAsync(
       final Duration delay, final Task task, final AsyncTaskGroup taskGroup) {
     final var actor = context.geAsyncActor(taskGroup);
-    final var actorService = context.getAsyncActorService(taskGroup);
+    final var actorService = actor.getScheduleService();
 
     final var futureScheduledTask = actor.<ScheduledTask>createFuture();
     actor.run(
@@ -77,7 +77,7 @@ class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService
   public ScheduledTask runAtAsync(
       final long timestamp, final Task task, final AsyncTaskGroup taskGroup) {
     final var actor = context.geAsyncActor(taskGroup);
-    final var actorService = context.getAsyncActorService(taskGroup);
+    final var actorService = actor.getScheduleService();
     final var futureScheduledTask = actor.<ScheduledTask>createFuture();
     actor.run(
         () -> {
@@ -92,7 +92,7 @@ class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService
   public ScheduledTask runDelayed(final Duration delay, final Runnable task) {
     if (alwaysAsync) {
       final var actor = context.geAsyncActor(ASYNC_PROCESSING);
-      final var actorService = context.getAsyncActorService(ASYNC_PROCESSING);
+      final var actorService = actor.getScheduleService();
       final var futureScheduledTask = actor.<ScheduledTask>createFuture();
       actor.run(
           () -> {
@@ -128,7 +128,7 @@ class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService
   public ScheduledTask runAt(final long timestamp, final Runnable task) {
     if (alwaysAsync) {
       final var actor = context.geAsyncActor(ASYNC_PROCESSING);
-      final var actorService = context.getAsyncActorService(ASYNC_PROCESSING);
+      final var actorService = actor.getScheduleService();
       final var futureScheduledTask = actor.<ScheduledTask>createFuture();
       actor.run(
           () -> {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
@@ -12,17 +12,18 @@ import static io.camunda.zeebe.stream.api.scheduling.AsyncSchedulePool.ASYNC_PRO
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.stream.api.scheduling.AsyncSchedulePool;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
+import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.Task;
 import java.time.Duration;
 
 public class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService {
   private final AsyncScheduleServiceContext context;
-  private final ProcessingScheduleServiceImpl processorActorService;
+  private final SimpleProcessingScheduleService processorActorService;
   private final boolean alwaysAsync;
 
   public ExtendedProcessingScheduleServiceImpl(
       final AsyncScheduleServiceContext asyncScheduleServiceContext,
-      final ProcessingScheduleServiceImpl processorActorService,
+      final SimpleProcessingScheduleService processorActorService,
       final boolean alwaysAsync) {
     context = asyncScheduleServiceContext;
     this.processorActorService = processorActorService;

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceFactory.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceFactory.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import io.camunda.zeebe.logstreams.log.LogStreamWriter;
+import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.StageableScheduledCommandCache;
+import io.camunda.zeebe.stream.impl.StreamProcessor.Phase;
+import io.camunda.zeebe.stream.impl.metrics.ScheduledTaskMetrics;
+import java.time.Duration;
+import java.time.InstantSource;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
+public class ProcessingScheduleServiceFactory {
+  private final Supplier<Phase> streamProcessorPhaseSupplier;
+  private final BooleanSupplier abortCondition;
+  private final Supplier<LogStreamWriter> writerSupplier;
+  private final StageableScheduledCommandCache commandCache;
+  private final InstantSource clock;
+  private final Duration interval;
+  private final ScheduledTaskMetrics metrics;
+
+  public ProcessingScheduleServiceFactory(
+      final Supplier<Phase> streamProcessorPhaseSupplier,
+      final BooleanSupplier abortCondition,
+      final Supplier<LogStreamWriter> writerSupplier,
+      final StageableScheduledCommandCache commandCache,
+      final InstantSource clock,
+      final Duration interval,
+      final ScheduledTaskMetrics metrics) {
+    this.streamProcessorPhaseSupplier = streamProcessorPhaseSupplier;
+    this.abortCondition = abortCondition;
+    this.writerSupplier = writerSupplier;
+    this.commandCache = commandCache;
+    this.clock = clock;
+    this.interval = interval;
+    this.metrics = metrics;
+  }
+
+  public ProcessingScheduleServiceImpl create() {
+    return new ProcessingScheduleServiceImpl(
+        streamProcessorPhaseSupplier, // this is volatile
+        abortCondition,
+        writerSupplier,
+        commandCache,
+        clock,
+        interval,
+        metrics);
+  }
+}

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -167,18 +167,20 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
       final var scheduledTaskMetrics =
           ScheduledTaskMetrics.of(streamProcessorContext.getMeterRegistry());
 
-      asyncScheduleServiceContext =
-          new AsyncScheduleServiceContext(
-              actorSchedulingService,
+      final var actorServiceFactory =
+          new ProcessingScheduleServiceFactory(
               streamProcessorContext::getStreamProcessorPhase,
               streamProcessorContext.getAbortCondition(),
               logStream::newLogStreamWriter,
               scheduledCommandCache,
               streamProcessorContext.getClock(),
               streamProcessorContext.getScheduledTaskCheckInterval(),
-              scheduledTaskMetrics,
-              partitionId);
-      processorActorService = asyncScheduleServiceContext.createActorService();
+              scheduledTaskMetrics);
+
+      asyncScheduleServiceContext =
+          new AsyncScheduleServiceContext(actorSchedulingService, actorServiceFactory, partitionId);
+
+      processorActorService = actorServiceFactory.create();
 
       final var processingScheduleService =
           new ExtendedProcessingScheduleServiceImpl(

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -374,7 +374,9 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
     AsyncUtil.chainSteps(
         0,
-        new Step[] {() -> processorActorService.open(actor)},
+        new Step[] {
+          () -> processorActorService.open(actor), () -> asyncScheduleServiceContext.submitActors()
+        },
         () -> startProcessing(lastProcessingPositions),
         this::onFailure);
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -281,7 +281,6 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
   private void tearDown() {
     processorActorService.close();
-    asyncScheduleServiceContext.closeActorServices();
     streamProcessorContext.getLogStreamReader().close();
     logStream.removeRecordAvailableListener(this);
     replayStateMachine.close();

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -254,8 +254,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   @Override
   public ActorFuture<Void> closeAsync() {
     if (isOpened.getAndSet(false)) {
-      actor.run(
-          () -> asyncScheduleServiceContext.closeActorsAsync().onComplete((v, t) -> actor.close()));
+      actor.run(() -> asyncScheduleServiceContext.closeAsync().onComplete((v, t) -> actor.close()));
     }
 
     return closeFuture;
@@ -386,7 +385,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   private void onFailure(final Throwable throwable) {
     LOG.error("Actor {} failed in phase {}.", actorName, actor.getLifecyclePhase(), throwable);
 
-    final var asyncActorCloseFuture = asyncScheduleServiceContext.closeActorsAsync();
+    final var asyncActorCloseFuture = asyncScheduleServiceContext.closeAsync();
     asyncActorCloseFuture.onComplete(
         (v, t) -> {
           actor.fail(throwable);

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImplTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImplTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
@@ -23,7 +22,7 @@ final class ExtendedProcessingScheduleServiceImplTest {
     // given
     final var sync = mock(ProcessingScheduleServiceImpl.class);
     final var async = mock(ProcessingScheduleServiceImpl.class);
-    final var concurrencyControl = mock(ConcurrencyControl.class);
+    final var concurrencyControl = mock(AsyncProcessingScheduleServiceActor.class);
     final var schedulingService =
         new ExtendedProcessingScheduleServiceImpl(sync, async, concurrencyControl, false);
 
@@ -40,7 +39,7 @@ final class ExtendedProcessingScheduleServiceImplTest {
     // given
     final var sync = mock(ProcessingScheduleServiceImpl.class);
     final var async = mock(ProcessingScheduleServiceImpl.class);
-    final var concurrencyControl = mock(ConcurrencyControl.class);
+    final var concurrencyControl = mock(AsyncProcessingScheduleServiceActor.class);
     when(concurrencyControl.createFuture()).thenReturn(new CompletableActorFuture<>());
     doAnswer(
             invocation -> {

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImplTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImplTest.java
@@ -51,7 +51,7 @@ final class ExtendedProcessingScheduleServiceImplTest {
         .run(Mockito.any());
 
     final var context = mock(AsyncScheduleServiceContext.class);
-    when(context.getOrCreateAsyncActor(ASYNC_PROCESSING)).thenReturn(asyncControl);
+    when(context.geAsyncActor(ASYNC_PROCESSING)).thenReturn(asyncControl);
     when(context.getAsyncActorService(ASYNC_PROCESSING)).thenReturn(async);
 
     final var schedulingService = new ExtendedProcessingScheduleServiceImpl(context, sync, true);

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImplTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImplTest.java
@@ -53,7 +53,7 @@ final class ExtendedProcessingScheduleServiceImplTest {
 
     final var context = mock(AsyncScheduleServiceContext.class);
     when(context.geAsyncActor(ASYNC_PROCESSING)).thenReturn(asyncControl);
-    when(context.getAsyncActorService(ASYNC_PROCESSING)).thenReturn(async);
+    when(asyncControl.getScheduleService()).thenReturn(async);
 
     final var schedulingService = new ExtendedProcessingScheduleServiceImpl(context, sync, true);
 

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImplTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImplTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -22,8 +21,8 @@ final class ExtendedProcessingScheduleServiceImplTest {
   @Test
   void shouldNotScheduleAsyncIfDisabled() {
     // given
-    final var sync = mock(SimpleProcessingScheduleService.class);
-    final var async = mock(SimpleProcessingScheduleService.class);
+    final var sync = mock(ProcessingScheduleServiceImpl.class);
+    final var async = mock(ProcessingScheduleServiceImpl.class);
     final var concurrencyControl = mock(ConcurrencyControl.class);
     final var schedulingService =
         new ExtendedProcessingScheduleServiceImpl(sync, async, concurrencyControl, false);
@@ -39,8 +38,8 @@ final class ExtendedProcessingScheduleServiceImplTest {
   @Test
   void shouldAlwaysScheduleAsyncIfEnabled() {
     // given
-    final var sync = mock(SimpleProcessingScheduleService.class);
-    final var async = mock(SimpleProcessingScheduleService.class);
+    final var sync = mock(ProcessingScheduleServiceImpl.class);
+    final var async = mock(ProcessingScheduleServiceImpl.class);
     final var concurrencyControl = mock(ConcurrencyControl.class);
     when(concurrencyControl.createFuture()).thenReturn(new CompletableActorFuture<>());
     doAnswer(

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImplTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImplTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -22,7 +23,7 @@ final class ExtendedProcessingScheduleServiceImplTest {
   void shouldNotScheduleAsyncIfDisabled() {
     // given
     final var context = mock(AsyncScheduleServiceContext.class);
-    final var sync = mock(ProcessingScheduleServiceImpl.class);
+    final var sync = mock(SimpleProcessingScheduleService.class);
 
     final var schedulingService = new ExtendedProcessingScheduleServiceImpl(context, sync, false);
 
@@ -37,8 +38,8 @@ final class ExtendedProcessingScheduleServiceImplTest {
   @Test
   void shouldAlwaysScheduleAsyncIfEnabled() {
     // given
-    final var sync = mock(ProcessingScheduleServiceImpl.class);
-    final var async = mock(ProcessingScheduleServiceImpl.class);
+    final var sync = mock(SimpleProcessingScheduleService.class);
+    final var async = mock(SimpleProcessingScheduleService.class);
     final var asyncControl = mock(AsyncProcessingScheduleServiceActor.class);
     when(asyncControl.createFuture()).thenReturn(new CompletableActorFuture<>());
     doAnswer(

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImplTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImplTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
@@ -23,12 +22,9 @@ final class ExtendedProcessingScheduleServiceImplTest {
   void shouldNotScheduleAsyncIfDisabled() {
     // given
     final var context = mock(AsyncScheduleServiceContext.class);
-    final var syncControl = mock(ActorControl.class);
     final var sync = mock(ProcessingScheduleServiceImpl.class);
-    when(context.createActorService()).thenReturn(sync);
 
-    final var schedulingService =
-        new ExtendedProcessingScheduleServiceImpl(context, syncControl, false);
+    final var schedulingService = new ExtendedProcessingScheduleServiceImpl(context, sync, false);
 
     // when
     schedulingService.runDelayed(Duration.ZERO, () -> {});
@@ -41,7 +37,7 @@ final class ExtendedProcessingScheduleServiceImplTest {
   @Test
   void shouldAlwaysScheduleAsyncIfEnabled() {
     // given
-    final var syncControl = mock(ActorControl.class);
+    final var sync = mock(ProcessingScheduleServiceImpl.class);
     final var async = mock(ProcessingScheduleServiceImpl.class);
     final var asyncControl = mock(AsyncProcessingScheduleServiceActor.class);
     when(asyncControl.createFuture()).thenReturn(new CompletableActorFuture<>());
@@ -58,8 +54,7 @@ final class ExtendedProcessingScheduleServiceImplTest {
     when(context.getOrCreateAsyncActor(ASYNC_PROCESSING)).thenReturn(asyncControl);
     when(context.getAsyncActorService(ASYNC_PROCESSING)).thenReturn(async);
 
-    final var schedulingService =
-        new ExtendedProcessingScheduleServiceImpl(context, syncControl, true);
+    final var schedulingService = new ExtendedProcessingScheduleServiceImpl(context, sync, true);
 
     // when
     schedulingService.runDelayed(Duration.ZERO, () -> {});

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImplTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImplTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.stream.impl;
 
-import static io.camunda.zeebe.stream.api.scheduling.AsyncSchedulePool.ASYNC_PROCESSING;
+import static io.camunda.zeebe.stream.api.scheduling.AsyncTaskGroup.ASYNC_PROCESSING;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
## Description

- We are introducing a new enum `AsyncTaskGroup` which should contain a set of scheduling group. A group is correspondent to an Asyc Actor that tasks from this group shall run on. 
- Actors for these groups are created on `StreamProcessor::onActorStarted`, and are submitted on `onRecovered`
- The `ProcessingScheduleService` is extended with a set of methods to allow scheduling a task on a certain `AsyncTaskGroup`
- Now, we can define a new entry in `AsyncTaskGroup`, and an actor will be automatically created for this entry. And can be used by to schedule tasks that need a separate actor than the `AsyncProcessingScheduleActor`

## Related issues

closes #29516


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210842403966096