### PR TITLE
feat: implement a claim validator for OIDC auth allowing the configuration of expected claims

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/ClaimValidator.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/ClaimValidator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import io.camunda.security.configuration.TokenClaim;
+import java.util.Collection;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+/**
+ * Validates the claims of a JWT token against the configured claims.
+ *
+ * <p>The claims are treated as an any match, meaning that at least one of the configured claims
+ * must be present in the token with the expected value.
+ */
+public class ClaimValidator implements OAuth2TokenValidator<Jwt> {
+  private static final Logger LOG = LoggerFactory.getLogger(ClaimValidator.class);
+  private final Set<TokenClaim> expectedClaims;
+
+  /** Creates a new validator with the given expected claims. */
+  public ClaimValidator(final Set<TokenClaim> expectedClaims) {
+    this.expectedClaims = Set.copyOf(expectedClaims);
+  }
+
+  @Override
+  public OAuth2TokenValidatorResult validate(final Jwt token) {
+    final var tokenClaims = token.getClaims();
+
+    for (final var expectedClaim : expectedClaims) {
+      final var tokenClaim = tokenClaims.get(expectedClaim.getClaim());
+      if (tokenClaim == null) {
+        continue;
+      }
+
+      if (tokenClaim instanceof final Collection<?> claim) {
+        if (claim.contains(expectedClaim.getValue())) {
+          return OAuth2TokenValidatorResult.success();
+        }
+      } else {
+        if (expectedClaim.getValue().equals(tokenClaim)) {
+          return OAuth2TokenValidatorResult.success();
+        }
+      }
+    }
+
+    LOG.debug("Invalid token: expected claims not found in token");
+    return OAuth2TokenValidatorResult.failure(
+        new OAuth2Error(
+            OAuth2ErrorCodes.INVALID_TOKEN,
+            "Invalid token: expected claims not found in token",
+            null));
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/config/ClaimValidator.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/ClaimValidator.java
@@ -23,6 +23,12 @@ import org.springframework.security.oauth2.jwt.Jwt;
  *
  * <p>The claims are treated as an any match, meaning that at least one of the configured claims
  * must be present in the token with the expected value.
+ *
+ * <p>For claims that are single values (e.g. "foo": "bar"), the validator will check if the value
+ * is equal to the expected value.
+ *
+ * <p>For claims that are arrays (e.g. "foo": ["one", "two", "three"]), the validator will check if
+ * the expected value is contained in the array.
  */
 public class ClaimValidator implements OAuth2TokenValidator<Jwt> {
   private static final Logger LOG = LoggerFactory.getLogger(ClaimValidator.class);

--- a/authentication/src/main/java/io/camunda/authentication/config/ClaimValidator.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/ClaimValidator.java
@@ -54,11 +54,12 @@ public class ClaimValidator implements OAuth2TokenValidator<Jwt> {
       }
     }
 
-    LOG.debug("Invalid token: expected claims not found in token");
+    LOG.debug(
+        "Invalid token: expected at least one claim from: {} to match the token", expectedClaims);
     return OAuth2TokenValidatorResult.failure(
         new OAuth2Error(
             OAuth2ErrorCodes.INVALID_TOKEN,
-            "Invalid token: expected claims not found in token",
+            "Invalid token claims: expected one of %s to match the token".formatted(expectedClaims),
             null));
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -302,6 +302,13 @@ public class WebSecurityConfig {
             JwtValidators.createDefaultWithValidators(new AudienceValidator(validAudiences)));
       }
 
+      final var expectedClaims =
+          securityConfiguration.getAuthentication().getOidc().getExpectedClaims();
+      if (expectedClaims != null) {
+        decoder.setJwtValidator(
+            JwtValidators.createDefaultWithValidators(new ClaimValidator(expectedClaims)));
+      }
+
       return decoder;
     }
 

