### PR TITLE
Fix flaky Raft data corruption test

### DIFF
--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCorruptedDataTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCorruptedDataTest.java
@@ -13,8 +13,6 @@ import io.atomix.cluster.MemberId;
 import io.atomix.raft.RaftServer.Role;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import org.awaitility.Awaitility;
 import org.junit.Rule;
 import org.junit.Test;
@@ -66,11 +64,10 @@ public class RaftCorruptedDataTest {
     final var server2 = raftRule.createServer(node2);
 
     // then
-    // node2 fails to boostrap, because it detects the commitIndex mismatch
-    assertThatThrownBy(() -> server2.bootstrap(node0, node1, node2).get(2, TimeUnit.SECONDS))
-        .isExactlyInstanceOf(TimeoutException.class);
+    // trigger bootstrap async
+    server2.bootstrap(node0, node1, node2);
 
-    // node does not become follower
+    // node does not become follower - goes to inactive as it detects that it has longer log
     Awaitility.await("node becomes INACTIVE").until(() -> server2.getRole().equals(Role.INACTIVE));
   }
 }


### PR DESCRIPTION
## Description


> [!Note]
>
> I haven't looked at the raft code base, since properly 1-2 years? I might have overseen something, and I might be wrong. But I felt good with the explanation for now. Let me know if you think otherwise.

After [a longer investigation of the test and the related code base ](https://github.com/camunda/camunda/issues/27849#issuecomment-2737010331), and thinking about it. I realized that the actual issue is that the:

 1. In most cases, the leader appender is sending an append quite quick, causing the follower to fail (as the log is larger then the others). This will cause the bootstrap logic to fail or never to complete. This is what the test asserts.
 2. But there are rare cases where bootstrap logic is sometimes just too quick, it is not timing out, nothing is prevent this from happening. In this case the assertion of having an timeout will simply fail. As it just succeeded.
 3. This is not a bug perse, because it will go inactive afterwards, when it receives the append from the leader.

Solution:

 Instead of expecting that the bootstrap fails, simply trigger the bootstrap, async. And just await the follower to go inactive, which will eventually happen.

I was running the test for more than 200 times again, looks ok so far. But Idk it wasn't reproducible locally anyhow.

## Related issues

relates to https://github.com/camunda/camunda/issues/27849


