### PR TITLE
[CPT] Assert that a process instance has exactly the given active elements

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
@@ -248,6 +248,29 @@ public interface ProcessInstanceAssert {
   ProcessInstanceAssert hasNoActiveElements(ElementSelector... elementSelectors);
 
   /**
+   * Verifies that only the given BPMN elements are active. The verification fails if at least one
+   * element is not active, or other elements are active.
+   *
+   * <p>The assertion waits until only the given elements are active.
+   *
+   * @param elementIds the BPMN element IDs
+   * @return the assertion object
+   */
+  ProcessInstanceAssert hasActiveElementsExactly(String... elementIds);
+
+  /**
+   * Verifies that only the given BPMN elements are active. The verification fails if at least one
+   * element is not active, or other elements are active.
+   *
+   * <p>The assertion waits until only the given elements are active.
+   *
+   * @param elementSelectors the selectors for the BPMN elements
+   * @return the assertion object
+   * @see ElementSelectors
+   */
+  ProcessInstanceAssert hasActiveElementsExactly(ElementSelector... elementSelectors);
+
+  /**
    * Verifies that the process instance has the given variables. The verification fails if at least
    * one variable doesn't exist.
    *

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -199,6 +199,18 @@ public class ProcessInstanceAssertj
   }
 
   @Override
+  public ProcessInstanceAssert hasActiveElementsExactly(final String... elementIds) {
+    elementAssertj.hasActiveElementsExactly(getProcessInstanceKey(), elementIds);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert hasActiveElementsExactly(final ElementSelector... elementSelectors) {
+    elementAssertj.hasActiveElementsExactly(getProcessInstanceKey(), elementSelectors);
+    return this;
+  }
+
+  @Override
   public ProcessInstanceAssert hasVariableNames(final String... variableNames) {
     variableAssertj.hasVariableNames(getProcessInstanceKey(), variableNames);
     return this;


### PR DESCRIPTION
## Description

Add a new assertion to verify that only the given elements are active.

The assertion is an equivalent for the assertions in: 
- C7: [isWaitingAtExactly()](https://docs.camunda.org/manual/7.21/user-guide/testing/assert-examples/#instance-iswaitingatexactly)
- ZPT: [isWaitingExactlyAtElements()](https://github.com/camunda/zeebe-process-test/blob/ae9b96c848ca1bf3d8efdbf43bf6b1003ac1536a/assertions/src/main/java/io/camunda/zeebe/process/test/assertions/ProcessInstanceAssert.java#L318)

**Reviewer note:** As a follow-up, I'll work on refactoring the assertions to reduce the duplicated code.

## Related issues

closes #23248 
