### PR TITLE
[CPT] refactor: Clean up element assertions

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ElementAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ElementAssertj.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractAssert;
 import org.awaitility.Awaitility;
@@ -75,14 +74,12 @@ public class ElementAssertj extends AbstractAssert<ElementAssertj, String> {
 
           assertThat(selectorsNotMatched)
               .withFailMessage(
-                  () ->
-                      String.format(
-                          "%s should have %s elements %s but the following elements were not %s:\n%s",
-                          actual,
-                          formatState(expectedState),
-                          formatElementSelectors(elementSelectors),
-                          formatState(expectedState),
-                          formatFlowNodeInstanceStates(selectorsNotMatched, flowNodeInstances)))
+                  "%s should have %s elements %s but the following elements were not %s:\n%s",
+                  actual,
+                  formatState(expectedState),
+                  formatElementSelectors(elementSelectors),
+                  formatState(expectedState),
+                  formatFlowNodeInstanceStates(selectorsNotMatched, flowNodeInstances))
               .isEmpty();
         });
   }
@@ -131,18 +128,16 @@ public class ElementAssertj extends AbstractAssert<ElementAssertj, String> {
 
           assertThat(actualTimes)
               .withFailMessage(
-                  () ->
-                      String.format(
-                          "%s should have %s element '%s' %d times but was %d. Element instances:\n%s",
-                          actual,
-                          formatState(expectedState),
-                          elementSelector.describe(),
-                          expectedTimes,
-                          actualTimes,
-                          elementInstances.isEmpty()
-                              ? "<None>"
-                              : formatFlowNodeInstanceStates(
-                                  elementInstances, elementInstance -> elementSelector.describe())))
+                  "%s should have %s element '%s' %d times but was %d. Element instances:\n%s",
+                  actual,
+                  formatState(expectedState),
+                  elementSelector.describe(),
+                  expectedTimes,
+                  actualTimes,
+                  elementInstances.isEmpty()
+                      ? "<None>"
+                      : formatFlowNodeInstanceStates(
+                          elementInstances, elementInstance -> elementSelector.describe()))
               .isEqualTo(expectedTimes);
         });
   }
@@ -159,12 +154,10 @@ public class ElementAssertj extends AbstractAssert<ElementAssertj, String> {
 
     assertThat(activatedElements)
         .withFailMessage(
-            () ->
-                String.format(
-                    "%s should have not activated elements %s but the following elements were activated:\n%s",
-                    actual,
-                    formatElementSelectors(elementSelectors),
-                    formatFlowNodeInstanceStates(activatedElements, flowNodeInstances)))
+            "%s should have not activated elements %s but the following elements were activated:\n%s",
+            actual,
+            formatElementSelectors(elementSelectors),
+            formatFlowNodeInstanceStates(activatedElements, flowNodeInstances))
         .isEmpty();
   }
 
@@ -183,12 +176,10 @@ public class ElementAssertj extends AbstractAssert<ElementAssertj, String> {
 
           assertThat(selectorsNotMatched)
               .withFailMessage(
-                  () ->
-                      String.format(
-                          "%s should have no active elements %s but the following elements were active:\n%s",
-                          actual,
-                          formatElementSelectors(elementSelectors),
-                          formatFlowNodeInstanceStates(selectorsNotMatched, flowNodeInstances)))
+                  "%s should have no active elements %s but the following elements were active:\n%s",
+                  actual,
+                  formatElementSelectors(elementSelectors),
+                  formatFlowNodeInstanceStates(selectorsNotMatched, flowNodeInstances))
               .isEmpty();
         });
   }
@@ -213,32 +204,28 @@ public class ElementAssertj extends AbstractAssert<ElementAssertj, String> {
                               .noneMatch(selector -> selector.test(flowNodeInstance)))
                   .collect(Collectors.toList());
 
