### PR TITLE
fix: rename state to status for batch operation in search domain #29713

### DIFF
--- a/search/search-domain/src/main/java/io/camunda/search/filter/BatchOperationFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/BatchOperationFilter.java
@@ -16,14 +16,14 @@ import java.util.List;
 import java.util.Objects;
 
 public record BatchOperationFilter(
-    List<Long> batchOperationKeys, List<String> operationTypes, List<String> states)
+    List<Long> batchOperationKeys, List<String> operationTypes, List<String> status)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<BatchOperationFilter> {
 
     private List<Long> batchOperationKeys;
     private List<String> operationTypes;
-    private List<String> states;
+    private List<String> status;
 
     public Builder batchOperationKeys(final Long value, final Long... values) {
       return batchOperationKeys(collectValues(value, values));
@@ -48,7 +48,7 @@ public record BatchOperationFilter(
     }
 
     public Builder status(final List<String> values) {
-      states = addValuesToList(states, values);
+      status = addValuesToList(status, values);
       return this;
     }
 
@@ -57,7 +57,7 @@ public record BatchOperationFilter(
       return new BatchOperationFilter(
           Objects.requireNonNullElse(batchOperationKeys, Collections.emptyList()),
           Objects.requireNonNullElse(operationTypes, Collections.emptyList()),
-          Objects.requireNonNullElse(states, Collections.emptyList()));
+          Objects.requireNonNullElse(status, Collections.emptyList()));
     }
   }
 }


### PR DESCRIPTION
## Description

Rename state to status for batch operation in search domain filter. Should already be done, the getter and setter are already correct, just the field name was forgotten. (And this one is used in rdbms in mybatis)
