### PR TITLE
Remove hardcoded default tenant access

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -177,10 +177,6 @@ public final class AuthorizationCheckBehavior {
   private boolean isUserAuthorizedForTenant(
       final AuthorizationRequest request, final PersistedUser user) {
     final var tenantId = request.tenantId;
-    if (tenantId.equals(TenantOwned.DEFAULT_TENANT_IDENTIFIER)) {
-      return true;
-    }
-
     if (user.getTenantIdsList().contains(tenantId)) {
       return true;
     }
@@ -191,10 +187,6 @@ public final class AuthorizationCheckBehavior {
   private boolean isMappingAuthorizedForTenant(
       final AuthorizationRequest request, final PersistedMapping mapping) {
     final var tenantId = request.tenantId;
-    if (tenantId.equals(TenantOwned.DEFAULT_TENANT_IDENTIFIER)) {
-      return true;
-    }
-
     if (mapping.getTenantIdsList().contains(request.getTenantId())) {
       return true;
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -37,7 +37,7 @@ public final class AuthorizationCheckBehavior {
   public static final String FORBIDDEN_ERROR_MESSAGE =
       "Insufficient permissions to perform operation '%s' on resource '%s'";
   public static final String FORBIDDEN_FOR_TENANT_ERROR_MESSAGE =
-      FORBIDDEN_ERROR_MESSAGE + " for tenant '%s'";
+      "Expected to perform operation '%s' on resource '%s' for tenant '%s', but user is not assigned to this tenant";
   public static final String FORBIDDEN_ERROR_MESSAGE_WITH_RESOURCE =
       FORBIDDEN_ERROR_MESSAGE + ", required resource identifiers are one of '%s'";
   public static final String NOT_FOUND_ERROR_MESSAGE =
@@ -118,8 +118,9 @@ public final class AuthorizationCheckBehavior {
                   request.getPermissionType(), request.getResourceType())));
     }
 
+    final var user = userOptional.get();
     if (multiTenancyEnabled) {
-      if (!isUserAuthorizedForTenant(request, userOptional.get())) {
+      if (!isUserAuthorizedForTenant(request, user)) {
         final var rejectionType =
             request.isNewResource() ? RejectionType.FORBIDDEN : RejectionType.NOT_FOUND;
         return Either.left(new Rejection(rejectionType, request.getTenantErrorMessage()));
@@ -129,7 +130,7 @@ public final class AuthorizationCheckBehavior {
     if (authorizationsEnabled) {
       final var authorizedResourceIdentifiers =
           getUserAuthorizedResourceIdentifiers(
-              userOptional.get(), request.getResourceType(), request.getPermissionType());
+              user, request.getResourceType(), request.getPermissionType());
       return checkResourceIdentifiers(request, authorizedResourceIdentifiers);
     }
     return Either.right(null);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
@@ -185,7 +185,13 @@ public class DbMappingState implements MutableMappingState {
   public Optional<PersistedMapping> get(final String claimName, final String claimValue) {
     this.claimName.wrapString(claimName);
     this.claimValue.wrapString(claimValue);
-    return Optional.ofNullable(mappingColumnFamily.get(claim));
+    final var persistedMapping = mappingColumnFamily.get(claim);
+
+    if (persistedMapping == null) {
+      return Optional.empty();
+    }
+
+    return Optional.of(persistedMapping.copy());
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedMapping.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedMapping.java
@@ -45,6 +45,12 @@ public class PersistedMapping extends UnpackedObject implements DbValue {
         .declareProperty(idProp);
   }
 
+  public PersistedMapping copy() {
+    final var copy = new PersistedMapping();
+    copy.copyFrom(this);
+    return copy;
+  }
+
   public long getMappingKey() {
     return mappingKeyProp.getValue();
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorMultiTenancyTest.java
@@ -1,0 +1,549 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.authorization;
+
+import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_ANONYMOUS_USER;
+import static io.camunda.zeebe.auth.Authorization.AUTHORIZED_USERNAME;
+import static io.camunda.zeebe.auth.Authorization.USER_TOKEN_CLAIM_PREFIX;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.configuration.AuthorizationsConfiguration;
+import io.camunda.security.configuration.MultiTenancyConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.MappingRecordValue;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Supplier;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class AuthorizationCheckBehaviorMultiTenancyTest {
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+  private AuthorizationCheckBehavior authorizationCheckBehavior;
+
+  @Before
+  public void before() {
+    final var processingState = engine.getProcessingState();
+    final var securityConfig = new SecurityConfiguration();
+    final var authConfig = new AuthorizationsConfiguration();
+    authConfig.setEnabled(true);
+    securityConfig.setAuthorizations(authConfig);
+    final var multiTenancyConfig = new MultiTenancyConfiguration();
+    multiTenancyConfig.setEnabled(true);
+    securityConfig.setMultiTenancy(multiTenancyConfig);
+    authorizationCheckBehavior = new AuthorizationCheckBehavior(processingState, securityConfig);
+  }
+
+  @Test
+  public void shouldBeAuthorizedForUserTenant() {
+    // given
+    final var user = createUser();
+    final var resourceType = AuthorizationResourceType.RESOURCE;
+    final var permissionType = PermissionType.CREATE;
+    final var resourceId = UUID.randomUUID().toString();
+    addPermission(
+        user.getUsername(), AuthorizationOwnerType.USER, resourceType, permissionType, resourceId);
+    final var tenantId = createAndAssignTenant(user.getUsername(), EntityType.USER);
+    final var command = mockCommand(user.getUsername());
+
+    // when
+    final var request =
+        new AuthorizationRequest(command, resourceType, permissionType, tenantId)
+            .addResourceId(resourceId);
+    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+
+    // then
+    assertThat(authorized.isRight()).isTrue();
+  }
+
+  @Test
+  public void shouldBeAuthorizedForUserTenantThroughGroup() {
+    // given
+    final var user = createUser();
+    final var resourceType = AuthorizationResourceType.RESOURCE;
+    final var permissionType = PermissionType.CREATE;
+    final var resourceId = UUID.randomUUID().toString();
+    addPermission(
+        user.getUsername(), AuthorizationOwnerType.USER, resourceType, permissionType, resourceId);
+    final var groupKey = createGroup(user.getUserKey(), EntityType.USER);
+    final var tenantId = createAndAssignTenant(groupKey, EntityType.GROUP);
+    final var command = mockCommand(user.getUsername());
+
+    // when
+    final var request =
+        new AuthorizationRequest(command, resourceType, permissionType, tenantId)
+            .addResourceId(resourceId);
+    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+
+    // then
+    assertThat(authorized.isRight()).isTrue();
+  }
+
+  @Test
+  public void shouldBeAuthorizedForMappingTenant() {
+    // given
+    final var claimName = UUID.randomUUID().toString();
+    final var claimValue = UUID.randomUUID().toString();
+    final var mappingId = createMapping(claimName, claimValue).getId();
+    final var resourceType = AuthorizationResourceType.RESOURCE;
+    final var permissionType = PermissionType.CREATE;
+    final var resourceId = UUID.randomUUID().toString();
+    addPermission(
+        mappingId, AuthorizationOwnerType.MAPPING, resourceType, permissionType, resourceId);
+    final var tenantId = createAndAssignTenant(mappingId, EntityType.MAPPING);
+    final var command = mockCommandWithMapping(claimName, claimValue);
+
+    // when
+    final var request =
+        new AuthorizationRequest(command, resourceType, permissionType, tenantId)
+            .addResourceId(resourceId);
+    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+
+    // then
+    assertThat(authorized.isRight()).isTrue();
+  }
+
+  @Test
+  public void shouldBeAuthorizedForMappingTenantThroughGroup() {
+    // given
+    final var claimName = UUID.randomUUID().toString();
+    final var claimValue = UUID.randomUUID().toString();
+    final var mapping = createMapping(claimName, claimValue);
+    final var resourceType = AuthorizationResourceType.RESOURCE;
+    final var permissionType = PermissionType.CREATE;
+    final var resourceId = UUID.randomUUID().toString();
+    addPermission(
+        mapping.getId(), AuthorizationOwnerType.MAPPING, resourceType, permissionType, resourceId);
+    final var groupKey = createGroup(mapping.getMappingKey(), EntityType.MAPPING);
+    final var tenantId = createAndAssignTenant(groupKey, EntityType.GROUP);
+    final var command = mockCommandWithMapping(claimName, claimValue);
+
+    // when
+    final var request =
+        new AuthorizationRequest(command, resourceType, permissionType, tenantId)
+            .addResourceId(resourceId);
+    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+
+    // then
+    assertThat(authorized.isRight()).isTrue();
+  }
+
+  @Test
+  public void shouldGetUserAuthorizedTenantIds() {
+    // given
+    final var user = createUser();
+    final var tenantId1 = createAndAssignTenant(user.getUsername(), EntityType.USER);
+    final var tenantId2 = createAndAssignTenant(user.getUsername(), EntityType.USER);
+    final var command = mockCommand(user.getUsername());
+
+    // when
+    final var authorizedTenantIds =
+        runTaskInActor(() -> authorizationCheckBehavior.getAuthorizedTenantIds(command));
+
+    // then
+    assertThat(authorizedTenantIds.getAuthorizedTenantIds())
+        .containsExactlyInAnyOrder(tenantId1, tenantId2);
+    assertThat(authorizedTenantIds.isAuthorizedForTenantId(tenantId1)).isTrue();
+    assertThat(authorizedTenantIds.isAuthorizedForTenantId(tenantId2)).isTrue();
+    assertThat(authorizedTenantIds.isAuthorizedForTenantIds(List.of(tenantId1, tenantId2)))
+        .isTrue();
+    assertThat(authorizedTenantIds.isAuthorizedForTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
+        .isFalse();
+  }
+
+  @Test
+  public void shouldGetMappingAuthorizedTenantIds() {
+    // given
+    final var claimName = UUID.randomUUID().toString();
+    final var claimValue = UUID.randomUUID().toString();
+    final var mappingId = createMapping(claimName, claimValue).getId();
+    final var tenantId1 = createAndAssignTenant(mappingId, EntityType.MAPPING);
+    final var tenantId2 = createAndAssignTenant(mappingId, EntityType.MAPPING);
+    final var command = mockCommandWithMapping(claimName, claimValue);
+
+    // when
+    final var authorizedTenantIds =
+        runTaskInActor(() -> authorizationCheckBehavior.getAuthorizedTenantIds(command));
+
+    // then
+    assertThat(authorizedTenantIds.getAuthorizedTenantIds())
+        .containsExactlyInAnyOrder(tenantId1, tenantId2);
+    assertThat(authorizedTenantIds.isAuthorizedForTenantId(tenantId1)).isTrue();
+    assertThat(authorizedTenantIds.isAuthorizedForTenantId(tenantId2)).isTrue();
+    assertThat(authorizedTenantIds.isAuthorizedForTenantIds(List.of(tenantId1, tenantId2)))
+        .isTrue();
+    assertThat(authorizedTenantIds.isAuthorizedForTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
+        .isFalse();
+  }
+
+  @Test
+  public void shouldGetUserAuthorizedTenantIdsThroughGroup() {
+    // given
+    final var user = createUser();
+    final var groupKey = createGroup(user.getUserKey(), EntityType.USER);
+    final var tenantId1 = createAndAssignTenant(groupKey, EntityType.GROUP);
+    final var tenantId2 = createAndAssignTenant(groupKey, EntityType.GROUP);
+    final var command = mockCommand(user.getUsername());
+
+    // when
+    final var authorizedTenantIds =
+        runTaskInActor(() -> authorizationCheckBehavior.getAuthorizedTenantIds(command));
+
+    // then
+    assertThat(authorizedTenantIds.getAuthorizedTenantIds())
+        .containsExactlyInAnyOrder(tenantId1, tenantId2);
+    assertThat(authorizedTenantIds.isAuthorizedForTenantId(tenantId1)).isTrue();
+    assertThat(authorizedTenantIds.isAuthorizedForTenantId(tenantId2)).isTrue();
+    assertThat(authorizedTenantIds.isAuthorizedForTenantIds(List.of(tenantId1, tenantId2)))
+        .isTrue();
+    assertThat(authorizedTenantIds.isAuthorizedForTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
+        .isFalse();
+  }
+
+  @Test
+  public void shouldGetMappingAuthorizedTenantIdsThroughGroup() {
+    // given
+    final var claimName = UUID.randomUUID().toString();
+    final var claimValue = UUID.randomUUID().toString();
+    final var mapping = createMapping(claimName, claimValue);
+    final var groupKey = createGroup(mapping.getMappingKey(), EntityType.MAPPING);
+    final var tenantId1 = createAndAssignTenant(groupKey, EntityType.GROUP);
+    final var tenantId2 = createAndAssignTenant(groupKey, EntityType.GROUP);
+    final var command = mockCommandWithMapping(claimName, claimValue);
+
+    // when
+    final var authorizedTenantIds =
+        runTaskInActor(() -> authorizationCheckBehavior.getAuthorizedTenantIds(command));
+
+    // then
+    assertThat(authorizedTenantIds.getAuthorizedTenantIds())
+        .containsExactlyInAnyOrder(tenantId1, tenantId2);
+    assertThat(authorizedTenantIds.isAuthorizedForTenantId(tenantId1)).isTrue();
+    assertThat(authorizedTenantIds.isAuthorizedForTenantId(tenantId2)).isTrue();
+    assertThat(authorizedTenantIds.isAuthorizedForTenantIds(List.of(tenantId1, tenantId2)))
+        .isTrue();
+    assertThat(authorizedTenantIds.isAuthorizedForTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
+        .isFalse();
+  }
+
+  @Test
+  public void shouldGetDefaultAuthorizedTenantIdsIfUserKeyIsNotPresent() {
+    // given
+    final var command = mock(TypedRecord.class);
+
+    // when
+    final var authorizedTenantIds =
+        runTaskInActor(
+            () ->
+                authorizationCheckBehavior
+                    .getAuthorizedTenantIds(command)
+                    .getAuthorizedTenantIds());
+
+    // then
+    assertThat(authorizedTenantIds).containsOnly(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+
+  @Test
+  public void shouldGetDefaultAuthorizedTenantIdsIfUserIsNotPresent() {
+    // given
+    final var command = mockCommand("not-exists");
+
+    // when
+    final var authorizedTenantIds =
+        runTaskInActor(() -> authorizationCheckBehavior.getAuthorizedTenantIds(command));
+
+    // then
+    assertThat(authorizedTenantIds.getAuthorizedTenantIds())
+        .containsOnly(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    assertThat(authorizedTenantIds.isAuthorizedForTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
+        .isTrue();
+    assertThat(
+            authorizedTenantIds.isAuthorizedForTenantIds(
+                List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER)))
+        .isTrue();
+    assertThat(authorizedTenantIds.isAuthorizedForTenantId("not-authorized")).isFalse();
+  }
+
+  @Test
+  public void shouldBeAuthorizedWhenMappingIsNotAssignedToRequestedTenant() {
+    // given
+    final var claimName = UUID.randomUUID().toString();
+    final var claimValue = UUID.randomUUID().toString();
+    final var mapping =
+        engine.mapping().newMapping(claimName).withClaimValue(claimValue).create().getValue();
+    final var tenantId = "tenant";
+    engine.tenant().newTenant().withTenantId(tenantId).create();
+    engine
+        .tenant()
+        .addEntity(tenantId)
+        .withEntityType(EntityType.MAPPING)
+        .withEntityId(mapping.getId())
+        .add();
+    final var resourceType = AuthorizationResourceType.RESOURCE;
+    final var permissionType = PermissionType.CREATE;
+    final var resourceId = UUID.randomUUID().toString();
+    addPermission(
+        mapping.getId(), AuthorizationOwnerType.MAPPING, resourceType, permissionType, resourceId);
+    final var command = mockCommandWithMapping(claimName, claimValue);
+
+    // when
+    final var request =
+        new AuthorizationRequest(command, resourceType, permissionType, "anotherTenantId")
+            .addResourceId(resourceId);
+    final var authorized = runTaskInActor(() -> authorizationCheckBehavior.isAuthorized(request));
+
+    // then
+    EitherAssert.assertThat(authorized).isLeft();
+  }
+
+  @Test
+  public void shouldBeUnauthorizedForMappingTenant() {
+    // given
+    final var claimName = UUID.randomUUID().toString();
+    final var claimValue = UUID.randomUUID().toString();
+    final var mappingId = createMapping(claimName, claimValue).getId();
+    final var resourceType = AuthorizationResourceType.RESOURCE;
+    final var permissionType = PermissionType.CREATE;
+    final var resourceId = UUID.randomUUID().toString();
+    addPermission(
+        mappingId, AuthorizationOwnerType.MAPPING, resourceType, permissionType, resourceId);
+    final var anotherTenantId = "authorizedForAnotherTenant";
+    createAndAssignTenant(mappingId, EntityType.MAPPING);
+    final var command = mockCommandWithMapping(claimName, claimValue);
+
+    // when
+    final var request =
+        new AuthorizationRequest(command, resourceType, permissionType, anotherTenantId)
+            .addResourceId(resourceId);
+    final var authorized = runTaskInActor(() -> authorizationCheckBehavior.isAuthorized(request));
+
+    // then
+    assertThat(authorized.isRight()).isFalse();
+  }
+
+  @Test
+  public void shouldBeUnauthorizedForUserTenant() {
+    // given
+    final var user = createUser();
+    final var resourceType = AuthorizationResourceType.RESOURCE;
+    final var permissionType = PermissionType.CREATE;
+    final var resourceId = UUID.randomUUID().toString();
+    addPermission(
+        user.getUsername(), AuthorizationOwnerType.USER, resourceType, permissionType, resourceId);
+    final var anotherTenantId = "authorizedForAnotherTenant";
+    createAndAssignTenant(user.getUsername(), EntityType.USER);
+    final var command = mockCommand(user.getUsername());
+
+    // when
+    final var request =
+        new AuthorizationRequest(command, resourceType, permissionType, anotherTenantId)
+            .addResourceId(resourceId);
+    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+
+    // then
+    assertThat(authorized.isRight()).isFalse();
+  }
+
+  @Test
+  public void shouldGetAuthorizedTenantsForMapping() {
+    // given
+    final var claimName = UUID.randomUUID().toString();
+    final var claimValue = UUID.randomUUID().toString();
+    final var mappingId = Strings.newRandomValidIdentityId();
+    engine
+        .mapping()
+        .newMapping(claimName)
+        .withClaimValue(claimValue)
+        .withId(mappingId)
+        .create()
+        .getValue();
+    final var tenantId = "tenant";
+    engine.tenant().newTenant().withTenantId(tenantId).create();
+    final var command = mockCommandWithMapping(claimName, claimValue);
+
+    // when
+    engine
+        .tenant()
+        .addEntity(tenantId)
+        .withEntityType(EntityType.MAPPING)
+        .withEntityId(mappingId)
+        .add();
+
+    // then
+    assertThat(
+            runTaskInActor(() -> authorizationCheckBehavior.getAuthorizedTenantIds(command))
+                .getAuthorizedTenantIds())
+        .singleElement()
+        .isEqualTo(tenantId);
+  }
+
+  @Test
+  public void shouldGetDefaultAuthorizedTenantForMapping() {
+    // given
+    final var claimName = UUID.randomUUID().toString();
+    final var claimValue = UUID.randomUUID().toString();
+    engine.mapping().newMapping(claimName).withClaimValue(claimValue).create().getValue();
+    final var command = mockCommandWithMapping(claimName, claimValue);
+
+    // when
+    // then
+    assertThat(
+            runTaskInActor(() -> authorizationCheckBehavior.getAuthorizedTenantIds(command))
+                .getAuthorizedTenantIds())
+        .singleElement()
+        .isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+
+  @Test
+  public void shouldReturnAnonymousAuthorizedTenants() {
+    // given
+    final var command = mockCommandWithAnonymousUser();
+
+    // when
+    final var authorizedTenants =
+        runTaskInActor(() -> authorizationCheckBehavior.getAuthorizedTenantIds(command));
+
+    assertThat(authorizedTenants).isEqualTo(AuthorizedTenants.ANONYMOUS);
+  }
+
+  @Test
+  public void shouldBeAuthorizedWhenMappingIsAssignedToRequestedTenant() {
+    // given
+    final var claimName = UUID.randomUUID().toString();
+    final var claimValue = UUID.randomUUID().toString();
+    final var mapping =
+        engine.mapping().newMapping(claimName).withClaimValue(claimValue).create().getValue();
+    final var tenantId = "tenant";
+    engine.tenant().newTenant().withTenantId(tenantId).create();
+    engine
+        .tenant()
+        .addEntity(tenantId)
+        .withEntityType(EntityType.MAPPING)
+        .withEntityId(mapping.getId())
+        .add();
+    final var resourceType = AuthorizationResourceType.RESOURCE;
+    final var permissionType = PermissionType.CREATE;
+    final var resourceId = UUID.randomUUID().toString();
+    addPermission(
+        mapping.getId(), AuthorizationOwnerType.MAPPING, resourceType, permissionType, resourceId);
+    final var command = mockCommandWithMapping(claimName, claimValue);
+
+    // when
+    final var request =
+        new AuthorizationRequest(command, resourceType, permissionType, tenantId)
+            .addResourceId(resourceId);
+    final var authorized = runTaskInActor(() -> authorizationCheckBehavior.isAuthorized(request));
+
+    // then
+    EitherAssert.assertThat(authorized).isRight();
+  }
+
+  private TypedRecord<?> mockCommandWithMapping(final String claimName, final String claimValue) {
+    final var command = mock(TypedRecord.class);
+    when(command.getAuthorizations())
+        .thenReturn(Map.of(USER_TOKEN_CLAIM_PREFIX + claimName, claimValue));
+    when(command.hasRequestMetadata()).thenReturn(true);
+    return command;
+  }
+
+  private UserRecordValue createUser() {
+    return engine
+        .user()
+        .newUser(UUID.randomUUID().toString())
+        .withName(UUID.randomUUID().toString())
+        .withEmail(UUID.randomUUID().toString())
+        .withPassword(UUID.randomUUID().toString())
+        .create()
+        .getValue();
+  }
+
+  private MappingRecordValue createMapping(final String claimName, final String claimValue) {
+    return engine
+        .mapping()
+        .newMapping(claimName)
+        .withClaimValue(claimValue)
+        .withId(Strings.newRandomValidIdentityId())
+        .create()
+        .getValue();
+  }
+
+  private void addPermission(
+      final String ownerId,
+      final AuthorizationOwnerType ownerType,
+      final AuthorizationResourceType resourceType,
+      final PermissionType permissionType,
+      final String... resourceIds) {
+    for (final String resourceId : resourceIds) {
+      engine
+          .authorization()
+          .newAuthorization()
+          .withPermissions(permissionType)
+          .withOwnerId(ownerId)
+          .withOwnerType(ownerType)
+          .withResourceType(resourceType)
+          .withResourceId(resourceId)
+          .create();
+    }
+  }
+
+  private long createGroup(final long entityKey, final EntityType entityType) {
+    final var groupKey = engine.group().newGroup(UUID.randomUUID().toString()).create().getKey();
+    engine.group().addEntity(groupKey).withEntityKey(entityKey).withEntityType(entityType).add();
+    return groupKey;
+  }
+
+  // TODO remove this method once Mappings and Groups are migrated to work with ids instead of
+  private String createAndAssignTenant(final Long entityKey, final EntityType entityType) {
+    return createAndAssignTenant(String.valueOf(entityKey), entityType);
+  }
+
+  private String createAndAssignTenant(final String entityId, final EntityType entityType) {
+    final var tenantId = UUID.randomUUID().toString();
+    engine.tenant().newTenant().withTenantId(tenantId).create();
+    engine.tenant().addEntity(tenantId).withEntityId(entityId).withEntityType(entityType).add();
+    return tenantId;
+  }
+
+  private TypedRecord<?> mockCommand(final String username) {
+    final var command = mock(TypedRecord.class);
+    when(command.getAuthorizations()).thenReturn(Map.of(AUTHORIZED_USERNAME, username));
+    when(command.hasRequestMetadata()).thenReturn(true);
+    return command;
+  }
+
+  private TypedRecord<?> mockCommandWithAnonymousUser() {
+    final var command = mock(TypedRecord.class);
+    when(command.getAuthorizations()).thenReturn(Map.of(AUTHORIZED_ANONYMOUS_USER, true));
+    when(command.hasRequestMetadata()).thenReturn(true);
+    return command;
+  }
+
+  private <A> A runTaskInActor(final Supplier<A> supplier) {
+    return engine.getStreamProcessor(1).call(supplier::get).join();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -15,18 +15,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.configuration.AuthorizationsConfiguration;
-import io.camunda.security.configuration.MultiTenancyConfiguration;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
-import io.camunda.zeebe.engine.processing.identity.AuthorizedTenants;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.MappingRecordValue;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
-import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.test.util.Strings;
@@ -53,9 +50,6 @@ public class AuthorizationCheckBehaviorTest {
     final var authConfig = new AuthorizationsConfiguration();
     authConfig.setEnabled(true);
     securityConfig.setAuthorizations(authConfig);
-    final var multiTenancyConfig = new MultiTenancyConfiguration();
-    multiTenancyConfig.setEnabled(true);
-    securityConfig.setMultiTenancy(multiTenancyConfig);
     authorizationCheckBehavior = new AuthorizationCheckBehavior(processingState, securityConfig);
   }
 
@@ -239,284 +233,6 @@ public class AuthorizationCheckBehaviorTest {
   }
 
   @Test
-  public void shouldBeAuthorizedForUserTenant() {
-    // given
-    final var user = createUser();
-    final var resourceType = AuthorizationResourceType.RESOURCE;
-    final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
-    addPermission(
-        user.getUsername(), AuthorizationOwnerType.USER, resourceType, permissionType, resourceId);
-    final var tenantId = createAndAssignTenant(user.getUsername(), EntityType.USER);
-    final var command = mockCommand(user.getUsername());
-
-    // when
-    final var request =
-        new AuthorizationRequest(command, resourceType, permissionType, tenantId)
-            .addResourceId(resourceId);
-    final var authorized = authorizationCheckBehavior.isAuthorized(request);
-
-    // then
-    assertThat(authorized.isRight()).isTrue();
-  }
-
-  @Test
-  public void shouldBeAuthorizedForUserTenantThroughGroup() {
-    // given
-    final var user = createUser();
-    final var resourceType = AuthorizationResourceType.RESOURCE;
-    final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
-    addPermission(
-        user.getUsername(), AuthorizationOwnerType.USER, resourceType, permissionType, resourceId);
-    final var groupKey = createGroup(user.getUserKey(), EntityType.USER);
-    final var tenantId = createAndAssignTenant(groupKey, EntityType.GROUP);
-    final var command = mockCommand(user.getUsername());
-
-    // when
-    final var request =
-        new AuthorizationRequest(command, resourceType, permissionType, tenantId)
-            .addResourceId(resourceId);
-    final var authorized = authorizationCheckBehavior.isAuthorized(request);
-
-    // then
-    assertThat(authorized.isRight()).isTrue();
-  }
-
-  @Test
-  public void shouldBeUnauthorizedForUserTenant() {
-    // given
-    final var user = createUser();
-    final var resourceType = AuthorizationResourceType.RESOURCE;
-    final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
-    addPermission(
-        user.getUsername(), AuthorizationOwnerType.USER, resourceType, permissionType, resourceId);
-    final var anotherTenantId = "authorizedForAnotherTenant";
-    createAndAssignTenant(user.getUsername(), EntityType.USER);
-    final var command = mockCommand(user.getUsername());
-
-    // when
-    final var request =
-        new AuthorizationRequest(command, resourceType, permissionType, anotherTenantId)
-            .addResourceId(resourceId);
-    final var authorized = authorizationCheckBehavior.isAuthorized(request);
-
-    // then
-    assertThat(authorized.isRight()).isFalse();
-  }
-
-  @Test
-  public void shouldBeAuthorizedForMappingTenant() {
-    // given
-    final var claimName = UUID.randomUUID().toString();
-    final var claimValue = UUID.randomUUID().toString();
-    final var mappingId = createMapping(claimName, claimValue).getId();
-    final var resourceType = AuthorizationResourceType.RESOURCE;
-    final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
-    addPermission(
-        mappingId, AuthorizationOwnerType.MAPPING, resourceType, permissionType, resourceId);
-    final var tenantId = createAndAssignTenant(mappingId, EntityType.MAPPING);
-    final var command = mockCommandWithMapping(claimName, claimValue);
-
-    // when
-    final var request =
-        new AuthorizationRequest(command, resourceType, permissionType, tenantId)
-            .addResourceId(resourceId);
-    final var authorized = authorizationCheckBehavior.isAuthorized(request);
-
-    // then
-    assertThat(authorized.isRight()).isTrue();
-  }
-
-  @Test
-  public void shouldBeAuthorizedForMappingTenantThroughGroup() {
-    // given
-    final var claimName = UUID.randomUUID().toString();
-    final var claimValue = UUID.randomUUID().toString();
-    final var mapping = createMapping(claimName, claimValue);
-    final var resourceType = AuthorizationResourceType.RESOURCE;
-    final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
-    addPermission(
-        mapping.getId(), AuthorizationOwnerType.MAPPING, resourceType, permissionType, resourceId);
-    final var groupKey = createGroup(mapping.getMappingKey(), EntityType.MAPPING);
-    final var tenantId = createAndAssignTenant(groupKey, EntityType.GROUP);
-    final var command = mockCommandWithMapping(claimName, claimValue);
-
-    // when
-    final var request =
-        new AuthorizationRequest(command, resourceType, permissionType, tenantId)
-            .addResourceId(resourceId);
-    final var authorized = authorizationCheckBehavior.isAuthorized(request);
-
-    // then
-    assertThat(authorized.isRight()).isTrue();
-  }
-
-  @Test
-  public void shouldBeUnauthorizedForMappingTenant() {
-    // given
-    final var claimName = UUID.randomUUID().toString();
-    final var claimValue = UUID.randomUUID().toString();
-    final var mappingId = createMapping(claimName, claimValue).getId();
-    final var resourceType = AuthorizationResourceType.RESOURCE;
-    final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
-    addPermission(
-        mappingId, AuthorizationOwnerType.MAPPING, resourceType, permissionType, resourceId);
-    final var anotherTenantId = "authorizedForAnotherTenant";
-    createAndAssignTenant(mappingId, EntityType.MAPPING);
-    final var command = mockCommandWithMapping(claimName, claimValue);
-
-    // when
-    final var request =
-        new AuthorizationRequest(command, resourceType, permissionType, anotherTenantId)
-            .addResourceId(resourceId);
-    final var authorized = runTaskInActor(() -> authorizationCheckBehavior.isAuthorized(request));
-
-    // then
-    assertThat(authorized.isRight()).isFalse();
-  }
-
-  @Test
-  public void shouldGetUserAuthorizedTenantIds() {
-    // given
-    final var user = createUser();
-    final var tenantId1 = createAndAssignTenant(user.getUsername(), EntityType.USER);
-    final var tenantId2 = createAndAssignTenant(user.getUsername(), EntityType.USER);
-    final var command = mockCommand(user.getUsername());
-
-    // when
-    final var authorizedTenantIds =
-        runTaskInActor(() -> authorizationCheckBehavior.getAuthorizedTenantIds(command));
-
-    // then
-    assertThat(authorizedTenantIds.getAuthorizedTenantIds())
-        .containsExactlyInAnyOrder(tenantId1, tenantId2);
-    assertThat(authorizedTenantIds.isAuthorizedForTenantId(tenantId1)).isTrue();
-    assertThat(authorizedTenantIds.isAuthorizedForTenantId(tenantId2)).isTrue();
-    assertThat(authorizedTenantIds.isAuthorizedForTenantIds(List.of(tenantId1, tenantId2)))
-        .isTrue();
-    assertThat(authorizedTenantIds.isAuthorizedForTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
-        .isFalse();
-  }
-
-  @Test
-  public void shouldGetMappingAuthorizedTenantIds() {
-    // given
-    final var claimName = UUID.randomUUID().toString();
-    final var claimValue = UUID.randomUUID().toString();
-    final var mappingId = createMapping(claimName, claimValue).getId();
-    final var tenantId1 = createAndAssignTenant(mappingId, EntityType.MAPPING);
-    final var tenantId2 = createAndAssignTenant(mappingId, EntityType.MAPPING);
-    final var command = mockCommandWithMapping(claimName, claimValue);
-
-    // when
-    final var authorizedTenantIds =
-        runTaskInActor(() -> authorizationCheckBehavior.getAuthorizedTenantIds(command));
-
-    // then
-    assertThat(authorizedTenantIds.getAuthorizedTenantIds())
-        .containsExactlyInAnyOrder(tenantId1, tenantId2);
-    assertThat(authorizedTenantIds.isAuthorizedForTenantId(tenantId1)).isTrue();
-    assertThat(authorizedTenantIds.isAuthorizedForTenantId(tenantId2)).isTrue();
-    assertThat(authorizedTenantIds.isAuthorizedForTenantIds(List.of(tenantId1, tenantId2)))
-        .isTrue();
-    assertThat(authorizedTenantIds.isAuthorizedForTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
-        .isFalse();
-  }
-
-  @Test
-  public void shouldGetUserAuthorizedTenantIdsThroughGroup() {
-    // given
-    final var user = createUser();
-    final var groupKey = createGroup(user.getUserKey(), EntityType.USER);
-    final var tenantId1 = createAndAssignTenant(groupKey, EntityType.GROUP);
-    final var tenantId2 = createAndAssignTenant(groupKey, EntityType.GROUP);
-    final var command = mockCommand(user.getUsername());
-
-    // when
-    final var authorizedTenantIds =
-        runTaskInActor(() -> authorizationCheckBehavior.getAuthorizedTenantIds(command));
-
-    // then
-    assertThat(authorizedTenantIds.getAuthorizedTenantIds())
-        .containsExactlyInAnyOrder(tenantId1, tenantId2);
-    assertThat(authorizedTenantIds.isAuthorizedForTenantId(tenantId1)).isTrue();
-    assertThat(authorizedTenantIds.isAuthorizedForTenantId(tenantId2)).isTrue();
-    assertThat(authorizedTenantIds.isAuthorizedForTenantIds(List.of(tenantId1, tenantId2)))
-        .isTrue();
-    assertThat(authorizedTenantIds.isAuthorizedForTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
-        .isFalse();
-  }
-
-  @Test
-  public void shouldGetMappingAuthorizedTenantIdsThroughGroup() {
-    // given
-    final var claimName = UUID.randomUUID().toString();
-    final var claimValue = UUID.randomUUID().toString();
-    final var mapping = createMapping(claimName, claimValue);
-    final var groupKey = createGroup(mapping.getMappingKey(), EntityType.MAPPING);
-    final var tenantId1 = createAndAssignTenant(groupKey, EntityType.GROUP);
-    final var tenantId2 = createAndAssignTenant(groupKey, EntityType.GROUP);
-    final var command = mockCommandWithMapping(claimName, claimValue);
-
-    // when
-    final var authorizedTenantIds =
-        runTaskInActor(() -> authorizationCheckBehavior.getAuthorizedTenantIds(command));
-
-    // then
-    assertThat(authorizedTenantIds.getAuthorizedTenantIds())
-        .containsExactlyInAnyOrder(tenantId1, tenantId2);
-    assertThat(authorizedTenantIds.isAuthorizedForTenantId(tenantId1)).isTrue();
-    assertThat(authorizedTenantIds.isAuthorizedForTenantId(tenantId2)).isTrue();
-    assertThat(authorizedTenantIds.isAuthorizedForTenantIds(List.of(tenantId1, tenantId2)))
-        .isTrue();
-    assertThat(authorizedTenantIds.isAuthorizedForTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
-        .isFalse();
-  }
-
-  @Test
-  public void shouldGetDefaultAuthorizedTenantIdsIfUserKeyIsNotPresent() {
-    // given
-    final var command = mock(TypedRecord.class);
-
-    // when
-    final var authorizedTenantIds =
-        runTaskInActor(
-            () ->
-                authorizationCheckBehavior
-                    .getAuthorizedTenantIds(command)
-                    .getAuthorizedTenantIds());
-
-    // then
-    assertThat(authorizedTenantIds).containsOnly(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-  }
-
-  @Test
-  public void shouldGetDefaultAuthorizedTenantIdsIfUserIsNotPresent() {
-    // given
-    final var command = mockCommand("not-exists");
-
-    // when
-    final var authorizedTenantIds =
-        runTaskInActor(() -> authorizationCheckBehavior.getAuthorizedTenantIds(command));
-
-    // then
-    assertThat(authorizedTenantIds.getAuthorizedTenantIds())
-        .containsOnly(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-    assertThat(authorizedTenantIds.isAuthorizedForTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER))
-        .isTrue();
-    assertThat(
-            authorizedTenantIds.isAuthorizedForTenantIds(
-                List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER)))
-        .isTrue();
-    assertThat(authorizedTenantIds.isAuthorizedForTenantId("not-authorized")).isFalse();
-  }
-
-  @Test
   public void shouldBeAuthorizedWhenAnonymousAuthenticationProvided() {
     // given
     final var user = createUser();
@@ -534,18 +250,6 @@ public class AuthorizationCheckBehaviorTest {
 
     // then
     assertThat(authorized.isRight()).isTrue();
-  }
-
-  @Test
-  public void shouldReturnAnonymousAuthorizedTenants() {
-    // given
-    final var command = mockCommandWithAnonymousUser();
-
-    // when
-    final var authorizedTenants =
-        runTaskInActor(() -> authorizationCheckBehavior.getAuthorizedTenantIds(command));
-
-    assertThat(authorizedTenants).isEqualTo(AuthorizedTenants.ANONYMOUS);
   }
 
   @Test
@@ -569,70 +273,6 @@ public class AuthorizationCheckBehaviorTest {
 
     // then
     EitherAssert.assertThat(authorized).isRight();
-  }
-
-  @Test
-  public void shouldBeAuthorizedWhenMappingIsAssignedToRequestedTenant() {
-    // given
-    final var claimName = UUID.randomUUID().toString();
-    final var claimValue = UUID.randomUUID().toString();
-    final var mapping =
-        engine.mapping().newMapping(claimName).withClaimValue(claimValue).create().getValue();
-    final var tenantId = "tenant";
-    engine.tenant().newTenant().withTenantId(tenantId).create();
-    engine
-        .tenant()
-        .addEntity(tenantId)
-        .withEntityType(EntityType.MAPPING)
-        .withEntityId(mapping.getId())
-        .add();
-    final var resourceType = AuthorizationResourceType.RESOURCE;
-    final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
-    addPermission(
-        mapping.getId(), AuthorizationOwnerType.MAPPING, resourceType, permissionType, resourceId);
-    final var command = mockCommandWithMapping(claimName, claimValue);
-
-    // when
-    final var request =
-        new AuthorizationRequest(command, resourceType, permissionType, tenantId)
-            .addResourceId(resourceId);
-    final var authorized = runTaskInActor(() -> authorizationCheckBehavior.isAuthorized(request));
-
-    // then
-    EitherAssert.assertThat(authorized).isRight();
-  }
-
-  @Test
-  public void shouldBeAuthorizedWhenMappingIsNotAssignedToRequestedTenant() {
-    // given
-    final var claimName = UUID.randomUUID().toString();
-    final var claimValue = UUID.randomUUID().toString();
-    final var mapping =
-        engine.mapping().newMapping(claimName).withClaimValue(claimValue).create().getValue();
-    final var tenantId = "tenant";
-    engine.tenant().newTenant().withTenantId(tenantId).create();
-    engine
-        .tenant()
-        .addEntity(tenantId)
-        .withEntityType(EntityType.MAPPING)
-        .withEntityId(mapping.getId())
-        .add();
-    final var resourceType = AuthorizationResourceType.RESOURCE;
-    final var permissionType = PermissionType.CREATE;
-    final var resourceId = UUID.randomUUID().toString();
-    addPermission(
-        mapping.getId(), AuthorizationOwnerType.MAPPING, resourceType, permissionType, resourceId);
-    final var command = mockCommandWithMapping(claimName, claimValue);
-
-    // when
-    final var request =
-        new AuthorizationRequest(command, resourceType, permissionType, "anotherTenantId")
-            .addResourceId(resourceId);
-    final var authorized = runTaskInActor(() -> authorizationCheckBehavior.isAuthorized(request));
-
-    // then
-    EitherAssert.assertThat(authorized).isLeft();
   }
 
   @Test
@@ -968,56 +608,6 @@ public class AuthorizationCheckBehaviorTest {
     assertThat(authorizations).containsExactlyInAnyOrder(resourceId);
   }
 
-  @Test
-  public void shouldGetAuthorizedTenantsForMapping() {
-    // given
-    final var claimName = UUID.randomUUID().toString();
-    final var claimValue = UUID.randomUUID().toString();
-    final var mappingId = Strings.newRandomValidIdentityId();
-    engine
-        .mapping()
-        .newMapping(claimName)
-        .withClaimValue(claimValue)
-        .withId(mappingId)
-        .create()
-        .getValue();
-    final var tenantId = "tenant";
-    engine.tenant().newTenant().withTenantId(tenantId).create();
-    final var command = mockCommandWithMapping(claimName, claimValue);
-
-    // when
-    engine
-        .tenant()
-        .addEntity(tenantId)
-        .withEntityType(EntityType.MAPPING)
-        .withEntityId(mappingId)
-        .add();
-
-    // then
-    assertThat(
-            runTaskInActor(() -> authorizationCheckBehavior.getAuthorizedTenantIds(command))
-                .getAuthorizedTenantIds())
-        .singleElement()
-        .isEqualTo(tenantId);
-  }
-
-  @Test
-  public void shouldGetDefaultAuthorizedTenantForMapping() {
-    // given
-    final var claimName = UUID.randomUUID().toString();
-    final var claimValue = UUID.randomUUID().toString();
-    engine.mapping().newMapping(claimName).withClaimValue(claimValue).create().getValue();
-    final var command = mockCommandWithMapping(claimName, claimValue);
-
-    // when
-    // then
-    assertThat(
-            runTaskInActor(() -> authorizationCheckBehavior.getAuthorizedTenantIds(command))
-                .getAuthorizedTenantIds())
-        .singleElement()
-        .isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-  }
-
   private TypedRecord<?> mockCommandWithMapping(final String claimName, final String claimValue) {
     final var command = mock(TypedRecord.class);
     when(command.getAuthorizations())
@@ -1086,18 +676,6 @@ public class AuthorizationCheckBehaviorTest {
           .withResourceId(resourceId)
           .create();
     }
-  }
-
-  // TODO remove this method once Mappings and Groups are migrated to work with ids instead of
-  private String createAndAssignTenant(final Long entityKey, final EntityType entityType) {
-    return createAndAssignTenant(String.valueOf(entityKey), entityType);
-  }
-
-  private String createAndAssignTenant(final String entityId, final EntityType entityType) {
-    final var tenantId = UUID.randomUUID().toString();
-    engine.tenant().newTenant().withTenantId(tenantId).create();
-    engine.tenant().addEntity(tenantId).withEntityId(entityId).withEntityType(entityType).add();
-    return tenantId;
   }
 
   private TypedRecord<?> mockCommand(final String username) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyIT.java
@@ -56,7 +56,6 @@ import org.apache.hc.core5.http.HttpStatus;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -232,7 +231,6 @@ public class MultiTenancyIT {
     }
   }
 
-  @Disabled("https://github.com/camunda/camunda/issues/29518")
   @Test
   void shouldDenyDeployResourceWhenUnauthorizedForDefaultTenant() {
     // given
@@ -256,7 +254,6 @@ public class MultiTenancyIT {
     }
   }
 
-  @Disabled("https://github.com/camunda/camunda/issues/29518")
   @SuppressWarnings("deprecation")
   @Test
   void shouldDenyDeployProcessWhenUnauthorizedForDefaultTenant() {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
If MT is enabled we would check if the provided tenant id was the default tenant. If this was true we'd always allow the user to perform the operation they are doing. This is not how it worked in old identity. In old identity, if MT is enabled, the user must be explicitly assigned to the default tenant to be able to interact with it. I have removed this entire check. Before this method is called we already check if MT is enabled or not.

I had to fix some tests in the process. I've also did some small refactorings. I extracted a few flags to fields to make the code simpler and I've slightly improved the error message if a user is not assigned to a tenant.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29518 
