### PR TITLE
[Backport stable/8.6] fix: default addresses are plaintext

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -71,8 +71,8 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
       "ZEEBE_CLIENT_WORKER_STREAM_ENABLED";
   public static final String DEFAULT_GATEWAY_ADDRESS = "0.0.0.0:26500";
   public static final URI DEFAULT_GRPC_ADDRESS =
-      getURIFromString("https://" + DEFAULT_GATEWAY_ADDRESS);
-  public static final URI DEFAULT_REST_ADDRESS = getURIFromString("https://0.0.0.0:8080");
+      getURIFromString("http://" + DEFAULT_GATEWAY_ADDRESS);
+  public static final URI DEFAULT_REST_ADDRESS = getURIFromString("http://0.0.0.0:8080");
   public static final String REST_ADDRESS_VAR = "ZEEBE_REST_ADDRESS";
   public static final String GRPC_ADDRESS_VAR = "ZEEBE_GRPC_ADDRESS";
   public static final String PREFER_REST_VAR = "ZEEBE_PREFER_REST";
@@ -111,7 +111,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   private int maxMessageSize = 4 * ONE_MB;
   private int maxMetadataSize = 16 * ONE_KB;
   private boolean streamEnabled = false;
-  private boolean grpcAddressUsed = false;
+  private boolean grpcAddressUsed = true;
   private ScheduledExecutorService jobWorkerExecutor;
   private boolean ownsJobWorkerExecutor;
   private boolean useDefaultRetryPolicy;
@@ -365,6 +365,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   @Override
   public ZeebeClientBuilder gatewayAddress(final String gatewayAddress) {
     this.gatewayAddress = gatewayAddress;
+    grpcAddressUsed = false;
     return this;
   }
 
@@ -401,7 +402,6 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
       throw new IllegalArgumentException("grpcAddress must be an absolute URI");
     }
     this.grpcAddress = grpcAddress;
-    grpcAddressUsed = true;
     return this;
   }
 

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
@@ -384,7 +384,7 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
   }
 
   private boolean composePlaintext() {
-    final String protocol = camundaClientProperties.getZeebe().getGrpcAddress().getScheme();
+    final String protocol = getGrpcAddress().getScheme();
     return switch (protocol) {
       case "http" -> true;
       case "https" -> false;

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationDefaultPropertiesTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationDefaultPropertiesTest.java
@@ -48,7 +48,7 @@ public class ZeebeClientConfigurationDefaultPropertiesTest {
   void testDefaultClientConfiguration() throws URISyntaxException {
     final ZeebeClient client = applicationContext.getBean(ZeebeClient.class);
 
-    assertThat(client.getConfiguration().isPlaintextConnectionEnabled()).isFalse();
+    assertThat(client.getConfiguration().isPlaintextConnectionEnabled()).isTrue();
     assertThat(client.getConfiguration().getCaCertificatePath()).isNull();
     assertThat(client.getConfiguration().getCredentialsProvider())
         .isInstanceOf(NoopCredentialsProvider.class);
@@ -67,14 +67,14 @@ public class ZeebeClientConfigurationDefaultPropertiesTest {
     assertThat(client.getConfiguration().getDefaultTenantId()).isEqualTo("<default>");
     assertThat(client.getConfiguration().getGatewayAddress()).isEqualTo("0.0.0.0:26500");
     assertThat(client.getConfiguration().getGrpcAddress())
-        .isEqualTo(new URI("https://0.0.0.0:26500"));
+        .isEqualTo(new URI("http://0.0.0.0:26500"));
     assertThat(client.getConfiguration().getKeepAlive()).isEqualTo(Duration.ofSeconds(45));
     assertThat(client.getConfiguration().getMaxMessageSize()).isEqualTo(4 * ONE_MB);
     assertThat(client.getConfiguration().getMaxMetadataSize()).isEqualTo(16 * ONE_KB);
     assertThat(client.getConfiguration().getNumJobWorkerExecutionThreads()).isEqualTo(1);
     assertThat(client.getConfiguration().getOverrideAuthority()).isNull();
     assertThat(client.getConfiguration().getRestAddress())
-        .isEqualTo(new URI("https://0.0.0.0:8080"));
+        .isEqualTo(new URI("http://0.0.0.0:8080"));
     assertThat(client.getConfiguration().preferRestOverGrpc()).isFalse();
   }
 }


### PR DESCRIPTION
# Description
Backport of #28779 to `stable/8.6`.

relates to 