### PR TITLE
[Backport stable/8.6] fix: made JWT typ header property optional in Operate and Tasklist

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/SecurityTestUtil.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/SecurityTestUtil.java
@@ -43,15 +43,17 @@ public class SecurityTestUtil {
   }
 
   public static String signAndSerialize(
-      final RSAKey rsaKey, final JWSAlgorithm alg, final JWTClaimsSet claimsSet)
+      final RSAKey rsaKey,
+      final JWSAlgorithm alg,
+      final JWTClaimsSet claimsSet,
+      final JOSEObjectType type)
       throws JOSEException {
     // Create RSA-signer with the private key
     final JWSSigner rsaSigner = new RSASSASigner(rsaKey);
 
     final SignedJWT rsaSignedJWT =
         new SignedJWT(
-            new JWSHeader.Builder(alg).type(JOSEObjectType.JWT).keyID(rsaKey.getKeyID()).build(),
-            claimsSet);
+            new JWSHeader.Builder(alg).type(type).keyID(rsaKey.getKeyID()).build(), claimsSet);
 
     rsaSignedJWT.sign(rsaSigner);
     final String serializedJwt = rsaSignedJWT.serialize();
@@ -59,25 +61,41 @@ public class SecurityTestUtil {
     return serializedJwt;
   }
 
+  public static String signAndSerialize(
+      final RSAKey rsaKey, final JWSAlgorithm alg, final JWTClaimsSet claimsSet)
+      throws JOSEException {
+    return signAndSerialize(rsaKey, alg, claimsSet, JOSEObjectType.JWT);
+  }
+
   public static String signAndSerialize(final RSAKey rsaKey, final JWSAlgorithm alg)
       throws JOSEException {
     return signAndSerialize(rsaKey, alg, getDefaultClaimsSet());
   }
 
