### PR TITLE
Configure Log4J2 for structured logging

### DIFF
--- a/dist/src/main/config/log4j2.xml
+++ b/dist/src/main/config/log4j2.xml
@@ -34,9 +34,9 @@
 
   <Loggers>
     <Logger name="io.camunda" level="${env:CAMUNDA_LOG_LEVEL:-INFO}" />
-    <Logger name="io.camunda.zeebe" level="${env:ZEEBE_LOG_LEVEL:-${env:CAMUNDA_LOG_LEVEL-INFO}}" />
-    <Logger name="io.atomix" level="${env:ATOMIX_LOG_LEVEL:-${env:CAMUNDA_LOG_LEVEL-INFO}}" />
-    <Logger name="io.camunda.optimize" level="${env:OPTIMIZE_LOG_LEVEL:-${env:CAMUNDA_LOG_LEVEL-INFO}}" />
+    <Logger name="io.camunda.zeebe" level="${env:ZEEBE_LOG_LEVEL:-${env:CAMUNDA_LOG_LEVEL:-INFO}}" />
+    <Logger name="io.atomix" level="${env:ATOMIX_LOG_LEVEL:-${env:CAMUNDA_LOG_LEVEL:-INFO}}" />
+    <Logger name="io.camunda.optimize" level="${env:OPTIMIZE_LOG_LEVEL:-${env:CAMUNDA_LOG_LEVEL:-INFO}}" />
     <Logger name="org.elasticsearch" level="${env:ES_LOG_LEVEL:-WARN}" />
     <Logger name="org.springframework" level="INFO" />
 

--- a/dist/src/main/config/log4j2.xml
+++ b/dist/src/main/config/log4j2.xml
@@ -6,7 +6,7 @@
                    https://logging.apache.org/xml/ns/log4j-config-2.xsd" status="WARN" shutdownHook="disable">
   <Properties>
     <Property name="log.path" value="${sys:app.home}/logs" />
-    <Property name="log.pattern" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{actor-scheduler}] [%t] [%X{actor-name}] %-5level%n\t%logger{36} - %msg%n" />
+    <Property name="log.pattern" value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%t] %notEmpty{[%X] }%-5level%n\t%logger{36} - %msg%n" />
     <Property name="log.stackdriver.serviceName" value="${env:ZEEBE_LOG_STACKDRIVER_SERVICENAME:-${env:OPERATE_LOG_STACKDRIVER_SERVICENAME:-${env:OPTIMIZE_LOG_STACKDRIVER_SERVICENAME:-${env:TASKLIST_LOG_STACKDRIVER_SERVICENAME:-}}}}"/>
     <Property name="log.stackdriver.serviceVersion" value="${env:ZEEBE_LOG_STACKDRIVER_SERVICEVERSION:-${env:OPERATE_LOG_STACKDRIVER_SERVICEVERSION:-${env:OPTIMIZE_LOG_STACKDRIVER_SERVICEVERSION:-${env:TASKLIST_LOG_STACKDRIVER_SERVICEVERSION:-}}}}"/>
   </Properties>

--- a/dist/src/main/config/log4j2.xml
+++ b/dist/src/main/config/log4j2.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" shutdownHook="disable">
-
+<Configuration xmlns="https://logging.apache.org/xml/ns"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="
+                   https://logging.apache.org/xml/ns
+                   https://logging.apache.org/xml/ns/log4j-config-2.xsd" status="WARN" shutdownHook="disable">
   <Properties>