-          final Supplier<String> failureMessage =
-              () -> {
-                final List<String> failureMessages = new ArrayList<>();
+          final List<String> failureMessages = new ArrayList<>();
+          if (!selectorsNotMatched.isEmpty()) {
+            failureMessages.add(
+                String.format(
+                    "%s should have active elements %s but the following elements were not active:\n%s",
+                    actual,
+                    formatElementSelectors(elementSelectors),
+                    formatFlowNodeInstanceStates(selectorsNotMatched, flowNodeInstances)));
+          }
+          if (!otherActiveElements.isEmpty()) {
+            failureMessages.add(
+                String.format(
+                    "%s should have no active elements except %s but the following elements were active:\n%s",
+                    actual,
+                    formatElementSelectors(elementSelectors),
+                    formatFlowNodeInstanceStates(
+                        otherActiveElements, FlowNodeInstance::getFlowNodeId)));
+          }
+          final String combinedFailureMessage = String.join("\n\n", failureMessages);
 
-                if (!selectorsNotMatched.isEmpty()) {
-                  failureMessages.add(
-                      String.format(
-                          "%s should have active elements %s but the following elements were not active:\n%s",
-                          actual,
-                          formatElementSelectors(elementSelectors),
-                          formatFlowNodeInstanceStates(selectorsNotMatched, flowNodeInstances)));
-                }
-                if (!otherActiveElements.isEmpty()) {
-                  failureMessages.add(
-                      String.format(
-                          "%s should have no active elements except %s but the following elements were active:\n%s",
-                          actual,
-                          formatElementSelectors(elementSelectors),
-                          formatFlowNodeInstanceStates(
-                              otherActiveElements, FlowNodeInstance::getFlowNodeId)));
-                }
-                return String.join("\n\n", failureMessages);
-              };
-
-          assertThat(selectorsNotMatched).withFailMessage(failureMessage).isEmpty();
-          assertThat(otherActiveElements).withFailMessage(failureMessage).isEmpty();
+          assertThat(selectorsNotMatched).withFailMessage(combinedFailureMessage).isEmpty();
+          assertThat(otherActiveElements).withFailMessage(combinedFailureMessage).isEmpty();
         });
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ElementAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ElementAssertj.java
@@ -24,7 +24,6 @@ import io.camunda.client.api.search.response.FlowNodeInstance;
 import io.camunda.client.api.search.response.FlowNodeInstanceState;
 import io.camunda.process.test.api.assertions.ElementSelector;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
