### PR TITLE
feat: batch operaton extend rdbms exporter handler

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/BatchOperationMapper.java
@@ -14,6 +14,7 @@ import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationStatus;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Set;
 
 public interface BatchOperationMapper {
 
@@ -42,7 +43,7 @@ public interface BatchOperationMapper {
 
   record BatchOperationUpdateTotalCountDto(long batchOperationKey, int operationsTotalCount) {}
 
-  record BatchOperationItemsDto(Long batchOperationKey, List<Long> items) {}
+  record BatchOperationItemsDto(Long batchOperationKey, Set<Long> items) {}
 
   record BatchOperationItemDto(
       Long batchOperationKey, Long itemKey, BatchOperationEntity.BatchOperationItemStatus status) {}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/BatchOperationDbModel.java
@@ -28,10 +28,10 @@ public record BatchOperationDbModel(
     private BatchOperationStatus status;
     private String operationType;
     private OffsetDateTime startDate;
-    private OffsetDateTime endDate;
-    private Integer operationsTotalCount;
-    private Integer operationsFailedCount;
-    private Integer operationsCompletedCount;
+    private OffsetDateTime endDate = null;
+    private Integer operationsTotalCount = 0;
+    private Integer operationsFailedCount = 0;
+    private Integer operationsCompletedCount = 0;
 
     public Builder() {}
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/BatchOperationWriter.java
@@ -21,7 +21,7 @@ import io.camunda.db.rdbms.write.queue.WriteStatementType;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemStatus;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationStatus;
 import java.time.OffsetDateTime;
-import java.util.List;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +56,7 @@ public class BatchOperationWriter {
     executionQueue.flush();
   }
 
-  public void updateBatchAndInsertItems(final long batchOperationKey, final List<Long> items) {
+  public void updateBatchAndInsertItems(final long batchOperationKey, final Set<Long> items) {
     if (items != null && !items.isEmpty()) {
       executionQueue.executeInQueue(
           new QueueItem(

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/batchoperation/BatchOperationIT.java
@@ -33,6 +33,7 @@ import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.assertj.core.data.TemporalUnitWithinOffset;
 import org.junit.jupiter.api.Tag;
@@ -79,9 +80,9 @@ public class BatchOperationIT {
             b -> b.status(BatchOperationStatus.ACTIVE).endDate(null).operationsTotalCount(0));
 
     // when
-    insertBatchOperationsItems(writer, batchOperation.batchOperationKey(), List.of(nextKey()));
+    insertBatchOperationsItems(writer, batchOperation.batchOperationKey(), Set.of(nextKey()));
     insertBatchOperationsItems(
-        writer, batchOperation.batchOperationKey(), List.of(nextKey(), nextKey()));
+        writer, batchOperation.batchOperationKey(), Set.of(nextKey(), nextKey()));
 
     // then
     final var updatedBatchOperation = getBatchOperation(rdbmsService, batchOperation);

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/BatchOperationFixtures.java
@@ -16,6 +16,7 @@ import io.camunda.db.rdbms.write.domain.BatchOperationDbModel.Builder;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationStatus;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -53,12 +54,12 @@ public final class BatchOperationFixtures {
 
   public static List<Long> createAndSaveRandomBatchOperationItems(
       final RdbmsWriter rdbmsWriter, final Long batchOperationKey, final int count) {
-    final List<Long> items =
+    final Set<Long> items =
         IntStream.range(0, count)
             .mapToObj(i -> CommonFixtures.nextKey())
-            .collect(Collectors.toList());
+            .collect(Collectors.toSet());
     insertBatchOperationsItems(rdbmsWriter, batchOperationKey, items);
-    return items;
+    return items.stream().toList();
   }
 
   public static BatchOperationDbModel createAndSaveBatchOperation(
@@ -77,7 +78,7 @@ public final class BatchOperationFixtures {
   }
 
   public static void insertBatchOperationsItems(
-      final RdbmsWriter rdbmsWriter, final Long batchOperationKey, final List<Long> items) {
+      final RdbmsWriter rdbmsWriter, final Long batchOperationKey, final Set<Long> items) {
     rdbmsWriter.getBatchOperationWriter().updateBatchAndInsertItems(batchOperationKey, items);
     rdbmsWriter.flush();
   }

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterBatchOperationsIT.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.exporter;
+
+import static io.camunda.it.rdbms.exporter.RecordFixtures.getBatchOperationChunkRecord;
+import static io.camunda.it.rdbms.exporter.RecordFixtures.getBatchOperationCreatedRecord;
+import static io.camunda.it.rdbms.exporter.RecordFixtures.getBatchOperationExecutionCompletedRecord;
+import static io.camunda.it.rdbms.exporter.RecordFixtures.getBatchOperationProcessCancelledRecord;
+import static io.camunda.it.rdbms.exporter.RecordFixtures.getFailedBatchOperationProcessCancelledRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.exporter.rdbms.RdbmsExporterWrapper;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationStatus;
+import io.camunda.zeebe.broker.exporter.context.ExporterConfiguration;
+import io.camunda.zeebe.broker.exporter.context.ExporterContext;
+import io.camunda.zeebe.exporter.test.ExporterTestController;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@Tag("rdbms")
+@SpringBootTest(classes = {RdbmsTestConfiguration.class})
+@TestPropertySource(
+    properties = {
+      "spring.liquibase.enabled=false",
+      "camunda.database.type=rdbms",
+      "zeebe.broker.exporters.rdbms.args.maxQueueSize=0",
+      "camunda.database.index-prefix=C8_"
+    })
+class RdbmsExporterBatchOperationsIT {
+
+  private final ExporterTestController controller = new ExporterTestController();
+
+  @Autowired private RdbmsService rdbmsService;
+
+  private RdbmsExporterWrapper exporter;
+
+  @BeforeEach
+  void setUp() {
+    exporter = new RdbmsExporterWrapper(rdbmsService);
+    exporter.configure(
+        new ExporterContext(
+            null,
+            new ExporterConfiguration("foo", Map.of("maxQueueSize", 0)),
+            1,
+            Mockito.mock(MeterRegistry.class, Mockito.RETURNS_DEEP_STUBS),
+            null));
+    exporter.open(controller);
+  }
+
+  @Test
+  public void shouldExportBatchOperation() {
+    // given
+    final var batchOperationCreatedRecord = getBatchOperationCreatedRecord(1L);
+    final var batchOperationKey = batchOperationCreatedRecord.getKey();
+    final var batchOperationChunkRecord = getBatchOperationChunkRecord(batchOperationKey, 2L);
+    final var batchOperationExecutionCompletedRecord =
+        getBatchOperationExecutionCompletedRecord(batchOperationKey, 3L);
+
+    // when
+    exporter.export(batchOperationCreatedRecord);
+    exporter.export(batchOperationChunkRecord);
+
+    // then
+    var batchOperation = rdbmsService.getBatchOperationReader().findOne(batchOperationKey).get();
+    assertThat(batchOperation).isNotNull();
+    assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
+    assertThat(batchOperation.status()).isEqualTo(BatchOperationStatus.ACTIVE);
+
+    // and when we complete it
+    exporter.export(batchOperationExecutionCompletedRecord);
+
+    // then it should be completed
+    batchOperation = rdbmsService.getBatchOperationReader().findOne(batchOperationKey).get();
+    assertThat(batchOperation.status()).isEqualTo(BatchOperationStatus.COMPLETED);
+  }
+
+  @Test
+  public void shouldMonitorProcessInstanceCancellationBatchOperation() {
+    // given
+    final var batchOperationCreatedRecord = getBatchOperationCreatedRecord(1L);
+    final var batchOperationKey = batchOperationCreatedRecord.getKey();
+    final var batchOperationChunkRecord = getBatchOperationChunkRecord(batchOperationKey, 2L);
+    final var processInstanceKey = 1L;
+    final var processCancelledRecord =
+        getBatchOperationProcessCancelledRecord(processInstanceKey, batchOperationKey, 3L);
+
+    // when
+    exporter.export(batchOperationCreatedRecord);
+    exporter.export(batchOperationChunkRecord);
+    exporter.export(processCancelledRecord);
+
+    // then
+    final var batchOperation =
+        rdbmsService.getBatchOperationReader().findOne(batchOperationKey).get();
+    assertThat(batchOperation).isNotNull();
+    assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
+    assertThat(batchOperation.operationsCompletedCount()).isEqualTo(1);
+    assertThat(batchOperation.operationsFailedCount()).isEqualTo(0);
+    assertThat(batchOperation.status()).isEqualTo(BatchOperationStatus.ACTIVE);
+  }
+
+  @Test
+  public void shouldMonitorFailedProcessInstanceCancellationBatchOperation() {
+    // given
+    final var batchOperationCreatedRecord = getBatchOperationCreatedRecord(1L);
+    final var batchOperationKey = batchOperationCreatedRecord.getKey();
+    final var batchOperationChunkRecord = getBatchOperationChunkRecord(batchOperationKey, 2L);
+    final var processInstanceKey = 1L;
+    final var processFailedCancelledRecord =
+        getFailedBatchOperationProcessCancelledRecord(processInstanceKey, batchOperationKey, 3L);
+
+    // when
+    exporter.export(batchOperationCreatedRecord);
+    exporter.export(batchOperationChunkRecord);
+    exporter.export(processFailedCancelledRecord);
+
+    // then
+    final var batchOperation =
+        rdbmsService.getBatchOperationReader().findOne(batchOperationKey).get();
+    assertThat(batchOperation).isNotNull();
+    assertThat(batchOperation.operationsTotalCount()).isEqualTo(3);
+    assertThat(batchOperation.operationsCompletedCount()).isEqualTo(0);
+    assertThat(batchOperation.operationsFailedCount()).isEqualTo(1);
+    assertThat(batchOperation.status()).isEqualTo(BatchOperationStatus.ACTIVE);
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
@@ -11,6 +11,7 @@ import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.ExporterPositionModel;
 import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.exporter.api.context.ScheduledTask;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.util.VisibleForTesting;
@@ -139,7 +140,11 @@ public class RdbmsExporter {
     }
 
     if (!exported) {
-      LOG.trace("[RDBMS Exporter] Record could not be exported {}", record);
+      LOG.trace(
+          "[RDBMS Exporter] Record with key {} and original partitionId {} could not be exported {}.",
+          record.getKey(),
+          Protocol.decodePartitionId(record.getKey()),
+          record);
     }
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/BatchOperationChunkExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/BatchOperationChunkExportHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import io.camunda.db.rdbms.write.service.BatchOperationWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationChunkIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationChunkRecordValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Exports a batch operation chunk record, which contains all the item keys, to the database. */
+public class BatchOperationChunkExportHandler
+    implements RdbmsExportHandler<BatchOperationChunkRecordValue> {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(BatchOperationChunkExportHandler.class);
+
+  private final BatchOperationWriter batchOperationWriter;
+
+  public BatchOperationChunkExportHandler(final BatchOperationWriter batchOperationWriter) {
+    this.batchOperationWriter = batchOperationWriter;
+  }
+
+  @Override
+  public boolean canExport(final Record<BatchOperationChunkRecordValue> record) {
+    return record.getValueType() == ValueType.BATCH_OPERATION_CHUNK
+        && record.getIntent().equals(BatchOperationChunkIntent.CREATE);
+  }
+
+  @Override
+  public void export(final Record<BatchOperationChunkRecordValue> record) {
+    final var value = record.getValue();
+    batchOperationWriter.updateBatchAndInsertItems(
+        value.getBatchOperationKey(), value.getItemKeys());
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/BatchOperationCreatedExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/BatchOperationCreatedExportHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import io.camunda.db.rdbms.write.domain.BatchOperationDbModel;
+import io.camunda.db.rdbms.write.service.BatchOperationWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationStatus;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationCreationRecordValue;
+import io.camunda.zeebe.util.DateUtil;
+
+/**
+ * Exports a batch operation creation record to the database. Where the creation in the db just
+ * happens, if it's not already existing. (Could be if another partition was faster)
+ */
+public class BatchOperationCreatedExportHandler
+    implements RdbmsExportHandler<BatchOperationCreationRecordValue> {
+
+  private final BatchOperationWriter batchOperationWriter;
+
+  public BatchOperationCreatedExportHandler(final BatchOperationWriter batchOperationWriter) {
+    this.batchOperationWriter = batchOperationWriter;
+  }
+
+  @Override
+  public boolean canExport(final Record<BatchOperationCreationRecordValue> record) {
+    return record.getValueType() == ValueType.BATCH_OPERATION_CREATION
+        && record.getIntent().equals(BatchOperationIntent.CREATED);
+  }
+
+  @Override
+  public void export(final Record<BatchOperationCreationRecordValue> record) {
+    batchOperationWriter.createIfNotAlreadyExists(map(record));
+  }
+
+  private BatchOperationDbModel map(final Record<BatchOperationCreationRecordValue> record) {
+    final var value = record.getValue();
+    return new BatchOperationDbModel.Builder()
+        .batchOperationKey(record.getKey())
+        .status(BatchOperationStatus.ACTIVE)
+        .operationType(value.getBatchOperationType().name())
+        .startDate(DateUtil.toOffsetDateTime(record.getTimestamp()))
+        .build();
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/BatchOperationExecutionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/BatchOperationExecutionExportHandler.java
@@ -12,6 +12,7 @@ import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
+import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.value.BatchOperationExecutionRecordValue;
 import io.camunda.zeebe.util.DateUtil;
 import java.util.Set;
@@ -20,7 +21,7 @@ import java.util.Set;
 public class BatchOperationExecutionExportHandler
     implements RdbmsExportHandler<BatchOperationExecutionRecordValue> {
 
-  private static final Set<BatchOperationExecutionIntent> EXPORTABLE_INTENTS =
+  private static final Set<Intent> EXPORTABLE_INTENTS =
       Set.of(
           BatchOperationExecutionIntent.EXECUTING,
           BatchOperationExecutionIntent.EXECUTED,
@@ -34,12 +35,8 @@ public class BatchOperationExecutionExportHandler
 
   @Override
   public boolean canExport(final Record<BatchOperationExecutionRecordValue> record) {
-    if (record.getValueType() == ValueType.BATCH_OPERATION_EXECUTION
-        && record.getIntent() instanceof final BatchOperationExecutionIntent intent) {
-      return EXPORTABLE_INTENTS.contains(intent);
-    }
-
-    return false;
+    return record.getValueType() == ValueType.BATCH_OPERATION_EXECUTION
+        && EXPORTABLE_INTENTS.contains(record.getIntent());
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/BatchOperationExecutionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/BatchOperationExecutionExportHandler.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import io.camunda.db.rdbms.write.service.BatchOperationWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.BatchOperationExecutionIntent;
+import io.camunda.zeebe.protocol.record.value.BatchOperationExecutionRecordValue;
+import io.camunda.zeebe.util.DateUtil;
+import java.util.Set;
+
+/** Tracks the execution of a batch operation, like completion. */
+public class BatchOperationExecutionExportHandler
+    implements RdbmsExportHandler<BatchOperationExecutionRecordValue> {
+
+  private static final Set<BatchOperationExecutionIntent> EXPORTABLE_INTENTS =
+      Set.of(
+          BatchOperationExecutionIntent.EXECUTING,
+          BatchOperationExecutionIntent.EXECUTED,
+          BatchOperationExecutionIntent.COMPLETED);
+
+  private final BatchOperationWriter batchOperationWriter;
+
+  public BatchOperationExecutionExportHandler(final BatchOperationWriter batchOperationWriter) {
+    this.batchOperationWriter = batchOperationWriter;
+  }
+
+  @Override
+  public boolean canExport(final Record<BatchOperationExecutionRecordValue> record) {
+    if (record.getValueType() == ValueType.BATCH_OPERATION_EXECUTION
+        && record.getIntent() instanceof final BatchOperationExecutionIntent intent) {
+      return EXPORTABLE_INTENTS.contains(intent);
+    }
+
+    return false;
+  }
+
+  @Override
+  public void export(final Record<BatchOperationExecutionRecordValue> record) {
+    final var value = record.getValue();
+    final var batchOperationKey = value.getBatchOperationKey();
+    if (record.getIntent().equals(BatchOperationExecutionIntent.COMPLETED)) {
+      batchOperationWriter.finish(
+          batchOperationKey, DateUtil.toOffsetDateTime(record.getTimestamp()));
+    }
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceBatchOperationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceBatchOperationExportHandler.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms.handlers;
+
+import static io.camunda.zeebe.protocol.record.RecordMetadataDecoder.operationReferenceNullValue;
+
+import io.camunda.db.rdbms.write.service.BatchOperationWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemStatus;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+
+/** This aggregates the batch operation status of process instance cancellations */
+public class ProcessInstanceBatchOperationExportHandler
+    implements RdbmsExportHandler<ProcessInstanceRecordValue> {
+
+  private final BatchOperationWriter batchOperationWriter;
+
+  public ProcessInstanceBatchOperationExportHandler(
+      final BatchOperationWriter batchOperationWriter) {
+    this.batchOperationWriter = batchOperationWriter;
+  }
+
+  @Override
+  public boolean canExport(final Record<ProcessInstanceRecordValue> record) {
+    return record.getOperationReference() != operationReferenceNullValue()
+        && record.getValueType() == ValueType.PROCESS_INSTANCE
+        && record.getValue().getParentProcessInstanceKey() == -1
+        && (isProcessCanceled(record) || isFailed(record));
+  }
+
+  @Override
+  public void export(final Record<ProcessInstanceRecordValue> record) {
+    final var value = record.getValue();
+    if (isProcessCanceled(record)) {
+      batchOperationWriter.updateItem(
+          record.getOperationReference(),
+          value.getProcessInstanceKey(),
+          BatchOperationItemStatus.COMPLETED);
+    } else if (isFailed(record)) {
+      batchOperationWriter.updateItem(
+          record.getOperationReference(),
+          value.getProcessInstanceKey(),
+          BatchOperationItemStatus.FAILED);
+    }
+  }
+
+  private boolean isProcessCanceled(final Record<ProcessInstanceRecordValue> record) {
+    return record.getValue().getBpmnElementType() == BpmnElementType.PROCESS
+        && record.getIntent().equals(ProcessInstanceIntent.ELEMENT_TERMINATED);
+  }
+
+  private boolean isFailed(final Record<ProcessInstanceRecordValue> record) {
+    return record.getIntent().equals(ProcessInstanceIntent.CANCEL)
+        && record.getRejectionType() != null;
+  }
+}


### PR DESCRIPTION
## Description

Last PR for the related issue to monitor batch operations. It adds the rdbms export handlers to persist the batch operations itself, as well as the status about the triggered process cancellations to aggregate the status of the batch operation. 

NOTE: This PR also relies on changes which comes with [Create, schedule and manage batch operations in Zeebe Engine](https://github.com/camunda/camunda/issues/29690). At least the execution is needed, as well as the the support for CANCEL_PROCESS_INSTANCE

## Related issues

closes #29701
