### PR TITLE
fix: fetch batch mod overlay data only when in batch mod mode

### DIFF
--- a/operate/client/src/App/Processes/ListView/DiagramPanel/v2/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/v2/index.tsx
@@ -121,7 +121,7 @@ const DiagramPanel: React.FC = observer(() => {
       sourceFlowNodeId: flowNodeId,
       targetFlowNodeId: selectedTargetFlowNodeId ?? undefined,
     },
-    processId !== undefined,
+    processId !== undefined && batchModificationStore.state.isEnabled,
   );
 
   const isDiagramLoading =

--- a/operate/client/src/modules/mocks/api/mockRequest.ts
+++ b/operate/client/src/modules/mocks/api/mockRequest.ts
@@ -37,9 +37,13 @@ const mockPostRequest = function <Type extends DefaultBodyType>(url: string) {
      *
      * Otherwise an error will be thrown
      */
-    withSuccess: (responseData: Type, options?: {expectPolling?: boolean}) => {
+    withSuccess: (
+      responseData: Type,
+      options?: {expectPolling?: boolean; mockResolverFn?: jest.Mock},
+    ) => {
       mockServer.use(
         rest.post(url, (req, res, ctx) => {
+          options?.mockResolverFn?.();
           checkPollingHeader({req, expectPolling: options?.expectPolling});
           return res.once(ctx.json(responseData));
         }),


### PR DESCRIPTION
## Description

This PR is a followup to https://github.com/camunda/camunda/pull/29416/

I realized that the statistics are fetched by `useBatchModificationOverlayData` every time instances are selected, even though the app is not in batch modification mode.

I'm not sure why it's fetched though, because `batchOverlayData` is only consumed in the component if `batchModificationStore.state.isEnabled`, is true. If I `add batchModificationStore.state.isEnabled` to the enabled flag here, it works as expected and is only fetching when in batch modification mode.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
