### PR TITLE
Fix flaky MigrationRunnerIT(shouldMigrateSuccessfullyWithMultipleRounds)

### DIFF
--- a/migration/process-migration/src/test/java/io/camunda/migration/process/it/MigrationRunnerIT.java
+++ b/migration/process-migration/src/test/java/io/camunda/migration/process/it/MigrationRunnerIT.java
@@ -176,7 +176,7 @@ public class MigrationRunnerIT extends AdapterTest {
             .ignoreExceptions()
             .until(
                 () -> readRecords(ProcessEntity.class, processIndex.getFullQualifiedName()),
-                res -> res.getFirst().getIsPublic() != null);
+                res -> res.stream().allMatch(entity -> entity.getIsPublic() != null));
 
     // Since the key field is marked as a keyword in ES/OS the sorting is done lexicographically
     assertProcessorStepContentIsStored("9");

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/ProcessEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/ProcessEntity.java
@@ -104,9 +104,6 @@ public class ProcessEntity extends OperateZeebeEntity<ProcessEntity> {
         + ", bpmnProcessId='"
         + bpmnProcessId
         + '\''
-        + ", bpmnXml='"
-        + bpmnXml
-        + '\''
         + ", resourceName='"
         + resourceName
         + '\''


### PR DESCRIPTION
## Description

Test is flaky due to not picking up post migration entities, resulting in a NPE.
