### PR TITLE
[Backport stable/8.7] feature: Increase the default inbound message size to 5MB for clients

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -196,8 +196,8 @@ public interface ZeebeClientBuilder {
 
   /**
    * A custom maxMessageSize allows the client to receive larger or smaller responses from Zeebe.
-   * Technically, it specifies the maxInboundMessageSize of the gRPC channel. The default is 4194304
-   * = 4MB.
+   * Technically, it specifies the maxInboundMessageSize of the gRPC channel. The default is 5242880
+   * = 5MB.
    */
   ZeebeClientBuilder maxMessageSize(int maxSize);
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -108,7 +108,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   private Duration keepAlive = Duration.ofSeconds(45);
   private JsonMapper jsonMapper = new ZeebeObjectMapper();
   private String overrideAuthority;
-  private int maxMessageSize = 4 * ONE_MB;
+  private int maxMessageSize = 5 * ONE_MB;
   private int maxMetadataSize = 16 * ONE_KB;
   private boolean streamEnabled = false;
   private boolean grpcAddressUsed = true;

--- a/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -102,7 +102,7 @@ public final class ZeebeClientTest extends ClientTest {
       assertThat(configuration.getDefaultJobPollInterval()).isEqualTo(Duration.ofMillis(100));
       assertThat(configuration.getDefaultMessageTimeToLive()).isEqualTo(Duration.ofHours(1));
       assertThat(configuration.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(10));
-      assertThat(configuration.getMaxMessageSize()).isEqualTo(4 * 1024 * 1024);
+      assertThat(configuration.getMaxMessageSize()).isEqualTo(5 * 1024 * 1024);
       assertThat(configuration.getMaxMetadataSize()).isEqualTo(16 * 1024);
       assertThat(configuration.getOverrideAuthority()).isNull();
       assertThat(configuration.getDefaultTenantId())

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationDefaultPropertiesTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationDefaultPropertiesTest.java
@@ -68,7 +68,7 @@ public class ZeebeClientConfigurationDefaultPropertiesTest {
     assertThat(client.getConfiguration().getGrpcAddress())
         .isEqualTo(new URI("http://0.0.0.0:26500"));
     assertThat(client.getConfiguration().getKeepAlive()).isEqualTo(Duration.ofSeconds(45));
-    assertThat(client.getConfiguration().getMaxMessageSize()).isEqualTo(4 * ONE_MB);
+    assertThat(client.getConfiguration().getMaxMessageSize()).isEqualTo(5 * ONE_MB);
     assertThat(client.getConfiguration().getMaxMetadataSize()).isEqualTo(16 * ONE_KB);
     assertThat(client.getConfiguration().getNumJobWorkerExecutionThreads()).isEqualTo(1);
     assertThat(client.getConfiguration().getOverrideAuthority()).isNull();


### PR DESCRIPTION
# Description
Backport of #29608 to `stable/8.7`.

relates to 