### PR TITLE
fix: made JWT typ header property optional [Backport stable/operate-8.5]

### DIFF
--- a/operate/qa/integration-tests/pom.xml
+++ b/operate/qa/integration-tests/pom.xml
@@ -285,6 +285,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.github.docker-java</groupId>
       <artifactId>docker-java-api</artifactId>
       <scope>test</scope>

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/SecurityTestUtil.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/SecurityTestUtil.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH
+ *
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
+ * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
+ *
+ * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
+ * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
+ * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
+ * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
+ *
+ * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
+ *
+ * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
+ */
+package io.camunda.operate.webapp.security;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import java.util.Date;
+
+public class SecurityTestUtil {
+
+  public static RSAKey getRsaJWK(final JWSAlgorithm alg) throws JOSEException {
+    return new RSAKeyGenerator(2048)
+        .keyID("123")
+        .keyUse(KeyUse.SIGNATURE)
+        .algorithm(alg)
+        .generate();
+  }
+
+  public static ECKey getEcJWK(final JWSAlgorithm alg, final Curve curve) throws JOSEException {
+    return new ECKeyGenerator(curve)
+        .algorithm(alg)
+        .keyUse(KeyUse.SIGNATURE)
+        .keyID("345")
+        .generate();
+  }
+
+  public static String signAndSerialize(
+      final RSAKey rsaKey,
+      final JWSAlgorithm alg,
+      final JWTClaimsSet claimsSet,
+      final JOSEObjectType type)
+      throws JOSEException {
+    // Create RSA-signer with the private key
+    final JWSSigner rsaSigner = new RSASSASigner(rsaKey);
+
+    final SignedJWT rsaSignedJWT =
+        new SignedJWT(
+            new JWSHeader.Builder(alg).type(type).keyID(rsaKey.getKeyID()).build(), claimsSet);
+
+    rsaSignedJWT.sign(rsaSigner);
+    final String serializedJwt = rsaSignedJWT.serialize();
+    System.out.println("JWT serialized=" + serializedJwt);
+    return serializedJwt;
+  }
+
+  public static String signAndSerialize(
+      final RSAKey rsaKey, final JWSAlgorithm alg, final JWTClaimsSet claimsSet)
+      throws JOSEException {
+    return signAndSerialize(rsaKey, alg, claimsSet, JOSEObjectType.JWT);
+  }
+
+  public static String signAndSerialize(final RSAKey rsaKey, final JWSAlgorithm alg)
+      throws JOSEException {
+    return signAndSerialize(rsaKey, alg, getDefaultClaimsSet());
+  }
+
+  public static String signAndSerialize(
+      final RSAKey rsaKey, final JWSAlgorithm alg, final JOSEObjectType type) throws JOSEException {
+    return signAndSerialize(rsaKey, alg, getDefaultClaimsSet(), type);
+  }
+
+  public static String signAndSerialize(
+      final ECKey ecKey, final JWSAlgorithm alg, final JOSEObjectType type) throws JOSEException {
+    // Create EC-signer with the private key
+    final ECDSASigner ecSigner = new ECDSASigner(ecKey);
+
+    final SignedJWT ecSignedJWT =
+        new SignedJWT(
+            new JWSHeader.Builder(alg).type(type).keyID(ecKey.getKeyID()).build(),
+            getDefaultClaimsSet());
+
+    ecSignedJWT.sign(ecSigner);
+    final String ecSerializedJwt = ecSignedJWT.serialize();
+    System.out.println("JWT serialized=" + ecSerializedJwt);
+    return ecSerializedJwt;
+  }
+
+  public static String signAndSerialize(final ECKey ecKey, final JWSAlgorithm alg)
+      throws JOSEException {
+    return signAndSerialize(ecKey, alg, JOSEObjectType.JWT);
+  }
+
+  public static JWTClaimsSet getDefaultClaimsSet() {
+    // prepare default JWT claims set
+    return new JWTClaimsSet.Builder()
+        .subject("alice")
+        .issuer("http://localhost")
+        .expirationTime(new Date(new Date().getTime() + 60 * 1000))
+        .build();
+  }
+}

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/oauth2/JwtDecoderIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/oauth2/JwtDecoderIT.java
@@ -18,6 +18,7 @@ package io.camunda.operate.webapp.security.oauth2;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
@@ -83,7 +84,7 @@ public class JwtDecoderIT {
     final String withoutAlg = publicKey.replaceFirst("\"alg\":\".*\",", "");
     final String authServerResponseBody = "{\"keys\":[" + withoutAlg + "]}";
     System.out.println("authServerResponse=" + authServerResponseBody);
-    assertFalse(authServerResponseBody.contains("alg:"));
+    assertFalse(authServerResponseBody.contains("alg\":"));
 
     wireMockInfo
         .getWireMock()
@@ -108,7 +109,7 @@ public class JwtDecoderIT {
     final String withoutAlg = publicKey.replaceFirst(",\"alg\":\".*\"", "");
     final String authServerResponseBody = "{\"keys\":[" + withoutAlg + "]}";
     System.out.println("authServerResponse=" + authServerResponseBody);
-    assertFalse(authServerResponseBody.contains("alg:"));
+    assertFalse(authServerResponseBody.contains("alg\":"));
 
     wireMockInfo
         .getWireMock()
@@ -130,7 +131,7 @@ public class JwtDecoderIT {
 
     final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
     System.out.println("authServerResponse=" + authServerResponseBody);
-    assertFalse(authServerResponseBody.contains("alg:"));
+    assertTrue(authServerResponseBody.contains("alg\":"));
 
     wireMockInfo
         .getWireMock()
@@ -152,7 +153,6 @@ public class JwtDecoderIT {
 
     final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
     System.out.println("authServerResponse=" + authServerResponseBody);
-    assertFalse(authServerResponseBody.contains("alg:"));
 
     wireMockInfo
         .getWireMock()
@@ -175,7 +175,6 @@ public class JwtDecoderIT {
 
     final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
     System.out.println("authServerResponse=" + authServerResponseBody);
-    assertFalse(authServerResponseBody.contains("alg:"));
 
     wireMockInfo
         .getWireMock()
@@ -198,7 +197,6 @@ public class JwtDecoderIT {
 
     final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
     System.out.println("authServerResponse=" + authServerResponseBody);
-    assertFalse(authServerResponseBody.contains("alg:"));
 
     wireMockInfo
         .getWireMock()

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/oauth2/JwtDecoderIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/oauth2/JwtDecoderIT.java
@@ -16,9 +16,10 @@
  */
 package io.camunda.operate.webapp.security.oauth2;
 
+import static io.camunda.operate.webapp.security.SecurityTestUtil.signAndSerialize;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
@@ -27,22 +28,20 @@ import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JOSEObjectType;
 import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.JWSHeader;
-import com.nimbusds.jose.JWSSigner;
-import com.nimbusds.jose.crypto.ECDSASigner;
-import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.JWSAlgorithm.Family;
+import com.nimbusds.jose.jwk.AsymmetricJWK;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
-import com.nimbusds.jwt.JWTClaimsSet;
-import com.nimbusds.jwt.SignedJWT;
 import io.camunda.identity.sdk.IdentityConfiguration;
-import java.util.Date;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.env.MockEnvironment;
@@ -73,15 +72,16 @@ public class JwtDecoderIT {
     decoder = ReflectionTestUtils.invokeMethod(identityOAuth2WebConfigurer, "jwtDecoder");
   }
 
-  @Test
-  public void testDecodeRs256JwtWithNoAlgFieldInJwkResponse() throws JOSEException {
+  @ParameterizedTest
+  @MethodSource("basicAlgTestParameters")
+  public void testDecodeJwtWithNoAlgFieldInJwkResponse(
+      final JWSAlgorithm algorithm, final Curve curve) throws JOSEException {
     // given
-    final RSAKey rsaJWK = getRsaJWK(JWSAlgorithm.RS256);
-    final String serializedJwt = signAndSerialize(rsaJWK, JWSAlgorithm.RS256);
-    final String publicKey = rsaJWK.toPublicJWK().toJSONString();
+    final JwtKeys jwtKeys = new JwtKeys(algorithm, curve);
+    System.out.println("publicKey=" + jwtKeys.publicKey);
 
     // remove alg field from mocked server response and assert it was removed to cover this use case
-    final String withoutAlg = publicKey.replaceFirst("\"alg\":\".*\",", "");
+    final String withoutAlg = jwtKeys.publicKey.replaceFirst(",\"alg\":\"[^\"]*\"", "");
     final String authServerResponseBody = "{\"keys\":[" + withoutAlg + "]}";
     System.out.println("authServerResponse=" + authServerResponseBody);
     assertFalse(authServerResponseBody.contains("alg\":"));
@@ -93,65 +93,18 @@ public class JwtDecoderIT {
                 .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
 
     // when - then
-    assertDoesNotThrow(() -> decoder.decode(serializedJwt));
+    assertDoesNotThrow(() -> decoder.decode(jwtKeys.serializedJwt));
     wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
   }
 
-  @Test
-  public void testDecodeES256JwtWithNoAlgFieldInJwkResponse() throws JOSEException {
+  @ParameterizedTest
+  @MethodSource("basicAlgTestParameters")
+  public void testDecodeJwtsWithNoTypeHeader(final JWSAlgorithm algorithm, final Curve curve)
+      throws JOSEException {
     // given
-    final ECKey ecJWK = getEcJWK(JWSAlgorithm.ES256, Curve.P_256);
-    final String ecSerializedJwt = signAndSerialize(ecJWK, JWSAlgorithm.ES256);
-    final String publicKey = ecJWK.toPublicJWK().toJSONString();
-    System.out.println("publicKey=" + publicKey);
-
-    // remove alg field from mocked server response and assert it was removed to cover this use case
-    final String withoutAlg = publicKey.replaceFirst(",\"alg\":\".*\"", "");
-    final String authServerResponseBody = "{\"keys\":[" + withoutAlg + "]}";
-    System.out.println("authServerResponse=" + authServerResponseBody);
-    assertFalse(authServerResponseBody.contains("alg\":"));
-
-    wireMockInfo
-        .getWireMock()
-        .register(
-            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
-                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
-
-    // when - then
-    assertDoesNotThrow(() -> decoder.decode(ecSerializedJwt));
-    wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
-  }
-
-  @Test
-  public void testDecodeRS384Jwt() throws JOSEException {
-    // given
-    final RSAKey rsaJWK = getRsaJWK(JWSAlgorithm.RS384);
-    final String serializedJwt = signAndSerialize(rsaJWK, JWSAlgorithm.RS384);
-    final String publicKey = rsaJWK.toPublicJWK().toJSONString();
-
-    final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
-    System.out.println("authServerResponse=" + authServerResponseBody);
-    assertTrue(authServerResponseBody.contains("alg\":"));
-
-    wireMockInfo
-        .getWireMock()
-        .register(
-            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
-                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
-
-    // when - then
-    assertDoesNotThrow(() -> decoder.decode(serializedJwt));
-    wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
-  }
-
-  @Test
-  public void testDecodeRS512Jwt() throws JOSEException {
-    // given
-    final RSAKey rsaJWK = getRsaJWK(JWSAlgorithm.RS512);
-    final String serializedJwt = signAndSerialize(rsaJWK, JWSAlgorithm.RS512);
-    final String publicKey = rsaJWK.toPublicJWK().toJSONString();
-
-    final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
+    final JwtKeys jwtKeys = new JwtKeys(algorithm, curve, null);
+    System.out.println("publicKey=" + jwtKeys.publicKey);
+    final String authServerResponseBody = "{\"keys\":[" + jwtKeys.publicKey + "]}";
     System.out.println("authServerResponse=" + authServerResponseBody);
 
     wireMockInfo
@@ -161,19 +114,18 @@ public class JwtDecoderIT {
                 .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
 
     // when - then
-    assertDoesNotThrow(() -> decoder.decode(serializedJwt));
+    assertDoesNotThrow(() -> decoder.decode(jwtKeys.serializedJwt));
     wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
   }
 
-  @Test
-  public void testDecodeES384Jwt() throws JOSEException {
+  @ParameterizedTest
+  @MethodSource("jwtTestParameters")
+  public void testDecodeJwtWithVariousAlgorithms(final JWSAlgorithm algorithm, final Curve curve)
+      throws JOSEException {
     // given
-    final ECKey ecJWK = getEcJWK(JWSAlgorithm.ES384, Curve.P_384);
-    final String ecSerializedJwt = signAndSerialize(ecJWK, JWSAlgorithm.ES384);
-    final String publicKey = ecJWK.toPublicJWK().toJSONString();
-    System.out.println("publicKey=" + publicKey);
-
-    final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
+    final JwtKeys jwtKeys = new JwtKeys(algorithm, curve);
+    System.out.println("publicKey=" + jwtKeys.publicKey);
+    final String authServerResponseBody = "{\"keys\":[" + jwtKeys.publicKey + "]}";
     System.out.println("authServerResponse=" + authServerResponseBody);
 
     wireMockInfo
@@ -183,33 +135,26 @@ public class JwtDecoderIT {
                 .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
 
     // when - then
-    assertDoesNotThrow(() -> decoder.decode(ecSerializedJwt));
+    assertDoesNotThrow(() -> decoder.decode(jwtKeys.serializedJwt));
     wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
   }
 
-  @Test
-  public void testDecodeES512Jwt() throws JOSEException {
-    // given
-    final ECKey ecJWK = getEcJWK(JWSAlgorithm.ES512, Curve.P_521);
-    final String ecSerializedJwt = signAndSerialize(ecJWK, JWSAlgorithm.ES512);
-    final String publicKey = ecJWK.toPublicJWK().toJSONString();
-    System.out.println("publicKey=" + publicKey);
-
-    final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
-    System.out.println("authServerResponse=" + authServerResponseBody);
-
-    wireMockInfo
-        .getWireMock()
-        .register(
-            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
-                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
-
-    // when - then
-    assertDoesNotThrow(() -> decoder.decode(ecSerializedJwt));
-    wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+  private static Stream<Arguments> jwtTestParameters() {
+    return Stream.of(
+        Arguments.of(JWSAlgorithm.RS256, null),
+        Arguments.of(JWSAlgorithm.RS384, null),
+        Arguments.of(JWSAlgorithm.RS512, null),
+        Arguments.of(JWSAlgorithm.ES256, Curve.P_256),
+        Arguments.of(JWSAlgorithm.ES384, Curve.P_384),
+        Arguments.of(JWSAlgorithm.ES512, Curve.P_521));
   }
 
-  private RSAKey getRsaJWK(final JWSAlgorithm alg) throws JOSEException {
+  private static Stream<Arguments> basicAlgTestParameters() {
+    return Stream.of(
+        Arguments.of(JWSAlgorithm.RS256, null), Arguments.of(JWSAlgorithm.ES256, Curve.P_256));
+  }
+
+  private static RSAKey getRsaJWK(final JWSAlgorithm alg) throws JOSEException {
     return new RSAKeyGenerator(2048)
         .keyID("123")
         .keyUse(KeyUse.SIGNATURE)
@@ -217,7 +162,7 @@ public class JwtDecoderIT {
         .generate();
   }
 
-  private ECKey getEcJWK(final JWSAlgorithm alg, final Curve curve) throws JOSEException {
+  private static ECKey getEcJWK(final JWSAlgorithm alg, final Curve curve) throws JOSEException {
     return new ECKeyGenerator(curve)
         .algorithm(alg)
         .keyUse(KeyUse.SIGNATURE)
@@ -225,43 +170,29 @@ public class JwtDecoderIT {
         .generate();
   }
 
-  private String signAndSerialize(final RSAKey rsaKey, final JWSAlgorithm alg)
-      throws JOSEException {
-    // Create RSA-signer with the private key
-    final JWSSigner rsaSigner = new RSASSASigner(rsaKey);
+  private static class JwtKeys {
+    AsymmetricJWK jwk;
+    String serializedJwt;
+    String publicKey;
 
-    final SignedJWT rsaSignedJWT =
-        new SignedJWT(
-            new JWSHeader.Builder(alg).type(JOSEObjectType.JWT).keyID(rsaKey.getKeyID()).build(),
-            getClaimsSet());
+    JwtKeys(final JWSAlgorithm algorithm, final Curve curve, final JOSEObjectType type)
+        throws JOSEException {
+      if (Family.RSA.contains(algorithm)) {
+        jwk = getRsaJWK(algorithm);
+        serializedJwt = signAndSerialize((RSAKey) jwk, algorithm, type);
+        publicKey = ((RSAKey) jwk).toPublicJWK().toJSONString();
+      } else if (Family.EC.contains(algorithm)) {
+        jwk = getEcJWK(algorithm, curve);
+        serializedJwt = signAndSerialize((ECKey) jwk, algorithm, type);
+        publicKey = ((ECKey) jwk).toPublicJWK().toJSONString();
+      } else {
+        serializedJwt = null;
+        fail("unsupported algorithm type");
+      }
+    }
 
-    rsaSignedJWT.sign(rsaSigner);
-    final String serializedJwt = rsaSignedJWT.serialize();
-    System.out.println("JWT serialized=" + serializedJwt);
-    return serializedJwt;
-  }
-
-  private String signAndSerialize(final ECKey ecKey, final JWSAlgorithm alg) throws JOSEException {
-    // Create EC-signer with the private key
-    final ECDSASigner ecSigner = new ECDSASigner(ecKey);
-
-    final SignedJWT ecSignedJWT =
-        new SignedJWT(
-            new JWSHeader.Builder(alg).type(JOSEObjectType.JWT).keyID(ecKey.getKeyID()).build(),
-            getClaimsSet());
-
-    ecSignedJWT.sign(ecSigner);
-    final String ecSerializedJwt = ecSignedJWT.serialize();
-    System.out.println("JWT serialized=" + ecSerializedJwt);
-    return ecSerializedJwt;
-  }
-
-  private JWTClaimsSet getClaimsSet() {
-    // prepare default JWT claims set
-    return new JWTClaimsSet.Builder()
-        .subject("alice")
-        .issuer("http://localhost")
-        .expirationTime(new Date(new Date().getTime() + 60 * 1000))
-        .build();
+    JwtKeys(final JWSAlgorithm algorithm, final Curve curve) throws JOSEException {
+      this(algorithm, curve, JOSEObjectType.JWT);
+    }
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/oauth2/IdentityOAuth2WebConfigurer.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/oauth2/IdentityOAuth2WebConfigurer.java
@@ -105,7 +105,7 @@ public class IdentityOAuth2WebConfigurer {
         .jwtProcessorCustomizer(
             processor -> {
               processor.setJWSTypeVerifier(
-                  new DefaultJOSEObjectTypeVerifier<>(JWT, new JOSEObjectType("at+jwt")));
+                  new DefaultJOSEObjectTypeVerifier<>(JWT, new JOSEObjectType("at+jwt"), null));
             })
         .build();
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Backport for Operate 8.5 of https://github.com/camunda/camunda/pull/29617

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

relates to https://github.com/camunda/camunda/issues/29314