### PR TITLE
Tasklist importer cannot deserialize user tasks variables with Long values

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/CommonsModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/CommonsModuleConfiguration.java
@@ -8,6 +8,7 @@
 package io.camunda.application.commons;
 
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -19,6 +20,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @EnableAutoConfiguration
 public class CommonsModuleConfiguration {
   @Bean
+  @ConditionalOnMissingBean
   public PasswordEncoder passwordEncoder() {
     return PasswordEncoderFactories.createDelegatingPasswordEncoder();
   }

--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/common/UserTaskRecordToVariableEntityMapper.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/common/UserTaskRecordToVariableEntityMapper.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -31,7 +32,9 @@ public class UserTaskRecordToVariableEntityMapper {
 
   @Autowired private TasklistProperties tasklistProperties;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   public List<TaskVariableEntity> mapVariables(final Record<UserTaskRecordValue> record) {
     final List<TaskVariableEntity> variables = new ArrayList<>();

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/common/UserTaskRecordToVariableEntityMapper.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/common/UserTaskRecordToVariableEntityMapper.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -31,7 +32,9 @@ public class UserTaskRecordToVariableEntityMapper {
 
   @Autowired private TasklistProperties tasklistProperties;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   public List<TaskVariableEntity> mapVariables(final Record<UserTaskRecordValue> record) {
     final List<TaskVariableEntity> variables = new ArrayList<>();

--- a/tasklist/qa/integration-tests/pom.xml
+++ b/tasklist/qa/integration-tests/pom.xml
@@ -490,6 +490,24 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit-junit5-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit-junit5-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/ObjectMapperQualifierArchTest.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/ObjectMapperQualifierArchTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+@AnalyzeClasses(
+    packages = "io.camunda.tasklist",
+    importOptions = ImportOption.DoNotIncludeTests.class)
+public class ObjectMapperQualifierArchTest {
+
+  @ArchTest
+  public static final ArchRule AUTOWIRED_OBJECT_MAPPER_FIELDS_SHOULD_HAVE_QUALIFIER =
+      fields()
+          .that()
+          .areAnnotatedWith(Autowired.class)
+          .and()
+          .haveRawType(ObjectMapper.class)
+          .should(
+              new ArchCondition<>("have @Qualifier(\"tasklistObjectMapper\")") {
+                @Override
+                public void check(final JavaField field, final ConditionEvents events) {
+                  final boolean hasQualifier = field.isAnnotatedWith(Qualifier.class);
+                  if (!hasQualifier) {
+                    events.add(
+                        SimpleConditionEvent.violated(
+                            field,
+                            "Field "
+                                + field.getFullName()
+                                + "in class "
+                                + field.getOwner().getFullName()
+                                + " is missing @Qualifier(\"tasklistObjectMapper\")"));
+                  } else if (!"tasklistObjectMapper"
+                      .equals(field.getAnnotationOfType(Qualifier.class).value())) {
+                    events.add(
+                        SimpleConditionEvent.violated(
+                            field,
+                            "Field "
+                                + field.getFullName()
+                                + "in class "
+                                + field.getOwner().getFullName()
+                                + " has @Qualifier(\"%s\")"
+                                    .formatted(
+                                        field.getAnnotationOfType(Qualifier.class).value())));
+                  }
+                }
+              });
+}

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestApplication.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestApplication.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.tasklist.util;
 
+import io.camunda.application.commons.CommonsModuleConfiguration;
 import io.camunda.tasklist.TasklistModuleConfiguration;
 import io.camunda.tasklist.data.DataGenerator;
 import io.camunda.tasklist.data.es.DevDataGeneratorElasticSearch;
@@ -34,7 +35,7 @@ import org.springframework.context.annotation.Profile;
           value = TasklistModuleConfiguration.class),
     },
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
-@Import({WebappsModuleConfiguration.class})
+@Import({WebappsModuleConfiguration.class, CommonsModuleConfiguration.class})
 public class TestApplication {
 
   public static void main(final String[] args) throws Exception {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeUserTaskImportIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeUserTaskImportIT.java
@@ -83,7 +83,7 @@ public class ZeebeUserTaskImportIT extends TasklistZeebeIntegrationTest {
   }
 
   @Test
-  public void shouldImportZeebeUserTaskWithNullVariableValue() {
+  public void shouldImportCompletedZeebeUserTaskWithVariables() {
     final String bpmnProcessId = "testProcess";
     final String flowNodeBpmnId1 = "taskA";
     final String flowNodeBpmnId2 = "taskB";
@@ -106,7 +106,17 @@ public class ZeebeUserTaskImportIT extends TasklistZeebeIntegrationTest {
             .startProcessInstance(bpmnProcessId)
             .waitUntil()
             .taskIsCreated(flowNodeBpmnId1)
-            .completeZeebeUserTask(flowNodeBpmnId1, Map.of("varA", objectMapper.nullNode()))
+            .completeZeebeUserTask(
+                flowNodeBpmnId1,
+                Map.of(
+                    "varA",
+                    objectMapper.nullNode(),
+                    "varB",
+                    Long.MAX_VALUE,
+                    "varC",
+                    Integer.MAX_VALUE,
+                    "varD",
+                    "str"))
             .waitUntil()
             .taskIsCreated(flowNodeBpmnId2)
             .getTaskId();
@@ -123,7 +133,11 @@ public class ZeebeUserTaskImportIT extends TasklistZeebeIntegrationTest {
         .hasApplicationJsonContentType()
         .extractingListContent(objectMapper, VariableSearchResponse.class)
         .extracting("name", "previewValue", "value")
-        .containsExactly(tuple("varA", "null", "null"));
+        .containsExactlyInAnyOrder(
+            tuple("varA", "null", "null"),
+            tuple("varB", "9223372036854775807", "9223372036854775807"),
+            tuple("varC", "2147483647", "2147483647"),
+            tuple("varD", "\"str\"", "\"str\""));
   }
 
   @Test

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/serializer/LongSerializer.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/serializer/LongSerializer.java
@@ -41,7 +41,8 @@ public class LongSerializer extends JsonSerializer<Long> {
 
   private boolean gatewayRestPackage(final JsonGenerator gen) {
     return gatewayRestPackage(gen.getOutputContext().getCurrentValue())
-        || gatewayRestPackage(gen.getOutputContext().getParent().getCurrentValue());
+        || (gen.getOutputContext().getParent() != null
+            && gatewayRestPackage(gen.getOutputContext().getParent().getCurrentValue()));
   }
 
   private boolean fieldNameEndsWithKey(final JsonGenerator gen) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

* Added `@Qualifier("tasklistObjectMapper")` to the `objectMapper` field in `UserTaskRecordToVariableEntityMapper` classes for both v850 and v860 processors. 
* Created `ObjectMapperQualifierArchTest` to ensure all `ObjectMapper` fields (under `io.camunda.tasklist` package) annotated with `@Autowired` also have the `@Qualifier("tasklistObjectMapper")` annotation.
* Updated `TestApplication` to import `CommonsModuleConfiguration` to reflect production like configuration (this allowed detecting the issue reported in #29874).
* Fixed a potential `NullPointerException` in `LongSerializer` by adding a null check for the parent context (as discussed in [slack](https://camunda.slack.com/archives/C06UKS51QV9/p1741795221605539) with @danielkelemen) .

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29517 
closes #29874
