### PR TITLE
feat: report stats from gateway process cache

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/rest/RestApiConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rest/RestApiConfiguration.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import io.camunda.zeebe.gateway.rest.cache.ProcessCache;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.util.ProcessFlowNodeProvider;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -36,9 +37,11 @@ public class RestApiConfiguration {
   public ProcessCache processCache(
       final GatewayRestConfiguration configuration,
       final ProcessFlowNodeProvider processFlowNodeProvider,
-      final BrokerTopologyManager brokerTopologyManager) {
+      final BrokerTopologyManager brokerTopologyManager,
+      final MeterRegistry meterRegistry) {
 
-    return new ProcessCache(configuration, processFlowNodeProvider, brokerTopologyManager);
+    return new ProcessCache(
+        configuration, processFlowNodeProvider, brokerTopologyManager, meterRegistry);
   }
 
   @ConfigurationProperties("camunda.rest")

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ExporterEntityCacheImpl.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ExporterEntityCacheImpl.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.cache;
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import io.camunda.zeebe.util.cache.CaffeineCacheStatsCounter;
 import java.util.Optional;
 
 public class ExporterEntityCacheImpl<K, T> implements ExporterEntityCache<K, T> {
@@ -19,11 +20,11 @@ public class ExporterEntityCacheImpl<K, T> implements ExporterEntityCache<K, T> 
   public ExporterEntityCacheImpl(
       final long maxSize,
       final CacheLoader<K, T> cacheLoader,
-      final ExporterCacheMetrics exporterCacheMetrics) {
+      final CaffeineCacheStatsCounter statsCounter) {
     cache =
         Caffeine.newBuilder()
             .maximumSize(maxSize)
-            .recordStats(() -> exporterCacheMetrics)
+            .recordStats(() -> statsCounter)
             .build(
                 k -> {
                   try {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/FormCacheIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/FormCacheIT.java
@@ -13,6 +13,7 @@ import static io.camunda.search.test.utils.SearchDBExtension.TEST_INTEGRATION_OP
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatException;
 
+import io.camunda.exporter.DefaultExporterResourceProvider;
 import io.camunda.exporter.cache.ExporterEntityCache.CacheLoaderFailedException;
 import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.cache.form.ElasticSearchFormCacheLoader;
@@ -22,6 +23,7 @@ import io.camunda.search.schema.elasticsearch.ElasticsearchEngineClient;
 import io.camunda.search.schema.opensearch.OpensearchEngineClient;
 import io.camunda.search.test.utils.SearchDBExtension;
 import io.camunda.webapps.schema.entities.form.FormEntity;
+import io.camunda.zeebe.util.cache.CaffeineCacheStatsCounter;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.util.function.Consumer;
@@ -118,7 +120,8 @@ class FormCacheIT {
         new ExporterEntityCacheImpl<>(
             10,
             new ElasticSearchFormCacheLoader(searchDB.esClient(), indexName),
-            new ExporterCacheMetrics("ES", new SimpleMeterRegistry())),
+            new CaffeineCacheStatsCounter(
+                DefaultExporterResourceProvider.NAMESPACE, "ES", new SimpleMeterRegistry())),
         FormCacheIT::indexInElasticSearch);
   }
 
@@ -127,7 +130,8 @@ class FormCacheIT {
         new ExporterEntityCacheImpl<>(
             10,
             new OpenSearchFormCacheLoader(searchDB.osClient(), indexName),
-            new ExporterCacheMetrics("ES", new SimpleMeterRegistry())),
+            new CaffeineCacheStatsCounter(
+                DefaultExporterResourceProvider.NAMESPACE, "ES", new SimpleMeterRegistry())),
         FormCacheIT::indexInOpenSearch);
   }
 

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -190,6 +190,11 @@
       <artifactId>camunda-authentication</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+
     <!-- dependencies required for OpenAPI model generation -->
     <dependency>
       <groupId>jakarta.validation</groupId>

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/cache/ProcessCache.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/cache/ProcessCache.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ProcessCache {
 
-  public static final String NAMESPACE = "zeebe.gateway.rest.cache";
+  public static final String NAMESPACE = "camunda.gateway.rest.cache";
   private static final Logger LOGGER = LoggerFactory.getLogger(ProcessCache.class);
   private final LoadingCache<Long, ProcessCacheItem> cache;
   private final ProcessFlowNodeProvider processFlowNodeProvider;

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/cache/ProcessCache.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/cache/ProcessCache.java
@@ -16,6 +16,8 @@ import io.camunda.zeebe.broker.client.api.BrokerTopologyListener;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.gateway.rest.config.GatewayRestConfiguration;
 import io.camunda.zeebe.gateway.rest.util.ProcessFlowNodeProvider;
+import io.camunda.zeebe.util.cache.CaffeineCacheStatsCounter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -38,18 +40,22 @@ import org.slf4j.LoggerFactory;
  */
 public class ProcessCache {
 
+  public static final String NAMESPACE = "zeebe.gateway.rest.cache";
   private static final Logger LOGGER = LoggerFactory.getLogger(ProcessCache.class);
-
   private final LoadingCache<Long, ProcessCacheItem> cache;
   private final ProcessFlowNodeProvider processFlowNodeProvider;
 
   public ProcessCache(
       final GatewayRestConfiguration configuration,
       final ProcessFlowNodeProvider processFlowNodeProvider,
-      final BrokerTopologyManager brokerTopologyManager) {
+      final BrokerTopologyManager brokerTopologyManager,
+      final MeterRegistry meterRegistry) {
     this.processFlowNodeProvider = processFlowNodeProvider;
+    final var statsCounter = new CaffeineCacheStatsCounter(NAMESPACE, "process", meterRegistry);
     final var cacheBuilder =
-        Caffeine.newBuilder().maximumSize(configuration.getProcessCache().getMaxSize());
+        Caffeine.newBuilder()
+            .maximumSize(configuration.getProcessCache().getMaxSize())
+            .recordStats(() -> statsCounter);
     final var expirationIdle = configuration.getProcessCache().getExpirationIdleMillis();
     if (expirationIdle != null && expirationIdle > 0) {
       cacheBuilder.expireAfterAccess(expirationIdle, TimeUnit.MILLISECONDS);

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/cache/CaffeineCacheStatsCounter.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/cache/CaffeineCacheStatsCounter.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.cache;
+package io.camunda.zeebe.util.cache;
 
 import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
@@ -15,18 +15,20 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.util.concurrent.TimeUnit;
 
-public class ExporterCacheMetrics implements StatsCounter {
+public class CaffeineCacheStatsCounter implements StatsCounter {
 
   public static final String TAG_TYPE = "type";
-  private static final String NAMESPACE = "zeebe.camunda.exporter.cache";
   private final Timer loadSuccessDuration;
   private final Timer loadFailureDuration;
   private final Counter evictionCount;
   private final String cacheName;
+  private final String namespace;
   private final MeterRegistry meterRegistry;
 
-  public ExporterCacheMetrics(final String cacheName, final MeterRegistry meterRegistry) {
+  public CaffeineCacheStatsCounter(
+      final String namespace, final String cacheName, final MeterRegistry meterRegistry) {
     this.cacheName = cacheName;
+    this.namespace = namespace;
     this.meterRegistry = meterRegistry;
 
     Counter.builder(meterName("result"))
@@ -85,7 +87,7 @@ public class ExporterCacheMetrics implements StatsCounter {
   }
 
   private String meterName(final String name) {
-    return NAMESPACE + "." + cacheName + "." + name;
+    return namespace + "." + cacheName + "." + name;
   }
 
   enum CacheResult {


### PR DESCRIPTION
## Description

- Move cache stats counter into zeebe-util
- Configure stats counter for REST Gateway Process Cache

## Related issues

closes https://github.com/camunda/camunda/issues/29862
