### PR TITLE
deps: set google libraries as second to last POM/import scope

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -975,14 +975,6 @@
       </dependency>
 
       <dependency>
-        <groupId>com.google.cloud</groupId>
-        <artifactId>libraries-bom</artifactId>
-        <version>${version.google-sdk}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-
-      <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bom</artifactId>
         <version>${version.awssdk}</version>
@@ -1058,6 +1050,18 @@
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-bom</artifactId>
         <version>${version.jetty}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!--
+        As this includes so-called "first party" dependencies" which may be of different versions,
+        this must also be after most library-specific BOMs (but above Spring's)
+      -->
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>${version.google-sdk}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
## Description

This PR fixes an error introduced when back porting the previous PR, which is that the `libraries-bom` for Google _must_ be second to last of all the POM/import scopes, otherwise they will overwrite declared dependencies.

[This fixes the following security issues, which was previously fixed, but reintroduced with 8.6.12.](https://github.com/advisories/GHSA-735f-pc8j-v9w8)
