### PR TITLE
[PoC] CPT with H2 

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
@@ -19,6 +19,7 @@ import io.camunda.process.test.impl.runtime.ContainerRuntimeEnvs;
 import io.camunda.process.test.impl.runtime.ContainerRuntimePorts;
 import java.net.URI;
 import java.time.Duration;
+import java.util.UUID;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
@@ -32,7 +33,7 @@ public class CamundaContainer extends GenericContainer<CamundaContainer> {
   private static final String READY_ENDPOINT = "/actuator/health";
 
   private static final String ACTIVE_SPRING_PROFILES =
-      "rdbmsH2"; // "operate,tasklist,broker,consolidated-auth";
+      "broker"; // "operate,tasklist,broker,consolidated-auth";
   private static final String LOG_APPENDER_STACKDRIVER = "Stackdriver";
 
   private static final String GRPC_API = "localhost:" + ContainerRuntimePorts.CAMUNDA_GATEWAY_API;
@@ -59,13 +60,32 @@ public class CamundaContainer extends GenericContainer<CamundaContainer> {
         //        .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_TASKLIST_CSRF_PREVENTION_ENABLED,
         // "false")
         .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_ZEEBE_LOG_APPENDER, LOG_APPENDER_STACKDRIVER)
-        .withEnv("camunda.database.type", "rdbms")
+        .withEnv("ZEEBE_BROKER_GATEWAY_ENABLE", "true")
+        .withEnv("ZEEBE_BROKER_GATEWAY_SECURITY_ENABLED", "false")
+        .withRdbms()
         .addExposedPorts(
             ContainerRuntimePorts.CAMUNDA_GATEWAY_API,
             ContainerRuntimePorts.CAMUNDA_COMMAND_API,
             ContainerRuntimePorts.CAMUNDA_INTERNAL_API,
             ContainerRuntimePorts.CAMUNDA_MONITORING_API,
             ContainerRuntimePorts.CAMUNDA_REST_API);
+  }
+
+  public CamundaContainer withRdbms() {
+      withEnv("CAMUNDA_DATABASE_TYPE", "rdbms")
+        .withEnv("SPRING_DATASOURCE_URL", "jdbc:h2:mem:testdb+" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL")
+        .withEnv("SPRING_DATASOURCE_DRIVER_CLASS_NAME", "org.h2.Driver")
+        .withEnv("SPRING_DATASOURCE_USERNAME", "sa")
+        .withEnv("SPRING_DATASOURCE_PASSWORD", "")
+        .withEnv("ZEEBE_BROKER_EXPORTERS_RDBMS_CLASSNAME", "io.camunda.exporter.rdbms.RdbmsExporter")
+        .withEnv("ZEEBE_BROKER_EXPORTERS_RDBMS_ARGS_FLUSH_INTERVAL", "PT0S")
+        .withEnv("ZEEBE_BROKER_EXPORTERS_RDBMS_ARGS_DEFAULT_HISTORY_TTL", "PT2S")
+        .withEnv("ZEEBE_BROKER_EXPORTERS_RDBMS_ARGS_MIN_HISTORY_CLEANUP_INTERVAL", "PT2S")
+        .withEnv("ZEEBE_BROKER_EXPORTERS_RDBMS_ARGS_MAX_HISTORY_CLEANUP_INTERVAL", "PT5S")
+        .withEnv("LOGGING_LEVEL_IO_CAMUNDA_DB_RDBMS", "DEBUG")
+        .withEnv("LOGGING_LEVEL_ORG_MYBATIS", "DEBUG");
+
+    return this;
   }
 
   public CamundaContainer withElasticsearchUrl(final String url) {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
@@ -37,9 +37,6 @@ public class CamundaContainer extends GenericContainer<CamundaContainer> {
       "broker"; // "operate,tasklist,broker,consolidated-auth";
   private static final String LOG_APPENDER_STACKDRIVER = "Stackdriver";
 
-  private static final String GRPC_API = "localhost:" + ContainerRuntimePorts.CAMUNDA_GATEWAY_API;
-  private static final String REST_API = "localhost:" + ContainerRuntimePorts.CAMUNDA_REST_API;
-
   private static final String CAMUNDA_EXPORTER_CLASSNAME = "io.camunda.exporter.CamundaExporter";
   private static final String CAMUNDA_EXPORTER_BULK_SIZE = "1";
 
@@ -53,13 +50,6 @@ public class CamundaContainer extends GenericContainer<CamundaContainer> {
         .waitingFor(newDefaultWaitStrategy())
         .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_SPRING_PROFILES_ACTIVE, ACTIVE_SPRING_PROFILES)
         .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_ZEEBE_CLOCK_CONTROLLED, "true")
-        //        .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_OPERATE_ZEEBE_GATEWAYADDRESS, GRPC_API)
-        //        .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_OPERATE_CSRF_PREVENTION_ENABLED,
-        // "false")
-        //        .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_TASKLIST_ZEEBE_GATEWAYADDRESS, GRPC_API)
-        //        .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_TASKLIST_ZEEBE_RESTADDRESS, REST_API)
-        //        .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_TASKLIST_CSRF_PREVENTION_ENABLED,
-        // "false")
         .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_ZEEBE_LOG_APPENDER, LOG_APPENDER_STACKDRIVER)
         .withEnv("ZEEBE_BROKER_GATEWAY_ENABLE", "true")
         .withEnv("ZEEBE_BROKER_GATEWAY_SECURITY_ENABLED", "false")

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
@@ -21,7 +21,6 @@ import java.net.URI;
 import java.time.Duration;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy.Mode;
@@ -30,9 +29,10 @@ import org.testcontainers.utility.DockerImageName;
 public class CamundaContainer extends GenericContainer<CamundaContainer> {
 
   private static final Duration DEFAULT_STARTUP_TIMEOUT = Duration.ofMinutes(1);
-  private static final String READY_ENDPOINT = "/ready";
+  private static final String READY_ENDPOINT = "/actuator/health";
 
-  private static final String ACTIVE_SPRING_PROFILES = "operate,tasklist,broker,consolidated-auth";
+  private static final String ACTIVE_SPRING_PROFILES =
+      "rdbmsH2"; // "operate,tasklist,broker,consolidated-auth";
   private static final String LOG_APPENDER_STACKDRIVER = "Stackdriver";
 
   private static final String GRPC_API = "localhost:" + ContainerRuntimePorts.CAMUNDA_GATEWAY_API;
@@ -51,12 +51,15 @@ public class CamundaContainer extends GenericContainer<CamundaContainer> {
         .waitingFor(newDefaultWaitStrategy())
         .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_SPRING_PROFILES_ACTIVE, ACTIVE_SPRING_PROFILES)
         .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_ZEEBE_CLOCK_CONTROLLED, "true")
-        .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_OPERATE_ZEEBE_GATEWAYADDRESS, GRPC_API)
-        .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_OPERATE_CSRF_PREVENTION_ENABLED, "false")
-        .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_TASKLIST_ZEEBE_GATEWAYADDRESS, GRPC_API)
-        .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_TASKLIST_ZEEBE_RESTADDRESS, REST_API)
-        .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_TASKLIST_CSRF_PREVENTION_ENABLED, "false")
+        //        .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_OPERATE_ZEEBE_GATEWAYADDRESS, GRPC_API)
+        //        .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_OPERATE_CSRF_PREVENTION_ENABLED,
+        // "false")
+        //        .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_TASKLIST_ZEEBE_GATEWAYADDRESS, GRPC_API)
+        //        .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_TASKLIST_ZEEBE_RESTADDRESS, REST_API)
+        //        .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_TASKLIST_CSRF_PREVENTION_ENABLED,
+        // "false")
         .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_ZEEBE_LOG_APPENDER, LOG_APPENDER_STACKDRIVER)
