### PR TITLE
Fix flaky ElasticsearchUpdateRegressionTest[shouldBeAbleToUpdateAndExport]

### DIFF
--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -20,7 +20,7 @@ import java.util.UUID;
  * Helper class to configure any {@link TestStandaloneApplication}, with specific secondary storage.
  */
 public class MultiDbConfigurator {
-  public static String zeebePrefix = "-zeebe-records";
+  public static String zeebePrefix = "zeebe-records";
 
   private final TestStandaloneApplication<?> testApplication;
   private String indexPrefix;
@@ -235,7 +235,9 @@ public class MultiDbConfigurator {
   }
 
   public String zeebeIndexPrefix() {
-    return indexPrefix != null ? indexPrefix + zeebePrefix : indexPrefix;
+    return indexPrefix != null && !indexPrefix.isBlank()
+        ? indexPrefix + "-" + zeebePrefix
+        : zeebePrefix;
   }
 
   public void configureAWSOpenSearchSupport(final String opensearchUrl, final String indexPrefix) {

--- a/qa/util/src/test/java/io/camunda/qa/util/multidb/MultiDbConfiguratorTest.java
+++ b/qa/util/src/test/java/io/camunda/qa/util/multidb/MultiDbConfiguratorTest.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 public class MultiDbConfiguratorTest {
 
   public static final String EXPECTED_PREFIX = "custom";
-  public static final String EXPECTED_ZEEBE_PREFIX = "custom" + zeebePrefix;
+  public static final String EXPECTED_ZEEBE_PREFIX = "custom-" + zeebePrefix;
   public static final String EXPECTED_URL = "localhost";
   public static final String EXPECTED_USER = "user";
   public static final String EXPECTED_PW = "pw";


### PR DESCRIPTION
## Description

The zeebe prefix was malformed for a blank index prefix, resulting in a malformed alias

