### PR TITLE
feat: accept empty input sources mapping

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeVariablesMappingBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeVariablesMappingBuilder.java
@@ -24,5 +24,9 @@ public interface ZeebeVariablesMappingBuilder<B> {
 
   B zeebeInput(String source, String target);
 
+  default B zeebeInput(final String target) {
+    return zeebeInput(null, target);
+  }
+
   B zeebeOutput(String source, String target);
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeInputImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeInputImpl.java
@@ -64,7 +64,6 @@ public class ZeebeInputImpl extends BpmnModelElementInstanceImpl implements Zeeb
         typeBuilder
             .stringAttribute(ZeebeConstants.ATTRIBUTE_SOURCE)
             .namespace(BpmnModelConstants.ZEEBE_NS)
-            .required()
             .build();
 
     targetAttribute =

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeInputTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeInputTest.java
@@ -36,7 +36,7 @@ public class ZeebeInputTest extends BpmnModelElementInstanceTest {
   @Override
   public Collection<AttributeAssumption> getAttributesAssumptions() {
     return Arrays.asList(
-        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "source", false, true),
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "source", false, false),
         new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "target", false, true));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.deployment.model.transformer;
 
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.el.impl.NullExpression;
 import io.camunda.zeebe.el.impl.StaticExpression;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeMapping;
 import java.util.ArrayList;
@@ -101,7 +102,10 @@ public final class VariableMappingTransformer {
         .map(
             mapping -> {
               final var source = mapping.getSource();
-              final var sourceExpression = expressionLanguage.parseExpression(source);
+              final var sourceExpression =
+                  source == null
+                      ? new NullExpression()
+                      : expressionLanguage.parseExpression(source);
               return new Mapping(sourceExpression, mapping.getTarget());
             })
         .collect(Collectors.toList());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -40,7 +40,7 @@ public final class ZeebeRuntimeValidators {
     return List.of(
         // ----------------------------------------
         ZeebeExpressionValidator.verifyThat(ZeebeInput.class)
-            .hasValidExpression(ZeebeInput::getSource, ExpressionVerification::isMandatory)
+            .hasValidExpression(ZeebeInput::getSource, ExpressionVerification::isOptional)
             .hasValidPath(ZeebeInput::getTarget)
             .build(expressionLanguage),
         // ----------------------------------------

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
@@ -109,15 +109,6 @@ public final class ZeebeRuntimeValidationTest {
         List.of(expect(ZeebeInput.class, INVALID_EXPRESSION_MESSAGE))
       },
       {
-        // empty expression
-        Bpmn.createExecutableProcess("process")
-            .startEvent()
-            .serviceTask("task", s -> s.zeebeInput("", "bar"))
-            .endEvent()
-            .done(),
-        List.of(expect(ZeebeInput.class, MISSING_EXPRESSION_MESSAGE))
-      },
-      {
         // empty path expression
         Bpmn.createExecutableProcess("process")
             .startEvent()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityInputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityInputMappingTest.java
@@ -123,7 +123,8 @@ public final class ActivityInputMappingTest {
         "{'x': %s}".formatted(A_YEAR_MONTH_DURATION_VALUE),
         mapping(b -> b.zeebeInputExpression("duration(x)", "y")),
         activityVariables(variable("y", A_YEAR_MONTH_DURATION_VALUE))
-      }
+      },
+      {"{'x': 1}", mapping(b -> b.zeebeInput("x")), activityVariables(variable("x", "null"))}
     };
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableMappingTransformerTest.java
@@ -120,6 +120,22 @@ public final class VariableMappingTransformerTest {
             "{tab:\"Hello\tWorld\",newline:\"Hello\nWorld\",carriageReturn:\"Hello\rWorld\",doubleQoutes:\"\\\"My Name is \\\"Zeebe\\\", nice to meet you\\\"\",encodedQuotes:\"My Name is &#34;Zeebe&#34;, nice to meet you\"}");
   }
 
+  @Test
+  public void shouldHandleNullSource() {
+    // given
+    final var mappings = List.of(mapping(null, "a"));
+    final var expression = transformer.transformInputMappings(mappings, expressionLanguage);
+
+    // when
+    final var result = expressionLanguage.evaluateExpression(expression, name -> null);
+
+    // then
+    assertThat(expression.isValid())
+        .describedAs("Expected valid expression: %s", expression.getFailureMessage())
+        .isTrue();
+    assertThat(result.getExpression()).isEqualTo("{a:null}");
+  }
+
   private static ZeebeMapping mapping(final String source, final String target) {
     return new ZeebeMapping() {
       @Override

--- a/zeebe/expression-language/pom.xml
+++ b/zeebe/expression-language/pom.xml
@@ -52,6 +52,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-msgpack-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>
     </dependency>

--- a/zeebe/expression-language/src/main/java/io/camunda/zeebe/el/impl/NullExpression.java
+++ b/zeebe/expression-language/src/main/java/io/camunda/zeebe/el/impl/NullExpression.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.el.impl;
+
+import io.camunda.zeebe.el.EvaluationResult;
+import io.camunda.zeebe.el.EvaluationWarning;
+import io.camunda.zeebe.el.Expression;
+import io.camunda.zeebe.el.ResultType;
+import io.camunda.zeebe.msgpack.spec.MsgPackHelper;
+import java.time.Duration;
+import java.time.Period;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+/** This class handles a null expression */
+public final class NullExpression implements Expression, EvaluationResult {
+
+  private static final UnsafeBuffer NIL_VALUE = new UnsafeBuffer(MsgPackHelper.NIL);
+  private final ResultType resultType;
+
+  public NullExpression() {
+    resultType = ResultType.NULL;
+  }
+
+  @Override
+  public String getExpression() {
+    return "null";
+  }
+
+  @Override
+  public Optional<String> getVariableName() {
+    return Optional.empty();
+  }
+
+  @Override
+  public boolean isStatic() {
+    return true;
+  }
+
+  @Override
+  public boolean isValid() {
+    return true;
+  }
+
+  @Override
+  public String getFailureMessage() {
+    return null;
+  }
+
+  @Override
+  public boolean isFailure() {
+    return false;
+  }
+
+  @Override
+  public List<EvaluationWarning> getWarnings() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public ResultType getType() {
+    return resultType;
+  }
+
+  @Override
+  public DirectBuffer toBuffer() {
+    return NIL_VALUE;
+  }
+
+  @Override
+  public String getString() {
+    return null;
+  }
+
+  @Override
+  public Boolean getBoolean() {
+    return null;
+  }
+
+  @Override
+  public Number getNumber() {
+    return null;
+  }
+
+  @Override
+  public Duration getDuration() {
+    return null;
+  }
+
+  @Override
+  public Period getPeriod() {
+    return null;
+  }
+
+  @Override
+  public ZonedDateTime getDateTime() {
+    return null;
+  }
+
+  @Override
+  public List<DirectBuffer> getList() {
+    return null;
+  }
+
+  @Override
+  public List<String> getListOfStrings() {
+    return null;
+  }
+}


### PR DESCRIPTION
## Description

This PR aims to make the input sources mapping optional so that it won't be necessary to include this attribute

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/camunda/issues/12961
