### PR TITLE
feat: init batch operation

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRe
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
@@ -90,6 +91,7 @@ public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequ
     RECORDS_BY_TYPE.put(ValueType.MAPPING, MappingRecord::new);
     RECORDS_BY_TYPE.put(ValueType.IDENTITY_SETUP, IdentitySetupRecord::new);
     RECORDS_BY_TYPE.put(ValueType.RESOURCE, ResourceRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.BATCH_OPERATION_CREATION, BatchOperationCreationRecord::new);
   }
 
   private UnifiedRecordValue value;

--- a/zeebe/engine/pom.xml
+++ b/zeebe/engine/pom.xml
@@ -302,7 +302,6 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-search-domain</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -315,7 +315,12 @@ public final class EngineProcessors {
     addResourceFetchProcessors(typedRecordProcessors, writers, processingState, authCheckBehavior);
 
     BatchOperationSetupProcessors.addBatchOperationProcessors(
-        keyGenerator, typedRecordProcessors, writers, commandDistributionBehavior);
+        keyGenerator,
+        typedRecordProcessors,
+        writers,
+        commandDistributionBehavior,
+        scheduledTaskStateFactory,
+        searchClientsProxy);
 
     return typedRecordProcessors;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateChunkProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationCreateChunkProcessor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ExcludeAuthorizationCheck
