### PR TITLE
ci: submit detailed failed test statistics

### DIFF
--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -84,7 +84,8 @@ runs:
         {
           echo 'result<<EOF'
           find . -iname 'TEST-*-FLAKY.xml' | xargs -d '\n' --no-run-if-empty -n1 python3 .github/actions/observe-build-status/junit-flaky-to-jsonl.py
-          echo EOF
+          (find . -iname 'TEST-*.xml' -exec grep -l '</failure>' {} + | grep -v 'FLAKY.xml' | xargs -d '\n' --no-run-if-empty -n1 python3 .github/actions/observe-build-status/junit-failure-to-jsonl.py || true)
+          echo 'EOF'
         } >> $GITHUB_OUTPUT
 
     - uses: camunda/infra-global-github-actions/submit-test-status@main

--- a/.github/actions/observe-build-status/junit-failure-to-jsonl.py
+++ b/.github/actions/observe-build-status/junit-failure-to-jsonl.py
@@ -1,0 +1,45 @@
+
+import sys
+import xml.etree.ElementTree
+
+def parse_junit_xml(file_path):
+    tree = xml.etree.ElementTree.parse(file_path)
+    root = tree.getroot()
+
+    if root.tag == 'testsuite':
+        parse_testsuite(root)
+    elif root.tag == 'testsuites':
+        for testsuite in root:
+            parse_testsuite(testsuite)
+
+def parse_testsuite(testsuite):
+    for testcase in testsuite.findall('testcase'):
+        test_class_name = testcase.get('classname')
+        test_class_duration_milliseconds = int(float(testsuite.get('time'))*1000)
+        test_name = testcase.get('name')
+        test_duration_milliseconds = int(float(testcase.get('time'))*1000)
+
+        if len(testcase.findall('skipped')) > 0:
+            test_status = 'skipped'
+        elif len(testcase.findall('failure')) > 0:
+            test_status = 'failure'
+        else:
+            # test_status = 'success'
+            # Do not submit test status of successes, since we could end up with
+            # two entries for one test if that test also was flaky!
+            continue
+
+        print((
+            f'{{"test_class_name": "{test_class_name}", '
+            f'"test_class_duration_milliseconds": {test_class_duration_milliseconds}, '
+            f'"test_name": "{test_name}", '
+            f'"test_status": "{test_status}", '
+            f'"test_duration_milliseconds": {test_duration_milliseconds}}}'
+        ))
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python3 junit-to-jsonl.py path/to/TEST-sometestname.xml", file=sys.stderr)
+        sys.exit(1)
+
+    parse_junit_xml(sys.argv[1])


### PR DESCRIPTION
## Description

This PR extends #26715 to also scan JUnit XMLs for failed tests and submit them to CI Analytics.

Example run that had a failed test: https://github.com/camunda/camunda/actions/runs/13926427008/job/38972104261?pr=29554 (failure enforced by deliberate code change)

![image](https://github.com/user-attachments/assets/c17505bc-1547-48db-930d-9b0ca6e37349)

This failure was correctly submitted to CI Analytics as shown above with query:

> SELECT * FROM `ci-30-162810.prod_ci_analytics.test_status_v1` WHERE ci_url="https://github.com/camunda/camunda" AND test_class_name="io.camunda.spring.client.config.CredentialsProviderSaasTest"

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [x] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Related #29541 
