### PR TITLE
refactor: add git commit info to built artifact

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -917,6 +917,32 @@
       </plugin>
 
       <plugin>
+        <groupId>io.github.git-commit-id</groupId>
+        <artifactId>git-commit-id-maven-plugin</artifactId>
+        <version>9.0.1</version>
+        <configuration>
+          <dotGitDirectory>${maven.multiModuleProjectDirectory}/.git</dotGitDirectory>
+          <generateGitPropertiesFile>true</generateGitPropertiesFile>
+          <includeOnlyProperties>
+            <includeOnlyProperty>^git.build.(time|version)$</includeOnlyProperty>
+            <includeOnlyProperty>^git.commit.(time)$</includeOnlyProperty>
+            <includeOnlyProperty>^git.commit.id.(abbrev|full)$</includeOnlyProperty>
+            <includeOnlyProperty>^git.(branch)$</includeOnlyProperty>
+          </includeOnlyProperties>
+          <commitIdGenerationMode>full</commitIdGenerationMode>
+        </configuration>
+        <executions>
+          <execution>
+            <id>resolve-git-info</id>
+            <goals>
+              <goal>revision</goal>
+            </goals>
+            <phase>initialize</phase>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <executions>


### PR DESCRIPTION
## Description

This PR adds the git commit info to the build. This creates a `git.properties` file in the `dist/target/classes` folder, which contains properties like:

```
#Generated by Git-Commit-Id-Plugin
git.branch=np-add-git-commit-info
git.build.time=2025-03-19T18\:42\:44+01\:00
git.build.version=8.8.0-SNAPSHOT
git.commit.id.abbrev=d9e7817
git.commit.id.full=d9e7817b16311eee567d2992a0d36ce91c1597e6
git.commit.time=2025-03-19T17\:49\:28+01\:00
```

This file will later be included in the `camunda-zeebe.jar` as is.

It's also picked up by Spring and display in the `9600:/actuator/info` endpoint (see `GitInfoContributor`), which now looks like:

```json
{
  "git": {
    "commit": {
      "id": "d9e7817",
      "time": "2025-03-19T16:49:28Z"
    }
  },
  "build": {
    "java": {
      "version": "21.0.5"
    },
    "description": "Zeebe Distribution",
    "version": "8.8.0-SNAPSHOT",
    "artifact": "camunda-zeebe",
    "name": "Zeebe Distribution",
    "time": "2025-03-19T17:39:51.932Z",
    "group": "io.camunda"
  }
}
```
