### PR TITLE
deps: temporarily disable Renovate automerges

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -176,12 +176,6 @@
       "description": "Both dependencies need to be updated at once for green CI.",
       "matchPackageNames": ["@playwright/test", "mcr.microsoft.com/playwright"],
       "groupName": "playwright"
-    },
-    {
-      "description": "Automerge all updates with green CI.",
-      "matchPackagePatterns": ["*"],
-      "automerge": true,
-      "addLabels": ["automerge"]
     }
   ],
   "dockerfile": {


### PR DESCRIPTION
## Description

_Action item from https://app.incident.io/camunda/incidents/2490_

This is to reduce chances of INC-2490 happening again until long-term fix https://github.com/camunda/camunda/pull/29634 is in place.
The [error of renovateconfiglint](https://github.com/camunda/camunda/actions/runs/13946351460/job/39034375679?pr=29834) is expected and can be ignored, open ticket #20694 

I'll also prepare already a 2nd PR that can be merged to enable automerges again on 2025-03-20 European afternoon: https://github.com/camunda/camunda/pull/29836

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

https://app.incident.io/camunda/incidents/2490
