### PR TITLE
feat: new records for batch operation

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestSupport.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestSupport.java
@@ -63,6 +63,9 @@ public final class TestSupport {
       case USER_TASK -> config.userTask = value;
       case COMPENSATION_SUBSCRIPTION -> config.compensationSubscription = value;
       case MESSAGE_CORRELATION -> config.messageCorrelation = value;
+      case BATCH_OPERATION_CREATION -> config.batchOperationCreation = value;
+      case BATCH_OPERATION_CHUNK -> config.batchOperationChunk = value;
+      case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);
@@ -109,6 +112,9 @@ public final class TestSupport {
       case USER_TASK -> config.userTask = value;
       case COMPENSATION_SUBSCRIPTION -> config.compensationSubscription = value;
       case MESSAGE_CORRELATION -> config.messageCorrelation = value;
+      case BATCH_OPERATION_CREATION -> config.batchOperationCreation = value;
+      case BATCH_OPERATION_CHUNK -> config.batchOperationChunk = value;
+      case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestSupport.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestSupport.java
@@ -64,6 +64,9 @@ public final class TestSupport {
       case MESSAGE_CORRELATION -> config.messageCorrelation = value;
       case USER -> config.user = value;
       case AUTHORIZATION -> config.authorization = value;
+      case BATCH_OPERATION_CREATION -> config.batchOperationCreation = value;
+      case BATCH_OPERATION_CHUNK -> config.batchOperationChunk = value;
+      case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);
@@ -112,6 +115,9 @@ public final class TestSupport {
       case MESSAGE_CORRELATION -> config.messageCorrelation = value;
       case USER -> config.user = value;
       case AUTHORIZATION -> config.authorization = value;
+      case BATCH_OPERATION_CREATION -> config.batchOperationCreation = value;
+      case BATCH_OPERATION_CHUNK -> config.batchOperationChunk = value;
+      case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -217,6 +217,10 @@ public class ElasticsearchExporterConfiguration {
     public boolean user = true;
     public boolean authorization = true;
 
+    public boolean batchOperationCreation = false;
+    public boolean batchOperationChunk = false;
+    public boolean batchOperationExecution = false;
+
     // index settings
     private Integer numberOfShards = null;
     private Integer numberOfReplicas = null;

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -62,6 +62,10 @@ final class TestSupport {
       case USER_TASK -> config.userTask = value;
       case COMPENSATION_SUBSCRIPTION -> config.compensationSubscription = value;
       case MESSAGE_CORRELATION -> config.messageCorrelation = value;
+
+      case BATCH_OPERATION_CREATION -> config.batchOperationCreation = value;
+      case BATCH_OPERATION_CHUNK -> config.batchOperationChunk = value;
+      case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);
@@ -109,7 +113,10 @@ final class TestSupport {
             ValueType.GROUP,
             ValueType.MAPPING,
             ValueType.IDENTITY_SETUP,
-            ValueType.RESOURCE);
+            ValueType.RESOURCE,
+            ValueType.BATCH_OPERATION_CREATION,
+            ValueType.BATCH_OPERATION_CHUNK,
+            ValueType.BATCH_OPERATION_EXECUTION);
     return EnumSet.complementOf(excludedValueTypes).stream();
   }
 }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -207,6 +207,10 @@ public class OpensearchExporterConfiguration {
 
     public boolean authorization = true;
 
+    public boolean batchOperationCreation = false;
+    public boolean batchOperationChunk = false;
+    public boolean batchOperationExecution = false;
+
     // index settings
     private Integer numberOfShards = null;
     private Integer numberOfReplicas = null;

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -64,6 +64,9 @@ final class TestSupport {
       case MESSAGE_CORRELATION -> config.messageCorrelation = value;
       case USER -> config.user = value;
       case AUTHORIZATION -> config.authorization = value;
+      case BATCH_OPERATION_CREATION -> config.batchOperationCreation = value;
+      case BATCH_OPERATION_CHUNK -> config.batchOperationChunk = value;
+      case BATCH_OPERATION_EXECUTION -> config.batchOperationExecution = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);
@@ -111,7 +114,10 @@ final class TestSupport {
             ValueType.GROUP,
             ValueType.MAPPING,
             ValueType.IDENTITY_SETUP,
-            ValueType.RESOURCE);
+            ValueType.RESOURCE,
+            ValueType.BATCH_OPERATION_CREATION,
+            ValueType.BATCH_OPERATION_CHUNK,
+            ValueType.BATCH_OPERATION_EXECUTION);
     return EnumSet.complementOf(excludedValueTypes).stream();
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationChunkRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationChunkRecord.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
+
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.value.LongValue;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class BatchOperationChunkRecord extends UnifiedRecordValue
+    implements BatchOperationChunkRecordValue {
+
+  public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
+  public static final String PROP_CHUNK_KEY = "chunkKey";
+  public static final String PROP_ENTITY_KEY_LIST = "entityKeys";
+
+  private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
+  private final LongProperty chunkKeyProp = new LongProperty(PROP_CHUNK_KEY);
+  private final ArrayProperty<LongValue> entityKeysProp =
+      new ArrayProperty<>(PROP_ENTITY_KEY_LIST, LongValue::new);
+
+  public BatchOperationChunkRecord() {
+    super(3);
+    declareProperty(batchOperationKeyProp)
+        .declareProperty(chunkKeyProp)
+        .declareProperty(entityKeysProp);
+  }
+
+  @Override
+  public Long getBatchOperationKey() {
+    return batchOperationKeyProp.getValue();
+  }
+
+  public BatchOperationChunkRecord setBatchOperationKey(final Long batchOperationKey) {
+    batchOperationKeyProp.reset();
+    batchOperationKeyProp.setValue(batchOperationKey);
+    return this;
+  }
+
+  @Override
+  public List<Long> getEntityKeys() {
+    return entityKeysProp.stream().map(LongValue::getValue).collect(Collectors.toList());
+  }
+
+  public BatchOperationChunkRecord setEntityKeys(final List<Long> keys) {
+    entityKeysProp.reset();
+    keys.forEach(key -> entityKeysProp.add().setValue(key));
+    return this;
+  }
+
+  @Override
+  public Long getChunkKey() {
+    return chunkKeyProp.getValue();
+  }
+
+  public BatchOperationChunkRecord setKeyChunkKey(final Long key) {
+    chunkKeyProp.setValue(key);
+    return this;
+  }
+
+  public void wrap(final BatchOperationChunkRecord record) {
+    setBatchOperationKey(record.getBatchOperationKey());
+    setEntityKeys(record.getEntityKeys());
+    setKeyChunkKey(record.getChunkKey());
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationCreationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationCreationRecord.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
+
+import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public final class BatchOperationCreationRecord extends UnifiedRecordValue
+    implements BatchOperationCreationRecordValue {
+
+  public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
+  public static final String PROP_BATCH_OPERATION_TYPE = "batchOperationType";
+  public static final String PROP_ENTITY_FILTER = "entityFilter";
+
+  private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY, -1);
+  private final EnumProperty<BatchOperationType> batchOperationTypeProp =
+      new EnumProperty<>(
+          PROP_BATCH_OPERATION_TYPE, BatchOperationType.class, BatchOperationType.UNSPECIFIED);
+  private final BinaryProperty entityFilterProp =
+      new BinaryProperty(PROP_ENTITY_FILTER, new UnsafeBuffer());
+
+  public BatchOperationCreationRecord() {
+    super(3);
+    declareProperty(batchOperationKeyProp)
+        .declareProperty(batchOperationTypeProp)
+        .declareProperty(entityFilterProp);
+  }
+
+  @Override
+  public Long getBatchOperationKey() {
+    return batchOperationKeyProp.getValue();
+  }
+
+  public BatchOperationCreationRecord setBatchOperationKey(final Long batchOperationKey) {
+    batchOperationKeyProp.reset();
+    batchOperationKeyProp.setValue(batchOperationKey);
+    return this;
+  }
+
+  @Override
+  public BatchOperationType getBatchOperationType() {
+    return batchOperationTypeProp.getValue();
+  }
+
+  public BatchOperationCreationRecord setBatchOperationType(
+      final BatchOperationType batchOperationType) {
+    batchOperationTypeProp.setValue(batchOperationType);
+    return this;
+  }
+
+  @Override
+  public String getEntityFilter() {
+    return MsgPackConverter.convertToJson(entityFilterProp.getValue());
+  }
+
+  public BatchOperationCreationRecord setEntityFilter(final DirectBuffer filterBuffer) {
+    entityFilterProp.setValue(new UnsafeBuffer(filterBuffer));
+    return this;
+  }
+
+  public DirectBuffer getEntityFilterBuffer() {
+    return entityFilterProp.getValue();
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationExecutionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationExecutionRecord.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.batchoperation;
+
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.value.LongValue;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationExecutionRecordValue;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public final class BatchOperationExecutionRecord extends UnifiedRecordValue
+    implements BatchOperationExecutionRecordValue {
+
+  public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
+  public static final String PROP_ENTITY_KEY_LIST = "entitykeys";
+
+  private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
+  private final ArrayProperty<LongValue> entityKeysProp =
+      new ArrayProperty<>(PROP_ENTITY_KEY_LIST, LongValue::new);
+
+  public BatchOperationExecutionRecord() {
+    super(2);
+    declareProperty(batchOperationKeyProp).declareProperty(entityKeysProp);
+  }
+
+  @Override
+  public Long getBatchOperationKey() {
+    return batchOperationKeyProp.getValue();
+  }
+
+  public BatchOperationExecutionRecord setBatchOperationKey(final Long batchOperationKey) {
+    batchOperationKeyProp.reset();
+    batchOperationKeyProp.setValue(batchOperationKey);
+    return this;
+  }
+
+  @Override
+  public Set<Long> getEntityKeys() {
+    return entityKeysProp.stream().map(LongValue::getValue).collect(Collectors.toSet());
+  }
+
+  public BatchOperationExecutionRecord setKeys(final Set<Long> keys) {
+    entityKeysProp.reset();
+    keys.forEach(key -> entityKeysProp.add().setValue(key));
+    return this;
+  }
+
+  public BatchOperationExecutionRecord wrap(final BatchOperationExecutionRecord record) {
+    setKeys(record.getEntityKeys());
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRe
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
@@ -57,6 +58,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
     RECORDS_BY_TYPE.put(ValueType.GROUP, GroupRecord::new);
     RECORDS_BY_TYPE.put(ValueType.REDISTRIBUTION, RedistributionRecord::new);
     RECORDS_BY_TYPE.put(ValueType.IDENTITY_SETUP, IdentitySetupRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.BATCH_OPERATION_CREATION, BatchOperationCreationRecord::new);
   }
 
   /*

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -16,6 +16,9 @@
 package io.camunda.zeebe.protocol.record;
 
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.CompensationSubscriptionIntent;
@@ -63,6 +66,9 @@ import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.RedistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationExecutionRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.CompensationSubscriptionRecordValue;
@@ -267,6 +273,16 @@ public final class ValueTypeMapping {
     mapping.put(
         ValueType.IDENTITY_SETUP,
         new Mapping<>(IdentitySetupRecordValue.class, IdentitySetupIntent.class));
+    mapping.put(
+        ValueType.BATCH_OPERATION_CREATION,
+        new Mapping<>(BatchOperationCreationRecordValue.class, BatchOperationIntent.class));
+    mapping.put(
+        ValueType.BATCH_OPERATION_CHUNK,
+        new Mapping<>(BatchOperationChunkRecordValue.class, BatchOperationChunkIntent.class));
+    mapping.put(
+        ValueType.BATCH_OPERATION_EXECUTION,
+        new Mapping<>(
+            BatchOperationExecutionRecordValue.class, BatchOperationExecutionIntent.class));
     return mapping;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/BatchOperationChunkIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/BatchOperationChunkIntent.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum BatchOperationChunkIntent implements Intent {
+  CREATE((short) 0);
+  //  CREATED((short) 1);
+
+  private final short value;
+
+  BatchOperationChunkIntent(final short value) {
+    this.value = value;
+  }
+
+  public short getIntent() {
+    return value;
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return CREATE;
+
+      default:
+        return Intent.UNKNOWN;
+    }
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      default:
+        return false;
+    }
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/BatchOperationExecutionIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/BatchOperationExecutionIntent.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum BatchOperationExecutionIntent implements Intent {
+  EXECUTE((short) 0),
+  //  EXECUTING((short) 1),
+  //  EXECUTED((short) 2),
+
+  //  COMPLETED((short) 3),
+
+  CANCEL((short) 4),
+  //  CANCELED((short) 5),
+
+  PAUSE((short) 6),
+  //  PAUSED((short) 7),
+
+  RESUME((short) 8);
+  //  RESUMED((short) 9),
+
+  private final short value;
+
+  BatchOperationExecutionIntent(final short value) {
+    this.value = value;
+  }
+
+  public short getIntent() {
+    return value;
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return EXECUTE;
+      case 4:
+        return CANCEL;
+      case 6:
+        return PAUSE;
+      case 8:
+        return RESUME;
+
+      default:
+        return Intent.UNKNOWN;
+    }
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      default:
+        return false;
+    }
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/BatchOperationIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/BatchOperationIntent.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum BatchOperationIntent implements Intent {
+  CREATE((short) 0);
+  //  CREATED((short) 1),
+
+  private final short value;
+
+  BatchOperationIntent(final short value) {
+    this.value = value;
+  }
+
+  public short getIntent() {
+    return value;
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return CREATE;
+
+      default:
+        return Intent.UNKNOWN;
+    }
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      default:
+        return false;
+    }
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -70,7 +70,10 @@ public interface Intent {
           RedistributionIntent.class,
           GroupIntent.class,
           MappingIntent.class,
-          IdentitySetupIntent.class);
+          IdentitySetupIntent.class,
+          BatchOperationIntent.class,
+          BatchOperationChunkIntent.class,
+          BatchOperationExecutionIntent.class);
   short NULL_VAL = 255;
   Intent UNKNOWN = UnknownIntent.UNKNOWN;
 
@@ -178,6 +181,12 @@ public interface Intent {
         return MappingIntent.from(intent);
       case IDENTITY_SETUP:
         return IdentitySetupIntent.from(intent);
+      case BATCH_OPERATION_CREATION:
+        return BatchOperationIntent.from(intent);
+      case BATCH_OPERATION_EXECUTION:
+        return BatchOperationExecutionIntent.from(intent);
+      case BATCH_OPERATION_CHUNK:
+        return BatchOperationChunkIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;
@@ -275,6 +284,12 @@ public interface Intent {
         return MappingIntent.valueOf(intent);
       case IDENTITY_SETUP:
         return IdentitySetupIntent.valueOf(intent);
+      case BATCH_OPERATION_CREATION:
+        return BatchOperationIntent.valueOf(intent);
+      case BATCH_OPERATION_EXECUTION:
+        return BatchOperationExecutionIntent.valueOf(intent);
+      case BATCH_OPERATION_CHUNK:
+        return BatchOperationChunkIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationChunkRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationChunkRecordValue.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import java.util.List;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableBatchOperationChunkRecordValue.Builder.class)
+public interface BatchOperationChunkRecordValue extends BatchOperationRelated, RecordValue {
+
+  /**
+   * @return subset of entity keys for the batch operation
+   */
+  List<Long> getEntityKeys();
+
+  /**
+   * @return the key of this chunk of entity keys
+   */
+  Long getChunkKey();
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationCreationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationCreationRecordValue.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableBatchOperationCreationRecordValue.Builder.class)
+public interface BatchOperationCreationRecordValue extends BatchOperationRelated, RecordValue {
+  /**
+   * @return batch operation type which defines the batch operation which should operate on the keys
+   */
+  BatchOperationType getBatchOperationType();
+
+  /**
+   * @return filter to apply in the batch operation to select the entities to operate on (as JSON)
+   */
+  String getEntityFilter();
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationExecutionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationExecutionRecordValue.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import java.util.Set;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableBatchOperationExecutionRecordValue.Builder.class)
+public interface BatchOperationExecutionRecordValue extends BatchOperationRelated, RecordValue {
+
+  /**
+   * @return subset of entity keys for the batch operation which are being or were processed
+   */
+  Set<Long> getEntityKeys();
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationRelated.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationRelated.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+public interface BatchOperationRelated {
+
+  /**
+   * @return the key of the batch operation aka operation reference key
+   */
+  Long getBatchOperationKey();
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+public enum BatchOperationType {
+  PROCESS_CANCELLATION,
+  UNSPECIFIED
+}

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -65,6 +65,9 @@
       <validValue name="MAPPING">47</validValue>
       <validValue name="IDENTITY_SETUP">48</validValue>
       <validValue name="RESOURCE">49</validValue>
+      <validValue name="BATCH_OPERATION_CREATION">50</validValue>
+      <validValue name="BATCH_OPERATION_EXECUTION">51</validValue>
+      <validValue name="BATCH_OPERATION_CHUNK">52</validValue>
 
       <!-- Management records / record not related to process automation -->
       <validValue name="REDISTRIBUTION">252</validValue>

--- a/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/ImmutableProtocolTest.java
+++ b/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/ImmutableProtocolTest.java
@@ -29,6 +29,7 @@ import com.tngtech.archunit.lang.SimpleConditionEvent;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.BatchOperationRelated;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.lang.reflect.Method;
@@ -90,6 +91,7 @@ final class ImmutableProtocolTest {
 
   private DescribedPredicate<JavaClass> getExcludedClasses() {
     return Predicates.equivalentTo(ProcessInstanceRelated.class)
+        .or(Predicates.equivalentTo(BatchOperationRelated.class))
         .or(Predicates.equivalentTo(TenantOwned.class));
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
@@ -12,6 +12,9 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRe
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
@@ -116,6 +119,9 @@ public final class TypedEventRegistry {
     registry.put(ValueType.GROUP, GroupRecord.class);
     registry.put(ValueType.REDISTRIBUTION, RedistributionRecord.class);
     registry.put(ValueType.IDENTITY_SETUP, IdentitySetupRecord.class);
+    registry.put(ValueType.BATCH_OPERATION_CREATION, BatchOperationCreationRecord.class);
+    registry.put(ValueType.BATCH_OPERATION_EXECUTION, BatchOperationExecutionRecord.class);
+    registry.put(ValueType.BATCH_OPERATION_CHUNK, BatchOperationChunkRecord.class);
 
     EVENT_REGISTRY = Collections.unmodifiableMap(registry);
 


### PR DESCRIPTION
## Description

Introduces new records and intents for managing batch operations in the engine.

There will be three new record types:

### BatchOperationCreationRecordValue
The initial record to create a batchOperation:

- batchOperationKey: the PK of the batch operation. on Intent.CREATE it will not contain a value
- entityFilter: a generic filter object. This is a serialized JSON string representation of the filter object from the camunda-search-domain and can be applied to the respective search service
- batchOperationType: an enum to specify the actual operation to execute on each entity

### BatchOperationKeyChunkRecordValue
A record containing a chunk of entity keys to perform the actual batch command on. This command/event can occur multiple times at the beginning of the batch operation. The total collection of keys will be sliced into smaller chunks of max. 495.000 entity keys, the max amount of 8-byte Long values in 4MB record size plus a bit overhead.

- batchOperationKey: the PK of the batch operation
- entityKeys: A list of entity keys to be added to the batch operation

### BatchOperationExecutionRecordValue
The record representing a batch operation in progress. Some records will not have any entityKeys, only EXECUTING and EXECUTED.

- batchOperationKey: the PK of the batch operation
- entityKeys: A list of entity keys to be added to the batch operation
- batchOperationType: an enum to specify the actual operation to execute on each entity

## Notes

Some changes in this PR do not relate directly to BatchOperations in the Engine.
- the legacy ES/OS exporters have unit tests checking that each existing valueType can be handled by the exporter. Therefore this PR also changes code in the ES/OS exporter

## Checklist

## Related issues

closes #29669 
