### PR TITLE
Remove the empty string check from mockCredentials

### DIFF
--- a/clients/java/src/test/java/io/camunda/client/OAuthCredentialsProviderTest.java
+++ b/clients/java/src/test/java/io/camunda/client/OAuthCredentialsProviderTest.java
@@ -143,6 +143,7 @@ public final class OAuthCredentialsProviderTest {
   private WireMockRuntimeInfo currentWiremockRuntimeInfo;
 
   private Path cacheFilePath;
+  private final ObjectMapper jsonMapper = new ObjectMapper();
 
   public OAuthCredentialsProviderTest(final WireMockRuntimeInfo defaultWiremockRuntimeInfo) {
     this.defaultWiremockRuntimeInfo = defaultWiremockRuntimeInfo;
@@ -188,6 +189,28 @@ public final class OAuthCredentialsProviderTest {
             .credentialsCachePath(cacheFilePath.toString())
             .build();
     mockCredentials(ACCESS_TOKEN, SCOPE);
+
+    // when
+    provider.applyCredentials(applier);
+
+    // then
+    assertThat(applier.getCredentials())
+        .containsExactly(new Credential("Authorization", TOKEN_TYPE + " " + ACCESS_TOKEN));
+  }
+
+  @Test
+  void shouldRequestTokenWithEmptyScopeAndAddToCall() throws IOException {
+    // given
+    final OAuthCredentialsProvider provider =
+        new OAuthCredentialsProviderBuilder()
+            .clientId(CLIENT_ID)
+            .clientSecret(SECRET)
+            .audience(AUDIENCE)
+            .scope("")
+            .authorizationServerUrl(tokenUrlString())
+            .credentialsCachePath(cacheFilePath.toString())
+            .build();
+    mockCredentials(ACCESS_TOKEN, "");
 
     // when
     provider.applyCredentials(applier);
@@ -395,7 +418,7 @@ public final class OAuthCredentialsProviderTest {
     map.put("client_id", CLIENT_ID);
     map.put("audience", AUDIENCE);
     map.put("grant_type", "client_credentials");
-    if (scope != null && !scope.isEmpty()) {
+    if (scope != null) {
       map.put("scope", scope);
     }
 
@@ -404,29 +427,29 @@ public final class OAuthCredentialsProviderTest {
             .map(e -> encode(e.getKey()) + "=" + encode(e.getValue()))
             .collect(Collectors.joining("&"));
 
-    currentWiremockRuntimeInfo
-        .getWireMock()
-        .register(
-            WireMock.post(WireMock.urlPathEqualTo("/oauth/token"))
-                .withHeader("Content-Type", equalTo("application/x-www-form-urlencoded"))
-                .withHeader("Accept", equalTo("application/json"))
-                .withHeader("User-Agent", matching("camunda-client-java/\\d+\\.\\d+\\.\\d+.*"))
-                .withRequestBody(equalTo(encodedBody))
-                .willReturn(
-                    WireMock.aResponse()
-                        .withBody(
-                            "{\"access_token\":\""
-                                + token
-                                + "\",\"token_type\":\""
-                                + TOKEN_TYPE
-                                + "\",\"expires_in\":"
-                                + (EXPIRY.getLong(ChronoField.INSTANT_SECONDS)
-                                    - Instant.now().getEpochSecond())
-                                + ",\"scope\": \""
-                                + AUDIENCE
-                                + "\"}")
-                        .withFixedDelay(0)
-                        .withStatus(200)));
+    map.put("access_token", token);
+    map.put("token_type", TOKEN_TYPE);
+    map.put(
+        "expires_in",
+        String.valueOf(
+            EXPIRY.getLong(ChronoField.INSTANT_SECONDS) - Instant.now().getEpochSecond()));
+
+    try {
+      final String body = jsonMapper.writeValueAsString(map);
+      currentWiremockRuntimeInfo
+          .getWireMock()
+          .register(
+              WireMock.post(WireMock.urlPathEqualTo("/oauth/token"))
+                  .withHeader("Content-Type", equalTo("application/x-www-form-urlencoded"))
+                  .withHeader("Accept", equalTo("application/json"))
+                  .withHeader("User-Agent", matching("camunda-client-java/\\d+\\.\\d+\\.\\d+.*"))
+                  .withRequestBody(equalTo(encodedBody))
+                  .willReturn(
+                      WireMock.aResponse().withBody(body).withFixedDelay(0).withStatus(200)));
+    } catch (final JsonProcessingException e) {
+      // Turn into a runtime exception so we don't have to add it to all test cases.
+      throw new RuntimeException(e);
+    }
   }
 
   private static String encode(final String param) {

--- a/clients/java/src/test/java/io/camunda/client/OAuthCredentialsProviderTest.java
+++ b/clients/java/src/test/java/io/camunda/client/OAuthCredentialsProviderTest.java
@@ -201,16 +201,17 @@ public final class OAuthCredentialsProviderTest {
   @Test
   void shouldRequestTokenWithEmptyScopeAndAddToCall() throws IOException {
     // given
+    final String scope = "";
     final OAuthCredentialsProvider provider =
         new OAuthCredentialsProviderBuilder()
             .clientId(CLIENT_ID)
             .clientSecret(SECRET)
             .audience(AUDIENCE)
-            .scope("")
+            .scope(scope)
             .authorizationServerUrl(tokenUrlString())
             .credentialsCachePath(cacheFilePath.toString())
             .build();
-    mockCredentials(ACCESS_TOKEN, "");
+    mockCredentials(ACCESS_TOKEN, scope);
 
     // when
     provider.applyCredentials(applier);

--- a/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderTest.java
@@ -96,6 +96,7 @@ public final class OAuthCredentialsProviderTest {
   private final WireMockRuntimeInfo wireMockInfo;
 
   private Path cacheFilePath;
+  private final ObjectMapper jsonMapper = new ObjectMapper();
 
   public OAuthCredentialsProviderTest(final WireMockRuntimeInfo wireMockInfo) {
     this.wireMockInfo = wireMockInfo;
@@ -140,6 +141,28 @@ public final class OAuthCredentialsProviderTest {
             .credentialsCachePath(cacheFilePath.toString())
             .build();
     mockCredentials(ACCESS_TOKEN, SCOPE);
+
+    // when
+    provider.applyCredentials(applier);
+
+    // then
+    assertThat(applier.credentials)
+        .containsExactly(new Credential("Authorization", TOKEN_TYPE + " " + ACCESS_TOKEN));
+  }
+
+  @Test
+  void shouldRequestTokenWithEmptyScopeAndAddToCall() throws IOException {
+    // given
+    final OAuthCredentialsProvider provider =
+        new OAuthCredentialsProviderBuilder()
+            .clientId(CLIENT_ID)
+            .clientSecret(SECRET)
+            .audience(AUDIENCE)
+            .scope("")
+            .authorizationServerUrl(tokenUrlString())
+            .credentialsCachePath(cacheFilePath.toString())
+            .build();
+    mockCredentials(ACCESS_TOKEN, "");
 
     // when
     provider.applyCredentials(applier);
@@ -345,7 +368,7 @@ public final class OAuthCredentialsProviderTest {
     map.put("client_id", CLIENT_ID);
     map.put("audience", AUDIENCE);
     map.put("grant_type", "client_credentials");
-    if (scope != null && !scope.isEmpty()) {
+    if (scope != null) {
       map.put("scope", scope);
     }
 
@@ -354,29 +377,30 @@ public final class OAuthCredentialsProviderTest {
             .map(e -> encode(e.getKey()) + "=" + encode(e.getValue()))
             .collect(Collectors.joining("&"));
 
-    wireMockInfo
-        .getWireMock()
-        .register(
-            WireMock.post(WireMock.urlPathEqualTo("/oauth/token"))
-                .withHeader("Content-Type", equalTo("application/x-www-form-urlencoded"))
-                .withHeader("Accept", equalTo("application/json"))
-                .withHeader("User-Agent", matching("zeebe-client-java/\\d+\\.\\d+\\.\\d+.*"))
-                .withRequestBody(equalTo(encodedBody))
-                .willReturn(
-                    WireMock.aResponse()
-                        .withBody(
-                            "{\"access_token\":\""
-                                + token
-                                + "\",\"token_type\":\""
-                                + TOKEN_TYPE
-                                + "\",\"expires_in\":"
-                                + (EXPIRY.getLong(ChronoField.INSTANT_SECONDS)
-                                    - Instant.now().getEpochSecond())
-                                + ",\"scope\": \""
-                                + AUDIENCE
-                                + "\"}")
-                        .withFixedDelay(0)
-                        .withStatus(200)));
+    map.put("access_token", token);
+    map.put("token_type", TOKEN_TYPE);
+    map.put(
+        "expires_in",
+        String.valueOf(
+            EXPIRY.getLong(ChronoField.INSTANT_SECONDS) - Instant.now().getEpochSecond()));
+
+    final String body;
+    try {
+      body = jsonMapper.writeValueAsString(map);
+      wireMockInfo
+          .getWireMock()
+          .register(
+              WireMock.post(WireMock.urlPathEqualTo("/oauth/token"))
+                  .withHeader("Content-Type", equalTo("application/x-www-form-urlencoded"))
+                  .withHeader("Accept", equalTo("application/json"))
+                  .withHeader("User-Agent", matching("zeebe-client-java/\\d+\\.\\d+\\.\\d+.*"))
+                  .withRequestBody(equalTo(encodedBody))
+                  .willReturn(
+                      WireMock.aResponse().withBody(body).withFixedDelay(0).withStatus(200)));
+    } catch (final JsonProcessingException e) {
+      // Turn into a runtime exception so we don't have to add it to all test cases.
+      throw new RuntimeException(e);
+    }
   }
 
   private static String encode(final String param) {

--- a/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderTest.java
@@ -153,16 +153,17 @@ public final class OAuthCredentialsProviderTest {
   @Test
   void shouldRequestTokenWithEmptyScopeAndAddToCall() throws IOException {
     // given
+    final String scope = "";
     final OAuthCredentialsProvider provider =
         new OAuthCredentialsProviderBuilder()
             .clientId(CLIENT_ID)
             .clientSecret(SECRET)
             .audience(AUDIENCE)
-            .scope("")
+            .scope(scope)
             .authorizationServerUrl(tokenUrlString())
             .credentialsCachePath(cacheFilePath.toString())
             .build();
-    mockCredentials(ACCESS_TOKEN, "");
+    mockCredentials(ACCESS_TOKEN, scope);
 
     // when
     provider.applyCredentials(applier);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

In our production code we allow an empty string. We should allow it in our tests as well. I've also added a test case to
 verify it behaves as expected.

Related production code: 
https://github.com/camunda/camunda/blob/498147e193939f8afd27522e819a82850a77ad8f/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsProvider.java#L142-L144

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

No issue, but this comment in a PR from a contributor https://github.com/camunda/camunda/pull/29363#discussion_r1991552404
