### PR TITLE
Migrate OperatePermissionsIT to a multi db test

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/operate/OperatePermissionsIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/operate/OperatePermissionsIT.java
@@ -23,28 +23,25 @@ import io.camunda.qa.util.auth.Permissions;
 import io.camunda.qa.util.auth.User;
 import io.camunda.qa.util.auth.UserDefinition;
 import io.camunda.qa.util.cluster.TestSimpleCamundaApplication;
-import io.camunda.qa.util.multidb.CamundaMultiDBExtension;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.qa.util.multidb.MultiDbTestApplication;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
-@Tag("multi-db-test")
+@MultiDbTest
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "rdbms")
 @DisabledIfSystemProperty(named = "test.integration.camunda.database.type", matches = "AWS_OS")
 public class OperatePermissionsIT {
 
+  @MultiDbTestApplication
   static final TestSimpleCamundaApplication STANDALONE_CAMUNDA =
       new TestSimpleCamundaApplication().withAuthorizationsEnabled().withBasicAuth();
-
-  @RegisterExtension
-  static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(STANDALONE_CAMUNDA);
 
   private static final String SUPER_USER_USERNAME = "super";
   private static final String RESTRICTED_USER_USERNAME = "restricted";

--- a/qa/integration-tests/src/test/java/io/camunda/it/operate/OperatePermissionsIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/operate/OperatePermissionsIT.java
@@ -46,33 +46,33 @@ public class OperatePermissionsIT {
   @RegisterExtension
   static final CamundaMultiDBExtension EXTENSION = new CamundaMultiDBExtension(STANDALONE_CAMUNDA);
 
-  private static final String SUPER_USER = "super";
-  private static final String RESTRICTED_USER = "restricted";
+  private static final String SUPER_USER_USERNAME = "super";
+  private static final String RESTRICTED_USER_USERNAME = "restricted";
   private static final String PROCESS_DEFINITION_ID_1 = "service_tasks_v1";
   private static final String PROCESS_DEFINITION_ID_2 = "incident_process_v1";
   private static final List<Process> DEPLOYED_PROCESSES = new ArrayList<>();
 
   @UserDefinition
-  private static final User superUser =
+  private static final User SUPER_USER =
       new User(
-          SUPER_USER,
+          SUPER_USER_USERNAME,
           "password",
           List.of(
               new Permissions(RESOURCE, CREATE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, READ_PROCESS_DEFINITION, List.of("*"))));
 
   @UserDefinition
-  private static final User restrictedUser =
+  private static final User RESTRICTED_USER =
       new User(
-          RESTRICTED_USER,
+          RESTRICTED_USER_USERNAME,
           "password",
           List.of(
               new Permissions(
                   PROCESS_DEFINITION, READ_PROCESS_DEFINITION, List.of(PROCESS_DEFINITION_ID_1))));
 
   @BeforeAll
-  public static void beforeAll(@Authenticated(SUPER_USER) final CamundaClient superUserClient)
-      throws Exception {
+  public static void beforeAll(
+      @Authenticated(SUPER_USER_USERNAME) final CamundaClient superUserClient) throws Exception {
     final List<String> processes = List.of(PROCESS_DEFINITION_ID_1, PROCESS_DEFINITION_ID_2);
     processes.forEach(
         process ->
@@ -91,8 +91,8 @@ public class OperatePermissionsIT {
 
   @Test
   public void shouldGetProcessByKeyOnlyForAuthorizedProcesses(
-      @Authenticated(SUPER_USER) final CamundaClient superClient,
-      @Authenticated(RESTRICTED_USER) final CamundaClient restrictedClient) {
+      @Authenticated(SUPER_USER_USERNAME) final CamundaClient superClient,
+      @Authenticated(RESTRICTED_USER_USERNAME) final CamundaClient restrictedClient) {
     // super user can read all process definitions
     DEPLOYED_PROCESSES.stream()
         .map(Process::getProcessDefinitionKey)

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestSimpleCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestSimpleCamundaApplication.java
@@ -263,4 +263,8 @@ public final class TestSimpleCamundaApplication
   public TestRestTasklistClient newTasklistClient() {
     return new TestRestTasklistClient(restAddress());
   }
+
+  public TestRestOperateClient newOperateClient(final String username, final String password) {
+    return new TestRestOperateClient(restAddress(), username, password);
+  }
 }

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestSimpleCamundaApplication.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestSimpleCamundaApplication.java
@@ -263,8 +263,4 @@ public final class TestSimpleCamundaApplication
   public TestRestTasklistClient newTasklistClient() {
     return new TestRestTasklistClient(restAddress());
   }
-
-  public TestRestOperateClient newOperateClient(final String username, final String password) {
-    return new TestRestOperateClient(restAddress(), username, password);
-  }
 }


### PR DESCRIPTION
## Description

Migrate OperatePermissionsIT to a multi db test, right now it's using the old `@Tag("multi-db-test")` approach, hence a draft PR, once https://github.com/camunda/camunda/pull/29636 is merged this can be migrated to the `@MultiDbTestApplication` approach.

## Related issues

closes #29479
