### PR TITLE
Remove flakiness of HistoryCleanupIT

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/client/QueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/QueryTest.java
@@ -154,23 +154,6 @@ public class QueryTest {
             });
   }
 
-  public static void waitUntilProcessInstanceIsGone(
-      final CamundaClient camundaClient, final long processInstanceKey) {
-    Awaitility.await("should wait until process is ended")
-        .atMost(TIMEOUT_DATA_AVAILABILITY)
-        .ignoreExceptions() // Ignore exceptions and continue retrying
-        .untilAsserted(
-            () -> {
-              final var result =
-                  camundaClient
-                      .newProcessInstanceQuery()
-                      .filter(f -> f.processInstanceKey(processInstanceKey))
-                      .send()
-                      .join();
-              assertThat(result.page().totalItems()).isEqualTo(0);
-            });
-  }
-
   public static void waitUntilFlowNodeInstanceHasIncidents(
       final CamundaClient camundaClient, final int expectedIncidents) {
     Awaitility.await("should wait until flow node instance has incidents")

--- a/qa/integration-tests/src/test/java/io/camunda/it/historycleanup/HistoryCleanupIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/historycleanup/HistoryCleanupIT.java
@@ -13,7 +13,6 @@ import static io.camunda.it.client.QueryTest.waitForFlowNodeInstances;
 import static io.camunda.it.client.QueryTest.waitForProcessInstancesToStart;
 import static io.camunda.it.client.QueryTest.waitForProcessesToBeDeployed;
 import static io.camunda.it.client.QueryTest.waitUntilProcessInstanceIsEnded;
-import static io.camunda.it.client.QueryTest.waitUntilProcessInstanceIsGone;
 import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -58,13 +57,20 @@ public class HistoryCleanupIT {
     waitUntilProcessInstanceIsEnded(camundaClient, processInstanceEvent.getProcessInstanceKey());
 
     // and soon it should be gone
-    waitUntilProcessInstanceIsGone(camundaClient, processInstanceEvent.getProcessInstanceKey());
-
-    Awaitility.await("should wait until tasks are deleted")
+    final long processInstanceKey = processInstanceEvent.getProcessInstanceKey();
+    Awaitility.await("should wait until process and tasks are deleted")
         .atMost(Duration.ofMinutes(5))
         .ignoreExceptions() // Ignore exceptions and continue retrying
         .untilAsserted(
             () -> {
+              final var result =
+                  camundaClient
+                      .newProcessInstanceQuery()
+                      .filter(f -> f.processInstanceKey(processInstanceKey))
+                      .send()
+                      .join();
+              assertThat(result.page().totalItems()).isEqualTo(0);
+
               final var taskAmount =
                   camundaClient
                       .newUserTaskQuery()


### PR DESCRIPTION
## Description

HistoryCleanUpIT was flaky on OS, as OS ISM is running non-deterministically, and can take between 1-4 minutes to delete data.

## What the PR does

 * Deletion of process data is checked only in one test, so inline the method makes sense here.
 * This allows to combine both checks (task and process data deletion) together and have a higher timeout -> 5 minutes
 * As described higher timeout is necessary for OS - reducing the need of repeating the test multiple times
