### PR TITLE
ci: link GH issues for daily stats if found

### DIFF
--- a/.github/workflows/statistics-daily.yml
+++ b/.github/workflows/statistics-daily.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Create message with BigQuery data
         id: message
+        env:
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           NUMBER_OF_ALL_JOBS=$(bq query --format=json --use_legacy_sql=false --quiet=true 'SELECT COUNT(*) as number_of_all_jobs FROM `ci-30-162810.prod_ci_analytics.build_status_v2` WHERE TIMESTAMP_SUB(TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY), INTERVAL 1 DAY)<=report_time AND report_time<=TIMESTAMP_TRUNC(CURRENT_TIMESTAMP, DAY) AND ci_url="https://github.com/camunda/camunda"' | jq -r '.[0].number_of_all_jobs')
@@ -61,16 +63,30 @@ jobs:
             echo ""
             echo "$TOP5_FLAKYTESTS" | jq -c '.[]' | while read -r top_flakytest; do
               NUMBER_OF_FLAKES=$(echo "$top_flakytest" | jq -r '.number_of_flakes')
-              TEST_CLASS_NAME=$(echo "$top_flakytest" | jq -r '.test_class_name')
+              FULLY_QUALIFIED_TEST_CLASS_NAME=$(echo "$top_flakytest" | jq -r '.test_class_name')
+              TEST_CLASS_NAME="${FULLY_QUALIFIED_TEST_CLASS_NAME##*.}"
               TEST_NAME=$(echo "$top_flakytest" | jq -r '.test_name')
-              echo "• ${NUMBER_OF_FLAKES}x \`${TEST_CLASS_NAME##*.}.$TEST_NAME\`\n"
+              SUFFIX=""
+
+              # Try to find GH issues about related flaky tests:
+              # First, search specifically by test class name + test name + "flaky"
+              GH_ISSUE_ID=$(gh issue list -R camunda/camunda --search "in:title $TEST_CLASS_NAME AND in:title $TEST_NAME AND in:title flaky" --json number --jq '.[].number' | head -n 1)
+              if [ -z "$GH_ISSUE_ID" ]; then
+                # If nothing found, search by test class name + "flaky"
+                GH_ISSUE_ID=$(gh issue list -R camunda/camunda --search "in:title $TEST_CLASS_NAME AND in:title flaky" --json number --jq '.[].number' | head -n 1)
+              fi
+              if [ -n "$GH_ISSUE_ID" ]; then
+                SUFFIX=" (<https://github.com/camunda/camunda/issues/$GH_ISSUE_ID|GH issue>)"
+              fi
+
+              echo "• ${NUMBER_OF_FLAKES}x \`$TEST_CLASS_NAME.$TEST_NAME\`$SUFFIX\n"
             done
             echo ""
             echo "📊 Check out <https://dashboard.int.camunda.com/d/ae2j69npxh3b4f/flaky-tests-camunda-camunda-monorepo?orgId=1&from=now-1d%2Fd&to=now-1d%2Fd&timezone=browser&var-branch=main|Grafana for links and more details>."
             echo "EOF"
           } >> $GITHUB_OUTPUT
 
-      - name: Debug notificatoin
+      - name: Debug notification
         if: github.event_name == 'pull_request'
         shell: bash
         run: |


### PR DESCRIPTION
## Description

PR extends the script that generates overview of daily flaky test statistics by trying to look up related GH issues via some heuristics about the issue name (no 100% hit rate, but good enough).

New result snippet locally (compared with [old on Slack](https://camunda.slack.com/archives/C071KP5BTHB/p1742371777975669)):

```
🥇 Top 5 flakiest tests yesterday:

• 29x `RaftCorruptedDataTest.upToDateFollowerShouldNotLoseDataWhenQuorumExperienceCorruption` (<https://github.com/camunda/camunda/issues/27849|GH issue>)\n
• 21x `MigrationRunnerIT.shouldMigrateSuccessfullyWithMultipleRounds(boolean)[2] isElasticsearch=false`\n
• 20x `ElasticsearchUpdateRegressionTest.shouldBeAbleToUpdateAndExport`\n
• 16x `ProcessCacheTest.shouldRemoveExpiredItem`\n
• 15x `PartitionJoinTest.canLeavePartitionAfterJoining(Scenario)[1] scenario=Scenario[initialClusterState=InitialClusterState[clusterSize=3, partitionCount=3, replicationFactor=1], operation=Operation[brokerId=1, partitionId=1, priority=2]]` (<https://github.com/camunda/camunda/issues/27847|GH issue>)\n
```

Results also in https://github.com/camunda/camunda/actions/runs/13950793756/job/39049493449?pr=29861#step:8:27

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Related #28988 
