### PR TITLE
[Backport stable/8.7] fix: Disable X-Frame-Options to allow PDF previews in <embed> tags [Firefox]

### DIFF
--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/BaseWebConfigurer.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/BaseWebConfigurer.java
@@ -68,6 +68,8 @@ public abstract class BaseWebConfigurer {
 
   protected void applySecurityHeadersSettings(final HttpSecurity http) throws Exception {
     http.headers()
+        .frameOptions()
+        .disable()
         .contentSecurityPolicy(
             tasklistProperties.getSecurityProperties().getContentSecurityPolicy());
   }


### PR DESCRIPTION
# Description
Backport of #29503 to `stable/8.7`.

relates to camunda/camunda#28498