### PR TITLE
fix: persisted partition count is used in EngineProcessors 

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -110,6 +110,7 @@ public final class PartitionManagerImpl implements PartitionManager, PartitionCh
             listeners,
             partitionRaftListeners,
             topologyManager,
+            partitionDistribution,
             featureFlags);
     managementService =
         new DefaultPartitionManagementService(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.broker.PartitionRaftListener;
 import io.camunda.zeebe.broker.clustering.ClusterServices;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.logstreams.state.StatePositionSupplier;
+import io.camunda.zeebe.broker.partitioning.topology.PartitionDistribution;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
@@ -103,6 +104,7 @@ public final class ZeebePartitionFactory {
   private final JobStreamer jobStreamer;
   private final List<PartitionListener> partitionListeners;
   private final TopologyManagerImpl topologyManager;
+  private final PartitionDistribution partitionDistribution;
   private final FeatureFlags featureFlags;
   private final List<PartitionRaftListener> partitionRaftListeners;
 
@@ -119,6 +121,7 @@ public final class ZeebePartitionFactory {
       final List<PartitionListener> partitionListeners,
       final List<PartitionRaftListener> partitionRaftListeners,
       final TopologyManagerImpl topologyManager,
+      final PartitionDistribution partitionDistribution,
       final FeatureFlags featureFlags) {
     this.actorSchedulingService = actorSchedulingService;
     this.brokerCfg = brokerCfg;
@@ -132,6 +135,7 @@ public final class ZeebePartitionFactory {
     this.partitionListeners = partitionListeners;
     this.partitionRaftListeners = partitionRaftListeners;
     this.topologyManager = topologyManager;
+    this.partitionDistribution = partitionDistribution;
     this.featureFlags = featureFlags;
   }
 
@@ -224,7 +228,7 @@ public final class ZeebePartitionFactory {
 
       return EngineProcessors.createEngineProcessors(
           recordProcessorContext,
-          localBroker.getPartitionsCount(),
+          partitionDistribution.partitions().size(),
           subscriptionCommandSender,
           partitionCommandSender,
           featureFlags,

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PersistedClusterTopologyTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PersistedClusterTopologyTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.clustering.dynamic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+@ZeebeIntegration
+@AutoCloseResources
+@Timeout(2 * 60)
+public class PersistedClusterTopologyTest {
+
+  private static final int CLUSTER_SIZE = 3;
+  private static final int PARTITION_COUNT = 3;
+  private static final int REPLICATION_FACTOR = 3;
+
+  @AutoCloseResource private ZeebeClient client;
+
+  @TestZeebe
+  private final TestCluster cluster =
+      TestCluster.builder()
+          .useRecordingExporter(true)
+          .withGatewaysCount(1)
+          .withEmbeddedGateway(true)
+          .withBrokersCount(CLUSTER_SIZE)
+          .withPartitionsCount(PARTITION_COUNT)
+          .withReplicationFactor(REPLICATION_FACTOR)
+          .withGatewayConfig(
+              g ->
+                  g.gatewayConfig()
+                      .getCluster()
+                      .getMembership()
+                      // Decrease the timeouts for fast convergence of gateway topology. When the
+                      // broker is shutdown, the topology update takes at least 10 seconds with
+                      // the
+                      // default values.
+                      .setSyncInterval(Duration.ofSeconds(1))
+                      .setFailureTimeout(Duration.ofSeconds(5)))
+          .build();
+
+  @Test
+  void canHandleTopologyRequestsWhenBroker0IsRemoved() {
+    // given
+    cluster.awaitCompleteTopology();
+    client = cluster.newClientBuilder().build();
+
+    ///  Overview of the process being deployed
+    ///                      _____________________________
+    //     START_EVENT ->   |         service1           |     -------> END_EVENT
+    //                      |-----(message catch event)--|                 ^
+    //                                        |          _______________   |
+    //                                        |---------| serviceCatch | --|
+    //                                                  ---------------
+    final var deploymentEvent =
+        client
+            .newDeployResourceCommand()
+            .addResourceFromClasspath("processes/catch_event.bpmn")
+            .send()
+            .join();
+
+    cluster.shutdown();
+    RecordingExporter.reset();
+
+    // when
+    cluster.setPartitionCount(1);
+    cluster.start();
+    cluster.awaitCompleteTopology(
+        CLUSTER_SIZE, PARTITION_COUNT, REPLICATION_FACTOR, Duration.ofSeconds(10));
+
+    final var processId =
+        client
+            .newCreateInstanceCommand()
+            .processDefinitionKey(
+                deploymentEvent.getProcesses().getFirst().getProcessDefinitionKey())
+            .send()
+            .join();
+
+    final var result =
+        client
+            .newPublishMessageCommand()
+            .messageName("catch_event")
+            .correlationKey("11")
+            .send()
+            .join();
+
+    // then
+    // there are not jobs to activate because of the successful message catch event triggered
+    final var activatedJobs =
+        client.newActivateJobsCommand().jobType("service1").maxJobsToActivate(1).send().join();
+    assertThat(activatedJobs.getJobs()).isEmpty();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/resources/processes/catch_event.bpmn
+++ b/zeebe/qa/integration-tests/src/test/resources/processes/catch_event.bpmn
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0a205ky" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.29.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="Process_1hxi2y5" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1xnqi7t</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1xnqi7t" sourceRef="StartEvent_1" targetRef="Activity_12d7i7n" />
+    <bpmn:endEvent id="Event_0z0e3ta">
+      <bpmn:incoming>Flow_1q2gddn</bpmn:incoming>
+      <bpmn:incoming>Flow_1c4pwky</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1q2gddn" sourceRef="Activity_12d7i7n" targetRef="Event_0z0e3ta" />
+    <bpmn:boundaryEvent id="Event_1mrcqki" attachedToRef="Activity_12d7i7n">
+      <bpmn:outgoing>Flow_19emq4q</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0w1t17r" messageRef="Message_3ce0n2t" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_19emq4q" sourceRef="Event_1mrcqki" targetRef="Activity_1ymyovs" />
+    <bpmn:sequenceFlow id="Flow_1c4pwky" sourceRef="Activity_1ymyovs" targetRef="Event_0z0e3ta" />
+    <bpmn:serviceTask id="Activity_12d7i7n" name="service1">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="service1" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1xnqi7t</bpmn:incoming>
+      <bpmn:outgoing>Flow_1q2gddn</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Activity_1ymyovs" name="serviceCatch">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="serviceCatch" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_19emq4q</bpmn:incoming>
+      <bpmn:outgoing>Flow_1c4pwky</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmn:message id="Message_3ce0n2t" name="catch_event">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=11" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1hxi2y5">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0z0e3ta_di" bpmnElement="Event_0z0e3ta">
+        <dc:Bounds x="542" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_06r1pum_di" bpmnElement="Activity_12d7i7n">
+        <dc:Bounds x="330" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_06om09f_di" bpmnElement="Activity_1ymyovs">
+        <dc:Bounds x="440" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ywyne3_di" bpmnElement="Event_1mrcqki">
+        <dc:Bounds x="362" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1xnqi7t_di" bpmnElement="Flow_1xnqi7t">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="330" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1q2gddn_di" bpmnElement="Flow_1q2gddn">
+        <di:waypoint x="430" y="120" />
+        <di:waypoint x="542" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19emq4q_di" bpmnElement="Flow_19emq4q">
+        <di:waypoint x="380" y="178" />
+        <di:waypoint x="380" y="230" />
+        <di:waypoint x="440" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c4pwky_di" bpmnElement="Flow_1c4pwky">
+        <di:waypoint x="490" y="190" />
+        <di:waypoint x="490" y="164" />
+        <di:waypoint x="560" y="164" />
+        <di:waypoint x="560" y="138" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
@@ -84,7 +84,7 @@ public final class TestCluster implements CloseableSilently {
   private final Map<MemberId, TestStandaloneGateway> gateways;
   private final Map<MemberId, TestStandaloneBroker> brokers;
   private final int replicationFactor;
-  private final int partitionsCount;
+  private int partitionsCount;
 
   /**
    * Creates a new cluster from the given parameters.
@@ -404,5 +404,10 @@ public final class TestCluster implements CloseableSilently {
         .filter(TestApplication::isGateway)
         .filter(TestGateway.class::isInstance)
         .map(node -> (TestGateway<?>) node);
+  }
+
+  public void setPartitionCount(final int count) {
+    partitionsCount = count;
+    brokers.forEach((id, b) -> b.brokerConfig().getCluster().setPartitionsCount(partitionsCount));
   }
 }


### PR DESCRIPTION
## Description
EngineProcessors were using the partition count defined in the `ClusterCfg`, but once a cluster is bootstrapped that value can be incorrect.
With this fix, `EngineProcessors` use the partitionCount from a `PartitionDistribution`, which is created from the partition information available in `ClusterTopologyManagerService`.

A new IT test has been added which tries to reproduce the original bug. Considering that his bug arises when a broker is restarted with a different configuration it would have been a bit difficult to test it with a unit test.

## Related issues

closes #29612 
