### PR TITLE
fix: allow endpoint to sort for resourceId

### DIFF
--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AuthorizationFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AuthorizationFilterTransformer.java
@@ -12,8 +12,8 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 import static io.camunda.webapps.schema.descriptors.usermanagement.index.AuthorizationIndex.OWNER_ID;
 import static io.camunda.webapps.schema.descriptors.usermanagement.index.AuthorizationIndex.OWNER_TYPE;
-import static io.camunda.webapps.schema.descriptors.usermanagement.index.AuthorizationIndex.PERMISSIONS_RESOURCEID;
 import static io.camunda.webapps.schema.descriptors.usermanagement.index.AuthorizationIndex.PERMISSIONS_TYPES;
+import static io.camunda.webapps.schema.descriptors.usermanagement.index.AuthorizationIndex.RESOURCE_ID;
 import static io.camunda.webapps.schema.descriptors.usermanagement.index.AuthorizationIndex.RESOURCE_TYPE;
 
 import io.camunda.search.clients.query.SearchQuery;
@@ -32,7 +32,7 @@ public final class AuthorizationFilterTransformer
     return and(
         stringTerms(OWNER_ID, filter.ownerIds()),
         filter.ownerType() == null ? null : term(OWNER_TYPE, filter.ownerType()),
-        stringTerms(PERMISSIONS_RESOURCEID, filter.resourceIds()),
+        stringTerms(RESOURCE_ID, filter.resourceIds()),
         filter.resourceType() == null ? null : term(RESOURCE_TYPE, filter.resourceType()),
         filter.permissionTypes() == null
             ? null

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/AuthorizationFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/AuthorizationFieldSortingTransformer.java
@@ -10,6 +10,7 @@ package io.camunda.search.clients.transformers.sort;
 import static io.camunda.webapps.schema.descriptors.usermanagement.index.AuthorizationIndex.ID;
 import static io.camunda.webapps.schema.descriptors.usermanagement.index.AuthorizationIndex.OWNER_ID;
 import static io.camunda.webapps.schema.descriptors.usermanagement.index.AuthorizationIndex.OWNER_TYPE;
+import static io.camunda.webapps.schema.descriptors.usermanagement.index.AuthorizationIndex.RESOURCE_ID;
 import static io.camunda.webapps.schema.descriptors.usermanagement.index.AuthorizationIndex.RESOURCE_TYPE;
 
 public class AuthorizationFieldSortingTransformer implements FieldSortingTransformer {
@@ -20,6 +21,7 @@ public class AuthorizationFieldSortingTransformer implements FieldSortingTransfo
       case "ownerId" -> OWNER_ID;
       case "ownerType" -> OWNER_TYPE;
       case "resourceType" -> RESOURCE_TYPE;
+      case "resourceId" -> RESOURCE_ID;
       default -> throw new IllegalArgumentException("Unknown field: " + domainField);
     };
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/AuthorizationIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/AuthorizationIndex.java
@@ -19,7 +19,7 @@ public class AuthorizationIndex extends UserManagementIndexDescriptor implements
   public static final String OWNER_TYPE = "ownerType";
   public static final String RESOURCE_TYPE = "resourceType";
   public static final String PERMISSIONS_TYPES = "permissionTypes";
-  public static final String PERMISSIONS_RESOURCEID = "resourceId";
+  public static final String RESOURCE_ID = "resourceId";
 
   public AuthorizationIndex(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR fix a bug related to sorting authorizations record with `resourceId`

## Related issues

closes #29054 