+public final class BatchOperationCreateChunkProcessor
+    implements TypedRecordProcessor<BatchOperationChunkRecord> {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(BatchOperationCreateChunkProcessor.class);
+
+  private final StateWriter stateWriter;
+
+  public BatchOperationCreateChunkProcessor(final Writers writers) {
+    stateWriter = writers.state();
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<BatchOperationChunkRecord> command) {
+    final var recordValue = command.getValue();
+    LOGGER.debug("Processing new command with key '{}': {}", command.getKey(), recordValue);
+
+    stateWriter.appendFollowUpEvent(
+        command.getKey(), BatchOperationChunkIntent.CREATED, recordValue);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionScheduler.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation;
+
+import com.google.common.collect.Lists;
+import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.search.page.SearchQueryPageBuilders;
+import io.camunda.search.query.SearchQueryBuilders;
+import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
+import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
+import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
+import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
+import io.camunda.zeebe.stream.api.scheduling.AsyncTaskGroup;
+import io.camunda.zeebe.stream.api.scheduling.TaskResult;
+import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BatchOperationExecutionScheduler implements StreamProcessorLifecycleAware {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BatchOperationExecutionScheduler.class);
+  private static final int BATCH_SIZE = 10;
+  private final Duration pollingInterval;
+  private final KeyGenerator keyGenerator;
+
+  private final BatchOperationState batchOperationState;
+  private ReadonlyStreamProcessorContext processingContext;
+  private final SearchClientsProxy queryService;
+
+  /** Marks if this scheduler is currently executing or not. */
+  private final AtomicBoolean executing = new AtomicBoolean(false);
+
+  public BatchOperationExecutionScheduler(
+      final Supplier<ScheduledTaskState> scheduledTaskStateFactory,
+      final SearchClientsProxy searchClientsProxy,
+      final KeyGenerator keyGenerator,
+      final Duration pollingInterval) {
+    batchOperationState = scheduledTaskStateFactory.get().getBatchOperationState();
+    this.keyGenerator = keyGenerator;
+    queryService = searchClientsProxy;
+    this.pollingInterval = pollingInterval;
+  }
+
+  @Override
+  public void onRecovered(final ReadonlyStreamProcessorContext context) {
+    processingContext = context;
+    scheduleExecution();
+  }
+
+  @Override
+  public void onResumed() {
+    scheduleExecution();
+  }
+
+  private void scheduleExecution() {
+    if (!executing.get()) {
+      processingContext
+          .getScheduleService()
+          .runDelayedAsync(pollingInterval, this::execute, AsyncTaskGroup.BATCH_OPERATIONS);
+    } else {
+      LOG.warn("Execution is already in progress, skipping scheduling.");
+    }
+  }
+
+  private TaskResult execute(final TaskResultBuilder taskResultBuilder) {
+    try {
+      LOG.trace("Looking for pending batch operations to execute (scheduled).");
+      executing.set(true);
+      batchOperationState.foreachPendingBatchOperation(
+          bo -> executeBatchOperation(bo, taskResultBuilder));
+      return taskResultBuilder.build();
+    } finally {
+      executing.set(false);
+      scheduleExecution();
+    }
+  }
+
+  private void executeBatchOperation(
+      final PersistedBatchOperation batchOperation, final TaskResultBuilder taskResultBuilder) {
+    final var keys = queryAllKeys(batchOperation);
+
+    Lists.partition(new ArrayList<>(keys), BATCH_SIZE)
+        .forEach(partition -> appendChunk(batchOperation, taskResultBuilder, partition));
+  }
+
+  private void appendChunk(
+      final PersistedBatchOperation batchOperation,
+      final TaskResultBuilder taskResultBuilder,
+      final List<Long> keys) {
+    final var chunkKey = keyGenerator.nextKey();
+    final var command = new BatchOperationChunkRecord();
+    command.setBatchOperationKey(batchOperation.getKey());
+    command.setItemKeys(keys);
+    command.setChunkKey(chunkKey);
+
+    LOG.debug(
+        "Appending batch operation {} subbatch with key {}", batchOperation.getKey(), chunkKey);
+    taskResultBuilder.appendCommandRecord(chunkKey, BatchOperationChunkIntent.CREATE, command);
+  }
+
+  private List<Long> queryAllKeys(final PersistedBatchOperation batchOperation) {
+    return switch (batchOperation.getBatchOperationType()) {
+      case PROCESS_CANCELLATION -> queryAllProcessInstanceKeys(batchOperation);
+      default ->
+          throw new IllegalArgumentException(
+              "Unexpected batch operation type: " + batchOperation.getBatchOperationType());
+    };
+  }
+
+  private List<Long> queryAllProcessInstanceKeys(final PersistedBatchOperation batchOperation) {
+    final ProcessInstanceFilter filter =
+        batchOperation.getEntityFilter(ProcessInstanceFilter.class);
+
+    final var itemKeys = new ArrayList<Long>();
+
+    Object[] searchValues = null;
+    final int batchSize = 400000;
+    while (true) {
+
+      final var page =
+          SearchQueryPageBuilders.page().size(batchSize).searchAfter(searchValues).build();
+      final var query =
+          SearchQueryBuilders.processInstanceSearchQuery()
+              .filter(filter)
+              .page(page)
+              .resultConfig(c -> c.onlyKey(true))
+              .build();
+      final var result = queryService.searchProcessInstances(query);
+      itemKeys.addAll(
+          result.items().stream()
+              .map(ProcessInstanceEntity::processInstanceKey)
+              .collect(Collectors.toSet()));
+      searchValues = result.lastSortValues();
+
+      if (itemKeys.size() >= result.total() || result.items().isEmpty()) {
+        break;
+      }
+    }
+
+    return itemKeys;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationSetupProcessors.java
@@ -7,12 +7,17 @@
  */
 package io.camunda.zeebe.engine.processing.batchoperation;
 
+import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import java.time.Duration;
+import java.util.function.Supplier;
 
 public final class BatchOperationSetupProcessors {
 
@@ -20,10 +25,23 @@ public final class BatchOperationSetupProcessors {
       final KeyGenerator keyGenerator,
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
-      final CommandDistributionBehavior commandDistributionBehavior) {
-    typedRecordProcessors.onCommand(
-        ValueType.BATCH_OPERATION_CREATION,
-        BatchOperationIntent.CREATE,
-        new BatchOperationCreateProcessor(writers, keyGenerator, commandDistributionBehavior));
+      final CommandDistributionBehavior commandDistributionBehavior,
+      final Supplier<ScheduledTaskState> scheduledTaskStateFactory,
+      final SearchClientsProxy searchClientsProxy) {
+    typedRecordProcessors
+        .onCommand(
+            ValueType.BATCH_OPERATION_CREATION,
+            BatchOperationIntent.CREATE,
+            new BatchOperationCreateProcessor(writers, keyGenerator, commandDistributionBehavior))
+        .onCommand(
+            ValueType.BATCH_OPERATION_CHUNK,
+            BatchOperationChunkIntent.CREATE,
+            new BatchOperationCreateChunkProcessor(writers))
+        .withListener(
+            new BatchOperationExecutionScheduler(
+                scheduledTaskStateFactory,
+                searchClientsProxy,
+                keyGenerator,
+                Duration.ofMillis(1000)));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationChunkCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationChunkCreatedApplier.java
@@ -23,6 +23,6 @@ public class BatchOperationChunkCreatedApplier
 
   @Override
   public void applyState(final long chunkKey, final BatchOperationChunkRecord value) {
-    batchOperationState.appendItemKeys(value.getBatchOperationKey(), value);
+    batchOperationState.appendItemKeys(value.getBatchOperationKey(), value.getItemKeys());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationChunkCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationChunkCreatedApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableBatchOperationState;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
+
+public class BatchOperationChunkCreatedApplier
+    implements TypedEventApplier<BatchOperationChunkIntent, BatchOperationChunkRecord> {
+
+  private final MutableBatchOperationState batchOperationState;
+
+  public BatchOperationChunkCreatedApplier(final MutableBatchOperationState batchOperationState) {
+    this.batchOperationState = batchOperationState;
+  }
+
+  @Override
+  public void applyState(final long key, final BatchOperationChunkRecord value) {
+    batchOperationState.appendKeys(key, value);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationChunkCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationChunkCreatedApplier.java
@@ -22,7 +22,7 @@ public class BatchOperationChunkCreatedApplier
   }
 
   @Override
-  public void applyState(final long key, final BatchOperationChunkRecord value) {
-    batchOperationState.appendItemKeys(key, value);
+  public void applyState(final long chunkKey, final BatchOperationChunkRecord value) {
+    batchOperationState.appendItemKeys(value.getBatchOperationKey(), value);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationChunkCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationChunkCreatedApplier.java
@@ -23,6 +23,6 @@ public class BatchOperationChunkCreatedApplier
 
   @Override
   public void applyState(final long key, final BatchOperationChunkRecord value) {
-    batchOperationState.appendKeys(key, value);
+    batchOperationState.appendItemKeys(key, value);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/BatchOperationCreatedApplier.java
@@ -22,7 +22,7 @@ public class BatchOperationCreatedApplier
   }
 
   @Override
-  public void applyState(final long key, final BatchOperationCreationRecord value) {
-    batchOperationState.create(key, value);
+  public void applyState(final long batchOperationKey, final BatchOperationCreationRecord value) {
+    batchOperationState.create(batchOperationKey, value);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.AdHocSubProcessActivityActivationIntent;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
@@ -586,6 +587,9 @@ public final class EventAppliers implements EventApplier {
     register(
         BatchOperationIntent.CREATED,
         new BatchOperationCreatedApplier(state.getBatchOperationState()));
+    register(
+        BatchOperationChunkIntent.CREATED,
+        new BatchOperationChunkCreatedApplier(state.getBatchOperationState()));
   }
 
   private void registerIdentitySetupAppliers() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/DbBatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/DbBatchOperationState.java
@@ -10,33 +10,56 @@ package io.camunda.zeebe.engine.state.batchoperation;
 import io.camunda.zeebe.db.ColumnFamily;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbCompositeKey;
+import io.camunda.zeebe.db.impl.DbForeignKey;
 import io.camunda.zeebe.db.impl.DbLong;
 import io.camunda.zeebe.db.impl.DbNil;
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation.BatchOperationStatus;
 import io.camunda.zeebe.engine.state.mutable.MutableBatchOperationState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
+import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class DbBatchOperationState implements MutableBatchOperationState {
 
+  public static final long MAX_BLOCK_SIZE = 3500;
+
   private static final Logger LOGGER = LoggerFactory.getLogger(DbBatchOperationState.class);
 
   private final DbLong batchKey = new DbLong();
+  private final DbForeignKey<DbLong> fkBatchKey;
+  private final DbLong blockKey;
+  private final DbCompositeKey<DbForeignKey<DbLong>, DbLong> fkBatchKeyAndBlockKey;
 
   private final ColumnFamily<DbLong, PersistedBatchOperation> batchOperationColumnFamily;
+  private final ColumnFamily<
+          DbCompositeKey<DbForeignKey<DbLong>, DbLong>, PersistedBatchOperationChunk>
+      batchOperationEntitiesColumnFamily;
   private final ColumnFamily<DbLong, DbNil> pendingBatchOperationColumnFamily;
 
   public DbBatchOperationState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    fkBatchKey = new DbForeignKey<>(batchKey, ZbColumnFamilies.BATCH_OPERATION);
+    blockKey = new DbLong();
+    fkBatchKeyAndBlockKey = new DbCompositeKey<>(fkBatchKey, blockKey);
+
     batchOperationColumnFamily =
         zeebeDb.createColumnFamily(
             ZbColumnFamilies.BATCH_OPERATION,
             transactionContext,
             batchKey,
             new PersistedBatchOperation());
+    batchOperationEntitiesColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.ENTITY_BY_BATCH_OPERATION,
+            transactionContext,
+            fkBatchKeyAndBlockKey,
+            new PersistedBatchOperationChunk());
     pendingBatchOperationColumnFamily =
         zeebeDb.createColumnFamily(
             ZbColumnFamilies.PENDING_BATCH_OPERATION, transactionContext, batchKey, DbNil.INSTANCE);
@@ -57,8 +80,114 @@ public class DbBatchOperationState implements MutableBatchOperationState {
   }
 
   @Override
+  public void appendKeys(final long batchKey, final BatchOperationChunkRecord record) {
+    LOGGER.trace(
+        "Appending {} keys to batch operation with key {}",
+        record.getEntityKeys().size(),
+        record.getBatchOperationKey());
+    final var batch = batchOperationColumnFamily.get(this.batchKey);
+
+    pendingBatchOperationColumnFamily.deleteIfExists(this.batchKey);
+
+    PersistedBatchOperationChunk block = null;
+    for (final long key : record.getEntityKeys()) {
+      final var currentBlockKey = batch.getMinBlockKey();
+      if (currentBlockKey == -1) {
+        block = createNewBlock(batch);
+        LOGGER.trace(
+            "Creating new block with key {} for batch operation with key {}",
+            block.getKey(),
+            record.getBatchOperationKey());
+      } else if (block == null) {
+        LOGGER.trace(
+            "Loading block with key {} for batch operation with key {}",
+            currentBlockKey,
+            record.getBatchOperationKey());
+        block = batchOperationEntitiesColumnFamily.get(fkBatchKeyAndBlockKey);
+        blockKey.wrapLong(block.getKey());
+      }
+      if (block.getKeys().size() >= MAX_BLOCK_SIZE) {
+        LOGGER.trace(
+            "Block with key {} is full, inserting it and creating new block for batch operation with key {}",
+            block.getKey(),
+            record.getBatchOperationKey());
+        batchOperationEntitiesColumnFamily.update(fkBatchKeyAndBlockKey, block);
+        block = createNewBlock(batch);
+      }
+      block.appendKey(key);
+    }
+    if (block != null) {
+      batchOperationEntitiesColumnFamily.update(fkBatchKeyAndBlockKey, block);
+    }
+
+    batchOperationColumnFamily.update(this.batchKey, batch);
+  }
+
+  @Override
+  public void removeKeys(final long batchKey, final BatchOperationExecutionRecord record) {
+    LOGGER.trace(
+        "Removing keys {} from batch operation with key {}",
+        record.getEntityKeys().size(),
+        record.getBatchOperationKey());
+    final var batch = batchOperationColumnFamily.get(this.batchKey);
+
+    blockKey.wrapLong(batch.getMinBlockKey());
+    final var block = batchOperationEntitiesColumnFamily.get(fkBatchKeyAndBlockKey);
+    block.removeKeys(record.getEntityKeys());
+
+    if (block.getKeys().isEmpty()) {
+      batchOperationEntitiesColumnFamily.deleteExisting(fkBatchKeyAndBlockKey);
+      batch.removeBlockKey(block.getKey());
+      batchOperationColumnFamily.update(this.batchKey, batch);
+    } else {
+      batchOperationEntitiesColumnFamily.update(fkBatchKeyAndBlockKey, block);
+    }
+  }
+
+  @Override
   public Optional<PersistedBatchOperation> get(final long key) {
     batchKey.wrapLong(key);
     return Optional.ofNullable(batchOperationColumnFamily.get(batchKey));
+  }
+
+  @Override
+  public void foreachPendingBatchOperation(final BatchOperationVisitor visitor) {
+    pendingBatchOperationColumnFamily.whileTrue(
+        (key, nil) -> {
+          final var batchOperation = batchOperationColumnFamily.get(key);
+          if (batchOperation != null) {
+            visitor.visit(batchOperation);
+          }
+          return true;
+        });
+  }
+
+  @Override
+  public List<Long> getNextEntityKeys(final long batchOperationKey, final int batchSize) {
+    batchKey.wrapLong(batchOperationKey);
+    final var batch = batchOperationColumnFamily.get(batchKey);
+
+    if (batch.getMinBlockKey() == -1) {
+      return List.of();
+    }
+
+    blockKey.wrapLong(batch.getMinBlockKey());
+    final var block = batchOperationEntitiesColumnFamily.get(fkBatchKeyAndBlockKey);
+    final var blockKeys = block.getKeys();
+
+    return blockKeys.stream().limit(batchSize).toList();
+  }
+
+  private PersistedBatchOperationChunk createNewBlock(final PersistedBatchOperation batch) {
+    final long currentBlockKey;
+    final PersistedBatchOperationChunk batchBlock;
+    currentBlockKey = batch.nextBlockKey();
+    batchBlock = new PersistedBatchOperationChunk();
+    batchBlock.setKey(currentBlockKey).setBatchOperationKey(batch.getKey());
+    blockKey.wrapLong(batchBlock.getKey());
+
+    batchOperationEntitiesColumnFamily.insert(fkBatchKeyAndBlockKey, batchBlock);
+
+    return batchBlock;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import java.util.Comparator;
 import org.agrona.DirectBuffer;
@@ -39,6 +40,13 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
         .declareProperty(statusProp)
         .declareProperty(entityFilterProp)
         .declareProperty(chunkKeysProp);
+  }
+
+  public PersistedBatchOperation wrap(final BatchOperationCreationRecord record) {
+    setKey(record.getBatchOperationKey());
+    setBatchOperationType(record.getBatchOperationType());
+    setEntityFilter(record.getEntityFilterBuffer());
+    return this;
   }
 
   public long getKey() {
@@ -83,10 +91,12 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
   }
 
   public long nextChunkKey() {
-    final var nextKey = getMaxChunkKey() + 1;
-    chunkKeysProp.add().setValue(nextKey);
+    return getMaxChunkKey() + 1;
+  }
 
-    return nextKey;
+  public PersistedBatchOperation addChunkKey(final Long chunkKey) {
+    chunkKeysProp.add().setValue(chunkKey);
+    return this;
   }
 
   public PersistedBatchOperation removeChunkKey(final Long chunkKey) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
@@ -9,11 +9,14 @@ package io.camunda.zeebe.engine.state.batchoperation;
 
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BinaryProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import java.util.Comparator;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -26,13 +29,16 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
   private final EnumProperty<BatchOperationStatus> statusProp =
       new EnumProperty<>("status", BatchOperationStatus.class);
   private final BinaryProperty entityFilterProp = new BinaryProperty("entityFilter");
+  private final ArrayProperty<LongValue> chunkKeysProp =
+      new ArrayProperty<>("chunkKeys", LongValue::new);
 
   public PersistedBatchOperation() {
-    super(4);
+    super(5);
     declareProperty(keyProp)
         .declareProperty(batchOperationTypeProp)
         .declareProperty(statusProp)
-        .declareProperty(entityFilterProp);
+        .declareProperty(entityFilterProp)
+        .declareProperty(chunkKeysProp);
   }
 
   public long getKey() {
@@ -70,6 +76,44 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
   public PersistedBatchOperation setEntityFilter(final DirectBuffer filter) {
     entityFilterProp.setValue(new UnsafeBuffer(filter));
     return this;
+  }
+
+  public <T> T getEntityFilter(final Class<T> clazz) {
+    return MsgPackConverter.convertToObject(entityFilterProp.getValue(), clazz);
+  }
+
+  public long nextBlockKey() {
+    final var nextKey = getMaxBlockKey() + 1;
+    chunkKeysProp.add().setValue(nextKey);
+
+    return nextKey;
+  }
+
+  public PersistedBatchOperation removeBlockKey(final Long blockKey) {
+    final var newKeys =
+        chunkKeysProp.stream().map(LongValue::getValue).filter(k -> !k.equals(blockKey)).toList();
+
+    chunkKeysProp.reset();
+
+    for (final var key : newKeys) {
+      chunkKeysProp.add().setValue(key);
+    }
+
+    return this;
+  }
+
+  public long getMinBlockKey() {
+    return chunkKeysProp.stream()
+        .min(Comparator.comparing(LongValue::getValue))
+        .map(LongValue::getValue)
+        .orElse(-1L);
+  }
+
+  public long getMaxBlockKey() {
+    return chunkKeysProp.stream()
+        .max(Comparator.comparing(LongValue::getValue))
+        .map(LongValue::getValue)
+        .orElse(-1L);
   }
 
   public enum BatchOperationStatus {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperation.java
@@ -82,16 +82,16 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
     return MsgPackConverter.convertToObject(entityFilterProp.getValue(), clazz);
   }
 
-  public long nextBlockKey() {
-    final var nextKey = getMaxBlockKey() + 1;
+  public long nextChunkKey() {
+    final var nextKey = getMaxChunkKey() + 1;
     chunkKeysProp.add().setValue(nextKey);
 
     return nextKey;
   }
 
-  public PersistedBatchOperation removeBlockKey(final Long blockKey) {
+  public PersistedBatchOperation removeChunkKey(final Long chunkKey) {
     final var newKeys =
-        chunkKeysProp.stream().map(LongValue::getValue).filter(k -> !k.equals(blockKey)).toList();
+        chunkKeysProp.stream().map(LongValue::getValue).filter(k -> !k.equals(chunkKey)).toList();
 
     chunkKeysProp.reset();
 
@@ -102,14 +102,14 @@ public class PersistedBatchOperation extends UnpackedObject implements DbValue {
     return this;
   }
 
-  public long getMinBlockKey() {
+  public long getMinChunkKey() {
     return chunkKeysProp.stream()
         .min(Comparator.comparing(LongValue::getValue))
         .map(LongValue::getValue)
         .orElse(-1L);
   }
 
-  public long getMaxBlockKey() {
+  public long getMaxChunkKey() {
     return chunkKeysProp.stream()
         .max(Comparator.comparing(LongValue::getValue))
         .map(LongValue::getValue)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperationChunk.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperationChunk.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.batchoperation;
+
+import io.camunda.zeebe.db.DbValue;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.value.LongValue;
+import java.util.Collection;
+import java.util.List;
+
+public class PersistedBatchOperationChunk extends UnpackedObject implements DbValue {
+
+  private final LongProperty keyProp = new LongProperty("key");
+  private final LongProperty batchOperationKeyProp = new LongProperty("batchOperationKey");
+  private final ArrayProperty<LongValue> keysProp = new ArrayProperty<>("keys", LongValue::new);
+
+  public PersistedBatchOperationChunk() {
+    super(3);
+    declareProperty(keyProp).declareProperty(batchOperationKeyProp).declareProperty(keysProp);
+  }
+
+  public long getKey() {
+    return keyProp.getValue();
+  }
+
+  public PersistedBatchOperationChunk setKey(final long key) {
+    keyProp.setValue(key);
+    return this;
+  }
+
+  public long getBatchOperationKey() {
+    return batchOperationKeyProp.getValue();
+  }
+
+  public PersistedBatchOperationChunk setBatchOperationKey(final long batchOperationKey) {
+    batchOperationKeyProp.setValue(batchOperationKey);
+    return this;
+  }
+
+  public List<Long> getKeys() {
+    return keysProp.stream().map(LongValue::getValue).toList();
+  }
+
+  public PersistedBatchOperationChunk appendKey(final Long key) {
+    keysProp.add().setValue(key);
+    return this;
+  }
+
+  public PersistedBatchOperationChunk removeKeys(final Collection<Long> keys) {
+    final var newKeys =
+        keysProp.stream().map(LongValue::getValue).filter(k -> !keys.contains(k)).toList();
+
+    keysProp.reset();
+
+    for (final var key : newKeys) {
+      keysProp.add().setValue(key);
+    }
+
+    return this;
+  }
+
+  public enum BatchOperationState {
+    CREATED,
+    ACTIVATED,
+    PAUSED,
+    CANCELED,
+    COMPLETED
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperationChunk.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperationChunk.java
@@ -58,8 +58,8 @@ public class PersistedBatchOperationChunk extends UnpackedObject implements DbVa
     final var newKeys =
         itemKeysProp.stream().map(LongValue::getValue).filter(k -> !itemKeys.contains(k)).toList();
 
+    // This is needed since ArrayProperty does not support removing items
     itemKeysProp.reset();
-
     for (final var key : newKeys) {
       itemKeysProp.add().setValue(key);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperationChunk.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/batchoperation/PersistedBatchOperationChunk.java
@@ -12,18 +12,19 @@ import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.value.LongValue;
-import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 public class PersistedBatchOperationChunk extends UnpackedObject implements DbValue {
 
   private final LongProperty keyProp = new LongProperty("key");
   private final LongProperty batchOperationKeyProp = new LongProperty("batchOperationKey");
-  private final ArrayProperty<LongValue> keysProp = new ArrayProperty<>("keys", LongValue::new);
+  private final ArrayProperty<LongValue> itemKeysProp =
+      new ArrayProperty<>("itemKeys", LongValue::new);
 
   public PersistedBatchOperationChunk() {
     super(3);
-    declareProperty(keyProp).declareProperty(batchOperationKeyProp).declareProperty(keysProp);
+    declareProperty(keyProp).declareProperty(batchOperationKeyProp).declareProperty(itemKeysProp);
   }
 
   public long getKey() {
@@ -44,33 +45,25 @@ public class PersistedBatchOperationChunk extends UnpackedObject implements DbVa
     return this;
   }
 
-  public List<Long> getKeys() {
-    return keysProp.stream().map(LongValue::getValue).toList();
+  public List<Long> getItemKeys() {
+    return itemKeysProp.stream().map(LongValue::getValue).toList();
   }
 
-  public PersistedBatchOperationChunk appendKey(final Long key) {
-    keysProp.add().setValue(key);
+  public PersistedBatchOperationChunk appendItemKey(final Long itemKey) {
+    itemKeysProp.add().setValue(itemKey);
     return this;
   }
 
-  public PersistedBatchOperationChunk removeKeys(final Collection<Long> keys) {
+  public PersistedBatchOperationChunk removeItemKeys(final Set<Long> itemKeys) {
     final var newKeys =
-        keysProp.stream().map(LongValue::getValue).filter(k -> !keys.contains(k)).toList();
+        itemKeysProp.stream().map(LongValue::getValue).filter(k -> !itemKeys.contains(k)).toList();
 
-    keysProp.reset();
+    itemKeysProp.reset();
 
     for (final var key : newKeys) {
-      keysProp.add().setValue(key);
+      itemKeysProp.add().setValue(key);
     }
 
     return this;
-  }
-
-  public enum BatchOperationState {
-    CREATED,
-    ACTIVATED,
-    PAUSED,
-    CANCELED,
-    COMPLETED
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BatchOperationState.java
@@ -8,9 +8,20 @@
 package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
+import java.util.List;
 import java.util.Optional;
 
 public interface BatchOperationState {
 
   Optional<PersistedBatchOperation> get(final long batchKey);
+
+  void foreachPendingBatchOperation(BatchOperationVisitor visitor);
+
+  List<Long> getNextEntityKeys(long batchOperationKey, int batchSize);
+
+  @FunctionalInterface
+  interface BatchOperationVisitor {
+
+    void visit(PersistedBatchOperation batchOperation);
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BatchOperationState.java
@@ -17,7 +17,7 @@ public interface BatchOperationState {
 
   void foreachPendingBatchOperation(BatchOperationVisitor visitor);
 
-  List<Long> getNextEntityKeys(long batchOperationKey, int batchSize);
+  List<Long> getNextItemKeys(long batchOperationKey, int batchSize);
 
   @FunctionalInterface
   interface BatchOperationVisitor {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableBatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableBatchOperationState.java
@@ -8,9 +8,8 @@
 package io.camunda.zeebe.engine.state.mutable;
 
 import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
+import java.util.Set;
 
 public interface MutableBatchOperationState extends BatchOperationState {
 
@@ -21,7 +20,7 @@ public interface MutableBatchOperationState extends BatchOperationState {
    */
   void create(final long batchOperationKey, final BatchOperationCreationRecord record);
 
-  void appendItemKeys(final long batchOperationKey, final BatchOperationChunkRecord record);
+  void appendItemKeys(final long batchOperationKey, final Set<Long> itemKeys);
 
-  void removeItemKeys(final long batchOperationKey, BatchOperationExecutionRecord record);
+  void removeItemKeys(final long batchOperationKey, final Set<Long> itemKeys);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableBatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableBatchOperationState.java
@@ -8,7 +8,9 @@
 package io.camunda.zeebe.engine.state.mutable;
 
 import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
 
 public interface MutableBatchOperationState extends BatchOperationState {
 
@@ -18,4 +20,8 @@ public interface MutableBatchOperationState extends BatchOperationState {
    * @param record the batch operation creation record to create
    */
   void create(final long batchKey, final BatchOperationCreationRecord record);
+
+  void appendKeys(final long batchKey, final BatchOperationChunkRecord record);
+
+  void removeKeys(final long batchKey, BatchOperationExecutionRecord record);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableBatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableBatchOperationState.java
@@ -19,9 +19,9 @@ public interface MutableBatchOperationState extends BatchOperationState {
    *
    * @param record the batch operation creation record to create
    */
-  void create(final long batchKey, final BatchOperationCreationRecord record);
+  void create(final long batchOperationKey, final BatchOperationCreationRecord record);
 
-  void appendItemKeys(final long batchKey, final BatchOperationChunkRecord record);
+  void appendItemKeys(final long batchOperationKey, final BatchOperationChunkRecord record);
 
-  void removeItemKeys(final long batchKey, BatchOperationExecutionRecord record);
+  void removeItemKeys(final long batchOperationKey, BatchOperationExecutionRecord record);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableBatchOperationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableBatchOperationState.java
@@ -21,7 +21,7 @@ public interface MutableBatchOperationState extends BatchOperationState {
    */
   void create(final long batchKey, final BatchOperationCreationRecord record);
 
-  void appendKeys(final long batchKey, final BatchOperationChunkRecord record);
+  void appendItemKeys(final long batchKey, final BatchOperationChunkRecord record);
 
-  void removeKeys(final long batchKey, BatchOperationExecutionRecord record);
+  void removeItemKeys(final long batchKey, BatchOperationExecutionRecord record);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionSchedulerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/BatchOperationExecutionSchedulerTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.batchoperation;
+
+import static io.camunda.zeebe.protocol.record.value.BatchOperationType.PROCESS_CANCELLATION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.search.query.ProcessInstanceQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.zeebe.engine.state.batchoperation.PersistedBatchOperation;
+import io.camunda.zeebe.engine.state.immutable.BatchOperationState;
+import io.camunda.zeebe.engine.state.immutable.BatchOperationState.BatchOperationVisitor;
+import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
+import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
+import io.camunda.zeebe.stream.api.scheduling.Task;
+import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import java.time.Duration;
+import java.util.List;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class BatchOperationExecutionSchedulerTest {
+
+  @Mock private Supplier<ScheduledTaskState> scheduledTaskStateFactory;
+  @Mock private SearchClientsProxy searchClientsProxy;
+  @Mock private KeyGenerator keyGenerator;
+  @Mock private TaskResultBuilder taskResultBuilder;
+  @Mock private ReadonlyStreamProcessorContext streamProcessorContext;
+  @Mock private ProcessingScheduleService scheduleService;
+  @Mock private BatchOperationState batchOperationState;
+  @Mock private PersistedBatchOperation batchOperation;
+
+  @Captor private ArgumentCaptor<Task> taskCaptor;
+  @Captor private ArgumentCaptor<ProcessInstanceQuery> queryCaptor;
+  @Captor private ArgumentCaptor<BatchOperationChunkRecord> chunkRecordCaptor;
+
+  private BatchOperationExecutionScheduler scheduler;
+
+  @BeforeEach
+  public void setUp() {
+    setUpBasicSchedulerBehaviour();
+
+    when(batchOperation.getBatchOperationType()).thenReturn(PROCESS_CANCELLATION);
+    when(batchOperation.getEntityFilter(eq(ProcessInstanceFilter.class)))
+        .thenReturn(mock(ProcessInstanceFilter.class));
+    doAnswer(
+            invocation -> {
+              final BatchOperationVisitor visitor = invocation.getArgument(0);
+              visitor.visit(batchOperation);
+              return null;
+            })
+        .when(batchOperationState)
+        .foreachPendingBatchOperation(any(BatchOperationVisitor.class));
+
+    scheduler =
+        new BatchOperationExecutionScheduler(
+            scheduledTaskStateFactory, searchClientsProxy, keyGenerator, Duration.ofSeconds(1));
+  }
+
+  @Test
+  public void shouldAppendChunkForBatchOperations() {
+    // given
+    final var result =
+        new SearchQueryResult.Builder<Long>().items(List.of(1L, 2L, 3L)).total(3).build();
+    when(searchClientsProxy.searchProcessInstanceKeys(queryCaptor.capture())).thenReturn(result);
+
+    // when our scheduler fires
+    execute();
+
+    // then
+    verify(batchOperationState).foreachPendingBatchOperation(any());
+    verify(taskResultBuilder)
+        .appendCommandRecord(
+            anyLong(), eq(BatchOperationChunkIntent.CREATE), chunkRecordCaptor.capture());
+    final var batchOperationChunkRecord = chunkRecordCaptor.getValue();
+    assertThat(batchOperationChunkRecord.getEntityKeys().size()).isEqualTo(3);
+  }
+
+  @Test
+  public void shouldQueryMultipleTimesIfTotalIsHigher() {
+    // given
+    final var result =
+        new SearchQueryResult.Builder<Long>().items(List.of(1L, 2L, 3L)).total(6).build();
+    when(searchClientsProxy.searchProcessInstanceKeys(queryCaptor.capture())).thenReturn(result);
+
+    // when our scheduler fires
+    execute();
+
+    // then
+    verify(batchOperationState).foreachPendingBatchOperation(any());
+    verify(taskResultBuilder)
+        .appendCommandRecord(
+            anyLong(), eq(BatchOperationChunkIntent.CREATE), chunkRecordCaptor.capture());
+    final var batchOperationChunkRecord = chunkRecordCaptor.getValue();
+    assertThat(batchOperationChunkRecord.getEntityKeys().size()).isEqualTo(6);
+  }
+
+  @Test
+  void shouldSkipAlreadyProcessedBatchOperations() {
+    // given
+    final var result =
+        new SearchQueryResult.Builder<Long>().items(List.of(1L, 2L, 3L)).total(3).build();
+    when(searchClientsProxy.searchProcessInstanceKeys(queryCaptor.capture())).thenReturn(result);
+    execute();
+
+    // when we execute it again
+    execute();
+
+    // we should only fetch keys once
+    verify(batchOperationState, times(2)).foreachPendingBatchOperation(any());
+    verify(taskResultBuilder, times(1))
+        .appendCommandRecord(
+            anyLong(), eq(BatchOperationChunkIntent.CREATE), chunkRecordCaptor.capture());
+    final var batchOperationChunkRecord = chunkRecordCaptor.getValue();
+    assertThat(batchOperationChunkRecord.getEntityKeys().size()).isEqualTo(3);
+  }
+
+  /** Bypasses the scheduling mechanism and executes the task directly */
+  private void execute() {
+    scheduler.onRecovered(streamProcessorContext);
+    taskCaptor.getValue().execute(taskResultBuilder);
+  }
+
+  private void setUpBasicSchedulerBehaviour() {
+    when(scheduledTaskStateFactory.get()).thenReturn(mock(ScheduledTaskState.class));
+    when(scheduledTaskStateFactory.get().getBatchOperationState()).thenReturn(batchOperationState);
+    when(streamProcessorContext.getScheduleService()).thenReturn(scheduleService);
+    when(scheduleService.runDelayedAsync(any(), taskCaptor.capture(), any())).thenReturn(null);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CreateBatchOperationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/batchoperation/CreateBatchOperationTest.java
@@ -9,18 +9,25 @@ package io.camunda.zeebe.engine.processing.batchoperation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.search.query.ProcessInstanceQuery;
+import io.camunda.search.query.SearchQueryResult;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 public final class CreateBatchOperationTest {
 
@@ -29,8 +36,11 @@ public final class CreateBatchOperationTest {
       new RecordingExporterTestWatcher();
 
   @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+  private final SearchClientsProxy searchClientsProxy = Mockito.mock(SearchClientsProxy.class);
 
-  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule
+  public final EngineRule engine =
+      EngineRule.singlePartition().withSearchClientsProxy(searchClientsProxy);
 
   @Test
   public void shouldRejectWithoutFilter() {
@@ -81,16 +91,21 @@ public final class CreateBatchOperationTest {
   }
 
   @Test
-  public void shouldCreateBatchOperation() {
+  public void shouldCreateAndInitBatchOperation() {
     // given
-    final String filter = "{\"processInstanceKeys\":[1,3,8]}";
+    final var filterBuffer =
+        convertToBuffer(
+            new ProcessInstanceFilter.Builder().processInstanceKeys(1L, 3L, 8L).build());
 
-    // when
+    // given
+    Mockito.when(
+            searchClientsProxy.searchProcessInstanceKeys(Mockito.any(ProcessInstanceQuery.class)))
+        .thenReturn(new SearchQueryResult<>(1, List.of(1L, 3L, 8L), null, null)); // when
     final long batchOperationKey =
         engine
             .batchOperation()
             .ofType(BatchOperationType.PROCESS_CANCELLATION)
-            .withFilter(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(filter)))
+            .withFilter(filterBuffer)
             .create()
             .getValue()
             .getBatchOperationKey();
@@ -101,13 +116,14 @@ public final class CreateBatchOperationTest {
                 .withBatchOperationKey(batchOperationKey))
         .extracting(Record::getIntent)
         .containsSequence(BatchOperationIntent.CREATED);
+
     assertThat(
-            RecordingExporter.batchOperationCreationRecords()
-                .withBatchOperationKey(batchOperationKey)
-                .withIntent(BatchOperationIntent.CREATED)
-                .getFirst()
-                .getValue()
-                .getEntityFilter())
-        .isEqualTo(filter);
+            RecordingExporter.batchOperationChunkRecords().withBatchOperationKey(batchOperationKey))
+        .extracting(Record::getIntent)
+        .containsSequence(BatchOperationChunkIntent.CREATE, BatchOperationChunkIntent.CREATED);
+  }
+
+  private static UnsafeBuffer convertToBuffer(final Object object) {
+    return new UnsafeBuffer(MsgPackConverter.convertToMsgPack(object));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/batchoperation/BatchOperationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/batchoperation/BatchOperationStateTest.java
@@ -18,9 +18,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableBatchOperationState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
-import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
 import java.util.ArrayList;
 import java.util.List;
@@ -103,11 +101,7 @@ public class BatchOperationStateTest {
 
     // when
     state.appendItemKeys(
-        batchOperationKey,
-        new BatchOperationChunkRecord()
-            .setBatchOperationKey(batchOperationKey)
-            .setChunkKey(2L)
-            .setItemKeys(LongStream.range(0, 99).boxed().toList()));
+        batchOperationKey, LongStream.range(0, 99).boxed().collect(Collectors.toSet()));
 
     // then
     final var pendingKeys = new ArrayList<>();
@@ -140,14 +134,8 @@ public class BatchOperationStateTest {
     state.create(batchOperationKey, createRecord);
 
     // when
-    final var subbatchKey = 2L;
-    final var keys = LongStream.rangeClosed(0, 10).boxed().toList();
-    final var subbatchRecord =
-        new BatchOperationChunkRecord()
-            .setBatchOperationKey(batchOperationKey)
-            .setChunkKey(subbatchKey)
-            .setItemKeys(keys);
-    state.appendItemKeys(batchOperationKey, subbatchRecord);
+    final var keys = LongStream.rangeClosed(0, 10).boxed().collect(Collectors.toSet());
+    state.appendItemKeys(batchOperationKey, keys);
 
     // then
     final var persistedBatchOperation = state.get(batchOperationKey).get();
@@ -172,14 +160,8 @@ public class BatchOperationStateTest {
     state.create(batchOperationKey, createRecord);
 
     // when
-    final var subbatchKey = 2L;
-    final var keys = LongStream.rangeClosed(0, 4).boxed().toList();
-    final var subbatchRecord =
-        new BatchOperationChunkRecord()
-            .setBatchOperationKey(batchOperationKey)
-            .setChunkKey(subbatchKey)
-            .setItemKeys(keys);
-    state.appendItemKeys(batchOperationKey, subbatchRecord);
+    final var keys = LongStream.rangeClosed(0, 4).boxed().collect(Collectors.toSet());
+    state.appendItemKeys(batchOperationKey, keys);
 
     // then
     final var persistedBatchOperation = state.get(batchOperationKey).get();
@@ -204,14 +186,9 @@ public class BatchOperationStateTest {
     state.create(batchOperationKey, createRecord);
 
     // when
-    final var subbatchKey = 2L;
-    final var keys = LongStream.range(0, MAX_DB_CHUNK_SIZE * 3 + 1).boxed().toList();
-    final var subbatchRecord =
-        new BatchOperationChunkRecord()
-            .setBatchOperationKey(batchOperationKey)
-            .setChunkKey(subbatchKey)
-            .setItemKeys(keys);
-    state.appendItemKeys(batchOperationKey, subbatchRecord);
+    final var keys =
+        LongStream.range(0, MAX_DB_CHUNK_SIZE * 3 + 1).boxed().collect(Collectors.toSet());
+    state.appendItemKeys(batchOperationKey, keys);
 
     // then
     final var persistedBatchOperation = state.get(batchOperationKey).get();
@@ -234,26 +211,17 @@ public class BatchOperationStateTest {
     // when
     state.appendItemKeys(
         batchOperationKey,
-        new BatchOperationChunkRecord()
-            .setBatchOperationKey(batchOperationKey)
-            .setChunkKey(2L)
-            .setItemKeys(LongStream.range(0, MAX_DB_CHUNK_SIZE - 1).boxed().toList()));
+        LongStream.range(0, MAX_DB_CHUNK_SIZE - 1).boxed().collect(Collectors.toSet()));
     state.appendItemKeys(
         batchOperationKey,
-        new BatchOperationChunkRecord()
-            .setBatchOperationKey(batchOperationKey)
-            .setChunkKey(3L)
-            .setItemKeys(
-                LongStream.range(MAX_DB_CHUNK_SIZE, MAX_DB_CHUNK_SIZE * 2 - 1).boxed().toList()));
+        LongStream.range(MAX_DB_CHUNK_SIZE, MAX_DB_CHUNK_SIZE * 2 - 1)
+            .boxed()
+            .collect(Collectors.toSet()));
     state.appendItemKeys(
         batchOperationKey,
-        new BatchOperationChunkRecord()
-            .setBatchOperationKey(batchOperationKey)
-            .setChunkKey(4L)
-            .setItemKeys(
-                LongStream.range(MAX_DB_CHUNK_SIZE * 2, MAX_DB_CHUNK_SIZE * 3 - 1)
-                    .boxed()
-                    .toList()));
+        LongStream.range(MAX_DB_CHUNK_SIZE * 2, MAX_DB_CHUNK_SIZE * 3 - 1)
+            .boxed()
+            .collect(Collectors.toSet()));
 
     // then
     final var persistedBatchOperation = state.get(batchOperationKey).get();
@@ -269,10 +237,7 @@ public class BatchOperationStateTest {
 
     // when
     state.removeItemKeys(
-        batchOperationKey,
-        new BatchOperationExecutionRecord()
-            .setBatchOperationKey(batchOperationKey)
-            .setItemKeys(LongStream.rangeClosed(0, 5).boxed().collect(Collectors.toSet())));
+        batchOperationKey, LongStream.rangeClosed(0, 5).boxed().collect(Collectors.toSet()));
 
     // then
     final var persistedBatchOperation = state.get(batchOperationKey).get();
@@ -293,10 +258,7 @@ public class BatchOperationStateTest {
     // when
     state.removeItemKeys(
         batchOperationKey,
-        new BatchOperationExecutionRecord()
-            .setBatchOperationKey(batchOperationKey)
-            .setItemKeys(
-                LongStream.range(0, MAX_DB_CHUNK_SIZE).boxed().collect(Collectors.toSet())));
+        LongStream.range(0, MAX_DB_CHUNK_SIZE).boxed().collect(Collectors.toSet()));
 
     // then
     final var persistedBatchOperation = state.get(batchOperationKey).get();
@@ -318,11 +280,7 @@ public class BatchOperationStateTest {
             .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION)
             .setEntityFilter(convertToBuffer(new ProcessInstanceFilter.Builder().build())));
     state.appendItemKeys(
-        batchOperationKey,
-        new BatchOperationChunkRecord()
-            .setBatchOperationKey(batchOperationKey)
-            .setChunkKey(2L)
-            .setItemKeys(LongStream.range(0, numKeys).boxed().toList()));
+        batchOperationKey, LongStream.range(0, numKeys).boxed().collect(Collectors.toSet()));
 
     return batchOperationKey;
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/batchoperation/BatchOperationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/batchoperation/BatchOperationStateTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.state.batchoperation;
 
+import static io.camunda.zeebe.engine.state.batchoperation.DbBatchOperationState.MAX_BLOCK_SIZE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -17,8 +18,14 @@ import io.camunda.zeebe.engine.state.mutable.MutableBatchOperationState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationChunkRecord;
 import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationCreationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.batchoperation.BatchOperationExecutionRecord;
 import io.camunda.zeebe.protocol.record.value.BatchOperationType;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -63,5 +70,261 @@ public class BatchOperationStateTest {
     assertThat(batchOperation.getBatchOperationType()).isEqualTo(type);
     assertThat(recordFilter).isEqualTo(filter);
     assertThat(batchOperation.getStatus()).isEqualTo(BatchOperationStatus.CREATED);
+  }
+
+  @Test
+  void newBatchShouldBePending() {
+    // given
+
+    // when
+    final var batchOperationKey = 1L;
+    final var roleRecord =
+        new BatchOperationCreationRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION);
+    state.create(batchOperationKey, roleRecord);
+
+    // then
+    final var pendingKeys = new ArrayList<>();
+    state.foreachPendingBatchOperation(bo -> pendingKeys.add(bo.getKey()));
+
+    assertThat(pendingKeys).containsExactly(batchOperationKey);
+  }
+
+  @Test
+  void startedBatchShouldNotBePending() {
+    // given
+    final var batchOperationKey = 1L;
+    final var roleRecord =
+        new BatchOperationCreationRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION);
+    state.create(batchOperationKey, roleRecord);
+
+    // when
+    state.appendKeys(
+        batchOperationKey,
+        new BatchOperationChunkRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setChunkKey(2L)
+            .setEntityKeys(LongStream.range(0, 99).boxed().toList()));
+
+    // then
+    final var pendingKeys = new ArrayList<>();
+    state.foreachPendingBatchOperation(bo -> pendingKeys.add(bo.getKey()));
+
+    assertThat(pendingKeys).isEmpty();
+  }
+
+  @Test
+  void shouldReturnNoKeysIfEmpty() {
+    // given
+    final var batchOperationKey = createDefaultBatch(1, 0);
+
+    // when
+    final var keys = state.getNextEntityKeys(batchOperationKey, 5);
+
+    // then
+    assertThat(keys).isEmpty();
+  }
+
+  @Test
+  void shouldAddAndGetKeys() {
+    // given
+    final var batchOperationKey = 1L;
+    final var createRecord =
+        new BatchOperationCreationRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION)
+            .setEntityFilter(convertToBuffer(new ProcessInstanceFilter.Builder().build()));
+    state.create(batchOperationKey, createRecord);
+
+    // when
+    final var subbatchKey = 2L;
+    final var keys = LongStream.rangeClosed(0, 10).boxed().toList();
+    final var subbatchRecord =
+        new BatchOperationChunkRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setChunkKey(subbatchKey)
+            .setEntityKeys(keys);
+    state.appendKeys(batchOperationKey, subbatchRecord);
+
+    // then
+    final var persistedBatchOperation = state.get(batchOperationKey).get();
+
+    assertThat(persistedBatchOperation.getMinBlockKey()).isEqualTo(0);
+    assertThat(persistedBatchOperation.getMaxBlockKey()).isEqualTo(0);
+
+    final var nextKeys = state.getNextEntityKeys(batchOperationKey, 5);
+    assertThat(nextKeys).hasSize(5);
+    assertThat(nextKeys).containsSequence(List.of(0L, 1L, 2L, 3L, 4L));
+  }
+
+  @Test
+  void shouldOnlyGetExistingNextKeys() {
+    // given
+    final var batchOperationKey = 1L;
+    final var createRecord =
+        new BatchOperationCreationRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION)
+            .setEntityFilter(convertToBuffer(new ProcessInstanceFilter.Builder().build()));
+    state.create(batchOperationKey, createRecord);
+
+    // when
+    final var subbatchKey = 2L;
+    final var keys = LongStream.rangeClosed(0, 4).boxed().toList();
+    final var subbatchRecord =
+        new BatchOperationChunkRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setChunkKey(subbatchKey)
+            .setEntityKeys(keys);
+    state.appendKeys(batchOperationKey, subbatchRecord);
+
+    // then
+    final var persistedBatchOperation = state.get(batchOperationKey).get();
+
+    assertThat(persistedBatchOperation.getMinBlockKey()).isEqualTo(0);
+    assertThat(persistedBatchOperation.getMaxBlockKey()).isEqualTo(0);
+
+    final var nextKeys = state.getNextEntityKeys(batchOperationKey, 10);
+    assertThat(nextKeys).hasSize(5);
+    assertThat(nextKeys).containsSequence(List.of(0L, 1L, 2L, 3L, 4L));
+  }
+
+  @Test
+  void shouldAddManyKeys() {
+    // given
+    final var batchOperationKey = 1L;
+    final var createRecord =
+        new BatchOperationCreationRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION)
+            .setEntityFilter(convertToBuffer(new ProcessInstanceFilter.Builder().build()));
+    state.create(batchOperationKey, createRecord);
+
+    // when
+    final var subbatchKey = 2L;
+    final var keys = LongStream.range(0, MAX_BLOCK_SIZE * 3 + 1).boxed().toList();
+    final var subbatchRecord =
+        new BatchOperationChunkRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setChunkKey(subbatchKey)
+            .setEntityKeys(keys);
+    state.appendKeys(batchOperationKey, subbatchRecord);
+
+    // then
+    final var persistedBatchOperation = state.get(batchOperationKey).get();
+
+    assertThat(persistedBatchOperation.getMinBlockKey()).isEqualTo(0);
+    assertThat(persistedBatchOperation.getMaxBlockKey()).isEqualTo(3);
+  }
+
+  @Test
+  void shouldAddKeysMultipleTimes() {
+    // given
+    final var batchOperationKey = 1L;
+    final var createRecord =
+        new BatchOperationCreationRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION)
+            .setEntityFilter(convertToBuffer(new ProcessInstanceFilter.Builder().build()));
+    state.create(batchOperationKey, createRecord);
+
+    // when
+    state.appendKeys(
+        batchOperationKey,
+        new BatchOperationChunkRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setChunkKey(2L)
+            .setEntityKeys(LongStream.range(0, MAX_BLOCK_SIZE - 1).boxed().toList()));
+    state.appendKeys(
+        batchOperationKey,
+        new BatchOperationChunkRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setChunkKey(3L)
+            .setEntityKeys(
+                LongStream.range(MAX_BLOCK_SIZE, MAX_BLOCK_SIZE * 2 - 1).boxed().toList()));
+    state.appendKeys(
+        batchOperationKey,
+        new BatchOperationChunkRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setChunkKey(4L)
+            .setEntityKeys(
+                LongStream.range(MAX_BLOCK_SIZE * 2, MAX_BLOCK_SIZE * 3 - 1).boxed().toList()));
+
+    // then
+    final var persistedBatchOperation = state.get(batchOperationKey).get();
+
+    assertThat(persistedBatchOperation.getMinBlockKey()).isEqualTo(0);
+    assertThat(persistedBatchOperation.getMaxBlockKey()).isEqualTo(2);
+  }
+
+  @Test
+  void shouldReturnNextNonRemovedItems() {
+    // given
+    final var batchOperationKey = createDefaultBatch(1, MAX_BLOCK_SIZE * 3);
+
+    // when
+    state.removeKeys(
+        batchOperationKey,
+        new BatchOperationExecutionRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setEntityKeys(LongStream.rangeClosed(0, 5).boxed().collect(Collectors.toSet())));
+
+    // then
+    final var persistedBatchOperation = state.get(batchOperationKey).get();
+
+    assertThat(persistedBatchOperation.getMinBlockKey()).isEqualTo(0);
+    assertThat(persistedBatchOperation.getMaxBlockKey()).isEqualTo(2);
+
+    final var nextKeys = state.getNextEntityKeys(batchOperationKey, 5);
+    assertThat(nextKeys).hasSize(5);
+    assertThat(nextKeys).containsSequence(List.of(6L, 7L, 8L, 9L, 10L));
+  }
+
+  @Test
+  void shouldRemoveChunkWhenAllItemsHasBeenRemoved() {
+    // given
+    final var batchOperationKey = createDefaultBatch(1, MAX_BLOCK_SIZE * 3);
+
+    // when
+    state.removeKeys(
+        batchOperationKey,
+        new BatchOperationExecutionRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setEntityKeys(
+                LongStream.range(0, MAX_BLOCK_SIZE).boxed().collect(Collectors.toSet())));
+
+    // then
+    final var persistedBatchOperation = state.get(batchOperationKey).get();
+
+    assertThat(persistedBatchOperation.getMinBlockKey()).isEqualTo(1);
+    assertThat(persistedBatchOperation.getMaxBlockKey()).isEqualTo(2);
+
+    final var nextKeys = state.getNextEntityKeys(batchOperationKey, 3);
+    assertThat(nextKeys)
+        .containsSequence(List.of(MAX_BLOCK_SIZE, MAX_BLOCK_SIZE + 1L, MAX_BLOCK_SIZE + 2L));
+  }
+
+  private long createDefaultBatch(final long batchOperationKey, final long numKeys) {
+    state.create(
+        batchOperationKey,
+        new BatchOperationCreationRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setBatchOperationType(BatchOperationType.PROCESS_CANCELLATION)
+            .setEntityFilter(convertToBuffer(new ProcessInstanceFilter.Builder().build())));
+    state.appendKeys(
+        batchOperationKey,
+        new BatchOperationChunkRecord()
+            .setBatchOperationKey(batchOperationKey)
+            .setChunkKey(2L)
+            .setEntityKeys(LongStream.range(0, numKeys).boxed().toList()));
+
+    return batchOperationKey;
+  }
+
+  private static UnsafeBuffer convertToBuffer(final Object object) {
+    return new UnsafeBuffer(MsgPackConverter.convertToMsgPack(object));
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MsgPackConverter.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/MsgPackConverter.java
@@ -216,6 +216,14 @@ public final class MsgPackConverter {
     }
   }
 
+  /**
+   * Please be aware that this method may not thread-safe depending on the object that gets
+   * serialized.
+   *
+   * @param buffer the buffer to be serialized
+   * @param clazz the class of the object to be deserialized
+   * @return the deserialized object
+   */
   public static <T> T convertToObject(final DirectBuffer buffer, final Class<T> clazz) {
     final byte[] msgpackBytes = BufferUtil.bufferAsArray(buffer);
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationChunkRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationChunkRecord.java
@@ -20,18 +20,18 @@ public final class BatchOperationChunkRecord extends UnifiedRecordValue
 
   public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
   public static final String PROP_CHUNK_KEY = "chunkKey";
-  public static final String PROP_ENTITY_KEY_LIST = "entityKeys";
+  public static final String PROP_ITEM_KEY_LIST = "itemKeys";
 
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
   private final LongProperty chunkKeyProp = new LongProperty(PROP_CHUNK_KEY);
-  private final ArrayProperty<LongValue> entityKeysProp =
-      new ArrayProperty<>(PROP_ENTITY_KEY_LIST, LongValue::new);
+  private final ArrayProperty<LongValue> itemKeysProp =
+      new ArrayProperty<>(PROP_ITEM_KEY_LIST, LongValue::new);
 
   public BatchOperationChunkRecord() {
     super(3);
     declareProperty(batchOperationKeyProp)
         .declareProperty(chunkKeyProp)
-        .declareProperty(entityKeysProp);
+        .declareProperty(itemKeysProp);
   }
 
   @Override
@@ -46,13 +46,13 @@ public final class BatchOperationChunkRecord extends UnifiedRecordValue
   }
 
   @Override
-  public List<Long> getEntityKeys() {
-    return entityKeysProp.stream().map(LongValue::getValue).collect(Collectors.toList());
+  public List<Long> getItemKeys() {
+    return itemKeysProp.stream().map(LongValue::getValue).collect(Collectors.toList());
   }
 
-  public BatchOperationChunkRecord setEntityKeys(final List<Long> keys) {
-    entityKeysProp.reset();
-    keys.forEach(key -> entityKeysProp.add().setValue(key));
+  public BatchOperationChunkRecord setItemKeys(final List<Long> keys) {
+    itemKeysProp.reset();
+    keys.forEach(key -> itemKeysProp.add().setValue(key));
     return this;
   }
 
@@ -68,7 +68,7 @@ public final class BatchOperationChunkRecord extends UnifiedRecordValue
 
   public void wrap(final BatchOperationChunkRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
-    setEntityKeys(record.getEntityKeys());
+    setItemKeys(record.getItemKeys());
     setChunkKey(record.getChunkKey());
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationChunkRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationChunkRecord.java
@@ -61,7 +61,7 @@ public final class BatchOperationChunkRecord extends UnifiedRecordValue
     return chunkKeyProp.getValue();
   }
 
-  public BatchOperationChunkRecord setKeyChunkKey(final Long key) {
+  public BatchOperationChunkRecord setChunkKey(final Long key) {
     chunkKeyProp.setValue(key);
     return this;
   }
@@ -69,6 +69,6 @@ public final class BatchOperationChunkRecord extends UnifiedRecordValue
   public void wrap(final BatchOperationChunkRecord record) {
     setBatchOperationKey(record.getBatchOperationKey());
     setEntityKeys(record.getEntityKeys());
-    setKeyChunkKey(record.getChunkKey());
+    setChunkKey(record.getChunkKey());
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationChunkRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationChunkRecord.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
-import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public final class BatchOperationChunkRecord extends UnifiedRecordValue
@@ -46,11 +46,11 @@ public final class BatchOperationChunkRecord extends UnifiedRecordValue
   }
 
   @Override
-  public List<Long> getItemKeys() {
-    return itemKeysProp.stream().map(LongValue::getValue).collect(Collectors.toList());
+  public Set<Long> getItemKeys() {
+    return itemKeysProp.stream().map(LongValue::getValue).collect(Collectors.toSet());
   }
 
-  public BatchOperationChunkRecord setItemKeys(final List<Long> keys) {
+  public BatchOperationChunkRecord setItemKeys(final Set<Long> keys) {
     itemKeysProp.reset();
     keys.forEach(key -> itemKeysProp.add().setValue(key));
     return this;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationExecutionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationExecutionRecord.java
@@ -46,14 +46,14 @@ public final class BatchOperationExecutionRecord extends UnifiedRecordValue
     return entityKeysProp.stream().map(LongValue::getValue).collect(Collectors.toSet());
   }
 
-  public BatchOperationExecutionRecord setKeys(final Set<Long> keys) {
+  public BatchOperationExecutionRecord setEntityKeys(final Set<Long> keys) {
     entityKeysProp.reset();
     keys.forEach(key -> entityKeysProp.add().setValue(key));
     return this;
   }
 
   public BatchOperationExecutionRecord wrap(final BatchOperationExecutionRecord record) {
-    setKeys(record.getEntityKeys());
+    setEntityKeys(record.getEntityKeys());
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationExecutionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/batchoperation/BatchOperationExecutionRecord.java
@@ -19,15 +19,15 @@ public final class BatchOperationExecutionRecord extends UnifiedRecordValue
     implements BatchOperationExecutionRecordValue {
 
   public static final String PROP_BATCH_OPERATION_KEY = "batchOperationKey";
-  public static final String PROP_ENTITY_KEY_LIST = "entitykeys";
+  public static final String PROP_ITEM_KEY_LIST = "itemKeys";
 
   private final LongProperty batchOperationKeyProp = new LongProperty(PROP_BATCH_OPERATION_KEY);
-  private final ArrayProperty<LongValue> entityKeysProp =
-      new ArrayProperty<>(PROP_ENTITY_KEY_LIST, LongValue::new);
+  private final ArrayProperty<LongValue> itemKeysProp =
+      new ArrayProperty<>(PROP_ITEM_KEY_LIST, LongValue::new);
 
   public BatchOperationExecutionRecord() {
     super(2);
-    declareProperty(batchOperationKeyProp).declareProperty(entityKeysProp);
+    declareProperty(batchOperationKeyProp).declareProperty(itemKeysProp);
   }
 
   @Override
@@ -42,18 +42,18 @@ public final class BatchOperationExecutionRecord extends UnifiedRecordValue
   }
 
   @Override
-  public Set<Long> getEntityKeys() {
-    return entityKeysProp.stream().map(LongValue::getValue).collect(Collectors.toSet());
+  public Set<Long> getItemKeys() {
+    return itemKeysProp.stream().map(LongValue::getValue).collect(Collectors.toSet());
   }
 
-  public BatchOperationExecutionRecord setEntityKeys(final Set<Long> keys) {
-    entityKeysProp.reset();
-    keys.forEach(key -> entityKeysProp.add().setValue(key));
+  public BatchOperationExecutionRecord setItemKeys(final Set<Long> keys) {
+    itemKeysProp.reset();
+    keys.forEach(key -> itemKeysProp.add().setValue(key));
     return this;
   }
 
   public BatchOperationExecutionRecord wrap(final BatchOperationExecutionRecord record) {
-    setEntityKeys(record.getEntityKeys());
+    setItemKeys(record.getItemKeys());
     return this;
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -232,11 +232,9 @@ public enum ZbColumnFamilies implements EnumValue {
 
   BATCH_OPERATION(120),
   PENDING_BATCH_OPERATION(121),
+  BATCH_OPERATION_CHUNKS(122),
 
-  VARIABLE_DOCUMENT_STATE_BY_SCOPE_KEY(122),
-
-  ENTITY_BY_BATCH_OPERATION(
-      123); // TODO can we change the value of this with VARIABLE_DOCUMENT_STATE_BY_SCOPE_KEY?
+  VARIABLE_DOCUMENT_STATE_BY_SCOPE_KEY(123);
 
   private final int value;
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -233,7 +233,10 @@ public enum ZbColumnFamilies implements EnumValue {
   BATCH_OPERATION(120),
   PENDING_BATCH_OPERATION(121),
 
-  VARIABLE_DOCUMENT_STATE_BY_SCOPE_KEY(122);
+  VARIABLE_DOCUMENT_STATE_BY_SCOPE_KEY(122),
+
+  ENTITY_BY_BATCH_OPERATION(
+      123); // TODO can we change the value of this with VARIABLE_DOCUMENT_STATE_BY_SCOPE_KEY?
 
   private final int value;
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/BatchOperationChunkIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/BatchOperationChunkIntent.java
@@ -16,8 +16,8 @@
 package io.camunda.zeebe.protocol.record.intent;
 
 public enum BatchOperationChunkIntent implements Intent {
-  CREATE((short) 0);
-  //  CREATED((short) 1);
+  CREATE((short) 0),
+  CREATED((short) 1);
 
   private final short value;
 
@@ -33,6 +33,8 @@ public enum BatchOperationChunkIntent implements Intent {
     switch (value) {
       case 0:
         return CREATE;
+      case 1:
+        return CREATED;
 
       default:
         return Intent.UNKNOWN;
@@ -47,6 +49,8 @@ public enum BatchOperationChunkIntent implements Intent {
   @Override
   public boolean isEvent() {
     switch (this) {
+      case CREATED:
+        return true;
       default:
         return false;
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationChunkRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationChunkRecordValue.java
@@ -17,7 +17,7 @@ package io.camunda.zeebe.protocol.record.value;
 
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
-import java.util.List;
+import java.util.Set;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -27,7 +27,7 @@ public interface BatchOperationChunkRecordValue extends BatchOperationRelated, R
   /**
    * @return subset of item keys for the batch operation
    */
-  List<Long> getItemKeys();
+  Set<Long> getItemKeys();
 
   /**
    * @return the key of this chunk of entity keys

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationChunkRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationChunkRecordValue.java
@@ -25,9 +25,9 @@ import org.immutables.value.Value;
 public interface BatchOperationChunkRecordValue extends BatchOperationRelated, RecordValue {
 
   /**
-   * @return subset of entity keys for the batch operation
+   * @return subset of item keys for the batch operation
    */
-  List<Long> getEntityKeys();
+  List<Long> getItemKeys();
 
   /**
    * @return the key of this chunk of entity keys

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationExecutionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BatchOperationExecutionRecordValue.java
@@ -27,5 +27,5 @@ public interface BatchOperationExecutionRecordValue extends BatchOperationRelate
   /**
    * @return subset of entity keys for the batch operation which are being or were processed
    */
-  Set<Long> getEntityKeys();
+  Set<Long> getItemKeys();
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/AsyncTaskGroup.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/AsyncTaskGroup.java
@@ -24,7 +24,8 @@ import io.camunda.zeebe.scheduler.SchedulingHints;
  * @see SchedulingHints
  */
 public enum AsyncTaskGroup {
-  ASYNC_PROCESSING("AsyncProcessingScheduleActor", SchedulingHints.cpuBound());
+  ASYNC_PROCESSING("AsyncProcessingScheduleActor", SchedulingHints.cpuBound()),
+  BATCH_OPERATIONS("BatchOperationActor", SchedulingHints.ioBound());
   private final String name;
   private final SchedulingHints schedulingHints;
 

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/BatchOperationChunkRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/BatchOperationChunkRecordStream.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
+import java.util.stream.Stream;
+
+public class BatchOperationChunkRecordStream
+    extends ExporterRecordStream<BatchOperationChunkRecordValue, BatchOperationChunkRecordStream> {
+
+  public BatchOperationChunkRecordStream(
+      final Stream<Record<BatchOperationChunkRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected BatchOperationChunkRecordStream supply(
+      final Stream<Record<BatchOperationChunkRecordValue>> wrappedStream) {
+    return new BatchOperationChunkRecordStream(wrappedStream);
+  }
+
+  public BatchOperationChunkRecordStream withBatchOperationKey(final long key) {
+    return valueFilter(v -> v.getBatchOperationKey() == key);
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
 import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
@@ -48,6 +49,7 @@ import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.protocol.record.value.AdHocSubProcessActivityActivationRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
+import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
 import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
@@ -555,6 +557,16 @@ public final class RecordingExporter implements Exporter {
   public static BatchOperationCreationRecordStream batchOperationCreationRecords(
       final BatchOperationIntent intent) {
     return batchOperationCreationRecords().withIntent(intent);
+  }
+
+  public static BatchOperationChunkRecordStream batchOperationChunkRecords() {
+    return new BatchOperationChunkRecordStream(
+        records(ValueType.BATCH_OPERATION_CHUNK, BatchOperationChunkRecordValue.class));
+  }
+
+  public static BatchOperationChunkRecordStream batchOperationChunkRecords(
+      final BatchOperationChunkIntent intent) {
+    return batchOperationChunkRecords().withIntent(intent);
   }
 
   public static void autoAcknowledge(final boolean shouldAcknowledgeRecords) {


### PR DESCRIPTION
## Description

This PR introduces:

#### Batch operation execution scheduler
This scheduler periodically looks for new batch operations. For any new batch operation it will perform a paged search using the respective searchClient to retrieve all the keys for the current partition. This needs to happen using paging because ES/OS only support 10K entries in the search result.
This result will then be split into chunks (BatchOperationChunkRecord) of 400.000 entity keys if needed, to keep the record smaller than 4MB.
To not block any stream processor, all this must happen in a separate `AsyncTaskGroup.BATCH_OPERATIONS`

#### DbBatchOperationState
The internal state is enhanced to store all the entity keys of the  batch operation. To not overload the RocksDB, the amount of keys will be split again here into smaller chunks of 3500 keys (smaller than the 32KB blocksize of RocksDB) and stored in a separate column family.
This block-list is implemented as queue. New entityKeys are added to the head, when keys are being processed they are picked and removed from the tail of the queue.

## Related issues

closes #29697 
