### PR TITLE
29662-c8-api-add-hasretriesleft-field-for-filtering

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/filter/ProcessInstanceFilter.java
@@ -122,4 +122,7 @@ public interface ProcessInstanceFilter extends SearchRequestFilter {
 
   /** Filter by error message using {@link StringProperty} consumer */
   ProcessInstanceFilter errorMessage(final Consumer<StringProperty> fn);
+
+  /** Filter by hasRetriesLeft */
+  ProcessInstanceFilter hasRetriesLeft(final Boolean hasRetriesLeft);
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/filter/ProcessInstanceFilterImpl.java
@@ -282,11 +282,17 @@ public class ProcessInstanceFilterImpl
   }
 
   @Override
+  public ProcessInstanceFilter hasRetriesLeft(final Boolean hasRetriesLeft) {
+    filter.hasRetriesLeft(hasRetriesLeft);
+    return this;
+  }
+
+  @Override
   protected io.camunda.client.protocol.rest.ProcessInstanceFilter getSearchRequestProperty() {
     return filter;
   }
 
-  static void variableValueNullCheck(Object value) {
+  static void variableValueNullCheck(final Object value) {
     if (value == null) {
       throw new IllegalArgumentException("Variable value cannot be null");
     }

--- a/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
@@ -88,7 +88,8 @@ public class QueryProcessInstanceTest extends ClientRestTest {
                     .hasIncident(true)
                     .tenantId("tenant")
                     .variables(variablesMap)
-                    .errorMessage("Error message"))
+                    .errorMessage("Error message")
+                    .hasRetriesLeft(true))
         .send()
         .join();
     // then
@@ -112,6 +113,7 @@ public class QueryProcessInstanceTest extends ClientRestTest {
     assertThat(filter.getTenantId().get$Eq()).isEqualTo("tenant");
     assertThat(filter.getVariables()).isEqualTo(variables);
     assertThat(filter.getErrorMessage().get$Eq()).isEqualTo("Error message");
+    assertThat(filter.getHasRetriesLeft()).isEqualTo(true);
   }
 
   @Test

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -540,6 +540,11 @@
     <column name="PARTITION_ID" type="NUMBER"/>
     <column name="HISTORY_CLEANUP_DATE" type="TIMESTAMP WITH TIME ZONE(3)" />
   </createTable>
+
+    <modifySql dbms="mariadb">
+      <!-- MariaDB doesn't support TIMESTAMP WITH TIME ZONE, but its TIMESTAMP type has already a time zone -->
+      <replace replace="TIMESTAMP WITH TIME ZONE" with="TIMESTAMP"/>
+    </modifySql>
   </changeSet>
 
 </databaseChangeLog>

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -529,4 +529,17 @@
     <addPrimaryKey tableName="${prefix}MAPPINGS" columnNames="MAPPING_ID" constraintName="${prefix}PK_MAPPINGS_ID"/>
   </changeSet>
 
+  <changeSet id="create_job_table" author="tsedekey">
+  <createTable tableName="${prefix}JOB">
+    <column name="JOB_KEY" type="BIGINT">
+      <constraints primaryKey="true"/>
+    </column>
+    <column name="PROCESS_INSTANCE_KEY" type="BIGINT"/>
+    <column name="RETRIES" type="SMALLINT"/>
+    <column name="STATE" type="VARCHAR(20)"/>
+    <column name="PARTITION_ID" type="NUMBER"/>
+    <column name="HISTORY_CLEANUP_DATE" type="TIMESTAMP WITH TIME ZONE(3)" />
+  </createTable>
+  </changeSet>
+
 </databaseChangeLog>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/JobMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/JobMapper.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql;
+
+import io.camunda.db.rdbms.write.domain.JobDbModel;
+
+public interface JobMapper extends HistoryCleanupMapper {
+
+  void insert(JobDbModel job);
+
+  void update(JobDbModel job);
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
@@ -79,7 +79,7 @@ public class RdbmsWriter {
       final UserTaskMapper userTaskMapper,
       final VariableMapper variableMapper,
       final VendorDatabaseProperties vendorDatabaseProperties,
-      final BatchOperationReader batchOperationReader) {
+      final BatchOperationReader batchOperationReader,
       final JobMapper jobMapper) {
     this.executionQueue = executionQueue;
     this.exporterPositionService = exporterPositionService;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
@@ -12,6 +12,7 @@ import io.camunda.db.rdbms.read.service.BatchOperationReader;
 import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
 import io.camunda.db.rdbms.sql.IncidentMapper;
+import io.camunda.db.rdbms.sql.JobMapper;
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper;
 import io.camunda.db.rdbms.sql.PurgeMapper;
 import io.camunda.db.rdbms.sql.UserTaskMapper;
@@ -28,6 +29,7 @@ import io.camunda.db.rdbms.write.service.FormWriter;
 import io.camunda.db.rdbms.write.service.GroupWriter;
 import io.camunda.db.rdbms.write.service.HistoryCleanupService;
 import io.camunda.db.rdbms.write.service.IncidentWriter;
+import io.camunda.db.rdbms.write.service.JobWriter;
 import io.camunda.db.rdbms.write.service.MappingWriter;
 import io.camunda.db.rdbms.write.service.ProcessDefinitionWriter;
 import io.camunda.db.rdbms.write.service.ProcessInstanceWriter;
@@ -60,6 +62,7 @@ public class RdbmsWriter {
   private final FormWriter formWriter;
   private final MappingWriter mappingWriter;
   private final BatchOperationWriter batchOperationWriter;
+  private final JobWriter jobWriter;
 
   private final HistoryCleanupService historyCleanupService;
 
@@ -77,6 +80,7 @@ public class RdbmsWriter {
       final VariableMapper variableMapper,
       final VendorDatabaseProperties vendorDatabaseProperties,
       final BatchOperationReader batchOperationReader) {
+      final JobMapper jobMapper) {
     this.executionQueue = executionQueue;
     this.exporterPositionService = exporterPositionService;
     rdbmsPurger = new RdbmsPurger(purgeMapper, vendorDatabaseProperties);
@@ -97,6 +101,7 @@ public class RdbmsWriter {
     formWriter = new FormWriter(executionQueue);
     mappingWriter = new MappingWriter(executionQueue);
     batchOperationWriter = new BatchOperationWriter(batchOperationReader, executionQueue);
+    jobWriter = new JobWriter(executionQueue, jobMapper);
 
     historyCleanupService =
         new HistoryCleanupService(
@@ -107,6 +112,7 @@ public class RdbmsWriter {
             userTaskWriter,
             variableWriter,
             decisionInstanceWriter,
+            jobWriter,
             metrics);
   }
 
@@ -176,6 +182,10 @@ public class RdbmsWriter {
 
   public BatchOperationWriter getBatchOperationWriter() {
     return batchOperationWriter;
+  }
+
+  public JobWriter getJobWriter() {
+    return jobWriter;
   }
 
   public ExporterPositionService getExporterPositionService() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
@@ -50,7 +50,7 @@ public class RdbmsWriterFactory {
       final UserTaskMapper userTaskMapper,
       final VariableMapper variableMapper,
       final RdbmsWriterMetrics metrics,
-      final BatchOperationReader batchOperationReader, {
+      final BatchOperationReader batchOperationReader,
       final JobMapper jobMapper) {
     this.sqlSessionFactory = sqlSessionFactory;
     this.exporterPositionMapper = exporterPositionMapper;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
@@ -13,6 +13,7 @@ import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
 import io.camunda.db.rdbms.sql.ExporterPositionMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
 import io.camunda.db.rdbms.sql.IncidentMapper;
+import io.camunda.db.rdbms.sql.JobMapper;
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper;
 import io.camunda.db.rdbms.sql.PurgeMapper;
 import io.camunda.db.rdbms.sql.UserTaskMapper;
@@ -35,6 +36,7 @@ public class RdbmsWriterFactory {
   private final VariableMapper variableMapper;
   private final RdbmsWriterMetrics metrics;
   private final BatchOperationReader batchOperationReader;
+  private final JobMapper jobMapper;
 
   public RdbmsWriterFactory(
       final SqlSessionFactory sqlSessionFactory,
@@ -48,7 +50,8 @@ public class RdbmsWriterFactory {
       final UserTaskMapper userTaskMapper,
       final VariableMapper variableMapper,
       final RdbmsWriterMetrics metrics,
-      final BatchOperationReader batchOperationReader) {
+      final BatchOperationReader batchOperationReader, {
+      final JobMapper jobMapper) {
     this.sqlSessionFactory = sqlSessionFactory;
     this.exporterPositionMapper = exporterPositionMapper;
     this.vendorDatabaseProperties = vendorDatabaseProperties;
@@ -59,6 +62,7 @@ public class RdbmsWriterFactory {
     this.purgeMapper = purgeMapper;
     this.userTaskMapper = userTaskMapper;
     this.variableMapper = variableMapper;
+    this.jobMapper = jobMapper;
     this.metrics = metrics;
     this.batchOperationReader = batchOperationReader;
   }
@@ -80,6 +84,7 @@ public class RdbmsWriterFactory {
         userTaskMapper,
         variableMapper,
         vendorDatabaseProperties,
-        batchOperationReader);
+        batchOperationReader,
+        jobMapper);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/JobDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/JobDbModel.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.domain;
+
+import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
+import java.util.function.Function;
+
+public record JobDbModel(
+    Long jobKey,
+    Long processInstanceKey,
+    Integer retries,
+    String state,
+    int partitionId,
+    OffsetDateTime historyCleanupDate)
+    implements DbModel<JobDbModel> {
+
+  @Override
+  public JobDbModel copy(
+      final Function<ObjectBuilder<JobDbModel>, ObjectBuilder<JobDbModel>> copyFunction) {
+    return copyFunction
+        .apply(
+            new Builder()
+                .jobKey(jobKey)
+                .processInstanceKey(processInstanceKey)
+                .retries(retries)
+                .partitionId(partitionId)
+                .historyCleanupDate(historyCleanupDate))
+        .build();
+  }
+
+  public static class Builder implements ObjectBuilder<JobDbModel> {
+
+    private Long jobKey;
+    private Long processInstanceKey;
+    private Integer retries;
+    private String state;
+    private int partitionId;
+    private OffsetDateTime historyCleanupDate;
+
+    public Builder jobKey(final Long jobKey) {
+      this.jobKey = jobKey;
+      return this;
+    }
+
+    public Builder processInstanceKey(final Long processInstanceKey) {
+      this.processInstanceKey = processInstanceKey;
+      return this;
+    }
+
+    public Builder retries(final int retries) {
+      this.retries = retries;
+      return this;
+    }
+
+    public Builder state(final String state) {
+      this.state = state;
+      return this;
+    }
+
+    public Builder partitionId(final int partitionId) {
+      this.partitionId = partitionId;
+      return this;
+    }
+
+    public Builder historyCleanupDate(final OffsetDateTime value) {
+      historyCleanupDate = value;
+      return this;
+    }
+
+    @Override
+    public JobDbModel build() {
+      return new JobDbModel(
+          jobKey, processInstanceKey, retries, state, partitionId, historyCleanupDate);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
@@ -24,11 +24,12 @@ public enum ContextType {
   USER_TASK(true),
   FORM(false),
   MAPPING(false),
-  BATCH_OPERATION(false);
+  BATCH_OPERATION(false),
+  JOB(false);
 
   private final boolean preserveOrder;
 
-  ContextType(boolean preserveOrder) {
+  ContextType(final boolean preserveOrder) {
     this.preserveOrder = preserveOrder;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/HistoryCleanupService.java
@@ -34,6 +34,7 @@ public class HistoryCleanupService {
   private final UserTaskWriter userTaskWriter;
   private final VariableWriter variableInstanceWriter;
   private final DecisionInstanceWriter decisionInstanceWriter;
+  private final JobWriter jobWriter;
 
   private final Map<Integer, Duration> lastCleanupInterval = new HashMap<>();
 
@@ -45,6 +46,7 @@ public class HistoryCleanupService {
       final UserTaskWriter userTaskWriter,
       final VariableWriter variableInstanceWriter,
       final DecisionInstanceWriter decisionInstanceWriter,
+      final JobWriter jobWriter,
       final RdbmsWriterMetrics metrics) {
     LOG.info(
         "Creating HistoryCleanupService with default history ttl {}", config.defaultHistoryTTL());
@@ -59,6 +61,7 @@ public class HistoryCleanupService {
     this.userTaskWriter = userTaskWriter;
     this.variableInstanceWriter = variableInstanceWriter;
     this.decisionInstanceWriter = decisionInstanceWriter;
+    this.jobWriter = jobWriter;
     this.metrics = metrics;
   }
 
@@ -76,6 +79,7 @@ public class HistoryCleanupService {
     userTaskWriter.scheduleForHistoryCleanup(processInstanceKey, historyCleanupDate);
     variableInstanceWriter.scheduleForHistoryCleanup(processInstanceKey, historyCleanupDate);
     decisionInstanceWriter.scheduleForHistoryCleanup(processInstanceKey, historyCleanupDate);
+    jobWriter.scheduleForHistoryCleanup(processInstanceKey, historyCleanupDate);
   }
 
   public Duration cleanupHistory(final int partitionId, final OffsetDateTime cleanupDate) {
@@ -101,6 +105,8 @@ public class HistoryCleanupService {
     numDeletedRecords.put(
         "decisionInstance",
         decisionInstanceWriter.cleanupHistory(partitionId, cleanupDate, cleanupBatchSize));
+    numDeletedRecords.put(
+        "job", jobWriter.cleanupHistory(partitionId, cleanupDate, cleanupBatchSize));
     final long end = System.currentTimeMillis();
     sample.close();
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/JobWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/JobWriter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.service;
+
+import io.camunda.db.rdbms.sql.HistoryCleanupMapper;
+import io.camunda.db.rdbms.sql.HistoryCleanupMapper.CleanupHistoryDto;
+import io.camunda.db.rdbms.sql.JobMapper;
+import io.camunda.db.rdbms.write.domain.JobDbModel;
+import io.camunda.db.rdbms.write.queue.ContextType;
+import io.camunda.db.rdbms.write.queue.ExecutionQueue;
+import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
+import java.time.OffsetDateTime;
+
+public class JobWriter {
+
+  private final ExecutionQueue executionQueue;
+  private final JobMapper mapper;
+
+  public JobWriter(final ExecutionQueue executionQueue, final JobMapper mapper) {
+    this.executionQueue = executionQueue;
+    this.mapper = mapper;
+  }
+
+  public void create(final JobDbModel job) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.JOB,
+            WriteStatementType.INSERT,
+            job.jobKey(),
+            "io.camunda.db.rdbms.sql.JobMapper.insert",
+            job));
+  }
+
+  public void update(final JobDbModel job) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.JOB,
+            WriteStatementType.UPDATE,
+            job.jobKey(),
+            "io.camunda.db.rdbms.sql.JobMapper.update",
+            job));
+  }
+
+  public void scheduleForHistoryCleanup(
+      final Long processInstanceKey, final OffsetDateTime historyCleanupDate) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.JOB,
+            WriteStatementType.UPDATE,
+            processInstanceKey,
+            "io.camunda.db.rdbms.sql.JobMapper.updateHistoryCleanupDate",
+            new HistoryCleanupMapper.UpdateHistoryCleanupDateDto.Builder()
+                .processInstanceKey(processInstanceKey)
+                .historyCleanupDate(historyCleanupDate)
+                .build()));
+  }
+
+  public int cleanupHistory(
+      final int partitionId, final OffsetDateTime cleanupDate, final int rowsToRemove) {
+    return mapper.cleanupHistory(
+        new CleanupHistoryDto.Builder()
+            .partitionId(partitionId)
+            .cleanupDate(cleanupDate)
+            .limit(rowsToRemove)
+            .build());
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RdbmsPurger.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/RdbmsPurger.java
@@ -40,7 +40,8 @@ public class RdbmsPurger {
           "GROUP_MEMBER",
           "GROUPS",
           "BATCH_OPERATION_ITEM",
-          "BATCH_OPERATION");
+          "BATCH_OPERATION",
+          "JOB");
 
   private final PurgeMapper purgeMapper;
   private final VendorDatabaseProperties vendorDatabaseProperties;

--- a/db/rdbms/src/main/resources/mapper/JobMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/JobMapper.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="io.camunda.db.rdbms.sql.JobMapper">
+
+  <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.JobDbModel">
+    INSERT INTO ${prefix}JOB (JOB_KEY, PROCESS_INSTANCE_KEY, RETRIES, STATE, PARTITION_ID,  HISTORY_CLEANUP_DATE)
+    VALUES (#{jobKey}, #{processInstanceKey}, #{retries}, #{state}, #{partitionId}, #{historyCleanupDate, jdbcType=TIMESTAMP})
+  </insert>
+
+  <update id="update" parameterType="io.camunda.db.rdbms.write.domain.JobDbModel">
+    UPDATE ${prefix}JOB
+    SET JOB_KEY = #{jobKey},
+        PROCESS_INSTANCE_KEY = #{processInstanceKey},
+        RETRIES = #{retries},
+        STATE  = #{state},
+        HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP}
+    WHERE JOB_KEY = #{jobKey}
+  </update>
+
+  <update
+    flushCache="true"
+    id="updateHistoryCleanupDate"
+    statementType="PREPARED">
+    UPDATE ${prefix}JOB SET
+      HISTORY_CLEANUP_DATE = #{historyCleanupDate, jdbcType=TIMESTAMP}
+    WHERE PROCESS_INSTANCE_KEY = #{processInstanceKey}
+  </update>
+
+  <delete
+    flushCache="true"
+    id="cleanupHistory"
+    statementType="PREPARED">
+    <bind name="tableName" value="'JOB'"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.historyCleanup"/>
+  </delete>
+
+</mapper>

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -117,6 +117,19 @@
         AND pi.NUM_INCIDENTS = 0
       </if>
     </if>
+    <if test="filter.hasRetriesLeft != null">
+      AND EXISTS (
+      SELECT 1
+      FROM ${prefix}JOB j
+      WHERE j.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
+      <if test="filter.hasRetriesLeft == true">
+        AND j.STATE IN ('FAILED', 'ERROR_THROWN') AND j.RETRIES > 0
+      </if>
+      <if test="filter.hasRetriesLeft == false">
+        AND j.RETRIES = 0
+      </if>
+      )
+    </if>
 
     <!-- date filters -->
     <if test="filter.startDateOperations != null and !filter.startDateOperations.isEmpty()">

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -122,11 +122,12 @@
       SELECT 1
       FROM ${prefix}JOB j
       WHERE j.PROCESS_INSTANCE_KEY = pi.PROCESS_INSTANCE_KEY
+      AND j.STATE IN ('FAILED', 'ERROR_THROWN')
       <if test="filter.hasRetriesLeft == true">
-        AND j.STATE IN ('FAILED', 'ERROR_THROWN') AND j.RETRIES > 0
+        AND j.RETRIES > 0
       </if>
       <if test="filter.hasRetriesLeft == false">
-        AND j.STATE IN ('FAILED', 'ERROR_THROWN') AND j.RETRIES = 0
+         AND j.RETRIES = 0
       </if>
       )
     </if>

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -126,7 +126,7 @@
         AND j.STATE IN ('FAILED', 'ERROR_THROWN') AND j.RETRIES > 0
       </if>
       <if test="filter.hasRetriesLeft == false">
-        AND j.RETRIES = 0
+        AND j.STATE IN ('FAILED', 'ERROR_THROWN') AND j.RETRIES = 0
       </if>
       )
     </if>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryCleanupServiceTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/HistoryCleanupServiceTest.java
@@ -35,6 +35,7 @@ class HistoryCleanupServiceTest {
   private UserTaskWriter userTaskWriter;
   private VariableWriter variableInstanceWriter;
   private DecisionInstanceWriter decisionInstanceWriter;
+  private JobWriter jobWriter;
 
   private HistoryCleanupService historyCleanupService;
 
@@ -47,6 +48,7 @@ class HistoryCleanupServiceTest {
     userTaskWriter = mock(UserTaskWriter.class);
     variableInstanceWriter = mock(VariableWriter.class);
     decisionInstanceWriter = mock(DecisionInstanceWriter.class);
+    jobWriter = mock(JobWriter.class);
 
     when(processInstanceWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(0);
     when(flowNodeInstanceWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(0);
@@ -54,6 +56,7 @@ class HistoryCleanupServiceTest {
     when(userTaskWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(0);
     when(variableInstanceWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(0);
     when(decisionInstanceWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(0);
+    when(jobWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(0);
 
     when(config.defaultHistoryTTL()).thenReturn(Duration.ofDays(30));
     when(config.minHistoryCleanupInterval()).thenReturn(Duration.ofHours(1));
@@ -69,6 +72,7 @@ class HistoryCleanupServiceTest {
             userTaskWriter,
             variableInstanceWriter,
             decisionInstanceWriter,
+            jobWriter,
             mock(RdbmsWriterMetrics.class, Mockito.RETURNS_DEEP_STUBS));
   }
 
@@ -81,6 +85,7 @@ class HistoryCleanupServiceTest {
     when(userTaskWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(1);
     when(variableInstanceWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(1);
     when(decisionInstanceWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(1);
+    when(jobWriter.cleanupHistory(anyInt(), any(), anyInt())).thenReturn(1);
 
     // when
     final Duration nextCleanupInterval =
@@ -94,6 +99,7 @@ class HistoryCleanupServiceTest {
     verify(userTaskWriter).cleanupHistory(PARTITION_ID, CLEANUP_DATE, 100);
     verify(variableInstanceWriter).cleanupHistory(PARTITION_ID, CLEANUP_DATE, 100);
     verify(decisionInstanceWriter).cleanupHistory(PARTITION_ID, CLEANUP_DATE, 100);
+    verify(jobWriter).cleanupHistory(PARTITION_ID, CLEANUP_DATE, 100);
   }
 
   @Test
@@ -106,7 +112,8 @@ class HistoryCleanupServiceTest {
             "incident", 0,
             "userTask", 0,
             "variable", 0,
-            "decisionInstance", 0);
+            "decisionInstance", 0,
+            "job", 0);
 
     // when
     final Duration nextDuration =
@@ -126,7 +133,8 @@ class HistoryCleanupServiceTest {
             "incident", 100,
             "userTask", 100,
             "variable", 100,
-            "decisionInstance", 100);
+            "decisionInstance", 100,
+            "job", 100);
 
     // when
     final Duration nextDuration =
@@ -146,7 +154,8 @@ class HistoryCleanupServiceTest {
             "incident", 50,
             "userTask", 50,
             "variable", 50,
-            "decisionInstance", 50);
+            "decisionInstance", 50,
+            "job", 50);
 
     // when
     final Duration nextDuration =

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -18,6 +18,7 @@ import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
 import io.camunda.db.rdbms.sql.FormMapper;
 import io.camunda.db.rdbms.sql.GroupMapper;
 import io.camunda.db.rdbms.sql.IncidentMapper;
+import io.camunda.db.rdbms.sql.JobMapper;
 import io.camunda.db.rdbms.sql.MappingMapper;
 import io.camunda.db.rdbms.sql.ProcessDefinitionMapper;
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper;
@@ -235,6 +236,11 @@ public class MyBatisConfiguration {
   public MapperFactoryBean<BatchOperationMapper> batchOperationMapper(
       final SqlSessionFactory sqlSessionFactory) {
     return createMapperFactoryBean(sqlSessionFactory, BatchOperationMapper.class);
+  }
+
+  @Bean
+  public MapperFactoryBean<JobMapper> jobMapper(final SqlSessionFactory sqlSessionFactory) {
+    return createMapperFactoryBean(sqlSessionFactory, JobMapper.class);
   }
 
   private <T> MapperFactoryBean<T> createMapperFactoryBean(

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -36,6 +36,7 @@ import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
 import io.camunda.db.rdbms.sql.FormMapper;
 import io.camunda.db.rdbms.sql.GroupMapper;
 import io.camunda.db.rdbms.sql.IncidentMapper;
+import io.camunda.db.rdbms.sql.JobMapper;
 import io.camunda.db.rdbms.sql.MappingMapper;
 import io.camunda.db.rdbms.sql.ProcessDefinitionMapper;
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper;
@@ -173,7 +174,8 @@ public class RdbmsConfiguration {
       final UserTaskMapper userTaskMapper,
       final VariableMapper variableMapper,
       final RdbmsWriterMetrics metrics,
-      final BatchOperationReader batchOperationReader) {
+      final BatchOperationReader batchOperationReader,
+      final JobMapper jobMapper) {
     return new RdbmsWriterFactory(
         sqlSessionFactory,
         exporterPositionMapper,
@@ -186,7 +188,8 @@ public class RdbmsConfiguration {
         userTaskMapper,
         variableMapper,
         metrics,
-        batchOperationReader);
+        batchOperationReader,
+        jobMapper);
   }
 
   @Bean

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceSearchTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceSearchTest.java
@@ -16,8 +16,10 @@ import static io.camunda.it.util.TestHelper.waitForFlowNodeInstances;
 import static io.camunda.it.util.TestHelper.waitForProcessInstancesToStart;
 import static io.camunda.it.util.TestHelper.waitForProcessesToBeDeployed;
 import static io.camunda.it.util.TestHelper.waitUntilFlowNodeInstanceHasIncidents;
+import static io.camunda.it.util.TestHelper.waitUntilJobWorkerHasFailedJob;
 import static io.camunda.it.util.TestHelper.waitUntilProcessInstanceHasIncidents;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 import io.camunda.client.CamundaClient;
@@ -31,12 +33,12 @@ import io.camunda.client.api.search.filter.ProcessInstanceVariableFilterRequest;
 import io.camunda.client.api.search.filter.StringFilterProperty;
 import io.camunda.client.api.search.response.FlowNodeInstance;
 import io.camunda.client.api.search.response.ProcessInstance;
+import io.camunda.client.api.worker.JobWorker;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Collectors;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -470,7 +472,7 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
 
   @Test
   void shouldQueryProcessInstancesByStateCompleted() {
-    Awaitility.await("process is completed")
+    await("process is completed")
         .untilAsserted(
             () -> {
 
@@ -1348,5 +1350,29 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
 
     // then:
     assertThat(result.items().size()).isEqualTo(0);
+  }
+
+  @Test
+  void shouldQueryProcessInstancesByHasRetriesLeft() {
+    // given
+    try (final JobWorker ignored =
+        camundaClient
+            .newWorker()
+            .jobType("taskA")
+            .handler((client, job) -> client.newFailCommand(job).retries(1).send().join())
+            .open()) {
+
+      waitUntilJobWorkerHasFailedJob(camundaClient);
+
+      // when
+      final var result =
+          camundaClient.newProcessInstanceSearchRequest().filter(f -> f.hasRetriesLeft(true)).send().join();
+
+      // then
+      assertThat(result.items().size()).isEqualTo(2);
+      assertThat(result.items())
+          .extracting("processDefinitionId")
+          .containsExactlyInAnyOrder("service_tasks_v1", "service_tasks_v1");
+    }
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceSearchTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceSearchTest.java
@@ -1366,7 +1366,11 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
 
       // when
       final var result =
-          camundaClient.newProcessInstanceSearchRequest().filter(f -> f.hasRetriesLeft(true)).send().join();
+          camundaClient
+              .newProcessInstanceSearchRequest()
+              .filter(f -> f.hasRetriesLeft(true))
+              .send()
+              .join();
 
       // then
       assertThat(result.items().size()).isEqualTo(2);

--- a/qa/integration-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -9,6 +9,7 @@ package io.camunda.it.util;
 
 import static io.camunda.qa.util.multidb.CamundaMultiDBExtension.TIMEOUT_DATA_AVAILABILITY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.api.command.CreateProcessInstanceCommandStep1;
@@ -249,6 +250,21 @@ public final class TestHelper {
                       .send()
                       .join();
               assertThat(result.page().totalItems()).isEqualTo(expectedIncidents);
+            });
+  }
+
+  public static void waitUntilJobWorkerHasFailedJob(final CamundaClient camundaClient) {
+    await("should wait until the process instance has been updated to reflect retries left.")
+        .atMost(TIMEOUT_DATA_AVAILABILITY)
+        .untilAsserted(
+            () -> {
+              final var result =
+                  camundaClient
+                      .newProcessInstanceQuery()
+                      .filter(f -> f.hasRetriesLeft(true))
+                      .send()
+                      .join();
+              assertThat(result.items().size()).isGreaterThan(0);
             });
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/util/TestHelper.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/util/TestHelper.java
@@ -260,7 +260,7 @@ public final class TestHelper {
             () -> {
               final var result =
                   camundaClient
-                      .newProcessInstanceQuery()
+                      .newProcessInstanceSearchRequest()
                       .filter(f -> f.hasRetriesLeft(true))
                       .send()
                       .join();

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
@@ -15,6 +15,7 @@ import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.BP
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.END_DATE;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.ERROR_MSG;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.INCIDENT;
+import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.JOB_FAILED_WITH_RETRIES_LEFT;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.JOIN_RELATION;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.KEY;
 import static io.camunda.webapps.schema.descriptors.template.ListViewTemplate.PARENT_FLOW_NODE_INSTANCE_KEY;
@@ -99,7 +100,14 @@ public final class ProcessInstanceFilterTransformer
     ofNullable(stringOperations(BATCH_OPERATION_IDS, filter.batchOperationIdOperations()))
         .ifPresent(queries::addAll);
 
+    ofNullable(geHasRetriesLeftQuery(filter.hasRetriesLeft())).ifPresent(queries::add);
+
     return and(queries);
+  }
+
+  private SearchQuery geHasRetriesLeftQuery(final Boolean hasRetriesLeft) {
+    return hasChildQuery(
+        ACTIVITIES_JOIN_RELATION, term(JOB_FAILED_WITH_RETRIES_LEFT, hasRetriesLeft));
   }
 
   private SearchQuery getIsProcessInstanceQuery() {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/ProcessInstanceFilterTransformer.java
@@ -106,8 +106,11 @@ public final class ProcessInstanceFilterTransformer
   }
 
   private SearchQuery geHasRetriesLeftQuery(final Boolean hasRetriesLeft) {
-    return hasChildQuery(
-        ACTIVITIES_JOIN_RELATION, term(JOB_FAILED_WITH_RETRIES_LEFT, hasRetriesLeft));
+    if (hasRetriesLeft != null) {
+      return hasChildQuery(
+          ACTIVITIES_JOIN_RELATION, term(JOB_FAILED_WITH_RETRIES_LEFT, hasRetriesLeft));
+    }
+    return null;
   }
 
   private SearchQuery getIsProcessInstanceQuery() {

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessInstanceQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/ProcessInstanceQueryTransformerTest.java
@@ -411,6 +411,33 @@ public final class ProcessInstanceQueryTransformerTest extends AbstractTransform
   }
 
   @Test
+  public void shouldQueryByHasRetriesLeft() {
+    // given
+    final var processInstanceFilter = FilterBuilders.processInstance(f -> f.hasRetriesLeft(true));
+
+    // when
+    final var searchRequest = transformQuery(processInstanceFilter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant).isInstanceOf(SearchBoolQuery.class);
+    assertThat(((SearchBoolQuery) queryVariant).must()).hasSize(2);
+
+    assertIsSearchTermQuery(
+        ((SearchBoolQuery) queryVariant).must().getFirst().queryOption(),
+        "joinRelation",
+        "processInstance");
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(1).queryOption())
+        .isInstanceOfSatisfying(
+            SearchHasChildQuery.class,
+            (searchHasChildQuery) -> {
+              assertIsSearchTermQuery(
+                  searchHasChildQuery.query().queryOption(), "jobFailedWithRetriesLeft", true);
+            });
+  }
+
+  @Test
   public void shouldCreateDefaultFilter() {
     // given
 

--- a/search/search-domain/src/main/java/io/camunda/search/filter/ProcessInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/ProcessInstanceFilter.java
@@ -33,7 +33,8 @@ public record ProcessInstanceFilter(
     List<Operation<String>> tenantIdOperations,
     List<VariableValueFilter> variableFilters,
     List<Operation<String>> batchOperationIdOperations,
-    List<Operation<String>> errorMessageOperations)
+    List<Operation<String>> errorMessageOperations,
+    Boolean hasRetriesLeft)
     implements FilterBase {
 
   public Builder toBuilder() {
@@ -73,6 +74,7 @@ public record ProcessInstanceFilter(
     private List<VariableValueFilter> variableFilters;
     private List<Operation<String>> batchOperationIdOperations;
     private List<Operation<String>> errorMessageOperations;
+    private Boolean hasRetriesLeft;
 
     public Builder processInstanceKeyOperations(final List<Operation<Long>> operations) {
       processInstanceKeyOperations = addValuesToList(processInstanceKeyOperations, operations);
@@ -292,6 +294,11 @@ public record ProcessInstanceFilter(
       return this;
     }
 
+    public Builder hasRetriesLeft(final Boolean value) {
+      hasRetriesLeft = value;
+      return this;
+    }
+
     @Override
     public ProcessInstanceFilter build() {
       return new ProcessInstanceFilter(
@@ -311,7 +318,8 @@ public record ProcessInstanceFilter(
           Objects.requireNonNullElse(tenantIdOperations, Collections.emptyList()),
           Objects.requireNonNullElse(variableFilters, Collections.emptyList()),
           Objects.requireNonNullElse(batchOperationIdOperations, Collections.emptyList()),
-          Objects.requireNonNullElse(errorMessageOperations, Collections.emptyList()));
+          Objects.requireNonNullElse(errorMessageOperations, Collections.emptyList()),
+          hasRetriesLeft);
     }
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -18,6 +18,7 @@ import io.camunda.exporter.rdbms.handlers.FlowNodeInstanceIncidentExportHandler;
 import io.camunda.exporter.rdbms.handlers.FormExportHandler;
 import io.camunda.exporter.rdbms.handlers.GroupExportHandler;
 import io.camunda.exporter.rdbms.handlers.IncidentExportHandler;
+import io.camunda.exporter.rdbms.handlers.JobExportHandler;
 import io.camunda.exporter.rdbms.handlers.MappingExportHandler;
 import io.camunda.exporter.rdbms.handlers.ProcessExportHandler;
 import io.camunda.exporter.rdbms.handlers.ProcessInstanceExportHandler;
@@ -193,5 +194,6 @@ public class RdbmsExporterWrapper implements Exporter {
     builder.withHandler(
         ValueType.USER_TASK, new UserTaskExportHandler(rdbmsWriter.getUserTaskWriter()));
     builder.withHandler(ValueType.FORM, new FormExportHandler(rdbmsWriter.getFormWriter()));
+    builder.withHandler(ValueType.JOB, new JobExportHandler(rdbmsWriter.getJobWriter()));
   }
 }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/JobExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/JobExportHandler.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import io.camunda.db.rdbms.write.domain.JobDbModel;
+import io.camunda.db.rdbms.write.domain.JobDbModel.Builder;
+import io.camunda.db.rdbms.write.service.JobWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import java.util.Set;
+
+public class JobExportHandler implements RdbmsExportHandler<JobRecordValue> {
+
+  private static final Set<JobIntent> EXPORTABLE_INTENTS =
+      Set.of(
+          JobIntent.CREATED,
+          JobIntent.COMPLETED,
+          JobIntent.TIMED_OUT,
+          JobIntent.FAILED,
+          JobIntent.RETRIES_UPDATED,
+          JobIntent.CANCELED,
+          JobIntent.ERROR_THROWN,
+          JobIntent.MIGRATED);
+
+  private final JobWriter jobWriter;
+
+  public JobExportHandler(final JobWriter jobWriter) {
+    this.jobWriter = jobWriter;
+  }
+
+  @Override
+  public boolean canExport(final Record<JobRecordValue> record) {
+    return record.getIntent() != null
+        && record.getIntent() instanceof final JobIntent intent
+        && EXPORTABLE_INTENTS.contains(intent);
+  }
+
+  @Override
+  public void export(final Record<JobRecordValue> record) {
+    if (record.getIntent().equals(JobIntent.CREATED)) {
+      jobWriter.create(map(record));
+    } else {
+      jobWriter.update(map(record));
+    }
+  }
+
+  private JobDbModel map(final Record<JobRecordValue> record) {
+    return new Builder()
+        .jobKey(record.getKey())
+        .processInstanceKey(record.getValue().getProcessInstanceKey())
+        .retries(record.getValue().getRetries())
+        .state(record.getIntent().name())
+        .partitionId(record.getPartitionId())
+        .build();
+  }
+}

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4585,6 +4585,9 @@ components:
           description: The error message related to the process.
           allOf:
             - $ref: "#/components/schemas/StringFilterProperty"
+        hasRetriesLeft:
+          description: Whether the process has failed jobs with retries left.
+          type: boolean
     ProcessInstanceVariableFilterRequest:
       description: Process instance variable filter.
       type: object

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -639,6 +639,7 @@ public final class SearchQueryRequestMapper {
       ofNullable(filter.getTenantId())
           .map(mapToOperations(String.class))
           .ifPresent(builder::tenantIdOperations);
+      ofNullable(filter.getHasRetriesLeft()).ifPresent(builder::hasRetriesLeft);
       if (!CollectionUtils.isEmpty(filter.getVariables())) {
         final Either<List<String>, List<VariableValueFilter>> either =
             toVariableValueFiltersForProcessInstance(filter.getVariables());


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR extends the v2 process-instances search endpoint by adding  hasRetriesLeft as a filter field. This enables users to filter process instances by whether they have failed jobs with retries remaining.

The implementation covers document-based (ES/OS) and RDBMS data stores and the Java client.

This change is part of the [Operate UI migration to C8 V2 API.](https://github.com/camunda/camunda/issues/27250)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29662
