### PR TITLE
[Backport stable/8.7] ci: correct operate port binding in tasklist docker compose

### DIFF
--- a/tasklist/config/docker-compose.yml
+++ b/tasklist/config/docker-compose.yml
@@ -288,7 +288,7 @@ services:
     container_name: operate-${DATABASE}
     image: camunda/operate:8.7.0-SNAPSHOT
     ports:
-      - 8088:8080
+      - 8088:8081
     environment:
       - SERVER_PORT=8081
       - SPRING_PROFILES_ACTIVE=dev,dev-data,auth


### PR DESCRIPTION
# Description
Backport of #29556 to `stable/8.7`.

relates to 