### PR TITLE
Split the user task and element instance termination logic

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessor.java
@@ -136,12 +136,16 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
    *   <li>clean up the state
    * </ul>
    *
-   * Next step: none.
+   * Next step: trigger {@link BpmnElementProcessor#finalizeTermination(ExecutableFlowElement,
+   * BpmnElementContext)}.
    *
    * @param element the instance of the BPMN element that is executed
    * @param context process instance-related data of the element that is executed
+   * @return TransitionOutcome transition outcome
    */
-  default void onTerminate(final T element, final BpmnElementContext context) {}
+  default TransitionOutcome onTerminate(final T element, final BpmnElementContext context) {
+    return TransitionOutcome.CONTINUE;
+  }
 
   /**
    * Finalizes the termination of the BPMN element. This method is called when the element has
@@ -151,4 +155,16 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
    * @param context process instance-related data of the element that is executed
    */
   default void finalizeTermination(final T element, final BpmnElementContext context) {}
+
+  /**
+   * Represents the outcome of a BPMN element transition method, indicating whether the next step
+   * (e.g. finalize method) should be invoked immediately or await an external trigger.
+   */
+  enum TransitionOutcome {
+    /** Continue processing by invoking the related finalize transition method immediately. */
+    CONTINUE,
+
+    /** Pause the transition and wait for an external trigger to finalize the step. */
+    AWAIT
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessor.java
@@ -142,4 +142,13 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
    * @param context process instance-related data of the element that is executed
    */
   default void onTerminate(final T element, final BpmnElementContext context) {}
+
+  /**
+   * Finalizes the termination of the BPMN element. This method is called when the element has
+   * finished executing its main behavior and is ready to transition to a terminated state.
+   *
+   * @param element the instance of the BPMN element that is executed
+   * @param context process instance-related data of the element that is executed
+   */
+  default void finalizeTermination(final T element, final BpmnElementContext context) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.engine.state.deployment.PersistedForm;
 import io.camunda.zeebe.engine.state.immutable.FormState;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
-import io.camunda.zeebe.engine.state.instance.UserTaskIntermediateStateValue;
 import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebePriorityDefinition;
@@ -36,6 +35,7 @@ import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -311,31 +311,46 @@ public final class BpmnUserTaskBehavior {
     userTaskCanceled(elementInstance);
   }
 
-  public void userTaskCanceling(final ElementInstance elementInstance) {
+  public Optional<UserTaskRecord> userTaskCanceling(final ElementInstance elementInstance) {
     final long userTaskKey = elementInstance.getUserTaskKey();
-    if (userTaskKey > 0) {
-      final LifecycleState lifecycleState = userTaskState.getLifecycleState(userTaskKey);
-      if (CANCELABLE_LIFECYCLE_STATES.contains(lifecycleState)) {
-        final UserTaskRecord userTask = userTaskState.getUserTask(userTaskKey);
-        if (userTask != null) {
-          stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CANCELING, userTask);
-        }
-      }
+    if (userTaskKey <= 0) {
+      return Optional.empty();
     }
+    final LifecycleState lifecycleState = userTaskState.getLifecycleState(userTaskKey);
+    if (!CANCELABLE_LIFECYCLE_STATES.contains(lifecycleState)) {
+      return Optional.empty();
+    }
+    final UserTaskRecord userTask = userTaskState.getUserTask(userTaskKey);
+    if (userTask == null) {
+      return Optional.empty();
+    }
+
+    stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CANCELING, userTask);
+    return Optional.of(userTask);
   }
 
   public void userTaskCanceled(final ElementInstance elementInstance) {
     final long userTaskKey = elementInstance.getUserTaskKey();
-    if (userTaskKey > 0) {
-      final UserTaskIntermediateStateValue intermediateState =
-          userTaskState.getIntermediateState(userTaskKey);
-      final UserTaskRecord userTask =
-          intermediateState != null
-              ? intermediateState.getRecord()
-              : userTaskState.getUserTask(userTaskKey);
-      if (userTask != null) {
-        stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CANCELED, userTask);
-      }
+    if (userTaskKey <= 0) {
+      return;
+    }
+    final LifecycleState lifecycleState = userTaskState.getLifecycleState(userTaskKey);
+    if (LifecycleState.CANCELING != lifecycleState) {
+      return;
+    }
+
+    final var currentUserTask = userTaskState.getUserTask(userTaskKey);
+    if (currentUserTask == null) {
+      return;
+    }
+
+    final var intermediateState = userTaskState.getIntermediateState(userTaskKey);
+    if (intermediateState == null) {
+      stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CANCELED, currentUserTask);
+    } else {
+      final var intermediateRecord = intermediateState.getRecord();
+      intermediateRecord.setDiffAsChangedAttributes(currentUserTask);
+      stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CANCELED, intermediateRecord);
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
@@ -105,7 +105,7 @@ public class AdHocSubProcessProcessor
   }
 
   @Override
