### PR TITLE
feat: batch operation creation in engine

### DIFF
--- a/zeebe/engine/pom.xml
+++ b/zeebe/engine/pom.xml
@@ -295,6 +295,11 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-domain</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.dmn.DecisionEngineFactory;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
+import io.camunda.zeebe.engine.processing.batchoperation.BatchOperationSetupProcessors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviorsImpl;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
@@ -310,6 +311,9 @@ public final class EngineProcessors {
         featureFlags);
 
     addResourceFetchProcessors(typedRecordProcessors, writers, processingState, authCheckBehavior);
+
+    BatchOperationSetupProcessors.addBatchOperationProcessors(
+        keyGenerator, typedRecordProcessors, writers, commandDistributionBehavior);
 
     return typedRecordProcessors;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateProcessor.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ExcludeAuthorizationCheck
+public final class BatchOperationCreateProcessor
+    implements DistributedTypedRecordProcessor<BatchOperationCreationRecord> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(BatchOperationCreateProcessor.class);
+
+  private static final String EMPTY_JSON_OBJECT = "{}";
+  private static final String MESSAGE_GIVEN_FILTER_IS_EMPTY = "Given filter is empty";
+
+  private final KeyGenerator keyGenerator;
+  private final CommandDistributionBehavior commandDistributionBehavior;
+  private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final TypedResponseWriter responseWriter;
+
+  public BatchOperationCreateProcessor(
+      final Writers writers,
+      final KeyGenerator keyGenerator,
+      final CommandDistributionBehavior commandDistributionBehavior) {
+    stateWriter = writers.state();
+    rejectionWriter = writers.rejection();
+    responseWriter = writers.response();
+    this.keyGenerator = keyGenerator;
+    this.commandDistributionBehavior = commandDistributionBehavior;
+  }
+
+  @Override
+  public void processNewCommand(final TypedRecord<BatchOperationCreationRecord> command) {
+    if (isEmptyOrNullFilter(command)) {
+      rejectionWriter.appendRejection(
+          command, RejectionType.INVALID_ARGUMENT, MESSAGE_GIVEN_FILTER_IS_EMPTY);
+      return;
+    }
+
+    final long key = keyGenerator.nextKey();
+    final var recordValue = command.getValue();
+    LOGGER.debug("Processing new command with key '{}': {}", key, recordValue);
+
+    final var recordWithKey = new BatchOperationCreationRecord();
+    recordWithKey.setBatchOperationKey(key);
+    recordWithKey.setBatchOperationType(recordValue.getBatchOperationType());
+    recordWithKey.setEntityFilter(command.getValue().getEntityFilterBuffer());
+
+    stateWriter.appendFollowUpEvent(key, BatchOperationIntent.CREATED, recordWithKey);
+    responseWriter.writeEventOnCommand(key, BatchOperationIntent.CREATED, recordWithKey, command);
+    commandDistributionBehavior
+        .withKey(key)
+        .unordered()
+        .distribute(command.getValueType(), command.getIntent(), recordWithKey);
+  }
+
+  @Override
+  public void processDistributedCommand(final TypedRecord<BatchOperationCreationRecord> command) {
+    final var recordValue = command.getValue();
+
+    LOGGER.debug("Processing distributed command with key '{}': {}", command.getKey(), recordValue);
+    stateWriter.appendFollowUpEvent(
+        command.getKey(), BatchOperationIntent.CREATED, command.getValue());
+    commandDistributionBehavior.acknowledgeCommand(command);
+  }
+
+  private static boolean isEmptyOrNullFilter(
+      final TypedRecord<BatchOperationCreationRecord> command) {
+    return command.getValue().getEntityFilter() == null
+        || command.getValue().getEntityFilter().equalsIgnoreCase(EMPTY_JSON_OBJECT);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation;
+
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+public final class BatchOperationSetupProcessors {
+
+  public static void addBatchOperationProcessors(
+      final KeyGenerator keyGenerator,
+      final TypedRecordProcessors typedRecordProcessors,
+      final Writers writers,
+      final CommandDistributionBehavior commandDistributionBehavior) {
+    typedRecordProcessors.onCommand(
+        ValueType.BATCH_OPERATION_CREATION,
+        BatchOperationIntent.CREATE,
+        new BatchOperationCreateProcessor(writers, keyGenerator, commandDistributionBehavior));
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.engine.scaling.redistribution.MutableRedistributionState
 import io.camunda.zeebe.engine.state.authorization.DbAuthorizationState;
 import io.camunda.zeebe.engine.state.authorization.DbMappingState;
 import io.camunda.zeebe.engine.state.authorization.DbRoleState;
+import io.camunda.zeebe.engine.state.batchoperation.DbBatchOperationState;
 import io.camunda.zeebe.engine.state.clock.DbClockState;
 import io.camunda.zeebe.engine.state.compensation.DbCompensationSubscriptionState;
 import io.camunda.zeebe.engine.state.deployment.DbDecisionState;
@@ -43,6 +44,7 @@ import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
 import io.camunda.zeebe.engine.state.migration.DbMigrationState;
 import io.camunda.zeebe.engine.state.mutable.MutableAuthorizationState;
 import io.camunda.zeebe.engine.state.mutable.MutableBannedInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableBatchOperationState;
 import io.camunda.zeebe.engine.state.mutable.MutableClockState;
 import io.camunda.zeebe.engine.state.mutable.MutableCompensationSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableDecisionState;
@@ -119,6 +121,7 @@ public class ProcessingDbState implements MutableProcessingState {
   private final MutableRoleState roleState;
   private final MutableGroupState groupState;
   private final MutableMappingState mappingState;
+  private final MutableBatchOperationState batchOperationState;
   private final TransientPendingSubscriptionState transientProcessMessageSubscriptionState;
   private final int partitionId;
 
@@ -173,6 +176,7 @@ public class ProcessingDbState implements MutableProcessingState {
     groupState = new DbGroupState(zeebeDb, transactionContext);
     tenantState = new DbTenantState(zeebeDb, transactionContext);
     mappingState = new DbMappingState(zeebeDb, transactionContext);
+    batchOperationState = new DbBatchOperationState(zeebeDb, transactionContext);
     this.transientProcessMessageSubscriptionState = transientProcessMessageSubscriptionState;
   }
 
@@ -337,6 +341,11 @@ public class ProcessingDbState implements MutableProcessingState {
   @Override
   public MutableMappingState getMappingState() {
     return mappingState;
+  }
+
+  @Override
+  public MutableBatchOperationState getBatchOperationState() {
+    return batchOperationState;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
@@ -9,8 +9,10 @@ package io.camunda.zeebe.engine.state;
 
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.state.batchoperation.DbBatchOperationState;
 import io.camunda.zeebe.engine.state.deployment.DbDeploymentState;
 import io.camunda.zeebe.engine.state.distribution.DbDistributionState;
+import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
 import io.camunda.zeebe.engine.state.immutable.DeploymentState;
 import io.camunda.zeebe.engine.state.immutable.DistributionState;
 import io.camunda.zeebe.engine.state.immutable.JobState;
@@ -41,6 +43,7 @@ public final class ScheduledTaskDbState implements ScheduledTaskState {
   private final PendingMessageSubscriptionState pendingMessageSubscriptionState;
   private final PendingProcessMessageSubscriptionState pendingProcessMessageSubscriptionState;
   private final UserTaskState userTaskState;
+  private final BatchOperationState batchOperationState;
 
   public ScheduledTaskDbState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
@@ -61,6 +64,7 @@ public final class ScheduledTaskDbState implements ScheduledTaskState {
         new DbProcessMessageSubscriptionState(
             zeebeDb, transactionContext, transientProcessMessageSubscriptionState, clock);
     userTaskState = new DbUserTaskState(zeebeDb, transactionContext);
+    batchOperationState = new DbBatchOperationState(zeebeDb, transactionContext);
   }
 
   @Override
@@ -101,5 +105,10 @@ public final class ScheduledTaskDbState implements ScheduledTaskState {
   @Override
   public UserTaskState getUserTaskState() {
     return userTaskState;
+  }
+
+  @Override
+  public BatchOperationState getBatchOperationState() {
+    return batchOperationState;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationCreatedApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableBatchOperationState;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+
+public class BatchOperationCreatedApplier
+    implements TypedEventApplier<BatchOperationIntent, BatchOperationCreationRecord> {
+
+  private final MutableBatchOperationState batchOperationState;
+
+  public BatchOperationCreatedApplier(final MutableBatchOperationState batchOperationState) {
+    this.batchOperationState = batchOperationState;
+  }
+
+  @Override
+  public void applyState(final long key, final BatchOperationCreationRecord value) {
+    batchOperationState.create(key, value);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.CompensationSubscriptionIntent;
@@ -134,6 +135,7 @@ public final class EventAppliers implements EventApplier {
     registerScalingAppliers(state);
     registerTenantAppliers(state);
     registerMappingAppliers(state);
+    registerBatchOperationAppliers(state);
     registerIdentitySetupAppliers();
 
     return this;
@@ -559,6 +561,12 @@ public final class EventAppliers implements EventApplier {
     register(MappingIntent.CREATED, new MappingCreatedApplier(state.getMappingState()));
     register(MappingIntent.DELETED, new MappingDeletedApplier(state.getMappingState()));
     register(MappingIntent.UPDATED, new MappingUpdatedApplier(state.getMappingState()));
+  }
+
+  private void registerBatchOperationAppliers(final MutableProcessingState state) {
+    register(
+        BatchOperationIntent.CREATED,
+        new BatchOperationCreatedApplier(state.getBatchOperationState()));
   }
 
   private void registerIdentitySetupAppliers() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/DbBatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/DbBatchOperationState.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.batchoperation;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbNil;
+import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation.BatchOperationStatus;
+import io.camunda.zeebe.engine.state.mutable.MutableBatchOperationState;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DbBatchOperationState implements MutableBatchOperationState {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DbBatchOperationState.class);
+
+  private final DbLong batchKey = new DbLong();
+
+  private final ColumnFamily<DbLong, PersistedBatchOperation> batchOperationColumnFamily;
+  private final ColumnFamily<DbLong, DbNil> pendingBatchOperationColumnFamily;
+
+  public DbBatchOperationState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    batchOperationColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.BATCH_OPERATION,
+            transactionContext,
+            batchKey,
+            new PersistedBatchOperation());
+    pendingBatchOperationColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.PENDING_BATCH_OPERATION, transactionContext, batchKey, DbNil.INSTANCE);
+  }
+
+  @Override
+  public void create(final long batchKey, final BatchOperationCreationRecord record) {
+    LOGGER.debug("Creating batch operation with key {}", record.getBatchOperationKey());
+    this.batchKey.wrapLong(record.getBatchOperationKey());
+    final var batchOperation = new PersistedBatchOperation();
+    batchOperation
+        .setKey(record.getBatchOperationKey())
+        .setStatus(BatchOperationStatus.CREATED)
+        .setBatchOperationType(record.getBatchOperationType())
+        .setEntityFilter(record.getEntityFilterBuffer());
+    batchOperationColumnFamily.upsert(this.batchKey, batchOperation);
+    pendingBatchOperationColumnFamily.upsert(this.batchKey, DbNil.INSTANCE);
+  }
+
+  @Override
+  public Optional<PersistedBatchOperation> get(final long key) {
+    batchKey.wrapLong(key);
+    return Optional.ofNullable(batchOperationColumnFamily.get(batchKey));
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.batchoperation;
+
+import io.camunda.zeebe.db.DbValue;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.BinaryProperty;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public class PersistedBatchOperation extends UnpackedObject implements DbValue {
+
+  private final LongProperty keyProp = new LongProperty("key");
+  private final EnumProperty<BatchOperationType> batchOperationTypeProp =
+      new EnumProperty<>(
+          "batchOperationType", BatchOperationType.class, BatchOperationType.UNSPECIFIED);
+  private final EnumProperty<BatchOperationStatus> statusProp =
+      new EnumProperty<>("status", BatchOperationStatus.class);
+  private final BinaryProperty entityFilterProp = new BinaryProperty("entityFilter");
+
+  public PersistedBatchOperation() {
+    super(4);
+    declareProperty(keyProp)
+        .declareProperty(batchOperationTypeProp)
+        .declareProperty(statusProp)
+        .declareProperty(entityFilterProp);
+  }
+
+  public long getKey() {
+    return keyProp.getValue();
+  }
+
+  public PersistedBatchOperation setKey(final long key) {
+    keyProp.setValue(key);
+    return this;
+  }
+
+  public BatchOperationType getBatchOperationType() {
+    return batchOperationTypeProp.getValue();
+  }
+
+  public PersistedBatchOperation setBatchOperationType(
+      final BatchOperationType batchOperationType) {
+    batchOperationTypeProp.setValue(batchOperationType);
+    return this;
+  }
+
+  public BatchOperationStatus getStatus() {
+    return statusProp.getValue();
+  }
+
+  public PersistedBatchOperation setStatus(final BatchOperationStatus status) {
+    statusProp.setValue(status);
+    return this;
+  }
+
+  public String getEntityFilter() {
+    return MsgPackConverter.convertToJson(entityFilterProp.getValue());
+  }
+
+  public PersistedBatchOperation setEntityFilter(final DirectBuffer filter) {
+    entityFilterProp.setValue(new UnsafeBuffer(filter));
+    return this;
+  }
+
+  public enum BatchOperationStatus {
+    CREATED,
+    ACTIVATED,
+    PAUSED,
+    CANCELED,
+    COMPLETED
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BatchOperationState.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.immutable;
+
+import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
+import java.util.Optional;
+
+public interface BatchOperationState {
+
+  Optional<PersistedBatchOperation> get(final long batchKey);
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
@@ -85,4 +85,6 @@ public interface ProcessingState extends StreamProcessorLifecycleAware {
   TenantState getTenantState();
 
   MappingState getMappingState();
+
+  BatchOperationState getBatchOperationState();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ScheduledTaskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ScheduledTaskState.java
@@ -24,4 +24,6 @@ public interface ScheduledTaskState {
   PendingProcessMessageSubscriptionState getPendingProcessMessageSubscriptionState();
 
   UserTaskState getUserTaskState();
+
+  BatchOperationState getBatchOperationState();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableBatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableBatchOperationState.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.mutable;
+
+import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+
+public interface MutableBatchOperationState extends BatchOperationState {
+
+  /**
+   * Stores the batch operation in the state.
+   *
+   * @param record the batch operation creation record to create
+   */
+  void create(final long batchKey, final BatchOperationCreationRecord record);
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
@@ -62,6 +62,9 @@ public interface MutableProcessingState extends ProcessingState {
   MutableFormState getFormState();
 
   @Override
+  MutableResourceState getResourceState();
+
+  @Override
   MutableSignalSubscriptionState getSignalSubscriptionState();
 
   @Override
@@ -104,7 +107,7 @@ public interface MutableProcessingState extends ProcessingState {
   MutableMappingState getMappingState();
 
   @Override
-  MutableResourceState getResourceState();
+  MutableBatchOperationState getBatchOperationState();
 
   KeyGenerator getKeyGenerator();
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CreateBatchOperationMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CreateBatchOperationMultiPartitionTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.stream.Collectors;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class CreateBatchOperationMultiPartitionTest {
+  private static final int PARTITION_COUNT = 3;
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Rule public final EngineRule engine = EngineRule.multiplePartition(PARTITION_COUNT);
+
+  @Test
+  public void shouldCreateOnAllPartitions() {
+    // given
+
+    // when
+    final long batchOperationKey =
+        engine
+            .batchOperation()
+            .ofType(BatchOperationType.PROCESS_CANCELLATION)
+            .withFilter(new UnsafeBuffer("{\"processInstanceKeys\": [1, 2, 3]}".getBytes()))
+            .create()
+            .getValue()
+            .getBatchOperationKey();
+
+    assertThat(
+            RecordingExporter.records()
+                .withPartitionId(1)
+                .limit(record -> record.getIntent().equals(CommandDistributionIntent.FINISHED))
+                .filter(
+                    record ->
+                        record.getValueType() == ValueType.BATCH_OPERATION_CREATION
+                            || (record.getValueType() == ValueType.COMMAND_DISTRIBUTION
+                                && ((CommandDistributionRecordValue) record.getValue()).getIntent()
+                                    == BatchOperationIntent.CREATE)))
+        .extracting(
+            Record::getIntent,
+            Record::getRecordType,
+            r ->
+                // We want to verify the partition id where the creation was distributing to and
+                // where it was completed. Since only the CommandDistribution records have a
+                // value that contains the partition id, we use the partition id the record was
+                // written on for the other records.
+                r.getValue() instanceof CommandDistributionRecordValue
+                    ? ((CommandDistributionRecordValue) r.getValue()).getPartitionId()
+                    : r.getPartitionId())
+        .startsWith(
+            tuple(BatchOperationIntent.CREATE, RecordType.COMMAND, 1),
+            tuple(BatchOperationIntent.CREATED, RecordType.EVENT, 1),
+            tuple(CommandDistributionIntent.STARTED, RecordType.EVENT, 1))
+        .containsSubsequence(
+            tuple(CommandDistributionIntent.DISTRIBUTING, RecordType.EVENT, 2),
+            tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 2),
+            tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 2))
+        .containsSubsequence(
+            tuple(CommandDistributionIntent.DISTRIBUTING, RecordType.EVENT, 3),
+            tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
+            tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
+        .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
+
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      assertThat(
+              RecordingExporter.batchOperationCreationRecords()
+                  .withBatchOperationKey(batchOperationKey)
+                  .withPartitionId(partitionId)
+                  .limit(record -> record.getIntent().equals(BatchOperationIntent.CREATED))
+                  .collect(Collectors.toList()))
+          .extracting(Record::getIntent)
+          .containsExactly(BatchOperationIntent.CREATE, BatchOperationIntent.CREATED);
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CreateBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CreateBatchOperationTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class CreateBatchOperationTest {
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Test
+  public void shouldRejectWithoutFilter() {
+    // when
+    final var batchOperationKey =
+        engine
+            .batchOperation()
+            .ofType(BatchOperationType.PROCESS_CANCELLATION)
+            .withFilter(new UnsafeBuffer())
+            .expectRejection()
+            .create()
+            .getValue()
+            .getBatchOperationKey();
+
+    // then
+    final var result =
+        RecordingExporter.batchOperationCreationRecords()
+            .withBatchOperationKey(batchOperationKey)
+            .onlyCommandRejections()
+            .getFirst();
+
+    assertThat(result.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(result.getIntent()).isEqualTo(BatchOperationIntent.CREATE);
+  }
+
+  @Test
+  public void shouldRejectWithEmptyFilter() {
+    // when
+    final var batchOperationKey =
+        engine
+            .batchOperation()
+            .ofType(BatchOperationType.PROCESS_CANCELLATION)
+            .withFilter(new UnsafeBuffer(MsgPackConverter.convertToMsgPack("{}")))
+            .expectRejection()
+            .create()
+            .getValue()
+            .getBatchOperationKey();
+
+    // then
+    final var result =
+        RecordingExporter.batchOperationCreationRecords()
+            .withBatchOperationKey(batchOperationKey)
+            .onlyCommandRejections()
+            .getFirst();
+
+    assertThat(result.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+    assertThat(result.getIntent()).isEqualTo(BatchOperationIntent.CREATE);
+  }
+
+  @Test
+  public void shouldCreateBatchOperation() {
+    // given
+    final String filter = "{\"processInstanceKeys\":[1,3,8]}";
+
+    // when
+    final long batchOperationKey =
+        engine
+            .batchOperation()
+            .ofType(BatchOperationType.PROCESS_CANCELLATION)
+            .withFilter(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(filter)))
+            .create()
+            .getValue()
+            .getBatchOperationKey();
+
+    // then
+    assertThat(
+            RecordingExporter.batchOperationCreationRecords()
+                .withBatchOperationKey(batchOperationKey))
+        .extracting(Record::getIntent)
+        .containsSequence(BatchOperationIntent.CREATED);
+    assertThat(
+            RecordingExporter.batchOperationCreationRecords()
+                .withBatchOperationKey(batchOperationKey)
+                .withIntent(BatchOperationIntent.CREATED)
+                .getFirst()
+                .getValue()
+                .getEntityFilter())
+        .isEqualTo(filter);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/batchoperation/BatchOperationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/batchoperation/BatchOperationStateTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.batchoperation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation.BatchOperationStatus;
+import io.camunda.zeebe.engine.state.mutable.MutableBatchOperationState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public class BatchOperationStateTest {
+
+  private MutableProcessingState processingState;
+  private MutableBatchOperationState state;
+
+  @BeforeEach
+  public void setup() {
+    state = processingState.getBatchOperationState();
+  }
+
+  @Test
+  void shouldCreateBatchOperation() throws JsonProcessingException {
+    // given
+    final var batchOperationKey = 1L;
+    final var type = BatchOperationType.PROCESS_CANCELLATION;
+    final var filter =
+        new ProcessInstanceFilter.Builder()
+            .processDefinitionIds("process")
+            .processDefinitionVersions(1)
+            .build();
+    final var record =
+        new BatchOperationCreationRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setBatchOperationType(type)
+            .setEntityFilter(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(filter)));
+
+    // when
+    state.create(batchOperationKey, record);
+
+    // then
+    final var batchOperation = state.get(batchOperationKey).get();
+    final var recordFilter =
+        new ObjectMapper().readValue(batchOperation.getEntityFilter(), ProcessInstanceFilter.class);
+
+    assertThat(batchOperation.getKey()).isEqualTo(batchOperationKey);
+    assertThat(batchOperation.getBatchOperationType()).isEqualTo(type);
+    assertThat(recordFilter).isEqualTo(filter);
+    assertThat(batchOperation.getStatus()).isEqualTo(BatchOperationStatus.CREATED);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.util.TestInterPartitionCommandSender.CommandInterceptor;
 import io.camunda.zeebe.engine.util.client.AuthorizationClient;
+import io.camunda.zeebe.engine.util.client.BatchOperationClient;
 import io.camunda.zeebe.engine.util.client.ClockClient;
 import io.camunda.zeebe.engine.util.client.DecisionEvaluationClient;
 import io.camunda.zeebe.engine.util.client.DeploymentClient;
@@ -415,6 +416,10 @@ public final class EngineRule extends ExternalResource {
 
   public GroupClient group() {
     return new GroupClient(environmentRule);
+  }
+
+  public BatchOperationClient batchOperation() {
+    return new BatchOperationClient(environmentRule);
   }
 
   public Record<JobRecordValue> createJob(final String type, final String processId) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/BatchOperationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/BatchOperationClient.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.util.client;
+
+import io.camunda.zeebe.auth.Authorization;
+import io.camunda.zeebe.engine.util.AuthorizationUtil;
+import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.Random;
+import java.util.function.Function;
+import org.agrona.DirectBuffer;
+
+public final class BatchOperationClient {
+
+  private final CommandWriter writer;
+
+  public BatchOperationClient(final CommandWriter writer) {
+    this.writer = writer;
+  }
+
+  public BatchOperationCreationClient ofType(final BatchOperationType type) {
+    return new BatchOperationCreationClient(writer, type);
+  }
+
+  public static class BatchOperationCreationClient {
+
+    private static final Function<Long, Record<BatchOperationCreationRecordValue>>
+        SUCCESS_EXPECTATION =
+            (position) ->
+                RecordingExporter.batchOperationCreationRecords()
+                    .withIntent(BatchOperationIntent.CREATED)
+                    .withSourceRecordPosition(position)
+                    .getFirst();
+
+    private static final Function<Long, Record<BatchOperationCreationRecordValue>>
+        REJECTION_EXPECTATION =
+            (position) ->
+                RecordingExporter.batchOperationCreationRecords()
+                    .onlyCommandRejections()
+                    .withIntent(BatchOperationIntent.CREATE)
+                    .withSourceRecordPosition(position)
+                    .getFirst();
+    private static final int DEFAULT_PARTITION = 1;
+
+    private final CommandWriter writer;
+    private final BatchOperationCreationRecord batchOperationCreationRecord;
+    private int partition = DEFAULT_PARTITION;
+
+    private Function<Long, Record<BatchOperationCreationRecordValue>> expectation =
+        SUCCESS_EXPECTATION;
+
+    public BatchOperationCreationClient(final CommandWriter writer, final BatchOperationType type) {
+      this.writer = writer;
+      batchOperationCreationRecord = new BatchOperationCreationRecord();
+      batchOperationCreationRecord.setBatchOperationType(type);
+    }
+
+    public BatchOperationCreationClient onPartition(final int partition) {
+      this.partition = partition;
+      return this;
+    }
+
+    public BatchOperationCreationClient withFilter(final DirectBuffer filter) {
+      batchOperationCreationRecord.setEntityFilter(filter);
+      return this;
+    }
+
+    public BatchOperationCreationWithResultClient withResult() {
+      return new BatchOperationCreationWithResultClient(writer, batchOperationCreationRecord);
+    }
+
+    public Record<BatchOperationCreationRecordValue> create() {
+      return create(
+          AuthorizationUtil.getAuthInfoWithClaim(Authorization.AUTHORIZED_ANONYMOUS_USER, true));
+    }
+
+    public Record<BatchOperationCreationRecordValue> create(final AuthInfo authorizations) {
+      final long position =
+          writer.writeCommandOnPartition(
+              partition,
+              r ->
+                  r.intent(ProcessInstanceCreationIntent.CREATE)
+                      .event(batchOperationCreationRecord)
+                      .authorizations(authorizations)
+                      .requestId(new Random().nextLong())
+                      .requestStreamId(new Random().nextInt()));
+
+      final var resultingRecord = expectation.apply(position);
+      return resultingRecord;
+    }
+
+    public Record<BatchOperationCreationRecordValue> create(final String username) {
+      return create(AuthorizationUtil.getAuthInfo(username));
+    }
+
+    public BatchOperationCreationClient expectRejection() {
+      expectation = REJECTION_EXPECTATION;
+      return this;
+    }
+  }
+
+  public static class BatchOperationCreationWithResultClient {
+    private final CommandWriter writer;
+    private final BatchOperationCreationRecord record;
+    private long requestId = 1L;
+    private int requestStreamId = 1;
+
+    public BatchOperationCreationWithResultClient(
+        final CommandWriter writer, final BatchOperationCreationRecord record) {
+      this.writer = writer;
+      this.record = record;
+    }
+
+    public BatchOperationCreationWithResultClient withRequestId(final long requestId) {
+      this.requestId = requestId;
+      return this;
+    }
+
+    public BatchOperationCreationWithResultClient withRequestStreamId(final int requestStreamId) {
+      this.requestStreamId = requestStreamId;
+      return this;
+    }
+
+    public long create() {
+      final long position =
+          writer.writeCommand(requestStreamId, requestId, BatchOperationIntent.CREATE, record);
+
+      return RecordingExporter.batchOperationCreationRecords()
+          .withIntent(BatchOperationIntent.CREATED)
+          .withSourceRecordPosition(position)
+          .getFirst()
+          .getValue()
+          .getBatchOperationKey();
+    }
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationCreationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationCreationRecord.java
@@ -62,7 +62,9 @@ public final class BatchOperationCreationRecord extends UnifiedRecordValue
 
   @Override
   public String getEntityFilter() {
-    return MsgPackConverter.convertToJson(entityFilterProp.getValue());
+    return entityFilterProp.getValue().capacity() == 0
+        ? null
+        : MsgPackConverter.convertToJson(entityFilterProp.getValue());
   }
 
   public BatchOperationCreationRecord setEntityFilter(final DirectBuffer filterBuffer) {

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -229,8 +229,10 @@ public enum ZbColumnFamilies implements EnumValue {
 
   USERNAME_BY_USER_KEY(118),
   CLAIM_BY_ID(119),
-  AUTHORIZATION_KEYS_BY_OWNER(120);
+  AUTHORIZATION_KEYS_BY_OWNER(120),
 
+  BATCH_OPERATION(121),
+  PENDING_BATCH_OPERATION(122);
   private final int value;
 
   ZbColumnFamilies(final int value) {

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/BatchOperationIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/BatchOperationIntent.java
@@ -16,8 +16,8 @@
 package io.camunda.zeebe.protocol.record.intent;
 
 public enum BatchOperationIntent implements Intent {
-  CREATE((short) 0);
-  //  CREATED((short) 1),
+  CREATE((short) 0),
+  CREATED((short) 1);
 
   private final short value;
 
@@ -33,6 +33,8 @@ public enum BatchOperationIntent implements Intent {
     switch (value) {
       case 0:
         return CREATE;
+      case 1:
+        return CREATED;
 
       default:
         return Intent.UNKNOWN;
@@ -47,6 +49,8 @@ public enum BatchOperationIntent implements Intent {
   @Override
   public boolean isEvent() {
     switch (this) {
+      case CREATED:
+        return true;
       default:
         return false;
     }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/BatchOperationCreationRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/BatchOperationCreationRecordStream.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import java.util.stream.Stream;
+
+public class BatchOperationCreationRecordStream
+    extends ExporterRecordStream<
+        BatchOperationCreationRecordValue, BatchOperationCreationRecordStream> {
+
+  public BatchOperationCreationRecordStream(
+      final Stream<Record<BatchOperationCreationRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected BatchOperationCreationRecordStream supply(
+      final Stream<Record<BatchOperationCreationRecordValue>> wrappedStream) {
+    return new BatchOperationCreationRecordStream(wrappedStream);
+  }
+
+  public BatchOperationCreationRecordStream withBatchOperationType(final BatchOperationType type) {
+    return valueFilter(v -> v.getBatchOperationType() == type);
+  }
+
+  public BatchOperationCreationRecordStream withBatchOperationKey(final long key) {
+    return valueFilter(v -> v.getBatchOperationKey() == key);
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
@@ -46,6 +47,7 @@ import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.CompensationSubscriptionRecordValue;
@@ -534,6 +536,16 @@ public final class RecordingExporter implements Exporter {
 
   public static IdentitySetupRecordStream identitySetupRecords(final IdentitySetupIntent intent) {
     return identitySetupRecords().withIntent(intent);
+  }
+
+  public static BatchOperationCreationRecordStream batchOperationCreationRecords() {
+    return new BatchOperationCreationRecordStream(
+        records(ValueType.BATCH_OPERATION_CREATION, BatchOperationCreationRecordValue.class));
+  }
+
+  public static BatchOperationCreationRecordStream batchOperationCreationRecords(
+      final BatchOperationIntent intent) {
+    return batchOperationCreationRecords().withIntent(intent);
   }
 
   public static void autoAcknowledge(final boolean shouldAcknowledgeRecords) {


### PR DESCRIPTION
## Description

This PR introduces the first step of BatchOperation handling in the Zeebe engine: The initial creation of the BatchOperation:
- BatchOperationCreateProcessor: Handles the BatchOperationIntent.CREATE command record
  - Validation if the given filter is null or empty
  - Command distribution to all other partitions
  - publishes BatchOperationIntent.CREATED record
- DbBatchOperationState
  - stores all necessary informations about the batch. In this iteration, it will store the filter and the status

Tests created:
- CreateBatchOperationTest: Tests the BatchOperationCreateProcessor
- BatchOperationStateTest: Tests the correct handling in the event applier and the state. 

## Related issues

closes #29695 
