### PR TITLE
Improve QA (acceptance test) readme

### DIFF
--- a/qa/README.md
+++ b/qa/README.md
@@ -83,6 +83,18 @@ public class ProcessDefinitionQueryTest {
 * We need to configure the broker for specific authentication, for that we need to make use of `TestStandaloneBroker` or `TestSimpleCamundaApplication`
 * We need to annotate the test applications with `MultiDbTestApplication`, to mark application managed by `CamundaMultiDbExtension`
 
+> [!Note]
+>
+> The separation of test application and extension (to configure different secondary storages) is on purpose.
+>
+> This is for:
+>  * Single responsibility
+>    * the `CamundaMultiDbExtension` only focuses on configuring the database based on various factors (e.g. CI job)
+>  * KISS: to keep things light
+>  * Favor composability: make it reusable
+>    * the extension handles configuring the DB, and can be used in different occasions together with using the standalone Camunda, standalone Broker, or something different
+>    * the test applications focus on the respective application lifecycle and flexible configuration
+
 **Optional:**
 
 * We might not want to run the test for all secondary storage, as it is not yet supported. We can use the `@DisabledIfSystemProperty` annotation

--- a/qa/README.md
+++ b/qa/README.md
@@ -1,6 +1,6 @@
 # Acceptance tests
 
-This module contains acceptance tests for the whole Camunda 8 platform, covering multiple or even all components at the same time in an integrated manner.
+This module contains acceptance tests (AT) for the whole Camunda 8 platform, covering multiple or even all components at the same time in an integrated manner.
 
 In the following document, we shortly highlight general recommendations and how-tos/examples of how to write them.
 This ensures we consistently write such tests and cover all necessary supported environments.
@@ -15,6 +15,18 @@ This ensures we consistently write such tests and cover all necessary supported 
 
 ## How to write acceptance tests
 
+We are providing with the `@MultiDbTest` annotation a consistent and easy way to write acceptance tests.
+ 
+* This reduces the barrier for engineers to write AT, which is less repetitive and has less boilerplate (especially regarding setup code).
+* Tests are executed against multiple supported environments, transparent to the Engineer.
+* Engineers can fully focus on business logic to test.
+* Tests using the `@MultiDbTest` annotation are normally faster to execute. As they start dependencies just once, and cleanly reuse them.
+
+While we want to make it as easy as possible to write AT for the engineers, this comes with some cost and complexity in the related extension.
+Additionally, we wanted to still make the solution composable, reusable and configurable to cover several use cases or even make it possible to support advanced use cases. For example to configure secondary storage on its own (if necessary) or handle the test application lifecycle.
+
+This means the separation of the test application and MultiDb configuration in the extension (to configure different secondary storages) is on purpose.
+
 ### For simple cases:
 
 * Make use of the `@MultiDbTest` annotation (if possible).
@@ -25,9 +37,9 @@ This ensures we consistently write such tests and cover all necessary supported 
 
 ### For advanced cases:
 
-* Advanced cases might apply when you want to run the complete platform or need to configure the broker test application.
+* Advanced cases might apply when you want to run the complete platform or need to configure the broker test application or have to control the application lifecycle on your own.
 * To run the complete platform, you can use `TestSimpleCamundaApplication`, which bundles all components together.
-* With that, you can use `@RegisterExtension` and `CamundaMultiDBExtension` directly.
+* With that, you can use `@RegisterExtension` and `CamundaMultiDBExtension` directly or annotate the test application with `@MultiDbTestApplication`
 * This might also be necessary for more sophisticated broker configurations, such as testing different or specific authentications.
 
 ### For special cases:
@@ -82,15 +94,6 @@ public class ProcessDefinitionQueryTest {
 
 * We need to configure the broker for specific authentication, for that we need to make use of `TestStandaloneBroker` or `TestSimpleCamundaApplication`
 * We need to annotate the test applications with `MultiDbTestApplication`, to mark application managed by `CamundaMultiDbExtension`
-
-> [!Note]
->
-> The separation of test application and extension (to configure different secondary storages) is on purpose.
->
-> This is for:
-> * Single responsibility: the `CamundaMultiDbExtension` only focuses on configuring the database based on various factors (e.g. CI job)
-> * KISS: to keep things light
-> * Favor composability: To make it reusable. The extension handles configuring the DB, and can be used in different occasions together with using the standalone Camunda, standalone Broker, or something different. The test applications focus on the respective application lifecycle and flexible configuration
 
 **Optional:**
 

--- a/qa/README.md
+++ b/qa/README.md
@@ -88,12 +88,9 @@ public class ProcessDefinitionQueryTest {
 > The separation of test application and extension (to configure different secondary storages) is on purpose.
 >
 > This is for:
->  * Single responsibility
->    * the `CamundaMultiDbExtension` only focuses on configuring the database based on various factors (e.g. CI job)
->  * KISS: to keep things light
->  * Favor composability: make it reusable
->    * the extension handles configuring the DB, and can be used in different occasions together with using the standalone Camunda, standalone Broker, or something different
->    * the test applications focus on the respective application lifecycle and flexible configuration
+> * Single responsibility: the `CamundaMultiDbExtension` only focuses on configuring the database based on various factors (e.g. CI job)
+> * KISS: to keep things light
+> * Favor composability: To make it reusable. The extension handles configuring the DB, and can be used in different occasions together with using the standalone Camunda, standalone Broker, or something different. The test applications focus on the respective application lifecycle and flexible configuration
 
 **Optional:**
 

--- a/qa/README.md
+++ b/qa/README.md
@@ -1,6 +1,6 @@
 # Acceptance tests
 
-This module contains acceptance tests (AT) for the whole Camunda 8 platform, covering multiple or even all components at the same time in an integrated manner.
+This module contains acceptance tests (ATs) for the whole Camunda 8 platform, covering multiple or even all components at the same time in an integrated manner.
 
 In the following document, we shortly highlight general recommendations and how-tos/examples of how to write them.
 This ensures we consistently write such tests and cover all necessary supported environments.
@@ -15,29 +15,29 @@ This ensures we consistently write such tests and cover all necessary supported 
 
 ## How to write acceptance tests
 
-We are providing with the `@MultiDbTest` annotation a consistent and easy way to write acceptance tests.
- 
-* This reduces the barrier for engineers to write AT, which is less repetitive and has less boilerplate (especially regarding setup code).
-* Tests are executed against multiple supported environments, transparent to the Engineer.
+With the `@MultiDbTest` annotation, we provide a consistent and easy way to write acceptance tests.
+
+* This reduces the barrier for engineers to write ATs, which is less repetitive and has less boilerplate (especially regarding setup code).
+* Tests are executed against multiple supported environments, transparent to the engineer.
 * Engineers can fully focus on business logic to test.
-* Tests using the `@MultiDbTest` annotation are normally faster to execute. As they start dependencies just once, and cleanly reuse them.
+* Tests using the `@MultiDbTest` annotation usually execute faster, as they start dependencies just once and cleanly reuse them.
 
-While we want to make it as easy as possible to write AT for the engineers, this comes with some cost and complexity in the related extension.
-Additionally, we wanted to still make the solution composable, reusable and configurable to cover several use cases or even make it possible to support advanced use cases. For example to configure secondary storage on its own (if necessary) or handle the test application lifecycle.
+While we want to make it as easy as possible for engineers to write ATs, this comes with some cost and complexity in the related extension.
+Additionally, the solution is meant to be composable, reusable, and configurable to cover several use cases or even make it possible to support advanced use cases. For example, to configure secondary storage on its own (if necessary) or handle the test application lifecycle.
 
-This means the separation of the test application and MultiDb configuration in the extension (to configure different secondary storages) is on purpose.
+This means the test application and MultiDb configuration in the extension are separated on purpose (to configure different secondary storages).
 
 ### For simple cases:
 
 * Make use of the `@MultiDbTest` annotation (if possible).
 * By default, it will use the `TestStandaloneBroker` class to reduce the scope to a minimum.
-* The `@MutliDbTest` annotation will ensure that your test is tagged as a test that should be executed against multiple secondary storage, such as Elasticsearch (ES), OpenSearch (OS), RDBMS, etc.
-* The `@MutliDbTest` annotation will mark your test class with `@ExtendsWith` using the `CamundaMultiDBExtension`.
+* The `@MultiDbTest` annotation will ensure that your test is tagged as a test that should be executed against multiple secondary storage, such as Elasticsearch (ES), OpenSearch (OS), RDBMS, etc.
+* The `@MultiDbTest` annotation will mark your test class with `@ExtendsWith` using the `CamundaMultiDBExtension`.
 * The execution against different secondary storage is done on our CI.yml GitHub workflow, where separate jobs exist. A specific test property is set for the database type, allowing the extension to configure the test application correctly (specific Exporter, etc.).
 
 ### For advanced cases:
 
-* Advanced cases might apply when you want to run the complete platform or need to configure the broker test application or have to control the application lifecycle on your own.
+* Advanced cases might apply when you want to run the complete platform, need to configure the broker test application, or have to control the application lifecycle on your own.
 * To run the complete platform, you can use `TestSimpleCamundaApplication`, which bundles all components together.
 * With that, you can use `@RegisterExtension` and `CamundaMultiDBExtension` directly or annotate the test application with `@MultiDbTestApplication`
 * This might also be necessary for more sophisticated broker configurations, such as testing different or specific authentications.
@@ -92,14 +92,14 @@ public class ProcessDefinitionQueryTest {
 
 **Need:**
 
-* We need to configure the broker for specific authentication, for that we need to make use of `TestStandaloneBroker` or `TestSimpleCamundaApplication`
-* We need to annotate the test applications with `MultiDbTestApplication`, to mark application managed by `CamundaMultiDbExtension`
+* We need to configure the broker for specific authentication. For that, we need to make use of `TestStandaloneBroker` or `TestSimpleCamundaApplication`.
+* We need to annotate the test applications with `MultiDbTestApplication` to mark the application managed by `CamundaMultiDbExtension`.
 
 **Optional:**
 
 * We might not want to run the test for all secondary storage, as it is not yet supported. We can use the `@DisabledIfSystemProperty` annotation
-* We might want to disable the lifecycle management of the annotated test application, this can be done via: `@MultiDbTestApplication(managedLifecycle = false)`
-  * This is especially useful, if we want to start and stop the test application inside the test (to validate restarts, or something similar)
+* We might want to disable the lifecycle management of the annotated test application. This can be done via `@MultiDbTestApplication(managedLifecycle = false)`.
+  * This is especially useful if we want to start and stop the test application inside the test (to validate restarts or something similar)
 
 ```java
 @MultiDbTest
@@ -129,7 +129,7 @@ class SomeIT {
 
 We want to highlight some special features for the authentication tests here.
 
-* For the authentication related tests, users (that are used in tests) can be predefined and annotated with `@UserDefinition`. This allows the extension to collect the related user definitions.
+* For authentication-related tests, users (who are used in tests) can be predefined and annotated with `@UserDefinition`. This allows the extension to collect the related user definitions.
 * Authenticated clients can be created via `@Authenticated` annotation, specifying a user to be used.
   * When a client annotated with `Authenticated` is injected (as field or parameter), the respective/referenced user is created.
 


### PR DESCRIPTION
## Description

Context:

We have introduced a new annotation https://github.com/camunda/camunda/pull/29636 to make the MultiDbTest annotation usage more convenient and consistent.

What the PR does:


 * Extend README and mention @MultiDbTestApplication, which simplifies our
   examples and also the explanations
 * Adjusted several descriptions to make them a bit more clearer
 * Added some important nodes, like the user/client creation in auth test setup
 * Explain why we have an extension for the configs and the test apps
