### PR TITLE
feat: check organization access 

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -88,6 +88,10 @@
       <artifactId>jsr305</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaOidcUser.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaOidcUser.java
@@ -20,13 +20,16 @@ public class CamundaOidcUser implements OidcUser, CamundaPrincipal, Serializable
   private final OidcUser user;
   private final AuthenticationContext authentication;
   private final Set<Long> mappingKeys;
+  private final Set<String> organizationIds;
 
   public CamundaOidcUser(
       final OidcUser oidcUser,
       final Set<Long> mappingKeys,
+      final Set<String> organizationIds,
       final AuthenticationContext authentication) {
     user = oidcUser;
     this.mappingKeys = mappingKeys;
+    this.organizationIds = organizationIds;
     this.authentication = authentication;
   }
 
@@ -38,6 +41,11 @@ public class CamundaOidcUser implements OidcUser, CamundaPrincipal, Serializable
   @Override
   public String getDisplayName() {
     return user.getPreferredUsername();
+  }
+
+  @Override
+  public Set<String> getOrganizationIds() {
+    return organizationIds;
   }
 
   @Override

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaPrincipal.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaPrincipal.java
@@ -7,10 +7,14 @@
  */
 package io.camunda.authentication.entity;
 
+import java.util.Set;
+
 public interface CamundaPrincipal {
   String getEmail();
 
   String getDisplayName();
+
+  Set<String> getOrganizationIds();
 
   AuthenticationContext getAuthenticationContext();
 }

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
@@ -24,6 +25,7 @@ public final class CamundaUser extends User implements CamundaPrincipal {
   private final String displayName;
   private final String salesPlanType;
   private final Map<ClusterMetadata.AppName, String> c8Links;
+  private final Set<String> organizationIds;
   private final boolean canLogout;
   private final String email;
   private final AuthenticationContext authentication;
@@ -38,6 +40,7 @@ public final class CamundaUser extends User implements CamundaPrincipal {
       final AuthenticationContext authentication,
       final String salesPlanType,
       final Map<ClusterMetadata.AppName, String> c8Links,
+      final Set<String> organizationIds,
       final boolean canLogout) {
     super(username, password, authorities);
     this.userKey = userKey;
@@ -45,6 +48,7 @@ public final class CamundaUser extends User implements CamundaPrincipal {
     this.salesPlanType = salesPlanType;
     this.authentication = authentication;
     this.c8Links = Objects.requireNonNullElse(c8Links, Collections.emptyMap());
+    this.organizationIds = organizationIds;
     this.canLogout = canLogout;
     this.email = email;
   }
@@ -89,6 +93,11 @@ public final class CamundaUser extends User implements CamundaPrincipal {
   }
 
   @Override
+  public Set<String> getOrganizationIds() {
+    return organizationIds;
+  }
+
+  @Override
   public AuthenticationContext getAuthenticationContext() {
     return authentication;
   }
@@ -106,6 +115,7 @@ public final class CamundaUser extends User implements CamundaPrincipal {
     private List<String> groups = List.of();
     private String salesPlanType;
     private Map<ClusterMetadata.AppName, String> c8Links = Map.of();
+    private Set<String> organizationIds;
     private boolean canLogout;
 
     private CamundaUserBuilder() {}
@@ -175,6 +185,11 @@ public final class CamundaUser extends User implements CamundaPrincipal {
       return this;
     }
 
+    public CamundaUserBuilder withOrganizationIds(final Set<String> organizationIds) {
+      this.organizationIds = organizationIds;
+      return this;
+    }
+
     public CamundaUserBuilder withCanLogout(final boolean canLogout) {
       this.canLogout = canLogout;
       return this;
@@ -191,6 +206,7 @@ public final class CamundaUser extends User implements CamundaPrincipal {
           new AuthenticationContext(roles, authorizedApplications, tenants, groups),
           salesPlanType,
           c8Links,
+          organizationIds,
           canLogout);
     }
   }

--- a/authentication/src/main/java/io/camunda/authentication/filters/OrganizationAccessCheckFilter.java
+++ b/authentication/src/main/java/io/camunda/authentication/filters/OrganizationAccessCheckFilter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.filters;
+
+import io.camunda.authentication.entity.CamundaPrincipal;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class OrganizationAccessCheckFilter extends OncePerRequestFilter {
+  private static final Logger LOG = LoggerFactory.getLogger(OrganizationAccessCheckFilter.class);
+
+  private final String requiredOrganizationId;
+
+  public OrganizationAccessCheckFilter(final String requiredOrganizationId) {
+    this.requiredOrganizationId = requiredOrganizationId;
+  }
+
+  @Override
+  protected void doFilterInternal(
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final FilterChain filterChain)
+      throws ServletException, IOException {
+    final var principal = request.getUserPrincipal();
+    if (principal == null) {
+      filterChain.doFilter(request, response);
+      return;
+    }
+
+    final CamundaPrincipal camundaPrincipal = findCurrentCamundaPrincipal();
+    if (camundaPrincipal == null) {
+      LOG.info("cannot verify required organization id: no camunda principal");
+    } else if (camundaPrincipal.getOrganizationIds() == null) {
+      filterChain.doFilter(request, response);
+      return;
+    } else if (!camundaPrincipal.getOrganizationIds().contains(requiredOrganizationId)) {
+      LOG.info("principal doesn't belong to required organization '{}'", requiredOrganizationId);
+    } else {
+      filterChain.doFilter(request, response);
+      return;
+    }
+    response.setStatus(HttpStatus.UNAUTHORIZED.value());
+  }
+
+  private CamundaPrincipal findCurrentCamundaPrincipal() {
+    final Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    if (auth != null
+        && auth.isAuthenticated()
+        && auth.getPrincipal() instanceof final CamundaPrincipal principal) {
+      return principal;
+    }
+    return null;
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/filters/OrganizationAccessCheckFilterTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/filters/OrganizationAccessCheckFilterTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.filters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.authentication.entity.CamundaUser;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.security.Principal;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+public class OrganizationAccessCheckFilterTest {
+  private FilterChain filterChain;
+  private HttpServletRequest request;
+  private MockHttpServletResponse response;
+  private Authentication authentication;
+  private Principal principal;
+
+  @BeforeEach
+  public void setUp() {
+    request = mock(HttpServletRequest.class);
+    when(request.getMethod()).thenReturn("GET");
+    response = new MockHttpServletResponse();
+    authentication = mock(Authentication.class);
+    principal = mock(Principal.class);
+    filterChain =
+        new MockFilterChain(
+            new HttpServlet() {
+              @Override
+              public void doGet(final HttpServletRequest req, final HttpServletResponse resp) {
+                resp.setStatus(HttpStatus.OK.value());
+              }
+            });
+    RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+    final SecurityContext securityContext = mock(SecurityContext.class);
+    when(securityContext.getAuthentication()).thenReturn(authentication);
+    SecurityContextHolder.setContext(securityContext);
+  }
+
+  @Test
+  @DisplayName("should pass through if no principal is set")
+  public void shouldPassThroughIfNoPrincipleSet() throws ServletException, IOException {
+    // given
+    final Filter filter = new OrganizationAccessCheckFilter("not-checked");
+
+    // when
+    filter.doFilter(request, response, filterChain);
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+  }
+
+  @Test
+  @DisplayName("should return unauthorized if principal is not a CamundaPrincipal")
+  public void shouldPassThroughIfPrincipalIsNotCamundaPrincipal()
+      throws ServletException, IOException {
+    // given
+    final Filter filter = new OrganizationAccessCheckFilter("not-checked");
+
+    // when
+    when(request.getUserPrincipal()).thenReturn(principal);
+    filter.doFilter(request, response, filterChain);
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+  }
+
+  @Test
+  @DisplayName("should pass through if principal has no organization ids")
+  public void shouldPassThroughIfPrincipalHasNoOrganizationIds()
+      throws ServletException, IOException {
+    // given
+    final var camundaUser =
+        CamundaUser.CamundaUserBuilder.aCamundaUser()
+            .withUsername("scooby-doo@mystery.inc")
+            .withPassword("scooby-doo")
+            .withName("Scooby Doo")
+            .withOrganizationIds(null)
+            .build();
+    final Filter filter = new OrganizationAccessCheckFilter("not-checked");
+
+    // when
+    when(request.getUserPrincipal()).thenReturn(principal);
+    when(authentication.isAuthenticated()).thenReturn(true);
+    when(authentication.getPrincipal()).thenReturn(camundaUser);
+    filter.doFilter(request, response, filterChain);
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+  }
+
+  @Test
+  @DisplayName("should reject if principal does not have a matching organization id")
+  public void shouldRejectIfPrincipalDoesNotHaveMatchingOrganizationId()
+      throws ServletException, IOException {
+    // given
+    final var camundaUser =
+        CamundaUser.CamundaUserBuilder.aCamundaUser()
+            .withUsername("imposter@mystery.inc")
+            .withPassword("imposter")
+            .withName("Imposter")
+            .withOrganizationIds(Set.of("imposter-org", "fake-org"))
+            .build();
+    final Filter filter = new OrganizationAccessCheckFilter("mystery-inc");
+
+    // when
+    when(request.getUserPrincipal()).thenReturn(principal);
+    when(authentication.isAuthenticated()).thenReturn(true);
+    when(authentication.getPrincipal()).thenReturn(camundaUser);
+    filter.doFilter(request, response, filterChain);
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+  }
+
+  @Test
+  @DisplayName("should pass through if principal has the required organization id")
+  public void shouldPassThroughIfPrincipalHasRequiredOrganizationId()
+      throws ServletException, IOException {
+    // given
+    final var camundaUser =
+        CamundaUser.CamundaUserBuilder.aCamundaUser()
+            .withUsername("scooby-doo@mystery.inc")
+            .withPassword("scooby-doo")
+            .withName("Scooby Doo")
+            .withOrganizationIds(Set.of("mystery-inc", "mystery-org"))
+            .build();
+    final Filter filter = new OrganizationAccessCheckFilter("mystery-inc");
+
+    // when
+    when(request.getUserPrincipal()).thenReturn(principal);
+    when(authentication.isAuthenticated()).thenReturn(true);
+    when(authentication.getPrincipal()).thenReturn(camundaUser);
+    filter.doFilter(request, response, filterChain);
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/configuration/AuthenticationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/AuthenticationConfiguration.java
@@ -17,6 +17,7 @@ public class AuthenticationConfiguration {
   private OidcAuthenticationConfiguration oidcAuthenticationConfiguration =
       new OidcAuthenticationConfiguration();
   private boolean unprotectedApi = DEFAULT_UNPROTECTED_API;
+  private String organizationId;
 
   public boolean getUnprotectedApi() {
     return unprotectedApi;
@@ -40,5 +41,13 @@ public class AuthenticationConfiguration {
 
   public void setOidc(final OidcAuthenticationConfiguration configuration) {
     oidcAuthenticationConfiguration = configuration;
+  }
+
+  public String getOrganizationId() {
+    return organizationId;
+  }
+
+  public void setOrganizationId(final String organizationId) {
+    this.organizationId = organizationId;
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Initially I went with an approach of using a JWT claim validator however I didn't feel it met the requirements in the end (during tests, and it could be current implementations but it would only trigger on bearer token requests and not the standard auth flows).

Given this I opted to use an approach that we have used in the past (spring security filters) to apply only when an organization is set.

To-do:
- Check that we can return a 401 here or if we need to provide a specific exception or error. Currently the code will just return a 401 that causes the browser to render the white error page.

## Related issues

Resolves the organisation access check part of https://github.com/camunda/camunda/issues/29425
