### PR TITLE
feat: add mapping id to search query and response

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MappingDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MappingDbModel.java
@@ -66,7 +66,7 @@ public record MappingDbModel(
 
     @Override
     public MappingDbModel build() {
-      return new MappingDbModel(mappingKey, claimName, claimValue, name, mappingId);
+      return new MappingDbModel(mappingId, mappingKey, claimName, claimValue, name);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MappingDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MappingDbModel.java
@@ -21,28 +21,23 @@ public record MappingDbModel(
     return builderFunction
         .apply(
             new MappingDbModelBuilder()
-                .mappingId(mappingId)
                 .mappingKey(mappingKey)
                 .claimName(claimName)
                 .claimValue(claimValue)
-                .name(name))
+                .name(name)
+                .mappingId(mappingId))
         .build();
   }
 
   public static class MappingDbModelBuilder implements ObjectBuilder<MappingDbModel> {
 
-    private String mappingId;
     private Long mappingKey;
     private String claimName;
     private String claimValue;
     private String name;
+    private String mappingId;
 
     public MappingDbModelBuilder() {}
-
-    public MappingDbModelBuilder mappingId(final String mappingId) {
-      this.mappingId = mappingId;
-      return this;
-    }
 
     public MappingDbModelBuilder mappingKey(final Long mappingKey) {
       this.mappingKey = mappingKey;
@@ -64,9 +59,14 @@ public record MappingDbModel(
       return this;
     }
 
+    public MappingDbModelBuilder mappingId(final String mappingId) {
+      this.mappingId = mappingId;
+      return this;
+    }
+
     @Override
     public MappingDbModel build() {
-      return new MappingDbModel(mappingId, mappingKey, claimName, claimValue, name);
+      return new MappingDbModel(mappingKey, claimName, claimValue, name, mappingId);
     }
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -559,7 +559,7 @@ class RdbmsExporterIT {
     exporter.export(mappingCreatedRecord);
 
     // then
-    final var mappingId = ((MappingRecordValue) mappingCreatedRecord.getValue()).getId();
+    final var mappingId = ((MappingRecordValue) mappingCreatedRecord.getValue()).getMappingId();
     final var mapping = rdbmsService.getMappingReader().findOne(mappingId);
     assertThat(mapping).isNotNull();
 

--- a/service/src/main/java/io/camunda/service/MappingServices.java
+++ b/service/src/main/java/io/camunda/service/MappingServices.java
@@ -74,7 +74,7 @@ public class MappingServices
             .setClaimName(request.claimName())
             .setClaimValue(request.claimValue())
             .setName(request.name())
-            .setId(request.id()));
+            .setMappingId(request.mappingId()));
   }
 
   public CompletableFuture<MappingRecord> updateMapping(final MappingDTO request) {
@@ -83,7 +83,7 @@ public class MappingServices
             .setClaimName(request.claimName())
             .setClaimValue(request.claimValue())
             .setName(request.name())
-            .setId(request.id()));
+            .setMappingId(request.mappingId()));
   }
 
   public MappingEntity getMapping(final Long mappingKey) {
@@ -139,5 +139,5 @@ public class MappingServices
     return Stream.of(String.valueOf(value));
   }
 
-  public record MappingDTO(String claimName, String claimValue, String name, String id) {}
+  public record MappingDTO(String claimName, String claimValue, String name, String mappingId) {}
 }

--- a/service/src/main/java/io/camunda/service/MappingServices.java
+++ b/service/src/main/java/io/camunda/service/MappingServices.java
@@ -74,7 +74,7 @@ public class MappingServices
             .setClaimName(request.claimName())
             .setClaimValue(request.claimValue())
             .setName(request.name())
-            .setMappingId(request.mappingId()));
+            .setMappingId(request.id()));
   }
 
   public CompletableFuture<MappingRecord> updateMapping(final MappingDTO request) {
@@ -83,7 +83,7 @@ public class MappingServices
             .setClaimName(request.claimName())
             .setClaimValue(request.claimValue())
             .setName(request.name())
-            .setMappingId(request.mappingId()));
+            .setMappingId(request.id()));
   }
 
   public MappingEntity getMapping(final Long mappingKey) {
@@ -139,5 +139,5 @@ public class MappingServices
     return Stream.of(String.valueOf(value));
   }
 
-  public record MappingDTO(String claimName, String claimValue, String name, String mappingId) {}
+  public record MappingDTO(String claimName, String claimValue, String name, String id) {}
 }

--- a/service/src/test/java/io/camunda/service/MappingServicesTest.java
+++ b/service/src/test/java/io/camunda/service/MappingServicesTest.java
@@ -183,7 +183,7 @@ public class MappingServicesTest {
 
     final var mappingDTO =
         new MappingDTO(
-            "newClaimName", "newClaimValue", "newMappingRuleName", mappingRecord.getId());
+            "newClaimName", "newClaimValue", "newMappingRuleName", mappingRecord.getMappingId());
 
     //  when
     testMappingServices.updateMapping(mappingDTO);
@@ -191,7 +191,7 @@ public class MappingServicesTest {
     // then
     verify(mockBrokerClient).sendRequest(mappingUpdateRequestArgumentCaptor.capture());
     final var request = mappingUpdateRequestArgumentCaptor.getValue();
-    assertThat(request.getRequestWriter().getId()).isEqualTo(mappingDTO.id());
+    assertThat(request.getRequestWriter().getMappingId()).isEqualTo(mappingDTO.id());
     assertThat(request.getRequestWriter().getClaimName()).isEqualTo(mappingDTO.claimName());
     assertThat(request.getRequestWriter().getClaimValue()).isEqualTo(mappingDTO.claimValue());
     assertThat(request.getRequestWriter().getName()).isEqualTo(mappingDTO.name());

--- a/service/src/test/java/io/camunda/service/MappingServicesTest.java
+++ b/service/src/test/java/io/camunda/service/MappingServicesTest.java
@@ -177,7 +177,7 @@ public class MappingServicesTest {
             mockBrokerClient, mock(SecurityContextProvider.class), client, testAuthentication);
 
     final var mappingRecord = new MappingRecord();
-    mappingRecord.setId("id");
+    mappingRecord.setMappingId("id");
     when(mockBrokerClient.sendRequest(any()))
         .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(mappingRecord)));
 
@@ -191,7 +191,7 @@ public class MappingServicesTest {
     // then
     verify(mockBrokerClient).sendRequest(mappingUpdateRequestArgumentCaptor.capture());
     final var request = mappingUpdateRequestArgumentCaptor.getValue();
-    assertThat(request.getRequestWriter().getMappingId()).isEqualTo(mappingDTO.id());
+    assertThat(request.getRequestWriter().getMappingId()).isEqualTo(mappingDTO.mappingId());
     assertThat(request.getRequestWriter().getClaimName()).isEqualTo(mappingDTO.claimName());
     assertThat(request.getRequestWriter().getClaimValue()).isEqualTo(mappingDTO.claimValue());
     assertThat(request.getRequestWriter().getName()).isEqualTo(mappingDTO.name());

--- a/service/src/test/java/io/camunda/service/MappingServicesTest.java
+++ b/service/src/test/java/io/camunda/service/MappingServicesTest.java
@@ -153,7 +153,7 @@ public class MappingServicesTest {
             mockBrokerClient, mock(SecurityContextProvider.class), client, testAuthentication);
 
     final var mappingRecord = new MappingRecord();
-    mappingRecord.setId("id");
+    mappingRecord.setMappingId("id");
     when(mockBrokerClient.sendRequest(any()))
         .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(mappingRecord)));
 
