### PR TITLE
pg-handle-empty-snapshots

### DIFF
--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepository.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepository.java
@@ -335,6 +335,10 @@ public class ElasticsearchBackupRepository implements BackupRepository {
     final GetSnapshotResponse response;
     try {
       response = esClient.snapshot().get(snapshotsStatusRequest);
+      if (response.snapshots().isEmpty()) {
+        throw new ResourceNotFoundException(
+            String.format("No backup with id [%s] found.", backupId));
+      }
       return response.snapshots();
     } catch (final IOException ex) {
       final String reason =


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
When querying ES for the state of snapshots, if a wildcard (*) is used in the snapshot id the response contains an empty array of snapshots instead of the `snapshot_missing_exception`. This caused a `NoSuchElementException` to be thrown later down the line. 

To mitigate this behavior, we treat the empty snaphots array the same as we do the `snapshot_missing_exception` throwing a `ResourceNotFoundException` to be handled by the controller.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues
closes: #29622