### PR TITLE
feat: clear ProcessCache during purge operation

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/rest/RestApiConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rest/RestApiConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.application.commons.rest;
 
 import io.camunda.application.commons.rest.RestApiConfiguration.GatewayRestProperties;
 import io.camunda.service.ProcessDefinitionServices;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import io.camunda.zeebe.gateway.rest.cache.ProcessCache;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
@@ -34,8 +35,10 @@ public class RestApiConfiguration {
   @Bean
   public ProcessCache processCache(
       final GatewayRestConfiguration configuration,
-      final ProcessFlowNodeProvider processFlowNodeProvider) {
-    return new ProcessCache(configuration, processFlowNodeProvider);
+      final ProcessFlowNodeProvider processFlowNodeProvider,
+      final BrokerTopologyManager brokerTopologyManager) {
+
+    return new ProcessCache(configuration, processFlowNodeProvider, brokerTopologyManager);
   }
 
   @ConfigurationProperties("camunda.rest")

--- a/qa/integration-tests/src/test/java/io/camunda/it/cluster/ClusterPurgeMultiDbIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/cluster/ClusterPurgeMultiDbIT.java
@@ -237,7 +237,19 @@ public class ClusterPurgeMultiDbIT {
             .join()
             .items();
 
-    // This will fail, if the ProcessCache is not cleared.
+    /*
+     * This will fail if the ProcessCache is not cleared.
+     *
+     * Scenario:
+     * - A new cluster is started and a Process model is deployed.
+     * - We execute a flow node instance query which also populates the ProcessCache.
+     * - We purge the cluster, but don't delete the ProcessCache.
+     * - We deploy a new Process model, but this will have the same key as the old one.
+     * - We execute a flow node instance query which finds outdated data in the ProcessCache.
+     * - The outdated data is returned instead of the correct information.
+     * - Therefore, without purging the ProcessCache, the query will not return a FlowNode of name
+     *   "test-task-2"
+     */
     assertThat((items2.get(1)).getFlowNodeName()).isEqualTo("test-task-2");
   }
 

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClusterState.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClusterState.java
@@ -16,7 +16,6 @@ public interface BrokerClusterState {
   int UNKNOWN_NODE_ID = -1;
   int NODE_ID_NULL = UNKNOWN_NODE_ID - 1;
   int PARTITION_ID_NULL = NODE_ID_NULL - 1;
-  int NO_LAST_COMPLETED_CHANGE_ID = -1;
 
   boolean isInitialized();
 
@@ -50,7 +49,5 @@ public interface BrokerClusterState {
 
   PartitionHealthStatus getPartitionHealth(int brokerId, int partition);
 
-  default long getLastCompletedChangeId() {
-    return NO_LAST_COMPLETED_CHANGE_ID;
-  }
+  long getLastCompletedChangeId();
 }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClusterState.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClusterState.java
@@ -48,4 +48,8 @@ public interface BrokerClusterState {
   String getBrokerVersion(int brokerId);
 
   PartitionHealthStatus getPartitionHealth(int brokerId, int partition);
+
+  default long getLastCompletedChangeId() {
+    return 0;
+  }
 }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClusterState.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClusterState.java
@@ -16,6 +16,7 @@ public interface BrokerClusterState {
   int UNKNOWN_NODE_ID = -1;
   int NODE_ID_NULL = UNKNOWN_NODE_ID - 1;
   int PARTITION_ID_NULL = NODE_ID_NULL - 1;
+  int NO_LAST_COMPLETED_CHANGE_ID = -1;
 
   boolean isInitialized();
 
@@ -50,6 +51,6 @@ public interface BrokerClusterState {
   PartitionHealthStatus getPartitionHealth(int brokerId, int partition);
 
   default long getLastCompletedChangeId() {
-    return 0;
+    return NO_LAST_COMPLETED_CHANGE_ID;
   }
 }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyListener.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyListener.java
@@ -9,7 +9,10 @@ package io.camunda.zeebe.broker.client.api;
 
 import io.atomix.cluster.MemberId;
 
-/** Listener which will be notified when a broker is added or removed from the topology. */
+/**
+ * Listener which will be notified when a broker is added or removed from the topology, or when a
+ * cluster change operation has completed.
+ */
 public interface BrokerTopologyListener {
 
   default void brokerAdded(final MemberId memberId) {}

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyListener.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyListener.java
@@ -12,7 +12,9 @@ import io.atomix.cluster.MemberId;
 /** Listener which will be notified when a broker is added or removed from the topology. */
 public interface BrokerTopologyListener {
 
-  void brokerAdded(MemberId memberId);
+  default void brokerAdded(final MemberId memberId) {}
 
-  void brokerRemoved(MemberId memberId);
+  default void brokerRemoved(final MemberId memberId) {}
+
+  default void completedClusterChange() {}
 }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClusterStateImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClusterStateImpl.java
@@ -21,6 +21,7 @@ import org.agrona.collections.IntArrayList;
 public final class BrokerClusterStateImpl implements BrokerClusterState {
 
   public static final int UNINITIALIZED_CLUSTER_SIZE = -1;
+  public static final long NO_COMPLETED_LAST_CHANGE_ID = -1;
   private static final Long TERM_NONE = -1L;
   private final Int2IntHashMap partitionLeaders;
   private final Int2ObjectHashMap<Long> partitionLeaderTerms;
@@ -36,6 +37,7 @@ public final class BrokerClusterStateImpl implements BrokerClusterState {
   private int clusterSize = UNINITIALIZED_CLUSTER_SIZE;
   private int partitionsCount;
   private int replicationFactor;
+  private long lastCompletedChangeId = NO_COMPLETED_LAST_CHANGE_ID;
 
   public BrokerClusterStateImpl(final BrokerClusterStateImpl topology) {
     this();
@@ -54,6 +56,7 @@ public final class BrokerClusterStateImpl implements BrokerClusterState {
       clusterSize = topology.clusterSize;
       partitionsCount = topology.partitionsCount;
       replicationFactor = topology.replicationFactor;
+      lastCompletedChangeId = topology.lastCompletedChangeId;
     }
   }
 
@@ -275,6 +278,15 @@ public final class BrokerClusterStateImpl implements BrokerClusterState {
     } else {
       return brokerHealthyPartitions.getOrDefault(partitionId, PartitionHealthStatus.UNHEALTHY);
     }
+  }
+
+  @Override
+  public long getLastCompletedChangeId() {
+    return lastCompletedChangeId;
+  }
+
+  public void setLastCompletedChangeId(final long lastCompletedChangeId) {
+    this.lastCompletedChangeId = lastCompletedChangeId;
   }
 
   @Override

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -248,33 +248,14 @@ public final class BrokerTopologyManagerImpl extends Actor
   private void notifyOnClusterChangeCompleted(
       final ClusterConfiguration clusterTopology, final BrokerClusterStateImpl topologyToUpdate) {
 
-    updateCurrentTopologyLastChangeIdIfNecessary(clusterTopology, topologyToUpdate);
-
     clusterTopology
         .lastChange()
         .filter(lastChange -> lastChange.id() > topologyToUpdate.getLastCompletedChangeId())
         .ifPresent(
             lastChange -> {
-              LOG.debug("The cluster has for sure been updated with new id " + lastChange.id());
+              LOG.info("The cluster has for sure been updated with new id " + lastChange.id());
 
               topologyListeners.forEach(BrokerTopologyListener::completedClusterChange);
-              topologyToUpdate.setLastCompletedChangeId(lastChange.id());
-            });
-  }
-
-  /*
-   * When the app starts up the lastCompletedChangeId is set to-1.
-   * We should ignore it by setting it to the current topology changeId
-   */
-  private void updateCurrentTopologyLastChangeIdIfNecessary(
-      final ClusterConfiguration clusterTopology, final BrokerClusterStateImpl topologyToUpdate) {
-
-    clusterTopology
-        .lastChange()
-        .filter(lastChange -> topologyToUpdate.getLastCompletedChangeId() == -1)
-        .ifPresent(
-            lastChange -> {
-              LOG.debug("Updating initial topologyState to " + lastChange.id());
               topologyToUpdate.setLastCompletedChangeId(lastChange.id());
             });
   }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -224,7 +224,7 @@ public final class BrokerTopologyManagerImpl extends Actor
 
     updateTopology(
         topologyToUpdate -> {
-          notifyOnClusterChangeCompleted(clusterTopology, topologyToUpdate);
+          updateOnClusterChangeCompleted(clusterTopology, topologyToUpdate);
 
           final var newClusterSize = clusterTopology.clusterSize();
           final var newPartitionsCount = clusterTopology.partitionCount();
@@ -245,7 +245,7 @@ public final class BrokerTopologyManagerImpl extends Actor
         });
   }
 
-  private void notifyOnClusterChangeCompleted(
+  private void updateOnClusterChangeCompleted(
       final ClusterConfiguration clusterTopology, final BrokerClusterStateImpl topologyToUpdate) {
 
     clusterTopology
@@ -253,10 +253,9 @@ public final class BrokerTopologyManagerImpl extends Actor
         .filter(lastChange -> lastChange.id() > topologyToUpdate.getLastCompletedChangeId())
         .ifPresent(
             lastChange -> {
-              LOG.info("The cluster has for sure been updated with new id " + lastChange.id());
-
               topologyListeners.forEach(BrokerTopologyListener::completedClusterChange);
               topologyToUpdate.setLastCompletedChangeId(lastChange.id());
+              LOG.debug("Updated topology with last completed change id " + lastChange.id());
             });
   }
 }

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -374,7 +374,7 @@ final class BrokerTopologyManagerTest {
     addTopologyListener(listener);
 
     // when
-    final ClusterConfiguration clusterTopologyWithTwoBrokers =
+    final ClusterConfiguration clusterTopology =
         new ClusterConfiguration(
             1,
             Map.of(),
@@ -382,7 +382,7 @@ final class BrokerTopologyManagerTest {
             Optional.empty(),
             Optional.empty());
 
-    topologyManager.onClusterConfigurationUpdated(clusterTopologyWithTwoBrokers);
+    topologyManager.onClusterConfigurationUpdated(clusterTopology);
     actorSchedulerRule.workUntilDone();
 
     // then

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -16,7 +16,9 @@ import io.atomix.cluster.Member;
 import io.atomix.cluster.MemberConfig;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.client.impl.BrokerTopologyManagerImpl;
+import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.CompletedChange;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
@@ -24,8 +26,10 @@ import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import org.awaitility.Awaitility;
@@ -364,6 +368,28 @@ final class BrokerTopologyManagerTest {
   }
 
   @Test
+  void shouldNotifyListenerWhenClusterChangeCompleted() {
+    // given
+    final ClusterCompletedChangeListener listener = new ClusterCompletedChangeListener();
+    addTopologyListener(listener);
+
+    // when
+    final ClusterConfiguration clusterTopologyWithTwoBrokers =
+        new ClusterConfiguration(
+            1,
+            Map.of(),
+            Optional.of(new CompletedChange(1, Status.COMPLETED, Instant.now(), Instant.now())),
+            Optional.empty(),
+            Optional.empty());
+
+    topologyManager.onClusterConfigurationUpdated(clusterTopologyWithTwoBrokers);
+    actorSchedulerRule.workUntilDone();
+
+    // then
+    assertThat(listener.wasExecutedAfterClusterChange()).isTrue();
+  }
+
+  @Test
   void shouldRemoveListener() {
     // given
     final RecordingTopologyListener topology = new RecordingTopologyListener();
@@ -493,7 +519,7 @@ final class BrokerTopologyManagerTest {
     assertThat(topologyManager.getTopology().getPartitionsCount()).isEqualTo(2);
   }
 
-  private void addTopologyListener(final RecordingTopologyListener listener) {
+  private void addTopologyListener(final BrokerTopologyListener listener) {
     topologyManager.addTopologyListener(listener);
     actorSchedulerRule.workUntilDone();
   }
@@ -555,6 +581,19 @@ final class BrokerTopologyManagerTest {
 
     Set<Integer> getBrokers() {
       return brokers;
+    }
+  }
+
+  private static final class ClusterCompletedChangeListener implements BrokerTopologyListener {
+    private boolean wasExecutedAfterClusterChange = false;
+
+    @Override
+    public void completedClusterChange() {
+      wasExecutedAfterClusterChange = true;
+    }
+
+    public boolean wasExecutedAfterClusterChange() {
+      return wasExecutedAfterClusterChange;
     }
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5805,8 +5805,7 @@ components:
           nullable: true
         lastCompletedChangeId:
           description: ID of the last completed change
-          type: integer
-          format: int64
+          type: string
           nullable: true
     LicenseResponse:
       description: The response of a license request.

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5803,6 +5803,11 @@ components:
           description: The version of the Zeebe Gateway.
           type: string
           nullable: true
+        lastCompletedChangeId:
+          description: ID of the last completed change
+          type: integer
+          format: int64
+          nullable: true
     LicenseResponse:
       description: The response of a license request.
       type: object

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/cache/ProcessCache.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/cache/ProcessCache.java
@@ -12,6 +12,8 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.UserTaskEntity;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyListener;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.util.ProcessFlowNodeProvider;
 import java.util.Collections;
@@ -39,7 +41,8 @@ public class ProcessCache {
 
   public ProcessCache(
       final GatewayRestConfiguration configuration,
-      final ProcessFlowNodeProvider processFlowNodeProvider) {
+      final ProcessFlowNodeProvider processFlowNodeProvider,
+      final BrokerTopologyManager brokerTopologyManager) {
     this.processFlowNodeProvider = processFlowNodeProvider;
     final var cacheBuilder =
         Caffeine.newBuilder().maximumSize(configuration.getProcessCache().getMaxSize());
@@ -48,6 +51,8 @@ public class ProcessCache {
       cacheBuilder.expireAfterAccess(expirationIdle, TimeUnit.MILLISECONDS);
     }
     cache = cacheBuilder.build(new ProcessCacheLoader());
+
+    brokerTopologyManager.addTopologyListener(new ProcessCacheInvalidator(this));
   }
 
   public ProcessCacheItem getCacheItem(final long processDefinitionKey) {
@@ -78,6 +83,10 @@ public class ProcessCache {
     return getCacheItem(flowNode.processDefinitionKey()).getFlowNodeName(flowNode.flowNodeId());
   }
 
+  public void invalidate() {
+    cache.invalidateAll();
+  }
+
   private final class ProcessCacheLoader implements CacheLoader<Long, ProcessCacheItem> {
 
     @Override
@@ -102,6 +111,19 @@ public class ProcessCache {
               Collectors.toMap(
                   Map.Entry::getKey,
                   entry -> new ProcessCacheItem(Collections.unmodifiableMap(entry.getValue()))));
+    }
+  }
+
+  private final class ProcessCacheInvalidator implements BrokerTopologyListener {
+    private final ProcessCache cache;
+
+    public ProcessCacheInvalidator(final ProcessCache cache) {
+      this.cache = cache;
+    }
+
+    @Override
+    public void completedClusterChange() {
+      cache.invalidate();
     }
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/cache/ProcessCache.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/cache/ProcessCache.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Process cache uses a Caffeine {@link LoadingCache} to store process definition key and {@link
@@ -35,6 +37,8 @@ import java.util.stream.Collectors;
  * GatewayRestConfiguration.ProcessCacheConfiguration} properties.
  */
 public class ProcessCache {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ProcessCache.class);
 
   private final LoadingCache<Long, ProcessCacheItem> cache;
   private final ProcessFlowNodeProvider processFlowNodeProvider;
@@ -85,6 +89,7 @@ public class ProcessCache {
 
   public void invalidate() {
     cache.invalidateAll();
+    LOGGER.debug("Cache invalidated");
   }
 
   private final class ProcessCacheLoader implements CacheLoader<Long, ProcessCacheItem> {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/TopologyController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/TopologyController.java
@@ -46,7 +46,8 @@ public final class TopologyController {
       response
           .clusterSize(topology.getClusterSize())
           .partitionsCount(topology.getPartitionsCount())
-          .replicationFactor(topology.getReplicationFactor());
+          .replicationFactor(topology.getReplicationFactor())
+          .lastCompletedChangeId(topology.getLastCompletedChangeId());
 
       topology
           .getBrokers()

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/TopologyController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/TopologyController.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.gateway.protocol.rest.Partition.RoleEnum;
 import io.camunda.zeebe.gateway.protocol.rest.TopologyResponse;
 import io.camunda.zeebe.gateway.rest.Loggers;
 import io.camunda.zeebe.gateway.rest.annotation.CamundaGetMapping;
+import io.camunda.zeebe.gateway.rest.util.KeyUtil;
 import io.camunda.zeebe.util.VersionUtil;
 import java.util.Set;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -47,7 +48,7 @@ public final class TopologyController {
           .clusterSize(topology.getClusterSize())
           .partitionsCount(topology.getPartitionsCount())
           .replicationFactor(topology.getReplicationFactor())
-          .lastCompletedChangeId(String.valueOf(topology.getLastCompletedChangeId()));
+          .lastCompletedChangeId(KeyUtil.keyToString(topology.getLastCompletedChangeId()));
 
       topology
           .getBrokers()

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/TopologyController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/TopologyController.java
@@ -47,7 +47,7 @@ public final class TopologyController {
           .clusterSize(topology.getClusterSize())
           .partitionsCount(topology.getPartitionsCount())
           .replicationFactor(topology.getReplicationFactor())
-          .lastCompletedChangeId(topology.getLastCompletedChangeId());
+          .lastCompletedChangeId(String.valueOf(topology.getLastCompletedChangeId()));
 
       topology
           .getBrokers()

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
@@ -47,7 +47,7 @@ public class TopologyControllerTest extends RestControllerTest {
           "clusterSize": 3,
           "partitionsCount": 1,
           "replicationFactor": 3,
-          "lastCompletedChangeId": 1,
+          "lastCompletedChangeId": "1",
           "brokers": [
             {
               "nodeId": 0,

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
@@ -219,5 +219,10 @@ public class TopologyControllerTest extends RestControllerTest {
         default -> PartitionHealthStatus.NULL_VAL;
       };
     }
+
+    @Override
+    public long getLastCompletedChangeId() {
+      return 0;
+    }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
@@ -21,14 +21,14 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @WebMvcTest(TopologyController.class)
 public class TopologyControllerTest extends RestControllerTest {
 
-  @MockBean BrokerClient brokerClient;
-  @MockBean BrokerTopologyManager topologyManager;
+  @MockitoBean BrokerClient brokerClient;
+  @MockitoBean BrokerTopologyManager topologyManager;
 
   @BeforeEach
   void setUp() {
@@ -47,6 +47,7 @@ public class TopologyControllerTest extends RestControllerTest {
           "clusterSize": 3,
           "partitionsCount": 1,
           "replicationFactor": 3,
+          "lastCompletedChangeId": 1,
           "brokers": [
             {
               "nodeId": 0,
@@ -222,7 +223,7 @@ public class TopologyControllerTest extends RestControllerTest {
 
     @Override
     public long getLastCompletedChangeId() {
-      return 0;
+      return 1;
     }
   }
 }

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategyTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategyTest.java
@@ -141,6 +141,11 @@ final class PublishMessageDispatchStrategyTest {
     public PartitionHealthStatus getPartitionHealth(final int brokerId, final int partition) {
       throw new UnsupportedOperationException();
     }
+
+    @Override
+    public long getLastCompletedChangeId() {
+      throw new UnsupportedOperationException();
+    }
   }
 
   private record TestTopologyManager(


### PR DESCRIPTION
## Description

After attempting to implement the purgeCluster operation as part of an effort to optimize the CamundaProcessTest, it became apparent that there was still information lingering in the ProcessCache that caused the tests to fail. This prompted an investigation and a "quick-fix" that attempts to purge the cache whenever a cluster update is detected. There are a couple of downsides:

- The caches are emptied after every cluster update, not just as part of a purge operation.
- We had to expose the lastCompletedChangeId variable as part of the TopologyResponse
- There are other ProcessCaches in Operate and Tasklist that aren't emptied and whose implementations differ from the ProcessCache in the Zeebe Gateway

There are follow-up issues to develop a better solution that fixes or avoids these downsides, see [Update purge cluster documentation to reflect the need to query the Topology API #29864](https://github.com/camunda/camunda/issues/29864)

## Related issues

[closes #29865](https://github.com/camunda/camunda/issues/29864)