### PR TITLE
build: use mvnw for release job build instead of mvn

### DIFF
--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Prepare release
         run: |
-          mvn -f optimize \
+          ./mvnw -f optimize \
             -DpushChanges="${{ github.event.inputs.IS_DRY_RUN != 'true' }}" \
             -DremoteTagging="${{ github.event.inputs.IS_DRY_RUN != 'true' }}" \
             -DskipTests=true \


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
https://github.com/camunda/camunda/actions/runs/14043236380/job/39318089640

The release job from `optimize-release-optimize-c8-only.yml` is failing with a command not found error

Use `mvnw` instead of `mvn`. Other GHAs use `mvnw`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
