### PR TITLE
refactor: extract schema initialization out of the exporter

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/migration/PrefixMigrationHelper.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/PrefixMigrationHelper.java
@@ -38,7 +38,6 @@ import io.camunda.webapps.schema.descriptors.operate.template.SequenceFlowTempla
 import io.camunda.webapps.schema.descriptors.operate.template.VariableTemplate;
 import io.camunda.webapps.schema.descriptors.tasklist.index.FormIndex;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -84,17 +83,8 @@ public final class PrefixMigrationHelper {
   public static void runPrefixMigration(
       final OperateProperties operateProperties,
       final TasklistProperties tasklistProperties,
-      final ConnectConfiguration connectConfiguration)
-      throws IOException {
+      final ConnectConfiguration connectConfiguration) {
     final var isElasticsearch = connectConfiguration.getTypeEnum() == DatabaseType.ELASTICSEARCH;
-
-    LOG.info("Creating/updating Elasticsearch schema for Camunda ...");
-
-    final var clientAdapter = SchemaManagerHelper.createClientAdapter(connectConfiguration);
-
-    SchemaManagerHelper.createSchema(connectConfiguration, clientAdapter);
-
-    LOG.info("... finished creating/updating schema for Camunda");
 
     LOG.info("Migrating runtime indices");
 
@@ -128,8 +118,6 @@ public final class PrefixMigrationHelper {
         executor);
 
     LOG.info("... finished migrating historic indices");
-
-    clientAdapter.close();
   }
 
   private static PrefixMigrationClient getPrefixMigrationClient(

--- a/dist/src/main/java/io/camunda/application/commons/migration/ProcessMigrationModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/ProcessMigrationModuleConfiguration.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.application.commons.migration;
 
-import io.camunda.application.commons.search.SearchClientDatabaseConfiguration;
+import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -16,5 +16,5 @@ import org.springframework.context.annotation.Profile;
 @Configuration(proxyBeanMethods = false)
 @ComponentScan(basePackages = {"io.camunda.migration.process"})
 @Profile("process-migration")
-@Import({SearchClientDatabaseConfiguration.class})
+@Import({SearchEngineDatabaseConfiguration.class})
 public class ProcessMigrationModuleConfiguration {}

--- a/dist/src/main/java/io/camunda/application/commons/migration/SchemaManagerHelper.java
+++ b/dist/src/main/java/io/camunda/application/commons/migration/SchemaManagerHelper.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.application.commons.migration;
 
+import io.camunda.application.commons.search.SearchEngineConfiguration;
 import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.schema.SchemaManager;
-import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.configuration.DatabaseType;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import org.slf4j.Logger;
@@ -22,12 +22,12 @@ public final class SchemaManagerHelper {
   private SchemaManagerHelper() {}
 
   public static void createSchema(
-      final ConnectConfiguration connectConfig, final ClientAdapter clientAdapter) {
-    final var config = createExporterConfig(connectConfig);
-    final var isElasticsearch = connectConfig.getTypeEnum() == DatabaseType.ELASTICSEARCH;
+      final SearchEngineConfiguration configuration, final ClientAdapter clientAdapter) {
+    final var config = createExporterConfig(configuration);
+    final var isElasticsearch = configuration.connect().getTypeEnum() == DatabaseType.ELASTICSEARCH;
 
     final IndexDescriptors indexDescriptors =
-        new IndexDescriptors(connectConfig.getIndexPrefix(), isElasticsearch);
+        new IndexDescriptors(configuration.index().getPrefix(), isElasticsearch);
 
     final SchemaManager schemaManager =
         new SchemaManager(
@@ -40,16 +40,13 @@ public final class SchemaManagerHelper {
     schemaManager.startup();
   }
 
-  public static ClientAdapter createClientAdapter(final ConnectConfiguration connectConfig) {
-    final var config = createExporterConfig(connectConfig);
-    return ClientAdapter.of(config);
-  }
-
   private static ExporterConfiguration createExporterConfig(
-      final ConnectConfiguration connectConfig) {
+      final SearchEngineConfiguration searchEngineConfiguration) {
     final var config = new ExporterConfiguration();
-    config.setConnect(connectConfig);
-    config.getIndex().setPrefix(connectConfig.getIndexPrefix());
+    config.setConnect(searchEngineConfiguration.connect());
+    config.setIndex(searchEngineConfiguration.index());
+    config.getIndex().setPrefix(searchEngineConfiguration.connect().getIndexPrefix()); // FIXME
+    config.getHistory().setRetention(searchEngineConfiguration.retention());
 
     return config;
   }

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.application.commons.search;
 
-import io.camunda.application.commons.search.SearchClientDatabaseConfiguration.SearchClientProperties;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.search.clients.DocumentBasedSearchClient;
 import io.camunda.search.clients.DocumentBasedSearchClients;
@@ -22,14 +21,11 @@ import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnRestGatewayEnabled
-@EnableConfigurationProperties(SearchClientProperties.class)
 public class SearchClientDatabaseConfiguration {
 
   @Bean
@@ -39,7 +35,7 @@ public class SearchClientDatabaseConfiguration {
       havingValue = DatabaseConfig.ELASTICSEARCH,
       matchIfMissing = true)
   public ElasticsearchSearchClient elasticsearchSearchClient(
-      final SearchClientProperties configuration) {
+      final ConnectConfiguration configuration) {
     final var connector = new ElasticsearchConnector(configuration);
     final var elasticsearch = connector.createClient();
     return new ElasticsearchSearchClient(elasticsearch);
@@ -50,7 +46,7 @@ public class SearchClientDatabaseConfiguration {
       prefix = "camunda.database",
       name = "type",
       havingValue = DatabaseConfig.OPENSEARCH)
-  public OpensearchSearchClient opensearchSearchClient(final SearchClientProperties configuration) {
+  public OpensearchSearchClient opensearchSearchClient(final ConnectConfiguration configuration) {
     final var connector = new OpensearchConnector(configuration);
     final var elasticsearch = connector.createClient();
     return new OpensearchSearchClient(elasticsearch);
@@ -76,7 +72,4 @@ public class SearchClientDatabaseConfiguration {
             connectConfiguration.getTypeEnum().isElasticSearch());
     return new DocumentBasedSearchClients(searchClient, indexDescriptors);
   }
-
-  @ConfigurationProperties("camunda.database")
-  public static final class SearchClientProperties extends ConnectConfiguration {}
 }

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.search;
+
+import static java.util.Optional.ofNullable;
+
+import io.camunda.exporter.config.ExporterConfiguration.IndexSettings;
+import io.camunda.exporter.config.ExporterConfiguration.RetentionConfiguration;
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import java.util.function.Function;
+
+public record SearchEngineConfiguration(
+    ConnectConfiguration connect, IndexSettings index, RetentionConfiguration retention) {
+
+  public static SearchEngineConfiguration of(final Function<Builder, Builder> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  public static class Builder {
+    private ConnectConfiguration connect;
+    private IndexSettings index;
+    private RetentionConfiguration retention;
+
+    public Builder connect(final ConnectConfiguration value) {
+      connect = value;
+      return this;
+    }
+
+    public Builder index(final IndexSettings value) {
+      index = value;
+      return this;
+    }
+
+    public Builder retention(final RetentionConfiguration value) {
+      retention = value;
+      return this;
+    }
+
+    public SearchEngineConfiguration build() {
+      return new SearchEngineConfiguration(
+          ofNullable(connect).orElseGet(ConnectConfiguration::new),
+          ofNullable(index).orElseGet(IndexSettings::new),
+          ofNullable(retention).orElseGet(RetentionConfiguration::new));
+    }
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineDatabaseConfiguration.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.search;
+
+import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineConnectProperties;
+import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineIndexProperties;
+import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineRetentionProperties;
+import io.camunda.exporter.config.ExporterConfiguration.IndexSettings;
+import io.camunda.exporter.config.ExporterConfiguration.RetentionConfiguration;
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+@Conditional(SearchEngineEnabledCondition.class)
+@EnableConfigurationProperties({
+  SearchEngineConnectProperties.class,
+  SearchEngineIndexProperties.class,
+  SearchEngineRetentionProperties.class,
+})
+public class SearchEngineDatabaseConfiguration {
+
+  @Bean
+  public SearchEngineSchemaInitializer searchEngineSchemaInitializer(
+      final SearchEngineConfiguration searchEngineConfiguration,
+      @Value("${camunda.database.create-schema:true}") final boolean createSchema) {
+    return new SearchEngineSchemaInitializer(searchEngineConfiguration, createSchema);
+  }
+
+  @Bean
+  public SearchEngineConfiguration searchEngineConfiguration(
+      final SearchEngineConnectProperties searchEngineConnectProperties,
+      final SearchEngineIndexProperties searchEngineIndexProperties,
+      final SearchEngineRetentionProperties searchEngineRetentionProperties) {
+    return SearchEngineConfiguration.of(
+        b ->
+            b.connect(searchEngineConnectProperties)
+                .index(searchEngineIndexProperties)
+                .retention(searchEngineRetentionProperties));
+  }
+
+  @ConfigurationProperties("camunda.database")
+  public static final class SearchEngineConnectProperties extends ConnectConfiguration {}
+
+  @ConfigurationProperties("camunda.database.index")
+  public static final class SearchEngineIndexProperties extends IndexSettings {}
+
+  @ConfigurationProperties("camunda.database.retention")
+  public static final class SearchEngineRetentionProperties extends RetentionConfiguration {}
+}

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineEnabledCondition.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineEnabledCondition.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.search;
+
+import io.camunda.search.connect.configuration.DatabaseConfig;
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+public class SearchEngineEnabledCondition extends AnyNestedCondition {
+
+  public SearchEngineEnabledCondition() {
+    super(ConfigurationPhase.PARSE_CONFIGURATION);
+  }
+
+  @ConditionalOnProperty(
+      prefix = "camunda.database",
+      name = "type",
+      havingValue = DatabaseConfig.ELASTICSEARCH,
+      matchIfMissing = true)
+  static class ElasticSearchEnabled {}
+
+  @ConditionalOnProperty(
+      prefix = "camunda.database",
+      name = "type",
+      havingValue = DatabaseConfig.OPENSEARCH)
+  static class OpenSearchEnabled {}
+}

--- a/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchEngineSchemaInitializer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.search;
+
+import io.camunda.application.commons.migration.SchemaManagerHelper;
+import io.camunda.exporter.adapters.ClientAdapter;
+import io.camunda.exporter.exceptions.ElasticsearchExporterException;
+import io.camunda.exporter.exceptions.OpensearchExporterException;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+
+public class SearchEngineSchemaInitializer implements InitializingBean {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SearchEngineSchemaInitializer.class);
+
+  private final SearchEngineConfiguration searchEngineConfiguration;
+  private final boolean createSchema;
+
+  public SearchEngineSchemaInitializer(
+      final SearchEngineConfiguration searchEngineConfiguration,
+      @Value("${camunda.database.create-schema:true}") final boolean createSchema) {
+    this.searchEngineConfiguration = searchEngineConfiguration;
+    this.createSchema = createSchema;
+  }
+
+  @Override
+  public void afterPropertiesSet() throws IOException {
+    if (createSchema) {
+      try (final ClientAdapter clientAdapter =
+          ClientAdapter.of(searchEngineConfiguration.connect())) {
+        SchemaManagerHelper.createSchema(searchEngineConfiguration, clientAdapter);
+      } catch (final ElasticsearchExporterException | OpensearchExporterException e) {
+        if (e.getCause() instanceof java.net.ConnectException) {
+          LOGGER.warn("Could not connect to search engine, skipping schema creation", e); // FIXME
+        } else {
+          throw e;
+        }
+      }
+    }
+  }
+}

--- a/dist/src/main/java/io/camunda/application/initializers/StandaloneSchemaManagerInitializer.java
+++ b/dist/src/main/java/io/camunda/application/initializers/StandaloneSchemaManagerInitializer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.initializers;
+
+import static io.camunda.search.connect.configuration.ConnectConfiguration.DATABASE_TYPE_DEFAULT;
+import static io.camunda.search.connect.configuration.DatabaseType.ELASTICSEARCH;
+import static java.util.Optional.ofNullable;
+
+import io.camunda.search.connect.configuration.DatabaseType;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+
+/** Ensures that the Standalone Schema Manager is only used for Elasticsearch databases. */
+public class StandaloneSchemaManagerInitializer
+    implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+  @Override
+  public void initialize(final ConfigurableApplicationContext applicationContext) {
+    final String databaseTypeProperty =
+        applicationContext.getEnvironment().getProperty("camunda.database.type");
+    if (ELASTICSEARCH
+        != ofNullable(databaseTypeProperty).map(DatabaseType::from).orElse(DATABASE_TYPE_DEFAULT)) {
+      throw new IllegalArgumentException(
+          "Cannot create schema for anything other than Elasticsearch with this script for now...");
+    }
+  }
+}

--- a/operate/qa/integration-tests/pom.xml
+++ b/operate/qa/integration-tests/pom.xml
@@ -544,6 +544,7 @@
           </systemPropertyVariables>
           <environmentVariables>
             <CAMUNDA_OPERATE_DATABASE>${itDatabase}</CAMUNDA_OPERATE_DATABASE>
+            <CAMUNDA_DATABASE_TYPE>${itDatabase}</CAMUNDA_DATABASE_TYPE>
           </environmentVariables>
         </configuration>
         <executions>

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/util/camunda/exporter/SchemaWithExporter.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/util/camunda/exporter/SchemaWithExporter.java
@@ -29,7 +29,7 @@ public class SchemaWithExporter {
                 ? ConnectionTypes.ELASTICSEARCH.getType()
                 : ConnectionTypes.OPENSEARCH.getType());
 
-    final var clientAdapter = ClientAdapter.of(config);
+    final var clientAdapter = ClientAdapter.of(config.getConnect());
     final var provider = new DefaultExporterResourceProvider();
     provider.init(
         config,

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchTestRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchTestRuleProvider.java
@@ -123,6 +123,7 @@ public class OpensearchTestRuleProvider implements SearchTestRuleProvider {
 
   @Override
   public void finished(final Description description) {
+    TestUtil.removeIlmPolicy(richOpenSearchClient);
     final String indexPrefix = operateProperties.getOpensearch().getIndexPrefix();
     TestUtil.removeAllIndices(
         richOpenSearchClient.index(), richOpenSearchClient.template(), indexPrefix);

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchTestRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OpensearchTestRuleProvider.java
@@ -123,7 +123,6 @@ public class OpensearchTestRuleProvider implements SearchTestRuleProvider {
 
   @Override
   public void finished(final Description description) {
-    TestUtil.removeIlmPolicy(richOpenSearchClient);
     final String indexPrefix = operateProperties.getOpensearch().getIndexPrefix();
     TestUtil.removeAllIndices(
         richOpenSearchClient.index(), richOpenSearchClient.template(), indexPrefix);

--- a/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContainerUtil.java
+++ b/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestContainerUtil.java
@@ -568,11 +568,15 @@ public class TestContainerUtil {
         .withEnv(
             "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_URL", getElasticURL(testContext))
         .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_DELAY", "1")
-        .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_SIZE", "1");
+        .withEnv("ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_SIZE", "1")
+        .withEnv("CAMUNDA_DATABASE_TYPE", testContext.getConnectionType())
+        .withEnv("CAMUNDA_DATABASE_URL", getElasticURL(testContext));
     if (testContext.getZeebeIndexPrefix() != null) {
-      broker.withEnv(
-          "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_PREFIX",
-          testContext.getZeebeIndexPrefix());
+      broker
+          .withEnv(
+              "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_PREFIX",
+              testContext.getZeebeIndexPrefix())
+          .withEnv("CAMUNDA_DATABASE_INDEX_PREFIX", testContext.getZeebeIndexPrefix());
     }
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/migration/PrefixMigrationIT.java
@@ -20,11 +20,11 @@ import static io.camunda.it.migration.util.PrefixMigrationITUtils.requestProcess
 import static io.camunda.it.migration.util.PrefixMigrationITUtils.startLatestCamunda;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.application.commons.migration.PrefixMigrationHelper;
+import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineConnectProperties;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.operate.property.OperateProperties;
-import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.zeebe.qa.util.cluster.TestPrefixMigrationApp;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import java.io.IOException;
 import java.net.http.HttpResponse;
@@ -94,13 +94,15 @@ public class PrefixMigrationIT {
   private void prefixMigration() throws IOException {
     final var operate = new OperateProperties();
     final var tasklist = new TasklistProperties();
-    final var connect = new ConnectConfiguration();
+    final var connect = new SearchEngineConnectProperties();
 
     operate.getElasticsearch().setIndexPrefix(OLD_OPERATE_PREFIX);
     tasklist.getElasticsearch().setIndexPrefix(OLD_TASKLIST_PREFIX);
     connect.setUrl(esContainer.getHttpHostAddress());
     connect.setIndexPrefix(NEW_PREFIX);
-    PrefixMigrationHelper.runPrefixMigration(operate, tasklist, connect);
+    try (final var app = new TestPrefixMigrationApp(connect, tasklist, operate)) {
+      app.start();
+    }
   }
 
   @Test

--- a/qa/integration-tests/src/test/java/io/camunda/it/migration/PrefixMigrationOSIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/migration/PrefixMigrationOSIT.java
@@ -20,11 +20,11 @@ import static io.camunda.it.migration.util.PrefixMigrationITUtils.requestProcess
 import static io.camunda.it.migration.util.PrefixMigrationITUtils.startLatestCamunda;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.application.commons.migration.PrefixMigrationHelper;
+import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineConnectProperties;
 import io.camunda.client.api.response.ProcessInstanceEvent;
 import io.camunda.operate.property.OperateProperties;
-import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.zeebe.qa.util.cluster.TestPrefixMigrationApp;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import java.io.IOException;
 import java.net.http.HttpResponse;
@@ -84,14 +84,16 @@ public class PrefixMigrationOSIT {
   private void prefixMigration() throws IOException {
     final var operate = new OperateProperties();
     final var tasklist = new TasklistProperties();
-    final var connect = new ConnectConfiguration();
+    final var connect = new SearchEngineConnectProperties();
 
     operate.getOpensearch().setIndexPrefix(OLD_OPERATE_PREFIX);
     tasklist.getOpenSearch().setIndexPrefix(OLD_TASKLIST_PREFIX);
     connect.setType("opensearch");
     connect.setUrl(osContainer.getHttpHostAddress());
     connect.setIndexPrefix(NEW_PREFIX);
-    PrefixMigrationHelper.runPrefixMigration(operate, tasklist, connect);
+    try (final var app = new TestPrefixMigrationApp(connect, tasklist, operate)) {
+      app.start();
+    }
   }
 
   @Test

--- a/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/multidb/MultiDbConfigurator.java
@@ -73,6 +73,12 @@ public class MultiDbConfigurator {
         io.camunda.search.connect.configuration.DatabaseType.ELASTICSEARCH);
     elasticsearchProperties.put("camunda.database.indexPrefix", indexPrefix);
     elasticsearchProperties.put("camunda.database.url", elasticsearchUrl);
+    elasticsearchProperties.put(
+        "camunda.database.retention.enabled", Boolean.toString(retentionEnabled));
+    elasticsearchProperties.put("camunda.database.retention.policyName", indexPrefix + "-ilm");
+    // 0s causes ILM to move data asap - it is normally the default
+    // https://www.elastic.co/guide/en/elasticsearch/reference/current/ilm-index-lifecycle.html#ilm-phase-transitions
+    elasticsearchProperties.put("camunda.database.retention.minimumAge", "0s");
 
     testApplication.withAdditionalProperties(elasticsearchProperties);
 
@@ -178,6 +184,10 @@ public class MultiDbConfigurator {
     opensearchProperties.put("camunda.database.username", userName);
     opensearchProperties.put("camunda.database.password", userPassword);
     opensearchProperties.put("camunda.database.url", opensearchUrl);
+    opensearchProperties.put(
+        "camunda.database.retention.enabled", Boolean.toString(retentionEnabled));
+    opensearchProperties.put("camunda.database.retention.policyName", indexPrefix + "-ilm");
+    opensearchProperties.put("camunda.database.retention.minimumAge", "0s");
 
     testApplication.withAdditionalProperties(opensearchProperties);
 

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/configuration/ConnectConfiguration.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/configuration/ConnectConfiguration.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 public class ConnectConfiguration {
 
-  private static final DatabaseType DATABASE_TYPE_DEFAULT = DatabaseType.ELASTICSEARCH;
+  public static final DatabaseType DATABASE_TYPE_DEFAULT = DatabaseType.ELASTICSEARCH;
   private static final String CLUSTER_NAME_DEFAULT = "elasticsearch";
   private static final String DATE_FORMAT_FIELD = "yyyy-MM-dd'T'HH:mm:ss.SSSZZ";
   private static final String FIELD_DATE_FORMAT_DEFAULT = "date_time";
@@ -28,7 +28,7 @@ public class ConnectConfiguration {
   private String username;
   private String password;
   private SecurityConfiguration security = new SecurityConfiguration();
-  private String indexPrefix;
+  private String indexPrefix = "";
   private List<PluginConfiguration> interceptorPlugins = new ArrayList<>();
 
   /** Use {@link ConnectConfiguration#getTypeEnum()} */

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionElasticSearch.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionElasticSearch.java
@@ -81,7 +81,11 @@ public class TasklistZeebeExtensionElasticSearch extends TasklistZeebeExtension 
         "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_PREFIX",
         indexPrefix,
         "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME",
-        "io.camunda.exporter.CamundaExporter");
+        "io.camunda.exporter.CamundaExporter",
+        "CAMUNDA_DATABASE_URL",
+        "http://host.testcontainers.internal:9200",
+        "CAMUNDA_DATABASE_INDEX_PREFIX",
+        indexPrefix);
   }
 
   @Override

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionOpenSearch.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionOpenSearch.java
@@ -75,7 +75,13 @@ public class TasklistZeebeExtensionOpenSearch extends TasklistZeebeExtension {
         "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_PREFIX",
         indexPrefix,
         "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME",
-        "io.camunda.exporter.CamundaExporter");
+        "io.camunda.exporter.CamundaExporter",
+        "CAMUNDA_DATABASE_TYPE",
+        "opensearch",
+        "CAMUNDA_DATABASE_URL",
+        "http://host.testcontainers.internal:9200",
+        "CAMUNDA_DATABASE_INDEX_PREFIX",
+        indexPrefix);
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -522,7 +522,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     for (final ExporterContainer container : containers) {
       container.initMetadata();
       final var openFuture =
-          new BackOffRetryStrategy(actor, Duration.ofSeconds(10))
+          new BackOffRetryStrategy(actor, Duration.ofSeconds(10), Duration.ofMillis(150))
               .runWithRetry(
                   () -> {
                     try {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -133,7 +133,7 @@ public class CamundaExporter implements Exporter {
       throw new IllegalStateException("Schema is not ready for use");
     }
 
-    writer = createBatchWriter(); // move before schemaManager.isSchemaReadyForUse()?
+    writer = createBatchWriter();
 
     checkImportersCompletedAndReschedule();
     controller.readMetadata().ifPresent(metadata::deserialize);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -98,6 +98,7 @@ import io.camunda.webapps.schema.descriptors.usermanagement.index.MappingIndex;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.RoleIndex;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.UserIndex;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.net.http.HttpClient;
 import java.util.Collection;
@@ -287,6 +288,11 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
   @Override
   public Collection<IndexDescriptor> getIndexDescriptors() {
     return indexDescriptors.indices();
+  }
+
+  @VisibleForTesting
+  void setIndexDescriptors(final IndexDescriptors indexDescriptors) {
+    this.indexDescriptors = indexDescriptors;
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ClientAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ClientAdapter.java
@@ -9,19 +9,19 @@ package io.camunda.exporter.adapters;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
-import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.schema.SearchEngineClient;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.configuration.DatabaseType;
 import java.io.IOException;
 
-public interface ClientAdapter {
+public interface ClientAdapter extends AutoCloseable {
 
-  static ClientAdapter of(final ExporterConfiguration configuration) {
-    final var databaseType = configuration.getConnect().getTypeEnum();
+  static ClientAdapter of(final ConnectConfiguration configuration) {
+    final var databaseType = configuration.getTypeEnum();
     return switch (databaseType) {
-      case DatabaseType.ELASTICSEARCH -> new ElasticsearchAdapter(configuration.getConnect());
-      case DatabaseType.OPENSEARCH -> new OpensearchAdapter(configuration.getConnect());
+      case DatabaseType.ELASTICSEARCH -> new ElasticsearchAdapter(configuration);
+      case DatabaseType.OPENSEARCH -> new OpensearchAdapter(configuration);
       default -> throw new IllegalArgumentException("Unsupported databaseType: " + databaseType);
     };
   }
@@ -34,5 +34,6 @@ public interface ClientAdapter {
 
   ExporterEntityCacheProvider getExporterEntityCacheProvider();
 
+  @Override
   void close() throws IOException;
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -117,7 +117,7 @@ public class ExporterConfiguration {
         + '}';
   }
 
-  public static final class IndexSettings {
+  public static class IndexSettings {
     public static final int DEFAULT_VARIABLE_SIZE_THRESHOLD = 8191;
     private String prefix = "";
     private String zeebeIndexPrefix = "zeebe-record";
@@ -218,7 +218,7 @@ public class ExporterConfiguration {
     }
   }
 
-  public static final class RetentionConfiguration {
+  public static class RetentionConfiguration {
     private boolean enabled = false;
     private String minimumAge = "30d";
     private String policyName;

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterAuthenticationIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterAuthenticationIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter;
 
+import static io.camunda.exporter.utils.CamundaExporterSchemaUtils.createSchemas;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -17,6 +18,7 @@ import io.camunda.zeebe.exporter.test.ExporterTestContext;
 import io.camunda.zeebe.exporter.test.ExporterTestController;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.io.IOException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
@@ -39,11 +41,11 @@ public class CamundaExporterAuthenticationIT {
   private final ExporterTestController controller = new ExporterTestController();
 
   @BeforeEach
-  void beforeEach() {
+  void beforeEach() throws IOException {
     CONFIG.getConnect().setUsername("elastic");
     CONFIG.getConnect().setPassword(ELASTIC_PASSWORD);
     CONFIG.getConnect().setUrl(CONTAINER.getHttpHostAddress());
-    CONFIG.setCreateSchema(true);
+    createSchemas(CONFIG);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -7,10 +7,13 @@
  */
 package io.camunda.exporter;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -41,7 +44,8 @@ final class CamundaExporterTest {
   private final MockedStatic<ClientAdapter> mockedClientAdapterFactory =
       Mockito.mockStatic(ClientAdapter.class);
 
-  private final ExporterResourceProvider resourceProvider = new DefaultExporterResourceProvider();
+  private final ExporterResourceProvider resourceProvider =
+      spy(new DefaultExporterResourceProvider());
   private final ExporterConfiguration configuration = new ExporterConfiguration();
   private final ExporterTestContext testContext =
       new ExporterTestContext()
@@ -57,8 +61,10 @@ final class CamundaExporterTest {
   void beforeEach() {
     stubbedClientAdapterInUse = new StubClientAdapter();
     mockedClientAdapterFactory
-        .when(() -> ClientAdapter.of(configuration))
+        .when(() -> ClientAdapter.of(configuration.getConnect()))
         .thenReturn(stubbedClientAdapterInUse);
+    doReturn(emptyList()).when(resourceProvider).getIndexDescriptors();
+    doReturn(emptyList()).when(resourceProvider).getIndexTemplateDescriptors();
   }
 
   @AfterEach

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepositoryIT.java
@@ -63,7 +63,7 @@ abstract class BatchOperationUpdateRepositoryIT {
     config.getConnect().setUrl(databaseUrl);
     config.getConnect().setType(isElastic ? "elasticsearch" : "opensearch");
 
-    clientAdapter = ClientAdapter.of(config);
+    clientAdapter = ClientAdapter.of(config.getConnect());
     engineClient = clientAdapter.getSearchEngineClient();
 
     batchOperationTemplate = new BatchOperationTemplate(indexPrefix, isElastic);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -97,7 +97,7 @@ abstract class IncidentUpdateRepositoryIT {
     config.getConnect().setUrl(databaseUrl);
     config.getConnect().setType(isElastic ? "elasticsearch" : "opensearch");
 
-    clientAdapter = ClientAdapter.of(config);
+    clientAdapter = ClientAdapter.of(config.getConnect());
     engineClient = clientAdapter.getSearchEngineClient();
 
     postImporterQueueTemplate = new PostImporterQueueTemplate(indexPrefix, isElastic);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterSchemaUtils.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterSchemaUtils.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.utils;
+
+import io.camunda.exporter.adapters.ClientAdapter;
+import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.schema.SchemaManager;
+import io.camunda.webapps.schema.descriptors.IndexDescriptors;
+import java.io.IOException;
+
+public final class CamundaExporterSchemaUtils {
+  private CamundaExporterSchemaUtils() {}
+
+  public static void createSchemas(final ExporterConfiguration config) throws IOException {
+    final var indexDescriptors =
+        new IndexDescriptors(
+            config.getIndex().getPrefix(), config.getConnect().getTypeEnum().isElasticSearch());
+    try (final ClientAdapter clientAdapter = ClientAdapter.of(config.getConnect())) {
+      new SchemaManager(
+              clientAdapter.getSearchEngineClient(),
+              indexDescriptors.indices(),
+              indexDescriptors.templates(),
+              config,
+              clientAdapter.objectMapper())
+          .startup();
+    }
+  }
+}

--- a/zeebe/qa/util/pom.xml
+++ b/zeebe/qa/util/pom.xml
@@ -228,5 +228,15 @@
       <groupId>org.opensearch.client</groupId>
       <artifactId>opensearch-java</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>tasklist-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>operate-common</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestPrefixMigrationApp.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestPrefixMigrationApp.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.qa.util.cluster;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.application.StandalonePrefixMigration;
+import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration;
+import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineConnectProperties;
+import io.camunda.operate.property.OperateProperties;
+import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.zeebe.qa.util.actuator.HealthActuator;
+import io.camunda.zeebe.restore.RestoreApp;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+
+/** Represents an instance of the {@link RestoreApp} Spring application. */
+public final class TestPrefixMigrationApp extends TestSpringApplication<TestPrefixMigrationApp> {
+
+  public TestPrefixMigrationApp(
+      final SearchEngineConnectProperties connectConfiguration,
+      final TasklistProperties tasklistProperties,
+      final OperateProperties operateProperties) {
+    super(StandalonePrefixMigration.class, SearchEngineDatabaseConfiguration.class);
+
+    withBean("connectConfiguration", connectConfiguration, SearchEngineConnectProperties.class)
+        .withBean("tasklistProperties", tasklistProperties, TasklistProperties.class)
+        .withBean("operateProperties", operateProperties, OperateProperties.class);
+  }
+
+  @Override
+  public TestPrefixMigrationApp self() {
+    return this;
+  }
+
+  @Override
+  public MemberId nodeId() {
+    return MemberId.from("prefix-migration");
+  }
+
+  @Override
+  public HealthActuator healthActuator() {
+    return new HealthActuator.NoopHealthActuator();
+  }
+
+  @Override
+  public boolean isGateway() {
+    return false;
+  }
+
+  @Override
+  protected SpringApplicationBuilder createSpringBuilder() {
+    return super.createSpringBuilder().web(WebApplicationType.NONE);
+  }
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -11,7 +11,7 @@ import io.atomix.cluster.MemberId;
 import io.camunda.application.Profile;
 import io.camunda.application.commons.CommonsModuleConfiguration;
 import io.camunda.application.commons.configuration.BrokerBasedConfiguration.BrokerBasedProperties;
-import io.camunda.application.commons.search.SearchClientDatabaseConfiguration.SearchClientProperties;
+import io.camunda.application.commons.search.SearchEngineDatabaseConfiguration.SearchEngineConnectProperties;
 import io.camunda.application.commons.security.CamundaSecurityConfiguration.CamundaSecurityProperties;
 import io.camunda.authentication.config.AuthenticationProperties;
 import io.camunda.security.configuration.ConfiguredUser;
@@ -258,9 +258,12 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
           cfg.setClassName("io.camunda.exporter.CamundaExporter");
           cfg.setArgs(exporterConfigArgs);
         });
-    final var searchClient = new SearchClientProperties();
-    searchClient.setUrl(elasticSearchUrl);
-    withBean("camundaSearchClient", searchClient, SearchClientProperties.class);
+    final var searchEngineConnectProperties = new SearchEngineConnectProperties();
+    searchEngineConnectProperties.setUrl(elasticSearchUrl);
+    withBean(
+        "searchEngineConnectProperties",
+        searchEngineConnectProperties,
+        SearchEngineConnectProperties.class);
     return this;
   }
 

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/BackOffRetryStrategy.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/retry/BackOffRetryStrategy.java
@@ -17,6 +17,7 @@ public final class BackOffRetryStrategy implements RetryStrategy {
 
   private final ActorControl actor;
   private final Duration maxBackOff;
+  private final Duration initialBackOff;
 
   private Duration backOffDuration;
   private CompletableActorFuture<Boolean> currentFuture;
@@ -24,8 +25,14 @@ public final class BackOffRetryStrategy implements RetryStrategy {
   private OperationToRetry currentCallable;
 
   public BackOffRetryStrategy(final ActorControl actor, final Duration maxBackOff) {
+    this(actor, maxBackOff, Duration.ofSeconds(1));
+  }
+
+  public BackOffRetryStrategy(
+      final ActorControl actor, final Duration maxBackOff, final Duration initialBackOff) {
     this.actor = actor;
     this.maxBackOff = maxBackOff;
+    this.initialBackOff = initialBackOff;
   }
 
   @Override
@@ -39,7 +46,7 @@ public final class BackOffRetryStrategy implements RetryStrategy {
     currentFuture = new CompletableActorFuture<>();
     currentTerminateCondition = terminateCondition;
     currentCallable = callable;
-    backOffDuration = Duration.ofSeconds(1);
+    backOffDuration = initialBackOff;
 
     actor.run(this::run);
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This pull request refactors the schema initialization process by extracting `schemaManager.startup()` from `camundaExporter.open()` and moving it to a Spring-managed component, `SearchEngineSchemaInitializer`. This component is now invoked at application startup.

It introduces a new configuration class, `SearchEngineDatabaseConfiguration`, which is conditionally enabled when a search engine (Elasticsearch or OpenSearch) is used.

#### Schema Initialization
* Introduced `SearchEngineSchemaInitializer` as a Spring-managed component.
* `SearchEngineSchemaInitializer` is a `InitializingBean` invoked at application startup instead of during exporter opening.

#### SearchEngineDatabaseConfiguration configuration class
- Conditionally enabled when Elasticsearch or OpenSearch is used.
- Provides:
   * Connect configuration required for ES/OS clients.
   * `SearchEngineSchemaInitializer` bean.
   * Properties required by `SchemaManager`: New `SchemaEngineConfiguration` Class, a wrapper for essential configurations required by `SchemaManager`, including:
      * `ConnectConfiguration`
     * `RetentionConfiguration`
     * `IndexSettings` 
  
 - Applications using `CommonsModuleConfiguration` or explicitly importing `SearchEngineDatabaseConfiguration`, will have the schema initialization part of the application startup, unless explicitly disabled via `camunda.database.initialization.createSchema=false` (see https://github.com/camunda/camunda/pull/29789)



#### Updates on Exporter Behavior
* When opening an exporter, it now checks if the schema is compatible with the expected specification.
* If the schema is not ready, an exception is thrown, and the exporter will be retried to open later using a backoff strategy.
* This check may be removed in https://github.com/camunda/camunda/issues/28896 if we decide to make the broker startup wait for the schema readiness (instead of the exporter only)

#### Additional Context

There is a follow-up pull request https://github.com/camunda/camunda/pull/29789 that enhances the resilience of schema manager startup, handling cases of connection issues and concurrent updates more effectively.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

relates to https://github.com/camunda/camunda/issues/28895
