### PR TITLE
fix: use compose from camunda-distributions instead

### DIFF
--- a/c8run/.env
+++ b/c8run/.env
@@ -4,5 +4,5 @@ CAMUNDA_VERSION=8.8.0-alpha2
 # Look here: https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/
 CONNECTORS_VERSION=8.8.0-alpha2
 # version of docker compose artifact (used for --docker option)
-COMPOSE_TAG=8.7-alpha3
-COMPOSE_EXTRACTED_FOLDER=camunda-platform-8.7-alpha3
+COMPOSE_TAG=alpha
+COMPOSE_EXTRACTED_FOLDER=docker-compose-alpha

--- a/c8run/internal/archive/archive.go
+++ b/c8run/internal/archive/archive.go
@@ -270,6 +270,15 @@ func UnzipSource(source, destination string) error {
 	}
 	defer reader.Close()
 
+        // if destination does not exist, create it
+        _, err = os.Stat(destination)
+        if errors.Is(err, os.ErrNotExist) {
+                err = os.Mkdir(destination, ReadWriteMode)
+                if err != nil {
+                        return fmt.Errorf("UnzipSource: failed to create directory %s\n%w\n%s", destination, err, debug.Stack())
+                }
+        }
+
 	destinationAbsPath, err := filepath.Abs(destination)
 	if err != nil {
 		return fmt.Errorf("UnzipSource: failed to determine absolute path for %s\n%w\n%s", destination, err, debug.Stack())

--- a/c8run/internal/packages/package.go
+++ b/c8run/internal/packages/package.go
@@ -34,7 +34,7 @@ func Clean(camundaVersion string, elasticsearchVersion string) {
 	}
 }
 
-func downloadAndExtract(filePath, url, extractDir string, authToken string, extractFunc func(string, string) error) error {
+func downloadAndExtract(filePath, url, extractDir string, baseDir string, authToken string, extractFunc func(string, string) error) error {
 	err := archive.DownloadFile(filePath, url, authToken)
 	if err != nil {
 		return fmt.Errorf("downloadAndExtract: failed to download file at url %s\n%w\n%s", url, err, debug.Stack())
@@ -42,7 +42,7 @@ func downloadAndExtract(filePath, url, extractDir string, authToken string, extr
 
 	_, err = os.Stat(extractDir)
 	if errors.Is(err, os.ErrNotExist) {
-		err = extractFunc(filePath, ".")
+		err = extractFunc(filePath, baseDir)
 		if err != nil {
 			return fmt.Errorf("downloadAndExtract: failed to extract from archive at %s\n%w\n%s", filePath, err, debug.Stack())
 		}
@@ -167,9 +167,12 @@ func New(camundaVersion, elasticsearchVersion, connectorsVersion, composeTag str
 	camundaUrl := "https://repository.nexus.camunda.cloud/content/groups/internal/io/camunda/camunda-zeebe/" + camundaVersion + "/camunda-zeebe-" + camundaVersion + pkgName
 	connectorsFilePath := "connector-runtime-bundle-" + connectorsVersion + "-with-dependencies.jar"
 	connectorsUrl := "https://repository.nexus.camunda.cloud/content/groups/internal/io/camunda/connector/connector-runtime-bundle/" + connectorsVersion + "/" + connectorsFilePath
-	composeUrl := "https://github.com/camunda/camunda-platform/archive/refs/tags/" + composeTag + pkgName
-	composeFilePath := composeTag + pkgName
-	composeExtractionPath := "camunda-platform-" + composeTag
+
+        composeUrl := "https://github.com/camunda/camunda-distributions/releases/download/docker-compose-" + composeTag + "/docker-compose-" + composeTag + ".zip"
+	composeFilePath := "docker-compose-" + composeTag + ".zip"
+        // just a file to check to see if it was already extracted
+	composeExtractionPath := "docker-compose-" + composeTag
+
 	authToken := os.Getenv("GH_TOKEN")
 
 
@@ -187,22 +190,22 @@ func New(camundaVersion, elasticsearchVersion, connectorsVersion, composeTag str
 
 	Clean(camundaVersion, elasticsearchVersion)
 
-	err = downloadAndExtract(elasticsearchFilePath, elasticsearchUrl, "elasticsearch-"+elasticsearchVersion, "", extractFunc)
+	err = downloadAndExtract(elasticsearchFilePath, elasticsearchUrl, "elasticsearch-"+elasticsearchVersion, ".", "", extractFunc)
 	if err != nil {
 		return fmt.Errorf("Package "+osType+": failed to fetch elasticsearch: %w\n%s", err, debug.Stack())
 	}
 
-	err = downloadAndExtract(camundaFilePath, camundaUrl, "camunda-zeebe-"+camundaVersion, javaArtifactsToken, extractFunc)
+	err = downloadAndExtract(camundaFilePath, camundaUrl, "camunda-zeebe-"+camundaVersion, ".", javaArtifactsToken, extractFunc)
 	if err != nil {
 		return fmt.Errorf("Package "+osType+": failed to download camunda %w\n%s", err, debug.Stack())
 	}
 
-	err = downloadAndExtract(connectorsFilePath, connectorsUrl, connectorsFilePath, javaArtifactsToken, func(_, _ string) error { return nil })
+	err = downloadAndExtract(connectorsFilePath, connectorsUrl, connectorsFilePath, ".", javaArtifactsToken, func(_, _ string) error { return nil })
 	if err != nil {
 		return fmt.Errorf("Package "+osType+": failed to fetch connectors: %w\n%s", err, debug.Stack())
 	}
 
-	err = downloadAndExtract(composeFilePath, composeUrl, composeExtractionPath, authToken, extractFunc)
+	err = downloadAndExtract(composeFilePath, composeUrl, composeExtractionPath, composeExtractionPath, authToken, archive.UnzipSource)
 	if err != nil {
 		return fmt.Errorf("Package "+osType+": failed to fetch compose release %w\n%s", err, debug.Stack())
 	}


### PR DESCRIPTION
## Description

we've been using the camunda-platform repo for our docker-compose file in c8run but we should be using the camunda-distributions version.


<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/camunda/issues/29243