--- a/authentication/src/test/java/io/camunda/authentication/config/ClaimValidatorTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/config/ClaimValidatorTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.security.configuration.TokenClaim;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+import org.assertj.core.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public class ClaimValidatorTest {
+  @Test
+  void shouldFailValidationForTokenWithNoMatchingClaim() {
+    // given
+    final var expectedClaims = Set.of(new TokenClaim("foo", "bar"));
+    final var validator = new ClaimValidator(expectedClaims);
+    final var token = createJwt(Map.of("something", "else", "not", "here"));
+
+    // when
+    final var result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isTrue();
+  }
+
+  @Test
+  void shouldPassValidationTokenWithExpectedSingleValueClaim() {
+    // given
+    final var expectedClaims =
+        Set.of(new TokenClaim("foo", "bar"), new TokenClaim("not", "present"));
+    final var validator = new ClaimValidator(expectedClaims);
+    final var token = createJwt(Map.of("foo", "bar", "baz", "foz"));
+
+    // when
+    final var result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isFalse();
+  }
+
+  @Test
+  void shouldPassValidationTokenWithExpectedArrayClaim() {
+    // given
+    final var expectedClaims =
+        Set.of(new TokenClaim("foo", "two"), new TokenClaim("not", "present"));
+    final var validator = new ClaimValidator(expectedClaims);
+    final var token =
+        createJwt(Map.of("foo", Arrays.asList(new String[] {"one", "two", "three"}), "baz", "foz"));
+
+    // when
+    final var result = validator.validate(token);
+
+    // then
+    assertThat(result.hasErrors()).isFalse();
+  }
+
+  private static Jwt createJwt(final Map<String, Object> claims) {
+    return new Jwt(
+        "token-value",
+        Instant.now(),
+        Instant.now().plusSeconds(60),
+        Map.of("alg", "RS256"),
+        claims);
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/OidcAuthenticationConfiguration.java
@@ -21,6 +21,7 @@ public class OidcAuthenticationConfiguration {
   private String jwkSetUri;
   private String authorizationUri;
   private Set<String> audiences;
+  private Set<TokenClaim> expectedClaims;
 
   public String getIssuerUri() {
     return issuerUri;
@@ -92,5 +93,13 @@ public class OidcAuthenticationConfiguration {
 
   public void setAudiences(final Set<String> audiences) {
     this.audiences = audiences;
+  }
+
+  public Set<TokenClaim> getExpectedClaims() {
+    return expectedClaims;
+  }
+
+  public void setExpectedClaims(final Set<TokenClaim> expectedClaims) {
+    this.expectedClaims = expectedClaims;
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/configuration/TokenClaim.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/TokenClaim.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.configuration;
+
+public class TokenClaim {
+  private String claim;
+  private String value;
+
+  public TokenClaim(final String claim, final String value) {
+    this.claim = claim;
+    this.value = value;
+  }
+
+  public String getClaim() {
+    return claim;
+  }
+
+  public void setClaim(final String claim) {
+    this.claim = claim;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(final String value) {
+    this.value = value;
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/configuration/TokenClaim.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/TokenClaim.java
@@ -31,4 +31,9 @@ public class TokenClaim {
   public void setValue(final String value) {
     this.value = value;
   }
+
+  @Override
+  public String toString() {
+    return "{" + "claim='" + claim + '\'' + ", value='" + value + '\'' + '}';
+  }
 }


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->

For our SaaS deployments we need to implement a method to validate that a token has access to the cluster (or the organisation a cluster exists within), there are a couple of methods we could use to provide this validation however after discussion with @lenaschoenburg I decided to align with her approach in using a JWT validator that sits along side the other JWT validator for audience checks.

I believe this is the right decision for us because:
1. It allows us to enforce the checks required for SaaS in all instances with a single and simple configuration
2. It aligns with the Audience validator and keeps similar checks in a familiar location (the other option would be Spring filters)
3. It is extendable so our Customers could use this configuration to apply their own claim checks in their self managed deployments (instead of the configuration being super specific to the SaaS deployments)

## Related issues

closes https://github.com/camunda/camunda/issues/29425
