### PR TITLE
pg-29951-adhoc-subp-vars-tasklist

### DIFF
--- a/tasklist/common/src/main/java/io/camunda/tasklist/entities/FlowNodeType.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/entities/FlowNodeType.java
@@ -28,17 +28,18 @@ public enum FlowNodeType {
   SEQUENCE_FLOW,
   MULTI_INSTANCE_BODY,
   CALL_ACTIVITY,
+  AD_HOC_SUB_PROCESS,
   UNKNOWN;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(FlowNodeType.class);
 
-  public static FlowNodeType fromZeebeBpmnElementType(String bpmnElementType) {
+  public static FlowNodeType fromZeebeBpmnElementType(final String bpmnElementType) {
     if (bpmnElementType == null) {
       return UNSPECIFIED;
     }
     try {
       return FlowNodeType.valueOf(bpmnElementType);
-    } catch (IllegalArgumentException ex) {
+    } catch (final IllegalArgumentException ex) {
       LOGGER.error(
           "Flow node type not found for value [{}]. UNKNOWN type will be assigned.",
           bpmnElementType);

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/es/ProcessInstanceZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/es/ProcessInstanceZeebeRecordProcessorElasticSearch.java
@@ -55,7 +55,8 @@ public class ProcessInstanceZeebeRecordProcessorElasticSearch {
           BpmnElementType.EVENT_SUB_PROCESS,
           BpmnElementType.SERVICE_TASK,
           BpmnElementType.USER_TASK,
-          BpmnElementType.MULTI_INSTANCE_BODY);
+          BpmnElementType.MULTI_INSTANCE_BODY,
+          BpmnElementType.AD_HOC_SUB_PROCESS);
 
   static {
     FLOW_NODE_STATES.add(ELEMENT_ACTIVATING.name());

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/os/ProcessInstanceZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/os/ProcessInstanceZeebeRecordProcessorOpenSearch.java
@@ -55,7 +55,8 @@ public class ProcessInstanceZeebeRecordProcessorOpenSearch {
           BpmnElementType.EVENT_SUB_PROCESS,
           BpmnElementType.SERVICE_TASK,
           BpmnElementType.USER_TASK,
-          BpmnElementType.MULTI_INSTANCE_BODY);
+          BpmnElementType.MULTI_INSTANCE_BODY,
+          BpmnElementType.AD_HOC_SUB_PROCESS);
 
   static {
     FLOW_NODE_STATES.add(ELEMENT_ACTIVATING.name());

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeImportAdHocSubProcessIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeImportAdHocSubProcessIT.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.zeebeimport;
+
+import static io.camunda.tasklist.util.assertions.CustomAssertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.tasklist.entities.TaskEntity;
+import io.camunda.tasklist.store.TaskStore;
+import io.camunda.tasklist.util.MockMvcHelper;
+import io.camunda.tasklist.util.TasklistZeebeIntegrationTest;
+import io.camunda.tasklist.webapp.api.rest.v1.entities.VariableSearchResponse;
+import io.camunda.tasklist.webapp.security.TasklistURIs;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+public class ZeebeImportAdHocSubProcessIT extends TasklistZeebeIntegrationTest {
+
+  @Autowired private TaskStore taskStore;
+
+  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired private WebApplicationContext context;
+
+  private MockMvcHelper mockMvcHelper;
+
+  @BeforeEach
+  public void setUp() {
+    mockMvcHelper =
+        new MockMvcHelper(MockMvcBuilders.webAppContextSetup(context).build(), objectMapper);
+  }
+
+  @Test
+  public void shouldImportAdHocSubProcess() {
+    final String bpmnProcessId = "AdhocSubProcess";
+
+    final String processInstanceId =
+        tester
+            .deployProcess("adhoc-subprocess.bpmn")
+            .waitUntil()
+            .processIsDeployed()
+            .startProcessInstance(
+                bpmnProcessId, "{\"someText\": \"text\", \"someNumber\": 1312, \"unmapped\": true}")
+            .waitUntil()
+            .taskIsCreated("task1")
+            .taskIsCreated("task2")
+            .taskIsCreated("task3")
+            .getProcessInstanceId();
+
+    // then
+    assertNotNull(processInstanceId);
+    final List<String> taskIds = taskStore.getTaskIdsByProcessInstanceId(processInstanceId);
+    assertEquals(3, taskIds.size());
+
+    for (final String taskId : taskIds) {
+      final TaskEntity entity = taskStore.getTask(taskId);
+      final var result =
+          mockMvcHelper.doRequest(
+              post(TasklistURIs.TASKS_URL_V1.concat("/{taskId}/variables/search"), taskId));
+      switch (entity.getFlowNodeBpmnId()) {
+        case "task1" ->
+            assertThat(result)
+                .hasOkHttpStatus()
+                .hasApplicationJsonContentType()
+                .extractingListContent(objectMapper, VariableSearchResponse.class)
+                .extracting("name", "previewValue", "value")
+                .containsExactlyInAnyOrder(
+                    tuple("someNumber", "1312", "1312"),
+                    tuple("someText", "\"text\"", "\"text\""),
+                    tuple("task1var", "\"text\"", "\"text\""),
+                    tuple("unmapped", "true", "true"),
+                    tuple(
+                        "tasks",
+                        "[\"task1\",\"task2\",\"task3\"]",
+                        "[\"task1\",\"task2\",\"task3\"]"));
+        case "task2" ->
+            assertThat(result)
+                .hasOkHttpStatus()
+                .hasApplicationJsonContentType()
+                .extractingListContent(objectMapper, VariableSearchResponse.class)
+                .extracting("name", "previewValue", "value")
+                .containsExactlyInAnyOrder(
+                    tuple("someNumber", "1312", "1312"),
+                    tuple("someText", "\"text\"", "\"text\""),
+                    tuple("task2var", "1312", "1312"),
+                    tuple("unmapped", "true", "true"),
+                    tuple(
+                        "tasks",
+                        "[\"task1\",\"task2\",\"task3\"]",
+                        "[\"task1\",\"task2\",\"task3\"]"));
+        case "task3" ->
+            assertThat(result)
+                .hasOkHttpStatus()
+                .hasApplicationJsonContentType()
+                .extractingListContent(objectMapper, VariableSearchResponse.class)
+                .extracting("name", "previewValue", "value")
+                .containsExactlyInAnyOrder(
+                    tuple("someNumber", "1312", "1312"),
+                    tuple("someText", "\"text\"", "\"text\""),
+                    tuple("unmapped", "true", "true"),
+                    tuple(
+                        "tasks",
+                        "[\"task1\",\"task2\",\"task3\"]",
+                        "[\"task1\",\"task2\",\"task3\"]"));
+        default -> throw new AssertionError("Unexpected task id: " + taskId);
+      }
+    }
+  }
+}

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeImportAdHocSubProcessIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeImportAdHocSubProcessIT.java
@@ -11,6 +11,7 @@ import static io.camunda.tasklist.util.assertions.CustomAssertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -115,7 +116,7 @@ public class ZeebeImportAdHocSubProcessIT extends TasklistZeebeIntegrationTest {
                         "tasks",
                         "[\"task1\",\"task2\",\"task3\"]",
                         "[\"task1\",\"task2\",\"task3\"]"));
-        default -> throw new AssertionError("Unexpected task id: " + taskId);
+        default -> fail("Unexpected task id: " + taskId);
       }
     }
   }