@@ -39,126 +38,25 @@ import org.awaitility.core.ConditionTimeoutException;
 public class ElementAssertj extends AbstractAssert<ElementAssertj, String> {
 
   private final CamundaDataSource dataSource;
-  private final Function<String, ElementSelector> elementSelector;
 
-  protected ElementAssertj(
-      final CamundaDataSource dataSource,
-      final String failureMessagePrefix,
-      final Function<String, ElementSelector> elementSelector) {
+  protected ElementAssertj(final CamundaDataSource dataSource, final String failureMessagePrefix) {
     super(failureMessagePrefix, ElementAssertj.class);
     this.dataSource = dataSource;
-    this.elementSelector = elementSelector;
-  }
-
-  public void hasActiveElements(final long processInstanceKey, final String... elementIds) {
-    hasElementsInState(
-        processInstanceKey, toElementSelectors(elementIds), FlowNodeInstanceState.ACTIVE);
   }
 
   public void hasActiveElements(
-      final long processInstanceKey, final ElementSelector... elementSelectors) {
-    hasElementsInState(
-        processInstanceKey, Arrays.asList(elementSelectors), FlowNodeInstanceState.ACTIVE);
-  }
-
-  public void hasCompletedElements(final long processInstanceKey, final String... elementIds) {
-    hasElementsInState(
-        processInstanceKey, toElementSelectors(elementIds), FlowNodeInstanceState.COMPLETED);
+      final long processInstanceKey, final List<ElementSelector> elementSelectors) {
+    hasElementsInState(processInstanceKey, elementSelectors, FlowNodeInstanceState.ACTIVE);
   }
 
   public void hasCompletedElements(
-      final long processInstanceKey, final ElementSelector... elementSelectors) {
-    hasElementsInState(
-        processInstanceKey, Arrays.asList(elementSelectors), FlowNodeInstanceState.COMPLETED);
-  }
-
-  public void hasTerminatedElements(final long processInstanceKey, final String... elementIds) {
-    hasElementsInState(
-        processInstanceKey, toElementSelectors(elementIds), FlowNodeInstanceState.TERMINATED);
+      final long processInstanceKey, final List<ElementSelector> elementSelectors) {
+    hasElementsInState(processInstanceKey, elementSelectors, FlowNodeInstanceState.COMPLETED);
   }
 
   public void hasTerminatedElements(
-      final long processInstanceKey, final ElementSelector... elementSelectors) {
-    hasElementsInState(
-        processInstanceKey, Arrays.asList(elementSelectors), FlowNodeInstanceState.TERMINATED);
-  }
-
-  public void hasActiveElement(
-      final long processInstanceKey, final String elementId, final int expectedTimes) {
-    hasElementInState(
-        processInstanceKey,
-        elementSelector.apply(elementId),
-        FlowNodeInstanceState.ACTIVE,
-        expectedTimes);
-  }
-
-  public void hasActiveElement(
-      final long processInstanceKey,
-      final ElementSelector elementSelector,
-      final int expectedTimes) {
-    hasElementInState(
-        processInstanceKey, elementSelector, FlowNodeInstanceState.ACTIVE, expectedTimes);
-  }
-
-  public void hasCompletedElement(
-      final long processInstanceKey, final String elementId, final int expectedTimes) {
-    hasElementInState(
-        processInstanceKey,
-        elementSelector.apply(elementId),
-        FlowNodeInstanceState.COMPLETED,
-        expectedTimes);
-  }
-
-  public void hasCompletedElement(
-      final long processInstanceKey,
-      final ElementSelector elementSelector,
-      final int expectedTimes) {
-    hasElementInState(
-        processInstanceKey, elementSelector, FlowNodeInstanceState.COMPLETED, expectedTimes);
-  }
-
-  public void hasTerminatedElement(
-      final long processInstanceKey, final String elementId, final int expectedTimes) {
-    hasElementInState(
-        processInstanceKey,
-        elementSelector.apply(elementId),
-        FlowNodeInstanceState.TERMINATED,
-        expectedTimes);
-  }
-
-  public void hasTerminatedElement(
-      final long processInstanceKey,
-      final ElementSelector elementSelector,
-      final int expectedTimes) {
-    hasElementInState(
-        processInstanceKey, elementSelector, FlowNodeInstanceState.TERMINATED, expectedTimes);
-  }
-
-  public void hasNotActivatedElements(final long processInstanceKey, final String... elementIds) {
-    hasNotActivatedElements(processInstanceKey, toElementSelectors(elementIds));
-  }
-
-  public void hasNotActivatedElements(
-      final long processInstanceKey, final ElementSelector... elementSelectors) {
-    hasNotActivatedElements(processInstanceKey, Arrays.asList(elementSelectors));
-  }
-
-  public void hasNoActiveElements(final long processInstanceKey, final String... elementIds) {
-    hasNoActiveElements(processInstanceKey, toElementSelectors(elementIds));
-  }
-
-  public void hasNoActiveElements(
-      final long processInstanceKey, final ElementSelector... elementSelectors) {
-    hasNoActiveElements(processInstanceKey, Arrays.asList(elementSelectors));
-  }
-
-  public void hasActiveElementsExactly(final long processInstanceKey, final String... elementIds) {
-    hasActiveElementsExactly(processInstanceKey, toElementSelectors(elementIds));
-  }
-
-  public void hasActiveElementsExactly(
-      final long processInstanceKey, final ElementSelector... elementSelectors) {
-    hasActiveElementsExactly(processInstanceKey, Arrays.asList(elementSelectors));
+      final long processInstanceKey, final List<ElementSelector> elementSelectors) {
+    hasElementsInState(processInstanceKey, elementSelectors, FlowNodeInstanceState.TERMINATED);
   }
 
   private void hasElementsInState(
@@ -187,6 +85,30 @@ public class ElementAssertj extends AbstractAssert<ElementAssertj, String> {
                           formatFlowNodeInstanceStates(selectorsNotMatched, flowNodeInstances)))
               .isEmpty();
         });
+  }
+
+  public void hasActiveElement(
+      final long processInstanceKey,
+      final ElementSelector elementSelector,
+      final int expectedTimes) {
+    hasElementInState(
+        processInstanceKey, elementSelector, FlowNodeInstanceState.ACTIVE, expectedTimes);
+  }
+
+  public void hasCompletedElement(
+      final long processInstanceKey,
+      final ElementSelector elementSelector,
+      final int expectedTimes) {
+    hasElementInState(
+        processInstanceKey, elementSelector, FlowNodeInstanceState.COMPLETED, expectedTimes);
+  }
+
+  public void hasTerminatedElement(
+      final long processInstanceKey,
+      final ElementSelector elementSelector,
+      final int expectedTimes) {
+    hasElementInState(
+        processInstanceKey, elementSelector, FlowNodeInstanceState.TERMINATED, expectedTimes);
   }
 
   private void hasElementInState(
@@ -225,7 +147,7 @@ public class ElementAssertj extends AbstractAssert<ElementAssertj, String> {
         });
   }
 
