### PR TITLE
Fix flaky ElasticsearchUpdateRegressionTest.shouldBeAbleToUpdateAndExport

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/migration/ElasticsearchUpdateRegressionTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/migration/ElasticsearchUpdateRegressionTest.java
@@ -98,6 +98,7 @@ public class ElasticsearchUpdateRegressionTest {
 
     // then
     Awaitility.await("wait for processes")
+        .atMost(Duration.ofMinutes(1))
         .untilAsserted(
             () -> {
               final SearchQueryResponse<ProcessDefinition> searchQueryResponse =


### PR DESCRIPTION
## Description

This test had a flake to do with aliases which was fixed and dramatically lowered the flake count (from 60~/day to 20~/day) , however the test was flaking for multiple reasons and I suspect that the wait for processes to be visible in Elasticsearch is not long enough due to the logs here https://github.com/camunda/camunda/actions/runs/13927382146/job/38975410889