--- a/tasklist/qa/integration-tests/src/test/resources/adhoc-subprocess.bpmn
+++ b/tasklist/qa/integration-tests/src/test/resources/adhoc-subprocess.bpmn
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.33.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="AdhocSubProcess" name="Test variable scope" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0y10cno</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0y10cno" sourceRef="StartEvent_1" targetRef="Activity_0kybtvz" />
+    <bpmn:adHocSubProcess id="Activity_013n10c">
+      <bpmn:extensionElements>
+        <zeebe:adHoc activeElementsCollection="=tasks" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=someText" target="someText" />
+          <zeebe:input source="=someNumber" target="someNumber" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0dl6067</bpmn:incoming>
+      <bpmn:outgoing>Flow_0t3bts6</bpmn:outgoing>
+      <bpmn:userTask id="task1" name="Task 1">
+        <bpmn:extensionElements>
+          <zeebe:userTask />
+          <zeebe:ioMapping>
+            <zeebe:input source="=someText" target="task1var" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+      </bpmn:userTask>
+      <bpmn:userTask id="task2" name="Task 2">
+        <bpmn:extensionElements>
+          <zeebe:userTask />
+          <zeebe:ioMapping>
+            <zeebe:input source="=someNumber" target="task2var" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
+      </bpmn:userTask>
+      <bpmn:userTask id="task3" name="Task 3">
+        <bpmn:extensionElements>
+          <zeebe:userTask />
+        </bpmn:extensionElements>
+      </bpmn:userTask>
+    </bpmn:adHocSubProcess>
+    <bpmn:sequenceFlow id="Flow_0dl6067" sourceRef="Activity_0kybtvz" targetRef="Activity_013n10c" />
+    <bpmn:scriptTask id="Activity_0kybtvz" name="Set Tasks">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=[&#34;task1&#34;, &#34;task2&#34;, &#34;task3&#34;]" resultVariable="tasks" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0y10cno</bpmn:incoming>
+      <bpmn:outgoing>Flow_0dl6067</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="Event_175yc08">
+      <bpmn:incoming>Flow_0t3bts6</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0t3bts6" sourceRef="Activity_013n10c" targetRef="Event_175yc08" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1tyxdmx">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="162" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="158" y="205" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1b4gcvb_di" bpmnElement="Activity_0kybtvz">
+        <dc:Bounds x="240" y="140" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_175yc08_di" bpmnElement="Event_175yc08">
+        <dc:Bounds x="982" y="227" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_013n10c_di" bpmnElement="Activity_013n10c" isExpanded="true">
+        <dc:Bounds x="395" y="80" width="525" height="330" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_16tjm58_di" bpmnElement="task1">
+        <dc:Bounds x="460" y="120" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1mgi0qp_di" bpmnElement="task2">
+        <dc:Bounds x="740" y="120" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ns21cb_di" bpmnElement="task3">
+        <dc:Bounds x="600" y="250" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0y10cno_di" bpmnElement="Flow_0y10cno">
+        <di:waypoint x="188" y="180" />
+        <di:waypoint x="240" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0dl6067_di" bpmnElement="Flow_0dl6067">
+        <di:waypoint x="340" y="180" />
+        <di:waypoint x="395" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0t3bts6_di" bpmnElement="Flow_0t3bts6">
+        <di:waypoint x="920" y="245" />
+        <di:waypoint x="982" y="245" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tasklist/qa/pom.xml
+++ b/tasklist/qa/pom.xml
@@ -21,8 +21,8 @@
   </modules>
 
   <properties>
-    <version.zeebe.docker.current>8.6.0</version.zeebe.docker.current>
-    <version.identity.docker.current>8.6.0</version.identity.docker.current>
+    <version.zeebe.docker.current>8.7.0-SNAPSHOT</version.zeebe.docker.current>
+    <version.identity.docker.current>8.7.0-alpha5</version.identity.docker.current>
   </properties>
 
 </project>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Support importing of AD_HOC_SUB_PROCESS node type in Tasklist

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29951
