### PR TITLE
fix: use database type from operate properties

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
@@ -11,8 +11,6 @@ import static io.camunda.application.commons.backup.ConfigValidation.allMatch;
 import static io.camunda.application.commons.backup.ConfigValidation.skipEmptyOptional;
 
 import io.camunda.application.commons.conditions.WebappEnabledCondition;
-import io.camunda.operate.conditions.DatabaseInfo;
-import io.camunda.operate.conditions.DatabaseType;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.optimize.service.db.es.schema.ElasticSearchSchemaManager;
 import io.camunda.optimize.service.db.es.schema.index.index.PositionBasedImportIndexES;
@@ -221,7 +219,7 @@ public class BackupPriorityConfiguration {
             Map.of(
                 "operate",
                 Optional.ofNullable(operateProperties)
-                    .map(ignored -> DatabaseInfo.isCurrent(DatabaseType.Elasticsearch)),
+                    .map(prop -> prop.getDatabase().equals(OperateProperties.ELASTIC_SEARCH)),
                 "tasklist",
                 Optional.ofNullable(tasklistProperties)
                     .map(prop -> prop.getDatabase().equals(TasklistProperties.ELASTIC_SEARCH)),

--- a/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.operate.property;
 
-import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.conditions.DatabaseType;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
@@ -27,6 +26,8 @@ public class OperateProperties {
   public static final String PREFIX = "camunda.operate";
 
   public static final long BATCH_OPERATION_MAX_SIZE_DEFAULT = 1_000_000L;
+
+  public static final String ELASTIC_SEARCH = "elasticsearch";
 
   private static final String UNKNOWN_VERSION = "unknown-version";
 
@@ -55,6 +56,8 @@ public class OperateProperties {
   private boolean enterprise = false;
 
   private String tasklistUrl = null;
+
+  private String database = ELASTIC_SEARCH;
 
   @Value("${camunda.operate.internal.version.current}")
   private String version = UNKNOWN_VERSION;
@@ -339,6 +342,14 @@ public class OperateProperties {
     this.rfc3339ApiDateFormat = rfc3339ApiDateFormat;
   }
 
+  public String getDatabase() {
+    return database;
+  }
+
+  public void setDatabase(final String database) {
+    this.database = database;
+  }
+
   public String getIndexPrefix(final DatabaseType databaseType) {
     return switch (databaseType) {
       case Elasticsearch -> getElasticsearch() == null ? null : getElasticsearch().getIndexPrefix();
@@ -348,6 +359,6 @@ public class OperateProperties {
   }
 
   public String getIndexPrefix() {
-    return getIndexPrefix(DatabaseInfo.getCurrent());
+    return getIndexPrefix(DatabaseType.byCode(database).orElse(DatabaseType.Elasticsearch));
   }
 }

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/IndexTemplateDescriptorsConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/IndexTemplateDescriptorsConfigurator.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.qa.util.cluster;
 
-import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.webapps.schema.descriptors.operate.index.DecisionIndex;
 import io.camunda.webapps.schema.descriptors.operate.index.DecisionRequirementsIndex;
@@ -41,189 +40,207 @@ import org.springframework.context.annotation.Profile;
 public class IndexTemplateDescriptorsConfigurator {
 
   @Bean
-  public DecisionIndex getDecisionIndex(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
-    return new DecisionIndex(operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+  public DecisionIndex getDecisionIndex(final OperateProperties operateProperties) {
+    return new DecisionIndex(
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean
   public DecisionRequirementsIndex getDecisionRequirementsIndex(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
+      final OperateProperties operateProperties) {
     return new DecisionRequirementsIndex(
-        operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean
-  public MetricIndex getMetricIndex(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
-    return new MetricIndex(operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+  public MetricIndex getMetricIndex(final OperateProperties operateProperties) {
+    return new MetricIndex(
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean
-  public ImportPositionIndex getImportPositionIndex(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
+  public ImportPositionIndex getImportPositionIndex(final OperateProperties operateProperties) {
     return new ImportPositionIndex(
-        operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean("operateProcessIndex")
-  public ProcessIndex getProcessIndex(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
-    return new ProcessIndex(operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+  public ProcessIndex getProcessIndex(final OperateProperties operateProperties) {
+    return new ProcessIndex(
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean
   public DecisionInstanceTemplate getDecisionInstanceTemplate(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
+      final OperateProperties operateProperties) {
     return new DecisionInstanceTemplate(
-        operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean
-  public EventTemplate getEventTemplate(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
-    return new EventTemplate(operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+  public EventTemplate getEventTemplate(final OperateProperties operateProperties) {
+    return new EventTemplate(
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean("operateFlowNodeInstanceTemplate")
   public FlowNodeInstanceTemplate getFlowNodeInstanceTemplate(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
+      final OperateProperties operateProperties) {
     return new FlowNodeInstanceTemplate(
-        operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean
-  public IncidentTemplate getIncidentTemplate(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
+  public IncidentTemplate getIncidentTemplate(final OperateProperties operateProperties) {
     return new IncidentTemplate(
-        operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean
-  public ListViewTemplate getListViewTemplate(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
+  public ListViewTemplate getListViewTemplate(final OperateProperties operateProperties) {
     return new ListViewTemplate(
-        operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean
-  public MessageTemplate getMessageTemplate(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
+  public MessageTemplate getMessageTemplate(final OperateProperties operateProperties) {
     return new MessageTemplate(
-        operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean
   public PostImporterQueueTemplate getPostImporterQueueTemplate(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
+      final OperateProperties operateProperties) {
     return new PostImporterQueueTemplate(
-        operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean
-  public SequenceFlowTemplate getSequenceFlowTemplate(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
+  public SequenceFlowTemplate getSequenceFlowTemplate(final OperateProperties operateProperties) {
     return new SequenceFlowTemplate(
-        operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean
-  public JobTemplate getJobTemplate(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
-    return new JobTemplate(operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+  public JobTemplate getJobTemplate(final OperateProperties operateProperties) {
+    return new JobTemplate(
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean("operateVariableTemplate")
-  public VariableTemplate getVariableTemplate(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
+  public VariableTemplate getVariableTemplate(final OperateProperties operateProperties) {
     return new VariableTemplate(
-        operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean
-  public OperationTemplate getOperationTemplate(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
+  public OperationTemplate getOperationTemplate(final OperateProperties operateProperties) {
     return new OperationTemplate(
-        operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean
   public BatchOperationTemplate getBatchOperationTemplate(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
+      final OperateProperties operateProperties) {
     return new BatchOperationTemplate(
-        operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean
   public DraftTaskVariableTemplate getDraftTaskVariableTemplate(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
+      final OperateProperties operateProperties) {
     // Just take the provided DatabaseInfo, no need to distinguish between Tasklist or Operate
     return new DraftTaskVariableTemplate(
-        operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean
-  public FormIndex getFormIndex(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
+  public FormIndex getFormIndex(final OperateProperties operateProperties) {
     // Just take the provided DatabaseInfo, no need to distinguish between Tasklist or Operate
-    return new FormIndex(operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+    return new FormIndex(
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean
-  public TasklistMetricIndex getTasklistMetricIndex(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
+  public TasklistMetricIndex getTasklistMetricIndex(final OperateProperties operateProperties) {
     // Just take the provided DatabaseInfo, no need to distinguish between Tasklist or Operate
     return new TasklistMetricIndex(
-        operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean("operateSnapshotTaskVariableTemplate")
   public SnapshotTaskVariableTemplate getOperateSnapshotTaskVariableTemplate(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
+      final OperateProperties operateProperties) {
     // Just take the provided DatabaseInfo, no need to distinguish between Tasklist or Operate
     return new SnapshotTaskVariableTemplate(
-        operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean("tasklistSnapshotTaskVariableTemplate")
   public SnapshotTaskVariableTemplate getTasklistSnapshotTaskVariableTemplate(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
+      final OperateProperties operateProperties) {
     // Just take the provided DatabaseInfo, no need to distinguish between Tasklist or Operate
     return new SnapshotTaskVariableTemplate(
-        operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean
-  public TaskTemplate getTaskTemplate(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
+  public TaskTemplate getTaskTemplate(final OperateProperties operateProperties) {
     // Just take the provided DatabaseInfo, no need to distinguish between Tasklist or Operate
-    return new TaskTemplate(operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+    return new TaskTemplate(
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean("tasklistVariableTemplate")
-  public VariableTemplate getTasklistVariableTemplate(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
+  public VariableTemplate getTasklistVariableTemplate(final OperateProperties operateProperties) {
     return new VariableTemplate(
-        operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean("tasklistFlowNodeInstanceTemplate")
   public FlowNodeInstanceTemplate getTasklistFlowNodeInstanceTemplate(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
+      final OperateProperties operateProperties) {
     return new FlowNodeInstanceTemplate(
-        operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean
   public TasklistImportPositionIndex getTasklistImportPositionIndex(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
+      final OperateProperties operateProperties) {
     return new TasklistImportPositionIndex(
-        operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 
   @Bean("tasklistProcessIndex")
-  public ProcessIndex getTasklistProcessIndex(
-      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
-    return new ProcessIndex(operateProperties.getIndexPrefix(), databaseInfo.isElasticsearchDb());
+  public ProcessIndex getTasklistProcessIndex(final OperateProperties operateProperties) {
+    return new ProcessIndex(
+        operateProperties.getIndexPrefix(),
+        operateProperties.getDatabase().equals(OperateProperties.ELASTIC_SEARCH));
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Database type for Operate was being accessed in a static manner for the test configuration `IndexTemplateDescriptorsConfigurator` not allowing Operate to run in parallel for both ES and OS. This was discovered when trying to have the Migration framework run parallel instances of the Spring application including operate. The `BackupPriorityConfiguration` was also utilizing the same mechanism to access the Operate's database type causing it to point to wrong configuration

These are the minimal impact changes to support this behavior in order to speed up Migration text execution. Tasklist uses similar accessors for the Database type property.
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
