### PR TITLE
fix: make ad hoc sub processes expandable in instance history

### DIFF
--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/index.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/index.tsx
@@ -24,6 +24,7 @@ import {TreeNode} from './styled';
 import {FlowNodeIcon} from 'modules/components/FlowNodeIcon';
 import {isSubProcess} from 'modules/bpmn-js/utils/isSubProcess';
 import {Bar} from './Bar';
+import {isAdHocSubProcess} from 'modules/bpmn-js/utils/isAdHocSubProcess';
 
 const TREE_NODE_HEIGHT = 32;
 
@@ -121,7 +122,10 @@ const FlowNodeInstancesTree: React.FC<Props> = observer(
     const isMultiInstanceBody = flowNodeInstance.type === 'MULTI_INSTANCE_BODY';
 
     const isFoldable =
-      isMultiInstanceBody || isSubProcess(businessObject) || isRoot;
+      isMultiInstanceBody ||
+      isSubProcess(businessObject) ||
+      isAdHocSubProcess(businessObject) ||
+      isRoot;
 
     const hasChildren = flowNodeInstance.isPlaceholder
       ? isFoldable &&

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/adHocSubProcess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/adHocSubProcess.test.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {createRef} from 'react';
+import {render, screen, waitFor} from 'modules/testing-library';
+import {flowNodeInstanceStore} from 'modules/stores/flowNodeInstance';
+import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
+import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstanceDetailsDiagram';
+import {open} from 'modules/mocks/diagrams';
+import {
+  Wrapper,
+  adHocSubProcessesInstance,
+  adHocNodeFlowNodeInstances,
+} from './mocks';
+import {FlowNodeInstancesTree} from '..';
+import {mockFetchProcessInstance} from 'modules/mocks/api/processInstances/fetchProcessInstance';
+import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
+import {mockFetchFlowNodeInstances} from 'modules/mocks/api/fetchFlowNodeInstances';
+
+describe('FlowNodeInstancesTree - Ad Hoc Sub Process', () => {
+  beforeEach(async () => {
+    mockFetchProcessInstance().withSuccess(adHocSubProcessesInstance);
+    mockFetchProcessXML().withSuccess(open('AdHocProcess.bpmn'));
+
+    await processInstanceDetailsDiagramStore.fetchProcessXml(
+      adHocSubProcessesInstance.bpmnProcessId,
+    );
+
+    processInstanceDetailsStore.init({id: adHocSubProcessesInstance.id});
+    flowNodeInstanceStore.init();
+
+    mockFetchFlowNodeInstances().withSuccess(adHocNodeFlowNodeInstances.level1);
+
+    await waitFor(() => {
+      expect(flowNodeInstanceStore.state.status).toBe('fetched');
+    });
+  });
+
+  it('should be able to unfold and fold ad hoc sub processes', async () => {
+    const {user} = render(
+      <FlowNodeInstancesTree
+        flowNodeInstance={{
+          id: adHocSubProcessesInstance.id,
+          type: 'PROCESS',
+          state: 'COMPLETED',
+          flowNodeId: 'AdHocSubProcess',
+          treePath: adHocSubProcessesInstance.id,
+          startDate: '',
+          endDate: null,
+          sortValues: [],
+        }}
+        scrollableContainerRef={createRef<HTMLElement>()}
+        isRoot
+      />,
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    expect(
+      screen.queryByLabelText('Ad Hoc Sub Process', {
+        selector: "[aria-expanded='true']",
+      }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Task A')).not.toBeInTheDocument();
+
+    mockFetchFlowNodeInstances().withSuccess(adHocNodeFlowNodeInstances.level2);
+
+    await user.type(
+      screen.getByLabelText('Ad Hoc Sub Process', {
+        selector: "[aria-expanded='false']",
+      }),
+      '{arrowright}',
+    );
+
+    expect(
+      await screen.findByLabelText('Ad Hoc Sub Process', {
+        selector: "[aria-expanded='true']",
+      }),
+    ).toBeInTheDocument();
+
+    expect(await screen.findByText('Task_A')).toBeInTheDocument();
+
+    await user.type(
+      screen.getByLabelText('Ad Hoc Sub Process', {
+        selector: "[aria-expanded='true']",
+      }),
+      '{arrowleft}',
+    );
+
+    expect(screen.queryByText('Task A')).not.toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/mocks.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/mocks.tsx
@@ -54,6 +54,16 @@ const nestedSubProcessesInstance = Object.freeze(
   }),
 );
 
+const adHocSubProcessesInstance = Object.freeze(
+  createInstance({
+    id: '222734982389310',
+    processId: '12517992348923884',
+    processName: 'Ad Hoc Process',
+    state: 'ACTIVE',
+    bpmnProcessId: 'AdHocProcess',
+  }),
+);
+
 const nestedSubProcessFlowNodeInstances: FlowNodeInstances = {
   [nestedSubProcessesInstance.id]: {
     running: null,
@@ -684,6 +694,66 @@ const multipleSubprocessesWithTwoRunningScopesMock: {
   },
 };
 
+const adHocNodeFlowNodeInstances: {
+  level1: FlowNodeInstances;
+  level2: FlowNodeInstances;
+} = {
+  level1: {
+    [adHocSubProcessesInstance.id]: {
+      running: null,
+      children: [
+        {
+          id: '2251799813686130',
+          type: 'START_EVENT',
+          state: 'COMPLETED',
+          flowNodeId: 'StartEvent_1',
+          startDate: '2020-08-18T12:07:33.953+0000',
+          endDate: '2020-08-18T12:07:34.034+0000',
+          treePath: `${adHocSubProcessesInstance.id}/2251799813686130`,
+          sortValues: ['1606300828415', '2251799813686130'],
+        },
+        {
+          id: '1241799813612356',
+          type: 'AD_HOC_SUB_PROCESS',
+          state: 'COMPLETED',
+          flowNodeId: 'AdHocSubProcess',
+          startDate: '2020-08-18T12:07:33.953+0000',
+          endDate: '2020-08-18T12:07:34.034+0000',
+          treePath: `${adHocSubProcessesInstance.id}/1241799813612356`,
+          sortValues: ['1606300828415', '2251799813686156'],
+        },
+        {
+          id: '2251799813686156',
+          type: 'END_EVENT',
+          state: 'COMPLETED',
+          flowNodeId: 'EndEvent_1',
+          startDate: '2020-08-18T12:07:33.953+0000',
+          endDate: '2020-08-18T12:07:34.034+0000',
+          treePath: `${adHocSubProcessesInstance.id}/2251799813686156`,
+          sortValues: ['1606300828415', '2251799813686156'],
+        },
+      ],
+    },
+  },
+  level2: {
+    [`${adHocSubProcessesInstance.id}/1241799813612356`]: {
+      running: null,
+      children: [
+        {
+          id: '22345625376130',
+          type: 'TASK',
+          state: 'COMPLETED',
+          flowNodeId: 'Task_A',
+          startDate: '2020-08-18T12:07:33.953+0000',
+          endDate: '2020-08-18T12:07:34.034+0000',
+          treePath: `${adHocSubProcessesInstance.id}/1241799813612356/22345625376130`,
+          sortValues: ['1606300828415', '2251799813686130'],
+        },
+      ],
+    },
+  },
+};
+
 const Wrapper = ({children}: {children?: React.ReactNode}) => {
   useEffect(() => {
     return () => {
@@ -706,12 +776,14 @@ const Wrapper = ({children}: {children?: React.ReactNode}) => {
 export {
   multiInstanceProcessInstance,
   nestedSubProcessesInstance,
+  adHocSubProcessesInstance,
   processId,
   processInstanceId,
   flowNodeInstances,
   eventSubProcessFlowNodeInstances,
   nestedSubProcessFlowNodeInstances,
   nestedSubProcessFlowNodeInstance,
+  adHocNodeFlowNodeInstances,
   mockFlowNodeInstance,
   multipleFlowNodeInstances,
   multipleSubprocessesWithOneRunningScopeMock,

--- a/operate/client/src/modules/bpmn-js/utils/isAdHocSubProcess.ts
+++ b/operate/client/src/modules/bpmn-js/utils/isAdHocSubProcess.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+import {hasType} from './hasType';
+
+function isAdHocSubProcess(businessObject?: BusinessObject) {
+  return (
+    businessObject !== undefined &&
+    hasType({businessObject, types: ['bpmn:AdHocSubProcess']})
+  );
+}
+
+export {isAdHocSubProcess};

--- a/operate/client/src/modules/mocks/diagrams/AdHocProcess.bpmn
+++ b/operate/client/src/modules/mocks/diagrams/AdHocProcess.bpmn
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_04esxm0" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.31.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="AdHocProvess" name="Ad Hoc Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0121ikd</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0121ikd" sourceRef="StartEvent_1" targetRef="AdHocSubProcess" />
+    <bpmn:adHocSubProcess id="AdHocSubProcess" name="Ad Hoc Sub Process">
+      <bpmn:incoming>Flow_0121ikd</bpmn:incoming>
+      <bpmn:outgoing>Flow_0icg2zd</bpmn:outgoing>
+      <bpmn:task id="TaskA" name="Task A" />
+    </bpmn:adHocSubProcess>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_0icg2zd</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0icg2zd" sourceRef="AdHocSubProcess" targetRef="EndEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="AdHocProvess">
+      <bpmndi:BPMNShape id="Event_1njz2oi_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="682" y="162" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="162" y="162" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_123x29v_di" bpmnElement="AdHocSubProcess" isExpanded="true">
+        <dc:Bounds x="270" y="80" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0tbzdlv_di" bpmnElement="TaskA">
+        <dc:Bounds x="390" y="130" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0121ikd_di" bpmnElement="Flow_0121ikd">
+        <di:waypoint x="198" y="180" />
+        <di:waypoint x="270" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0icg2zd_di" bpmnElement="Flow_0icg2zd">
+        <di:waypoint x="620" y="180" />
+        <di:waypoint x="682" y="180" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

This fixes a bug where ad hoc sub processes were not expandable in the instance history of Operate

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
