### PR TITLE
feature: Increase the default inbound message size to 5MB for clients

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/CamundaClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/client/CamundaClientBuilder.java
@@ -196,8 +196,8 @@ public interface CamundaClientBuilder {
 
   /**
    * A custom maxMessageSize allows the client to receive larger or smaller responses from Camunda.
-   * Technically, it specifies the maxInboundMessageSize of the gRPC channel. The default is 4194304
-   * = 4MB.
+   * Technically, it specifies the maxInboundMessageSize of the gRPC channel. The default is 5242880
+   * = 5MB.
    */
   CamundaClientBuilder maxMessageSize(int maxSize);
 

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
@@ -111,7 +111,7 @@ public final class CamundaClientBuilderImpl
   private Duration keepAlive = Duration.ofSeconds(45);
   private JsonMapper jsonMapper = new CamundaObjectMapper();
   private String overrideAuthority;
-  private int maxMessageSize = 4 * ONE_MB;
+  private int maxMessageSize = 5 * ONE_MB;
   private int maxMetadataSize = 16 * ONE_KB;
   private boolean streamEnabled = false;
   private boolean grpcAddressUsed = true;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -201,8 +201,8 @@ public interface ZeebeClientBuilder {
 
   /**
    * A custom maxMessageSize allows the client to receive larger or smaller responses from Zeebe.
-   * Technically, it specifies the maxInboundMessageSize of the gRPC channel. The default is 4194304
-   * = 4MB.
+   * Technically, it specifies the maxInboundMessageSize of the gRPC channel. The default is 5242880
+   * = 5MB.
    */
   ZeebeClientBuilder maxMessageSize(int maxSize);
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -109,7 +109,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   private Duration keepAlive = Duration.ofSeconds(45);
   private JsonMapper jsonMapper = new ZeebeObjectMapper();
   private String overrideAuthority;
-  private int maxMessageSize = 4 * ONE_MB;
+  private int maxMessageSize = 5 * ONE_MB;
   private int maxMetadataSize = 16 * ONE_KB;
   private boolean streamEnabled = false;
   private boolean grpcAddressUsed = true;

--- a/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
+++ b/clients/java/src/test/java/io/camunda/client/CamundaClientTest.java
@@ -105,7 +105,7 @@ public final class CamundaClientTest {
       assertThat(configuration.getDefaultJobPollInterval()).isEqualTo(Duration.ofMillis(100));
       assertThat(configuration.getDefaultMessageTimeToLive()).isEqualTo(Duration.ofHours(1));
       assertThat(configuration.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(10));
-      assertThat(configuration.getMaxMessageSize()).isEqualTo(4 * 1024 * 1024);
+      assertThat(configuration.getMaxMessageSize()).isEqualTo(5 * 1024 * 1024);
       assertThat(configuration.getMaxMetadataSize()).isEqualTo(16 * 1024);
       assertThat(configuration.getOverrideAuthority()).isNull();
       assertThat(configuration.getDefaultTenantId())

--- a/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -102,7 +102,7 @@ public final class ZeebeClientTest extends ClientTest {
       assertThat(configuration.getDefaultJobPollInterval()).isEqualTo(Duration.ofMillis(100));
       assertThat(configuration.getDefaultMessageTimeToLive()).isEqualTo(Duration.ofHours(1));
       assertThat(configuration.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(10));
-      assertThat(configuration.getMaxMessageSize()).isEqualTo(4 * 1024 * 1024);
+      assertThat(configuration.getMaxMessageSize()).isEqualTo(5 * 1024 * 1024);
       assertThat(configuration.getMaxMetadataSize()).isEqualTo(16 * 1024);
       assertThat(configuration.getOverrideAuthority()).isNull();
       assertThat(configuration.getDefaultTenantId())

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CamundaClientConfigurationDefaultPropertiesTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CamundaClientConfigurationDefaultPropertiesTest.java
@@ -64,7 +64,7 @@ public class CamundaClientConfigurationDefaultPropertiesTest {
     assertThat(configuration.getGatewayAddress()).isEqualTo("0.0.0.0:26500");
     assertThat(configuration.getGrpcAddress()).isEqualTo(new URI("http://0.0.0.0:26500"));
     assertThat(configuration.getKeepAlive()).isEqualTo(Duration.ofSeconds(45));
-    assertThat(configuration.getMaxMessageSize()).isEqualTo(4 * ONE_MB);
+    assertThat(configuration.getMaxMessageSize()).isEqualTo(5 * ONE_MB);
     assertThat(configuration.getMaxMetadataSize()).isEqualTo(16 * ONE_KB);
     assertThat(configuration.getNumJobWorkerExecutionThreads()).isEqualTo(1);
     assertThat(configuration.getOverrideAuthority()).isNull();


### PR DESCRIPTION
## Description

**This PR increases the default  inbound message size limit to 5MB**

We stumbled across an [issue](https://github.com/camunda/camunda/issues/29606) that made us think raising the limit on the client might be useful if the payload size approximation on the server is slightly off. Thus for the client it's still acceptable to process this slightly larger payload and not raise an error.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] update camunda-docs if needed (here is the docs [PR](https://github.com/camunda/camunda-docs/pull/5300) 🕵️ )
- [x] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)
