### PR TITLE
[Backport stable/8.5]  fix: don't pollute the command cache 

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCache.java
@@ -81,6 +81,15 @@ public final class BoundedCommandCache {
         });
   }
 
+  public void removeAll(final LongHashSet keys) {
+    LockUtil.withLock(
+        lock,
+        () -> {
+          cache.removeAll(keys);
+          sizeReporter.accept(cache.size());
+        });
+  }
+
   public int size() {
     return LockUtil.withLock(lock, cache::size);
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCache.java
@@ -129,8 +129,7 @@ public final class BoundedScheduledCommandCache implements StageableScheduledCom
       for (final var entry : stagedKeys.entrySet()) {
         final var cache = caches.get(entry.getKey());
         if (cache != null) {
-          // TODO: use a batch remove operation to avoid multiple locks
-          entry.getValue().forEachLong(cache::remove);
+          cache.removeAll(entry.getValue());
         }
       }
     }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCache.java
@@ -60,9 +60,7 @@ public final class BoundedScheduledCommandCache implements StageableScheduledCom
   public void add(final Intent intent, final long key) {
     final var cache = caches.get(intent);
     if (cache != null) {
-      final var singleton = new LongHashSet();
-      singleton.add(key);
-      cache.add(singleton);
+      cache.add(key);
     }
   }
 
@@ -119,7 +117,7 @@ public final class BoundedScheduledCommandCache implements StageableScheduledCom
       for (final var entry : stagedKeys.entrySet()) {
         final var cache = caches.get(entry.getKey());
         if (cache != null) {
-          cache.add(entry.getValue());
+          cache.addAll(entry.getValue());
         }
       }
     }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/engine/impl/BoundedScheduledCommandCache.java
@@ -124,6 +124,17 @@ public final class BoundedScheduledCommandCache implements StageableScheduledCom
       }
     }
 
+    @Override
+    public void rollback() {
+      for (final var entry : stagedKeys.entrySet()) {
+        final var cache = caches.get(entry.getKey());
+        if (cache != null) {
+          // TODO: use a batch remove operation to avoid multiple locks
+          entry.getValue().forEachLong(cache::remove);
+        }
+      }
+    }
+
     private LongHashSet stagedKeys(final Intent intent) {
       return stagedKeys.computeIfAbsent(intent, ignored -> new LongHashSet());
     }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCacheTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCacheTest.java