-  public void onTerminate(
+  public TransitionOutcome onTerminate(
       final ExecutableAdHocSubProcess element, final BpmnElementContext terminating) {
 
     if (element.hasExecutionListeners()) {
@@ -120,6 +120,7 @@ public class AdHocSubProcessProcessor
     if (noActiveChildInstances) {
       terminate(element, terminating);
     }
+    return TransitionOutcome.CONTINUE;
   }
 
   private void terminate(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -141,7 +141,8 @@ public final class CallActivityProcessor
   }
 
   @Override
-  public void onTerminate(final ExecutableCallActivity element, final BpmnElementContext context) {
+  public TransitionOutcome onTerminate(
+      final ExecutableCallActivity element, final BpmnElementContext context) {
     if (element.hasExecutionListeners()) {
       jobBehavior.cancelJob(context);
     }
@@ -149,6 +150,7 @@ public final class CallActivityProcessor
     eventSubscriptionBehavior.unsubscribeFromEvents(context);
     incidentBehavior.resolveIncidents(context);
     stateTransitionBehavior.terminateChildProcessInstance(this, element, context);
+    return TransitionOutcome.CONTINUE;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/EventSubProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/EventSubProcessProcessor.java
@@ -72,7 +72,7 @@ public final class EventSubProcessProcessor
   }
 
   @Override
-  public void onTerminate(
+  public TransitionOutcome onTerminate(
       final ExecutableFlowElementContainer element, final BpmnElementContext terminating) {
     if (element.hasExecutionListeners()) {
       jobBehavior.cancelJob(terminating);
@@ -84,6 +84,7 @@ public final class EventSubProcessProcessor
     if (noActiveChildInstances) {
       onChildTerminated(element, terminating, null);
     }
+    return TransitionOutcome.CONTINUE;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
@@ -119,7 +119,7 @@ public final class MultiInstanceBodyProcessor
   }
 
   @Override
-  public void onTerminate(
+  public TransitionOutcome onTerminate(
       final ExecutableMultiInstanceBody element, final BpmnElementContext context) {
 
     eventSubscriptionBehavior.unsubscribeFromEvents(context);
@@ -128,6 +128,7 @@ public final class MultiInstanceBodyProcessor
     if (noActiveChildInstances) {
       terminate(element, context);
     }
+    return TransitionOutcome.CONTINUE;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -91,7 +91,7 @@ public final class ProcessProcessor
   }
 
   @Override
-  public void onTerminate(
+  public TransitionOutcome onTerminate(
       final ExecutableFlowElementContainer element, final BpmnElementContext context) {
     if (element.hasExecutionListeners()) {
       jobBehavior.cancelJob(context);
@@ -112,6 +112,7 @@ public final class ProcessProcessor
                   stateTransitionBehavior.transitionToTerminated(
                       terminating, element.getEventType())));
     }
+    return TransitionOutcome.CONTINUE;
   }
 
   private void activateStartEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -96,7 +96,7 @@ public final class SubProcessProcessor
   }
 
   @Override
-  public void onTerminate(
+  public TransitionOutcome onTerminate(
       final ExecutableFlowElementContainer element, final BpmnElementContext terminating) {
     if (element.hasExecutionListeners()) {
       jobBehavior.cancelJob(terminating);
@@ -110,6 +110,7 @@ public final class SubProcessProcessor
     if (noActiveChildInstances) {
       onChildTerminated(element, terminating, null);
     }
+    return TransitionOutcome.CONTINUE;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/BoundaryEventProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/BoundaryEventProcessor.java
@@ -66,7 +66,8 @@ public final class BoundaryEventProcessor implements BpmnElementProcessor<Execut
   }
 
   @Override
-  public void onTerminate(final ExecutableBoundaryEvent element, final BpmnElementContext context) {
+  public TransitionOutcome onTerminate(
+      final ExecutableBoundaryEvent element, final BpmnElementContext context) {
     if (element.hasExecutionListeners()) {
       jobBehavior.cancelJob(context);
     }
@@ -76,5 +77,6 @@ public final class BoundaryEventProcessor implements BpmnElementProcessor<Execut
     final var terminated =
         stateTransitionBehavior.transitionToTerminated(context, element.getEventType());
     stateTransitionBehavior.onElementTerminated(element, terminated);
+    return TransitionOutcome.CONTINUE;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
@@ -92,7 +92,8 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
   }
 
   @Override
-  public void onTerminate(final ExecutableEndEvent element, final BpmnElementContext terminating) {
+  public TransitionOutcome onTerminate(
+      final ExecutableEndEvent element, final BpmnElementContext terminating) {
     eventBehaviorOf(element).onTerminate(element, terminating);
 
     if (element.hasExecutionListeners()) {
@@ -105,6 +106,7 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
     final var terminated =
         stateTransitionBehavior.transitionToTerminated(terminating, element.getEventType());
     stateTransitionBehavior.onElementTerminated(element, terminated);
+    return TransitionOutcome.CONTINUE;
   }
 
   private EndEventBehavior eventBehaviorOf(final ExecutableEndEvent element) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateCatchEventProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateCatchEventProcessor.java
@@ -77,7 +77,7 @@ public class IntermediateCatchEventProcessor
   }
 
   @Override
-  public void onTerminate(
+  public TransitionOutcome onTerminate(
       final ExecutableCatchEventElement element, final BpmnElementContext terminating) {
     if (element.hasExecutionListeners()) {
       jobBehavior.cancelJob(terminating);
@@ -89,6 +89,7 @@ public class IntermediateCatchEventProcessor
     final var terminated =
         stateTransitionBehavior.transitionToTerminated(terminating, element.getEventType());
     stateTransitionBehavior.onElementTerminated(element, terminated);
+    return TransitionOutcome.CONTINUE;
   }
 
   private IntermediateCatchEventBehavior eventBehaviorOf(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
@@ -90,7 +90,7 @@ public class IntermediateThrowEventProcessor
   }
 
   @Override
-  public void onTerminate(
+  public TransitionOutcome onTerminate(
       final ExecutableIntermediateThrowEvent element, final BpmnElementContext terminating) {
     eventBehaviorOf(element).onTerminate(element, terminating);
 
@@ -103,6 +103,7 @@ public class IntermediateThrowEventProcessor
         stateTransitionBehavior.transitionToTerminated(terminating, element.getEventType());
     incidentBehavior.resolveIncidents(terminated);
     stateTransitionBehavior.onElementTerminated(element, terminated);
+    return TransitionOutcome.CONTINUE;
   }
 
   private IntermediateThrowEventBehavior eventBehaviorOf(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/StartEventProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/StartEventProcessor.java
@@ -78,7 +78,8 @@ public class StartEventProcessor implements BpmnElementProcessor<ExecutableStart
   }
 
   @Override
-  public void onTerminate(final ExecutableStartEvent element, final BpmnElementContext context) {
+  public TransitionOutcome onTerminate(
+      final ExecutableStartEvent element, final BpmnElementContext context) {
     if (element.hasExecutionListeners()) {
       jobBehavior.cancelJob(context);
     }
@@ -88,6 +89,7 @@ public class StartEventProcessor implements BpmnElementProcessor<ExecutableStart
 
     incidentBehavior.resolveIncidents(terminated);
     stateTransitionBehavior.onElementTerminated(element, terminated);
+    return TransitionOutcome.CONTINUE;
   }
 
   private BpmnElementContextImpl buildContextForFlowScopeInstance(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/EventBasedGatewayProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/EventBasedGatewayProcessor.java
@@ -83,7 +83,7 @@ public final class EventBasedGatewayProcessor
   }
 
   @Override
-  public void onTerminate(
+  public TransitionOutcome onTerminate(
       final ExecutableEventBasedGateway element, final BpmnElementContext context) {
     if (element.hasExecutionListeners()) {
       jobBehavior.cancelJob(context);
@@ -95,5 +95,6 @@ public final class EventBasedGatewayProcessor
     final var terminated =
         stateTransitionBehavior.transitionToTerminated(context, element.getEventType());
     stateTransitionBehavior.onElementTerminated(element, terminated);
+    return TransitionOutcome.CONTINUE;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayProcessor.java
@@ -77,7 +77,7 @@ public final class ExclusiveGatewayProcessor
   }
 
   @Override
-  public void onTerminate(
+  public TransitionOutcome onTerminate(
       final ExecutableExclusiveGateway element, final BpmnElementContext context) {
     if (element.hasExecutionListeners()) {
       jobBehavior.cancelJob(context);
@@ -87,6 +87,7 @@ public final class ExclusiveGatewayProcessor
     final var terminated =
         stateTransitionBehavior.transitionToTerminated(context, element.getEventType());
     stateTransitionBehavior.onElementTerminated(element, terminated);
+    return TransitionOutcome.CONTINUE;
   }
 
   private Either<Failure, Optional<ExecutableSequenceFlow>> findSequenceFlowToTake(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/InclusiveGatewayProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/InclusiveGatewayProcessor.java
@@ -80,7 +80,7 @@ public final class InclusiveGatewayProcessor
   }
 
   @Override
-  public void onTerminate(
+  public TransitionOutcome onTerminate(
       final ExecutableInclusiveGateway element, final BpmnElementContext context) {
     if (element.hasExecutionListeners()) {
       jobBehavior.cancelJob(context);
@@ -90,6 +90,7 @@ public final class InclusiveGatewayProcessor
     final var terminated =
         stateTransitionBehavior.transitionToTerminated(context, element.getEventType());
     stateTransitionBehavior.onElementTerminated(element, terminated);
+    return TransitionOutcome.CONTINUE;
   }
 
   private Either<Failure, List<ExecutableSequenceFlow>> findSequenceFlowsToTake(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ParallelGatewayProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ParallelGatewayProcessor.java
@@ -61,7 +61,8 @@ public final class ParallelGatewayProcessor implements BpmnElementProcessor<Exec
   }
 
   @Override
-  public void onTerminate(final ExecutableFlowNode element, final BpmnElementContext context) {
+  public TransitionOutcome onTerminate(
+      final ExecutableFlowNode element, final BpmnElementContext context) {
     if (element.hasExecutionListeners()) {
       jobBehavior.cancelJob(context);
     }
@@ -69,5 +70,6 @@ public final class ParallelGatewayProcessor implements BpmnElementProcessor<Exec
     final var terminated =
         stateTransitionBehavior.transitionToTerminated(context, element.getEventType());
     stateTransitionBehavior.onElementTerminated(element, terminated);
+    return TransitionOutcome.CONTINUE;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/BusinessRuleTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/BusinessRuleTaskProcessor.java
@@ -106,7 +106,7 @@ public final class BusinessRuleTaskProcessor
   }
 
   @Override
-  public void onTerminateInternal(
+  public TransitionOutcome onTerminateInternal(
       final ExecutableBusinessRuleTask element, final BpmnElementContext context) {
     if (element.hasExecutionListeners()) {
       jobBehavior.cancelJob(context);
@@ -135,5 +135,6 @@ public final class BusinessRuleTaskProcessor
                   stateTransitionBehavior.transitionToTerminated(context, element.getEventType());
               stateTransitionBehavior.onElementTerminated(element, terminated);
             });
+    return TransitionOutcome.CONTINUE;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskProcessor.java
@@ -92,7 +92,8 @@ public final class JobWorkerTaskProcessor implements BpmnElementProcessor<Execut
   }
 
   @Override
-  public void onTerminate(final ExecutableJobWorkerTask element, final BpmnElementContext context) {
+  public TransitionOutcome onTerminate(
+      final ExecutableJobWorkerTask element, final BpmnElementContext context) {
     final var flowScopeInstance = stateBehavior.getFlowScopeInstance(context);
     // cancel any active job associated with the task element being terminated
     // (e.g. execution listener or BPMN element job)
@@ -119,5 +120,7 @@ public final class JobWorkerTaskProcessor implements BpmnElementProcessor<Execut
                   stateTransitionBehavior.transitionToTerminated(context, element.getEventType());
               stateTransitionBehavior.onElementTerminated(element, terminated);
             });
+
+    return TransitionOutcome.CONTINUE;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskSupportingProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskSupportingProcessor.java
@@ -55,11 +55,11 @@ public abstract class JobWorkerTaskSupportingProcessor<T extends ExecutableJobWo
   }
 
   @Override
-  public void onTerminate(final T element, final BpmnElementContext context) {
+  public TransitionOutcome onTerminate(final T element, final BpmnElementContext context) {
     if (isJobBehavior(element, context)) {
-      delegate.onTerminate(element, context);
+      return delegate.onTerminate(element, context);
     } else {
-      onTerminateInternal(element, context);
+      return onTerminateInternal(element, context);
     }
   }
 
@@ -90,7 +90,8 @@ public abstract class JobWorkerTaskSupportingProcessor<T extends ExecutableJobWo
     return SUCCESS;
   }
 
-  protected abstract void onTerminateInternal(final T element, final BpmnElementContext context);
+  protected abstract TransitionOutcome onTerminateInternal(
+      final T element, final BpmnElementContext context);
 
   protected void onFinalizeTerminationInternal(final T element, final BpmnElementContext context) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskSupportingProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskSupportingProcessor.java
@@ -63,6 +63,15 @@ public abstract class JobWorkerTaskSupportingProcessor<T extends ExecutableJobWo
     }
   }
 
+  @Override
+  public void finalizeTermination(final T element, final BpmnElementContext context) {
+    if (isJobBehavior(element, context)) {
+      delegate.finalizeTermination(element, context);
+    } else {
+      onFinalizeTerminationInternal(element, context);
+    }
+  }
+
   protected abstract boolean isJobBehavior(final T element, final BpmnElementContext context);
 
   protected abstract Either<Failure, ?> onActivateInternal(
@@ -82,4 +91,6 @@ public abstract class JobWorkerTaskSupportingProcessor<T extends ExecutableJobWo
   }
 
   protected abstract void onTerminateInternal(final T element, final BpmnElementContext context);
+
+  protected void onFinalizeTerminationInternal(final T element, final BpmnElementContext context) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/ReceiveTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/ReceiveTaskProcessor.java
@@ -84,7 +84,8 @@ public final class ReceiveTaskProcessor implements BpmnElementProcessor<Executab
   }
 
   @Override
-  public void onTerminate(final ExecutableReceiveTask element, final BpmnElementContext context) {
+  public TransitionOutcome onTerminate(
+      final ExecutableReceiveTask element, final BpmnElementContext context) {
     final var flowScopeInstance = stateBehavior.getFlowScopeInstance(context);
 
     if (element.hasExecutionListeners()) {
@@ -113,5 +114,7 @@ public final class ReceiveTaskProcessor implements BpmnElementProcessor<Executab
                   stateTransitionBehavior.transitionToTerminated(context, element.getEventType());
               stateTransitionBehavior.onElementTerminated(element, terminated);
             });
+
+    return TransitionOutcome.CONTINUE;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/ScriptTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/ScriptTaskProcessor.java
@@ -112,7 +112,7 @@ public final class ScriptTaskProcessor
   }
 
   @Override
-  protected void onTerminateInternal(
+  protected TransitionOutcome onTerminateInternal(
       final ExecutableScriptTask element, final BpmnElementContext context) {
     final var flowScopeInstance = stateBehavior.getFlowScopeInstance(context);
 
@@ -140,6 +140,7 @@ public final class ScriptTaskProcessor
                   stateTransitionBehavior.transitionToTerminated(context, element.getEventType());
               stateTransitionBehavior.onElementTerminated(element, terminated);
             });
+    return TransitionOutcome.CONTINUE;
   }
 
   private void triggerProcessEventWithResultVariable(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UndefinedTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UndefinedTaskProcessor.java
@@ -62,7 +62,8 @@ public class UndefinedTaskProcessor implements BpmnElementProcessor<ExecutableAc
   }
 
   @Override
-  public void onTerminate(final ExecutableActivity element, final BpmnElementContext context) {
+  public TransitionOutcome onTerminate(
+      final ExecutableActivity element, final BpmnElementContext context) {
     if (element.hasExecutionListeners()) {
       jobBehavior.cancelJob(context);
     }
@@ -71,5 +72,6 @@ public class UndefinedTaskProcessor implements BpmnElementProcessor<ExecutableAc
         stateTransitionBehavior.transitionToTerminated(context, element.getEventType());
     incidentBehavior.resolveIncidents(context);
     stateTransitionBehavior.onElementTerminated(element, terminated);
+    return TransitionOutcome.CONTINUE;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
@@ -134,7 +134,7 @@ public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<Ex
         // Placeholder for calling task listeners and then finalizing
         return TransitionOutcome.AWAIT;
       } else {
-        userTaskBehavior.userTaskCanceled(elementInstance);
+        userTaskBehavior.userTaskCanceled(userTaskRecord.get());
         return TransitionOutcome.CONTINUE;
       }
     } else {


### PR DESCRIPTION
## Description
This is a refactoring step for [[EPIC] Listen to the user task canceling event](https://github.com/camunda/camunda/issues/28479)

In order to support task listeners for the canceling event the refactoring of the lifecycle of the user task is needed.

## Key changes in this PR

- `BpmnElementProcessor`: added `finalizeTermination`.

- `JobWorkerTaskSupportingProcessor`: added `finalizeTermination` and `onFinalizeTerminationInternal`

- `UserTaskProcessor`: refactor `onTerminateInternal` and introduce `onFinalizeTerminationInternal`.
   - `onTerminateInternal`:
     - Unsubscribe the user task from events
     - Resolve remaining incident
     - Append user task `CANCELING`
     - `userTaskCanceling` now returns an `Optional`. Based on this we can: introduce canceling task listeners logic (placeholder for now) or call `onFinalizeTerminationInternal`
     
  - `onFinalizeTerminationInternal`:
    - Append user task `CANCELED` using modified intermediate state record
    - Continue with regular termination:

- `BpmnUserTaskBehavior`: Splitting single `cancelUserTask` method into `userTaskCanceling` and `userTaskCanceled`:
  - This is done so they could be called separately in order to accommodate introduction of canceling user task listeners.
  - Behaviour of `cancelUserTask` was left intact as it is used in other places (the first commit)

   `userTaskCanceling`:
    - refactored the code to return early if certain conditions are not met (open to improvements and suggestions here)
    - added a `null` check for a user task. Please let me know if this is not needed here
    - appending ` UserTaskIntent.CANCELING`
    - returning `Optional<UserTaskRecord>` for further use

   `userTaskCanceled`
    - early returns if certain conditions are not met
    - `null` check for a user task
    - Checking for `intermediateState`:
      - if it does not exist - write `UserTaskIntent.CANCELED` with current user task
      - if it does exist - set changed attributes and write `UserTaskIntent.CANCELED` with `intermediateRecord`

Open questions:
Naming:

- `BpmnElementProcessor`: I've named the method `finalizeTermination` to follow the naming pattern present in the class, such as `finalizeCompletion` and `finalizeActivation`. Please let me know if you'd prefer to rename this
- `JobWorkerTaskSupportingProcessor`: method names `finalizeTermination` and `onFinalizeTerminationInternal` were introduced in order to keep naming consistent with `finalizeCompletion`, `onFinalizeCompletionInternal` etc. I am open to suggestions here.

> [!NOTE]
> there are no new test cases as the aim of this PR was to split the functionality without breaking it.
A new test that verifies the cancelation of a user task functions was introduced in [Clean intermediate data when cancelling user task](https://github.com/camunda/camunda/pull/29537) PR. 
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #28563
