### PR TITLE
fix: use correct schema reference for resource result in REST API spec

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1904,7 +1904,7 @@ paths:
           content:
             application/json:
               schema:
-                type: "#/components/schemas/ResourceResult"
+                $ref: "#/components/schemas/ResourceResult"
         "404":
           description: A resource with the given key was not found.
           content:


### PR DESCRIPTION
## Description
Use the correct property `$ref` for referencing the response schema of the "get resource" endpoint. This slipped through in https://github.com/camunda/camunda/pull/28223.

## Related issues
relates to https://github.com/camunda/camunda/issues/25281
