### PR TITLE
Feat: batch operaton extend rdbms exporter db services part

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
@@ -8,6 +8,7 @@
 package io.camunda.db.rdbms;
 
 import io.camunda.db.rdbms.read.service.AuthorizationReader;
+import io.camunda.db.rdbms.read.service.BatchOperationReader;
 import io.camunda.db.rdbms.read.service.DecisionDefinitionReader;
 import io.camunda.db.rdbms.read.service.DecisionInstanceReader;
 import io.camunda.db.rdbms.read.service.DecisionRequirementsReader;
@@ -47,6 +48,7 @@ public class RdbmsService {
   private final UserTaskReader userTaskReader;
   private final FormReader formReader;
   private final MappingReader mappingReader;
+  private final BatchOperationReader batchOperationReader;
 
   public RdbmsService(
       final RdbmsWriterFactory rdbmsWriterFactory,
@@ -65,7 +67,8 @@ public class RdbmsService {
       final UserReader userReader,
       final UserTaskReader userTaskReader,
       final FormReader formReader,
-      final MappingReader mappingReader) {
+      final MappingReader mappingReader,
+      final BatchOperationReader batchOperationReader) {
     this.rdbmsWriterFactory = rdbmsWriterFactory;
     this.authorizationReader = authorizationReader;
     this.decisionRequirementsReader = decisionRequirementsReader;
@@ -83,6 +86,7 @@ public class RdbmsService {
     this.userTaskReader = userTaskReader;
     this.formReader = formReader;
     this.mappingReader = mappingReader;
+    this.batchOperationReader = batchOperationReader;
   }
 
   public AuthorizationReader getAuthorizationReader() {
@@ -147,6 +151,10 @@ public class RdbmsService {
 
   public MappingReader getMappingReader() {
     return mappingReader;
+  }
+
+  public BatchOperationReader getBatchOperationReader() {
+    return batchOperationReader;
   }
 
   public RdbmsWriter createWriter(final long partitionId) { // todo fix in all itests afterwards?

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/BatchOperationEntityMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/mapper/BatchOperationEntityMapper.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.mapper;
+
+import io.camunda.db.rdbms.write.domain.BatchOperationDbModel;
+import io.camunda.search.entities.BatchOperationEntity;
+
+public class BatchOperationEntityMapper {
+
+  public static BatchOperationEntity toEntity(final BatchOperationDbModel dbModel) {
+    return new BatchOperationEntity(
+        dbModel.batchOperationKey(),
+        dbModel.status(),
+        dbModel.operationType(),
+        dbModel.startDate(),
+        dbModel.endDate(),
+        dbModel.operationsTotalCount(),
+        dbModel.operationsFailedCount(),
+        dbModel.operationsCompletedCount());
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationReader.java
@@ -16,6 +16,7 @@ import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
 import io.camunda.search.query.BatchOperationQuery;
 import io.camunda.search.query.SearchQueryResult;
 import java.util.List;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +38,12 @@ public class BatchOperationReader extends AbstractEntityReader<BatchOperationEnt
             .build();
 
     return batchOperationMapper.count(query) == 1;
+  }
+
+  public Optional<BatchOperationEntity> findOne(final long batchOperationKey) {
+    final var result =
+        search(BatchOperationQuery.of(b -> b.filter(f -> f.batchOperationKeys(batchOperationKey))));
+    return Optional.ofNullable(result.items()).flatMap(it -> it.stream().findFirst());
   }
 
   public SearchQueryResult<BatchOperationEntity> search(final BatchOperationQuery query) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/BatchOperationReader.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import io.camunda.db.rdbms.read.domain.BatchOperationDbQuery;
+import io.camunda.db.rdbms.read.mapper.BatchOperationEntityMapper;
+import io.camunda.db.rdbms.sql.BatchOperationMapper;
+import io.camunda.db.rdbms.sql.columns.BatchOperationSearchColumn;
+import io.camunda.search.entities.BatchOperationEntity;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
+import io.camunda.search.query.BatchOperationQuery;
+import io.camunda.search.query.SearchQueryResult;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BatchOperationReader extends AbstractEntityReader<BatchOperationEntity> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BatchOperationReader.class);
+
+  private final BatchOperationMapper batchOperationMapper;
+
+  public BatchOperationReader(final BatchOperationMapper batchOperationMapper) {
+    super(BatchOperationSearchColumn::findByProperty);
+    this.batchOperationMapper = batchOperationMapper;
+  }
+
+  public boolean exists(final Long batchOperationKey) {
+    final var query =
+        new BatchOperationDbQuery.Builder()
+            .filter(b -> b.batchOperationKeys(batchOperationKey))
+            .build();
+
+    return batchOperationMapper.count(query) == 1;
+  }
+
+  public SearchQueryResult<BatchOperationEntity> search(final BatchOperationQuery query) {
+    final var dbSort = convertSort(query.sort(), BatchOperationSearchColumn.BATCH_OPERATION_KEY);
+    final var dbQuery =
+        BatchOperationDbQuery.of(
+            b -> b.filter(query.filter()).sort(dbSort).page(convertPaging(dbSort, query.page())));
+
+    LOG.trace("[RDBMS DB] Search for batch operations with filter {}", dbQuery);
+    final var totalHits = batchOperationMapper.count(dbQuery);
+    final var hits =
+        batchOperationMapper.search(dbQuery).stream()
+            .map(BatchOperationEntityMapper::toEntity)
+            .toList();
+    return buildSearchQueryResult(totalHits, hits, dbSort);
+  }
+
+  public List<BatchOperationItemEntity> getItems(final Long batchOperationKey) {
+
+    return batchOperationMapper.getItems(batchOperationKey).stream().toList();
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/BatchOperationSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/BatchOperationSearchColumn.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.columns;
+
+import io.camunda.search.entities.BatchOperationEntity;
+import java.util.function.Function;
+
+public enum BatchOperationSearchColumn implements SearchColumn<BatchOperationEntity> {
+  BATCH_OPERATION_KEY("batchOperationKey", BatchOperationEntity::batchOperationKey);
+
+  private final String property;
+  private final Function<BatchOperationEntity, Object> propertyReader;
+  private final Function<Object, Object> sortOptionConverter;
+
+  BatchOperationSearchColumn(
+      final String property, final Function<BatchOperationEntity, Object> propertyReader) {
+    this(property, propertyReader, Function.identity());
+  }
+
+  BatchOperationSearchColumn(
+      final String property,
+      final Function<BatchOperationEntity, Object> propertyReader,
+      final Function<Object, Object> sortOptionConverter) {
+    this.property = property;
+    this.propertyReader = propertyReader;
+    this.sortOptionConverter = sortOptionConverter;
+  }
+
+  @Override
+  public Object getPropertyValue(final BatchOperationEntity entity) {
+    return propertyReader.apply(entity);
+  }
+
+  @Override
+  public Object convertSortOption(final Object object) {
+    if (object == null) {
+      return null;
+    }
+
+    return sortOptionConverter.apply(object);
+  }
+
+  public static BatchOperationSearchColumn findByProperty(final String property) {
+    for (final BatchOperationSearchColumn column : BatchOperationSearchColumn.values()) {
+      if (column.property.equals(property)) {
+        return column;
+      }
+    }
+
+    return null;
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
@@ -8,6 +8,7 @@
 package io.camunda.db.rdbms.write;
 
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import io.camunda.db.rdbms.read.service.BatchOperationReader;
 import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
 import io.camunda.db.rdbms.sql.IncidentMapper;
@@ -17,6 +18,7 @@ import io.camunda.db.rdbms.sql.UserTaskMapper;
 import io.camunda.db.rdbms.sql.VariableMapper;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.service.AuthorizationWriter;
+import io.camunda.db.rdbms.write.service.BatchOperationWriter;
 import io.camunda.db.rdbms.write.service.DecisionDefinitionWriter;
 import io.camunda.db.rdbms.write.service.DecisionInstanceWriter;
 import io.camunda.db.rdbms.write.service.DecisionRequirementsWriter;
@@ -57,6 +59,7 @@ public class RdbmsWriter {
   private final UserTaskWriter userTaskWriter;
   private final FormWriter formWriter;
   private final MappingWriter mappingWriter;
+  private final BatchOperationWriter batchOperationWriter;
 
   private final HistoryCleanupService historyCleanupService;
 
@@ -72,7 +75,8 @@ public class RdbmsWriter {
       final PurgeMapper purgeMapper,
       final UserTaskMapper userTaskMapper,
       final VariableMapper variableMapper,
-      final VendorDatabaseProperties vendorDatabaseProperties) {
+      final VendorDatabaseProperties vendorDatabaseProperties,
+      final BatchOperationReader batchOperationReader) {
     this.executionQueue = executionQueue;
     this.exporterPositionService = exporterPositionService;
     rdbmsPurger = new RdbmsPurger(purgeMapper, vendorDatabaseProperties);
@@ -92,6 +96,7 @@ public class RdbmsWriter {
     userTaskWriter = new UserTaskWriter(executionQueue, userTaskMapper);
     formWriter = new FormWriter(executionQueue);
     mappingWriter = new MappingWriter(executionQueue);
+    batchOperationWriter = new BatchOperationWriter(batchOperationReader, executionQueue);
 
     historyCleanupService =
         new HistoryCleanupService(
@@ -167,6 +172,10 @@ public class RdbmsWriter {
 
   public MappingWriter getMappingWriter() {
     return mappingWriter;
+  }
+
+  public BatchOperationWriter getBatchOperationWriter() {
+    return batchOperationWriter;
   }
 
   public ExporterPositionService getExporterPositionService() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
@@ -8,6 +8,7 @@
 package io.camunda.db.rdbms.write;
 
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
+import io.camunda.db.rdbms.read.service.BatchOperationReader;
 import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
 import io.camunda.db.rdbms.sql.ExporterPositionMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
@@ -33,6 +34,7 @@ public class RdbmsWriterFactory {
   private final UserTaskMapper userTaskMapper;
   private final VariableMapper variableMapper;
   private final RdbmsWriterMetrics metrics;
+  private final BatchOperationReader batchOperationReader;
 
   public RdbmsWriterFactory(
       final SqlSessionFactory sqlSessionFactory,
@@ -45,7 +47,8 @@ public class RdbmsWriterFactory {
       final PurgeMapper purgeMapper,
       final UserTaskMapper userTaskMapper,
       final VariableMapper variableMapper,
-      final RdbmsWriterMetrics metrics) {
+      final RdbmsWriterMetrics metrics,
+      final BatchOperationReader batchOperationReader) {
     this.sqlSessionFactory = sqlSessionFactory;
     this.exporterPositionMapper = exporterPositionMapper;
     this.vendorDatabaseProperties = vendorDatabaseProperties;
@@ -57,6 +60,7 @@ public class RdbmsWriterFactory {
     this.userTaskMapper = userTaskMapper;
     this.variableMapper = variableMapper;
     this.metrics = metrics;
+    this.batchOperationReader = batchOperationReader;
   }
 
   public RdbmsWriter createWriter(final RdbmsWriterConfig config) {
@@ -75,6 +79,7 @@ public class RdbmsWriterFactory {
         purgeMapper,
         userTaskMapper,
         variableMapper,
-        vendorDatabaseProperties);
+        vendorDatabaseProperties,
+        batchOperationReader);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
@@ -23,7 +23,8 @@ public enum ContextType {
   USER(false),
   USER_TASK(true),
   FORM(false),
-  MAPPING(false);
+  MAPPING(false),
+  BATCH_OPERATION(false);
 
   private final boolean preserveOrder;
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.service;
+
+import io.camunda.db.rdbms.read.service.BatchOperationReader;
+import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationItemDto;
+import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationItemStatusUpdateDto;
+import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationItemsDto;
+import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationUpdateDto;
+import io.camunda.db.rdbms.sql.BatchOperationMapper.BatchOperationUpdateTotalCountDto;
+import io.camunda.db.rdbms.write.domain.BatchOperationDbModel;
+import io.camunda.db.rdbms.write.queue.ContextType;
+import io.camunda.db.rdbms.write.queue.ExecutionQueue;
+import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.WriteStatementType;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemStatus;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationStatus;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BatchOperationWriter {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(BatchOperationWriter.class);
+
+  private final ExecutionQueue executionQueue;
+
+  private final BatchOperationReader reader;
+
+  public BatchOperationWriter(
+      final BatchOperationReader reader, final ExecutionQueue executionQueue) {
+    this.reader = reader;
+    this.executionQueue = executionQueue;
+  }
+
+  public void createIfNotAlreadyExists(final BatchOperationDbModel batchOperation) {
+    if (reader.exists(batchOperation.batchOperationKey())) {
+      LOGGER.trace("Batch operation already exists: {}", batchOperation);
+      return;
+    }
+
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.BATCH_OPERATION,
+            WriteStatementType.INSERT,
+            batchOperation.batchOperationKey(),
+            "io.camunda.db.rdbms.sql.BatchOperationMapper.insert",
+            batchOperation));
+    LOGGER.trace("Force flush to directly create batch operation: {}", batchOperation);
+    executionQueue.flush();
+  }
+
+  public void updateBatchAndInsertItems(final long batchOperationKey, final List<Long> items) {
+    if (items != null && !items.isEmpty()) {
+      executionQueue.executeInQueue(
+          new QueueItem(
+              ContextType.BATCH_OPERATION,
+              WriteStatementType.UPDATE,
+              batchOperationKey,
+              "io.camunda.db.rdbms.sql.BatchOperationMapper.incrementOperationsTotalCount",
+              new BatchOperationUpdateTotalCountDto(batchOperationKey, items.size())));
+      insertItems(new BatchOperationItemsDto(batchOperationKey, items));
+    }
+  }
+
+  public void updateItem(
+      final long batchOperationKey, final long itemKey, final BatchOperationItemStatus state) {
+
+    // TODO merging this into one statement would be more efficient
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.BATCH_OPERATION,
+            WriteStatementType.UPDATE,
+            batchOperationKey,
+            "io.camunda.db.rdbms.sql.BatchOperationMapper.updateItem",
+            new BatchOperationItemDto(batchOperationKey, itemKey, state)));
+
+    if (state == BatchOperationItemStatus.FAILED) {
+      executionQueue.executeInQueue(
+          new QueueItem(
+              ContextType.BATCH_OPERATION,
+              WriteStatementType.UPDATE,
+              batchOperationKey,
+              "io.camunda.db.rdbms.sql.BatchOperationMapper.incrementFailedOperationsCount",
+              batchOperationKey));
+    } else if (state == BatchOperationItemStatus.COMPLETED) {
+      executionQueue.executeInQueue(
+          new QueueItem(
+              ContextType.BATCH_OPERATION,
+              WriteStatementType.UPDATE,
+              batchOperationKey,
+              "io.camunda.db.rdbms.sql.BatchOperationMapper.incrementCompletedOperationsCount",
+              batchOperationKey));
+    }
+  }
+
+  public void finish(final long batchOperationKey, final OffsetDateTime endDate) {
+    updateCompleted(
+        batchOperationKey,
+        new BatchOperationUpdateDto(batchOperationKey, BatchOperationStatus.COMPLETED, endDate));
+  }
+
+  public void cancel(final long batchOperationKey, final OffsetDateTime endDate) {
+    updateCompleted(
+        batchOperationKey,
+        new BatchOperationUpdateDto(batchOperationKey, BatchOperationStatus.CANCELED, endDate));
+  }
+
+  public void paused(final long batchOperationKey) {
+    updateCompleted(
+        batchOperationKey,
+        new BatchOperationUpdateDto(batchOperationKey, BatchOperationStatus.PAUSED, null));
+  }
+
+  public void resumed(final long batchOperationKey) {
+    updateCompleted(
+        batchOperationKey,
+        new BatchOperationUpdateDto(batchOperationKey, BatchOperationStatus.ACTIVE, null));
+  }
+
+  private void updateCompleted(final long batchOperationKey, final BatchOperationUpdateDto dto) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.BATCH_OPERATION,
+            WriteStatementType.UPDATE,
+            batchOperationKey,
+            "io.camunda.db.rdbms.sql.BatchOperationMapper.updateCompleted",
+            dto));
+  }
+
+  private void updateItemsWithStatus(
+      final long batchOperationKey,
+      final BatchOperationItemStatus oldState,
+      final BatchOperationItemStatus newState) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.BATCH_OPERATION,
+            WriteStatementType.UPDATE,
+            batchOperationKey,
+            "io.camunda.db.rdbms.sql.BatchOperationMapper.updateItemsWithState",
+            new BatchOperationItemStatusUpdateDto(batchOperationKey, oldState, newState)));
+  }
+
+  private void insertItems(final BatchOperationItemsDto items) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.BATCH_OPERATION,
+            WriteStatementType.INSERT,
+            items.batchOperationKey(),
+            "io.camunda.db.rdbms.sql.BatchOperationMapper.insertItems",
+            items));
+  }
+}

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -10,6 +10,7 @@ package io.camunda.application.commons.rdbms;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.config.VendorDatabaseProperties;
 import io.camunda.db.rdbms.read.service.AuthorizationReader;
+import io.camunda.db.rdbms.read.service.BatchOperationReader;
 import io.camunda.db.rdbms.read.service.DecisionDefinitionReader;
 import io.camunda.db.rdbms.read.service.DecisionInstanceReader;
 import io.camunda.db.rdbms.read.service.DecisionRequirementsReader;
@@ -26,6 +27,7 @@ import io.camunda.db.rdbms.read.service.UserReader;
 import io.camunda.db.rdbms.read.service.UserTaskReader;
 import io.camunda.db.rdbms.read.service.VariableReader;
 import io.camunda.db.rdbms.sql.AuthorizationMapper;
+import io.camunda.db.rdbms.sql.BatchOperationMapper;
 import io.camunda.db.rdbms.sql.DecisionDefinitionMapper;
 import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
 import io.camunda.db.rdbms.sql.DecisionRequirementsMapper;
@@ -148,6 +150,12 @@ public class RdbmsConfiguration {
   }
 
   @Bean
+  public BatchOperationReader batchOperationReader(
+      final BatchOperationMapper batchOperationMapper) {
+    return new BatchOperationReader(batchOperationMapper);
+  }
+
+  @Bean
   public RdbmsWriterMetrics rdbmsExporterMetrics(final MeterRegistry meterRegistry) {
     return new RdbmsWriterMetrics(meterRegistry);
   }
@@ -164,7 +172,8 @@ public class RdbmsConfiguration {
       final PurgeMapper purgeMapper,
       final UserTaskMapper userTaskMapper,
       final VariableMapper variableMapper,
-      final RdbmsWriterMetrics metrics) {
+      final RdbmsWriterMetrics metrics,
+      final BatchOperationReader batchOperationReader) {
     return new RdbmsWriterFactory(
         sqlSessionFactory,
         exporterPositionMapper,
@@ -176,7 +185,8 @@ public class RdbmsConfiguration {
         purgeMapper,
         userTaskMapper,
         variableMapper,
-        metrics);
+        metrics,
+        batchOperationReader);
   }
 
   @Bean
@@ -197,7 +207,8 @@ public class RdbmsConfiguration {
       final UserReader userReader,
       final UserTaskReader userTaskReader,
       final FormReader formReader,
-      final MappingReader mappingReader) {
+      final MappingReader mappingReader,
+      final BatchOperationReader batchOperationReader) {
     return new RdbmsService(
         rdbmsWriterFactory,
         authorizationReader,
@@ -215,6 +226,7 @@ public class RdbmsConfiguration {
         userReader,
         userTaskReader,
         formReader,
-        mappingReader);
+        mappingReader,
+        batchOperationReader);
   }
 }

--- a/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
+++ b/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
@@ -283,9 +283,7 @@ public class RdbmsSearchClient implements SearchClientsProxy {
       final BatchOperationQuery query) {
     LOG.debug("[RDBMS Search Client] Search for batch operations: {}", query);
 
-    // return rdbmsService.getBatchOperationReader().search(query);
-    throw new UnsupportedOperationException(
-        "BatchOperationSearchClient searchBatchOperations not implemented yet.");
+    return rdbmsService.getBatchOperationReader().search(query);
   }
 
   @Override
@@ -294,8 +292,6 @@ public class RdbmsSearchClient implements SearchClientsProxy {
         "[RDBMS Search Client] Search for batch operation items by batchOperationKey: {}",
         batchOperationKey);
 
-    // return rdbmsService.getBatchOperationReader().getItems(batchOperationKey);
-    throw new UnsupportedOperationException(
-        "BatchOperationSearchClient getBatchOperationItems not implemented yet.");
+    return rdbmsService.getBatchOperationReader().getItems(batchOperationKey);
   }
 }


### PR DESCRIPTION
## Description

This is the follow up for [Feat/29701 batch operaton extend rdbms exporter db part](https://github.com/camunda/camunda/pull/30052) to the the service classes for the batch operation feature to rdbms. 
It additionally extends the RdbmsSeachClient to be able to search via Rest for batch operations. 

Additional PRs for services and the export handlers will follow. 

NOTE: [Feat/29701 batch operaton extend rdbms exporter db part](https://github.com/camunda/camunda/pull/30052) has to be merged before!

## Related issues

#29701 
