### PR TITLE
feat: [C8API] batch operation cancel process instances

### DIFF
--- a/search/search-domain/src/main/java/io/camunda/search/filter/ProcessInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ProcessInstanceFilter.java
@@ -7,7 +7,8 @@
  */
 package io.camunda.search.filter;
 
-import static io.camunda.util.CollectionUtil.*;
+import static io.camunda.util.CollectionUtil.addValuesToList;
+import static io.camunda.util.CollectionUtil.collectValues;
 
 import io.camunda.util.FilterUtil;
 import io.camunda.util.ObjectBuilder;
@@ -33,6 +34,25 @@ public record ProcessInstanceFilter(
     List<VariableValueFilter> variableFilters,
     List<Operation<String>> batchOperationIdOperations)
     implements FilterBase {
+
+  public Builder toBuilder() {
+    return new Builder()
+        .processInstanceKeyOperations(processInstanceKeyOperations)
+        .processDefinitionIdOperations(processDefinitionIdOperations)
+        .processDefinitionNameOperations(processDefinitionNameOperations)
+        .processDefinitionVersionOperations(processDefinitionVersionOperations)
+        .processDefinitionVersionTagOperations(processDefinitionVersionTagOperations)
+        .processDefinitionKeyOperations(processDefinitionKeyOperations)
+        .parentProcessInstanceKeyOperations(parentProcessInstanceKeyOperations)
+        .parentFlowNodeInstanceKeyOperations(parentFlowNodeInstanceKeyOperations)
+        .startDateOperations(startDateOperations)
+        .endDateOperations(endDateOperations)
+        .stateOperations(stateOperations)
+        .hasIncident(hasIncident)
+        .tenantIdOperations(tenantIdOperations)
+        .variables(variableFilters)
+        .batchOperationIdOperations(batchOperationIdOperations);
+  }
 
   public static final class Builder implements ObjectBuilder<ProcessInstanceFilter> {
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/data/MsgPackConverterTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/data/MsgPackConverterTest.java
@@ -17,6 +17,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.agrona.LangUtil;
+import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -137,6 +138,19 @@ public final class MsgPackConverterTest {
     MsgPackConverter.convertToMsgPack("}");
   }
 
+  @Test
+  public void shouldConvertMsgPackToObject() {
+    // given
+    final var originalObject = new TestObject("test", 123);
+    final var msgPack = new UnsafeBuffer(MsgPackConverter.convertToMsgPack(originalObject));
+
+    // when
+    final var result = MsgPackConverter.convertToObject(msgPack, TestObject.class);
+
+    // then
+    assertThat(result).isEqualTo(originalObject);
+  }
+
   private static byte[] createMsgPack() {
     byte[] msgPack = null;
 
@@ -152,4 +166,6 @@ public final class MsgPackConverterTest {
     }
     return msgPack;
   }
+
+  private record TestObject(String name, int value) {}
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1520,6 +1520,42 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /process-instances/batch-operations/cancellation:
+    post:
+      tags:
+        - Process instance
+      operationId: cancelProcessInstancesBatchOperation
+      summary: Create a batch operation to cancel process instances
+      description: |
+        Cancels multiple running process instances.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProcessInstanceFilter"
+      responses:
+        "202":
+          description: The batch operation request was accepted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BatchOperationCreatedResult"
+        "400":
+          description: >
+            The process instance batch operation failed.
+            More details are provided in the response body.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   /process-instances/{processInstanceKey}/migration:
     post:
       tags:
@@ -7261,6 +7297,16 @@ components:
         formKey:
           description: The assigned key, which acts as a unique identifier for this form.
           type: string
+    BatchOperationCreatedResult:
+      type: object
+      properties:
+        batchOperationKey:
+          description: Key of the batch operation.
+          type: string
+        batchOperationType:
+          description: The type of the batch operation.
+          type: string
+          example: PROCESS_CANCELLATION
     BatchOperationSearchQuerySortRequest:
       type: object
       properties:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.gateway.impl.job.JobActivationResult;
 import io.camunda.zeebe.gateway.protocol.rest.ActivatedJobResult;
 import io.camunda.zeebe.gateway.protocol.rest.AuthorizationCreateResult;
+import io.camunda.zeebe.gateway.protocol.rest.BatchOperationCreatedResult;
 import io.camunda.zeebe.gateway.protocol.rest.CreateProcessInstanceResult;
 import io.camunda.zeebe.gateway.protocol.rest.DeploymentDecisionRequirementsResult;
 import io.camunda.zeebe.gateway.protocol.rest.DeploymentDecisionResult;
@@ -59,6 +60,7 @@ import io.camunda.zeebe.msgpack.value.ValueArray;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsMetadataRecord;
@@ -452,6 +454,15 @@ public final class ResponseMapper {
     }
 
     return new ResponseEntity<>(response, HttpStatus.OK);
+  }
+
+  public static ResponseEntity<Object> toCancelProcessInstanceBatchOperationWithResultResponse(
+      final BatchOperationCreationRecord brokerResponse) {
+    final var response =
+        new BatchOperationCreatedResult()
+            .batchOperationKey(KeyUtil.keyToString(brokerResponse.getBatchOperationKey()))
+            .batchOperationType(brokerResponse.getBatchOperationType().toString());
+    return new ResponseEntity<>(response, HttpStatus.CREATED);
   }
 
   public static ResponseEntity<Object> toSignalBroadcastResponse(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -597,7 +597,7 @@ public final class SearchQueryRequestMapper {
     return StringUtils.isEmpty(text) ? null : OffsetDateTime.parse(text);
   }
 
-  private static Either<List<String>, ProcessInstanceFilter> toProcessInstanceFilter(
+  public static Either<List<String>, ProcessInstanceFilter> toProcessInstanceFilter(
       final io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceFilter filter) {
     final var builder = FilterBuilders.processInstance();
     final List<String> validationErrors = new ArrayList<>();

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -18,6 +18,7 @@ import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyRequest;
 import io.camunda.zeebe.gateway.protocol.rest.CancelProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceCreationInstruction;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceFilter;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceMigrationInstruction;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceModificationInstruction;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceSearchQuery;
@@ -29,6 +30,7 @@ import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaPostMapping;
+import io.camunda.zeebe.gateway.rest.validator.RequestValidator;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -103,6 +105,18 @@ public class ProcessInstanceController {
     }
   }
 
+  @CamundaPostMapping(path = "/batch-operations/cancellation")
+  public CompletableFuture<ResponseEntity<Object>> cancelProcessInstanceBatchOperation(
+      @RequestBody(required = false) final ProcessInstanceFilter filter) {
+
+    return SearchQueryRequestMapper.toProcessInstanceFilter(filter)
+        .fold(
+            (errors) ->
+                RestErrorMapper.mapProblemToCompletedResponse(
+                    RequestValidator.createProblemDetail(errors).get()),
+            this::batchOperationCancellation);
+  }
+
   private ResponseEntity<ProcessInstanceSearchQueryResult> search(
       final ProcessInstanceQuery query) {
     try {
@@ -115,6 +129,17 @@ public class ProcessInstanceController {
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
+  }
+
+  private CompletableFuture<ResponseEntity<Object>> batchOperationCancellation(
+      final io.camunda.search.filter.ProcessInstanceFilter filter) {
+    return RequestMapper.executeServiceMethod(
+        () ->
+            processInstanceServices
+                .withAuthentication(RequestMapper.getAuthentication())
+                .cancelProcessInstanceBatchOperationWithResult(filter),
+        ResponseMapper
+            ::toCancelProcessInstanceBatchOperationWithResultResponse); // TODO better response
   }
 
   private CompletableFuture<ResponseEntity<Object>> createProcessInstance(

--- a/zeebe/gateway/pom.xml
+++ b/zeebe/gateway/pom.xml
@@ -67,6 +67,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-domain</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.agrona</groupId>
       <artifactId>agrona</artifactId>
     </dependency>

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateBatchOperationRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCreateBatchOperationRequest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.search.filter.FilterBase;
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public class BrokerCreateBatchOperationRequest
+    extends BrokerExecuteCommand<BatchOperationCreationRecord> {
+
+  BatchOperationCreationRecord requestDto = new BatchOperationCreationRecord();
+
+  public BrokerCreateBatchOperationRequest() {
+    super(ValueType.BATCH_OPERATION_CREATION, BatchOperationIntent.CREATE);
+  }
+
+  public BrokerCreateBatchOperationRequest setBatchOperationType(
+      final BatchOperationType batchOperationType) {
+    requestDto.setBatchOperationType(batchOperationType);
+    return this;
+  }
+
+  @Override
+  public BatchOperationCreationRecord getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected BatchOperationCreationRecord toResponseDto(final DirectBuffer buffer) {
+    final BatchOperationCreationRecord responseDto = new BatchOperationCreationRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+
+  public BrokerCreateBatchOperationRequest setFilter(final FilterBase filter) {
+    requestDto.setEntityFilter(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(filter)));
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MsgPackConverter.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MsgPackConverter.java
@@ -215,4 +215,14 @@ public final class MsgPackConverter {
       throw new RuntimeException(e);
     }
   }
+
+  public static <T> T convertToObject(final DirectBuffer buffer, final Class<T> clazz) {
+    final byte[] msgpackBytes = BufferUtil.bufferAsArray(buffer);
+
+    try {
+      return MESSSAGE_PACK_OBJECT_MAPPER.readValue(msgpackBytes, clazz);
+    } catch (final IOException e) {
+      throw new RuntimeException("Failed to deserialize MessagePack to Map", e);
+    }
+  }
 }


### PR DESCRIPTION
## Description

Adds a new endpoint to process instance controller to cancel instances via batch operation. This just sends in the end the broker command, the implementation itself is here: [#29736](https://github.com/camunda/camunda/pull/29736)

## Related issues

closes #29703 
