### PR TITLE
ci: path-filters GHA: include zeebe-change in tasklist-backend-changes

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -74,6 +74,7 @@ outputs:
         github.event_name == 'schedule' ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-tasklist.outputs.tasklist-backend-change == 'true' ||
+        steps.filter-zeebe.outputs.zeebe-change == 'true' ||
         steps.filter-common.outputs.webapps-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-common.outputs.dockerfile-change == 'true'


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Lately some changes in Zeebe (in the exporter) has broken Tasklist CI, however this was not detected in the PR since Tasklist CI was not triggered
I propose we add zeebe-change as condition for Tasklist backend changes

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
