### PR TITLE
fix: ensure mapping id is set for Elasticsearch indexing

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MappingDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MappingDbModel.java
@@ -10,7 +10,8 @@ package io.camunda.db.rdbms.write.domain;
 import io.camunda.util.ObjectBuilder;
 import java.util.function.Function;
 
-public record MappingDbModel(Long mappingKey, String claimName, String claimValue, String name)
+public record MappingDbModel(
+    String id, Long mappingKey, String claimName, String claimValue, String name)
     implements DbModel<MappingDbModel> {
 
   @Override
@@ -20,6 +21,7 @@ public record MappingDbModel(Long mappingKey, String claimName, String claimValu
     return builderFunction
         .apply(
             new MappingDbModelBuilder()
+                .id(id)
                 .mappingKey(mappingKey)
                 .claimName(claimName)
                 .claimValue(claimValue)
@@ -29,12 +31,18 @@ public record MappingDbModel(Long mappingKey, String claimName, String claimValu
 
   public static class MappingDbModelBuilder implements ObjectBuilder<MappingDbModel> {
 
+    private String id;
     private Long mappingKey;
     private String claimName;
     private String claimValue;
     private String name;
 
     public MappingDbModelBuilder() {}
+
+    public MappingDbModelBuilder id(final String id) {
+      this.id = id;
+      return this;
+    }
 
     public MappingDbModelBuilder mappingKey(final Long mappingKey) {
       this.mappingKey = mappingKey;
@@ -58,7 +66,7 @@ public record MappingDbModel(Long mappingKey, String claimName, String claimValu
 
     @Override
     public MappingDbModel build() {
-      return new MappingDbModel(mappingKey, claimName, claimValue, name);
+      return new MappingDbModel(id, mappingKey, claimName, claimValue, name);
     }
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/MappingFixtures.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/MappingFixtures.java
@@ -27,6 +27,7 @@ public final class MappingFixtures extends CommonFixtures {
       final Function<MappingDbModelBuilder, MappingDbModelBuilder> builderFunction) {
     final var builder =
         new MappingDbModelBuilder()
+            .id(nextStringId())
             .mappingKey(nextKey())
             .claimName("claimName-" + UUID.randomUUID())
             .claimValue("claimValue-" + UUID.randomUUID())

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/MappingFixtures.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/MappingFixtures.java
@@ -25,10 +25,11 @@ public final class MappingFixtures extends CommonFixtures {
 
   public static MappingDbModel createRandomized(
       final Function<MappingDbModelBuilder, MappingDbModelBuilder> builderFunction) {
+    final var id = nextKey();
     final var builder =
         new MappingDbModelBuilder()
-            .id(nextStringId())
-            .mappingKey(nextKey())
+            .id(String.valueOf(id))
+            .mappingKey(id)
             .claimName("claimName-" + UUID.randomUUID())
             .claimValue("claimValue-" + UUID.randomUUID())
             .name("name" + UUID.randomUUID());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
@@ -159,6 +159,7 @@ public final class IdentitySetupInitializeProcessor
                     .ifPresentOrElse(
                         persistedMapping -> {
                           mapping.setMappingKey(persistedMapping.getMappingKey());
+                          mapping.setId(persistedMapping.getId());
                           if (assignEntityToRole(
                               role.getRoleKey(),
                               persistedMapping.getMappingKey(),
@@ -173,6 +174,10 @@ public final class IdentitySetupInitializeProcessor
                           createdNewEntities.set(true);
                           final long mappingKey = keyGenerator.nextKey();
                           mapping.setMappingKey(mappingKey);
+                          // TODO: Remove null checks after migrating fully to mapping ID #27820
+                          if (mapping.getId() == null || mapping.getId().isBlank()) {
+                            mapping.setId(String.valueOf(mappingKey));
+                          }
                           createMapping(mapping, role.getRoleKey(), tenant);
                         }));
     return createdNewEntities.get();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingCreatedUpdatedHandler.java
@@ -47,7 +47,7 @@ public class MappingCreatedUpdatedHandler
 
   @Override
   public List<String> generateIds(final Record<MappingRecordValue> record) {
-    return List.of(String.valueOf(record.getValue().getId()));
+    return List.of(record.getValue().getId());
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MappingExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MappingExportHandler.java
@@ -45,6 +45,7 @@ public class MappingExportHandler implements RdbmsExportHandler<MappingRecordVal
   private MappingDbModel map(final Record<MappingRecordValue> record) {
     final var value = record.getValue();
     return new MappingDbModelBuilder()
+        .id(value.getId())
         .mappingKey(value.getMappingKey())
         .claimName(value.getClaimName())
         .claimValue(value.getClaimValue())


### PR DESCRIPTION
## Description

This PR introduces a new id field to MappingDbModel and propagates it across the engine, exporter, and integration tests. The `id` is now used for document indexing in Elasticsearch. This change fixes the exporter error:
`Index failed for type [...] and id []: if _id is specified it must not be empty,
`which occurred when the mapping ID was not properly set.
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)
