### PR TITLE
ci: revert temporary dependency convergence exclusion

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2559,8 +2559,6 @@
                            pin it to the wrong version, but azure-sdk also, transitively, causes
                            dependency convergence issues -->
                       <exclude>com.microsoft.azure:msal4j</exclude>
-                      <!-- Needed to mitigate INC-2490, to be removed afterwards -->
-                      <exclude>com.opencsv:opencsv</exclude>
                     </excludes>
                   </dependencyConvergence>
                 </rules>


### PR DESCRIPTION
## Description

https://github.com/camunda/camunda/actions/runs/13923686560 was green so now we should have a consistent SNAPSHOT again so https://github.com/camunda/camunda/pull/29745 can be removed

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