+        .withEnv("camunda.database.type", "rdbms")
         .addExposedPorts(
             ContainerRuntimePorts.CAMUNDA_GATEWAY_API,
             ContainerRuntimePorts.CAMUNDA_COMMAND_API,
@@ -93,7 +96,7 @@ public class CamundaContainer extends GenericContainer<CamundaContainer> {
 
   private WaitAllStrategy newDefaultWaitStrategy() {
     return new WaitAllStrategy(Mode.WITH_OUTER_TIMEOUT)
-        .withStrategy(new HostPortWaitStrategy())
+        //        .withStrategy(new HostPortWaitStrategy())
         .withStrategy(newDefaultBrokerReadyCheck())
         .withStartupTimeout(DEFAULT_STARTUP_TIMEOUT);
   }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
@@ -33,8 +33,7 @@ public class CamundaContainer extends GenericContainer<CamundaContainer> {
   private static final Duration DEFAULT_STARTUP_TIMEOUT = Duration.ofMinutes(1);
   private static final String READY_ENDPOINT = "/ready";
 
-  private static final String ACTIVE_SPRING_PROFILES =
-      "broker"; // "operate,tasklist,broker,consolidated-auth";
+  private static final String ACTIVE_SPRING_PROFILES = "broker,consolidated-auth";
   private static final String LOG_APPENDER_STACKDRIVER = "Stackdriver";
 
   private static final String CAMUNDA_EXPORTER_CLASSNAME = "io.camunda.exporter.CamundaExporter";
@@ -51,8 +50,6 @@ public class CamundaContainer extends GenericContainer<CamundaContainer> {
         .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_SPRING_PROFILES_ACTIVE, ACTIVE_SPRING_PROFILES)
         .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_ZEEBE_CLOCK_CONTROLLED, "true")
         .withEnv(ContainerRuntimeEnvs.CAMUNDA_ENV_ZEEBE_LOG_APPENDER, LOG_APPENDER_STACKDRIVER)
-        .withEnv("ZEEBE_BROKER_GATEWAY_ENABLE", "true")
-        .withEnv("ZEEBE_BROKER_GATEWAY_SECURITY_ENABLED", "false")
         .withRdbms()
         .addExposedPorts(
             ContainerRuntimePorts.CAMUNDA_GATEWAY_API,

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
@@ -31,7 +31,7 @@ import org.testcontainers.utility.DockerImageName;
 public class CamundaContainer extends GenericContainer<CamundaContainer> {
 
   private static final Duration DEFAULT_STARTUP_TIMEOUT = Duration.ofMinutes(1);
-  private static final String READY_ENDPOINT = "/ready";
+  private static final String READY_ENDPOINT = "/actuator/health";
 
   private static final String ACTIVE_SPRING_PROFILES = "broker,consolidated-auth";
   private static final String LOG_APPENDER_STACKDRIVER = "Stackdriver";

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import java.util.UUID;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
 import org.testcontainers.containers.wait.strategy.WaitAllStrategy.Mode;
@@ -30,7 +31,7 @@ import org.testcontainers.utility.DockerImageName;
 public class CamundaContainer extends GenericContainer<CamundaContainer> {
 
   private static final Duration DEFAULT_STARTUP_TIMEOUT = Duration.ofMinutes(1);
-  private static final String READY_ENDPOINT = "/actuator/health";
+  private static final String READY_ENDPOINT = "/ready";
 
   private static final String ACTIVE_SPRING_PROFILES =
       "broker"; // "operate,tasklist,broker,consolidated-auth";
@@ -72,12 +73,15 @@ public class CamundaContainer extends GenericContainer<CamundaContainer> {
   }
 
   public CamundaContainer withRdbms() {
-      withEnv("CAMUNDA_DATABASE_TYPE", "rdbms")
-        .withEnv("SPRING_DATASOURCE_URL", "jdbc:h2:mem:testdb+" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL")
+    withEnv("CAMUNDA_DATABASE_TYPE", "rdbms")
+        .withEnv(
+            "SPRING_DATASOURCE_URL",
+            "jdbc:h2:mem:testdb+" + UUID.randomUUID() + ";DB_CLOSE_DELAY=-1;MODE=PostgreSQL")
         .withEnv("SPRING_DATASOURCE_DRIVER_CLASS_NAME", "org.h2.Driver")
         .withEnv("SPRING_DATASOURCE_USERNAME", "sa")
         .withEnv("SPRING_DATASOURCE_PASSWORD", "")
-        .withEnv("ZEEBE_BROKER_EXPORTERS_RDBMS_CLASSNAME", "io.camunda.exporter.rdbms.RdbmsExporter")
+        .withEnv(
+            "ZEEBE_BROKER_EXPORTERS_RDBMS_CLASSNAME", "io.camunda.exporter.rdbms.RdbmsExporter")
         .withEnv("ZEEBE_BROKER_EXPORTERS_RDBMS_ARGS_FLUSH_INTERVAL", "PT0S")
         .withEnv("ZEEBE_BROKER_EXPORTERS_RDBMS_ARGS_DEFAULT_HISTORY_TTL", "PT2S")
         .withEnv("ZEEBE_BROKER_EXPORTERS_RDBMS_ARGS_MIN_HISTORY_CLEANUP_INTERVAL", "PT2S")
@@ -116,7 +120,7 @@ public class CamundaContainer extends GenericContainer<CamundaContainer> {
 
   private WaitAllStrategy newDefaultWaitStrategy() {
     return new WaitAllStrategy(Mode.WITH_OUTER_TIMEOUT)
-        //        .withStrategy(new HostPortWaitStrategy())
+        .withStrategy(new HostPortWaitStrategy())
         .withStrategy(newDefaultBrokerReadyCheck())
         .withStartupTimeout(DEFAULT_STARTUP_TIMEOUT);
   }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/ConnectorsContainer.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/ConnectorsContainer.java
@@ -49,15 +49,15 @@ public class ConnectorsContainer extends GenericContainer<ConnectorsContainer> {
   }
 
   public ConnectorsContainer withZeebeGrpcApi(final String zeebeGrpcApi) {
-    withEnv(ContainerRuntimeEnvs.CONNECTORS_ENV_ZEEBE_CLIENT_BROKER_GATEWAY_ADDRESS, zeebeGrpcApi);
-    withEnv(ContainerRuntimeEnvs.CONNECTORS_ENV_ZEEBE_CLIENT_SECURITY_PLAINTEXT, "true");
+    withEnv("CAMUNDA_CLIENT_GRPC-ADDRESS", zeebeGrpcApi);
     return this;
   }
 
   public ConnectorsContainer withOperateApi(final String operateRestApi) {
-    withEnv(ContainerRuntimeEnvs.CONNECTORS_ENV_CAMUNDA_OPERATE_CLIENT_URL, operateRestApi);
-    withEnv(ContainerRuntimeEnvs.CONNECTORS_ENV_CAMUNDA_OPERATE_CLIENT_USERNAME, "demo");
-    withEnv(ContainerRuntimeEnvs.CONNECTORS_ENV_CAMUNDA_OPERATE_CLIENT_PASSWORD, "demo");
+    withEnv("CAMUNDA_CLIENT_REST-ADDRESS", operateRestApi);
+    withEnv("CAMUNDA_CLIENT_MODE", "self-managed");
+    withEnv("CAMUNDA_CLIENT_AUTH_USERNAME", "demo");
+    withEnv("CAMUNDA_CLIENT_AUTH_PASSWORD", "demo");
     return this;
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaContainerRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaContainerRuntime.java
@@ -39,11 +39,11 @@ public class CamundaContainerRuntime implements AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(CamundaContainerRuntime.class);
 
   private static final String NETWORK_ALIAS_CAMUNDA = "camunda";
-  private static final String NETWORK_ALIAS_ELASTICSEARCH = "elasticsearch";
+  //private static final String NETWORK_ALIAS_ELASTICSEARCH = "elasticsearch";
   private static final String NETWORK_ALIAS_CONNECTORS = "connectors";
 
-  private static final String ELASTICSEARCH_URL =
-      "http://" + NETWORK_ALIAS_ELASTICSEARCH + ":" + ContainerRuntimePorts.ELASTICSEARCH_REST_API;
+  //private static final String ELASTICSEARCH_URL =
+  //    "http://" + NETWORK_ALIAS_ELASTICSEARCH + ":" + ContainerRuntimePorts.ELASTICSEARCH_REST_API;
 
   private static final String CAMUNDA_GRPC_API =
       NETWORK_ALIAS_CAMUNDA + ":" + ContainerRuntimePorts.CAMUNDA_GATEWAY_API;
@@ -54,7 +54,7 @@ public class CamundaContainerRuntime implements AutoCloseable {
 
   private final Network network;
   private final CamundaContainer camundaContainer;
-  private final ElasticsearchContainer elasticsearchContainer;
+  //private final ElasticsearchContainer elasticsearchContainer;
   private final ConnectorsContainer connectorsContainer;
 
   private final boolean connectorsEnabled;
@@ -65,12 +65,12 @@ public class CamundaContainerRuntime implements AutoCloseable {
     connectorsEnabled = builder.isConnectorsEnabled();
     network = Network.newNetwork();
 
-    elasticsearchContainer = createElasticsearchContainer(network, builder);
+    //elasticsearchContainer = createElasticsearchContainer(network, builder);
     camundaContainer = createCamundaContainer(network, builder);
     connectorsContainer = createConnectorsContainer(network, builder);
   }
 
-  private ElasticsearchContainer createElasticsearchContainer(
+  /** private ElasticsearchContainer createElasticsearchContainer(
       final Network network, final CamundaContainerRuntimeBuilder builder) {
     final ElasticsearchContainer container =
         containerFactory
@@ -86,7 +86,7 @@ public class CamundaContainerRuntime implements AutoCloseable {
     builder.getElasticsearchExposedPorts().forEach(container::addExposedPort);
 
     return container;
-  }
+  } **/
 
   private CamundaContainer createCamundaContainer(
       final Network network, final CamundaContainerRuntimeBuilder builder) {
@@ -155,7 +155,7 @@ public class CamundaContainerRuntime implements AutoCloseable {
   }
 
   public ElasticsearchContainer getElasticsearchContainer() {
-    return elasticsearchContainer;
+    return null;
   }
 
   public ConnectorsContainer getConnectorsContainer() {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaContainerRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaContainerRuntime.java
@@ -46,7 +46,7 @@ public class CamundaContainerRuntime implements AutoCloseable {
       "http://" + NETWORK_ALIAS_ELASTICSEARCH + ":" + ContainerRuntimePorts.ELASTICSEARCH_REST_API;
 
   private static final String CAMUNDA_GRPC_API =
-      NETWORK_ALIAS_CAMUNDA + ":" + ContainerRuntimePorts.CAMUNDA_GATEWAY_API;
+      "http://" + NETWORK_ALIAS_CAMUNDA + ":" + ContainerRuntimePorts.CAMUNDA_GATEWAY_API;
   private static final String CAMUNDA_REST_API =
       "http://" + NETWORK_ALIAS_CAMUNDA + ":" + ContainerRuntimePorts.CAMUNDA_REST_API;
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaContainerRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaContainerRuntime.java
@@ -98,8 +98,9 @@ public class CamundaContainerRuntime implements AutoCloseable {
                 createContainerJsonLogger(builder.getCamundaLoggerName(), CamundaLogEntry.class))
             .withNetwork(network)
             .withNetworkAliases(NETWORK_ALIAS_CAMUNDA)
-            .withElasticsearchUrl(ELASTICSEARCH_URL)
-            .withEnv(builder.getCamundaEnvVars());
+        // .withElasticsearchUrl(ELASTICSEARCH_URL)
+        // .withEnv(builder.getCamundaEnvVars())
+        ;
 
     builder.getCamundaExposedPorts().forEach(container::addExposedPort);
 
@@ -129,7 +130,7 @@ public class CamundaContainerRuntime implements AutoCloseable {
 
   public void start() {
     final List<GenericContainer<?>> containers = new ArrayList<>();
-    containers.add(elasticsearchContainer);
+    //    containers.add(elasticsearchContainer);
     containers.add(camundaContainer);
     if (connectorsEnabled) {
       containers.add(connectorsContainer);
@@ -171,7 +172,7 @@ public class CamundaContainerRuntime implements AutoCloseable {
     }
 
     camundaContainer.stop();
-    elasticsearchContainer.stop();
+    //    elasticsearchContainer.stop();
     network.close();
 
     final Instant endTime = Instant.now();

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaContainerRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaContainerRuntime.java
@@ -39,11 +39,11 @@ public class CamundaContainerRuntime implements AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(CamundaContainerRuntime.class);
 
   private static final String NETWORK_ALIAS_CAMUNDA = "camunda";
-  //private static final String NETWORK_ALIAS_ELASTICSEARCH = "elasticsearch";
+  private static final String NETWORK_ALIAS_ELASTICSEARCH = "elasticsearch";
   private static final String NETWORK_ALIAS_CONNECTORS = "connectors";
 
-  //private static final String ELASTICSEARCH_URL =
-  //    "http://" + NETWORK_ALIAS_ELASTICSEARCH + ":" + ContainerRuntimePorts.ELASTICSEARCH_REST_API;
+  private static final String ELASTICSEARCH_URL =
+      "http://" + NETWORK_ALIAS_ELASTICSEARCH + ":" + ContainerRuntimePorts.ELASTICSEARCH_REST_API;
 
   private static final String CAMUNDA_GRPC_API =
       NETWORK_ALIAS_CAMUNDA + ":" + ContainerRuntimePorts.CAMUNDA_GATEWAY_API;
@@ -54,7 +54,7 @@ public class CamundaContainerRuntime implements AutoCloseable {
 
   private final Network network;
   private final CamundaContainer camundaContainer;
-  //private final ElasticsearchContainer elasticsearchContainer;
+  private final ElasticsearchContainer elasticsearchContainer;
   private final ConnectorsContainer connectorsContainer;
 
   private final boolean connectorsEnabled;
@@ -65,12 +65,12 @@ public class CamundaContainerRuntime implements AutoCloseable {
     connectorsEnabled = builder.isConnectorsEnabled();
     network = Network.newNetwork();
 
-    //elasticsearchContainer = createElasticsearchContainer(network, builder);
+    elasticsearchContainer = createElasticsearchContainer(network, builder);
     camundaContainer = createCamundaContainer(network, builder);
     connectorsContainer = createConnectorsContainer(network, builder);
   }
 
-  /** private ElasticsearchContainer createElasticsearchContainer(
+  private ElasticsearchContainer createElasticsearchContainer(
       final Network network, final CamundaContainerRuntimeBuilder builder) {
     final ElasticsearchContainer container =
         containerFactory
@@ -86,7 +86,7 @@ public class CamundaContainerRuntime implements AutoCloseable {
     builder.getElasticsearchExposedPorts().forEach(container::addExposedPort);
 
     return container;
-  } **/
+  }
 
   private CamundaContainer createCamundaContainer(
       final Network network, final CamundaContainerRuntimeBuilder builder) {
@@ -98,9 +98,8 @@ public class CamundaContainerRuntime implements AutoCloseable {
                 createContainerJsonLogger(builder.getCamundaLoggerName(), CamundaLogEntry.class))
             .withNetwork(network)
             .withNetworkAliases(NETWORK_ALIAS_CAMUNDA)
-        // .withElasticsearchUrl(ELASTICSEARCH_URL)
-        // .withEnv(builder.getCamundaEnvVars())
-        ;
+            // .withElasticsearchUrl(ELASTICSEARCH_URL)
+            .withEnv(builder.getCamundaEnvVars());
 
     builder.getCamundaExposedPorts().forEach(container::addExposedPort);
 

--- a/testing/camunda-process-test-java/src/test/resources/log4j2-test.xml
+++ b/testing/camunda-process-test-java/src/test/resources/log4j2-test.xml
@@ -17,7 +17,7 @@
 
     <!-- Hide default logging from Testcontainers -->
     <Logger name="org.testcontainers" level="warn"/>
-    <Logger name="tc" level="info"/>
+    <Logger name="tc" level="error"/>
 
 
   </Loggers>

--- a/testing/camunda-process-test-java/src/test/resources/log4j2-test.xml
+++ b/testing/camunda-process-test-java/src/test/resources/log4j2-test.xml
@@ -17,7 +17,8 @@
 
     <!-- Hide default logging from Testcontainers -->
     <Logger name="org.testcontainers" level="warn"/>
-    <Logger name="tc" level="error"/>
+    <Logger name="tc" level="info"/>
+
 
   </Loggers>
 


### PR DESCRIPTION
## Description

> [!IMPORTANT]
> Do not merge! This PR is just a prototype to validate the solution design. 

Replace Elasticsearch for CPT with H2. Goal: reduce startup time.  

## Results
- We can run all tests with H2
- The runtime starts in ~ 10 seconds (before: 30 seconds) 

## Related issues

related to https://github.com/camunda/camunda/issues/27719
