### PR TITLE
feat: support mapping ID in MappingMapper.xml

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaOidcUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOidcUserService.java
@@ -66,7 +66,7 @@ public class CamundaOidcUserService extends OidcUserService {
     final Set<String> mappingKeysAsString =
         mappingKeys.stream().map(String::valueOf).collect(Collectors.toSet());
     final Set<String> mappingIds =
-        mappings.stream().map(MappingEntity::id).collect(Collectors.toSet());
+        mappings.stream().map(MappingEntity::mappingId).collect(Collectors.toSet());
     if (mappingKeys.isEmpty()) {
       LOG.debug("No mappings found for these claims: {}", claims);
     }

--- a/authentication/src/main/java/io/camunda/authentication/CamundaOidcUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOidcUserService.java
@@ -63,8 +63,10 @@ public class CamundaOidcUserService extends OidcUserService {
     final Set<Long> mappingKeys =
         mappings.stream().map(MappingEntity::mappingKey).collect(Collectors.toSet());
     // TODO remove mapping when refactoring to IDs
-    final Set<String> mappingIds =
+    final Set<String> mappingKeysAsString =
         mappingKeys.stream().map(String::valueOf).collect(Collectors.toSet());
+    final Set<String> mappingIds =
+        mappings.stream().map(MappingEntity::id).collect(Collectors.toSet());
     if (mappingKeys.isEmpty()) {
       LOG.debug("No mappings found for these claims: {}", claims);
     }
@@ -74,6 +76,7 @@ public class CamundaOidcUserService extends OidcUserService {
     return new CamundaOidcUser(
         oidcUser,
         mappingKeys,
+        mappingIds,
         new AuthenticationContext(
             assignedRoles,
             authorizationServices.getAuthorizedApplications(
@@ -82,7 +85,7 @@ public class CamundaOidcUserService extends OidcUserService {
                         mappingKeys.stream()
                             .map(String::valueOf)) // TODO remove mapping when refactoring to IDs
                     .collect(Collectors.toSet())),
-            tenantServices.getTenantsByMemberIds(mappingIds).stream()
+            tenantServices.getTenantsByMemberIds(mappingKeysAsString).stream()
                 .map(TenantDTO::fromEntity)
                 .toList(),
             groupServices.getGroupsByMemberKeys(mappingKeys).stream()

--- a/authentication/src/main/java/io/camunda/authentication/CamundaOidcUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOidcUserService.java
@@ -62,9 +62,6 @@ public class CamundaOidcUserService extends OidcUserService {
     final List<MappingEntity> mappings = mappingServices.getMatchingMappings(claims);
     final Set<Long> mappingKeys =
         mappings.stream().map(MappingEntity::mappingKey).collect(Collectors.toSet());
-    // TODO remove mapping when refactoring to IDs
-    final Set<String> mappingKeysAsString =
-        mappingKeys.stream().map(String::valueOf).collect(Collectors.toSet());
     final Set<String> mappingIds =
         mappings.stream().map(MappingEntity::mappingId).collect(Collectors.toSet());
     if (mappingKeys.isEmpty()) {
@@ -85,7 +82,7 @@ public class CamundaOidcUserService extends OidcUserService {
                         mappingKeys.stream()
                             .map(String::valueOf)) // TODO remove mapping when refactoring to IDs
                     .collect(Collectors.toSet())),
-            tenantServices.getTenantsByMemberIds(mappingKeysAsString).stream()
+            tenantServices.getTenantsByMemberIds(mappingIds).stream()
                 .map(TenantDTO::fromEntity)
                 .toList(),
             groupServices.getGroupsByMemberKeys(mappingKeys).stream()

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaOidcUser.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaOidcUser.java
@@ -19,14 +19,18 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 public class CamundaOidcUser implements OidcUser, CamundaPrincipal, Serializable {
   private final OidcUser user;
   private final AuthenticationContext authentication;
+  // todo remove after fully migrating to mapping IDs #27207
   private final Set<Long> mappingKeys;
+  private final Set<String> mappingIds;
 
   public CamundaOidcUser(
       final OidcUser oidcUser,
       final Set<Long> mappingKeys,
+      final Set<String> mappingIds,
       final AuthenticationContext authentication) {
     user = oidcUser;
     this.mappingKeys = mappingKeys;
+    this.mappingIds = mappingIds;
     this.authentication = authentication;
   }
 
@@ -77,5 +81,9 @@ public class CamundaOidcUser implements OidcUser, CamundaPrincipal, Serializable
 
   public Set<Long> getMappingKeys() {
     return mappingKeys;
+  }
+
+  public Set<String> getMappingIds() {
+    return mappingIds;
   }
 }

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
@@ -70,8 +70,8 @@ public class CamundaOidcUserServiceTest {
     when(mappingServices.getMatchingMappings(claims))
         .thenReturn(
             List.of(
-                new MappingEntity(5L, "role", "R1", "role-r1"),
-                new MappingEntity(7L, "group", "G1", "group-g1")));
+                new MappingEntity("test-id", 5L, "role", "R1", "role-r1"),
+                new MappingEntity("test-id-2", 7L, "group", "G1", "group-g1")));
 
     final var roleR1 = new RoleEntity(8L, "Role R1");
     when(roleServices.getRolesByMemberKeys(Set.of(5L, 7L))).thenReturn(List.of(roleR1));
@@ -87,6 +87,7 @@ public class CamundaOidcUserServiceTest {
     final var camundaUser = (CamundaOidcUser) oidcUser;
     assertThat(camundaUser.getEmail()).isEqualTo("foo@camunda.test");
     assertThat(camundaUser.getMappingKeys()).isEqualTo(Set.of(5L, 7L));
+    assertThat(camundaUser.getMappingIds()).isEqualTo(Set.of("test-id", "test-id-2"));
     final AuthenticationContext authenticationContext = camundaUser.getAuthenticationContext();
     assertThat(authenticationContext.roles()).containsAll(Set.of(roleR1));
     assertThat(authenticationContext.groups()).isEmpty();

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -501,4 +501,27 @@
     </modifySql>
   </changeSet>
 
+  <changeSet id="migrate_mapping_id_from_key" author="Oleksii Ivanov">
+    <!-- Step 1: Add ID column -->
+    <addColumn tableName="${prefix}MAPPINGS">
+      <column name="ID" type="VARCHAR(255)">
+        <constraints nullable="true"/>
+      </column>
+    </addColumn>
+
+    <!-- Step 2: Copy values from MAPPING_KEY to ID as string -->
+    <update tableName="${prefix}MAPPINGS">
+      <column name="ID" valueComputed="CAST(MAPPING_KEY AS CHAR(255))"/>
+    </update>
+
+    <!-- Step 3: Set ID as NOT NULL (after it's populated) -->
+    <addNotNullConstraint tableName="${prefix}MAPPINGS" columnName="ID" columnDataType="VARCHAR(255)"/>
+
+    <!-- Step 4: Drop old PK on MAPPING_KEY -->
+    <dropPrimaryKey tableName="${prefix}MAPPINGS"/>
+
+    <!-- Step 5: Make ID the new PK -->
+    <addPrimaryKey tableName="${prefix}MAPPINGS" columnNames="ID" constraintName="${prefix}PK_MAPPINGS_ID"/>
+  </changeSet>
+
 </databaseChangeLog>

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -504,24 +504,24 @@
   <changeSet id="migrate_mapping_id_from_key" author="Oleksii Ivanov">
     <!-- Step 1: Add ID column -->
     <addColumn tableName="${prefix}MAPPINGS">
-      <column name="ID" type="VARCHAR(255)">
+      <column name="MAPPING_ID" type="VARCHAR(255)">
         <constraints nullable="true"/>
       </column>
     </addColumn>
 
     <!-- Step 2: Copy values from MAPPING_KEY to ID as string -->
     <update tableName="${prefix}MAPPINGS">
-      <column name="ID" valueComputed="CAST(MAPPING_KEY AS CHAR(255))"/>
+      <column name="MAPPING_ID" valueComputed="CAST(MAPPING_KEY AS CHAR(255))"/>
     </update>
 
     <!-- Step 3: Set ID as NOT NULL (after it's populated) -->
-    <addNotNullConstraint tableName="${prefix}MAPPINGS" columnName="ID" columnDataType="VARCHAR(255)"/>
+    <addNotNullConstraint tableName="${prefix}MAPPINGS" columnName="MAPPING_ID" columnDataType="VARCHAR(255)"/>
 
     <!-- Step 4: Drop old PK on MAPPING_KEY -->
     <dropPrimaryKey tableName="${prefix}MAPPINGS"/>
 
     <!-- Step 5: Make ID the new PK -->
-    <addPrimaryKey tableName="${prefix}MAPPINGS" columnNames="ID" constraintName="${prefix}PK_MAPPINGS_ID"/>
+    <addPrimaryKey tableName="${prefix}MAPPINGS" columnNames="MAPPING_ID" constraintName="${prefix}PK_MAPPINGS_ID"/>
   </changeSet>
 
 </databaseChangeLog>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/MappingReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/MappingReader.java
@@ -31,12 +31,12 @@ public class MappingReader extends AbstractEntityReader<MappingEntity> {
   public Optional<MappingEntity> findOne(final String mappingId) {
     LOG.trace("[RDBMS DB] Search for mapping with mapping ID {}", mappingId);
     final SearchQueryResult<MappingEntity> queryResult =
-        search(MappingQuery.of(b -> b.filter(f -> f.id(mappingId))));
+        search(MappingQuery.of(b -> b.filter(f -> f.mappingId(mappingId))));
     return Optional.ofNullable(queryResult.items()).flatMap(hits -> hits.stream().findFirst());
   }
 
   public SearchQueryResult<MappingEntity> search(final MappingQuery query) {
-    final var dbSort = convertSort(query.sort(), MappingSearchColumn.ID);
+    final var dbSort = convertSort(query.sort(), MappingSearchColumn.MAPPING_ID);
     final var dbQuery =
         MappingDbQuery.of(
             b -> b.filter(query.filter()).sort(dbSort).page(convertPaging(dbSort, query.page())));

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/MappingReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/MappingReader.java
@@ -28,15 +28,15 @@ public class MappingReader extends AbstractEntityReader<MappingEntity> {
     this.mappingMapper = mappingMapper;
   }
 
-  public Optional<MappingEntity> findOne(final Long mappingKey) {
-    LOG.trace("[RDBMS DB] Search for mapping with mapping key {}", mappingKey);
+  public Optional<MappingEntity> findOne(final String mappingId) {
+    LOG.trace("[RDBMS DB] Search for mapping with mapping ID {}", mappingId);
     final SearchQueryResult<MappingEntity> queryResult =
-        search(MappingQuery.of(b -> b.filter(f -> f.mappingKey(mappingKey))));
+        search(MappingQuery.of(b -> b.filter(f -> f.id(mappingId))));
     return Optional.ofNullable(queryResult.items()).flatMap(hits -> hits.stream().findFirst());
   }
 
   public SearchQueryResult<MappingEntity> search(final MappingQuery query) {
-    final var dbSort = convertSort(query.sort(), MappingSearchColumn.MAPPING_KEY);
+    final var dbSort = convertSort(query.sort(), MappingSearchColumn.ID);
     final var dbQuery =
         MappingDbQuery.of(
             b -> b.filter(query.filter()).sort(dbSort).page(convertPaging(dbSort, query.page())));

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/MappingSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/MappingSearchColumn.java
@@ -11,7 +11,7 @@ import io.camunda.search.entities.MappingEntity;
 import java.util.function.Function;
 
 public enum MappingSearchColumn implements SearchColumn<MappingEntity> {
-  ID("id", MappingEntity::id),
+  MAPPING_ID("mappingId", MappingEntity::mappingId),
   MAPPING_KEY("mappingKey", MappingEntity::mappingKey),
   CLAIM_NAME("claimName", MappingEntity::claimName),
   CLAIM_VALUE("claimValue", MappingEntity::claimValue),

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/MappingSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/MappingSearchColumn.java
@@ -11,6 +11,7 @@ import io.camunda.search.entities.MappingEntity;
 import java.util.function.Function;
 
 public enum MappingSearchColumn implements SearchColumn<MappingEntity> {
+  ID("id", MappingEntity::id),
   MAPPING_KEY("mappingKey", MappingEntity::mappingKey),
   CLAIM_NAME("claimName", MappingEntity::claimName),
   CLAIM_VALUE("claimValue", MappingEntity::claimValue),

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MappingDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/MappingDbModel.java
@@ -11,7 +11,7 @@ import io.camunda.util.ObjectBuilder;
 import java.util.function.Function;
 
 public record MappingDbModel(
-    String id, Long mappingKey, String claimName, String claimValue, String name)
+    String mappingId, Long mappingKey, String claimName, String claimValue, String name)
     implements DbModel<MappingDbModel> {
 
   @Override
@@ -21,7 +21,7 @@ public record MappingDbModel(
     return builderFunction
         .apply(
             new MappingDbModelBuilder()
-                .id(id)
+                .mappingId(mappingId)
                 .mappingKey(mappingKey)
                 .claimName(claimName)
                 .claimValue(claimValue)
@@ -31,7 +31,7 @@ public record MappingDbModel(
 
   public static class MappingDbModelBuilder implements ObjectBuilder<MappingDbModel> {
 
-    private String id;
+    private String mappingId;
     private Long mappingKey;
     private String claimName;
     private String claimValue;
@@ -39,8 +39,8 @@ public record MappingDbModel(
 
     public MappingDbModelBuilder() {}
 
-    public MappingDbModelBuilder id(final String id) {
-      this.id = id;
+    public MappingDbModelBuilder mappingId(final String mappingId) {
+      this.mappingId = mappingId;
       return this;
     }
 
@@ -66,7 +66,7 @@ public record MappingDbModel(
 
     @Override
     public MappingDbModel build() {
-      return new MappingDbModel(id, mappingKey, claimName, claimValue, name);
+      return new MappingDbModel(mappingId, mappingKey, claimName, claimValue, name);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MappingWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/MappingWriter.java
@@ -31,13 +31,13 @@ public class MappingWriter {
             mapping));
   }
 
-  public void delete(final Long mappingKey) {
+  public void delete(final String mappingId) {
     executionQueue.executeInQueue(
         new QueueItem(
             ContextType.MAPPING,
             WriteStatementType.DELETE,
-            mappingKey,
+            mappingId,
             "io.camunda.db.rdbms.sql.MappingMapper.delete",
-            mappingKey));
+            mappingId));
   }
 }

--- a/db/rdbms/src/main/resources/mapper/MappingMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MappingMapper.xml
@@ -14,7 +14,7 @@
 
   <resultMap id="searchResultMap" type="io.camunda.search.entities.MappingEntity">
     <constructor>
-      <idArg column="ID" javaType="string"/>
+      <idArg column="MAPPING_ID" javaType="string"/>
       <arg column="MAPPING_KEY" javaType="long"/>
       <arg column="CLAIM_NAME" javaType="string"/>
       <arg column="CLAIM_VALUE" javaType="string"/>
@@ -23,14 +23,14 @@
   </resultMap>
 
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.MappingDbModel">
-    INSERT INTO ${prefix}MAPPINGS (ID, MAPPING_KEY, CLAIM_NAME, CLAIM_VALUE, NAME)
-    VALUES (#{id}, #{mappingKey}, #{claimName}, #{claimValue}, #{name})
+    INSERT INTO ${prefix}MAPPINGS (MAPPING_ID, MAPPING_KEY, CLAIM_NAME, CLAIM_VALUE, NAME)
+    VALUES (#{mappingId}, #{mappingKey}, #{claimName}, #{claimValue}, #{name})
   </insert>
 
   <delete id="delete" parameterType="string">
     DELETE
     FROM ${prefix}MAPPINGS
-    WHERE ID = #{id}
+    WHERE MAPPING_ID = #{mappingId}
   </delete>
 
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.MappingDbQuery"
@@ -44,7 +44,7 @@
     resultMap="io.camunda.db.rdbms.sql.MappingMapper.searchResultMap">
     SELECT * FROM (
     SELECT
-    ID,
+    MAPPING_ID,
     MAPPING_KEY,
     CLAIM_NAME,
     CLAIM_VALUE,
@@ -59,8 +59,8 @@
 
   <sql id="searchFilter">
     WHERE 1 = 1
-    <if test="filter.id != null">
-      AND ID = #{filter.id}
+    <if test="filter.mappingId != null">
+      AND MAPPING_ID = #{filter.mappingId}
     </if>
     <if test="filter.mappingKey != null">
       AND MAPPING_KEY = #{filter.mappingKey}

--- a/db/rdbms/src/main/resources/mapper/MappingMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MappingMapper.xml
@@ -14,7 +14,8 @@
 
   <resultMap id="searchResultMap" type="io.camunda.search.entities.MappingEntity">
     <constructor>
-      <idArg column="MAPPING_KEY" javaType="long"/>
+      <idArg column="ID" javaType="string"/>
+      <arg column="MAPPING_KEY" javaType="long"/>
       <arg column="CLAIM_NAME" javaType="string"/>
       <arg column="CLAIM_VALUE" javaType="string"/>
       <arg column="NAME" javaType="string"/>
@@ -22,14 +23,14 @@
   </resultMap>
 
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.MappingDbModel">
-    INSERT INTO ${prefix}MAPPINGS (MAPPING_KEY, CLAIM_NAME, CLAIM_VALUE, NAME)
-    VALUES (#{mappingKey}, #{claimName}, #{claimValue}, #{name})
+    INSERT INTO ${prefix}MAPPINGS (ID, MAPPING_KEY, CLAIM_NAME, CLAIM_VALUE, NAME)
+    VALUES (#{id}, #{mappingKey}, #{claimName}, #{claimValue}, #{name})
   </insert>
 
   <delete id="delete" parameterType="long">
     DELETE
     FROM ${prefix}MAPPINGS
-    WHERE MAPPING_KEY = #{mappingKey}
+    WHERE ID = #{id}
   </delete>
 
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.MappingDbQuery"
@@ -43,6 +44,7 @@
     resultMap="io.camunda.db.rdbms.sql.MappingMapper.searchResultMap">
     SELECT * FROM (
     SELECT
+    ID,
     MAPPING_KEY,
     CLAIM_NAME,
     CLAIM_VALUE,
@@ -57,6 +59,9 @@
 
   <sql id="searchFilter">
     WHERE 1 = 1
+    <if test="filter.id != null">
+      AND ID = #{id}
+    </if>
     <if test="filter.mappingKey != null">
       AND MAPPING_KEY = #{filter.mappingKey}
     </if>

--- a/db/rdbms/src/main/resources/mapper/MappingMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/MappingMapper.xml
@@ -27,7 +27,7 @@
     VALUES (#{id}, #{mappingKey}, #{claimName}, #{claimValue}, #{name})
   </insert>
 
-  <delete id="delete" parameterType="long">
+  <delete id="delete" parameterType="string">
     DELETE
     FROM ${prefix}MAPPINGS
     WHERE ID = #{id}
@@ -60,7 +60,7 @@
   <sql id="searchFilter">
     WHERE 1 = 1
     <if test="filter.id != null">
-      AND ID = #{id}
+      AND ID = #{filter.id}
     </if>
     <if test="filter.mappingKey != null">
       AND MAPPING_KEY = #{filter.mappingKey}

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/MappingFixtures.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/MappingFixtures.java
@@ -28,7 +28,7 @@ public final class MappingFixtures extends CommonFixtures {
     final var id = nextKey();
     final var builder =
         new MappingDbModelBuilder()
-            .id(String.valueOf(id))
+            .mappingId(String.valueOf(id))
             .mappingKey(id)
             .claimName("claimName-" + UUID.randomUUID())
             .claimValue("claimValue-" + UUID.randomUUID())

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/mapping/MappingIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/mapping/MappingIT.java
@@ -38,7 +38,7 @@ public class MappingIT {
     createAndSaveMapping(rdbmsService, randomizedMapping);
 
     final var mapping =
-        rdbmsService.getMappingReader().findOne(randomizedMapping.mappingKey()).orElse(null);
+        rdbmsService.getMappingReader().findOne(randomizedMapping.id()).orElse(null);
     assertThat(mapping).isNotNull();
     assertThat(mapping).usingRecursiveComparison().isEqualTo(randomizedMapping);
   }
@@ -52,18 +52,18 @@ public class MappingIT {
     createAndSaveMapping(rdbmsService, randomizedMapping);
 
     // Verify the mapping is saved
-    final Long mappingKey = randomizedMapping.mappingKey();
-    final var mapping = rdbmsService.getMappingReader().findOne(mappingKey).orElse(null);
+    final var mappingId = randomizedMapping.id();
+    final var mapping = rdbmsService.getMappingReader().findOne(mappingId).orElse(null);
     assertThat(mapping).isNotNull();
     assertThat(mapping).usingRecursiveComparison().isEqualTo(randomizedMapping);
 
     // Delete the mapping
     final RdbmsWriter writer = rdbmsService.createWriter(1L);
-    writer.getMappingWriter().delete(mappingKey);
+    writer.getMappingWriter().delete(mappingId);
     writer.flush();
 
     // Verify the mapping is deleted
-    final var deletedMappingResult = rdbmsService.getMappingReader().findOne(mappingKey);
+    final var deletedMappingResult = rdbmsService.getMappingReader().findOne(mappingId);
     assertThat(deletedMappingResult).isEmpty();
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/mapping/MappingIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/mapping/MappingIT.java
@@ -38,7 +38,7 @@ public class MappingIT {
     createAndSaveMapping(rdbmsService, randomizedMapping);
 
     final var mapping =
-        rdbmsService.getMappingReader().findOne(randomizedMapping.id()).orElse(null);
+        rdbmsService.getMappingReader().findOne(randomizedMapping.mappingId()).orElse(null);
     assertThat(mapping).isNotNull();
     assertThat(mapping).usingRecursiveComparison().isEqualTo(randomizedMapping);
   }
@@ -52,7 +52,7 @@ public class MappingIT {
     createAndSaveMapping(rdbmsService, randomizedMapping);
 
     // Verify the mapping is saved
-    final var mappingId = randomizedMapping.id();
+    final var mappingId = randomizedMapping.mappingId();
     final var mapping = rdbmsService.getMappingReader().findOne(mappingId).orElse(null);
     assertThat(mapping).isNotNull();
     assertThat(mapping).usingRecursiveComparison().isEqualTo(randomizedMapping);

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -559,8 +559,8 @@ class RdbmsExporterIT {
     exporter.export(mappingCreatedRecord);
 
     // then
-    final var id = ((MappingRecordValue) mappingCreatedRecord.getValue()).getId();
-    final var mapping = rdbmsService.getMappingReader().findOne(id);
+    final var mappingId = ((MappingRecordValue) mappingCreatedRecord.getValue()).getId();
+    final var mapping = rdbmsService.getMappingReader().findOne(mappingId);
     assertThat(mapping).isNotNull();
 
     // given
@@ -570,7 +570,7 @@ class RdbmsExporterIT {
     exporter.export(mappingDeletedRecord);
 
     // then
-    final var deletedMapping = rdbmsService.getMappingReader().findOne(id);
+    final var deletedMapping = rdbmsService.getMappingReader().findOne(mappingId);
     assertThat(deletedMapping).isEmpty();
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -559,8 +559,8 @@ class RdbmsExporterIT {
     exporter.export(mappingCreatedRecord);
 
     // then
-    final var key = ((MappingRecordValue) mappingCreatedRecord.getValue()).getMappingKey();
-    final var mapping = rdbmsService.getMappingReader().findOne(key);
+    final var id = ((MappingRecordValue) mappingCreatedRecord.getValue()).getId();
+    final var mapping = rdbmsService.getMappingReader().findOne(id);
     assertThat(mapping).isNotNull();
 
     // given
@@ -570,7 +570,7 @@ class RdbmsExporterIT {
     exporter.export(mappingDeletedRecord);
 
     // then
-    final var deletedMapping = rdbmsService.getMappingReader().findOne(key);
+    final var deletedMapping = rdbmsService.getMappingReader().findOne(id);
     assertThat(deletedMapping).isEmpty();
   }
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/MappingEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/MappingEntityTransformer.java
@@ -18,6 +18,10 @@ public class MappingEntityTransformer
   public MappingEntity apply(
       final io.camunda.webapps.schema.entities.usermanagement.MappingEntity value) {
     return new MappingEntity(
-        value.getKey(), value.getClaimName(), value.getClaimValue(), value.getName());
+        value.getId(),
+        value.getKey(),
+        value.getClaimName(),
+        value.getClaimValue(),
+        value.getName());
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/MappingEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/MappingEntity.java
@@ -11,4 +11,4 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record MappingEntity(
-    String id, Long mappingKey, String claimName, String claimValue, String name) {}
+    String mappingId, Long mappingKey, String claimName, String claimValue, String name) {}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/MappingEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/MappingEntity.java
@@ -10,4 +10,5 @@ package io.camunda.search.entities;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record MappingEntity(Long mappingKey, String claimName, String claimValue, String name) {}
+public record MappingEntity(
+    String id, Long mappingKey, String claimName, String claimValue, String name) {}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/MappingFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/MappingFilter.java
@@ -13,6 +13,7 @@ import io.camunda.util.ObjectBuilder;
 import java.util.List;
 
 public record MappingFilter(
+    String id,
     Long mappingKey,
     String claimName,
     List<String> claimNames,
@@ -21,12 +22,18 @@ public record MappingFilter(
     List<Claim> claims)
     implements FilterBase {
   public static final class Builder implements ObjectBuilder<MappingFilter> {
+    private String id;
     private Long mappingKey;
     private String claimName;
     private List<String> claimNames;
     private String claimValue;
     private String name;
     private List<Claim> claims;
+
+    public Builder id(final String value) {
+      id = value;
+      return this;
+    }
 
     public Builder mappingKey(final Long value) {
       mappingKey = value;
@@ -60,7 +67,7 @@ public record MappingFilter(
 
     @Override
     public MappingFilter build() {
-      return new MappingFilter(mappingKey, claimName, claimNames, claimValue, name, claims);
+      return new MappingFilter(id, mappingKey, claimName, claimNames, claimValue, name, claims);
     }
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/filter/MappingFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/MappingFilter.java
@@ -13,7 +13,7 @@ import io.camunda.util.ObjectBuilder;
 import java.util.List;
 
 public record MappingFilter(
-    String id,
+    String mappingId,
     Long mappingKey,
     String claimName,
     List<String> claimNames,
@@ -22,7 +22,7 @@ public record MappingFilter(
     List<Claim> claims)
     implements FilterBase {
   public static final class Builder implements ObjectBuilder<MappingFilter> {
-    private String id;
+    private String mappingId;
     private Long mappingKey;
     private String claimName;
     private List<String> claimNames;
@@ -30,8 +30,8 @@ public record MappingFilter(
     private String name;
     private List<Claim> claims;
 
-    public Builder id(final String value) {
-      id = value;
+    public Builder mappingId(final String value) {
+      mappingId = value;
       return this;
     }
 
@@ -67,7 +67,8 @@ public record MappingFilter(
 
     @Override
     public MappingFilter build() {
-      return new MappingFilter(id, mappingKey, claimName, claimNames, claimValue, name, claims);
+      return new MappingFilter(
+          mappingId, mappingKey, claimName, claimNames, claimValue, name, claims);
     }
   }
 

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-mapping.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-mapping.json
@@ -5,6 +5,9 @@
       "id": {
         "type": "keyword"
       },
+      "mappingId": {
+        "type": "keyword"
+      },
       "key": {
         "type": "long"
       },

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-mapping.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-mapping.json
@@ -5,6 +5,9 @@
       "id": {
         "type": "keyword"
       },
+      "mappingId": {
+        "type": "keyword"
+      },
       "key": {
         "type": "long"
       },

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MappingExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MappingExportHandler.java
@@ -38,7 +38,7 @@ public class MappingExportHandler implements RdbmsExportHandler<MappingRecordVal
     if (record.getIntent().equals(MappingIntent.CREATED)) {
       mappingWriter.create(map(record));
     } else if (record.getIntent().equals(MappingIntent.DELETED)) {
-      mappingWriter.delete(record.getValue().getMappingKey());
+      mappingWriter.delete(record.getValue().getId());
     }
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MappingExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MappingExportHandler.java
@@ -45,7 +45,7 @@ public class MappingExportHandler implements RdbmsExportHandler<MappingRecordVal
   private MappingDbModel map(final Record<MappingRecordValue> record) {
     final var value = record.getValue();
     return new MappingDbModelBuilder()
-        .id(value.getId())
+        .mappingId(value.getId())
         .mappingKey(value.getMappingKey())
         .claimName(value.getClaimName())
         .claimValue(value.getClaimValue())

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingQueryControllerTest.java
@@ -42,7 +42,7 @@ public class MappingQueryControllerTest extends RestControllerTest {
   @Test
   void getMappingShouldReturnOk() {
     // given
-    final var mapping = new MappingEntity(100L, "Claim Name", "Claim Value", "Map Name");
+    final var mapping = new MappingEntity("100-id", 100L, "Claim Name", "Claim Value", "Map Name");
     when(mappingServices.getMapping(mapping.mappingKey())).thenReturn(mapping);
 
     // when
@@ -112,9 +112,12 @@ public class MappingQueryControllerTest extends RestControllerTest {
                 .lastSortValues(new Object[] {"v"})
                 .items(
                     List.of(
-                        new MappingEntity(100L, "Claim Name1", "Claim Value1", "Map Name1"),
-                        new MappingEntity(200L, "Claim Name2", "Claim Value2", "Map Name2"),
-                        new MappingEntity(300L, "Claim Name3", "Claim Value3", "Map Name3")))
+                        new MappingEntity(
+                            "100-id", 100L, "Claim Name1", "Claim Value1", "Map Name1"),
+                        new MappingEntity(
+                            "200-id", 200L, "Claim Name2", "Claim Value2", "Map Name2"),
+                        new MappingEntity(
+                            "300-id", 300L, "Claim Name3", "Claim Value3", "Map Name3")))
                 .build());
 
     // when / then
@@ -172,9 +175,12 @@ public class MappingQueryControllerTest extends RestControllerTest {
                 .total(3)
                 .items(
                     List.of(
-                        new MappingEntity(100L, "Claim Name1", "Claim Value1", "Map Name1"),
-                        new MappingEntity(200L, "Claim Name2", "Claim Value2", "Map Name2"),
-                        new MappingEntity(300L, "Claim Name3", "Claim Value3", "Map Name3")))
+                        new MappingEntity(
+                            "100-id", 100L, "Claim Name1", "Claim Value1", "Map Name1"),
+                        new MappingEntity(
+                            "200-id", 200L, "Claim Name2", "Claim Value2", "Map Name2"),
+                        new MappingEntity(
+                            "300-id", 300L, "Claim Name3", "Claim Value3", "Map Name3")))
                 .build());
 
     // when / then
@@ -211,9 +217,12 @@ public class MappingQueryControllerTest extends RestControllerTest {
                 .total(3)
                 .items(
                     List.of(
-                        new MappingEntity(100L, "Claim Name1", "Claim Value1", "Map Name3"),
-                        new MappingEntity(200L, "Claim Name2", "Claim Value2", "Map Name1"),
-                        new MappingEntity(300L, "Claim Name3", "Claim Value3", "Map Name2")))
+                        new MappingEntity(
+                            "100-id", 100L, "Claim Name1", "Claim Value1", "Map Name3"),
+                        new MappingEntity(
+                            "200-id", 200L, "Claim Name2", "Claim Value2", "Map Name1"),
+                        new MappingEntity(
+                            "300-id", 300L, "Claim Name3", "Claim Value3", "Map Name2")))
                 .build());
 
     // when / then


### PR DESCRIPTION
This PR introduces support for mapping Id alongside the existing mappingKey to ensure consistency across entities, services, and search logic.

Key changes include:

 - Added id field to MappingEntity and adjusted constructor accordingly.
 - Updated CamundaOidcUser and CamundaOidcUserService to support mappingId, including test updates.
 - Enhanced search functionality by adding a new search column and updating filters to support mappingId.
 - Modified MappingMapper.xml to handle the new id field in insert, delete, and search operations.
 - renamed `id` to `mappingId`

next step : [refactor: rename id to mappingID](https://github.com/camunda/camunda/pull/30136) in all other code

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29666

