### PR TITLE
feat: add rdbms IT Tests for batch operations #29701

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationDbModel.java
@@ -17,9 +17,9 @@ public record BatchOperationDbModel(
     String operationType,
     OffsetDateTime startDate,
     OffsetDateTime endDate,
-    int operationsTotalCount,
-    int operationsFailedCount,
-    int operationsCompletedCount) {
+    Integer operationsTotalCount,
+    Integer operationsFailedCount,
+    Integer operationsCompletedCount) {
 
   // Builder class
   public static class Builder implements ObjectBuilder<BatchOperationDbModel> {
@@ -29,9 +29,9 @@ public record BatchOperationDbModel(
     private String operationType;
     private OffsetDateTime startDate;
     private OffsetDateTime endDate;
-    private int operationsTotalCount;
-    private int operationsFailedCount;
-    private int operationsCompletedCount;
+    private Integer operationsTotalCount;
+    private Integer operationsFailedCount;
+    private Integer operationsCompletedCount;
 
     public Builder() {}
 
@@ -60,17 +60,17 @@ public record BatchOperationDbModel(
       return this;
     }
 
-    public Builder operationsTotalCount(final int operationsTotalCount) {
+    public Builder operationsTotalCount(final Integer operationsTotalCount) {
       this.operationsTotalCount = operationsTotalCount;
       return this;
     }
 
-    public Builder operationsFailedCount(final int operationsFailedCount) {
+    public Builder operationsFailedCount(final Integer operationsFailedCount) {
       this.operationsFailedCount = operationsFailedCount;
       return this;
     }
 
-    public Builder operationsCompletedCount(final int operationsCompletedCount) {
+    public Builder operationsCompletedCount(final Integer operationsCompletedCount) {
       this.operationsCompletedCount = operationsCompletedCount;
       return this;
     }

--- a/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/BatchOperationMapper.xml
@@ -9,15 +9,15 @@
     type="io.camunda.db.rdbms.write.domain.BatchOperationDbModel">
     <constructor>
       <idArg column="BATCH_OPERATION_KEY" javaType="java.lang.Long"/>
+      <arg column="STATUS"
+        javaType="io.camunda.search.entities.BatchOperationEntity$BatchOperationStatus"/>
+      <arg column="OPERATION_TYPE" javaType="java.lang.String"/>
+      <arg column="START_DATE" javaType="java.time.OffsetDateTime"/>
+      <arg column="END_DATE" javaType="java.time.OffsetDateTime"/>
+      <arg column="OPERATIONS_TOTAL_COUNT" javaType="int"/>
+      <arg column="OPERATIONS_FAILED_COUNT" javaType="int"/>
+      <arg column="OPERATIONS_COMPLETED_COUNT" javaType="int"/>
     </constructor>
-    <result column="STATUS" property="status"
-      javaType="io.camunda.search.entities.BatchOperationEntity$BatchOperationStatus"/>
-    <result column="OPERATION_TYPE" property="operationType" javaType="java.lang.String"/>
-    <result column="START_DATE" property="startDate" javaType="java.time.OffsetDateTime"/>
-    <result column="END_DATE" property="endDate" javaType="java.time.OffsetDateTime"/>
-    <result column="OPERATIONS_TOTAL_COUNT" property="operationsTotalCount" javaType="int"/>
-    <result column="OPERATIONS_FAILED_COUNT" property="operationsFailedCount" javaType="int"/>
-    <result column="OPERATIONS_COMPLETED_COUNT" property="operationsCompletedCount" javaType="int"/>
   </resultMap>
 
   <resultMap id="BatchOperationItemResultMap"

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
@@ -1,0 +1,462 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.batchoperation;
+
+import static io.camunda.it.rdbms.db.fixtures.BatchOperationFixtures.createAndSaveBatchOperation;
+import static io.camunda.it.rdbms.db.fixtures.BatchOperationFixtures.createAndSaveRandomBatchOperationItems;
+import static io.camunda.it.rdbms.db.fixtures.BatchOperationFixtures.createAndSaveRandomBatchOperations;
+import static io.camunda.it.rdbms.db.fixtures.BatchOperationFixtures.insertBatchOperationsItems;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.write.RdbmsWriter;
+import io.camunda.db.rdbms.write.domain.BatchOperationDbModel;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.BatchOperationEntity;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemStatus;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationStatus;
+import io.camunda.search.filter.BatchOperationFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.BatchOperationQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.sort.BatchOperationSort;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.assertj.core.data.TemporalUnitWithinOffset;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class BatchOperationIT {
+
+  @TestTemplate
+  public void shouldReturnTrueForExists(final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    final var batchOperation =
+        createAndSaveRandomBatchOperations(rdbmsService.createWriter(0), b -> b).getLast();
+
+    final var searchResult =
+        rdbmsService.getBatchOperationReader().exists(batchOperation.batchOperationKey());
+
+    assertThat(searchResult).isTrue();
+  }
+
+  @TestTemplate
+  public void shouldReturnFalseForExists(final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    createAndSaveRandomBatchOperations(rdbmsService.createWriter(0), b -> b);
+
+    final var searchResult = rdbmsService.getBatchOperationReader().exists(nextKey());
+
+    assertThat(searchResult).isFalse();
+  }
+
+  @TestTemplate
+  public void shouldInsertBatchItems(final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    // given
+    final RdbmsWriter writer = rdbmsService.createWriter(0);
+    final var batchOperation =
+        createAndSaveBatchOperation(
+            writer,
+            b -> b.status(BatchOperationStatus.ACTIVE).endDate(null).operationsTotalCount(0));
+
+    // when
+    insertBatchOperationsItems(writer, batchOperation.batchOperationKey(), List.of(nextKey()));
+    insertBatchOperationsItems(
+        writer, batchOperation.batchOperationKey(), List.of(nextKey(), nextKey()));
+
+    // then
+    final var updatedBatchOperation = getBatchOperation(rdbmsService, batchOperation);
+
+    // batch is updated
+    assertThat(updatedBatchOperation).isNotNull();
+    final BatchOperationEntity batchOperationEntity = updatedBatchOperation.items().getFirst();
+    assertThat(batchOperationEntity.endDate()).isNull();
+    assertThat(batchOperationEntity.operationsTotalCount()).isEqualTo(3);
+    assertThat(batchOperationEntity.status()).isEqualTo(BatchOperationStatus.ACTIVE);
+
+    // and items are there
+    final var updatedItems =
+        rdbmsService.getBatchOperationReader().getItems(batchOperation.batchOperationKey());
+    assertThat(updatedItems).isNotNull();
+    assertThat(updatedItems).hasSize(3);
+    assertThat(updatedItems.stream().map(BatchOperationItemEntity::status))
+        .containsOnly(BatchOperationItemStatus.ACTIVE);
+  }
+
+  @TestTemplate
+  public void shouldUpdateCompletedBatchItem(final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    // given
+    final RdbmsWriter writer = rdbmsService.createWriter(0);
+    final var batchOperation =
+        createAndSaveBatchOperation(
+            writer,
+            b ->
+                b.status(BatchOperationStatus.ACTIVE)
+                    .endDate(null)
+                    .operationsTotalCount(0)
+                    .operationsCompletedCount(0));
+
+    final List<Long> items =
+        createAndSaveRandomBatchOperationItems(writer, batchOperation.batchOperationKey(), 2);
+
+    // when
+    writer
+        .getBatchOperationWriter()
+        .updateItem(
+            batchOperation.batchOperationKey(),
+            items.getFirst(),
+            BatchOperationItemStatus.COMPLETED);
+    writer.flush();
+
+    // then
+    final var updatedBatchOperation = getBatchOperation(rdbmsService, batchOperation);
+
+    assertThat(updatedBatchOperation).isNotNull();
+    final BatchOperationEntity batchOperationEntity = updatedBatchOperation.items().getFirst();
+    assertThat(batchOperationEntity.endDate()).isNull();
+    assertThat(batchOperationEntity.operationsTotalCount()).isEqualTo(2);
+    assertThat(batchOperationEntity.operationsCompletedCount()).isEqualTo(1);
+    assertThat(batchOperationEntity.status()).isEqualTo(BatchOperationStatus.ACTIVE);
+
+    // and items have correct state
+    final var updatedItems =
+        rdbmsService.getBatchOperationReader().getItems(batchOperation.batchOperationKey());
+    assertThat(updatedItems).isNotNull();
+    assertThat(updatedItems).hasSize(2);
+    final var firstItem =
+        updatedItems.stream()
+            .filter(i -> Objects.equals(i.itemKey(), items.getFirst()))
+            .findFirst()
+            .get();
+    assertThat(firstItem.status()).isEqualTo(BatchOperationItemStatus.COMPLETED);
+
+    final var lastItem =
+        updatedItems.stream()
+            .filter(i -> Objects.equals(i.itemKey(), items.getLast()))
+            .findFirst()
+            .get();
+    assertThat(lastItem.status()).isEqualTo(BatchOperationItemStatus.ACTIVE);
+  }
+
+  @TestTemplate
+  public void shouldUpdateFailedBatchItem(final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    // given
+    final RdbmsWriter writer = rdbmsService.createWriter(0);
+    final var batchOperation =
+        createAndSaveBatchOperation(
+            writer,
+            b ->
+                b.status(BatchOperationStatus.ACTIVE)
+                    .endDate(null)
+                    .operationsTotalCount(0)
+                    .operationsFailedCount(0));
+
+    final List<Long> items =
+        createAndSaveRandomBatchOperationItems(writer, batchOperation.batchOperationKey(), 2);
+
+    // when
+    writer
+        .getBatchOperationWriter()
+        .updateItem(
+            batchOperation.batchOperationKey(), items.getFirst(), BatchOperationItemStatus.FAILED);
+    writer.flush();
+
+    // then
+    final var updatedBatchOperation = getBatchOperation(rdbmsService, batchOperation);
+
+    assertThat(updatedBatchOperation).isNotNull();
+    final BatchOperationEntity batchOperationEntity = updatedBatchOperation.items().getFirst();
+    assertThat(batchOperationEntity.endDate()).isNull();
+    assertThat(batchOperationEntity.operationsTotalCount()).isEqualTo(2);
+    assertThat(batchOperationEntity.operationsFailedCount()).isEqualTo(1);
+    assertThat(batchOperationEntity.status()).isEqualTo(BatchOperationStatus.ACTIVE);
+
+    // and items have correct state
+    final var updatedItems =
+        rdbmsService.getBatchOperationReader().getItems(batchOperation.batchOperationKey());
+    assertThat(updatedItems).isNotNull();
+    assertThat(updatedItems).hasSize(2);
+    final var firstItem =
+        updatedItems.stream()
+            .filter(i -> Objects.equals(i.itemKey(), items.getFirst()))
+            .findFirst()
+            .get();
+    assertThat(firstItem.status()).isEqualTo(BatchOperationItemStatus.FAILED);
+
+    final var lastItem =
+        updatedItems.stream()
+            .filter(i -> Objects.equals(i.itemKey(), items.getLast()))
+            .findFirst()
+            .get();
+    assertThat(lastItem.status()).isEqualTo(BatchOperationItemStatus.ACTIVE);
+  }
+
+  @TestTemplate
+  public void shouldCancelBatchOperationAndActiveItems(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    // given
+    final RdbmsWriter writer = rdbmsService.createWriter(0);
+    final var batchOperation =
+        createAndSaveBatchOperation(
+            writer, b -> b.status(BatchOperationStatus.ACTIVE).endDate(null));
+
+    final var items =
+        createAndSaveRandomBatchOperationItems(writer, batchOperation.batchOperationKey(), 2);
+
+    writer
+        .getBatchOperationWriter()
+        .updateItem(
+            batchOperation.batchOperationKey(),
+            items.getFirst(),
+            BatchOperationItemStatus.COMPLETED);
+
+    // when
+    final OffsetDateTime endDate = OffsetDateTime.now();
+    writer.getBatchOperationWriter().cancel(batchOperation.batchOperationKey(), endDate);
+    writer.flush();
+
+    // then
+    final var updatedBatchOperation = getBatchOperation(rdbmsService, batchOperation);
+
+    // batch is canceled
+    assertThat(updatedBatchOperation).isNotNull();
+    assertThat(updatedBatchOperation.items().getFirst().endDate())
+        .isCloseTo(endDate, new TemporalUnitWithinOffset(1, ChronoUnit.MILLIS));
+    assertThat(updatedBatchOperation.items().getFirst().status())
+        .isEqualTo(BatchOperationStatus.CANCELED);
+  }
+
+  @TestTemplate
+  public void shouldPauseBatchOperation(final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    // given
+    final RdbmsWriter writer = rdbmsService.createWriter(0);
+    final var batchOperation =
+        createAndSaveBatchOperation(
+            writer, b -> b.status(BatchOperationStatus.ACTIVE).endDate(null));
+
+    createAndSaveRandomBatchOperationItems(writer, batchOperation.batchOperationKey(), 2);
+
+    // when
+    writer.getBatchOperationWriter().paused(batchOperation.batchOperationKey());
+    writer.flush();
+
+    // then
+    final var updatedBatchOperation = getBatchOperation(rdbmsService, batchOperation);
+
+    assertThat(updatedBatchOperation).isNotNull();
+    assertThat(updatedBatchOperation.items().getFirst().endDate()).isNull();
+    assertThat(updatedBatchOperation.items().getFirst().status())
+        .isEqualTo(BatchOperationStatus.PAUSED);
+  }
+
+  @TestTemplate
+  public void shouldResumeBatchOperation(final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    // given
+    final RdbmsWriter writer = rdbmsService.createWriter(0);
+    final var batchOperation =
+        createAndSaveBatchOperation(
+            writer, b -> b.status(BatchOperationStatus.ACTIVE).endDate(null));
+
+    createAndSaveRandomBatchOperationItems(writer, batchOperation.batchOperationKey(), 2);
+
+    writer.getBatchOperationWriter().paused(batchOperation.batchOperationKey());
+    writer.flush();
+
+    // when
+    writer.getBatchOperationWriter().resumed(batchOperation.batchOperationKey());
+    writer.flush();
+
+    // then
+    final var updatedBatchOperation = getBatchOperation(rdbmsService, batchOperation);
+
+    assertThat(updatedBatchOperation).isNotNull();
+    assertThat(updatedBatchOperation.items().getFirst().endDate()).isNull();
+    assertThat(updatedBatchOperation.items().getFirst().status())
+        .isEqualTo(BatchOperationStatus.ACTIVE);
+  }
+
+  @TestTemplate
+  public void shouldFinishBatchOperation(final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    // given
+    final RdbmsWriter writer = rdbmsService.createWriter(0);
+    final var batchOperation =
+        createAndSaveBatchOperation(
+            writer, b -> b.status(BatchOperationStatus.ACTIVE).endDate(null));
+
+    createAndSaveRandomBatchOperationItems(writer, batchOperation.batchOperationKey(), 2);
+
+    // when
+    final OffsetDateTime endDate = OffsetDateTime.now();
+    writer.getBatchOperationWriter().finish(batchOperation.batchOperationKey(), endDate);
+    writer.flush();
+
+    // then
+    final var updatedBatchOperation = getBatchOperation(rdbmsService, batchOperation);
+
+    assertThat(updatedBatchOperation).isNotNull();
+    assertThat(updatedBatchOperation.items().getFirst().endDate())
+        .isCloseTo(endDate, new TemporalUnitWithinOffset(1, ChronoUnit.MILLIS));
+    assertThat(updatedBatchOperation.items().getFirst().status())
+        .isEqualTo(BatchOperationStatus.COMPLETED);
+  }
+
+  @TestTemplate
+  public void shouldFindBatchOperationByKey(final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    final var batchOperation =
+        createAndSaveRandomBatchOperations(rdbmsService.createWriter(0), b -> b).getLast();
+
+    final var searchResult =
+        rdbmsService
+            .getBatchOperationReader()
+            .search(
+                new BatchOperationQuery(
+                    new BatchOperationFilter.Builder()
+                        .batchOperationKeys(batchOperation.batchOperationKey())
+                        .build(),
+                    BatchOperationSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(10))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertBatchOperationEntity(searchResult.items().getFirst(), batchOperation);
+  }
+
+  @TestTemplate
+  public void shouldFindBatchOperationByOperationType(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    final var batchOperation =
+        createAndSaveRandomBatchOperations(rdbmsService.createWriter(0), b -> b).getLast();
+
+    final var searchResult =
+        rdbmsService
+            .getBatchOperationReader()
+            .search(
+                new BatchOperationQuery(
+                    new BatchOperationFilter.Builder()
+                        .operationTypes(batchOperation.operationType())
+                        .build(),
+                    BatchOperationSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(10))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isGreaterThanOrEqualTo(1);
+    assertThat(searchResult.items().size()).isGreaterThanOrEqualTo(1);
+    final var operationTypes =
+        searchResult.items().stream()
+            .map(BatchOperationEntity::operationType)
+            .collect(Collectors.toSet());
+    assertThat(operationTypes).containsOnly(batchOperation.operationType());
+  }
+
+  @TestTemplate
+  public void shouldFindBatchOperationByState(final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    createAndSaveRandomBatchOperations(
+        rdbmsService.createWriter(0),
+        b -> b.status(BatchOperationEntity.BatchOperationStatus.COMPLETED));
+    final var batchOperation =
+        createAndSaveBatchOperation(
+            rdbmsService.createWriter(0), b -> b.status(BatchOperationStatus.ACTIVE));
+
+    final var searchResult =
+        rdbmsService
+            .getBatchOperationReader()
+            .search(
+                new BatchOperationQuery(
+                    new BatchOperationFilter.Builder()
+                        .status(BatchOperationStatus.ACTIVE.name())
+                        .build(),
+                    BatchOperationSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(10))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertBatchOperationEntity(searchResult.items().getFirst(), batchOperation);
+  }
+
+  @TestTemplate
+  public void shouldFindAllBatchOperationsPaged(final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+
+    final String operationType = nextStringId();
+    createAndSaveRandomBatchOperations(
+        rdbmsService.createWriter(0), b -> b.operationType(operationType));
+
+    final var searchResult =
+        rdbmsService
+            .getBatchOperationReader()
+            .search(
+                new BatchOperationQuery(
+                    new BatchOperationFilter.Builder().operationTypes(operationType).build(),
+                    BatchOperationSort.of(b -> b),
+                    SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(20);
+    assertThat(searchResult.items()).hasSize(5);
+  }
+
+  private static void assertBatchOperationEntity(
+      final BatchOperationEntity instance, final BatchOperationDbModel batchOperation) {
+    assertThat(instance).isNotNull();
+    assertThat(instance)
+        .usingRecursiveComparison()
+        .ignoringFields("startDate", "endDate")
+        .isEqualTo(batchOperation);
+    assertThat(instance.startDate())
+        .isCloseTo(batchOperation.startDate(), new TemporalUnitWithinOffset(1, ChronoUnit.MILLIS));
+    assertThat(instance.endDate())
+        .isCloseTo(batchOperation.endDate(), new TemporalUnitWithinOffset(1, ChronoUnit.MILLIS));
+  }
+
+  private static SearchQueryResult<BatchOperationEntity> getBatchOperation(
+      final RdbmsService rdbmsService, final BatchOperationDbModel batchOperation) {
+    return rdbmsService
+        .getBatchOperationReader()
+        .search(
+            new BatchOperationQuery(
+                new BatchOperationFilter.Builder()
+                    .batchOperationKeys(batchOperation.batchOperationKey())
+                    .build(),
+                BatchOperationSort.of(b -> b),
+                SearchQueryPage.of(b -> b)));
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.fixtures;
+
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.RANDOM;
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.randomEnum;
+
+import io.camunda.db.rdbms.write.RdbmsWriter;
+import io.camunda.db.rdbms.write.domain.BatchOperationDbModel;
+import io.camunda.db.rdbms.write.domain.BatchOperationDbModel.Builder;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationStatus;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public final class BatchOperationFixtures {
+
+  private BatchOperationFixtures() {}
+
+  public static BatchOperationDbModel createRandomized(
+      final Function<Builder, Builder> builderFunction) {
+    final var key = CommonFixtures.nextKey();
+    final var builder =
+        new Builder()
+            .batchOperationKey(key)
+            .status(randomEnum(BatchOperationStatus.class))
+            .operationType("some-operation" + RANDOM.nextInt(1000))
+            .startDate(OffsetDateTime.now())
+            .endDate(OffsetDateTime.now().plusSeconds(1))
+            .operationsTotalCount(RANDOM.nextInt(1000))
+            .operationsFailedCount(RANDOM.nextInt(1000))
+            .operationsCompletedCount(RANDOM.nextInt(1000));
+    return builderFunction.apply(builder).build();
+  }
+
+  public static List<BatchOperationDbModel> createAndSaveRandomBatchOperations(
+      final RdbmsWriter rdbmsWriter, final Function<Builder, Builder> builderFunction) {
+    final List<BatchOperationDbModel> models =
+        IntStream.range(0, 20)
+            .mapToObj(i -> createRandomized(builderFunction))
+            .peek(rdbmsWriter.getBatchOperationWriter()::createIfNotAlreadyExists)
+            .collect(Collectors.toList());
+    rdbmsWriter.flush();
+    return models;
+  }
+
+  public static List<Long> createAndSaveRandomBatchOperationItems(
+      final RdbmsWriter rdbmsWriter, final Long batchOperationKey, final int count) {
+    final List<Long> items =
+        IntStream.range(0, count)
+            .mapToObj(i -> CommonFixtures.nextKey())
+            .collect(Collectors.toList());
+    insertBatchOperationsItems(rdbmsWriter, batchOperationKey, items);
+    return items;
+  }
+
+  public static BatchOperationDbModel createAndSaveBatchOperation(
+      final RdbmsWriter rdbmsWriter, final Function<Builder, Builder> builderFunction) {
+    final var instance = createRandomized(builderFunction);
+    createAndSaveBatchOperations(rdbmsWriter, List.of(instance));
+    return instance;
+  }
+
+  public static void createAndSaveBatchOperations(
+      final RdbmsWriter rdbmsWriter, final List<BatchOperationDbModel> batchOperationList) {
+    for (final BatchOperationDbModel batchOperation : batchOperationList) {
+      rdbmsWriter.getBatchOperationWriter().createIfNotAlreadyExists(batchOperation);
+    }
+    rdbmsWriter.flush();
+  }
+
+  public static void insertBatchOperationsItems(
+      final RdbmsWriter rdbmsWriter, final Long batchOperationKey, final List<Long> items) {
+    rdbmsWriter.getBatchOperationWriter().updateBatchAndInsertItems(batchOperationKey, items);
+    rdbmsWriter.flush();
+  }
+}


### PR DESCRIPTION
## Description

Integration tests for the batch operations feature in rdbms db modul.

NOTE: [Feat/29701 batch operaton extend rdbms exporter db services part](https://github.com/camunda/camunda/pull/30058) has to be merged before!

## Related issues

#29701
