### PR TITLE
Backporting Adding timestamp expiry and X509 checks to JWT token

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -426,6 +426,7 @@
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock-standalone</artifactId>
       <scope>test</scope>
+      <version>3.12.1</version>
     </dependency>
 
     <dependency>

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -421,6 +421,20 @@
       <artifactId>camunda-license-check</artifactId>
       <version>2.9.0</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.wiremock</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
+      <version>10.0.2</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/JwtDecoderIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/JwtDecoderIT.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.optimize.test.it.extension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import io.camunda.optimize.AbstractCCSMIT;
+import io.camunda.optimize.rest.security.AbstractSecurityConfigurerAdapter;
+import io.camunda.optimize.rest.security.ccsm.CCSMSecurityConfigurerAdapter;
+import io.camunda.optimize.rest.security.cloud.CCSaaSSecurityConfigurerAdapter;
+import java.util.Date;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.security.oauth2.jwt.BadJwtException;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtValidationException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@WireMockTest
+public class JwtDecoderIT extends AbstractCCSMIT {
+
+  private final MockEnvironment environment = new MockEnvironment();
+  private final WireMockRuntimeInfo wireMockInfo;
+  private final String authServerMockUrl;
+  private JwtDecoder decoder;
+
+  public JwtDecoderIT(final WireMockRuntimeInfo wireMockInfo) {
+    this.wireMockInfo = wireMockInfo;
+    authServerMockUrl = wireMockInfo.getHttpBaseUrl();
+  }
+
+  @BeforeEach
+  public void setup() {
+    embeddedOptimizeExtension
+        .getConfigurationService()
+        .getOptimizeApiConfiguration()
+        .setJwtSetUri(authServerMockUrl + "/protocol/openid-connect/certs");
+    embeddedOptimizeExtension
+        .getConfigurationService()
+        .getAuthConfiguration()
+        .getCloudAuthConfiguration()
+        .setAudience("optimize");
+    embeddedOptimizeExtension
+        .getConfigurationService()
+        .getAuthConfiguration()
+        .getCloudAuthConfiguration()
+        .setClusterId("456");
+    embeddedOptimizeExtension
+        .getConfigurationService()
+        .getAuthConfiguration()
+        .getCcsmAuthConfiguration()
+        .setAudience("optimize");
+  }
+
+  @ParameterizedTest
+  @MethodSource("decoderProvider")
+  public void testDecodeRs256JwtWithNoAlgFieldInJwkResponse(
+      final String type, final String methodName) throws JOSEException {
+    // given
+    final RSAKey rsaJWK = getRsaJWK(JWSAlgorithm.RS256);
+    final String serializedJwt = signAndSerialize(rsaJWK, JWSAlgorithm.RS256);
+    final String publicKey = rsaJWK.toPublicJWK().toJSONString();
+
+    final JwtDecoder decoder = createDecoder(authServerMockUrl, methodName, type);
+
+    // remove alg field from mocked server response and assert it was removed to cover this use case
+    final String withoutAlg = publicKey.replaceFirst("\"alg\":\".*\",", "");
+    final String authServerResponseBody = "{\"keys\":[" + withoutAlg + "]}";
+    System.out.println("authServerResponse=" + authServerResponseBody);
+    assertFalse(authServerResponseBody.contains("alg\":"));
+    wireMockInfo
+        .getWireMock()
+        .register(
+            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
+                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
+
+    // when - then
+    assertDoesNotThrow(() -> decoder.decode(serializedJwt));
+    wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+  }
+
+  @ParameterizedTest
+  @MethodSource("decoderProvider")
+  public void testDecodeRs256Jwt(final String type, final String methodName) throws JOSEException {
+    // given
+    final RSAKey rsaJWK = getRsaJWK(JWSAlgorithm.RS256);
+    final String serializedJwt = signAndSerialize(rsaJWK, JWSAlgorithm.RS256);
+    final String publicKey = rsaJWK.toPublicJWK().toJSONString();
+
+    final JwtDecoder decoder = createDecoder(authServerMockUrl, methodName, type);
+
+    final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
+    System.out.println("authServerResponse=" + authServerResponseBody);
+
+    wireMockInfo
+        .getWireMock()
+        .register(
+            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
+                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
+
+    // when - then
+    assertDoesNotThrow(() -> decoder.decode(serializedJwt));
+    wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+  }
+
+  @ParameterizedTest
+  @MethodSource("decoderProvider")
+  public void testDecodeRs256JwtExpired(final String type, final String methodName)
+      throws JOSEException {
+    // given
+    final RSAKey rsaJWK = getRsaJWK(JWSAlgorithm.RS256);
+    final String serializedJwt =
+        signAndSerialize(rsaJWK, JWSAlgorithm.RS256, getExpiredClaimsSet());
+    final String publicKey = rsaJWK.toPublicJWK().toJSONString();
+    final JwtDecoder decoder = createDecoder(authServerMockUrl, methodName, type);
+
+    final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
+    System.out.println("authServerResponse=" + authServerResponseBody);
+
+    wireMockInfo
+        .getWireMock()
+        .register(
+            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
+                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
+
+    // when - then
+    final Exception exception =
+        assertThrows(JwtValidationException.class, () -> decoder.decode(serializedJwt));
+    wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+    assertThat(exception.getMessage()).containsIgnoringCase("Jwt expired");
+  }
+
+  @ParameterizedTest
+  @MethodSource("decoderProvider")
+  public void testDecodeRs256JwtInvalidSignature(final String type, final String methodName)
+      throws JOSEException {
+    // given
+    final RSAKey rsaJWK = getRsaJWK(JWSAlgorithm.RS256);
+    final String serializedJwt = signAndSerialize(rsaJWK, JWSAlgorithm.RS256);
+    final String publicKey = rsaJWK.toPublicJWK().toJSONString();
+
+    final JwtDecoder decoder = createDecoder(authServerMockUrl, methodName, type);
+
+    final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
+    System.out.println("authServerResponse=" + authServerResponseBody);
+
+    wireMockInfo
+        .getWireMock()
+        .register(
+            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
+                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
+
+    final String[] jwtParts = serializedJwt.split("\\.");
+    if (jwtParts.length == 3) {
+      final String unsignedJwt = jwtParts[0] + "." + jwtParts[1] + ".anySignature";
+      // when - then
+      final Exception exception =
+          assertThrows(BadJwtException.class, (() -> decoder.decode(unsignedJwt)));
+      wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+      assertThat(exception.getMessage()).containsIgnoringCase("Invalid Signature");
+    } else {
+      throw new RuntimeException("Invalid JWT token format");
+    }
+  }
+
+  private RSAKey getRsaJWK(final JWSAlgorithm alg) throws JOSEException {
+    return new RSAKeyGenerator(2048)
+        .keyID("123")
+        .keyUse(KeyUse.SIGNATURE)
+        .algorithm(alg)
+        .generate();
+  }
+
+  public static String signAndSerialize(
+      final RSAKey rsaKey, final JWSAlgorithm alg, final JWTClaimsSet claimsSet)
+      throws JOSEException {
+    // Create RSA-signer with the private key
+    final JWSSigner rsaSigner = new RSASSASigner(rsaKey);
+
+    final SignedJWT rsaSignedJWT =
+        new SignedJWT(
+            new JWSHeader.Builder(alg).type(JOSEObjectType.JWT).keyID(rsaKey.getKeyID()).build(),
+            claimsSet);
+
+    rsaSignedJWT.sign(rsaSigner);
+    final String serializedJwt = rsaSignedJWT.serialize();
+    System.out.println("JWT serialized=" + serializedJwt);
+    return serializedJwt;
+  }
+
+  public static String signAndSerialize(final RSAKey rsaKey, final JWSAlgorithm alg)
+      throws JOSEException {
+    return signAndSerialize(rsaKey, alg, getDefaultClaimsSet());
+  }
+
+  public static JWTClaimsSet getDefaultClaimsSet() {
+    // prepare default JWT claims set
+    return new JWTClaimsSet.Builder()
+        .subject("alice")
+        .audience("optimize")
+        .issuer("http://localhost")
+        .claim("https://camunda.com/clusterId", "456")
+        .expirationTime(new Date(new Date().getTime() + 60 * 1000))
+        .build();
+  }
+
+  public static JWTClaimsSet getExpiredClaimsSet() {
+    return new JWTClaimsSet.Builder()
+        .subject("alice")
+        .audience("optimize")
+        .issuer("http://localhost")
+        .claim("https://camunda.com/clusterId", "456")
+        .expirationTime(new Date(System.currentTimeMillis() - 100000))
+        .build();
+  }
+
+  private String getAuthServerMockUrl() {
+    return authServerMockUrl;
+  }
+
+  private static JwtDecoder createDecoder(
+      final String authServerMockUrl, final String methodName, final String type) {
+    final AbstractSecurityConfigurerAdapter configurerAdapter;
+    if ("SaaS".equalsIgnoreCase(type)) {
+      configurerAdapter =
+          new CCSaaSSecurityConfigurerAdapter(
+              embeddedOptimizeExtension.getConfigurationService(), null, null, null, null, null);
+    } else if ("CCSM".equalsIgnoreCase(type)) {
+      configurerAdapter =
+          new CCSMSecurityConfigurerAdapter(
+              embeddedOptimizeExtension.getConfigurationService(), null, null, null, null);
+    } else {
+      throw new IllegalArgumentException("Invalid type: " + type);
+    }
+    return ReflectionTestUtils.invokeMethod(configurerAdapter, methodName);
+  }
+
+  static Stream<Arguments> decoderProvider() {
+    return Stream.of(
+        Arguments.of("SaaS", "publicApiJwtDecoder"),
+        Arguments.of("CCSM", "publicApiJwtDecoder"),
+        Arguments.of("SaaS", "publicApiJwtDecoder"));
+  }
+
+  public static class JwtDecoderArgumentsProvider implements ArgumentsProvider {
+    @Override
+    public Stream<? extends Arguments> provideArguments(final ExtensionContext context) {
+      final JwtDecoderIT testInstance = (JwtDecoderIT) context.getRequiredTestInstance();
+      final String authServerMockUrl = testInstance.getAuthServerMockUrl();
+      return Stream.of(
+          Arguments.of(createSaaSDecoder(authServerMockUrl)),
+          Arguments.of(createSaaSDecoderPublicApi(authServerMockUrl)),
+          Arguments.of(createCCSMDecoderPublicApi(authServerMockUrl)));
+    }
+
+    private static JwtDecoder createSaaSDecoder(final String authServerMockUrl) {
+      embeddedOptimizeExtension
+          .getConfigurationService()
+          .getOptimizeApiConfiguration()
+          .setJwtSetUri(authServerMockUrl + "/protocol/openid-connect/certs");
+      embeddedOptimizeExtension
+          .getConfigurationService()
+          .getAuthConfiguration()
+          .getCloudAuthConfiguration()
+          .setAudience("optimize");
+      embeddedOptimizeExtension
+          .getConfigurationService()
+          .getAuthConfiguration()
+          .getCloudAuthConfiguration()
+          .setClusterId("456");
+      final CCSaaSSecurityConfigurerAdapter saasWebConfigurer =
+          new CCSaaSSecurityConfigurerAdapter(
+              embeddedOptimizeExtension.getConfigurationService(), null, null, null, null, null);
+      return ReflectionTestUtils.invokeMethod(saasWebConfigurer, "jwtDecoder");
+    }
+
+    private static JwtDecoder createSaaSDecoderPublicApi(final String authServerMockUrl) {
+      embeddedOptimizeExtension
+          .getConfigurationService()
+          .getOptimizeApiConfiguration()
+          .setJwtSetUri(authServerMockUrl + "/protocol/openid-connect/certs");
+      embeddedOptimizeExtension
+          .getConfigurationService()
+          .getOptimizeApiConfiguration()
+          .setAudience("optimize");
+      embeddedOptimizeExtension
+          .getConfigurationService()
+          .getAuthConfiguration()
+          .getCloudAuthConfiguration()
+          .setClusterId("456");
+      final CCSaaSSecurityConfigurerAdapter saasWebConfigurer =
+          new CCSaaSSecurityConfigurerAdapter(
+              embeddedOptimizeExtension.getConfigurationService(), null, null, null, null, null);
+      return ReflectionTestUtils.invokeMethod(saasWebConfigurer, "publicApiJwtDecoder");
+    }
+
+    private static JwtDecoder createCCSMDecoderPublicApi(final String authServerMockUrl) {
+      embeddedOptimizeExtension
+          .getConfigurationService()
+          .getOptimizeApiConfiguration()
+          .setJwtSetUri(authServerMockUrl + "/protocol/openid-connect/certs");
+      embeddedOptimizeExtension
+          .getConfigurationService()
+          .getOptimizeApiConfiguration()
+          .setAudience("optimize");
+      final CCSMSecurityConfigurerAdapter ccsmWebConfigurer =
+          new CCSMSecurityConfigurerAdapter(
+              embeddedOptimizeExtension.getConfigurationService(), null, null, null, null);
+      return ReflectionTestUtils.invokeMethod(ccsmWebConfigurer, "publicApiJwtDecoder");
+    }
+  }
+}

--- a/optimize/backend/src/main/java/io/camunda/optimize/rest/security/ccsm/CCSMSecurityConfigurerAdapter.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/rest/security/ccsm/CCSMSecurityConfigurerAdapter.java
@@ -45,6 +45,7 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
@@ -165,11 +166,15 @@ public class CCSMSecurityConfigurerAdapter extends AbstractSecurityConfigurerAda
         .orElseGet(() -> new OptimizeStaticTokenDecoder(configurationService));
   }
 
+  @SuppressWarnings("unchecked")
   private JwtDecoder createJwtDecoderWithAudience(final String jwtSetUri) {
     final NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder.withJwkSetUri(jwtSetUri).build();
     final OAuth2TokenValidator<Jwt> audienceValidator =
         new AudienceValidator(getAudienceFromConfiguration());
-    jwtDecoder.setJwtValidator(audienceValidator);
+    // The default validator already contains validation for timestamp and X509 thumbprint
+    final OAuth2TokenValidator<Jwt> combinedValidatorWithDefaults =
+        JwtValidators.createDefaultWithValidators(audienceValidator);
+    jwtDecoder.setJwtValidator(combinedValidatorWithDefaults);
     return jwtDecoder;
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Backporting Adding timestamp expiry and X509 checks to JWT token #29506

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

related to #29508 
