### PR TITLE
test: acceptance tests for incident update

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentSearchTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentSearchTest.java
@@ -67,6 +67,7 @@ class IncidentSearchTest {
 
     waitForProcessInstancesToStart(camundaClient, 5);
     waitUntilProcessInstanceHasIncidents(camundaClient, amountOfIncidents);
+    waitUntilIncidentsAreActive(camundaClient, amountOfIncidents);
 
     incident = camundaClient.newIncidentSearchRequest().send().join().items().getFirst();
   }

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentSearchTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentSearchTest.java
@@ -7,10 +7,12 @@
  */
 package io.camunda.it.client;
 
+import static io.camunda.client.api.search.response.IncidentState.ACTIVE;
 import static io.camunda.it.util.TestHelper.deployResource;
 import static io.camunda.it.util.TestHelper.startProcessInstance;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitUntilIncidentsAreActive;
 import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceHasIncidents;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -38,6 +40,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 class IncidentSearchTest {
 
   private static final List<Process> DEPLOYED_PROCESSES = new ArrayList<>();
+  private static final int amountOfIncidents = 3;
 
   private static CamundaClient camundaClient;
 
@@ -63,7 +66,7 @@ class IncidentSearchTest {
     startProcessInstance(camundaClient, "incident_process_v1");
 
     waitForProcessInstancesToStart(camundaClient, 5);
-    waitUntilProcessInstanceHasIncidents(camundaClient, 3);
+    waitUntilProcessInstanceHasIncidents(camundaClient, amountOfIncidents);
 
     incident = camundaClient.newIncidentSearchRequest().send().join().items().getFirst();
   }
@@ -71,6 +74,18 @@ class IncidentSearchTest {
   @AfterAll
   static void afterAll() {
     DEPLOYED_PROCESSES.clear();
+  }
+
+  @Test
+  void testIncidentsAreActive() {
+    // given
+    waitUntilIncidentsAreActive(camundaClient, amountOfIncidents);
+
+    // when
+    final List<Incident> incidents = camundaClient.newIncidentSearchRequest().send().join().items();
+
+    // then incidents are updated by background task, PENDING state is changed on ACTIVE
+    assertThat(incidents).extracting(Incident::getState).containsOnly(ACTIVE);
   }
 
   @Test

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentSearchTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentSearchTest.java
@@ -40,7 +40,7 @@ import org.junit.jupiter.params.provider.EnumSource;
 class IncidentSearchTest {
 
   private static final List<Process> DEPLOYED_PROCESSES = new ArrayList<>();
-  private static final int amountOfIncidents = 3;
+  private static final int AMOUNT_OF_INCIDENTS = 3;
 
   private static CamundaClient camundaClient;
 
@@ -66,8 +66,8 @@ class IncidentSearchTest {
     startProcessInstance(camundaClient, "incident_process_v1");
 
     waitForProcessInstancesToStart(camundaClient, 5);
-    waitUntilProcessInstanceHasIncidents(camundaClient, amountOfIncidents);
-    waitUntilIncidentsAreActive(camundaClient, amountOfIncidents);
+    waitUntilProcessInstanceHasIncidents(camundaClient, AMOUNT_OF_INCIDENTS);
+    waitUntilIncidentsAreActive(camundaClient, AMOUNT_OF_INCIDENTS);
 
     incident = camundaClient.newIncidentSearchRequest().send().join().items().getFirst();
   }
@@ -80,7 +80,7 @@ class IncidentSearchTest {
   @Test
   void testIncidentsAreActive() {
     // given
-    waitUntilIncidentsAreActive(camundaClient, amountOfIncidents);
+    waitUntilIncidentsAreActive(camundaClient, AMOUNT_OF_INCIDENTS);
 
     // when
     final List<Incident> incidents = camundaClient.newIncidentSearchRequest().send().join().items();

--- a/qa/integration-tests/src/test/java/io/camunda/it/orchestration/incidents/IncidentFullResolveCallActivityTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/orchestration/incidents/IncidentFullResolveCallActivityTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.orchestration.incidents;
+
+import static io.camunda.client.api.search.response.ProcessInstanceState.ACTIVE;
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitUntilFlowNodeInstanceHasIncidents;
+import static io.camunda.it.util.TestHelper.waitUntilIncidentsAreActive;
+import static io.camunda.it.util.TestHelper.waitUntilIncidentsAreResolved;
+import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceHasIncidents;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.Process;
+import io.camunda.client.api.search.response.FlowNodeInstance;
+import io.camunda.client.api.search.response.FlowNodeInstanceState;
+import io.camunda.client.api.search.response.Incident;
+import io.camunda.client.api.search.response.IncidentState;
+import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that when all of the incidents are resolved, all involved flow node instances and process
+ * instances in the call stack stay go out of incident state.
+ */
+@MultiDbTest
+public class IncidentFullResolveCallActivityTest {
+
+  private static CamundaClient camundaClient;
+  private static final String CALLED_PROCESS_ID = "calledProcess";
+  private static final String SERVICE_TASK_ID = "serviceTask";
+  private static final String SERVICE_TASK_1_ID = "serviceTask1";
+  private static final String SERVICE_TASK_2_ID = "serviceTask2";
+  private static final String PARENT_PROCESS_ID = "parentProcess";
+  private static final String CALL_ACTIVITY_ID = "callActivity";
+  private static final String ERROR_MSG = "Error in called process task";
+  private static final List<Process> DEPLOYED_PROCESSES = new ArrayList<>();
+  private static Process parentProcess;
+  private static Process childProcess;
+
+  /**
+   * Data for the test: 1. parentProcess instance with call activity 2. calledProcess instance with
+   * two resolved incidents on service tasks (no more incidents)
+   */
+  @BeforeAll
+  static void beforeAll() {
+    final BpmnModelInstance testProcess =
+        Bpmn.createExecutableProcess(PARENT_PROCESS_ID)
+            .startEvent()
+            .parallelGateway("parallel")
+            .serviceTask(SERVICE_TASK_ID)
+            .zeebeJobType(SERVICE_TASK_ID)
+            .moveToNode("parallel")
+            .callActivity(CALL_ACTIVITY_ID)
+            .zeebeProcessId(CALLED_PROCESS_ID)
+            .done();
+    parentProcess =
+        deployResource(camundaClient, testProcess, "testProcess.bpmn").getProcesses().getFirst();
+    DEPLOYED_PROCESSES.add(parentProcess);
+
+    final BpmnModelInstance testProcess1 =
+        Bpmn.createExecutableProcess(CALLED_PROCESS_ID)
+            .startEvent()
+            .parallelGateway("parallel")
+            .serviceTask(SERVICE_TASK_1_ID)
+            .zeebeJobType(SERVICE_TASK_1_ID)
+            .moveToNode("parallel")
+            .serviceTask(SERVICE_TASK_2_ID)
+            .zeebeJobType(SERVICE_TASK_2_ID)
+            .done();
+    childProcess =
+        deployResource(camundaClient, testProcess1, "calledProcess.bpmn").getProcesses().getFirst();
+    DEPLOYED_PROCESSES.add(childProcess);
+
+    waitForProcessesToBeDeployed(camundaClient, 2);
+
+    startProcessInstance(camundaClient, PARENT_PROCESS_ID).getProcessInstanceKey();
+    waitForProcessInstancesToStart(camundaClient, 2);
+
+    final List<Long> jobKeys = new ArrayList<>();
+    // fail 2 service tasks
+    List.of(SERVICE_TASK_1_ID, SERVICE_TASK_2_ID)
+        .forEach(
+            taskId -> {
+              final Long jobKey =
+                  camundaClient
+                      .newActivateJobsCommand()
+                      .jobType(taskId)
+                      .maxJobsToActivate(1)
+                      .send()
+                      .join()
+                      .getJobs()
+                      .getFirst()
+                      .getKey();
+              jobKeys.add(jobKey);
+              camundaClient.newFailCommand(jobKey).retries(0).errorMessage(ERROR_MSG).send().join();
+            });
+    waitUntilProcessInstanceHasIncidents(camundaClient, 2);
+    waitUntilIncidentsAreActive(camundaClient, 2);
+
+    // resolve incidents
+    jobKeys.forEach(
+        jobKey -> {
+          camundaClient.newUpdateRetriesCommand(jobKey).retries(1).send().join();
+          final Incident incident =
+              camundaClient
+                  .newIncidentSearchRequest()
+                  .filter(f -> f.jobKey(jobKey))
+                  .send()
+                  .join()
+                  .items()
+                  .getFirst();
+          camundaClient.newResolveIncidentCommand(incident.getIncidentKey()).send().join();
+        });
+    waitUntilIncidentsAreResolved(camundaClient, 2);
+    waitUntilProcessInstanceHasIncidents(camundaClient, 0);
+    waitUntilFlowNodeInstanceHasIncidents(camundaClient, 0);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    DEPLOYED_PROCESSES.clear();
+  }
+
+  @Test
+  public void testNoActiveIncidents() {
+    // when
+    final List<Incident> incidents =
+        camundaClient
+            .newIncidentSearchRequest()
+            .filter(fn -> fn.state(IncidentState.ACTIVE))
+            .send()
+            .join()
+            .items();
+
+    // then
+    assertThat(incidents).isEmpty();
+  }
+
+  @Test
+  public void testParentFlowNodeInstanceIsActive() {
+    // when
+    final FlowNodeInstance flowNodeInstance =
+        camundaClient
+            .newFlownodeInstanceSearchRequest()
+            .filter(f -> f.flowNodeId(CALL_ACTIVITY_ID))
+            .page(p -> p.limit(100))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+
+    // then
+    assertThat(flowNodeInstance).isNotNull();
+    assertThat(flowNodeInstance.getState()).isEqualTo(FlowNodeInstanceState.ACTIVE);
+    assertThat(flowNodeInstance.getIncident()).isEqualTo(false);
+  }
+
+  @Test
+  public void testParentProcessInstanceIsActive() {
+    // when
+    final ProcessInstance processInstance =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.processDefinitionKey(parentProcess.getProcessDefinitionKey()))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+
+    // then
+    assertThat(processInstance).isNotNull();
+    assertThat(processInstance.getState()).isEqualTo(ACTIVE);
+    assertThat(processInstance.getHasIncident()).isFalse();
+  }
+
+  @Test
+  public void testChildFlowNodeInstanceIsActive() {
+    // when
+    final FlowNodeInstance flowNodeInstance =
+        camundaClient
+            .newFlownodeInstanceSearchRequest()
+            .filter(f -> f.flowNodeId(SERVICE_TASK_1_ID))
+            .page(p -> p.limit(100))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+
+    // then
+    assertThat(flowNodeInstance).isNotNull();
+    assertThat(flowNodeInstance.getState()).isEqualTo(FlowNodeInstanceState.ACTIVE);
+    assertThat(flowNodeInstance.getIncident()).isEqualTo(false);
+  }
+
+  @Test
+  public void testChildProcessInstanceIsActive() {
+    // when
+    final ProcessInstance processInstance =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.processDefinitionKey(childProcess.getProcessDefinitionKey()))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+
+    // then
+    assertThat(processInstance).isNotNull();
+    assertThat(processInstance.getState()).isEqualTo(ACTIVE);
+    assertThat(processInstance.getHasIncident()).isFalse();
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/orchestration/incidents/IncidentPartialResolveCallActivityTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/orchestration/incidents/IncidentPartialResolveCallActivityTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.orchestration.incidents;
+
+import static io.camunda.client.api.search.response.ProcessInstanceState.ACTIVE;
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitUntilIncidentsAreActive;
+import static io.camunda.it.util.TestHelper.waitUntilIncidentsAreResolved;
+import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceHasIncidents;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.Process;
+import io.camunda.client.api.search.response.FlowNodeInstance;
+import io.camunda.client.api.search.response.FlowNodeInstanceState;
+import io.camunda.client.api.search.response.Incident;
+import io.camunda.client.api.search.response.IncidentState;
+import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that when one of several incidents is resolved all involved flow node instances and process
+ * instances in the call stack stay in incident state.
+ */
+@MultiDbTest
+public class IncidentPartialResolveCallActivityTest {
+
+  private static CamundaClient camundaClient;
+  private static final String CALLED_PROCESS_ID = "calledProcess";
+  private static final String SERVICE_TASK_ID = "serviceTask";
+  private static final String SERVICE_TASK_1_ID = "serviceTask1";
+  private static final String SERVICE_TASK_2_ID = "serviceTask2";
+  private static final String PARENT_PROCESS_ID = "parentProcess";
+  private static final String CALL_ACTIVITY_ID = "callActivity";
+  private static final String ERROR_MSG = "Error in called process task";
+  private static final List<Process> DEPLOYED_PROCESSES = new ArrayList<>();
+  private static Process parentProcess;
+  private static Process childProcess;
+
+  /**
+   * Data for the test: 1. parentProcess instance with call activity 2. calledProcess instance with
+   * one resolved and one active incident
+   */
+  @BeforeAll
+  static void beforeAll() {
+    final BpmnModelInstance testProcess =
+        Bpmn.createExecutableProcess(PARENT_PROCESS_ID)
+            .startEvent()
+            .parallelGateway("parallel")
+            .serviceTask(SERVICE_TASK_ID)
+            .zeebeJobType(SERVICE_TASK_ID)
+            .moveToNode("parallel")
+            .callActivity(CALL_ACTIVITY_ID)
+            .zeebeProcessId(CALLED_PROCESS_ID)
+            .done();
+    parentProcess =
+        deployResource(camundaClient, testProcess, "testProcess.bpmn").getProcesses().getFirst();
+    DEPLOYED_PROCESSES.add(parentProcess);
+
+    final BpmnModelInstance testProcess1 =
+        Bpmn.createExecutableProcess(CALLED_PROCESS_ID)
+            .startEvent()
+            .parallelGateway("parallel")
+            .serviceTask(SERVICE_TASK_1_ID)
+            .zeebeJobType(SERVICE_TASK_1_ID)
+            .moveToNode("parallel")
+            .serviceTask(SERVICE_TASK_2_ID)
+            .zeebeJobType(SERVICE_TASK_2_ID)
+            .done();
+    childProcess =
+        deployResource(camundaClient, testProcess1, "calledProcess.bpmn").getProcesses().getFirst();
+    DEPLOYED_PROCESSES.add(childProcess);
+
+    waitForProcessesToBeDeployed(camundaClient, 2);
+
+    startProcessInstance(camundaClient, PARENT_PROCESS_ID).getProcessInstanceKey();
+    waitForProcessInstancesToStart(camundaClient, 2);
+
+    final long[] serviceTaskKey = new long[1];
+    // fail 2 service tasks
+    List.of(SERVICE_TASK_1_ID, SERVICE_TASK_2_ID)
+        .forEach(
+            taskId -> {
+              serviceTaskKey[0] =
+                  camundaClient
+                      .newActivateJobsCommand()
+                      .jobType(taskId)
+                      .maxJobsToActivate(1)
+                      .send()
+                      .join()
+                      .getJobs()
+                      .getFirst()
+                      .getKey();
+              camundaClient
+                  .newFailCommand(serviceTaskKey[0])
+                  .retries(0)
+                  .errorMessage(ERROR_MSG)
+                  .send()
+                  .join();
+            });
+    waitUntilProcessInstanceHasIncidents(camundaClient, 2);
+    waitUntilIncidentsAreActive(camundaClient, 2);
+
+    // resolve incident in the first service task
+    camundaClient.newUpdateRetriesCommand(serviceTaskKey[0]).retries(1).send().join();
+    final Incident incident =
+        camundaClient
+            .newIncidentSearchRequest()
+            .filter(f -> f.jobKey(serviceTaskKey[0]))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+    camundaClient.newResolveIncidentCommand(incident.getIncidentKey()).send().join();
+
+    waitUntilIncidentsAreResolved(camundaClient, 1);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    DEPLOYED_PROCESSES.clear();
+  }
+
+  @Test
+  public void testOneIncident() {
+    // when
+    final List<Incident> incidents =
+        camundaClient
+            .newIncidentSearchRequest()
+            .filter(fn -> fn.state(IncidentState.ACTIVE))
+            .send()
+            .join()
+            .items();
+
+    // then
+    assertThat(incidents).hasSize(1);
+  }
+
+  @Test
+  public void testParentFlowNodeInstanceInIncidentState() {
+    // when
+    final FlowNodeInstance flowNodeInstance =
+        camundaClient
+            .newFlownodeInstanceSearchRequest()
+            .filter(f -> f.flowNodeId(CALL_ACTIVITY_ID))
+            .page(p -> p.limit(100))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+
+    // then
+    assertThat(flowNodeInstance).isNotNull();
+    assertThat(flowNodeInstance.getState()).isEqualTo(FlowNodeInstanceState.ACTIVE);
+    assertThat(flowNodeInstance.getIncident()).isEqualTo(true);
+  }
+
+  @Test
+  public void testParentProcessInstanceInIncidentState() {
+    // when
+    final ProcessInstance processInstance =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.processDefinitionKey(parentProcess.getProcessDefinitionKey()))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+
+    // then
+    assertThat(processInstance).isNotNull();
+    assertThat(processInstance.getState()).isEqualTo(ACTIVE);
+    assertThat(processInstance.getHasIncident()).isTrue();
+  }
+
+  @Test
+  public void testChildFlowNodeInstanceInIncidentState() {
+    // when
+    final FlowNodeInstance flowNodeInstance =
+        camundaClient
+            .newFlownodeInstanceSearchRequest()
+            .filter(f -> f.flowNodeId(SERVICE_TASK_1_ID))
+            .page(p -> p.limit(100))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+
+    // then
+    assertThat(flowNodeInstance).isNotNull();
+    assertThat(flowNodeInstance.getState()).isEqualTo(FlowNodeInstanceState.ACTIVE);
+    assertThat(flowNodeInstance.getIncident()).isEqualTo(true);
+  }
+
+  @Test
+  public void testChildProcessInstanceInIncidentState() {
+    // when
+    final ProcessInstance processInstance =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.processDefinitionKey(childProcess.getProcessDefinitionKey()))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+
+    // then
+    assertThat(processInstance).isNotNull();
+    assertThat(processInstance.getState()).isEqualTo(ACTIVE);
+    assertThat(processInstance.getHasIncident()).isTrue();
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/orchestration/incidents/IncidentPropagationTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/orchestration/incidents/IncidentPropagationTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.orchestration.incidents;
+
+import static io.camunda.client.api.search.response.IncidentState.ACTIVE;
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitUntilIncidentsAreActive;
+import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceHasIncidents;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.Process;
+import io.camunda.client.api.search.response.FlowNodeInstance;
+import io.camunda.client.api.search.response.Incident;
+import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the incident propagation from a called process to the parent process, implemented in {@link
+ * io.camunda.exporter.tasks.incident.IncidentUpdateTask}
+ */
+@MultiDbTest
+class IncidentPropagationTest {
+
+  private static final String CALL_ACTIVITY_2_ID = "callActivity2";
+  private static final String CALLED_PROCESS_ID = "calledProcess";
+  private static final String LAST_CALLED_TASK_ID = "taskA";
+  private static final String SERVICE_TASK_ID = "serviceTask";
+  private static final String PARENT_PROCESS_ID = "parentProcess";
+  private static final String CALL_ACTIVITY_1_ID = "callActivity1";
+  private static final String ERROR_MSG_1 = "Error in called process task";
+  private static final String ERROR_MSG_2 = "Error in last called process task";
+  private static final List<Process> DEPLOYED_PROCESSES = new ArrayList<>();
+  private static CamundaClient camundaClient;
+
+  /** parentProcess -> calledProcess (has incident) -> process (has incident) */
+  @BeforeAll
+  static void beforeAll() {
+    final String calledProcess2Id = "service_tasks_v1";
+    final BpmnModelInstance testProcess =
+        Bpmn.createExecutableProcess(PARENT_PROCESS_ID)
+            .startEvent()
+            .callActivity(CALL_ACTIVITY_1_ID)
+            .zeebeProcessId(CALLED_PROCESS_ID)
+            .done();
+    DEPLOYED_PROCESSES.addAll(
+        deployResource(camundaClient, testProcess, "testProcess.bpmn").getProcesses());
+    final BpmnModelInstance testProcess2 =
+        Bpmn.createExecutableProcess(CALLED_PROCESS_ID)
+            .startEvent()
+            .parallelGateway("parallel")
+            .serviceTask(SERVICE_TASK_ID)
+            .zeebeJobType(SERVICE_TASK_ID)
+            .moveToNode("parallel")
+            .callActivity(CALL_ACTIVITY_2_ID)
+            .zeebeProcessId(calledProcess2Id)
+            .done();
+    DEPLOYED_PROCESSES.addAll(
+        deployResource(camundaClient, testProcess2, "testProcess2.bpmn").getProcesses());
+    DEPLOYED_PROCESSES.addAll(
+        deployResource(camundaClient, "process/service_tasks_v1.bpmn").getProcesses());
+
+    waitForProcessesToBeDeployed(camundaClient, 3);
+
+    startProcessInstance(camundaClient, PARENT_PROCESS_ID);
+
+    waitForProcessInstancesToStart(camundaClient, 3);
+
+    // fail task in last called process
+    long jobKey =
+        camundaClient
+            .newActivateJobsCommand()
+            .jobType(LAST_CALLED_TASK_ID)
+            .maxJobsToActivate(1)
+            .send()
+            .join()
+            .getJobs()
+            .getFirst()
+            .getKey();
+    camundaClient.newFailCommand(jobKey).retries(0).errorMessage(ERROR_MSG_2).send().join();
+    // fail task in the second process
+    jobKey =
+        camundaClient
+            .newActivateJobsCommand()
+            .jobType(SERVICE_TASK_ID)
+            .maxJobsToActivate(1)
+            .send()
+            .join()
+            .getJobs()
+            .getFirst()
+            .getKey();
+    camundaClient.newFailCommand(jobKey).retries(0).errorMessage(ERROR_MSG_1).send().join();
+    waitUntilProcessInstanceHasIncidents(camundaClient, 3);
+    waitUntilIncidentsAreActive(camundaClient, 2);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    DEPLOYED_PROCESSES.clear();
+  }
+
+  @Test
+  void testIncidentsAreActive() {
+    // incidents are updated by background task, PENDING state is changed on ACTIVE
+    final List<Incident> incidents = camundaClient.newIncidentSearchRequest().send().join().items();
+    assertThat(incidents).hasSize(2);
+    incidents.forEach(
+        incident -> {
+          assertThat(incident.getState()).isEqualTo(ACTIVE);
+        });
+    assertThat(incidents).extracting(Incident::getErrorMessage).contains(ERROR_MSG_1, ERROR_MSG_2);
+  }
+
+  @Test
+  void testFlowNodeInstanceInIncidentState() {
+    final FlowNodeInstance flowNodeInstance1 =
+        camundaClient
+            .newFlownodeInstanceSearchRequest()
+            .filter(f -> f.flowNodeId(SERVICE_TASK_ID))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+    assertThat(flowNodeInstance1).isNotNull();
+    assertThat(flowNodeInstance1.getIncident()).isTrue();
+
+    final FlowNodeInstance flowNodeInstance2 =
+        camundaClient
+            .newFlownodeInstanceSearchRequest()
+            .filter(f -> f.flowNodeId(LAST_CALLED_TASK_ID))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+    assertThat(flowNodeInstance2).isNotNull();
+    assertThat(flowNodeInstance2.getIncident()).isTrue();
+  }
+
+  @Test
+  void testSecondProcessInstanceHasIncident() {
+    final ProcessInstance processInstance =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.processDefinitionId(CALLED_PROCESS_ID))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+    assertThat(processInstance).isNotNull();
+    assertThat(processInstance.getHasIncident()).isTrue();
+  }
+
+  @Test
+  void testSecondCallActivityHasIncident() {
+    final FlowNodeInstance flowNodeInstance =
+        camundaClient
+            .newFlownodeInstanceSearchRequest()
+            .filter(f -> f.flowNodeId(CALL_ACTIVITY_2_ID))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+    assertThat(flowNodeInstance).isNotNull();
+    assertThat(flowNodeInstance.getIncident()).isTrue();
+  }
+
+  @Test
+  void testFirstProcessInstanceHasIncident() {
+    final ProcessInstance processInstance =
+        camundaClient
+            .newProcessInstanceSearchRequest()
+            .filter(f -> f.processDefinitionId(PARENT_PROCESS_ID))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+    assertThat(processInstance).isNotNull();
+    assertThat(processInstance.getHasIncident()).isTrue();
+  }
+
+  @Test
+  void testFirstCallActivityHasIncident() {
+    final FlowNodeInstance flowNodeInstance =
+        camundaClient
+            .newFlownodeInstanceSearchRequest()
+            .filter(f -> f.flowNodeId(CALL_ACTIVITY_1_ID))
+            .send()
+            .join()
+            .items()
+            .getFirst();
+    assertThat(flowNodeInstance).isNotNull();
+    assertThat(flowNodeInstance.getIncident()).isTrue();
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/orchestration/incidents/IncidentSimpleResolveTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/orchestration/incidents/IncidentSimpleResolveTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.orchestration.incidents;
+
+import static io.camunda.client.api.search.response.ProcessInstanceState.ACTIVE;
+import static io.camunda.it.util.TestHelper.deployResource;
+import static io.camunda.it.util.TestHelper.startProcessInstance;
+import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
+import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
+import static io.camunda.it.util.TestHelper.waitUntilIncidentIsResolvedOnFlowNodeInstance;
+import static io.camunda.it.util.TestHelper.waitUntilIncidentIsResolvedOnProcessInstance;
+import static io.camunda.it.util.TestHelper.waitUntilIncidentsAreResolved;
+import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceHasIncidents;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.response.Process;
+import io.camunda.client.api.search.response.FlowNodeInstance;
+import io.camunda.client.api.search.response.FlowNodeInstanceState;
+import io.camunda.client.api.search.response.Incident;
+import io.camunda.client.api.search.response.IncidentState;
+import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.qa.util.multidb.MultiDbTest;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that when incident is resolved all involved flow node instances and process instance are in
+ * ACTIVE state.
+ */
+@MultiDbTest
+public class IncidentSimpleResolveTest {
+
+  private static CamundaClient camundaClient;
+
+  private static final List<Process> DEPLOYED_PROCESSES = new ArrayList<>();
+  private static long processInstanceKey;
+  private static final String SERVICE_TASK_ID = "taskA";
+
+  @BeforeAll
+  static void beforeAll() {
+    DEPLOYED_PROCESSES.addAll(
+        deployResource(camundaClient, "process/service_tasks_v1.bpmn").getProcesses());
+
+    waitForProcessesToBeDeployed(camundaClient, 1);
+
+    processInstanceKey =
+        startProcessInstance(camundaClient, "service_tasks_v1").getProcessInstanceKey();
+
+    waitForProcessInstancesToStart(camundaClient, 1);
+    final long jobKey =
+        camundaClient
+            .newActivateJobsCommand()
+            .jobType(SERVICE_TASK_ID)
+            .maxJobsToActivate(1)
+            .send()
+            .join()
+            .getJobs()
+            .getFirst()
+            .getKey();
+    camundaClient.newFailCommand(jobKey).retries(0).send().join();
+    waitUntilProcessInstanceHasIncidents(camundaClient, 1);
+
+    camundaClient.newUpdateRetriesCommand(jobKey).retries(1).send().join();
+    final Incident incident =
+        camundaClient.newIncidentSearchRequest().send().join().items().getFirst();
+    camundaClient.newResolveIncidentCommand(incident.getIncidentKey()).send().join();
+
+    waitUntilIncidentIsResolvedOnProcessInstance(camundaClient, 1);
+    waitUntilIncidentIsResolvedOnFlowNodeInstance(camundaClient, 2);
+    waitUntilIncidentsAreResolved(camundaClient, 1);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    DEPLOYED_PROCESSES.clear();
+  }
+
+  @Test
+  public void testFlowNodeInstanceWithoutIncident() {
+    // when
+    final FlowNodeInstance flowNodeInstance =
+        camundaClient
+            .newFlownodeInstanceSearchRequest()
+            .filter(f -> f.flowNodeId(SERVICE_TASK_ID))
+            .page(p -> p.limit(100))
+            .sort(s -> s.flowNodeId().asc())
+            .send()
+            .join()
+            .items()
+            .getFirst();
+
+    // then
+    assertThat(flowNodeInstance).isNotNull();
+    assertThat(flowNodeInstance.getState()).isEqualTo(FlowNodeInstanceState.ACTIVE);
+    assertThat(flowNodeInstance.getIncident()).isEqualTo(false);
+  }
+
+  @Test
+  public void testProcessInstanceWithoutIncident() {
+    // when
+    final ProcessInstance processInstance =
+        camundaClient.newProcessInstanceGetRequest(processInstanceKey).send().join();
+
+    // then
+    assertThat(processInstance).isNotNull();
+    assertThat(processInstance.getState()).isEqualTo(ACTIVE);
+    assertThat(processInstance.getHasIncident()).isFalse();
+  }
+
+  @Test
+  public void testNoIncidents() {
+    // when
+    final List<Incident> incidents =
+        camundaClient
+            .newIncidentSearchRequest()
+            .filter(fn -> fn.state(IncidentState.ACTIVE))
+            .send()
+            .join()
+            .items();
+
+    // then
+    assertThat(incidents).isEmpty();
+  }
+}


### PR DESCRIPTION
These only test Exporter (including background tasks) and get values for assertions via new Camunda API. This way Operate Internal API logic for Get incidents endpoint is not covered.

closes #24932