-  public static String signAndSerialize(final ECKey ecKey, final JWSAlgorithm alg)
-      throws JOSEException {
+  public static String signAndSerialize(
+      final RSAKey rsaKey, final JWSAlgorithm alg, final JOSEObjectType type) throws JOSEException {
+    return signAndSerialize(rsaKey, alg, getDefaultClaimsSet(), type);
+  }
+
+  public static String signAndSerialize(
+      final ECKey ecKey, final JWSAlgorithm alg, final JOSEObjectType type) throws JOSEException {
     // Create EC-signer with the private key
     final ECDSASigner ecSigner = new ECDSASigner(ecKey);
 
     final SignedJWT ecSignedJWT =
         new SignedJWT(
-            new JWSHeader.Builder(alg).type(JOSEObjectType.JWT).keyID(ecKey.getKeyID()).build(),
+            new JWSHeader.Builder(alg).type(type).keyID(ecKey.getKeyID()).build(),
             getDefaultClaimsSet());
 
     ecSignedJWT.sign(ecSigner);
     final String ecSerializedJwt = ecSignedJWT.serialize();
     System.out.println("JWT serialized=" + ecSerializedJwt);
     return ecSerializedJwt;
+  }
+
+  public static String signAndSerialize(final ECKey ecKey, final JWSAlgorithm alg)
+      throws JOSEException {
+    return signAndSerialize(ecKey, alg, JOSEObjectType.JWT);
   }
 
   public static JWTClaimsSet getDefaultClaimsSet() {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/oauth2/JwtDecoderIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/oauth2/JwtDecoderIT.java
@@ -10,6 +10,7 @@ package io.camunda.operate.webapp.security.oauth2;
 import static io.camunda.operate.webapp.security.SecurityTestUtil.signAndSerialize;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
@@ -67,7 +68,7 @@ public class JwtDecoderIT {
     final String withoutAlg = publicKey.replaceFirst("\"alg\":\".*\",", "");
     final String authServerResponseBody = "{\"keys\":[" + withoutAlg + "]}";
     System.out.println("authServerResponse=" + authServerResponseBody);
-    assertFalse(authServerResponseBody.contains("alg:"));
+    assertFalse(authServerResponseBody.contains("alg\":"));
 
     wireMockInfo
         .getWireMock()
@@ -92,7 +93,7 @@ public class JwtDecoderIT {
     final String withoutAlg = publicKey.replaceFirst(",\"alg\":\".*\"", "");
     final String authServerResponseBody = "{\"keys\":[" + withoutAlg + "]}";
     System.out.println("authServerResponse=" + authServerResponseBody);
-    assertFalse(authServerResponseBody.contains("alg:"));
+    assertFalse(authServerResponseBody.contains("alg\":"));
 
     wireMockInfo
         .getWireMock()
@@ -114,7 +115,7 @@ public class JwtDecoderIT {
 
     final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
     System.out.println("authServerResponse=" + authServerResponseBody);
-    assertFalse(authServerResponseBody.contains("alg:"));
+    assertTrue(authServerResponseBody.contains("alg\":"));
 
     wireMockInfo
         .getWireMock()
@@ -136,7 +137,6 @@ public class JwtDecoderIT {
 
     final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
     System.out.println("authServerResponse=" + authServerResponseBody);
-    assertFalse(authServerResponseBody.contains("alg:"));
 
     wireMockInfo
         .getWireMock()
@@ -159,7 +159,6 @@ public class JwtDecoderIT {
 
     final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
     System.out.println("authServerResponse=" + authServerResponseBody);
-    assertFalse(authServerResponseBody.contains("alg:"));
 
     wireMockInfo
         .getWireMock()
@@ -182,7 +181,6 @@ public class JwtDecoderIT {
 
     final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
     System.out.println("authServerResponse=" + authServerResponseBody);
-    assertFalse(authServerResponseBody.contains("alg:"));
 
     wireMockInfo
         .getWireMock()

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/oauth2/JwtDecoderIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/oauth2/JwtDecoderIT.java
@@ -10,14 +10,17 @@ package io.camunda.operate.webapp.security.oauth2;
 import static io.camunda.operate.webapp.security.SecurityTestUtil.signAndSerialize;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
 import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
 import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSAlgorithm.Family;
+import com.nimbusds.jose.jwk.AsymmetricJWK;
 import com.nimbusds.jose.jwk.Curve;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jose.jwk.KeyUse;
@@ -25,8 +28,11 @@ import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
 import io.camunda.identity.sdk.IdentityConfiguration;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.env.MockEnvironment;
@@ -57,15 +63,16 @@ public class JwtDecoderIT {
     decoder = ReflectionTestUtils.invokeMethod(identityOAuth2WebConfigurer, "jwtDecoder");
   }
 
-  @Test
-  public void testDecodeRs256JwtWithNoAlgFieldInJwkResponse() throws JOSEException {
+  @ParameterizedTest
+  @MethodSource("basicAlgTestParameters")
+  public void testDecodeJwtWithNoAlgFieldInJwkResponse(
+      final JWSAlgorithm algorithm, final Curve curve) throws JOSEException {
     // given
-    final RSAKey rsaJWK = getRsaJWK(JWSAlgorithm.RS256);
-    final String serializedJwt = signAndSerialize(rsaJWK, JWSAlgorithm.RS256);
-    final String publicKey = rsaJWK.toPublicJWK().toJSONString();
+    final JwtKeys jwtKeys = new JwtKeys(algorithm, curve);
+    System.out.println("publicKey=" + jwtKeys.publicKey);
 
     // remove alg field from mocked server response and assert it was removed to cover this use case
-    final String withoutAlg = publicKey.replaceFirst("\"alg\":\".*\",", "");
+    final String withoutAlg = jwtKeys.publicKey.replaceFirst(",\"alg\":\"[^\"]*\"", "");
     final String authServerResponseBody = "{\"keys\":[" + withoutAlg + "]}";
     System.out.println("authServerResponse=" + authServerResponseBody);
     assertFalse(authServerResponseBody.contains("alg\":"));
@@ -77,65 +84,18 @@ public class JwtDecoderIT {
                 .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
 
     // when - then
-    assertDoesNotThrow(() -> decoder.decode(serializedJwt));
+    assertDoesNotThrow(() -> decoder.decode(jwtKeys.serializedJwt));
     wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
   }
 
-  @Test
-  public void testDecodeES256JwtWithNoAlgFieldInJwkResponse() throws JOSEException {
+  @ParameterizedTest
+  @MethodSource("basicAlgTestParameters")
+  public void testDecodeJwtsWithNoTypeHeader(final JWSAlgorithm algorithm, final Curve curve)
+      throws JOSEException {
     // given
-    final ECKey ecJWK = getEcJWK(JWSAlgorithm.ES256, Curve.P_256);
-    final String ecSerializedJwt = signAndSerialize(ecJWK, JWSAlgorithm.ES256);
-    final String publicKey = ecJWK.toPublicJWK().toJSONString();
-    System.out.println("publicKey=" + publicKey);
-
-    // remove alg field from mocked server response and assert it was removed to cover this use case
-    final String withoutAlg = publicKey.replaceFirst(",\"alg\":\".*\"", "");
-    final String authServerResponseBody = "{\"keys\":[" + withoutAlg + "]}";
-    System.out.println("authServerResponse=" + authServerResponseBody);
-    assertFalse(authServerResponseBody.contains("alg\":"));
-
-    wireMockInfo
-        .getWireMock()
-        .register(
-            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
-                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
-
-    // when - then
-    assertDoesNotThrow(() -> decoder.decode(ecSerializedJwt));
-    wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
-  }
-
-  @Test
-  public void testDecodeRS384Jwt() throws JOSEException {
-    // given
-    final RSAKey rsaJWK = getRsaJWK(JWSAlgorithm.RS384);
-    final String serializedJwt = signAndSerialize(rsaJWK, JWSAlgorithm.RS384);
-    final String publicKey = rsaJWK.toPublicJWK().toJSONString();
-
-    final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
-    System.out.println("authServerResponse=" + authServerResponseBody);
-    assertTrue(authServerResponseBody.contains("alg\":"));
-
-    wireMockInfo
-        .getWireMock()
-        .register(
-            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
-                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
-
-    // when - then
-    assertDoesNotThrow(() -> decoder.decode(serializedJwt));
-    wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
-  }
-
-  @Test
-  public void testDecodeRS512Jwt() throws JOSEException {
-    // given
-    final RSAKey rsaJWK = getRsaJWK(JWSAlgorithm.RS512);
-    final String serializedJwt = signAndSerialize(rsaJWK, JWSAlgorithm.RS512);
-    final String publicKey = rsaJWK.toPublicJWK().toJSONString();
-
-    final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
+    final JwtKeys jwtKeys = new JwtKeys(algorithm, curve, null);
+    System.out.println("publicKey=" + jwtKeys.publicKey);
+    final String authServerResponseBody = "{\"keys\":[" + jwtKeys.publicKey + "]}";
     System.out.println("authServerResponse=" + authServerResponseBody);
 
     wireMockInfo
@@ -145,19 +105,18 @@ public class JwtDecoderIT {
                 .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
 
     // when - then
-    assertDoesNotThrow(() -> decoder.decode(serializedJwt));
+    assertDoesNotThrow(() -> decoder.decode(jwtKeys.serializedJwt));
     wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
   }
 
-  @Test
-  public void testDecodeES384Jwt() throws JOSEException {
+  @ParameterizedTest
+  @MethodSource("jwtTestParameters")
+  public void testDecodeJwtWithVariousAlgorithms(final JWSAlgorithm algorithm, final Curve curve)
+      throws JOSEException {
     // given
-    final ECKey ecJWK = getEcJWK(JWSAlgorithm.ES384, Curve.P_384);
-    final String ecSerializedJwt = signAndSerialize(ecJWK, JWSAlgorithm.ES384);
-    final String publicKey = ecJWK.toPublicJWK().toJSONString();
-    System.out.println("publicKey=" + publicKey);
-
-    final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
+    final JwtKeys jwtKeys = new JwtKeys(algorithm, curve);
+    System.out.println("publicKey=" + jwtKeys.publicKey);
+    final String authServerResponseBody = "{\"keys\":[" + jwtKeys.publicKey + "]}";
     System.out.println("authServerResponse=" + authServerResponseBody);
 
     wireMockInfo
@@ -167,33 +126,26 @@ public class JwtDecoderIT {
                 .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
 
     // when - then
-    assertDoesNotThrow(() -> decoder.decode(ecSerializedJwt));
+    assertDoesNotThrow(() -> decoder.decode(jwtKeys.serializedJwt));
     wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
   }
 
-  @Test
-  public void testDecodeES512Jwt() throws JOSEException {
-    // given
-    final ECKey ecJWK = getEcJWK(JWSAlgorithm.ES512, Curve.P_521);
-    final String ecSerializedJwt = signAndSerialize(ecJWK, JWSAlgorithm.ES512);
-    final String publicKey = ecJWK.toPublicJWK().toJSONString();
-    System.out.println("publicKey=" + publicKey);
-
-    final String authServerResponseBody = "{\"keys\":[" + publicKey + "]}";
-    System.out.println("authServerResponse=" + authServerResponseBody);
-
-    wireMockInfo
-        .getWireMock()
-        .register(
-            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
-                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
-
-    // when - then
-    assertDoesNotThrow(() -> decoder.decode(ecSerializedJwt));
-    wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+  private static Stream<Arguments> jwtTestParameters() {
+    return Stream.of(
+        Arguments.of(JWSAlgorithm.RS256, null),
+        Arguments.of(JWSAlgorithm.RS384, null),
+        Arguments.of(JWSAlgorithm.RS512, null),
+        Arguments.of(JWSAlgorithm.ES256, Curve.P_256),
+        Arguments.of(JWSAlgorithm.ES384, Curve.P_384),
+        Arguments.of(JWSAlgorithm.ES512, Curve.P_521));
   }
 
-  private RSAKey getRsaJWK(final JWSAlgorithm alg) throws JOSEException {
+  private static Stream<Arguments> basicAlgTestParameters() {
+    return Stream.of(
+        Arguments.of(JWSAlgorithm.RS256, null), Arguments.of(JWSAlgorithm.ES256, Curve.P_256));
+  }
+
+  private static RSAKey getRsaJWK(final JWSAlgorithm alg) throws JOSEException {
     return new RSAKeyGenerator(2048)
         .keyID("123")
         .keyUse(KeyUse.SIGNATURE)
@@ -201,11 +153,37 @@ public class JwtDecoderIT {
         .generate();
   }
 
-  private ECKey getEcJWK(final JWSAlgorithm alg, final Curve curve) throws JOSEException {
+  private static ECKey getEcJWK(final JWSAlgorithm alg, final Curve curve) throws JOSEException {
     return new ECKeyGenerator(curve)
         .algorithm(alg)
         .keyUse(KeyUse.SIGNATURE)
         .keyID("345")
         .generate();
+  }
+
+  private static class JwtKeys {
+    AsymmetricJWK jwk;
+    String serializedJwt;
+    String publicKey;
+
+    JwtKeys(final JWSAlgorithm algorithm, final Curve curve, final JOSEObjectType type)
+        throws JOSEException {
+      if (Family.RSA.contains(algorithm)) {
+        jwk = getRsaJWK(algorithm);
+        serializedJwt = signAndSerialize((RSAKey) jwk, algorithm, type);
+        publicKey = ((RSAKey) jwk).toPublicJWK().toJSONString();
+      } else if (Family.EC.contains(algorithm)) {
+        jwk = getEcJWK(algorithm, curve);
+        serializedJwt = signAndSerialize((ECKey) jwk, algorithm, type);
+        publicKey = ((ECKey) jwk).toPublicJWK().toJSONString();
+      } else {
+        serializedJwt = null;
+        fail("unsupported algorithm type");
+      }
+    }
+
+    JwtKeys(final JWSAlgorithm algorithm, final Curve curve) throws JOSEException {
+      this(algorithm, curve, JOSEObjectType.JWT);
+    }
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/oauth2/IdentityOAuth2WebConfigurer.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/oauth2/IdentityOAuth2WebConfigurer.java
@@ -23,6 +23,7 @@ import io.camunda.identity.sdk.IdentityConfiguration;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
@@ -86,12 +87,7 @@ public class IdentityOAuth2WebConfigurer {
     return NimbusJwtDecoder.withJwkSetUri(getJwkSetUriProperty())
         .jwsAlgorithms(
             algorithms -> {
-              algorithms.add(RS256);
-              algorithms.add(RS384);
-              algorithms.add(RS512);
-              algorithms.add(ES256);
-              algorithms.add(ES384);
-              algorithms.add(ES512);
+              algorithms.addAll(List.of(RS256, RS384, RS512, ES256, ES384, ES512));
             })
         .jwtProcessorCustomizer(
             processor -> {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/oauth2/IdentityOAuth2WebConfigurer.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/oauth2/IdentityOAuth2WebConfigurer.java
@@ -96,7 +96,7 @@ public class IdentityOAuth2WebConfigurer {
         .jwtProcessorCustomizer(
             processor -> {
               processor.setJWSTypeVerifier(
-                  new DefaultJOSEObjectTypeVerifier<>(JWT, new JOSEObjectType("at+jwt")));
+                  new DefaultJOSEObjectTypeVerifier<>(JWT, new JOSEObjectType("at+jwt"), null));
             })
         .build();
   }

--- a/tasklist/qa/integration-tests/pom.xml
+++ b/tasklist/qa/integration-tests/pom.xml
@@ -450,6 +450,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock</artifactId>
       <scope>test</scope>

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/SecurityTestUtil.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/SecurityTestUtil.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.webapp.security;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import java.util.Date;
+
+public class SecurityTestUtil {
+
+  public static String signAndSerialize(
+      final RSAKey rsaKey,
+      final JWSAlgorithm alg,
+      final JWTClaimsSet claimsSet,
+      final JOSEObjectType type)
+      throws JOSEException {
+    // Create RSA-signer with the private key
+    final JWSSigner rsaSigner = new RSASSASigner(rsaKey);
+
+    final SignedJWT rsaSignedJWT =
+        new SignedJWT(
+            new JWSHeader.Builder(alg).type(type).keyID(rsaKey.getKeyID()).build(), claimsSet);
+
+    rsaSignedJWT.sign(rsaSigner);
+    final String serializedJwt = rsaSignedJWT.serialize();
+    System.out.println("JWT serialized=" + serializedJwt);
+    return serializedJwt;
+  }
+
+  public static String signAndSerialize(
+      final RSAKey rsaKey, final JWSAlgorithm alg, final JWTClaimsSet claimsSet)
+      throws JOSEException {
+    return signAndSerialize(rsaKey, alg, claimsSet, JOSEObjectType.JWT);
+  }
+
+  public static String signAndSerialize(final RSAKey rsaKey, final JWSAlgorithm alg)
+      throws JOSEException {
+    return signAndSerialize(rsaKey, alg, getDefaultClaimsSet());
+  }
+
+  public static String signAndSerialize(
+      final RSAKey rsaKey, final JWSAlgorithm alg, final JOSEObjectType type) throws JOSEException {
+    return signAndSerialize(rsaKey, alg, getDefaultClaimsSet(), type);
+  }
+
+  public static String signAndSerialize(
+      final ECKey ecKey, final JWSAlgorithm alg, final JOSEObjectType type) throws JOSEException {
+    // Create EC-signer with the private key
+    final ECDSASigner ecSigner = new ECDSASigner(ecKey);
+
+    final SignedJWT ecSignedJWT =
+        new SignedJWT(
+            new JWSHeader.Builder(alg).type(type).keyID(ecKey.getKeyID()).build(),
+            getDefaultClaimsSet());
+
+    ecSignedJWT.sign(ecSigner);
+    final String ecSerializedJwt = ecSignedJWT.serialize();
+    System.out.println("JWT serialized=" + ecSerializedJwt);
+    return ecSerializedJwt;
+  }
+
+  public static String signAndSerialize(final ECKey ecKey, final JWSAlgorithm alg)
+      throws JOSEException {
+    return signAndSerialize(ecKey, alg, JOSEObjectType.JWT);
+  }
+
+  public static JWTClaimsSet getDefaultClaimsSet() {
+    // prepare default JWT claims set
+    return new JWTClaimsSet.Builder()
+        .subject("alice")
+        .issuer("http://localhost")
+        .expirationTime(new Date(new Date().getTime() + 60 * 1000))
+        .build();
+  }
+}

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/oauth/JwtDecoderIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/oauth/JwtDecoderIT.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.webapp.security.oauth;
+
+import static io.camunda.tasklist.webapp.security.SecurityTestUtil.signAndSerialize;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSAlgorithm.Family;
+import com.nimbusds.jose.jwk.AsymmetricJWK;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import io.camunda.identity.sdk.IdentityConfiguration;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@WireMockTest
+public class JwtDecoderIT {
+
+  private final MockEnvironment environment = new MockEnvironment();
+  @Mock private IdentityJwt2AuthenticationTokenConverter jwtConverter;
+  private final WireMockRuntimeInfo wireMockInfo;
+  private final String authServerMockUrl;
+  private JwtDecoder decoder;
+
+  public JwtDecoderIT(final WireMockRuntimeInfo wireMockInfo) {
+    this.wireMockInfo = wireMockInfo;
+    authServerMockUrl = wireMockInfo.getHttpBaseUrl();
+  }
+
+  @BeforeEach
+  public void setup() {
+    final IdentityConfiguration identityConfiguration =
+        new IdentityConfiguration(null, authServerMockUrl, null, null, null);
+    final IdentityOAuth2WebConfigurer identityOAuth2WebConfigurer =
+        new IdentityOAuth2WebConfigurer(environment, identityConfiguration, jwtConverter);
+
+    decoder = ReflectionTestUtils.invokeMethod(identityOAuth2WebConfigurer, "jwtDecoder");
+  }
+
+  @ParameterizedTest
+  @MethodSource("basicAlgTestParameters")
+  public void testDecodeJwtWithNoAlgFieldInJwkResponse(
+      final JWSAlgorithm algorithm, final Curve curve) throws JOSEException {
+    // given
+    final JwtKeys jwtKeys = new JwtKeys(algorithm, curve);
+    System.out.println("publicKey=" + jwtKeys.publicKey);
+
+    // remove alg field from mocked server response and assert it was removed to cover this use case
+    final String withoutAlg = jwtKeys.publicKey.replaceFirst(",\"alg\":\"[^\"]*\"", "");
+    final String authServerResponseBody = "{\"keys\":[" + withoutAlg + "]}";
+    System.out.println("authServerResponse=" + authServerResponseBody);
+    assertFalse(authServerResponseBody.contains("alg\":"));
+
+    wireMockInfo
+        .getWireMock()
+        .register(
+            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
+                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
+
+    // when - then
+    assertDoesNotThrow(() -> decoder.decode(jwtKeys.serializedJwt));
+    wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+  }
+
+  @ParameterizedTest
+  @MethodSource("basicAlgTestParameters")
+  public void testDecodeJwtsWithNoTypeHeader(final JWSAlgorithm algorithm, final Curve curve)
+      throws JOSEException {
+    // given
+    final JwtKeys jwtKeys = new JwtKeys(algorithm, curve, null);
+    System.out.println("publicKey=" + jwtKeys.publicKey);
+    final String authServerResponseBody = "{\"keys\":[" + jwtKeys.publicKey + "]}";
+    System.out.println("authServerResponse=" + authServerResponseBody);
+
+    wireMockInfo
+        .getWireMock()
+        .register(
+            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
+                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
+
+    // when - then
+    assertDoesNotThrow(() -> decoder.decode(jwtKeys.serializedJwt));
+    wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+  }
+
+  @ParameterizedTest
+  @MethodSource("jwtTestParameters")
+  public void testDecodeJwtWithVariousAlgorithms(final JWSAlgorithm algorithm, final Curve curve)
+      throws JOSEException {
+    // given
+    final JwtKeys jwtKeys = new JwtKeys(algorithm, curve);
+    System.out.println("publicKey=" + jwtKeys.publicKey);
+    final String authServerResponseBody = "{\"keys\":[" + jwtKeys.publicKey + "]}";
+    System.out.println("authServerResponse=" + authServerResponseBody);
+
+    wireMockInfo
+        .getWireMock()
+        .register(
+            WireMock.get(WireMock.urlMatching(".*/protocol/openid-connect/certs"))
+                .willReturn(WireMock.jsonResponse(authServerResponseBody, HttpStatus.OK.value())));
+
+    // when - then
+    assertDoesNotThrow(() -> decoder.decode(jwtKeys.serializedJwt));
+    wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
+  }
+
+  private static Stream<Arguments> jwtTestParameters() {
+    return Stream.of(
+        Arguments.of(JWSAlgorithm.RS256, null),
+        Arguments.of(JWSAlgorithm.RS384, null),
+        Arguments.of(JWSAlgorithm.RS512, null),
+        Arguments.of(JWSAlgorithm.ES256, Curve.P_256),
+        Arguments.of(JWSAlgorithm.ES384, Curve.P_384),
+        Arguments.of(JWSAlgorithm.ES512, Curve.P_521));
+  }
+
+  private static Stream<Arguments> basicAlgTestParameters() {
+    return Stream.of(
+        Arguments.of(JWSAlgorithm.RS256, null), Arguments.of(JWSAlgorithm.ES256, Curve.P_256));
+  }
+
+  private static RSAKey getRsaJWK(final JWSAlgorithm alg) throws JOSEException {
+    return new RSAKeyGenerator(2048)
+        .keyID("123")
+        .keyUse(KeyUse.SIGNATURE)
+        .algorithm(alg)
+        .generate();
+  }
+
+  private static ECKey getEcJWK(final JWSAlgorithm alg, final Curve curve) throws JOSEException {
+    return new ECKeyGenerator(curve)
+        .algorithm(alg)
+        .keyUse(KeyUse.SIGNATURE)
+        .keyID("345")
+        .generate();
+  }
+
+  private static class JwtKeys {
+    AsymmetricJWK jwk;
+    String serializedJwt;
+    String publicKey;
+
+    JwtKeys(final JWSAlgorithm algorithm, final Curve curve, final JOSEObjectType type)
+        throws JOSEException {
+      if (Family.RSA.contains(algorithm)) {
+        jwk = getRsaJWK(algorithm);
+        serializedJwt = signAndSerialize((RSAKey) jwk, algorithm, type);
+        publicKey = ((RSAKey) jwk).toPublicJWK().toJSONString();
+      } else if (Family.EC.contains(algorithm)) {
+        jwk = getEcJWK(algorithm, curve);
+        serializedJwt = signAndSerialize((ECKey) jwk, algorithm, type);
+        publicKey = ((ECKey) jwk).toPublicJWK().toJSONString();
+      } else {
+        serializedJwt = null;
+        fail("unsupported algorithm type");
+      }
+    }
+
+    JwtKeys(final JWSAlgorithm algorithm, final Curve curve) throws JOSEException {
+      this(algorithm, curve, JOSEObjectType.JWT);
+    }
+  }
+}

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/oauth/IdentityOAuth2WebConfigurer.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/oauth/IdentityOAuth2WebConfigurer.java
@@ -79,10 +79,10 @@ public class IdentityOAuth2WebConfigurer {
   private JwtDecoder jwtDecoder() {
     return NimbusJwtDecoder.withJwkSetUri(getJwkSetUriProperty())
         .jwtProcessorCustomizer(
-            processor ->
-                processor.setJWSTypeVerifier(
-                    new DefaultJOSEObjectTypeVerifier<>(
-                        JWT, new JOSEObjectType("at+jwt")))) // TODO add null
+            processor -> {
+              processor.setJWSTypeVerifier(
+                  new DefaultJOSEObjectTypeVerifier<>(JWT, new JOSEObjectType("at+jwt"), null));
+            })
         .build();
   }
 

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/oauth/IdentityOAuth2WebConfigurer.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/oauth/IdentityOAuth2WebConfigurer.java
@@ -10,6 +10,12 @@ package io.camunda.tasklist.webapp.security.oauth;
 import static com.nimbusds.jose.JOSEObjectType.JWT;
 import static io.camunda.tasklist.webapp.security.BaseWebConfigurer.sendJSONErrorMessage;
 import static io.camunda.tasklist.webapp.security.TasklistProfileService.IDENTITY_AUTH_PROFILE;
+import static org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.ES256;
+import static org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.ES384;
+import static org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.ES512;
+import static org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.RS256;
+import static org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.RS384;
+import static org.springframework.security.oauth2.jose.jws.SignatureAlgorithm.RS512;
 
 import com.nimbusds.jose.JOSEObjectType;
 import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier;
@@ -17,6 +23,7 @@ import io.camunda.identity.sdk.IdentityConfiguration;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
@@ -78,6 +85,10 @@ public class IdentityOAuth2WebConfigurer {
    */
   private JwtDecoder jwtDecoder() {
     return NimbusJwtDecoder.withJwkSetUri(getJwkSetUriProperty())
+        .jwsAlgorithms(
+            algorithms -> {
+              algorithms.addAll(List.of(RS256, RS384, RS512, ES256, ES384, ES512));
+            })
         .jwtProcessorCustomizer(
             processor -> {
               processor.setJWSTypeVerifier(

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/oauth/IdentityOAuth2WebConfigurer.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/oauth/IdentityOAuth2WebConfigurer.java
@@ -19,7 +19,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -43,11 +42,20 @@ public class IdentityOAuth2WebConfigurer {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IdentityOAuth2WebConfigurer.class);
 
-  @Autowired private Environment env;
+  private final Environment env;
 
-  @Autowired private IdentityConfiguration identityConfiguration;
+  private final IdentityConfiguration identityConfiguration;
 
-  @Autowired private IdentityJwt2AuthenticationTokenConverter jwtConverter;
+  private final IdentityJwt2AuthenticationTokenConverter jwtConverter;
+
+  public IdentityOAuth2WebConfigurer(
+      final Environment env,
+      final IdentityConfiguration identityConfiguration,
+      final IdentityJwt2AuthenticationTokenConverter jwtConverter) {
+    this.env = env;
+    this.identityConfiguration = identityConfiguration;
+    this.jwtConverter = jwtConverter;
+  }
 
   public void configure(final HttpSecurity http) throws Exception {
     if (isJWTEnabled()) {
@@ -73,7 +81,8 @@ public class IdentityOAuth2WebConfigurer {
         .jwtProcessorCustomizer(
             processor ->
                 processor.setJWSTypeVerifier(
-                    new DefaultJOSEObjectTypeVerifier<>(JWT, new JOSEObjectType("at+jwt"))))
+                    new DefaultJOSEObjectTypeVerifier<>(
+                        JWT, new JOSEObjectType("at+jwt")))) // TODO add null
         .build();
   }
 

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/security/oauth/IdentityOAuth2WebConfigurerTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/security/oauth/IdentityOAuth2WebConfigurerTest.java
@@ -101,7 +101,7 @@ class IdentityOAuth2WebConfigurerTest {
 
     // Ensure that both jwt and at+jwt types are being verified
     assertThat(joseVerifier.getAllowedTypes())
-        .containsExactlyInAnyOrder(new JOSEObjectType("jwt"), new JOSEObjectType("at+jwt"));
+        .containsExactlyInAnyOrder(new JOSEObjectType("jwt"), new JOSEObjectType("at+jwt"), null);
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #29617 to `stable/8.6`.

relates to camunda/camunda#29314