### PR TITLE
test: increase timeouts to reduce flakiness

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PartitionJoinTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PartitionJoinTest.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 final class PartitionJoinTest {
+  private static final Duration JOIN_TIMEOUT = Duration.ofSeconds(20);
+
   @ParameterizedTest
   @MethodSource("testScenarios")
   void canJoinPartition(final Scenario scenario) {
@@ -30,6 +32,7 @@ final class PartitionJoinTest {
       // then
       assertChangeIsPlanned(response);
       Awaitility.await("Requested change is completed in time")
+          .timeout(JOIN_TIMEOUT)
           .untilAsserted(
               () -> ClusterActuatorAssert.assertThat(cluster).hasCompletedChanges(response));
       ClusterActuatorAssert.assertThat(cluster)
@@ -55,6 +58,7 @@ final class PartitionJoinTest {
       // then
       assertChangeIsPlanned(leave);
       Awaitility.await("Requested change is completed in time")
+          .timeout(JOIN_TIMEOUT)
           .untilAsserted(
               () -> ClusterActuatorAssert.assertThat(cluster).hasCompletedChanges(leave));
       ClusterActuatorAssert.assertThat(cluster).hasAppliedChanges(leave);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PartitionLeaveTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PartitionLeaveTest.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 final class PartitionLeaveTest {
+  private static final Duration LEAVE_TIMEOUT = Duration.ofSeconds(20);
+
   @ParameterizedTest
   @MethodSource("testScenarios")
   void canLeavePartition(final Scenario scenario) {
@@ -30,6 +32,7 @@ final class PartitionLeaveTest {
       // then
       assertChangeIsPlanned(response);
       Awaitility.await("Requested change is completed in time")
+          .timeout(LEAVE_TIMEOUT)
           .untilAsserted(
               () -> ClusterActuatorAssert.assertThat(cluster).hasCompletedChanges(response));
       ClusterActuatorAssert.assertThat(cluster).hasAppliedChanges(response);
@@ -48,6 +51,7 @@ final class PartitionLeaveTest {
       final var leave = runOperation(cluster, scenario.operation());
       assertChangeIsPlanned(leave);
       Awaitility.await("Leaving is completed in time")
+          .timeout(LEAVE_TIMEOUT)
           .untilAsserted(
               () -> ClusterActuatorAssert.assertThat(cluster).hasCompletedChanges(leave));
       ClusterActuatorAssert.assertThat(cluster).hasAppliedChanges(leave);


### PR DESCRIPTION
These would often fail in CI and even locally, the default timeout of 10 seconds appeared to be a bit too aggressive.

closes #27847