-    <Property name="log.path">${sys:app.home}/logs</Property>
-    <Property name="log.pattern">%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{actor-scheduler}] [%t] [%X{actor-name}] %-5level
-      %logger{36} - %msg%n
-    </Property>
-    <Property name="log.stackdriver.serviceName">${env:ZEEBE_LOG_STACKDRIVER_SERVICENAME:-${env:OPERATE_LOG_STACKDRIVER_SERVICENAME:-${env:OPTIMIZE_LOG_STACKDRIVER_SERVICENAME:-${env:TASKLIST_LOG_STACKDRIVER_SERVICENAME:-}}}}
-    </Property>
-    <Property name="log.stackdriver.serviceVersion">${env:ZEEBE_LOG_STACKDRIVER_SERVICEVERSION:-${env:OPERATE_LOG_STACKDRIVER_SERVICEVERSION:-${env:OPTIMIZE_LOG_STACKDRIVER_SERVICEVERSION:-${env:TASKLIST_LOG_STACKDRIVER_SERVICEVERSION:-}}}}
-    </Property>
+    <Property name="log.path" value="${sys:app.home}/logs" />
+    <Property name="log.pattern" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{actor-scheduler}] [%t] [%X{actor-name}] %-5level
+      %logger{36} - %msg%n" />
+    <Property name="log.stackdriver.serviceName" value="${env:ZEEBE_LOG_STACKDRIVER_SERVICENAME:-${env:OPERATE_LOG_STACKDRIVER_SERVICENAME:-${env:OPTIMIZE_LOG_STACKDRIVER_SERVICENAME:-${env:TASKLIST_LOG_STACKDRIVER_SERVICENAME:-}}}}"/>
+    <Property name="log.stackdriver.serviceVersion" value="${env:ZEEBE_LOG_STACKDRIVER_SERVICEVERSION:-${env:OPERATE_LOG_STACKDRIVER_SERVICEVERSION:-${env:OPTIMIZE_LOG_STACKDRIVER_SERVICEVERSION:-${env:TASKLIST_LOG_STACKDRIVER_SERVICEVERSION:-}}}}"/>
   </Properties>
 
   <Appenders>
@@ -25,9 +25,7 @@
 
     <RollingFile name="RollingFile" fileName="${log.path}/zeebe.log"
       filePattern="${log.path}/zeebe-%d{yyyy-MM-dd}-%i.log.gz">
-      <PatternLayout>
-        <Pattern>${log.pattern}</Pattern>
-      </PatternLayout>
+      <PatternLayout pattern="${log.pattern}" />
       <Policies>
         <TimeBasedTriggeringPolicy/>
         <SizeBasedTriggeringPolicy size="250 MB"/>
@@ -36,14 +34,14 @@
   </Appenders>
 
   <Loggers>
-    <Logger name="io.camunda.zeebe" level="${env:ZEEBE_LOG_LEVEL:-info}"/>
-    <Logger name="io.atomix" level="${env:ATOMIX_LOG_LEVEL:-info}"/>
-    <Logger name="io.camunda.operate" level="info" />
-    <Logger name="io.camunda.optimize" level="${env:OPTIMIZE_LOG_LEVEL:-info}" />
-    <Logger name="io.camunda.tasklist" level="info" />
-    <Logger name="org.elasticsearch" level="${env:ES_LOG_LEVEL:-warn}" />
+    <Logger name="io.camunda.zeebe" level="${env:ZEEBE_LOG_LEVEL:-INFO}"/>
+    <Logger name="io.atomix" level="${env:ATOMIX_LOG_LEVEL:-INFO}"/>
+    <Logger name="io.camunda.operate" level="INFO" />
+    <Logger name="io.camunda.optimize" level="${env:OPTIMIZE_LOG_LEVEL:-INFO}" />
+    <Logger name="io.camunda.tasklist" level="INFO" />
+    <Logger name="org.elasticsearch" level="${env:ES_LOG_LEVEL:-WARN}" />
 
-    <Root level="info">
+    <Root level="WARN">
       <AppenderRef ref="RollingFile"/>
 
       <!-- remove to disable console logging -->
@@ -51,7 +49,7 @@
     </Root>
 
     <!-- disable noisy loggers -->
-    <Logger name="org.ehcache.core.EhcacheManager" level="warn"/>
+    <Logger name="org.ehcache.core.EhcacheManager" level="WARN"/>
   </Loggers>
 
 </Configuration>

--- a/dist/src/main/config/log4j2.xml
+++ b/dist/src/main/config/log4j2.xml
@@ -6,8 +6,7 @@
                    https://logging.apache.org/xml/ns/log4j-config-2.xsd" status="WARN" shutdownHook="disable">
   <Properties>
     <Property name="log.path" value="${sys:app.home}/logs" />
-    <Property name="log.pattern" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{actor-scheduler}] [%t] [%X{actor-name}] %-5level
-      %logger{36} - %msg%n" />
+    <Property name="log.pattern" value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{actor-scheduler}] [%t] [%X{actor-name}] %-5level%n\t%logger{36} - %msg%n" />
     <Property name="log.stackdriver.serviceName" value="${env:ZEEBE_LOG_STACKDRIVER_SERVICENAME:-${env:OPERATE_LOG_STACKDRIVER_SERVICENAME:-${env:OPTIMIZE_LOG_STACKDRIVER_SERVICENAME:-${env:TASKLIST_LOG_STACKDRIVER_SERVICENAME:-}}}}"/>
     <Property name="log.stackdriver.serviceVersion" value="${env:ZEEBE_LOG_STACKDRIVER_SERVICEVERSION:-${env:OPERATE_LOG_STACKDRIVER_SERVICEVERSION:-${env:OPTIMIZE_LOG_STACKDRIVER_SERVICEVERSION:-${env:TASKLIST_LOG_STACKDRIVER_SERVICEVERSION:-}}}}"/>
   </Properties>