@@ -163,7 +163,7 @@ public class MappingServicesTest {
     // then
     verify(mockBrokerClient).sendRequest(mappingDeleteRequestArgumentCaptor.capture());
     final var request = mappingDeleteRequestArgumentCaptor.getValue();
-    assertThat(request.getRequestWriter().getId()).isEqualTo("id");
+    assertThat(request.getRequestWriter().getMappingId()).isEqualTo("id");
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/MappingServicesTest.java
+++ b/service/src/test/java/io/camunda/service/MappingServicesTest.java
@@ -191,7 +191,7 @@ public class MappingServicesTest {
     // then
     verify(mockBrokerClient).sendRequest(mappingUpdateRequestArgumentCaptor.capture());
     final var request = mappingUpdateRequestArgumentCaptor.getValue();
-    assertThat(request.getRequestWriter().getMappingId()).isEqualTo(mappingDTO.mappingId());
+    assertThat(request.getRequestWriter().getMappingId()).isEqualTo(mappingDTO.id());
     assertThat(request.getRequestWriter().getClaimName()).isEqualTo(mappingDTO.claimName());
     assertThat(request.getRequestWriter().getClaimValue()).isEqualTo(mappingDTO.claimValue());
     assertThat(request.getRequestWriter().getName()).isEqualTo(mappingDTO.name());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -317,7 +317,7 @@ public final class AuthorizationCheckBehavior {
             (mapping, stream) -> {
               getAuthorizedResourceIdentifiersForOwners(
                       AuthorizationOwnerType.MAPPING,
-                      List.of(mapping.getId()),
+                      List.of(mapping.getMappingId()),
                       request.getResourceType(),
                       request.getPermissionType())
                   .forEach(stream);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
@@ -159,7 +159,7 @@ public final class IdentitySetupInitializeProcessor
                     .ifPresentOrElse(
                         persistedMapping -> {
                           mapping.setMappingKey(persistedMapping.getMappingKey());
-                          mapping.setId(persistedMapping.getId());
+                          mapping.setMappingId(persistedMapping.getMappingId());
                           if (assignEntityToRole(
                               role.getRoleKey(),
                               persistedMapping.getMappingKey(),
@@ -176,8 +176,8 @@ public final class IdentitySetupInitializeProcessor
                           final long mappingKey = keyGenerator.nextKey();
                           mapping.setMappingKey(mappingKey);
                           // TODO: Remove null checks after migrating fully to mapping ID #27820
-                          if (mapping.getId() == null || mapping.getId().isBlank()) {
-                            mapping.setId(String.valueOf(mappingKey));
+                          if (mapping.getMappingId() == null || mapping.getMappingId().isBlank()) {
+                            mapping.setMappingId(String.valueOf(mappingKey));
                           }
                           createMapping(mapping, role.getRoleKey(), tenant);
                         }));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
@@ -166,7 +166,8 @@ public final class IdentitySetupInitializeProcessor
                               EntityType.MAPPING)) {
                             createdNewEntities.set(true);
                           }
-                          if (assignEntityToTenant(tenant, mapping.getId(), EntityType.MAPPING)) {
+                          if (assignEntityToTenant(
+                              tenant, mapping.getMappingId(), EntityType.MAPPING)) {
                             createdNewEntities.set(true);
                           }
                         },
@@ -221,7 +222,7 @@ public final class IdentitySetupInitializeProcessor
                               role.getRoleKey(),
                               persistedMapping.getMappingKey(),
                               EntityType.MAPPING);
-                          assignEntityToTenant(tenant, mapping.getId(), EntityType.MAPPING);
+                          assignEntityToTenant(tenant, mapping.getMappingId(), EntityType.MAPPING);
                         },
                         () -> createMapping(mapping, role.getRoleKey(), tenant)));
   }
@@ -244,7 +245,7 @@ public final class IdentitySetupInitializeProcessor
       final MappingRecord mapping, final long roleKey, final TenantRecord tenant) {
     stateWriter.appendFollowUpEvent(mapping.getMappingKey(), MappingIntent.CREATED, mapping);
     assignEntityToRole(roleKey, mapping.getMappingKey(), EntityType.MAPPING);
-    assignEntityToTenant(tenant, mapping.getId(), EntityType.MAPPING);
+    assignEntityToTenant(tenant, mapping.getMappingId(), EntityType.MAPPING);
   }
 
   private boolean assignEntityToRole(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingCreateProcessor.java
@@ -79,10 +79,10 @@ public class MappingCreateProcessor implements DistributedTypedRecordProcessor<M
       return;
     }
 
