### PR TITLE
[CPT] Assert that the given elements are not active

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
@@ -225,6 +225,29 @@ public interface ProcessInstanceAssert {
   ProcessInstanceAssert hasNotActivatedElements(ElementSelector... elementSelectors);
 
   /**
+   * Verifies that the given BPMN elements are not active. The verification fails if at least one
+   * element is active.
+   *
+   * <p>The assertion waits until the elements are completed or terminated, if they are active.
+   *
+   * @param elementIds the BPMN element IDs
+   * @return the assertion object
+   */
+  ProcessInstanceAssert hasNoActiveElements(String... elementIds);
+
+  /**
+   * Verifies that the given BPMN elements are not active. The verification fails if at least one
+   * element is active.
+   *
+   * <p>The assertion waits until the elements are completed or terminated, if they are active.
+   *
+   * @param elementSelectors the selectors for the BPMN elements
+   * @return the assertion object
+   * @see ElementSelectors
+   */
+  ProcessInstanceAssert hasNoActiveElements(ElementSelector... elementSelectors);
+
+  /**
    * Verifies that the process instance has the given variables. The verification fails if at least
    * one variable doesn't exist.
    *

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -187,6 +187,18 @@ public class ProcessInstanceAssertj
   }
 
   @Override
+  public ProcessInstanceAssert hasNoActiveElements(final String... elementIds) {
+    elementAssertj.hasNoActiveElements(getProcessInstanceKey(), elementIds);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert hasNoActiveElements(final ElementSelector... elementSelectors) {
+    elementAssertj.hasNoActiveElements(getProcessInstanceKey(), elementSelectors);
+    return this;
+  }
+
+  @Override
   public ProcessInstanceAssert hasVariableNames(final String... variableNames) {
     variableAssertj.hasVariableNames(getProcessInstanceKey(), variableNames);
     return this;


### PR DESCRIPTION
## Description

Add a new assertion to verify that the given elements are not active.

This assertion is an equivalent for: 
- C7: [isNotWaitingAt()](https://docs.camunda.org/manual/7.21/user-guide/testing/assert-examples/#instance-isnotwaitingat)
- ZPT: [isNotWaitingAtElements()](https://github.com/camunda/zeebe-process-test/blob/ae9b96c848ca1bf3d8efdbf43bf6b1003ac1536a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/ProcessInstanceAssert.java#L276)

## Related issues

closes #23243 
