### PR TITLE
fix: fix tenant selection on processes tab

### DIFF
--- a/tasklist/client/src/v1/Processes/index.tsx
+++ b/tasklist/client/src/v1/Processes/index.tsx
@@ -43,6 +43,7 @@ import {useIsMultitenancyEnabled} from 'common/multitenancy/useIsMultitenancyEna
 import {MultitenancyDropdown} from 'common/multitenancy/MultitenancyDropdown';
 import styles from './styles.module.scss';
 import cn from 'classnames';
+import {getClientConfig} from 'common/config/getClientConfig';
 
 type UseProcessesFilterParams = Omit<
   Parameters<typeof useProcesses>[0],
@@ -210,7 +211,11 @@ const Processes: React.FC = observer(() => {
   }, [match, data, isLoading, navigate, location, t]);
 
   useEffect(() => {
-    if (searchParams.get('tenantId') === null && initialTenantId !== null) {
+    if (
+      searchParams.get('tenantId') === null &&
+      initialTenantId !== null &&
+      getClientConfig().isMultiTenancyEnabled
+    ) {
       searchParams.set('tenantId', initialTenantId);
       setSearchParams(searchParams, {replace: true});
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Recently we changed the user implementation on Identity which made the default tenant always being returned even with multi-tenancy enabled. This broke the tenant selection on the processes tab in Tasklist.

This prevents the tenant ID from being added to the query string if multi-tenancy is disabled.
