### PR TITLE
feat: Migrate TargetDiagram component to v2

### DIFF
--- a/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/index.tsx
+++ b/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/index.tsx
@@ -12,6 +12,7 @@ import {ResizablePanel} from 'modules/components/ResizablePanel';
 import {DiagramContainer} from './styled';
 import {SourceDiagram as SourceDiagramV2} from './v2/SourceDiagram';
 import {SourceDiagram} from './SourceDiagram';
+import {TargetDiagram as TargetDiagramV2} from './v2/TargetDiagram';
 import {TargetDiagram} from './TargetDiagram';
 import {IS_PROCESS_INSTANCE_STATISTICS_V2_ENABLED} from 'modules/feature-flags';
 
@@ -38,7 +39,11 @@ const Diagrams: React.FC = () => {
         ) : (
           <SourceDiagram />
         )}
-        <TargetDiagram />
+        {IS_PROCESS_INSTANCE_STATISTICS_V2_ENABLED ? (
+          <TargetDiagramV2 />
+        ) : (
+          <TargetDiagram />
+        )}
       </ResizablePanel>
     </DiagramContainer>
   );

--- a/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/v2/TargetDiagram.test.tsx
+++ b/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/v2/TargetDiagram.test.tsx
@@ -1,0 +1,199 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from 'modules/testing-library';
+import {mockFetchGroupedProcesses} from 'modules/mocks/api/processes/fetchGroupedProcesses';
+import {
+  groupedProcessesMock,
+  mockProcessStatisticsV2,
+  mockProcessWithInputOutputMappingsXML,
+  mockProcessXML,
+} from 'modules/testUtils';
+import {processesStore} from 'modules/stores/processes/processes.migration';
+import {TargetDiagram} from './TargetDiagram';
+import {processInstanceMigrationStore} from 'modules/stores/processInstanceMigration';
+import {Wrapper} from '../tests/mocks';
+import * as filterModule from 'modules/hooks/useProcessInstancesFilters';
+import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
+import {mockFetchProcessInstancesStatistics} from 'modules/mocks/api/v2/processInstances/fetchProcessInstancesStatistics';
+import {mockFetchProcessDefinitionXml} from 'modules/mocks/api/v2/processDefinitions/fetchProcessDefinitionXml';
+
+jest.mock('modules/hooks/useProcessInstancesFilters');
+
+describe('Target Diagram', () => {
+  beforeEach(() => {
+    jest.spyOn(filterModule, 'useProcessInstanceFilters').mockReturnValue({});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should display initial state in the diagram header and diagram panel', async () => {
+    processInstanceMigrationStore.setCurrentStep('elementMapping');
+
+    render(<TargetDiagram />, {wrapper: Wrapper});
+
+    expect(screen.getByText('Target')).toBeInTheDocument();
+    expect(screen.getByText('Version')).toBeInTheDocument();
+    expect(
+      screen.getByRole('combobox', {
+        name: /target version/i,
+      }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole('combobox', {
+        name: /target version/i,
+      }),
+    ).toHaveTextContent('-');
+
+    expect(
+      screen.getByText('Select a target process and version'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render process and version components according to the step number', async () => {
+    mockFetchGroupedProcesses().withSuccess(groupedProcessesMock);
+    mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
+
+    await processesStore.fetchProcesses();
+    const {user} = render(<TargetDiagram />, {wrapper: Wrapper});
+
+    await user.click(screen.getByRole('button', {name: /element mapping/i}));
+    await user.click(screen.getByRole('combobox', {name: /^target$/i}));
+    await user.click(screen.getByRole('option', {name: 'New demo process'}));
+
+    expect(
+      screen.getByRole('combobox', {
+        name: /^target$/i,
+      }),
+    ).toHaveValue('New demo process');
+    expect(
+      screen.getByRole('combobox', {
+        name: /target version/i,
+      }),
+    ).toHaveTextContent('3');
+    expect(
+      screen.getByRole('combobox', {
+        name: /target version/i,
+      }),
+    ).toBeEnabled();
+
+    expect(await screen.findByTestId('diagram')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', {name: /summary/i}));
+
+    expect(
+      screen.queryByRole('combobox', {
+        name: /^target$/i,
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('combobox', {
+        name: /target version/i,
+      }),
+    ).not.toBeInTheDocument();
+
+    expect(screen.queryByText('New demo process')).not.toBeInTheDocument();
+    expect(screen.queryByText('3')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', {name: /element mapping/i}));
+
+    expect(
+      screen.getByRole('combobox', {
+        name: /^target$/i,
+      }),
+    ).toHaveValue('New demo process');
+    expect(
+      screen.getByRole('combobox', {
+        name: /target version/i,
+      }),
+    ).toHaveTextContent('3');
+  });
+
+  it('should render diagram on selection and re-render on version change', async () => {
+    mockFetchGroupedProcesses().withSuccess(groupedProcessesMock);
+    mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
+
+    await processesStore.fetchProcesses();
+
+    const {user} = render(<TargetDiagram />, {wrapper: Wrapper});
+
+    await user.click(screen.getByRole('button', {name: /element mapping/i}));
+    await user.click(screen.getByRole('combobox', {name: 'Target'}));
+    await user.click(screen.getByRole('option', {name: 'New demo process'}));
+
+    expect(await screen.findByTestId('diagram')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /reset diagram zoom/i}));
+    expect(screen.getByRole('button', {name: /zoom in diagram/i}));
+    expect(screen.getByRole('button', {name: /zoom out diagram/i}));
+
+    mockFetchProcessDefinitionXml().withDelay(
+      mockProcessWithInputOutputMappingsXML,
+    );
+
+    await user.click(screen.getByRole('combobox', {name: 'Target Version'}));
+    await user.click(screen.getByRole('option', {name: '2'}));
+
+    expect(await screen.findByTestId('diagram-spinner')).toBeInTheDocument();
+
+    await waitForElementToBeRemoved(() =>
+      screen.getByTestId('diagram-spinner'),
+    );
+  });
+
+  it('should display error message on selection if diagram could not be fetched', async () => {
+    mockFetchGroupedProcesses().withSuccess(groupedProcessesMock);
+    mockFetchProcessDefinitionXml().withServerError();
+    await processesStore.fetchProcesses();
+
+    const {user} = render(<TargetDiagram />, {wrapper: Wrapper});
+
+    await user.click(screen.getByRole('button', {name: /element mapping/i}));
+    await user.click(screen.getByRole('combobox', {name: 'Target'}));
+    await user.click(screen.getByRole('option', {name: 'New demo process'}));
+
+    expect(
+      await screen.findByText('Data could not be fetched'),
+    ).toBeInTheDocument();
+  });
+
+  it('should render flow node overlays', async () => {
+    mockFetchGroupedProcesses().withSuccess(groupedProcessesMock);
+    mockFetchProcessDefinitionXml().withSuccess(mockProcessXML);
+    mockFetchProcessInstancesStatistics().withSuccess(mockProcessStatisticsV2);
+    processInstancesSelectionStore.setselectedProcessInstanceIds(['1']);
+    await processesStore.fetchProcesses();
+
+    const {user} = render(<TargetDiagram />, {wrapper: Wrapper});
+
+    await user.click(screen.getByRole('button', {name: /element mapping/i}));
+    await user.click(screen.getByRole('combobox', {name: 'Target'}));
+    await user.click(screen.getByRole('option', {name: 'New demo process'}));
+    await user.click(screen.getByRole('button', {name: /map elements/i}));
+
+    expect(await screen.findByText(/diagram mock/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', {name: /summary/i}));
+
+    expect(
+      await screen.findByTestId('modifications-overlay'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('modifications-overlay')).toHaveTextContent('1');
+
+    await user.click(screen.getByRole('button', {name: /element mapping/i}));
+
+    expect(await screen.findByText(/diagram mock/i)).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('modifications-overlay'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/v2/TargetDiagram.tsx
+++ b/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/v2/TargetDiagram.tsx
@@ -1,0 +1,170 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {processInstanceMigrationStore} from 'modules/stores/processInstanceMigration';
+import {Header} from '../Header';
+import {DiagramWrapper} from '../styled';
+import {observer} from 'mobx-react';
+import {TargetProcessField} from '../TargetProcessField';
+import {TargetVersionField} from '../TargetVersionField';
+import {processesStore} from 'modules/stores/processes/processes.migration';
+import {DiagramShell} from 'modules/components/DiagramShell';
+import {Diagram} from 'modules/components/Diagram';
+import {useEffect} from 'react';
+import {diagramOverlaysStore} from 'modules/stores/diagramOverlays';
+import {ModificationBadgeOverlay} from 'App/ProcessInstance/TopPanel/ModificationBadgeOverlay';
+import {useProcessInstanceFilters} from 'modules/hooks/useProcessInstancesFilters';
+import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
+import {useProcessInstancesFlowNodeStates} from 'modules/queries/processInstancesStatistics/useFlowNodeStates';
+import {useMigrationTargetXml} from 'modules/queries/processDefinitions/useMigrationTargetXml';
+import {getProcessInstanceKey} from 'modules/utils/statistics/processInstances';
+
+const OVERLAY_TYPE = 'migrationTargetSummary';
+
+const TargetDiagram: React.FC = observer(() => {
+  const {
+    migrationState: {selectedTargetVersion},
+    selectedTargetProcessId,
+  } = processesStore;
+  const isVersionSelected = selectedTargetVersion !== null;
+  const {isSummaryStep} = processInstanceMigrationStore;
+  const stateOverlays = diagramOverlaysStore.state.overlays.filter(
+    ({type}) => type === OVERLAY_TYPE,
+  );
+
+  const {
+    data,
+    isLoading: isMigrationTargetXmlLoading,
+    isError: isMigrationTargetXmlError,
+  } = useMigrationTargetXml({
+    processDefinitionKey: selectedTargetProcessId!,
+    enabled: selectedTargetProcessId !== undefined,
+  });
+
+  useEffect(() => {
+    processInstanceMigrationStore.setTargetProcessDefinitionKey(
+      selectedTargetProcessId ?? null,
+    );
+  }, [selectedTargetProcessId]);
+
+  const processInstanceFilters = useProcessInstanceFilters();
+
+  const {data: flowNodeData} = useProcessInstancesFlowNodeStates(
+    {
+      ...processInstanceFilters,
+      processInstanceKey: getProcessInstanceKey(),
+    },
+    processInstancesSelectionStore.selectedProcessInstanceIds.length > 0,
+  );
+
+  const getStatus = () => {
+    if (isMigrationTargetXmlLoading) {
+      return 'loading';
+    }
+    if (isMigrationTargetXmlError) {
+      return 'error';
+    }
+    if (!isVersionSelected) {
+      return 'empty';
+    }
+    return 'content';
+  };
+
+  const getFlowNodeCountByTargetId = () => {
+    return Object.entries(
+      processInstanceMigrationStore.state.flowNodeMapping,
+    ).reduce<{
+      [targetElementId: string]: number;
+    }>((mappingByTarget, [sourceElementId, targetElementId]) => {
+      const previousCount = mappingByTarget[targetElementId];
+      const newCount = flowNodeData
+        ? flowNodeData
+            .filter((state) => {
+              return (
+                state.flowNodeId === sourceElementId &&
+                ['active', 'incidents'].includes(state.flowNodeState)
+              );
+            })
+            .reduce((count, state) => {
+              return count + state.count;
+            }, 0)
+        : 0;
+
+      return {
+        ...mappingByTarget,
+        [targetElementId]:
+          previousCount !== undefined ? previousCount + newCount : newCount,
+      };
+    }, {});
+  };
+
+  return (
+    <DiagramWrapper>
+      {!processInstanceMigrationStore.isSummaryStep && (
+        <Header mode="edit" label="Target">
+          <TargetProcessField />
+          <TargetVersionField />
+        </Header>
+      )}
+      <DiagramShell
+        status={getStatus()}
+        emptyMessage={{
+          message: 'Select a target process and version',
+        }}
+        messagePosition="center"
+      >
+        {data?.xml !== undefined && (
+          <Diagram
+            xml={data.xml}
+            selectableFlowNodes={data.selectableFlowNodes.map(
+              (flowNode) => flowNode.id,
+            )}
+            selectedFlowNodeIds={
+              processInstanceMigrationStore.selectedTargetFlowNodeId
+                ? [processInstanceMigrationStore.selectedTargetFlowNodeId]
+                : undefined
+            }
+            onFlowNodeSelection={
+              processInstanceMigrationStore.selectTargetFlowNode
+            }
+            overlaysData={
+              isSummaryStep
+                ? Object.entries(getFlowNodeCountByTargetId()).map(
+                    ([targetId, count]) => ({
+                      payload: {count},
+                      type: OVERLAY_TYPE,
+                      flowNodeId: targetId,
+                      position: {top: -14, right: -7},
+                    }),
+                  )
+                : []
+            }
+          >
+            {isSummaryStep &&
+              stateOverlays.map((overlay) => {
+                const payload = overlay.payload as {
+                  count: number;
+                };
+
+                return (
+                  <ModificationBadgeOverlay
+                    key={overlay.flowNodeId}
+                    newTokenCount={payload.count}
+                    cancelledTokenCount={0}
+                    container={overlay.container}
+                  />
+                );
+              })}
+          </Diagram>
+        )}
+      </DiagramShell>
+    </DiagramWrapper>
+  );
+});
+
+export {TargetDiagram};

--- a/operate/client/src/modules/queries/processInstancesStatistics/useFlowNodeStates.test.tsx
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useFlowNodeStates.test.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {renderHook, waitFor} from '@testing-library/react';
+import {QueryClientProvider} from '@tanstack/react-query';
+import {useProcessInstancesFlowNodeStates} from './useFlowNodeStates';
+import {mockFetchProcessInstancesStatistics} from 'modules/mocks/api/v2/processInstances/fetchProcessInstancesStatistics';
+import {getMockQueryClient} from 'modules/react-query/mockQueryClient';
+import * as filterModule from 'modules/hooks/useProcessInstancesFilters';
+
+jest.mock('modules/hooks/useProcessInstancesFilters');
+
+describe('useProcessInstancesFlowNodeStates', () => {
+  const wrapper = ({children}: {children: React.ReactNode}) => (
+    <QueryClientProvider client={getMockQueryClient()}>
+      {children}
+    </QueryClientProvider>
+  );
+
+  beforeEach(() => {
+    jest.spyOn(filterModule, 'useProcessInstanceFilters').mockReturnValue({});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch flow node states successfully', async () => {
+    const mockData = [
+      {
+        flowNodeId: 'task1',
+        active: 5,
+        canceled: 2,
+        incidents: 1,
+        completed: 3,
+      },
+      {
+        flowNodeId: 'task2',
+        active: 0,
+        canceled: 0,
+        incidents: 0,
+        completed: 4,
+      },
+    ];
+
+    const expectedParsedData = [
+      {flowNodeId: 'task1', count: 5, flowNodeState: 'active'},
+      {flowNodeId: 'task1', count: 1, flowNodeState: 'incidents'},
+      {flowNodeId: 'task1', count: 2, flowNodeState: 'canceled'},
+      {flowNodeId: 'task1', count: 3, flowNodeState: 'completedEndEvents'},
+      {flowNodeId: 'task2', count: 4, flowNodeState: 'completedEndEvents'},
+    ];
+
+    mockFetchProcessInstancesStatistics().withSuccess(mockData);
+
+    const {result} = renderHook(() => useProcessInstancesFlowNodeStates({}), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(expectedParsedData);
+  });
+
+  it('should handle server error while fetching flow node states', async () => {
+    mockFetchProcessInstancesStatistics().withServerError();
+
+    const {result} = renderHook(() => useProcessInstancesFlowNodeStates({}), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.error?.variant).toBe('failed-response');
+    expect(result.current.error?.response).toBeDefined();
+  });
+
+  it('should handle network error while fetching flow node states', async () => {
+    mockFetchProcessInstancesStatistics().withNetworkError();
+
+    const {result} = renderHook(() => useProcessInstancesFlowNodeStates({}), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeDefined();
+    expect(result.current.error?.variant).toBe('network-error');
+    expect(result.current.error?.response).toBeNull();
+  });
+
+  it('should handle empty data', async () => {
+    mockFetchProcessInstancesStatistics().withSuccess([]);
+
+    const {result} = renderHook(() => useProcessInstancesFlowNodeStates({}), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('should handle loading state', async () => {
+    const {result} = renderHook(() => useProcessInstancesFlowNodeStates({}), {
+      wrapper,
+    });
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('should not fetch data when enabled is false', async () => {
+    const {result} = renderHook(
+      () => useProcessInstancesFlowNodeStates({}, false),
+      {
+        wrapper,
+      },
+    );
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isFetched).toBe(false);
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/operate/client/src/modules/queries/processInstancesStatistics/useFlowNodeStates.ts
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useFlowNodeStates.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {
+  ProcessInstancesStatisticsDto,
+  ProcessInstancesStatisticsRequest,
+} from 'modules/api/v2/processInstances/fetchProcessInstancesStatistics';
+import {useProcessInstancesStatisticsOptions} from './useProcessInstancesStatistics';
+import {useQuery} from '@tanstack/react-query';
+
+type FlowNodeState =
+  | 'active'
+  | 'incidents'
+  | 'canceled'
+  | 'completed'
+  | 'completedEndEvents';
+
+type FlowNodeData = {
+  flowNodeId: string;
+  count: number;
+  flowNodeState: FlowNodeState;
+};
+
+const flowNodeStatesParser = (data: ProcessInstancesStatisticsDto[]) => {
+  return data.flatMap((statistics) => {
+    const types: FlowNodeState[] = [
+      'active',
+      'incidents',
+      'canceled',
+      'completed',
+    ];
+    return types.reduce<FlowNodeData[]>((states, flowNodeState) => {
+      const count = Number(
+        statistics[flowNodeState as keyof ProcessInstancesStatisticsDto],
+      );
+      if (count > 0) {
+        return [
+          ...states,
+          {
+            flowNodeId: statistics.flowNodeId,
+            count,
+            flowNodeState:
+              flowNodeState === 'completed'
+                ? 'completedEndEvents'
+                : flowNodeState,
+          },
+        ];
+      } else {
+        return states;
+      }
+    }, []);
+  });
+};
+
+function useProcessInstancesFlowNodeStates(
+  payload: ProcessInstancesStatisticsRequest,
+  enabled?: boolean,
+) {
+  return useQuery(
+    useProcessInstancesStatisticsOptions<FlowNodeData[]>(
+      payload,
+      flowNodeStatesParser,
+      enabled,
+    ),
+  );
+}
+
+export {flowNodeStatesParser, useProcessInstancesFlowNodeStates};

--- a/operate/client/src/modules/queries/processInstancesStatistics/useOverlayData.ts
+++ b/operate/client/src/modules/queries/processInstancesStatistics/useOverlayData.ts
@@ -20,13 +20,7 @@ import {
 } from 'modules/bpmn-js/badgePositions';
 import {useProcessInstancesStatisticsOptions} from './useProcessInstancesStatistics';
 import {useQuery} from '@tanstack/react-query';
-
-type FlowNodeState =
-  | 'active'
-  | 'incidents'
-  | 'canceled'
-  | 'completed'
-  | 'completedEndEvents';
+import {flowNodeStatesParser} from './useFlowNodeStates';
 
 const overlayPositions = {
   active: ACTIVE_BADGE,
@@ -39,40 +33,7 @@ const overlayPositions = {
 export function overlayParser(
   data: ProcessInstancesStatisticsDto[],
 ): OverlayData[] {
-  const flowNodeStates = data.flatMap((statistics) => {
-    const types: FlowNodeState[] = [
-      'active',
-      'incidents',
-      'canceled',
-      'completed',
-    ];
-    return types.reduce<
-      {
-        flowNodeId: string;
-        count: number;
-        flowNodeState: FlowNodeState;
-      }[]
-    >((states, flowNodeState) => {
-      const count = Number(
-        statistics[flowNodeState as keyof ProcessInstancesStatisticsDto],
-      );
-      if (count > 0) {
-        return [
-          ...states,
-          {
-            flowNodeId: statistics.flowNodeId,
-            count,
-            flowNodeState:
-              flowNodeState === 'completed'
-                ? 'completedEndEvents'
-                : flowNodeState,
-          },
-        ];
-      } else {
-        return states;
-      }
-    }, []);
-  });
+  const flowNodeStates = flowNodeStatesParser(data);
 
   return flowNodeStates.map(({flowNodeState, count, flowNodeId}) => ({
     payload: {flowNodeState, count},


### PR DESCRIPTION
## Description

This PR creates a v2 component that fetches flow node PI statistics data in the `TargetDiagram` following [this comment](https://github.com/camunda/camunda/pull/29476#pullrequestreview-2701986980). The `flowNodeStates` data shares similarities with `overlayData` so I did a minor refactoring as well.

<img width="1507" alt="Screenshot 2568-03-24 at 16 56 52" src="https://github.com/user-attachments/assets/0dbe0cb5-3c4d-4aa6-a8fd-3b8e0bb7fdc3" />

## Related issues

related to #29288
