### PR TITLE
feat: Increase multipart request max sizes

### DIFF
--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -68,8 +68,8 @@ camunda.security.initialization.users[0].password=demo
 camunda.security.initialization.users[0].name=Demo
 camunda.security.initialization.users[0].email=demo@demo.com
 # Multipart file uploads
-spring.servlet.multipart.max-file-size=4MB
-spring.servlet.multipart.max-request-size=4MB
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB
 #
 # RDBMS extension default properties
 #

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/rest/ClientConfigRestServiceIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/rest/ClientConfigRestServiceIT.java
@@ -92,6 +92,6 @@ public class ClientConfigRestServiceIT {
                 + "\"mixpanelAPIHost\":\"https://fake.mixpanel.com\","
                 + "\"isResourcePermissionsEnabled\":false,"
                 + "\"isUserAccessRestrictionsEnabled\":true,"
-                + "\"maxRequestSize\":4194304};");
+                + "\"maxRequestSize\":10485760};");
   }
 }


### PR DESCRIPTION
## Description

As part of https://github.com/camunda/product-hub/issues/2555 we want to increase the default values of
```
spring.servlet.multipart.max-file-size
spring.servlet.multipart.max-request-size
```
to allow file upload requests up to 10MB.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Relates to https://github.com/camunda/camunda/issues/29852
