### PR TITLE
feat: add env configuration adapted for vite and IS_OIDC variable

### DIFF
--- a/identity/client/src/configuration/env.ts
+++ b/identity/client/src/configuration/env.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda
+ * Services GmbH under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file except in compliance with the Camunda License 1.0.
+ */
+
+interface AppWindow {
+  env: Record<string, string>;
+}
+
+const { env } = window as unknown as AppWindow;
+
+export type GetEnv<R = string | undefined> = (
+  key: string,
+  defaultValue?: R,
+) => R;
+
+const getEnv = <R>(
+  key: string,
+  defaultValue: R,
+  parser: (value: string) => R,
+): R => {
+  const viteKey = `VITE_${key}`;
+  if (env && env[viteKey] !== undefined) {
+    return parser(env[viteKey]);
+  }
+  if (import.meta.env[viteKey] !== undefined) {
+    return parser(import.meta.env[viteKey] as string);
+  }
+  return defaultValue;
+};
+
+export const getEnvString: GetEnv<string> = (key, defaultValue = "") =>
+  getEnv(key, defaultValue, (value) => value);
+
+export const getEnvBoolean: GetEnv<boolean> = (key, defaultValue = false) =>
+  getEnv(key, defaultValue, (value) => value === "true");

--- a/identity/client/src/configuration/env.ts
+++ b/identity/client/src/configuration/env.ts
@@ -31,8 +31,5 @@ const getEnv = <R>(
   return defaultValue;
 };
 
-export const getEnvString: GetEnv<string> = (key, defaultValue = "") =>
-  getEnv(key, defaultValue, (value) => value);
-
 export const getEnvBoolean: GetEnv<boolean> = (key, defaultValue = false) =>
   getEnv(key, defaultValue, (value) => value === "true");

--- a/identity/client/src/configuration/env.ts
+++ b/identity/client/src/configuration/env.ts
@@ -6,10 +6,10 @@
  */
 
 interface AppWindow {
-  env: Record<string, string>;
+  clientConfig: Record<string, string>;
 }
 
-const { env } = window as unknown as AppWindow;
+const { clientConfig } = window as unknown as AppWindow;
 
 export type GetEnv<R = string | undefined> = (
   key: string,
@@ -22,8 +22,8 @@ const getEnv = <R>(
   parser: (value: string) => R,
 ): R => {
   const viteKey = `VITE_${key}`;
-  if (env && env[viteKey] !== undefined) {
-    return parser(env[viteKey]);
+  if (clientConfig && clientConfig[viteKey] !== undefined) {
+    return parser(clientConfig[viteKey]);
   }
   if (import.meta.env[viteKey] !== undefined) {
     return parser(import.meta.env[viteKey] as string);

--- a/identity/client/src/configuration/index.ts
+++ b/identity/client/src/configuration/index.ts
@@ -1,6 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda
+ * Services GmbH under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file except in compliance with the Camunda License 1.0.
+ */
+
+import { getEnvBoolean } from "src/configuration/env";
+
 const baseUrl = "/identity";
 
 const apiBaseUrl = "/v2";
+
+export const isOIDC = getEnvBoolean("IS_OIDC");
 
 export const docsUrl = "https://docs.camunda.io";
 


### PR DESCRIPTION
## Description

- Configures setup for getting env variables in Vite;
- Setup `IS_OIDC` variable from window and makes it available for use on FE;
-  Align with BE for variable name so it's already "pre-integrated"

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #30072 
