### PR TITLE
ci: correct operate port binding in tasklist docker compose

### DIFF
--- a/tasklist/config/docker-compose.yml
+++ b/tasklist/config/docker-compose.yml
@@ -289,7 +289,7 @@ services:
     container_name: operate-${DATABASE}
     image: camunda/operate:8.6.11
     ports:
-      - 8088:8080
+      - 8088:8081
     environment:
       - SERVER_PORT=8081
       - SPRING_PROFILES_ACTIVE=dev,dev-data,auth


### PR DESCRIPTION
## Description
Operate is configured with `SERVER_PORT=8081` in the docker compose, correcting the port binding

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
