### PR TITLE
fix: Clean up `VariableDocumentState` on user task cancellation

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -441,7 +441,8 @@ public final class EventAppliers implements EventApplier {
   private void registerUserTaskAppliers(final MutableProcessingState state) {
     register(UserTaskIntent.CREATING, new UserTaskCreatingApplier(state));
     register(UserTaskIntent.CREATED, new UserTaskCreatedApplier(state));
-    register(UserTaskIntent.CANCELING, new UserTaskCancelingApplier(state));
+    register(UserTaskIntent.CANCELING, 1, new UserTaskCancelingV1Applier(state));
+    register(UserTaskIntent.CANCELING, 2, new UserTaskCancelingV2Applier(state));
     register(UserTaskIntent.CANCELED, new UserTaskCanceledApplier(state));
     register(UserTaskIntent.COMPLETING, 1, new UserTaskCompletingV1Applier(state));
     register(UserTaskIntent.COMPLETING, 2, new UserTaskCompletingV2Applier(state));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV1Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV1Applier.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+
+public final class UserTaskCancelingV1Applier
+    implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
+
+  private final MutableUserTaskState userTaskState;
+
+  public UserTaskCancelingV1Applier(final MutableProcessingState processingState) {
+    userTaskState = processingState.getUserTaskState();
+  }
+
+  @Override
+  public void applyState(final long key, final UserTaskRecord value) {
+    userTaskState.updateUserTaskLifecycleState(key, LifecycleState.CANCELING);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV2Applier.java
@@ -14,12 +14,12 @@ import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 
-public final class UserTaskCancelingApplier
+public final class UserTaskCancelingV2Applier
     implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
 
   private final MutableUserTaskState userTaskState;
 
-  public UserTaskCancelingApplier(final MutableProcessingState processingState) {
+  public UserTaskCancelingV2Applier(final MutableProcessingState processingState) {
     userTaskState = processingState.getUserTaskState();
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV2Applier.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.engine.state.mutable.MutableVariableState;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 
@@ -18,13 +19,18 @@ public final class UserTaskCancelingV2Applier
     implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
 
   private final MutableUserTaskState userTaskState;
+  private final MutableVariableState variableState;
 
   public UserTaskCancelingV2Applier(final MutableProcessingState processingState) {
     userTaskState = processingState.getUserTaskState();
+    variableState = processingState.getVariableState();
   }
 
   @Override
   public void applyState(final long key, final UserTaskRecord value) {
     userTaskState.updateUserTaskLifecycleState(key, LifecycleState.CANCELING);
+
+    // Clean up data that may have been persisted by a previous transition
+    variableState.removeVariableDocumentState(value.getElementInstanceKey());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingApplierTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import java.util.Random;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public class UserTaskCancelingApplierTest {
+
+  /** Injected by {@link ProcessingStateExtension} */
+  private MutableProcessingState processingState;
+
+  /** The class under test. */
+  private UserTaskCancelingApplier userTaskCancelingApplier;
+
+  /** Used for state assertions. */
+  private MutableUserTaskState userTaskState;
+
+  /** For setting up the state before testing the applier. */
+  private AppliersTestSetupHelper testSetup;
+
+  @BeforeEach
+  public void setup() {
+    userTaskCancelingApplier = new UserTaskCancelingApplier(processingState);
+    userTaskState = processingState.getUserTaskState();
+    testSetup = new AppliersTestSetupHelper(processingState);
+  }
+
+  @Test
+  void shouldTransitionUserTaskLifecycleToCancelingOnApply() {
+    // given
+    final long userTaskKey = new Random().nextLong();
+    final long elementInstanceKey = new Random().nextLong();
+
+    final var userTaskRecord =
+        new UserTaskRecord().setUserTaskKey(userTaskKey).setElementInstanceKey(elementInstanceKey);
+
+    // simulate a user task creation
+    testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATING, userTaskRecord);
+    testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATED, userTaskRecord);
+
+    // verify initial state
+    assertThat(userTaskState.getLifecycleState(userTaskKey))
+        .describedAs("Expected user task to be in CREATED state before applying CANCELING")
+        .isEqualTo(LifecycleState.CREATED);
+
+    // when
+    userTaskCancelingApplier.applyState(userTaskKey, userTaskRecord);
+
+    // then
+    assertThat(userTaskState.getLifecycleState(userTaskKey))
+        .describedAs("Expected user task to transition to CANCELING state")
+        .isEqualTo(LifecycleState.CANCELING);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV1ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV1ApplierTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import java.util.Random;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public class UserTaskCancelingV1ApplierTest {
+
+  /** Injected by {@link ProcessingStateExtension} */
+  private MutableProcessingState processingState;
+
+  /** The class under test. */
+  private UserTaskCancelingV1Applier userTaskCancelingApplier;
+
+  /** Used for state assertions. */
+  private MutableUserTaskState userTaskState;
+
+  /** For setting up the state before testing the applier. */
+  private AppliersTestSetupHelper testSetup;
+
+  @BeforeEach
+  public void setup() {
+    userTaskCancelingApplier = new UserTaskCancelingV1Applier(processingState);
+    userTaskState = processingState.getUserTaskState();
+    testSetup = new AppliersTestSetupHelper(processingState);
+  }
+
+  @Test
+  void shouldTransitionUserTaskLifecycleToCancelingOnApply() {
+    // given
+    final long userTaskKey = new Random().nextLong();
+    final long elementInstanceKey = new Random().nextLong();
+
+    final var userTaskRecord =
+        new UserTaskRecord().setUserTaskKey(userTaskKey).setElementInstanceKey(elementInstanceKey);
+
+    // simulate a user task creation
+    testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATING, userTaskRecord);
+    testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATED, userTaskRecord);
+
+    // verify initial state
+    assertThat(userTaskState.getLifecycleState(userTaskKey))
+        .describedAs("Expected user task to be in CREATED state before applying CANCELING")
+        .isEqualTo(LifecycleState.CREATED);
+
+    // when
+    userTaskCancelingApplier.applyState(userTaskKey, userTaskRecord);
+
+    // then
+    assertThat(userTaskState.getLifecycleState(userTaskKey))
+        .describedAs("Expected user task to transition to CANCELING state")
+        .isEqualTo(LifecycleState.CANCELING);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV2ApplierTest.java
@@ -14,7 +14,12 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
+import io.camunda.zeebe.protocol.record.value.VariableDocumentUpdateSemantic;
+import io.camunda.zeebe.test.util.MsgPackUtil;
+import java.util.Map;
 import java.util.Random;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -67,5 +72,49 @@ public class UserTaskCancelingV2ApplierTest {
     assertThat(userTaskState.getLifecycleState(userTaskKey))
         .describedAs("Expected user task to transition to CANCELING state")
         .isEqualTo(LifecycleState.CANCELING);
+  }
+
+  @Test
+  void shouldRemoveVariableDocumentStateOnUserTaskCancelingTransition() {
+    // given
+    final long userTaskKey = new Random().nextLong();
+    final long elementInstanceKey = new Random().nextLong();
+    final long variableDocumentKey = new Random().nextLong();
+
+    final var variablesBuffer = MsgPackUtil.asMsgPack(Map.of("status", "approved"));
+
+    final var userTaskRecord =
+        new UserTaskRecord().setUserTaskKey(userTaskKey).setElementInstanceKey(elementInstanceKey);
+
+    final var variableDocumentRecord =
+        new VariableDocumentRecord()
+            .setScopeKey(elementInstanceKey)
+            .setVariables(variablesBuffer)
+            .setUpdateSemantics(VariableDocumentUpdateSemantic.LOCAL);
+
+    // simulate user task creation
+    testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATING, userTaskRecord);
+    testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATED, userTaskRecord);
+
+    // simulate a VariableDocument.UPDATE triggering a user task update
+    testSetup.applyEventToState(
+        variableDocumentKey, VariableDocumentIntent.UPDATING, variableDocumentRecord);
+    testSetup.applyEventToState(
+        userTaskKey,
+        UserTaskIntent.UPDATING,
+        userTaskRecord.copy().setVariables(variablesBuffer).setVariablesChanged());
+
+    // precondition: variable document state should exist before canceling
+    assertThat(processingState.getVariableState().findVariableDocumentState(elementInstanceKey))
+        .describedAs("Expected variable document state to exist before user task cancellation")
+        .isPresent();
+
+    // when: user task is canceled
+    userTaskCancelingApplier.applyState(userTaskKey, userTaskRecord);
+
+    // then: variable document state should be cleaned up
+    assertThat(processingState.getVariableState().findVariableDocumentState(elementInstanceKey))
+        .describedAs("Expected variable document state to be removed after user task cancellation")
+        .isEmpty();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCancelingV2ApplierTest.java
@@ -21,13 +21,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ProcessingStateExtension.class)
-public class UserTaskCancelingApplierTest {
+public class UserTaskCancelingV2ApplierTest {
 
   /** Injected by {@link ProcessingStateExtension} */
   private MutableProcessingState processingState;
 
   /** The class under test. */
-  private UserTaskCancelingApplier userTaskCancelingApplier;
+  private UserTaskCancelingV2Applier userTaskCancelingApplier;
 
   /** Used for state assertions. */
   private MutableUserTaskState userTaskState;
@@ -37,7 +37,7 @@ public class UserTaskCancelingApplierTest {
 
   @BeforeEach
   public void setup() {
-    userTaskCancelingApplier = new UserTaskCancelingApplier(processingState);
+    userTaskCancelingApplier = new UserTaskCancelingV2Applier(processingState);
     userTaskState = processingState.getUserTaskState();
     testSetup = new AppliersTestSetupHelper(processingState);
   }


### PR DESCRIPTION
## Description

When a user task update is triggered by a `VariableDocument.UPDATE` command, a `VariableDocumentState` is persisted. However, if the task is later canceled (e.g., due to instance termination or boundary event), this state is not cleaned up, leading to potential memory leaks or inconsistencies.

### What's changed

- Introduced `UserTaskCancelingV2Applier` that extends the existing cancellation behavior by removing the associated `VariableDocumentState`.

### Why versioned

Although cleanup logic could technically be added to the existing applier (due to use of `deleteIfExists` in `DbVariableState#removeVariableDocumentState`), the versioned approach is preferred because:
- It avoids redundant cleanup calls for records created by earlier Zeebe versions on events replay, where `VariableDocumentState` was not previously persisted.
- We'll have to create a new applier version anyway, to provide support for `"canceling"` user task listeners in the near future (to clean up `recordRequestMetadata` and `intermediateUserTaskState` persisted by the previous transition and persist new `intermediateUserTaskState` for `CANCELING` transition).


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29989
