### PR TITLE
[Backport stable/8.4] bugfix: message cardinality can be broken by instance migration

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance.migration;
+
+import static io.camunda.zeebe.engine.processing.processinstance.migration.MigrationTestUtil.extractProcessDefinitionKeyByProcessId;
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationMappingInstruction;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.assertj.core.api.Assertions;
+import java.util.List;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class MigrateProcessInstanceTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldWriteMigratedEventForProcessInstance() {
+    // given
+    final String processId1 = helper.getBpmnProcessId();
+    final String processId2 = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId1)
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId2)
+                    .startEvent()
+                    .serviceTask("B", a -> a.zeebeJobType("B"))
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long otherProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, processId2);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId1).create();
+
+    // when
+    final var event =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(otherProcessDefinitionKey)
+            .addMappingInstruction("A", "B")
+            .migrate();
+
+    // then
+    assertThat(event)
+        .hasKey(processInstanceKey)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATED);
+
+    assertThat(event.getValue())
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasTargetProcessDefinitionKey(otherProcessDefinitionKey)
+        .hasMappingInstructions(
+            new ProcessInstanceMigrationMappingInstruction()
+                .setSourceElementId("A")
+                .setTargetElementId("B"));
+  }
+
+  @Test
+  public void shouldWriteElementMigratedEventForProcessInstance() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String otherProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(otherProcessId)
+                    .startEvent()
+                    .serviceTask("B", a -> a.zeebeJobType("B"))
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long otherProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, otherProcessId);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(otherProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that process definition key changed")
+        .hasProcessDefinitionKey(otherProcessDefinitionKey)
+        .describedAs("Expect that bpmn process id and element id changed")
+        .hasBpmnProcessId(otherProcessId)
+        .hasElementId(otherProcessId)
+        .describedAs("Expect that version number did not change")
+        .hasVersion(1)
+        .hasElementInstancePath(List.of(processInstanceKey))
+        .describedAs(
+            "Expect that process definition path changed to contain new process definition key")
+        .hasProcessDefinitionPath(List.of(otherProcessDefinitionKey))
+        .hasCallingElementPath(List.of());
+  }
+
+  @Test
+  public void shouldWriteElementMigratedEventForProcessInstanceToNewVersion() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask("A", a -> a.zeebeJobType("A"))
+                .endEvent()
+                .done())
+        .deploy();
+    final var secondVersionDeployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .userTask()
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long v2ProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(secondVersionDeployment, processId);
+
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(processId).withVersion(1).create();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(v2ProcessDefinitionKey)
+        .addMappingInstruction("A", "A")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .onlyEvents()
+                .withIntent(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that process definition key changed")
+        .hasProcessDefinitionKey(v2ProcessDefinitionKey)
+        .describedAs("Expect that version number changed")
+        .hasVersion(2)
+        .describedAs("Expect that bpmn process id and element id did not change")
+        .hasBpmnProcessId(processId)
+        .hasElementInstancePath(List.of(processInstanceKey))
+        .describedAs(
+            "Expect that process definition path changed to contain new process definition key")
+        .hasProcessDefinitionPath(List.of(v2ProcessDefinitionKey))
+        .hasCallingElementPath(List.of());
+  }
+
+  @Test
+  public void shouldAdjustMessageCardinalityTrackingWhenMigratedForProcessInstance() {
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent("msg_start")
+                    .message("msg1")
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent("msg_start")
+                    .message("msg2")
+                    .serviceTask("B", t -> t.zeebeJobType("B"))
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    ENGINE.message().withName("msg1").withCorrelationKey("cardinality").publish();
+    final var processInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withElementType(BpmnElementType.START_EVENT)
+            .withElementId("msg_start")
+            .withBpmnProcessId(processId)
+            .getFirst()
+            .getValue()
+            .getProcessInstanceKey();
+
+    // when
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    ENGINE.message().withName("msg1").withCorrelationKey("cardinality").publish();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withElementType(BpmnElementType.PROCESS)
+                .withBpmnProcessId(processId)
+                .withElementId(processId)
+                .skip(1) // skip the first activation
+                .exists())
+        .isTrue();
+  }
+
+}


### PR DESCRIPTION
# Description
Backport of #27114 to `stable/8.4`.

relates to #26008