-  private void hasNotActivatedElements(
+  public void hasNotActivatedElements(
       final long processInstanceKey, final List<ElementSelector> elementSelectors) {
 
     final List<FlowNodeInstance> flowNodeInstances =
@@ -246,7 +168,7 @@ public class ElementAssertj extends AbstractAssert<ElementAssertj, String> {
         .isEmpty();
   }
 
-  private void hasNoActiveElements(
+  public void hasNoActiveElements(
       final long processInstanceKey, final List<ElementSelector> elementSelectors) {
 
     final Consumer<FlownodeInstanceFilter> flowNodeInstanceFilter =
@@ -271,7 +193,7 @@ public class ElementAssertj extends AbstractAssert<ElementAssertj, String> {
         });
   }
 
-  private void hasActiveElementsExactly(
+  public void hasActiveElementsExactly(
       final long processInstanceKey, final List<ElementSelector> elementSelectors) {
 
     awaitFlowNodeInstanceAssertion(
@@ -408,10 +330,6 @@ public class ElementAssertj extends AbstractAssert<ElementAssertj, String> {
                     flowNodeDescriptor.apply(flowNodeInstance),
                     formatState(flowNodeInstance.getState())))
         .collect(Collectors.joining("\n"));
-  }
-
-  private List<ElementSelector> toElementSelectors(final String[] elementIds) {
-    return Arrays.stream(elementIds).map(elementSelector).collect(Collectors.toList());
   }
 
   private static String formatState(final FlowNodeInstanceState state) {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ElementAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ElementAssertj.java
@@ -114,8 +114,8 @@ public class ElementAssertj extends AbstractAssert<ElementAssertj, String> {
       final FlowNodeInstanceState expectedState,
       final int expectedTimes) {
 
-    if (expectedTimes < 1) {
-      throw new IllegalArgumentException("The amount must be greater than zero.");
+    if (expectedTimes < 0) {
+      throw new IllegalArgumentException("The amount must be greater than or equal to zero.");
     }
 
     awaitFlowNodeInstanceAssertion(

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ElementAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ElementAssertj.java
@@ -171,15 +171,15 @@ public class ElementAssertj extends AbstractAssert<ElementAssertj, String> {
     awaitFlowNodeInstanceAssertion(
         flowNodeInstanceFilter,
         flowNodeInstances -> {
-          final List<ElementSelector> selectorsNotMatched =
+          final List<ElementSelector> selectorsWithActiveElements =
               getSelectorsWithInstances(elementSelectors, flowNodeInstances);
 
-          assertThat(selectorsNotMatched)
+          assertThat(selectorsWithActiveElements)
               .withFailMessage(
                   "%s should have no active elements %s but the following elements were active:\n%s",
                   actual,
                   formatElementSelectors(elementSelectors),
-                  formatFlowNodeInstanceStates(selectorsNotMatched, flowNodeInstances))
+                  formatFlowNodeInstanceStates(selectorsWithActiveElements, flowNodeInstances))
               .isEmpty();
         });
   }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ElementAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ElementAssertj.java
@@ -239,10 +239,8 @@ public class ElementAssertj extends AbstractAssert<ElementAssertj, String> {
       Awaitility.await()
           .ignoreException(ClientException.class)
           .untilAsserted(
-              () -> {
-                final List<FlowNodeInstance> flowNodeInstances =
-                    dataSource.findFlowNodeInstances(filter);
-
+              () -> dataSource.findFlowNodeInstances(filter),
+              flowNodeInstances -> {
                 try {
                   assertion.accept(flowNodeInstances);
                 } catch (final AssertionError e) {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -25,12 +25,15 @@ import io.camunda.process.test.api.assertions.ElementSelector;
 import io.camunda.process.test.api.assertions.ProcessInstanceAssert;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelector;
 import io.camunda.process.test.api.assertions.ProcessInstanceSelectors;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import org.assertj.core.api.AbstractAssert;
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionTimeoutException;
@@ -45,6 +48,7 @@ public class ProcessInstanceAssertj
   private final ElementAssertj elementAssertj;
   private final VariableAssertj variableAssertj;
   private final String failureMessagePrefix;
+  private final Function<String, ElementSelector> elementSelector;
 
   private final AtomicReference<ProcessInstance> actualProcessInstance = new AtomicReference<>();
 
@@ -63,7 +67,8 @@ public class ProcessInstanceAssertj
     this.dataSource = dataSource;
     failureMessagePrefix =
         String.format("Process instance [%s]", processInstanceSelector.describe());
-    elementAssertj = new ElementAssertj(dataSource, failureMessagePrefix, elementSelector);
+    this.elementSelector = elementSelector;
+    elementAssertj = new ElementAssertj(dataSource, failureMessagePrefix);
     variableAssertj = new VariableAssertj(dataSource, failureMessagePrefix);
   }
 
@@ -101,43 +106,44 @@ public class ProcessInstanceAssertj
 
   @Override
   public ProcessInstanceAssert hasActiveElements(final String... elementIds) {
-    elementAssertj.hasActiveElements(getProcessInstanceKey(), elementIds);
+    elementAssertj.hasActiveElements(getProcessInstanceKey(), toElementSelectors(elementIds));
     return this;
   }
 
   @Override
   public ProcessInstanceAssert hasActiveElements(final ElementSelector... elementSelectors) {
-    elementAssertj.hasActiveElements(getProcessInstanceKey(), elementSelectors);
+    elementAssertj.hasActiveElements(getProcessInstanceKey(), Arrays.asList(elementSelectors));
     return this;
   }
 
   @Override
   public ProcessInstanceAssert hasCompletedElements(final String... elementIds) {
-    elementAssertj.hasCompletedElements(getProcessInstanceKey(), elementIds);
+    elementAssertj.hasCompletedElements(getProcessInstanceKey(), toElementSelectors(elementIds));
     return this;
   }
 
   @Override
   public ProcessInstanceAssert hasCompletedElements(final ElementSelector... elementSelectors) {
-    elementAssertj.hasCompletedElements(getProcessInstanceKey(), elementSelectors);
+    elementAssertj.hasCompletedElements(getProcessInstanceKey(), Arrays.asList(elementSelectors));
     return this;
   }
 
   @Override
   public ProcessInstanceAssert hasTerminatedElements(final String... elementIds) {
-    elementAssertj.hasTerminatedElements(getProcessInstanceKey(), elementIds);
+    elementAssertj.hasTerminatedElements(getProcessInstanceKey(), toElementSelectors(elementIds));
     return this;
   }
 
   @Override
   public ProcessInstanceAssert hasTerminatedElements(final ElementSelector... elementSelectors) {
-    elementAssertj.hasTerminatedElements(getProcessInstanceKey(), elementSelectors);
+    elementAssertj.hasTerminatedElements(getProcessInstanceKey(), Arrays.asList(elementSelectors));
     return this;
   }
 
   @Override
   public ProcessInstanceAssert hasActiveElement(final String elementId, final int times) {
-    elementAssertj.hasActiveElement(getProcessInstanceKey(), elementId, times);
+    elementAssertj.hasActiveElement(
+        getProcessInstanceKey(), elementSelector.apply(elementId), times);
     return this;
   }
 
@@ -150,7 +156,8 @@ public class ProcessInstanceAssertj
 
   @Override
   public ProcessInstanceAssert hasCompletedElement(final String elementId, final int times) {
-    elementAssertj.hasCompletedElement(getProcessInstanceKey(), elementId, times);
+    elementAssertj.hasCompletedElement(
+        getProcessInstanceKey(), elementSelector.apply(elementId), times);
     return this;
   }
 
@@ -163,7 +170,8 @@ public class ProcessInstanceAssertj
 
   @Override
   public ProcessInstanceAssert hasTerminatedElement(final String elementId, final int times) {
-    elementAssertj.hasTerminatedElement(getProcessInstanceKey(), elementId, times);
+    elementAssertj.hasTerminatedElement(
+        getProcessInstanceKey(), elementSelector.apply(elementId), times);
     return this;
   }
 
@@ -176,37 +184,40 @@ public class ProcessInstanceAssertj
 
   @Override
   public ProcessInstanceAssert hasNotActivatedElements(final String... elementIds) {
-    elementAssertj.hasNotActivatedElements(getProcessInstanceKey(), elementIds);
+    elementAssertj.hasNotActivatedElements(getProcessInstanceKey(), toElementSelectors(elementIds));
     return this;
   }
 
   @Override
   public ProcessInstanceAssert hasNotActivatedElements(final ElementSelector... elementSelectors) {
-    elementAssertj.hasNotActivatedElements(getProcessInstanceKey(), elementSelectors);
+    elementAssertj.hasNotActivatedElements(
+        getProcessInstanceKey(), Arrays.asList(elementSelectors));
     return this;
   }
 
   @Override
   public ProcessInstanceAssert hasNoActiveElements(final String... elementIds) {
-    elementAssertj.hasNoActiveElements(getProcessInstanceKey(), elementIds);
+    elementAssertj.hasNoActiveElements(getProcessInstanceKey(), toElementSelectors(elementIds));
     return this;
   }
 
   @Override
   public ProcessInstanceAssert hasNoActiveElements(final ElementSelector... elementSelectors) {
-    elementAssertj.hasNoActiveElements(getProcessInstanceKey(), elementSelectors);
+    elementAssertj.hasNoActiveElements(getProcessInstanceKey(), Arrays.asList(elementSelectors));
     return this;
   }
 
   @Override
   public ProcessInstanceAssert hasActiveElementsExactly(final String... elementIds) {
-    elementAssertj.hasActiveElementsExactly(getProcessInstanceKey(), elementIds);
+    elementAssertj.hasActiveElementsExactly(
+        getProcessInstanceKey(), toElementSelectors(elementIds));
     return this;
   }
 
   @Override
   public ProcessInstanceAssert hasActiveElementsExactly(final ElementSelector... elementSelectors) {
-    elementAssertj.hasActiveElementsExactly(getProcessInstanceKey(), elementSelectors);
+    elementAssertj.hasActiveElementsExactly(
+        getProcessInstanceKey(), Arrays.asList(elementSelectors));
     return this;
   }
 
@@ -305,5 +316,9 @@ public class ProcessInstanceAssertj
     } else {
       return state.name().toLowerCase();
     }
+  }
+
+  private List<ElementSelector> toElementSelectors(final String[] elementIds) {
+    return Arrays.stream(elementIds).map(elementSelector).collect(Collectors.toList());
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ElementAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ElementAssertTest.java
@@ -751,15 +751,38 @@ public class ElementAssertTest {
     }
 
     @Test
-    void shouldFailIfNumberIsZero() {
+    void shouldHasZeroActiveElements() {
+      // given
+      when(camundaDataSource.findFlowNodeInstances(any()))
+          .thenReturn(
+              Arrays.asList(newCompletedFlowNodeInstance("A"), newTerminatedFlowNodeInstance("B")));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThat(processInstanceEvent)
+          .hasActiveElement("A", 0)
+          .hasActiveElement("B", 0)
+          .hasActiveElement("C", 0);
+    }
+
+    @Test
+    void shouldFailIfExpectedZero() {
+      // given
+      when(camundaDataSource.findFlowNodeInstances(any()))
+          .thenReturn(Collections.singletonList(newActiveFlowNodeInstance("A")));
+
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // then
       Assertions.assertThatThrownBy(
               () -> CamundaAssert.assertThat(processInstanceEvent).hasActiveElement("A", 0))
-          .isInstanceOf(IllegalArgumentException.class)
-          .hasMessage("The amount must be greater than zero.");
+          .hasMessage(
+              "Process instance [key: %d] should have active element 'A' 0 times but was 1. Element instances:\n"
+                  + "\t- 'A': active",
+              PROCESS_INSTANCE_KEY);
     }
 
     @Test
@@ -771,7 +794,7 @@ public class ElementAssertTest {
       Assertions.assertThatThrownBy(
               () -> CamundaAssert.assertThat(processInstanceEvent).hasActiveElement("A", -1))
           .isInstanceOf(IllegalArgumentException.class)
-          .hasMessage("The amount must be greater than zero.");
+          .hasMessage("The amount must be greater than or equal to zero.");
     }
 
     @Test
@@ -913,15 +936,38 @@ public class ElementAssertTest {
     }
 
     @Test
-    void shouldFailIfNumberIsZero() {
+    void shouldHasZeroCompletedElements() {
+      // given
+      when(camundaDataSource.findFlowNodeInstances(any()))
+          .thenReturn(
+              Arrays.asList(newActiveFlowNodeInstance("A"), newTerminatedFlowNodeInstance("B")));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThat(processInstanceEvent)
+          .hasCompletedElement("A", 0)
+          .hasCompletedElement("B", 0)
+          .hasCompletedElement("C", 0);
+    }
+
+    @Test
+    void shouldFailIfExpectedZero() {
+      // given
+      when(camundaDataSource.findFlowNodeInstances(any()))
+          .thenReturn(Collections.singletonList(newCompletedFlowNodeInstance("A")));
+
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // then
       Assertions.assertThatThrownBy(
               () -> CamundaAssert.assertThat(processInstanceEvent).hasCompletedElement("A", 0))
-          .isInstanceOf(IllegalArgumentException.class)
-          .hasMessage("The amount must be greater than zero.");
+          .hasMessage(
+              "Process instance [key: %d] should have completed element 'A' 0 times but was 1. Element instances:\n"
+                  + "\t- 'A': completed",
+              PROCESS_INSTANCE_KEY);
     }
 
     @Test
@@ -933,7 +979,7 @@ public class ElementAssertTest {
       Assertions.assertThatThrownBy(
               () -> CamundaAssert.assertThat(processInstanceEvent).hasCompletedElement("A", -1))
           .isInstanceOf(IllegalArgumentException.class)
-          .hasMessage("The amount must be greater than zero.");
+          .hasMessage("The amount must be greater than or equal to zero.");
     }
 
     @Test
@@ -1075,15 +1121,38 @@ public class ElementAssertTest {
     }
 
     @Test
-    void shouldFailIfNumberIsZero() {
+    void shouldHasZeroCompletedElements() {
+      // given
+      when(camundaDataSource.findFlowNodeInstances(any()))
+          .thenReturn(
+              Arrays.asList(newActiveFlowNodeInstance("A"), newCompletedFlowNodeInstance("B")));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThat(processInstanceEvent)
+          .hasTerminatedElement("A", 0)
+          .hasTerminatedElement("B", 0)
+          .hasTerminatedElement("C", 0);
+    }
+
+    @Test
+    void shouldFailIfExpectedZero() {
+      // given
+      when(camundaDataSource.findFlowNodeInstances(any()))
+          .thenReturn(Collections.singletonList(newTerminatedFlowNodeInstance("A")));
+
       // when
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // then
       Assertions.assertThatThrownBy(
               () -> CamundaAssert.assertThat(processInstanceEvent).hasTerminatedElement("A", 0))
-          .isInstanceOf(IllegalArgumentException.class)
-          .hasMessage("The amount must be greater than zero.");
+          .hasMessage(
+              "Process instance [key: %d] should have terminated element 'A' 0 times but was 1. Element instances:\n"
+                  + "\t- 'A': terminated",
+              PROCESS_INSTANCE_KEY);
     }
 
     @Test
@@ -1095,7 +1164,7 @@ public class ElementAssertTest {
       Assertions.assertThatThrownBy(
               () -> CamundaAssert.assertThat(processInstanceEvent).hasTerminatedElement("A", -1))
           .isInstanceOf(IllegalArgumentException.class)
-          .hasMessage("The amount must be greater than zero.");
+          .hasMessage("The amount must be greater than or equal to zero.");
     }
 
     @Test

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ElementAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ElementAssertTest.java
@@ -323,8 +323,6 @@ public class ElementAssertTest {
                   + "\t- 'B': completed\n"
                   + "\t- 'C': terminated",
               PROCESS_INSTANCE_KEY);
-
-      verify(camundaDataSource).findFlowNodeInstances(any());
     }
 
     @Test
@@ -461,8 +459,6 @@ public class ElementAssertTest {
               "Process instance [key: %d] should have completed elements ['A', 'B'] but the following elements were not completed:\n"
                   + "\t- 'B': terminated",
               PROCESS_INSTANCE_KEY);
-
-      verify(camundaDataSource).findFlowNodeInstances(any());
     }
 
     @Test
@@ -599,8 +595,6 @@ public class ElementAssertTest {
               "Process instance [key: %d] should have terminated elements ['A', 'B'] but the following elements were not terminated:\n"
                   + "\t- 'A': completed",
               PROCESS_INSTANCE_KEY);
-
-      verify(camundaDataSource).findFlowNodeInstances(any());
     }
 
     @Test


### PR DESCRIPTION
## Description

Refactoring of the element assertion to reduce the duplicated code in the different assertions and for generating the failure message.

## Related issues

Alternative proposal: https://github.com/camunda/camunda/pull/29976#discussion_r2009910875

