### PR TITLE
Fix: webapps_backups thread are not stopped gracefully when terminating the application

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -724,6 +724,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-websocket</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/dist/src/main/java/io/camunda/application/commons/backup/HistoryBackupComponent.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/HistoryBackupComponent.java
@@ -15,6 +15,9 @@ import io.camunda.webapps.backup.DynamicIndicesProvider;
 import io.camunda.webapps.backup.repository.BackupRepositoryProps;
 import io.camunda.webapps.profiles.ProfileWebApp;
 import io.camunda.webapps.schema.descriptors.backup.BackupPriorities;
+import jakarta.websocket.OnClose;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -28,6 +31,7 @@ import org.springframework.stereotype.Component;
 @ProfileWebApp
 public class HistoryBackupComponent {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(HistoryBackupComponent.class);
   private final ThreadPoolTaskExecutor threadPoolTaskExecutor;
   private final BackupPriorities backupPriorities;
   private final BackupRepositoryProps backupRepositoryProps;
@@ -55,5 +59,11 @@ public class HistoryBackupComponent {
         backupRepositoryProps,
         backupRepository,
         dynamicIndicesProvider);
+  }
+
+  @OnClose
+  public void shutdownExecutor() {
+    LOGGER.info("Shutting down history backup thread pool.");
+    threadPoolTaskExecutor.shutdown();
   }
 }

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -414,11 +414,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-backup-store-azure</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
       <scope>test</scope>

--- a/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import feign.FeignException.NotFound;
+import io.camunda.application.commons.backup.HistoryBackupComponent;
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.search.response.ProcessInstanceState;
 import io.camunda.management.backups.StateCode;
@@ -24,7 +25,6 @@ import io.camunda.webapps.backup.BackupStateDto;
 import io.camunda.webapps.backup.Metadata;
 import io.camunda.webapps.backup.repository.SnapshotNameProvider;
 import io.camunda.webapps.schema.descriptors.backup.SnapshotIndexCollection;
-import io.camunda.zeebe.backup.azure.AzureBackupStore;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
 import io.camunda.zeebe.qa.util.actuator.BackupActuator;
@@ -183,7 +183,7 @@ public class BackupRestoreIT {
 
   @ParameterizedTest
   @MethodSource(value = {"sources"})
-  public void shonldBackupAndRestoreToPreviousState(final BackupRestoreTestConfig config)
+  public void shouldBackupAndRestoreToPreviousState(final BackupRestoreTestConfig config)
       throws Exception {
     // given
     setup(config);
@@ -205,6 +205,8 @@ public class BackupRestoreIT {
     exportingActuator.resume();
 
     // when
+    // closing down backup's thread poll before shutting down testStandaloneApplication
+    testStandaloneApplication.bean(HistoryBackupComponent.class).shutdownExecutor();
     // if we stop all apps and restart elasticsearch
     testStandaloneApplication.stop();
     // Zeebe's folder is deleted by ZeebeIntegration automatically when the application is stop()

--- a/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/backup/BackupRestoreIT.java
@@ -101,7 +101,6 @@ public class BackupRestoreIT {
   final ContainerLogsDumper logsWatcher =
       new ContainerLogsDumper(() -> Map.of("azurite", AZURITE_CONTAINER));
 
-  private AzureBackupStore store;
   private final String containerName =
       RandomStringUtils.insecure().nextAlphabetic(10).toLowerCase();
   // cannot be a @Container because it's initialized in setup()


### PR DESCRIPTION
## Description

When running BackupRestoreIT the backup components thread pool is not terminated, before terminating the testStandaloneApplication mid test:

```
10:56:26.992 [] [] [main] WARN  org.apache.catalina.loader.WebappClassLoaderBase - The web application [ROOT] appears to have started a thread named [webapps_backup_1] but has failed to stop it. This is very likely to create a memory leak. Stack trace of thread:
 java.base/jdk.internal.misc.Unsafe.park(Native Method)
 java.base/java.util.concurrent.locks.LockSupport.park(LockSupport.java:371)
 java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(AbstractQueuedSynchronizer.java:519)
 java.base/java.util.concurrent.ForkJoinPool.unmanagedBlock(ForkJoinPool.java:3780)
 java.base/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3725)
 java.base/java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:1712)
 java.base/java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:435)
 java.base/java.util.concurrent.ThreadPoolExecutor.getTask(ThreadPoolExecutor.java:1070)
 java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
 java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
 java.base/java.lang.Thread.run(Thread.java:1583)
```

https://github.com/camunda/camunda/blob/a80ccee34537558c1e6253b3f2917dfff59380e6/dist/src/main/java/io/camunda/application/commons/backup/BackupConfig.java#L91-L100

The thread that is not being closed properly comes from the tread pool  above, and is called from a bean. This bean is used in following components `ElasticsearchBackupRepository`, `ElasticsearchOptimizeBackupRepository`, `ElasticsearchTasklistBackupRepository` and `HistoryBackupComponent`. Is in fact shared across all these components as the same bean instance of the thread pool is being called.

One easy fix seems to be to add the shutdown method to the `HistoryBackupComponent` component, and adding the following before stopping the application, this way we make sure we stop the executor before, and remove the error message.

```
testStandaloneApplication.bean(HistoryBackupComponent.class).shutdownExecutor();
```

more context in: https://github.com/camunda/camunda/issues/28464#issuecomment-2725326335 and https://github.com/camunda/camunda/issues/28464#issuecomment-2725522029 .

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/camunda/issues/28464