@@ -13,54 +13,10 @@ import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.agrona.collections.LongHashSet;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 final class BoundedCommandCacheTest {
-  @Test
-  void shouldNotExceedCapacity() {
-    // given
-    final var cache = new BoundedCommandCache(4);
-    cache.addAll(setOf(1, 2, 3, 4));
-
-    // when
-    cache.addAll(setOf(5, 6));
-
-    // then
-    assertThat(cache.size()).isEqualTo(4);
-    assertThat(cache.contains(5)).isTrue();
-    assertThat(cache.contains(6)).isTrue();
-  }
-
-  @Test
-  void shouldEvictRandomKeysOnCapacityReached() {
-    // given
-    final var cache = new BoundedCommandCache(4);
-    final var initialKeys = setOf(1, 2, 3, 4);
-    cache.addAll(initialKeys);
-
-    // when
-    cache.addAll(setOf(5, 6));
-
-    // then
-    final var remainingInitialKeys =
-        initialKeys.stream().filter(cache::contains).collect(Collectors.toSet());
-    assertThat(remainingInitialKeys).hasSize(2).containsAnyElementsOf(initialKeys);
-  }
-
-  @Test
-  void shouldReportSizeChanges() {
-    // given
-    final var reportedSize = new AtomicInteger();
-    final var cache = new BoundedCommandCache(reportedSize::set);
-
-    // when - then
-    cache.addAll(setOf(1, 2, 3, 4));
-    assertThat(reportedSize).hasValue(4);
-
-    // when - then
-    cache.remove(1);
-    assertThat(reportedSize).hasValue(3);
-  }
 
   @Test
   void shouldReportSizeToResetMetricOnCreation() {
@@ -93,5 +49,105 @@ final class BoundedCommandCacheTest {
     final var set = new LongHashSet();
     set.addAll(Arrays.stream(keys).boxed().toList());
     return set;
+  }
+
+  @Nested
+  final class BulkOperations {
+
+    @Test
+    void shouldNotExceedCapacity() {
+      // given
+      final var cache = new BoundedCommandCache(4);
+      cache.addAll(setOf(1, 2, 3, 4));
+
+      // when
+      cache.addAll(setOf(5, 6));
+
+      // then
+      assertThat(cache.size()).isEqualTo(4);
+      assertThat(cache.contains(5)).isTrue();
+      assertThat(cache.contains(6)).isTrue();
+    }
+
+    @Test
+    void shouldEvictRandomKeysOnCapacityReached() {
+      // given
+      final var cache = new BoundedCommandCache(4);
+      final var initialKeys = setOf(1, 2, 3, 4);
+      cache.addAll(initialKeys);
+
+      // when
+      cache.addAll(setOf(5, 6));
+
+      // then
+      final var remainingInitialKeys =
+          initialKeys.stream().filter(cache::contains).collect(Collectors.toSet());
+      assertThat(remainingInitialKeys).hasSize(2).containsAnyElementsOf(initialKeys);
+    }
+
+    @Test
+    void shouldReportSizeChanges() {
+      // given
+      final var reportedSize = new AtomicInteger();
+      final var cache = new BoundedCommandCache(reportedSize::set);
+
+      // when - then
+      cache.addAll(setOf(1, 2, 3, 4));
+      assertThat(reportedSize).hasValue(4);
+
+      // when - then
+      cache.remove(1);
+      assertThat(reportedSize).hasValue(3);
+    }
+  }
+
+  @Nested
+  final class SingletonOperations {
+
+    @Test
+    void shouldNotExceedCapacity() {
+      // given
+      final var cache = new BoundedCommandCache(4);
+      cache.addAll(setOf(1, 2, 3, 4));
+
+      // when
+      cache.add(5);
+
+      // then
+      assertThat(cache.size()).isEqualTo(4);
+      assertThat(cache.contains(5)).isTrue();
+    }
+
+    @Test
+    void shouldEvictRandomKeysOnCapacityReached() {
+      // given
+      final var cache = new BoundedCommandCache(4);
+      final var initialKeys = setOf(1, 2, 3, 4);
+      cache.addAll(initialKeys);
+
+      // when
+      cache.add(5);
+
+      // then
+      final var remainingInitialKeys =
+          initialKeys.stream().filter(cache::contains).collect(Collectors.toSet());
+      assertThat(remainingInitialKeys).hasSize(3).containsAnyElementsOf(initialKeys);
+    }
+
+    @Test
+    void shouldReportSizeChanges() {
+      // given
+      final var reportedSize = new AtomicInteger();
+      final var cache = new BoundedCommandCache(reportedSize::set);
+
+      // when - then
+      cache.add(1);
+      cache.add(2);
+      assertThat(reportedSize).hasValue(2);
+
+      // when - then
+      cache.remove(1);
+      assertThat(reportedSize).hasValue(1);
+    }
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCacheTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/engine/impl/BoundedCommandCacheTest.java
@@ -20,10 +20,10 @@ final class BoundedCommandCacheTest {
   void shouldNotExceedCapacity() {
     // given
     final var cache = new BoundedCommandCache(4);
-    cache.add(setOf(1, 2, 3, 4));
+    cache.addAll(setOf(1, 2, 3, 4));
 
     // when
-    cache.add(setOf(5, 6));
+    cache.addAll(setOf(5, 6));
 
     // then
     assertThat(cache.size()).isEqualTo(4);
@@ -36,10 +36,10 @@ final class BoundedCommandCacheTest {
     // given
     final var cache = new BoundedCommandCache(4);
     final var initialKeys = setOf(1, 2, 3, 4);
-    cache.add(initialKeys);
+    cache.addAll(initialKeys);
 
     // when
-    cache.add(setOf(5, 6));
+    cache.addAll(setOf(5, 6));
 
     // then
     final var remainingInitialKeys =
@@ -54,7 +54,7 @@ final class BoundedCommandCacheTest {
     final var cache = new BoundedCommandCache(reportedSize::set);
 
     // when - then
-    cache.add(setOf(1, 2, 3, 4));
+    cache.addAll(setOf(1, 2, 3, 4));
     assertThat(reportedSize).hasValue(4);
 
     // when - then
@@ -79,7 +79,7 @@ final class BoundedCommandCacheTest {
     // given
     final var reportedSize = new AtomicInteger();
     final var cache = new BoundedCommandCache(reportedSize::set);
-    cache.add(setOf(1, 2, 3, 4));
+    cache.addAll(setOf(1, 2, 3, 4));
 
     // when
     cache.clear();

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ScheduledCommandCache.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ScheduledCommandCache.java
@@ -41,6 +41,9 @@ public interface ScheduledCommandCache {
     public void persist() {}
 
     @Override
+    public void rollback() {}
+
+    @Override
     public void add(final Intent intent, final long key) {}
 
     @Override
@@ -64,11 +67,16 @@ public interface ScheduledCommandCache {
    * Represents staged changes to the cache that have not been persisted yet. Call {@link
    * #persist()} to do so.
    *
+   * <p>Once persisted, staged changes can be rolled back by calling {@link #rollback()}. This will
+   * remove all staged changes from the main cache.
+   *
    * <p>See {@link StageableScheduledCommandCache} for more.
    */
   interface ScheduledCommandCacheChanges {
 
     void persist();
+
+    void rollback();
   }
 
   /**

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
@@ -155,6 +155,10 @@ public class ProcessingScheduleServiceImpl
       final var result = task.execute(builder);
       final var recordBatch = result.getRecordBatch();
 
+      // Persist before writing to ensure that we add to the cache before processing can remove it
+      // again.
+      stagedCache.persist();
+
       // we need to retry the writing if the dispatcher return zero or negative position (this means
       // it was full during writing)
       // it will be freed from the LogStorageAppender concurrently, which means we might be able to
@@ -173,13 +177,12 @@ public class ProcessingScheduleServiceImpl
 
       writeFuture.onComplete(
           (v, t) -> {
-            if (t == null) {
-              stagedCache.persist();
-            } else {
+            if (t != null) {
+              stagedCache.rollback();
               // todo handle error;
               //   can happen if we tried to write a too big batch of records
               //   this should resolve if we use the buffered writer were we detect these errors
-              // earlier
+              //   earlier
               LOG.warn("Writing of scheduled TaskResult failed!", t);
             }
           });

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/TestScheduledCommandCache.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/TestScheduledCommandCache.java
@@ -48,6 +48,7 @@ public class TestScheduledCommandCache implements ScheduledCommandCache {
     @Override
     public StagedScheduledCommandCache stage() {
       stagedCache.persisted = false;
+      stagedCache.cachedKeys.clear();
       return stagedCache;
     }
 
@@ -69,7 +70,12 @@ public class TestScheduledCommandCache implements ScheduledCommandCache {
       public void persist() {
         persisted = true;
         cachedKeys.forEach((i, keys) -> keys.forEach(key -> TestCommandCache.this.add(i, key)));
-        cachedKeys.clear();
+      }
+
+      @Override
+      public void rollback() {
+        persisted = false;
+        cachedKeys.forEach((i, keys) -> keys.forEach(key -> TestCommandCache.this.remove(i, key)));
       }
 
       public boolean persisted() {


### PR DESCRIPTION
# Description
Backport of #29769 to `stable/8.5`.

relates to #29735