### PR TITLE
feat: use backoff supplier bean in spring sdk

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/annotation/processor/JobWorkerAnnotationProcessor.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/annotation/processor/JobWorkerAnnotationProcessor.java
@@ -70,7 +70,7 @@ public class JobWorkerAnnotationProcessor extends AbstractCamundaAnnotationProce
         ReflectionUtils.USER_DECLARED_METHODS);
 
     LOGGER.info(
-        "Configuring {} Zeebe worker(s) of bean '{}': {}",
+        "Configuring {} Job worker(s) of bean '{}': {}",
         newJobWorkerValues.size(),
         beanInfo.getBeanName(),
         newJobWorkerValues);

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaClientAllAutoConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaClientAllAutoConfiguration.java
@@ -20,7 +20,6 @@ import static java.util.Optional.ofNullable;
 
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.worker.BackoffSupplier;
-import io.camunda.client.impl.worker.ExponentialBackoffBuilderImpl;
 import io.camunda.spring.client.annotation.customizer.JobWorkerValueCustomizer;
 import io.camunda.spring.client.jobhandling.CamundaClientExecutorService;
 import io.camunda.spring.client.jobhandling.CommandExceptionHandlingStrategy;
@@ -103,12 +102,7 @@ public class CamundaClientAllAutoConfiguration {
   @Bean
   @ConditionalOnMissingBean
   public BackoffSupplier backoffSupplier() {
-    return new ExponentialBackoffBuilderImpl()
-        .maxDelay(1000L)
-        .minDelay(50L)
-        .backoffFactor(1.5)
-        .jitterFactor(0.2)
-        .build();
+    return BackoffSupplier.newBackoffBuilder().build();
   }
 
   @Bean("propertyBasedJobWorkerValueCustomizer")

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaClientAllAutoConfiguration.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/configuration/CamundaClientAllAutoConfiguration.java
@@ -90,15 +90,18 @@ public class CamundaClientAllAutoConfiguration {
       final CommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
       final MetricsRecorder metricsRecorder,
       final ParameterResolverStrategy parameterResolverStrategy,
-      final ResultProcessorStrategy resultProcessorStrategy) {
+      final ResultProcessorStrategy resultProcessorStrategy,
+      final BackoffSupplier backoffSupplier) {
     return new JobWorkerManager(
         commandExceptionHandlingStrategy,
         metricsRecorder,
         parameterResolverStrategy,
-        resultProcessorStrategy);
+        resultProcessorStrategy,
+        backoffSupplier);
   }
 
   @Bean
+  @ConditionalOnMissingBean
   public BackoffSupplier backoffSupplier() {
     return new ExponentialBackoffBuilderImpl()
         .maxDelay(1000L)

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/jobhandling/JobWorkerManager.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/spring/client/jobhandling/JobWorkerManager.java
@@ -16,6 +16,7 @@
 package io.camunda.spring.client.jobhandling;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.client.api.worker.BackoffSupplier;
 import io.camunda.client.api.worker.JobHandler;
 import io.camunda.client.api.worker.JobWorker;
 import io.camunda.client.api.worker.JobWorkerBuilderStep1;
@@ -39,6 +40,7 @@ public class JobWorkerManager {
   private final MetricsRecorder metricsRecorder;
   private final ParameterResolverStrategy parameterResolverStrategy;
   private final ResultProcessorStrategy resultProcessorStrategy;
+  private final BackoffSupplier backoffSupplier;
 
   private List<JobWorker> openedWorkers = new ArrayList<>();
   private final List<JobWorkerValue> workerValues = new ArrayList<>();
@@ -47,11 +49,13 @@ public class JobWorkerManager {
       final CommandExceptionHandlingStrategy commandExceptionHandlingStrategy,
       final MetricsRecorder metricsRecorder,
       final ParameterResolverStrategy parameterResolverStrategy,
-      final ResultProcessorStrategy resultProcessorStrategy) {
+      final ResultProcessorStrategy resultProcessorStrategy,
+      final BackoffSupplier backoffSupplier) {
     this.commandExceptionHandlingStrategy = commandExceptionHandlingStrategy;
     this.metricsRecorder = metricsRecorder;
     this.parameterResolverStrategy = parameterResolverStrategy;
     this.resultProcessorStrategy = resultProcessorStrategy;
+    this.backoffSupplier = backoffSupplier;
   }
 
   public JobWorker openWorker(final CamundaClient client, final JobWorkerValue jobWorkerValue) {
@@ -75,6 +79,7 @@ public class JobWorkerManager {
             .jobType(jobWorkerValue.getType())
             .handler(handler)
             .name(jobWorkerValue.getName())
+            .backoffSupplier(backoffSupplier)
             .metrics(new CamundaClientMetricsBridge(metricsRecorder, jobWorkerValue.getType()));
 
     if (jobWorkerValue.getMaxJobsActive() != null && jobWorkerValue.getMaxJobsActive() > 0) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR enables the usage of a backoff supplier, effectively allowing users to override the backoff supplier bean with their own implementation instead of enforcing the default.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29753 
