### PR TITLE
fix: c8run retrieve JAVA_HOME and JAVA_VERSION from a java script

### DIFF
--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -203,10 +203,6 @@ jobs:
         run: ls
         working-directory: .\c8run
 
-      - name: ls
-        run: ls
-        working-directory: .\c8run\elasticsearch-8.13.4
-
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ c8run/log/*.log
 c8run/camunda-zeebe*
 c8run/elasticsearch*
 c8run/c8run
+c8run/*.class
 
 /camunda.mv.db
 /camunda.trace.db

--- a/c8run/.env
+++ b/c8run/.env
@@ -1,4 +1,4 @@
-ELASTICSEARCH_VERSION=8.13.4
+ELASTICSEARCH_VERSION=8.17.3
 # this is the version of camunda/ zeebe
 CAMUNDA_VERSION=8.8.0-alpha2
 # Look here: https://artifacts.camunda.com/ui/native/connectors/io/camunda/connector/connector-runtime-bundle/

--- a/c8run/JavaHome.java
+++ b/c8run/JavaHome.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+public class JavaHome {
+    public static void main(String[] args) {
+      System.out.print(System.getProperty("java.home"));
+    }
+}

--- a/c8run/JavaVersion.java
+++ b/c8run/JavaVersion.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+public class JavaVersion {
+    public static void main(String[] args) {
+      System.out.print(System.getProperty("java.version"));
+    }
+}


### PR DESCRIPTION
## Description

JAVA_HOME and JAVA_VERSION are difficult things for users to set correctly, and are also things that are difficult for non-java programs to be able to see correctly.  This PR proposes a new approach to retrieving JAVA_HOME and JAVA_VERSION. We have  a java program called JavaHome and JavaVersion, which serves the purpose of printing out these properties. We then call these java scripts via c8run.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
