### PR TITLE
fix: fix document upload metadata injection for complex bindings

### DIFF
--- a/tasklist/client/src/common/form-js/FormJSRenderer/extractFilePath.test.ts
+++ b/tasklist/client/src/common/form-js/FormJSRenderer/extractFilePath.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {extractFilePath} from './extractFilePath';
+
+describe.only('extractFilePath', () => {
+  it('should extract file paths from an object', () => {
+    const mock = {
+      a: 'files::123',
+      b: {
+        c: 'files::456',
+        d: 'not a file',
+      },
+      e: [
+        'files::789',
+        {
+          f: 'files::012',
+        },
+      ],
+    };
+
+    const result = extractFilePath(mock);
+
+    expect(result.size).toBe(4);
+    expect(result.get('files::123')).toBe('a');
+    expect(result.get('files::456')).toBe('b.c');
+    expect(result.get('files::789')).toBe('e[0]');
+    expect(result.get('files::012')).toBe('e[1].f');
+  });
+
+  it('should handle objects with no file paths', () => {
+    const mock = {
+      a: 1,
+      b: 'text',
+      c: {
+        d: true,
+      },
+    };
+
+    const result = extractFilePath(mock);
+
+    expect(result.size).toBe(0);
+  });
+
+  it('should handle empty objects', () => {
+    expect(extractFilePath({}).size).toBe(0);
+  });
+
+  it('should handle null and undefined values in the object', () => {
+    const mock = {
+      a: null,
+      b: undefined,
+      c: 'files::789',
+    };
+
+    const result = extractFilePath(mock);
+
+    expect(result.size).toBe(1);
+    expect(result.get('files::789')).toBe('c');
+  });
+
+  it('should handle nested arrays and objects with file paths', () => {
+    const mock = {
+      deeply: {
+        nested: {
+          array: [
+            {
+              with: 'files::deep-file',
+            },
+          ],
+        },
+      },
+    };
+
+    const result = extractFilePath(mock);
+
+    expect(result.size).toBe(1);
+    expect(result.get('files::deep-file')).toBe('deeply.nested.array[0].with');
+  });
+
+  it('should handle primitive values as input', () => {
+    expect(extractFilePath(null).size).toBe(0);
+    expect(extractFilePath(undefined).size).toBe(0);
+    expect(extractFilePath(123).size).toBe(0);
+    expect(extractFilePath('string').size).toBe(0);
+    expect(extractFilePath(true).size).toBe(0);
+    expect(extractFilePath(Symbol('test')).size).toBe(0);
+    expect(extractFilePath(BigInt(123)).size).toBe(0);
+    expect(extractFilePath(() => {}).size).toBe(0);
+    expect(extractFilePath(NaN).size).toBe(0);
+    expect(extractFilePath(Infinity).size).toBe(0);
+  });
+});

--- a/tasklist/client/src/common/form-js/FormJSRenderer/extractFilePath.test.ts
+++ b/tasklist/client/src/common/form-js/FormJSRenderer/extractFilePath.test.ts
@@ -15,22 +15,26 @@ describe('extractFilePath', () => {
       b: {
         c: 'files::456',
         d: 'not a file',
+        e: {
+          f: 'files::789',
+        },
       },
-      e: [
-        'files::789',
+      g: [
+        'files::012',
         {
-          f: 'files::012',
+          h: 'files::345',
         },
       ],
     };
 
     const result = extractFilePath(mock);
 
-    expect(result.size).toBe(4);
+    expect(result.size).toBe(5);
     expect(result.get('files::123')).toBe('a');
     expect(result.get('files::456')).toBe('b.c');
-    expect(result.get('files::789')).toBe('e[0]');
-    expect(result.get('files::012')).toBe('e[1].f');
+    expect(result.get('files::789')).toBe('b.e.f');
+    expect(result.get('files::012')).toBe('g[0]');
+    expect(result.get('files::345')).toBe('g[1].h');
   });
 
   it('should handle objects with no file paths', () => {

--- a/tasklist/client/src/common/form-js/FormJSRenderer/extractFilePath.test.ts
+++ b/tasklist/client/src/common/form-js/FormJSRenderer/extractFilePath.test.ts
@@ -8,7 +8,7 @@
 
 import {extractFilePath} from './extractFilePath';
 
-describe.only('extractFilePath', () => {
+describe('extractFilePath', () => {
   it('should extract file paths from an object', () => {
     const mock = {
       a: 'files::123',

--- a/tasklist/client/src/common/form-js/FormJSRenderer/extractFilePath.ts
+++ b/tasklist/client/src/common/form-js/FormJSRenderer/extractFilePath.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+function flattenObject(
+  data: unknown,
+  basePath: string = '',
+): Map<string, unknown> {
+  const result = new Map<string, unknown>();
+
+  if (data === null || data === undefined) {
+    return result;
+  }
+
+  if (typeof data !== 'object') {
+    return result;
+  }
+
+  const entries = Array.isArray(data)
+    ? data.map((val, index) => [index.toString(), val])
+    : Object.entries(data);
+
+  for (const [key, value] of entries) {
+    let currentPath = key;
+
+    if (basePath.length > 0) {
+      currentPath = Array.isArray(data)
+        ? `${basePath}[${key}]`
+        : `${basePath}.${key}`;
+    }
+
+    if (value === null || value === undefined || typeof value !== 'object') {
+      result.set(currentPath, value);
+    } else {
+      const nestedPaths = flattenObject(value, currentPath);
+
+      for (const [nestedPath, nestedValue] of nestedPaths) {
+        result.set(nestedPath, nestedValue);
+      }
+    }
+  }
+
+  return result;
+}
+
+function extractFilePath(data: unknown): Map<string, string> {
+  const flattened = flattenObject(data);
+  const filePaths = new Map<string, string>();
+
+  for (const [path, value] of flattened.entries()) {
+    if (typeof value === 'string' && value.startsWith('files::')) {
+      filePaths.set(value, path);
+    }
+  }
+
+  return filePaths;
+}
+
+export {extractFilePath};


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Because on `form-js` we can't really correlate the field type to the data value output we need to manually keep track of where files are present. After doing the upload we must inject the upload metadata on the form-js output data.

My previous implementation of this had bugs and would break with complex binding like `foo.bar.my_files`. This new implementation should fix these errors. I also added some unit test to this util

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Closes https://github.com/camunda/camunda/issues/27834