@@ -34,12 +33,12 @@
   </Appenders>
 
   <Loggers>
-    <Logger name="io.camunda.zeebe" level="${env:ZEEBE_LOG_LEVEL:-INFO}"/>
-    <Logger name="io.atomix" level="${env:ATOMIX_LOG_LEVEL:-INFO}"/>
-    <Logger name="io.camunda.operate" level="INFO" />
+    <Logger name="io.camunda" level="${env:CAMUNDA_LOG_LEVEL:-INFO}" />
+    <Logger name="io.camunda.zeebe" level="${env:ZEEBE_LOG_LEVEL:-INFO}" />
+    <Logger name="io.atomix" level="${env:ATOMIX_LOG_LEVEL:-INFO}" />
     <Logger name="io.camunda.optimize" level="${env:OPTIMIZE_LOG_LEVEL:-INFO}" />
-    <Logger name="io.camunda.tasklist" level="INFO" />
     <Logger name="org.elasticsearch" level="${env:ES_LOG_LEVEL:-WARN}" />
+    <Logger name="org.springframework" level="INFO" />
 
     <Root level="WARN">
       <AppenderRef ref="RollingFile"/>
@@ -47,9 +46,6 @@
       <!-- remove to disable console logging -->
       <AppenderRef ref="${env:ZEEBE_LOG_APPENDER:-${env:OPERATE_LOG_APPENDER:-${env:OPTIMIZE_LOG_APPENDER:-${env:TASKLIST_LOG_APPENDER:-Console}}}}"/>
     </Root>
-
-    <!-- disable noisy loggers -->
-    <Logger name="org.ehcache.core.EhcacheManager" level="WARN"/>
   </Loggers>
 
 </Configuration>

--- a/dist/src/main/config/log4j2.xml
+++ b/dist/src/main/config/log4j2.xml
@@ -34,9 +34,9 @@
 
   <Loggers>
     <Logger name="io.camunda" level="${env:CAMUNDA_LOG_LEVEL:-INFO}" />
-    <Logger name="io.camunda.zeebe" level="${env:ZEEBE_LOG_LEVEL:-INFO}" />
-    <Logger name="io.atomix" level="${env:ATOMIX_LOG_LEVEL:-INFO}" />
-    <Logger name="io.camunda.optimize" level="${env:OPTIMIZE_LOG_LEVEL:-INFO}" />
+    <Logger name="io.camunda.zeebe" level="${env:ZEEBE_LOG_LEVEL:-${env:CAMUNDA_LOG_LEVEL-INFO}}" />
+    <Logger name="io.atomix" level="${env:ATOMIX_LOG_LEVEL:-${env:CAMUNDA_LOG_LEVEL-INFO}}" />
+    <Logger name="io.camunda.optimize" level="${env:OPTIMIZE_LOG_LEVEL:-${env:CAMUNDA_LOG_LEVEL-INFO}}" />
     <Logger name="org.elasticsearch" level="${env:ES_LOG_LEVEL:-WARN}" />
     <Logger name="org.springframework" level="INFO" />
 


### PR DESCRIPTION
## Description

This PR configures Log4j2 for structured logging, by printing out the complete MDC and not just specific keys.

Additionally, it:

- Adds the schema to the file such that we can now get warnings about incorrect configurations.
- Fixes the configuration to conform to the expected schema.
- Changes the default level configuration which was broken; it seems the root `WARN` was not taken into account, requiring us to add things for EhCache, for example, but also letting through things like the Hibernate info logs.
- Introduces `CAMUNDA_LOG_LEVEL` which can set the log level for all `io.camunda` logs, but still allows overrides via `ZEEBE_LOG_LEVEL` and so on.

Note that changing the pattern can be a breaking change for people who set up alerts are the default logging pattern, if they were not matching messages but actual pattern information. This doesn't affect anyone using `StackdriverLayout`, however - just the default pattern layout.

I would also add an announcement for it. I would backport this PR partially, minus the pattern changes - I don't think it's worth adding that for a patch. But the fixes to the config are good, at least for the mono repo versions.
