### PR TITLE
Add new @MultiDbTestApplication annotation

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/StandaloneCamundaTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/StandaloneCamundaTest.java
@@ -12,26 +12,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.client.CamundaClient;
 import io.camunda.qa.util.cluster.TestRestOperateClient.ProcessInstanceResult;
 import io.camunda.qa.util.cluster.TestSimpleCamundaApplication;
-import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.util.Either;
 import java.time.Duration;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
-@Tag("multi-db-test")
+@MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 public class StandaloneCamundaTest {
 
+  @MultiDbTestApplication
   private static final TestSimpleCamundaApplication CAMUNDA_APPLICATION =
       new TestSimpleCamundaApplication().withUnauthenticatedAccess();
-
-  @RegisterExtension
-  private static final CamundaMultiDBExtension EXTENSION =
-      new CamundaMultiDBExtension(CAMUNDA_APPLICATION);
 
   private static CamundaClient camundaClient;
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/ApplicationAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/ApplicationAuthorizationIT.java
@@ -19,7 +19,8 @@ import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.User;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.cluster.TestSimpleCamundaApplication;
-import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
@@ -31,26 +32,22 @@ import java.net.http.HttpResponse;
 import java.util.Base64;
 import java.util.List;
 import org.junit.jupiter.api.AutoClose;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-@Tag("multi-db-test")
+@MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 class ApplicationAuthorizationIT {
 
   private static final String PATH_OPERATE = "operate";
   private static final String PATH_OPERATE_WEBAPP_USER = "/user";
+
+  @MultiDbTestApplication
   private static final TestSimpleCamundaApplication STANDALONE_CAMUNDA =
       new TestSimpleCamundaApplication().withBasicAuth().withAuthorizationsEnabled();
-
-  @RegisterExtension
-  private static final CamundaMultiDBExtension EXTENSION =
-      new CamundaMultiDBExtension(STANDALONE_CAMUNDA);
 
   private static final String RESTRICTED = "restricted";
   private static final String ADMIN = "admin";

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/AuthorizationSearchIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/AuthorizationSearchIT.java
@@ -18,7 +18,8 @@ import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.User;
 import io.camunda.qa.util.auth.UserDefinition;
-import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.io.IOException;
 import java.net.URI;
@@ -29,21 +30,17 @@ import java.net.http.HttpResponse;
 import java.util.Base64;
 import java.util.List;
 import org.junit.jupiter.api.AutoClose;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
-@Tag("multi-db-test")
+@MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 class AuthorizationSearchIT {
 
+  @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
       new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
-
-  @RegisterExtension
-  static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(BROKER);
 
   private static final ObjectMapper OBJECT_MAPPER =
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthenticationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthenticationIT.java
@@ -13,7 +13,8 @@ import io.camunda.client.CamundaClient;
 import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.User;
 import io.camunda.qa.util.auth.UserDefinition;
-import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.net.HttpURLConnection;
 import java.net.URI;
@@ -24,22 +25,19 @@ import java.net.http.HttpResponse;
 import java.util.Base64;
 import java.util.List;
 import org.junit.jupiter.api.AutoClose;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
-@Tag("multi-db-test")
+@MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class BasicAuthenticationIT {
 
   public static final String PATH_V2_AUTHENTICATION_ME = "v2/authentication/me";
+
+  @MultiDbTestApplication
   private static final TestStandaloneBroker BROKER =
       new TestStandaloneBroker().withBasicAuth().withAuthenticatedAccess();
-
-  @RegisterExtension
-  private static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(BROKER);
 
   private static final String USERNAME = "correct_username";
   private static final String PASSWORD = "correct_password";

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/DecisionAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/DecisionAuthorizationIT.java
@@ -23,28 +23,25 @@ import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.User;
 import io.camunda.qa.util.auth.UserDefinition;
-import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.function.Executable;
 
-@Tag("multi-db-test")
+@MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 class DecisionAuthorizationIT {
 
+  @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
       new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
-
-  @RegisterExtension
-  static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(BROKER);
 
   private static final String DECISION_DEFINITION_ID_1 = "decision_1";
   private static final String DECISION_REQUIREMENTS_ID_1 = "definitions_1";

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/DecisionInstanceAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/DecisionInstanceAuthorizationIT.java
@@ -24,28 +24,25 @@ import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.User;
 import io.camunda.qa.util.auth.UserDefinition;
-import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.function.Executable;
 
-@Tag("multi-db-test")
+@MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 class DecisionInstanceAuthorizationIT {
 
+  @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
       new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
-
-  @RegisterExtension
-  static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(BROKER);
 
   private static final String DECISION_DEFINITION_ID_1 = "decision_1";
   private static final String DECISION_DEFINITION_ID_2 = "test_qa";

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/GroupSearchingAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/GroupSearchingAuthorizationIT.java
@@ -19,7 +19,8 @@ import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.User;
 import io.camunda.qa.util.auth.UserDefinition;
-import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.io.IOException;
 import java.net.URI;
@@ -33,21 +34,17 @@ import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
-@Tag("multi-db-test")
+@MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 class GroupSearchingAuthorizationIT {
 
+  @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
       new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
-
-  @RegisterExtension
-  static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(BROKER);
 
   private static final ObjectMapper OBJECT_MAPPER =
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/MappingAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/MappingAuthorizationIT.java
@@ -19,7 +19,8 @@ import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.User;
 import io.camunda.qa.util.auth.UserDefinition;
-import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.io.IOException;
 import java.net.URI;
@@ -33,21 +34,17 @@ import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
-@Tag("multi-db-test")
+@MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 class MappingAuthorizationIT {
 
+  @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
       new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
-
-  @RegisterExtension
-  static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(BROKER);
 
   private static final ObjectMapper OBJECT_MAPPER =
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/ProcessAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/ProcessAuthorizationIT.java
@@ -21,28 +21,25 @@ import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.User;
 import io.camunda.qa.util.auth.UserDefinition;
-import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.function.Executable;
 
-@Tag("multi-db-test")
+@MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 class ProcessAuthorizationIT {
 
+  @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
       new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
-
-  @RegisterExtension
-  static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(BROKER);
 
   private static final String ADMIN = "admin";
   private static final String RESTRICTED = "restrictedUser";

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/ProcessInstanceAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/ProcessInstanceAuthorizationIT.java
@@ -22,28 +22,25 @@ import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.User;
 import io.camunda.qa.util.auth.UserDefinition;
-import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.function.Executable;
 
-@Tag("multi-db-test")
+@MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 class ProcessInstanceAuthorizationIT {
 
+  @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
       new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
-
-  @RegisterExtension
-  static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(BROKER);
 
   private static final String PROCESS_ID_1 = "incident_process_v1";
   private static final String PROCESS_ID_2 = "service_tasks_v1";

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/RoleSearchingAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/RoleSearchingAuthorizationIT.java
@@ -19,7 +19,8 @@ import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.User;
 import io.camunda.qa.util.auth.UserDefinition;
-import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.io.IOException;
 import java.net.URI;
@@ -33,21 +34,17 @@ import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
-@Tag("multi-db-test")
+@MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 class RoleSearchingAuthorizationIT {
 
+  @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
       new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
-
-  @RegisterExtension
-  static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(BROKER);
 
   private static final ObjectMapper OBJECT_MAPPER =
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/TenantAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/TenantAuthorizationIT.java
@@ -19,7 +19,8 @@ import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.User;
 import io.camunda.qa.util.auth.UserDefinition;
-import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.collection.Tuple;
@@ -37,13 +38,11 @@ import java.util.UUID;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.http.HttpStatus;
 
-@Tag("multi-db-test")
+@MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 class TenantAuthorizationIT {
@@ -51,11 +50,10 @@ class TenantAuthorizationIT {
   public static final ObjectMapper OBJECT_MAPPER =
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
   public static final String PASSWORD = "password";
+
+  @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
       new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
-
-  @RegisterExtension
-  static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(BROKER);
 
   private static final String ADMIN = "admin";
   private static final String RESTRICTED = "restrictedUser";

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/UnprotectedApiIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/UnprotectedApiIT.java
@@ -10,20 +10,17 @@ package io.camunda.it.auth;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import io.camunda.client.CamundaClient;
-import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 @MultiDbTest
 public class UnprotectedApiIT {
+  @MultiDbTestApplication
   private static final TestStandaloneBroker BROKER =
       // it's the default right now, setting explicitly still given this test's purpose
       new TestStandaloneBroker().withUnauthenticatedAccess();
-
-  @RegisterExtension
-  private static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(BROKER);
 
   private static CamundaClient camundaClient;
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/UserSearchingAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/UserSearchingAuthorizationIT.java
@@ -19,7 +19,8 @@ import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.User;
 import io.camunda.qa.util.auth.UserDefinition;
-import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.io.IOException;
 import java.net.URI;
@@ -34,23 +35,20 @@ import java.util.UUID;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AutoClose;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
-@Tag("multi-db-test")
+@MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 class UserSearchingAuthorizationIT {
 
   public static final ObjectMapper OBJECT_MAPPER =
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+  @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
       new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
-
-  @RegisterExtension
-  static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(BROKER);
 
   private static final String ADMIN = "admin";
   private static final String RESTRICTED = "restrictedUser";

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/UserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/UserTaskAuthorizationIT.java
@@ -21,27 +21,24 @@ import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.User;
 import io.camunda.qa.util.auth.UserDefinition;
-import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.function.Executable;
 
-@Tag("multi-db-test")
+@MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 class UserTaskAuthorizationIT {
+  @MultiDbTestApplication
   static final TestStandaloneBroker BROKER =
       new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
-
-  @RegisterExtension
-  static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(BROKER);
 
   private static final String PROCESS_ID_1 = "bpmProcessVariable";
   private static final String PROCESS_ID_2 = "processWithForm";

--- a/qa/integration-tests/src/test/java/io/camunda/it/cluster/ClusterPurgeMultiDbIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/cluster/ClusterPurgeMultiDbIT.java
@@ -17,8 +17,8 @@ import io.camunda.client.api.search.response.ProcessInstanceState;
 import io.camunda.client.api.search.response.SearchQueryResponse;
 import io.camunda.client.api.search.response.UserTask;
 import io.camunda.client.protocol.rest.ProblemDetail;
-import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
 import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -36,18 +36,15 @@ import org.assertj.core.api.Assertions;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 @MultiDbTest
 public class ClusterPurgeMultiDbIT {
 
   private static CamundaClient client;
 
+  @MultiDbTestApplication
   private static final TestStandaloneApplication<?> APPLICATION =
       new TestStandaloneBroker().withUnauthenticatedAccess();
-
-  @RegisterExtension
-  public static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(APPLICATION);
 
   private static final int TIMEOUT = 40;
 

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -244,7 +244,7 @@ public class CamundaMultiDBExtension
   public void beforeAll(final ExtensionContext context) {
     LOGGER.info("Starting up Camunda instance, with {}", databaseType);
     final Class<?> testClass = context.getRequiredTestClass();
-    final var isHistoryRelatedTest = testClass.getAnnotation(HistoryMultiDbTest.class) != null;
+    final var isHistoryRelatedTest = testClass.isAnnotationPresent(HistoryMultiDbTest.class);
     testPrefix = testClass.getSimpleName().toLowerCase();
 
     setupTestApplication(testClass);
@@ -335,7 +335,7 @@ public class CamundaMultiDBExtension
       final Class<?> testClass, Predicate<Field> predicate) {
     var testStandaloneApplication = defaultTestApplication;
     var shouldBeManaged = true;
-    predicate = predicate.and(field -> field.getAnnotation(MultiDbTestApplication.class) != null);
+    predicate = predicate.and(field -> field.isAnnotationPresent(MultiDbTestApplication.class));
     for (final Field field : testClass.getDeclaredFields()) {
       try {
         if (predicate.test(field)) {

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -354,7 +354,11 @@ public class CamundaMultiDBExtension
           }
         }
       } catch (final Exception ex) {
-        throw new RuntimeException(ex);
+        throw new RuntimeException(
+            String.format(
+                "Expected to find field annotated with %s from type %s, but fail during that.",
+                MultiDbTestApplication.class, TestSpringApplication.class),
+            ex);
       }
     }
     return new ApplicationUnderTest(testStandaloneApplication, shouldBeManaged);

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/CamundaMultiDBExtension.java
@@ -14,6 +14,7 @@ import io.camunda.qa.util.auth.Authenticated;
 import io.camunda.qa.util.auth.User;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
+import io.camunda.zeebe.qa.util.cluster.TestSpringApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -92,29 +93,23 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
  *   }
  * }</pre>
  *
- * <p>There are more complex scenarios that might need to start respective TestApplication externally.
- * For such cases the extension can be used via:
+ * <p>There are more complex scenarios that might need to start or configure respective TestApplication externally.
+ * For such cases the respective {@link TestStandaloneApplication} can be annotated with {@link MultiDbTestApplication}:
  * <pre>{@code
- * @RegisterExtension
- * public final CamundaMultiDBExtension extension =
- *    new CamundaMultiDBExtension(new TestStandaloneBroker());
+ *    @MultiDbTestApplication
+ *    static final TestStandaloneBroker BROKER =
+ *        new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
  * }</pre>
  *
  * This is for example necessary for authentication tests.
  *
- * <b>We need to make sure to tag the
- * corresponding tests as @Tag("multi-db-test"), otherwise tests are not executed in multi db fashion.</b>
- * This is per default done by the {@link MultiDbTest} annotation.
- *
  *  <pre>{@code
- *  @Tag("multi-db-test")
+ *  @MultiDbTest
  *  final class MyAuthMultiDbTest {
  *
+ *    @MultiDbTestApplication
  *    static final TestStandaloneBroker BROKER =
  *        new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
- *
- *    @RegisterExtension
- *    static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(BROKER);
  *
  *    private static final String ADMIN = "admin";
  *
@@ -149,10 +144,47 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
  * </pre>
  *
  *
- *
- *<p>The extension will take care of the life cycle of the {@link TestStandaloneApplication}, which
+ *<p>The extension will take care of the life cycle of the {@link TestStandaloneApplication} per default, which
  * means configuring the detected database (this includes Operate, Tasklist, Broker properties and
  * exporter), starting the application, and tearing down at the end.
+ *
+ * If this is not wanted, the {@link TestStandaloneApplication} can be annotated with  {@link MultiDbTestApplication}
+ * and the respective {@link MultiDbTestApplication#managedLifecycle()} set to false:
+ *
+ *
+ *  <pre>{@code
+ *  @MultiDbTest
+ *  final class MyAuthMultiDbTest {
+ *
+ *    @MultiDbTestApplication(managedLifecycle = false)
+ *    static final TestStandaloneBroker BROKER =
+ *        new TestStandaloneBroker().withBasicAuth().withAuthorizationsEnabled();
+ *
+ *    private static final String ADMIN = "admin";
+ *
+ *    @UserDefinition
+ *    private static final User ADMIN_USER =
+ *      new User(ADMIN,
+ *               "password",
+ *               List.of(new Permissions(AUTHORIZATION, PermissionTypeEnum.READ, List.of("*"))));
+ *
+ *   @BeforeAll
+ *   static void setup() {
+ *     // start BROKER separate
+ *   }
+ *
+ *    @Test
+ *    void shouldMakeUseOfClient(@Authenticated(ADMIN) final CamundaClient adminClient) {
+ *      // given
+ *      // ... set up
+ *
+ *      // when
+ *      topology = adminClient.newTopologyRequest().send().join();
+ *
+ *      // then
+ *      assertThat(topology.getClusterSize()).isEqualTo(1);
+ *    }
+ *  }</pre>
  *
  * <p>See {@link TestStandaloneApplication} for more details.
  */
@@ -177,28 +209,35 @@ public class CamundaMultiDBExtension
   private static final Logger LOGGER = LoggerFactory.getLogger(CamundaMultiDBExtension.class);
   private final DatabaseType databaseType;
   private final List<AutoCloseable> closeables = new ArrayList<>();
-  private final TestStandaloneApplication<?> testApplication;
+  private final TestStandaloneApplication<?> defaultTestApplication;
+
+  private ApplicationUnderTest applicationUnderTest;
   private String testPrefix;
-  private final MultiDbConfigurator multiDbConfigurator;
+  private MultiDbConfigurator multiDbConfigurator;
   private MultiDbSetupHelper setupHelper = new NoopDBSetupHelper();
   private CamundaClientTestFactory authenticatedClientFactory;
 
   public CamundaMultiDBExtension() {
     this(new TestStandaloneBroker());
-    closeables.add(testApplication);
-    testApplication
-        .withBrokerConfig(cfg -> cfg.getGateway().setEnable(true))
-        .withExporter(
-            "recordingExporter", cfg -> cfg.setClassName(RecordingExporter.class.getName()));
   }
 
   public CamundaMultiDBExtension(final TestStandaloneApplication testApplication) {
-    this.testApplication = testApplication;
-    multiDbConfigurator = new MultiDbConfigurator(testApplication);
+    defaultTestApplication = testApplication;
     // resolve active database and exporter type
     final String property = System.getProperty(PROP_CAMUNDA_IT_DATABASE_TYPE);
     databaseType =
         property == null ? DatabaseType.LOCAL : DatabaseType.valueOf(property.toUpperCase());
+  }
+
+  private void setupTestApplication(final Class<?> testClass) {
+    applicationUnderTest = getApplicationUnderTest(testClass, ModifierSupport::isStatic);
+
+    final var application = applicationUnderTest.application();
+    multiDbConfigurator = new MultiDbConfigurator(application);
+    application
+        .withBrokerConfig(cfg -> cfg.getGateway().setEnable(true))
+        .withExporter(
+            "recordingExporter", cfg -> cfg.setClassName(RecordingExporter.class.getName()));
   }
 
   @Override
@@ -208,6 +247,7 @@ public class CamundaMultiDBExtension
     final var isHistoryRelatedTest = testClass.getAnnotation(HistoryMultiDbTest.class) != null;
     testPrefix = testClass.getSimpleName().toLowerCase();
 
+    setupTestApplication(testClass);
     switch (databaseType) {
       case LOCAL -> {
         final ElasticsearchContainer elasticsearchContainer = setupElasticsearch();
@@ -251,13 +291,9 @@ public class CamundaMultiDBExtension
         .timeout(TIMEOUT_DATABASE_READINESS)
         .until(setupHelper::validateConnection);
 
-    testApplication.start();
-    testApplication.awaitCompleteTopology();
-
-    Awaitility.await("Await exporter readiness")
-        .timeout(TIMEOUT_DATABASE_EXPORTER_READINESS)
-        .pollInterval(Duration.ofMillis(500))
-        .until(() -> setupHelper.validateSchemaCreation(testPrefix));
+    if (applicationUnderTest.shouldBeManaged) {
+      manageApplicationUnderTest();
+    }
 
     authenticatedClientFactory = new CamundaClientTestFactory();
     // we support only static fields for now - to make sure test setups are build in a way
@@ -268,6 +304,18 @@ public class CamundaMultiDBExtension
     if (!users.isEmpty()) {
       authenticatedClientFactory.withUsers(users);
     }
+  }
+
+  private void manageApplicationUnderTest() {
+    final var application = applicationUnderTest.application;
+    closeables.add(application);
+    application.start();
+    application.awaitCompleteTopology();
+
+    Awaitility.await("Await exporter readiness")
+        .timeout(TIMEOUT_DATABASE_EXPORTER_READINESS)
+        .pollInterval(Duration.ofMillis(500))
+        .until(() -> setupHelper.validateSchemaCreation(testPrefix));
   }
 
   private ElasticsearchContainer setupElasticsearch() {
@@ -281,6 +329,35 @@ public class CamundaMultiDBExtension
     elasticsearchContainer.start();
     closeables.add(elasticsearchContainer);
     return elasticsearchContainer;
+  }
+
+  private ApplicationUnderTest getApplicationUnderTest(
+      final Class<?> testClass, Predicate<Field> predicate) {
+    var testStandaloneApplication = defaultTestApplication;
+    var shouldBeManaged = true;
+    predicate = predicate.and(field -> field.getAnnotation(MultiDbTestApplication.class) != null);
+    for (final Field field : testClass.getDeclaredFields()) {
+      try {
+        if (predicate.test(field)) {
+          if (TestStandaloneApplication.class.isAssignableFrom(field.getType())) {
+            field.setAccessible(true);
+            testStandaloneApplication = (TestStandaloneApplication<?>) field.get(null);
+            final MultiDbTestApplication annotation =
+                field.getAnnotation(MultiDbTestApplication.class);
+            shouldBeManaged = annotation.managedLifecycle();
+            field.setAccessible(false);
+          } else {
+            fail(
+                String.format(
+                    "Expected to find field annotated with %s from type %s, but found %s. It doesn't apply criteria.",
+                    MultiDbTestApplication.class, TestSpringApplication.class, field.getType()));
+          }
+        }
+      } catch (final Exception ex) {
+        throw new RuntimeException(ex);
+      }
+    }
+    return new ApplicationUnderTest(testStandaloneApplication, shouldBeManaged);
   }
 
   private List<User> findUsers(
@@ -342,10 +419,13 @@ public class CamundaMultiDBExtension
 
   private CamundaClient createCamundaClient(final Authenticated authenticated) {
     final CamundaClient camundaClient =
-        authenticatedClientFactory.createCamundaClient(testApplication, authenticated);
+        authenticatedClientFactory.createCamundaClient(
+            applicationUnderTest.application, authenticated);
     closeables.add(camundaClient);
     return camundaClient;
   }
+
+  record ApplicationUnderTest(TestStandaloneApplication<?> application, boolean shouldBeManaged) {}
 
   private static final class NoopDBSetupHelper implements MultiDbSetupHelper {
     @Override

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbTest.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbTest.java
@@ -45,6 +45,31 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *     assertThat(topology.getClusterSize()).isEqualTo(1);
  *   }
  * }</pre>
+ *
+ * For more complex use cases a specific {@link io.camunda.zeebe.qa.util.cluster.TestStandaloneApplication} can be used and annotated with {@link MultiDbTestApplication}
+ *
+ * <pre>{@code
+ * @MultiDbTest
+ * final class MyMultiDbTest {
+ *
+ *   private CamundaClient client;
+ *
+ *   @MultiDbTestApplication
+ *   private static final TestSimpleCamundaApplication STANDALONE_CAMUNDA =
+ *       new TestSimpleCamundaApplication().withBasicAuth().withAuthorizationsEnabled();
+ *
+ *   @Test
+ *   void shouldMakeUseOfClient() {
+ *     // given
+ *     // ... set up
+ *
+ *     // when
+ *     topology = c.newTopologyRequest().send().join();
+ *
+ *     // then
+ *     assertThat(topology.getClusterSize()).isEqualTo(1);
+ *   }
+ * }</pre>
  */
 @Target({ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbTestApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbTestApplication.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.qa.util.multidb;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * {@code @MultiDbTestApplication} is used to signal that the corresponding {@link io.camunda.zeebe.qa.util.cluster.TestSpringApplication}
+ *  is used by the {@link CamundaMultiDBExtension}. The annotated application will be configured and be used to run tests against multiple
+ *  databases.
+ *  <p/>Per default the lifecycle of the annotated {@link io.camunda.zeebe.qa.util.cluster.TestSpringApplication} is managed by the {@link CamundaMultiDBExtension}. This means the application is started and stopped by the extension.
+ *  If this is not wanted, this can be disabled via {@link MultiDbTestApplication#managedLifecycle()}.
+ *
+ * <pre>{@code
+ *   @MultiDbTestApplication(managedLifecycle = false)
+ *   private static final TestSimpleCamundaApplication STANDALONE_CAMUNDA =
+ *       new TestSimpleCamundaApplication().withBasicAuth().withAuthorizationsEnabled();
+ * }</pre>
+ *
+ *  <p/> This is useful for more complex use cases where the test application lifecycle needs to be managed separately or needs to be further configured before starting.
+ *
+ * <pre>{@code
+ * @MultiDbTest
+ * final class MyMultiDbTest {
+ *
+ *   private static CamundaClient client;
+ *
+ *   @MultiDbTestApplication
+ *   private static final TestSimpleCamundaApplication STANDALONE_CAMUNDA =
+ *       new TestSimpleCamundaApplication().withBasicAuth().withAuthorizationsEnabled();
+ *
+ *   @Test
+ *   void shouldMakeUseOfClient() {
+ *     // given
+ *     // ... set up
+ *
+ *     // when
+ *     topology = c.newTopologyRequest().send().join();
+ *
+ *     // then
+ *     assertThat(topology.getClusterSize()).isEqualTo(1);
+ *   }
+ * }</pre>
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MultiDbTestApplication {
+
+  /**
+   * @return if true, then {@link CamundaMultiDBExtension} will manage the lifecycle of the test
+   *     application. Otherwise, the user is in charge of start and stopping the application.
+   */
+  boolean managedLifecycle() default true;
+}


### PR DESCRIPTION
## Description

 * Introduce new annotation that allows to mark TestStandaloneApplication
   that it is used by CamundaMultiDbExtension
 * The new annotation makes it possible to reduce boilerplate code, using RegisterExtension.
 * Furthermore, we can now use @MultiDbTest again on all tests - and mark external test applications. This makes tests more consistent, as all now use the same annotations, and
   no need to extra tag tests with the `multi-db-test` group, if the `@RegisterExtension`
   is used.
 * Per default, applications are managed by extension, but this can be turned off for
   further use cases now (NEW)
 * Extended java doc and examples
 * All tests that used `RegisterExtension` have been migrated.
 
## Related issues

related #26896 
