### PR TITLE
feat: do not autoconfigure quartz with Optimize

### DIFF
--- a/optimize/backend/src/main/resources/application.properties
+++ b/optimize/backend/src/main/resources/application.properties
@@ -8,3 +8,6 @@
 management.endpoints.web.base-path=/actuator
 management.endpoint.metrics.enabled=true
 management.endpoints.web.exposure.include=metrics,health,info,prometheus,backups
+
+spring.autoconfigure.exclude=\
+  org.springframework.boot.autoconfigure.quartz.QuartzAutoConfiguration


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Quartz is initializing liquibase even if Optimize is not running.
Since Optimize is starting liquibase explicitly, we can deactivate the autoconfiguration of Quartz.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