-    final var persistedMappingWithSameId = mappingState.get(record.getId());
+    final var persistedMappingWithSameId = mappingState.get(record.getMappingId());
     if (persistedMappingWithSameId.isPresent()) {
       final var errorMessage =
-          MAPPING_SAME_ID_ALREADY_EXISTS_ERROR_MESSAGE.formatted(record.getId());
+          MAPPING_SAME_ID_ALREADY_EXISTS_ERROR_MESSAGE.formatted(record.getMappingId());
       rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
       responseWriter.writeRejectionOnCommand(command, RejectionType.ALREADY_EXISTS, errorMessage);
       return;
@@ -104,7 +104,7 @@ public class MappingCreateProcessor implements DistributedTypedRecordProcessor<M
   public void processDistributedCommand(final TypedRecord<MappingRecord> command) {
     final var record = command.getValue();
     mappingState
-        .get(record.getId())
+        .get(record.getMappingId())
         .ifPresentOrElse(
             existingMapping -> {
               final var errorMessage =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingCreateProcessor.java
@@ -108,7 +108,8 @@ public class MappingCreateProcessor implements DistributedTypedRecordProcessor<M
         .ifPresentOrElse(
             existingMapping -> {
               final var errorMessage =
-                  MAPPING_SAME_ID_ALREADY_EXISTS_ERROR_MESSAGE.formatted(existingMapping.getId());
+                  MAPPING_SAME_ID_ALREADY_EXISTS_ERROR_MESSAGE.formatted(
+                      existingMapping.getMappingId());
               rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
             },
             () -> stateWriter.appendFollowUpEvent(command.getKey(), MappingIntent.CREATED, record));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
@@ -72,7 +72,7 @@ public class MappingDeleteProcessor implements DistributedTypedRecordProcessor<M
   @Override
   public void processNewCommand(final TypedRecord<MappingRecord> command) {
     final var record = command.getValue();
-    final String id = record.getId();
+    final String id = record.getMappingId();
     final var persistedMappingOptional = mappingState.get(id);
     if (persistedMappingOptional.isEmpty()) {
       final var errorMessage = MAPPING_NOT_FOUND_ERROR_MESSAGE.formatted(id);
@@ -108,7 +108,7 @@ public class MappingDeleteProcessor implements DistributedTypedRecordProcessor<M
   public void processDistributedCommand(final TypedRecord<MappingRecord> command) {
     final var record = command.getValue();
     mappingState
-        .get(record.getId())
+        .get(record.getMappingId())
         .ifPresentOrElse(
             this::deleteMapping,
             () -> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
@@ -131,7 +131,7 @@ public class MappingDeleteProcessor implements DistributedTypedRecordProcessor<M
           new TenantRecord()
               .setTenantKey(tenant.getTenantKey())
               .setTenantId(tenant.getTenantId())
-              .setEntityId(mapping.getId())
+              .setEntityId(mapping.getMappingId())
               .setEntityType(EntityType.MAPPING));
     }
     for (final var roleKey : mapping.getRoleKeysList()) {
@@ -155,7 +155,7 @@ public class MappingDeleteProcessor implements DistributedTypedRecordProcessor<M
     stateWriter.appendFollowUpEvent(
         mappingKey,
         MappingIntent.DELETED,
-        new MappingRecord().setMappingKey(mappingKey).setId(mapping.getId()));
+        new MappingRecord().setMappingKey(mappingKey).setMappingId(mapping.getMappingId()));
   }
 
   private void deleteAuthorizations(final long mappingKey) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingUpdateProcessor.java
@@ -82,7 +82,7 @@ public class MappingUpdateProcessor implements DistributedTypedRecordProcessor<M
     final var persistedMappingWithSameClaim =
         mappingState.get(record.getClaimName(), record.getClaimValue());
     if (persistedMappingWithSameClaim.isPresent()
-        && !persistedMappingWithSameClaim.get().getId().equals(mappingId)) {
+        && !persistedMappingWithSameClaim.get().getMappingId().equals(mappingId)) {
       final var errorMessage =
           MAPPING_SAME_CLAIM_ALREADY_EXISTS_ERROR_MESSAGE.formatted(
               record.getClaimName(), record.getClaimValue());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingUpdateProcessor.java
@@ -58,7 +58,7 @@ public class MappingUpdateProcessor implements DistributedTypedRecordProcessor<M
   public void processNewCommand(final TypedRecord<MappingRecord> command) {
 
     final var record = command.getValue();
-    final var mappingId = record.getId();
+    final var mappingId = record.getMappingId();
     final var persistedRecord = mappingState.get(mappingId);
     if (persistedRecord.isEmpty()) {
       final var errorMessage = MAPPING_ID_DOES_NOT_EXIST_ERROR_MESSAGE.formatted(mappingId);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MappingDeletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MappingDeletedApplier.java
@@ -22,6 +22,6 @@ public class MappingDeletedApplier implements TypedEventApplier<MappingIntent, M
 
   @Override
   public void applyState(final long key, final MappingRecord value) {
-    mappingState.delete(value.getId());
+    mappingState.delete(value.getMappingId());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
@@ -63,7 +63,7 @@ public class DbMappingState implements MutableMappingState {
   @Override
   public void create(final MappingRecord mappingRecord) {
     final var key = mappingRecord.getMappingKey();
-    final var id = mappingRecord.getId();
+    final var id = mappingRecord.getMappingId();
     final var name = mappingRecord.getName();
     final var claimName = mappingRecord.getClaimName();
     final var value = mappingRecord.getClaimValue();
@@ -85,8 +85,8 @@ public class DbMappingState implements MutableMappingState {
 
   @Override
   public void update(final MappingRecord mappingRecord) {
-    mappingId.wrapString(mappingRecord.getId());
-    get(mappingRecord.getId())
+    mappingId.wrapString(mappingRecord.getMappingId());
+    get(mappingRecord.getMappingId())
         .ifPresentOrElse(
             persistedMapping -> {
               mappingKey.wrapLong(persistedMapping.getMappingKey());
@@ -110,7 +110,7 @@ public class DbMappingState implements MutableMappingState {
               throw new IllegalStateException(
                   String.format(
                       "Expected to update mapping with id '%s', but a mapping with this id does not exist.",
-                      mappingRecord.getId()));
+                      mappingRecord.getMappingId()));
             });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
@@ -76,7 +76,7 @@ public class DbMappingState implements MutableMappingState {
     persistedMapping.setClaimName(claimName);
     persistedMapping.setClaimValue(value);
     persistedMapping.setName(name);
-    persistedMapping.setId(id);
+    persistedMapping.setMappingId(id);
 
     mappingColumnFamily.insert(claim, persistedMapping);
     claimByIdColumnFamily.insert(mappingId, fkClaim);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedMapping.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedMapping.java
@@ -25,7 +25,7 @@ public class PersistedMapping extends UnpackedObject implements DbValue {
   private final StringProperty claimNameProp = new StringProperty("claimName", "");
   private final StringProperty claimValueProp = new StringProperty("claimValue", "");
   private final StringProperty nameProp = new StringProperty("name", "");
-  private final StringProperty idProp = new StringProperty("id", "");
+  private final StringProperty mappingIdProp = new StringProperty("mappingId", "");
   private final ArrayProperty<LongValue> roleKeysProp =
       new ArrayProperty<>("roleKeys", LongValue::new);
   private final ArrayProperty<StringValue> tenantIdsProp =
@@ -42,7 +42,7 @@ public class PersistedMapping extends UnpackedObject implements DbValue {
         .declareProperty(roleKeysProp)
         .declareProperty(tenantIdsProp)
         .declareProperty(groupKeysProp)
-        .declareProperty(idProp);
+        .declareProperty(mappingIdProp);
   }
 
   public PersistedMapping copy() {
@@ -87,12 +87,12 @@ public class PersistedMapping extends UnpackedObject implements DbValue {
     return this;
   }
 
-  public String getId() {
-    return BufferUtil.bufferAsString(idProp.getValue());
+  public String getMappingId() {
+    return BufferUtil.bufferAsString(mappingIdProp.getValue());
   }
 
-  public PersistedMapping setId(final String id) {
-    idProp.setValue(id);
+  public PersistedMapping setMappingId(final String id) {
+    mappingIdProp.setValue(id);
     return this;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
@@ -140,7 +140,7 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
     // given
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
-    final var mappingId = createMapping(claimName, claimValue).getId();
+    final var mappingId = createMapping(claimName, claimValue).getMappingId();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
@@ -169,7 +169,11 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(
-        mapping.getId(), AuthorizationOwnerType.MAPPING, resourceType, permissionType, resourceId);
+        mapping.getMappingId(),
+        AuthorizationOwnerType.MAPPING,
+        resourceType,
+        permissionType,
+        resourceId);
     final var groupKey = createGroup(mapping.getMappingKey(), EntityType.MAPPING);
     final var tenantId = createAndAssignTenant(groupKey, EntityType.GROUP);
     final var command = mockCommandWithMapping(claimName, claimValue);
@@ -211,7 +215,7 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
     // given
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
-    final var mappingId = createMapping(claimName, claimValue).getId();
+    final var mappingId = createMapping(claimName, claimValue).getMappingId();
     final var tenantId1 = createAndAssignTenant(mappingId, EntityType.MAPPING);
     final var tenantId2 = createAndAssignTenant(mappingId, EntityType.MAPPING);
     final var command = mockCommandWithMapping(claimName, claimValue);
@@ -317,12 +321,16 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
     final var mapping = createMapping(claimName, claimValue);
-    createAndAssignTenant(mapping.getId(), EntityType.MAPPING);
+    createAndAssignTenant(mapping.getMappingId(), EntityType.MAPPING);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(
-        mapping.getId(), AuthorizationOwnerType.MAPPING, resourceType, permissionType, resourceId);
+        mapping.getMappingId(),
+        AuthorizationOwnerType.MAPPING,
+        resourceType,
+        permissionType,
+        resourceId);
     final var command = mockCommandWithMapping(claimName, claimValue);
 
     // when
@@ -340,7 +348,7 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
     // given
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
-    final var mappingId = createMapping(claimName, claimValue).getId();
+    final var mappingId = createMapping(claimName, claimValue).getMappingId();
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
@@ -391,7 +399,7 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
     final var mapping = createMapping(claimName, claimValue);
 
     // when
-    final var tenantId = createAndAssignTenant(mapping.getId(), EntityType.MAPPING);
+    final var tenantId = createAndAssignTenant(mapping.getMappingId(), EntityType.MAPPING);
     final var command = mockCommandWithMapping(claimName, claimValue);
 
     // then
@@ -432,12 +440,16 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
     final var mapping = createMapping(claimName, claimValue);
-    final var tenantId = createAndAssignTenant(mapping.getId(), EntityType.MAPPING);
+    final var tenantId = createAndAssignTenant(mapping.getMappingId(), EntityType.MAPPING);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(
-        mapping.getId(), AuthorizationOwnerType.MAPPING, resourceType, permissionType, resourceId);
+        mapping.getMappingId(),
+        AuthorizationOwnerType.MAPPING,
+        resourceType,
+        permissionType,
+        resourceId);
     final var command = mockCommandWithMapping(claimName, claimValue);
 
     // when
@@ -476,7 +488,7 @@ final class AuthorizationCheckBehaviorMultiTenancyTest {
     final var mapping =
         new MappingRecord()
             .setMappingKey(mappingKey)
-            .setId(Strings.newRandomValidIdentityId())
+            .setMappingId(Strings.newRandomValidIdentityId())
             .setName(Strings.newRandomValidUsername())
             .setClaimName(claimName)
             .setClaimValue(claimValue);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -299,7 +299,11 @@ final class AuthorizationCheckBehaviorTest {
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(
-        mapping.getId(), AuthorizationOwnerType.MAPPING, resourceType, permissionType, resourceId);
+        mapping.getMappingId(),
+        AuthorizationOwnerType.MAPPING,
+        resourceType,
+        permissionType,
+        resourceId);
     final var command = mockCommandWithMapping(claimName, claimValue);
 
     // when
@@ -399,13 +403,13 @@ final class AuthorizationCheckBehaviorTest {
     final var firstResourceId = UUID.randomUUID().toString();
     final var secondResourceId = UUID.randomUUID().toString();
     addPermission(
-        String.valueOf(firstMapping.getId()),
+        String.valueOf(firstMapping.getMappingId()),
         AuthorizationOwnerType.MAPPING,
         resourceType,
         permissionType,
         firstResourceId);
     addPermission(
-        String.valueOf(secondMapping.getId()),
+        String.valueOf(secondMapping.getMappingId()),
         AuthorizationOwnerType.MAPPING,
         resourceType,
         permissionType,
@@ -449,13 +453,13 @@ final class AuthorizationCheckBehaviorTest {
     final var firstResourceId = UUID.randomUUID().toString();
     final var secondResourceId = UUID.randomUUID().toString();
     addPermission(
-        firstMapping.getId(),
+        firstMapping.getMappingId(),
         AuthorizationOwnerType.MAPPING,
         resourceType,
         permissionType,
         firstResourceId);
     addPermission(
-        secondMapping.getId(),
+        secondMapping.getMappingId(),
         AuthorizationOwnerType.MAPPING,
         resourceType,
         permissionType,
@@ -492,7 +496,11 @@ final class AuthorizationCheckBehaviorTest {
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
     addPermission(
-        mapping.getId(), AuthorizationOwnerType.MAPPING, resourceType, permissionType, resourceId);
+        mapping.getMappingId(),
+        AuthorizationOwnerType.MAPPING,
+        resourceType,
+        permissionType,
+        resourceId);
     final var command = mockCommandWithMapping(claimName, claimValue);
 
     // when
@@ -619,7 +627,7 @@ final class AuthorizationCheckBehaviorTest {
     final var mapping =
         new MappingRecord()
             .setMappingKey(mappingKey)
-            .setId(Strings.newRandomValidIdentityId())
+            .setMappingId(Strings.newRandomValidIdentityId())
             .setName(Strings.newRandomValidUsername())
             .setClaimName(claimName)
             .setClaimValue(claimValue);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
@@ -343,8 +343,8 @@ public class IdentitySetupInitializeTest {
             tuple(mapping1.getClaimName(), mapping1.getClaimValue()),
             tuple(mapping2.getClaimName(), mapping2.getClaimValue()));
     Assertions.assertThat(createdMappings)
-        .extracting(MappingRecordValue::getId)
-        .containsExactly(mapping1.getId(), mapping2.getId());
+        .extracting(MappingRecordValue::getMappingId)
+        .containsExactly(mapping1.getMappingId(), mapping2.getMappingId());
     Assertions.assertThat(createdMappings)
         .satisfiesExactly(
             m1 ->

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
@@ -311,12 +311,12 @@ public class IdentitySetupInitializeTest {
     final var role = new RoleRecord().setName(UUID.randomUUID().toString());
     final var mapping1 =
         new MappingRecord()
-            .setId(UUID.randomUUID().toString())
+            .setMappingId(UUID.randomUUID().toString())
             .setClaimName(UUID.randomUUID().toString())
             .setClaimValue(UUID.randomUUID().toString());
     final var mapping2 =
         new MappingRecord()
-            .setId(UUID.randomUUID().toString())
+            .setMappingId(UUID.randomUUID().toString())
             .setClaimName(UUID.randomUUID().toString())
             .setClaimValue(UUID.randomUUID().toString());
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -335,7 +335,7 @@ public class CommandDistributionIdempotencyTest {
                 MappingIntent.UPDATE,
                 () -> {
                   final var mapping = createMapping();
-                  return ENGINE.mapping().updateMapping(mapping.getValue().getId()).update();
+                  return ENGINE.mapping().updateMapping(mapping.getValue().getMappingId()).update();
                 }),
             MappingUpdateProcessor.class
           },
@@ -346,7 +346,7 @@ public class CommandDistributionIdempotencyTest {
                 MappingIntent.DELETE,
                 () -> {
                   final var mapping = createMapping();
-                  return ENGINE.mapping().deleteMapping(mapping.getValue().getId()).delete();
+                  return ENGINE.mapping().deleteMapping(mapping.getValue().getMappingId()).delete();
                 }),
             MappingDeleteProcessor.class
           },

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -589,7 +589,7 @@ public class CommandDistributionIdempotencyTest {
                         .withMapping(
                             new MappingRecord()
                                 .setMappingKey(4)
-                                .setId("id")
+                                .setMappingId("id")
                                 .setClaimName("claimName")
                                 .setClaimValue("claimValue"))
                         .initialize()),
@@ -684,7 +684,7 @@ public class CommandDistributionIdempotencyTest {
         .mapping()
         .newMapping(UUID.randomUUID().toString())
         .withClaimValue(UUID.randomUUID().toString())
-        .withId(UUID.randomUUID().toString())
+        .withMappingId(UUID.randomUUID().toString())
         .create();
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/DeleteMappingMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/DeleteMappingMultiPartitionTest.java
@@ -42,7 +42,7 @@ public class DeleteMappingMultiPartitionTest {
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
     final var id = UUID.randomUUID().toString();
-    engine.mapping().newMapping(claimName).withClaimValue(claimValue).withId(id).create();
+    engine.mapping().newMapping(claimName).withClaimValue(claimValue).withMappingId(id).create();
     engine.mapping().deleteMapping(id).delete();
 
     // then
@@ -92,7 +92,7 @@ public class DeleteMappingMultiPartitionTest {
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
     final var id = UUID.randomUUID().toString();
-    engine.mapping().newMapping(claimName).withClaimValue(claimValue).withId(id).create();
+    engine.mapping().newMapping(claimName).withClaimValue(claimValue).withMappingId(id).create();
     engine.mapping().deleteMapping(id).delete();
 
     // then
@@ -114,7 +114,7 @@ public class DeleteMappingMultiPartitionTest {
     final var claimValue = UUID.randomUUID().toString();
     final var id = UUID.randomUUID().toString();
 
-    engine.mapping().newMapping(claimName).withClaimValue(claimValue).withId(id).create();
+    engine.mapping().newMapping(claimName).withClaimValue(claimValue).withMappingId(id).create();
     engine.mapping().deleteMapping(id).delete();
 
     // Increase time to trigger a redistribution

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingTest.java
@@ -38,7 +38,7 @@ public class MappingTest {
             .mapping()
             .newMapping(claimName)
             .withClaimValue(claimValue)
-            .withId(id)
+            .withMappingId(id)
             .withName(name)
             .create();
 
@@ -82,7 +82,7 @@ public class MappingTest {
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
     final var id = UUID.randomUUID().toString();
-    engine.mapping().newMapping(claimName).withClaimValue(claimValue).withId(id).create();
+    engine.mapping().newMapping(claimName).withClaimValue(claimValue).withMappingId(id).create();
 
     // when
     final var duplicatedMappingRecord =
@@ -90,7 +90,7 @@ public class MappingTest {
             .mapping()
             .newMapping(UUID.randomUUID().toString())
             .withClaimValue(UUID.randomUUID().toString())
-            .withId(id)
+            .withMappingId(id)
             .expectRejection()
             .create();
 
@@ -115,7 +115,7 @@ public class MappingTest {
             .newMapping(claimName)
             .withClaimValue(claimValue)
             .withName(name)
-            .withId(id)
+            .withMappingId(id)
             .create()
             .getKey();
 
@@ -183,7 +183,7 @@ public class MappingTest {
             .newMapping(claimName)
             .withClaimValue(claimValue)
             .withName(name)
-            .withId(id)
+            .withMappingId(id)
             .create();
 
     // when
@@ -218,7 +218,7 @@ public class MappingTest {
         .newMapping(claimName)
         .withClaimValue(claimValue)
         .withName(name)
-        .withId(id)
+        .withMappingId(id)
         .create()
         .getValue();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingTest.java
@@ -49,7 +49,7 @@ public class MappingTest {
         .hasFieldOrPropertyWithValue("claimName", claimName)
         .hasFieldOrPropertyWithValue("claimValue", claimValue)
         .hasFieldOrPropertyWithValue("name", name)
-        .hasFieldOrPropertyWithValue("id", id);
+        .hasFieldOrPropertyWithValue("mappingId", id);
   }
 
   @Test
@@ -133,7 +133,7 @@ public class MappingTest {
     // then
     Assertions.assertThat(updatedMapping)
         .isNotNull()
-        .hasFieldOrPropertyWithValue("id", id)
+        .hasFieldOrPropertyWithValue("mappingId", id)
         .hasFieldOrPropertyWithValue("name", name + "New")
         .hasFieldOrPropertyWithValue("claimName", claimName + "New")
         .hasFieldOrPropertyWithValue("claimValue", claimValue + "New");
@@ -226,7 +226,7 @@ public class MappingTest {
     final var deletedMapping = engine.mapping().deleteMapping(id).delete().getValue();
 
     // then
-    Assertions.assertThat(deletedMapping).isNotNull().hasFieldOrPropertyWithValue("id", id);
+    Assertions.assertThat(deletedMapping).isNotNull().hasFieldOrPropertyWithValue("mappingId", id);
   }
 
   @Test
@@ -251,7 +251,7 @@ public class MappingTest {
         .add();
 
     // when
-    engine.mapping().deleteMapping(mappingRecord.getValue().getId()).delete();
+    engine.mapping().deleteMapping(mappingRecord.getValue().getMappingId()).delete();
 
     // then
     Assertions.assertThat(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingUpdateAuthorizationTest.java
@@ -56,7 +56,7 @@ public class MappingUpdateAuthorizationTest {
         .newMapping(claimName)
         .withClaimValue(claimValue)
         .withName(name)
-        .withId(id)
+        .withMappingId(id)
         .create(DEFAULT_USER.getUsername());
 
     // when
@@ -94,7 +94,7 @@ public class MappingUpdateAuthorizationTest {
         .newMapping(claimName)
         .withClaimValue(claimValue)
         .withName(name)
-        .withId(id)
+        .withMappingId(id)
         .create(DEFAULT_USER.getUsername());
 
     // when
@@ -130,7 +130,7 @@ public class MappingUpdateAuthorizationTest {
         .newMapping(claimName)
         .withClaimValue(claimValue)
         .withName(name)
-        .withId(id)
+        .withMappingId(id)
         .create(DEFAULT_USER.getUsername());
 
     // when

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/UpdateMappingMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/UpdateMappingMultiPartitionTest.java
@@ -44,7 +44,7 @@ public class UpdateMappingMultiPartitionTest {
         .newMapping(claimName)
         .withClaimValue(claimValue)
         .withName(name)
-        .withId(id)
+        .withMappingId(id)
         .create();
 
     // when
@@ -80,7 +80,7 @@ public class UpdateMappingMultiPartitionTest {
         .newMapping(claimName)
         .withClaimValue(claimValue)
         .withName(name)
-        .withId(id)
+        .withMappingId(id)
         .create();
 
     // when
@@ -116,7 +116,7 @@ public class UpdateMappingMultiPartitionTest {
         .newMapping(claimName)
         .withClaimValue(claimValue)
         .withName(name)
-        .withId(id)
+        .withMappingId(id)
         .create();
     engine
         .mapping()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantTest.java
@@ -233,7 +233,7 @@ public class AddEntityTenantTest {
         .mapping()
         .newMapping("mappingName")
         .withClaimValue("claimValue")
-        .withId(Strings.newRandomValidIdentityId())
+        .withMappingId(Strings.newRandomValidIdentityId())
         .create()
         .getValue()
         .getMappingId();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantTest.java
@@ -236,6 +236,6 @@ public class AddEntityTenantTest {
         .withId(Strings.newRandomValidIdentityId())
         .create()
         .getValue()
-        .getId();
+        .getMappingId();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
@@ -65,7 +65,7 @@ public class MappingAppliersTest {
     mappingDeletedApplier.applyState(mappingRecord.getMappingKey(), mappingRecord);
 
     // then
-    assertThat(mappingState.get(mappingRecord.getId())).isEmpty();
+    assertThat(mappingState.get(mappingRecord.getMappingId())).isEmpty();
   }
 
   @Test
@@ -96,8 +96,8 @@ public class MappingAppliersTest {
     mappingUpdatedApplier.applyState(mappingRecord.getMappingKey(), mappingRecord);
 
     // then
-    assertThat(mappingState.get(mappingRecord.getId())).isNotEmpty();
-    final var updatedMapping = mappingState.get(mappingRecord.getId()).get();
+    assertThat(mappingState.get(mappingRecord.getMappingId())).isNotEmpty();
+    final var updatedMapping = mappingState.get(mappingRecord.getMappingId()).get();
     assertThat(updatedMapping.getClaimName()).isEqualTo(newClaimName);
     assertThat(updatedMapping.getClaimValue()).isEqualTo(newClaimValue);
     assertThat(updatedMapping.getName()).isEqualTo(newName);
@@ -115,7 +115,7 @@ public class MappingAppliersTest {
         .hasMessageContaining(
             String.format(
                 "Expected to update mapping with id '%s', but a mapping with this id does not exist.",
-                mappingRecord.getId()));
+                mappingRecord.getMappingId()));
   }
 
   private MappingRecord createMapping() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
@@ -72,7 +72,7 @@ public class MappingAppliersTest {
   public void shouldThrowExceptionWhenDeleteNotExistingMapping() {
     // given
     final String id = "id";
-    final var mappingRecord = new MappingRecord().setId(id);
+    final var mappingRecord = new MappingRecord().setMappingId(id);
 
     // when + then
     assertThatThrownBy(
@@ -107,7 +107,7 @@ public class MappingAppliersTest {
   public void shouldThrowExceptionWhenUpdateNotExistingMappingId() {
     // given
     final var mappingRecord = createMapping();
-    mappingRecord.setId(UUID.randomUUID().toString());
+    mappingRecord.setMappingId(UUID.randomUUID().toString());
     // when + then
     assertThatThrownBy(
             () -> mappingUpdatedApplier.applyState(mappingRecord.getMappingKey(), mappingRecord))
@@ -126,11 +126,10 @@ public class MappingAppliersTest {
     final var mappingRecord =
         new MappingRecord()
             .setMappingKey(mappingKey)
-            .setId(mappingId)
+            .setMappingId(mappingId)
             .setClaimName(claimName)
             .setClaimValue(claimValue)
-            .setName(claimName)
-            .setId(UUID.randomUUID().toString());
+            .setName(claimName);
     mappingState.create(mappingRecord);
     // create role
     final long roleKey = 2L;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
@@ -77,7 +77,10 @@ public class TenantAppliersTest {
     // given
     final var mappingId = "mappingId";
     mappingState.create(
-        new MappingRecord().setId(mappingId).setClaimName("claimName").setClaimValue("claimValue"));
+        new MappingRecord()
+            .setMappingId(mappingId)
+            .setClaimName("claimName")
+            .setClaimValue("claimValue"));
     final String tenantId = "tenantId";
     final long tenantKey = 11L;
     final var tenantRecord = new TenantRecord().setTenantId(tenantId).setTenantKey(tenantKey);
@@ -157,7 +160,10 @@ public class TenantAppliersTest {
     // given
     final var mappingId = "mappingId";
     mappingState.create(
-        new MappingRecord().setId(mappingId).setClaimName("claimName").setClaimValue("claimValue"));
+        new MappingRecord()
+            .setMappingId(mappingId)
+            .setClaimName("claimName")
+            .setClaimValue("claimValue"));
     final String tenantId = "tenantId";
     final long tenantKey = 11L;
     final var tenantRecord = new TenantRecord().setTenantId(tenantId).setTenantKey(tenantKey);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingStateTest.java
@@ -40,7 +40,7 @@ public class MappingStateTest {
     final var mapping =
         new MappingRecord()
             .setMappingKey(key)
-            .setId(id)
+            .setMappingId(id)
             .setClaimName(claimName)
             .setName(name)
             .setClaimValue(claimValue);
@@ -51,7 +51,7 @@ public class MappingStateTest {
     // then
     final var persistedMapping = mappingState.get(key).get();
     assertThat(persistedMapping.getMappingKey()).isEqualTo(key);
-    assertThat(persistedMapping.getId()).isEqualTo(id);
+    assertThat(persistedMapping.getMappingId()).isEqualTo(id);
     assertThat(persistedMapping.getName()).isEqualTo(name);
     assertThat(persistedMapping.getClaimName()).isEqualTo(claimName);
     assertThat(persistedMapping.getClaimValue()).isEqualTo(claimValue);
@@ -80,7 +80,7 @@ public class MappingStateTest {
             .setClaimName(claimName)
             .setClaimValue(claimValue)
             .setName(name)
-            .setId(id);
+            .setMappingId(id);
     mappingState.create(mapping);
 
     // when
@@ -90,7 +90,7 @@ public class MappingStateTest {
     assertThat(retrievedMapping).isPresent();
     assertThat(retrievedMapping.get().getMappingKey()).isEqualTo(key);
     assertThat(retrievedMapping.get().getName()).isEqualTo(name);
-    assertThat(retrievedMapping.get().getId()).isEqualTo(id);
+    assertThat(retrievedMapping.get().getMappingId()).isEqualTo(id);
   }
 
   @Test
@@ -116,7 +116,7 @@ public class MappingStateTest {
             .setClaimName(claimName)
             .setClaimValue(claimValue)
             .setName(name)
-            .setId(id);
+            .setMappingId(id);
     mappingState.create(mapping);
 
     // when
@@ -178,7 +178,7 @@ public class MappingStateTest {
     final String mappingId = Strings.newRandomValidIdentityId();
     final var mapping =
         new MappingRecord()
-            .setId(mappingId)
+            .setMappingId(mappingId)
             .setMappingKey(key)
             .setClaimName(claimName)
             .setClaimValue(claimValue);
@@ -202,7 +202,7 @@ public class MappingStateTest {
     final String mappingId = Strings.newRandomValidIdentityId();
     final var mapping =
         new MappingRecord()
-            .setId(mappingId)
+            .setMappingId(mappingId)
             .setMappingKey(key)
             .setClaimName(claimName)
             .setClaimValue(claimValue);
@@ -227,7 +227,7 @@ public class MappingStateTest {
     final String id = "id";
     final var mapping =
         new MappingRecord()
-            .setId(id)
+            .setMappingId(id)
             .setMappingKey(key)
             .setClaimName(claimName)
             .setClaimValue(claimValue);
@@ -253,7 +253,7 @@ public class MappingStateTest {
     final var mapping =
         new MappingRecord()
             .setMappingKey(key)
-            .setId(id)
+            .setMappingId(id)
             .setName(name)
             .setClaimName(claimName)
             .setClaimValue(claimValue);
@@ -266,7 +266,7 @@ public class MappingStateTest {
     final var updateMapping =
         new MappingRecord()
             .setMappingKey(key)
-            .setId(id)
+            .setMappingId(id)
             .setName(newName)
             .setClaimName(newClaimName)
             .setClaimValue(newClaimValue);
@@ -283,6 +283,6 @@ public class MappingStateTest {
     assertThat(mappingState.get(newClaimName, newClaimValue)).isNotEmpty();
     final var mappingByClaim = mappingState.get(newClaimName, newClaimValue).get();
     assertThat(mappingByClaim.getName()).isEqualTo(newName);
-    assertThat(mappingByClaim.getId()).isEqualTo(id);
+    assertThat(mappingByClaim.getMappingId()).isEqualTo(id);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/MappingClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/MappingClient.java
@@ -136,7 +136,7 @@ public class MappingClient {
                 .withIntent(MappingIntent.UPDATED)
                 .filter(
                     mappingRecordValueRecord ->
-                        mappingRecordValueRecord.getValue().getId().equals(position))
+                        mappingRecordValueRecord.getValue().getMappingId().equals(position))
                 .getFirst();
 
     private static final Function<String, Record<MappingRecordValue>> REJECTION_SUPPLIER =
@@ -146,7 +146,7 @@ public class MappingClient {
                 .withIntent(MappingIntent.UPDATE)
                 .filter(
                     mappingRecordValueRecord ->
-                        mappingRecordValueRecord.getValue().getId().equals(position))
+                        mappingRecordValueRecord.getValue().getMappingId().equals(position))
                 .getFirst();
     private final CommandWriter writer;
     private final MappingRecord mappingRecord;
@@ -160,12 +160,12 @@ public class MappingClient {
 
     public Record<MappingRecordValue> update() {
       writer.writeCommand(MappingIntent.UPDATE, mappingRecord);
-      return expectation.apply(mappingRecord.getId());
+      return expectation.apply(mappingRecord.getMappingId());
     }
 
     public Record<MappingRecordValue> update(final String username) {
       writer.writeCommand(MappingIntent.UPDATE, username, mappingRecord);
-      return expectation.apply(mappingRecord.getId());
+      return expectation.apply(mappingRecord.getMappingId());
     }
 
     public MappingUpdateClient withClaimName(final String claimName) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/MappingClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/MappingClient.java
@@ -65,8 +65,8 @@ public class MappingClient {
       return this;
     }
 
-    public MappingCreateClient withId(final String id) {
-      mappingRecord.setId(id);
+    public MappingCreateClient withMappingId(final String id) {
+      mappingRecord.setMappingId(id);
       return this;
     }
 
@@ -114,7 +114,7 @@ public class MappingClient {
     public MappingDeleteClient(final CommandWriter writer, final String id) {
       this.writer = writer;
       mappingRecord = new MappingRecord();
-      mappingRecord.setId(id);
+      mappingRecord.setMappingId(id);
     }
 
     public Record<MappingRecordValue> delete() {
@@ -155,7 +155,7 @@ public class MappingClient {
     public MappingUpdateClient(final CommandWriter writer, final String id) {
       this.writer = writer;
       mappingRecord = new MappingRecord();
-      mappingRecord.setId(id);
+      mappingRecord.setMappingId(id);
     }
 
     public Record<MappingRecordValue> update() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingCreatedUpdatedHandler.java
@@ -47,7 +47,7 @@ public class MappingCreatedUpdatedHandler
 
   @Override
   public List<String> generateIds(final Record<MappingRecordValue> record) {
-    return List.of(record.getValue().getId());
+    return List.of(String.valueOf(record.getValue().getMappingId()));
   }
 
   @Override
@@ -60,7 +60,7 @@ public class MappingCreatedUpdatedHandler
     final MappingRecordValue value = record.getValue();
     entity
         .setKey(value.getMappingKey())
-        .setId(value.getId())
+        .setId(value.getMappingId())
         .setClaimName(value.getClaimName())
         .setClaimValue(value.getClaimValue())
         .setName(value.getName());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingDeletedHandler.java
@@ -41,7 +41,7 @@ public class MappingDeletedHandler implements ExportHandler<MappingEntity, Mappi
 
   @Override
   public List<String> generateIds(final Record<MappingRecordValue> record) {
-    return List.of(String.valueOf(record.getValue().getId()));
+    return List.of(String.valueOf(record.getValue().getMappingId()));
   }
 
   @Override
@@ -54,7 +54,7 @@ public class MappingDeletedHandler implements ExportHandler<MappingEntity, Mappi
     final MappingRecordValue value = record.getValue();
     entity
         .setKey(value.getMappingKey())
-        .setId(value.getId())
+        .setId(value.getMappingId())
         .setClaimName(value.getClaimName())
         .setClaimValue(value.getClaimValue());
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MappingCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MappingCreatedUpdatedHandlerTest.java
@@ -70,7 +70,7 @@ public class MappingCreatedUpdatedHandlerTest {
     final var idList = underTest.generateIds(mappingRecord);
 
     // then
-    assertThat(idList).containsExactly(String.valueOf(mappingRecord.getValue().getId()));
+    assertThat(idList).containsExactly(String.valueOf(mappingRecord.getValue().getMappingId()));
   }
 
   @Test
@@ -92,7 +92,7 @@ public class MappingCreatedUpdatedHandlerTest {
             .withClaimName("updated-claim")
             .withClaimValue("updated-value")
             .withName("updated-name")
-            .withId("updated-id")
+            .withMappingId("updated-id")
             .build();
 
     final Record<MappingRecordValue> mappingRecord =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MappingDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MappingDeletedHandlerTest.java
@@ -57,7 +57,7 @@ public class MappingDeletedHandlerTest {
     final var idList = underTest.generateIds(mappingRecord);
 
     // then
-    assertThat(idList).containsExactly(String.valueOf(mappingRecord.getValue().getId()));
+    assertThat(idList).containsExactly(String.valueOf(mappingRecord.getValue().getMappingId()));
   }
 
   @Test

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MappingExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MappingExportHandler.java
@@ -38,14 +38,14 @@ public class MappingExportHandler implements RdbmsExportHandler<MappingRecordVal
     if (record.getIntent().equals(MappingIntent.CREATED)) {
       mappingWriter.create(map(record));
     } else if (record.getIntent().equals(MappingIntent.DELETED)) {
-      mappingWriter.delete(record.getValue().getId());
+      mappingWriter.delete(record.getValue().getMappingId());
     }
   }
 
   private MappingDbModel map(final Record<MappingRecordValue> record) {
     final var value = record.getValue();
     return new MappingDbModelBuilder()
-        .mappingId(value.getId())
+        .mappingId(value.getMappingId())
         .mappingKey(value.getMappingKey())
         .claimName(value.getClaimName())
         .claimValue(value.getClaimValue())

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5565,6 +5565,9 @@ components:
         name:
           type: string
           description: The name of the mapping.
+        mappingId:
+          type: string
+          description: The id of the mapping.
     CamundaUserResult:
       type: object
       properties:
@@ -5944,6 +5947,9 @@ components:
         name:
           type: string
           description: The name of the mapping.
+        mappingId:
+          type: string
+          description: The id of the mapping.
         mappingKey:
           description: The key of the created mapping rule.
           type: string

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5567,7 +5567,7 @@ components:
           description: The name of the mapping.
         mappingId:
           type: string
-          description: The id of the mapping.
+          description: The ID of the mapping.
     CamundaUserResult:
       type: object
       properties:
@@ -5949,7 +5949,7 @@ components:
           description: The name of the mapping.
         mappingId:
           type: string
-          description: The id of the mapping.
+          description: The ID of the mapping.
         mappingKey:
           description: The key of the created mapping rule.
           type: string

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -565,7 +565,7 @@ public final class ResponseMapper {
             .mappingKey(KeyUtil.keyToString(record.getMappingKey()))
             .claimName(record.getClaimName())
             .claimValue(record.getClaimValue())
-            .id(record.getId())
+            .id(record.getMappingId())
             .name(record.getName());
     return new ResponseEntity<>(response, HttpStatus.CREATED);
   }
@@ -576,7 +576,7 @@ public final class ResponseMapper {
             .mappingKey(KeyUtil.keyToString(record.getMappingKey()))
             .claimName(record.getClaimName())
             .claimValue(record.getClaimValue())
-            .id(record.getId())
+            .id(record.getMappingId())
             .name(record.getName());
     return new ResponseEntity<>(response, HttpStatus.OK);
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -671,6 +671,8 @@ public final class SearchQueryRequestMapper {
     if (filter != null) {
       ofNullable(filter.getClaimName()).ifPresent(builder::claimName);
       ofNullable(filter.getClaimValue()).ifPresent(builder::claimValue);
+      ofNullable(filter.getName()).ifPresent(builder::name);
+      ofNullable(filter.getMappingId()).ifPresent(builder::mappingId);
     }
     return builder.build();
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -407,6 +407,7 @@ public final class SearchQueryResponseMapper {
         .mappingKey(KeyUtil.keyToString(mappingEntity.mappingKey()))
         .claimName(mappingEntity.claimName())
         .claimValue(mappingEntity.claimValue())
+        .mappingId(mappingEntity.mappingId())
         .name(mappingEntity.name());
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
@@ -285,7 +285,7 @@ public class MappingControllerTest extends RestControllerTest {
     // given
     final String mappingId = "id";
 
-    final var mappingRecord = new MappingRecord().setId(mappingId);
+    final var mappingRecord = new MappingRecord().setMappingId(mappingId);
 
     when(mappingServices.deleteMapping(mappingId))
         .thenReturn(CompletableFuture.completedFuture(mappingRecord));
@@ -313,7 +313,7 @@ public class MappingControllerTest extends RestControllerTest {
             .setMappingKey(1L)
             .setClaimName(dto.claimName())
             .setClaimValue(dto.claimValue())
-            .setId(id)
+            .setMappingId(id)
             .setName(dto.name());
 
     when(mappingServices.updateMapping(dto))

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
@@ -52,7 +52,7 @@ public class MappingControllerTest extends RestControllerTest {
             .setMappingKey(1L)
             .setClaimName(dto.claimName())
             .setClaimValue(dto.claimValue())
-            .setId(id)
+            .setMappingId(id)
             .setName(dto.name());
 
     when(mappingServices.createMapping(dto))

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerMappingCreateRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerMappingCreateRequest.java
@@ -38,8 +38,8 @@ public class BrokerMappingCreateRequest extends BrokerExecuteCommand<MappingReco
     return this;
   }
 
-  public BrokerMappingCreateRequest setId(final String id) {
-    requestDto.setId(id);
+  public BrokerMappingCreateRequest setMappingId(final String id) {
+    requestDto.setMappingId(id);
     return this;
   }
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerMappingDeleteRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerMappingDeleteRequest.java
@@ -23,7 +23,7 @@ public class BrokerMappingDeleteRequest extends BrokerExecuteCommand<MappingReco
   }
 
   public BrokerMappingDeleteRequest setId(final String mappingId) {
-    requestDto.setId(mappingId);
+    requestDto.setMappingId(mappingId);
     return this;
   }
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerMappingUpdateRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerMappingUpdateRequest.java
@@ -38,8 +38,8 @@ public class BrokerMappingUpdateRequest extends BrokerExecuteCommand<MappingReco
     return this;
   }
 
-  public BrokerMappingUpdateRequest setId(final String id) {
-    requestDto.setId(id);
+  public BrokerMappingUpdateRequest setMappingId(final String id) {
+    requestDto.setMappingId(id);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/MappingRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/MappingRecord.java
@@ -75,7 +75,7 @@ public class MappingRecord extends UnifiedRecordValue implements MappingRecordVa
     return BufferUtil.bufferAsString(mappingIdProp.getValue());
   }
 
-  public MappingRecord setId(final String id) {
+  public MappingRecord setMappingId(final String id) {
     mappingIdProp.setValue(id);
     return this;
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/MappingRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/MappingRecord.java
@@ -19,7 +19,7 @@ public class MappingRecord extends UnifiedRecordValue implements MappingRecordVa
   private final StringProperty claimNameProp = new StringProperty("claimName", "");
   private final StringProperty claimValueProp = new StringProperty("claimValue", "");
   private final StringProperty nameProp = new StringProperty("name", "");
-  private final StringProperty idProp = new StringProperty("id", "");
+  private final StringProperty mappingIdProp = new StringProperty("mappingId", "");
 
   public MappingRecord() {
     super(5);
@@ -27,7 +27,7 @@ public class MappingRecord extends UnifiedRecordValue implements MappingRecordVa
         .declareProperty(claimNameProp)
         .declareProperty(claimValueProp)
         .declareProperty(nameProp)
-        .declareProperty(idProp);
+        .declareProperty(mappingIdProp);
   }
 
   @Override
@@ -71,12 +71,12 @@ public class MappingRecord extends UnifiedRecordValue implements MappingRecordVa
   }
 
   @Override
-  public String getId() {
-    return BufferUtil.bufferAsString(idProp.getValue());
+  public String getMappingId() {
+    return BufferUtil.bufferAsString(mappingIdProp.getValue());
   }
 
   public MappingRecord setId(final String id) {
-    idProp.setValue(id);
+    mappingIdProp.setValue(id);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -3017,7 +3017,7 @@ final class JsonSerializableToJsonTest {
         "mappingKey": 1,
         "claimName": "claimName",
         "claimValue": "claimValue",
-        "id": "id1",
+        "mappingId": "id1",
         "name": "name"
       }
       """
@@ -3033,7 +3033,7 @@ final class JsonSerializableToJsonTest {
         "mappingKey": -1,
         "claimName": "",
         "claimValue": "",
-        "id": "",
+        "mappingId": "",
         "name": ""
       }
       """
@@ -3121,14 +3121,14 @@ final class JsonSerializableToJsonTest {
         "mappings": [
           {
             "mappingKey": 6,
-            "id": "id1",
+            "mappingId": "id1",
             "claimName": "claim1",
             "claimValue": "value1",
             "name": "Claim 1"
           },
           {
             "mappingKey": 7,
-            "id": "id2",
+            "mappingId": "id2",
             "claimName": "claim2",
             "claimValue": "value2",
             "name": "Claim 2"

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -3010,7 +3010,7 @@ final class JsonSerializableToJsonTest {
                     .setMappingKey(1L)
                     .setClaimName("claimName")
                     .setClaimValue("claimValue")
-                    .setId("id1")
+                    .setMappingId("id1")
                     .setName("name"),
         """
       {
@@ -3073,14 +3073,14 @@ final class JsonSerializableToJsonTest {
                     .addMapping(
                         new MappingRecord()
                             .setMappingKey(6)
-                            .setId("id1")
+                            .setMappingId("id1")
                             .setClaimName("claim1")
                             .setClaimValue("value1")
                             .setName("Claim 1"))
                     .addMapping(
                         new MappingRecord()
                             .setMappingKey(7)
-                            .setId("id2")
+                            .setMappingId("id2")
                             .setClaimName("claim2")
                             .setClaimValue("value2")
                             .setName("Claim 2")),

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MappingRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MappingRecordValue.java
@@ -39,5 +39,5 @@ public interface MappingRecordValue extends RecordValue {
   String getName();
 
   /** The unique identifier of the mapping for external usage. */
-  String getId();
+  String getMappingId();
 }


### PR DESCRIPTION
## Description

The mapping id should be available in Filter and Response of mapping search endpoint.

## Related issues

closes #29761 
