### PR TITLE
Fix print dry run command to delete version specific api changes

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -186,7 +186,7 @@ jobs:
           IFS='\n' readarray -t files <<< $(find . -name 'ignored-changes.json')
           for file in "${files[@]}"; do
             if [ '${{ inputs.dryRun }}' = 'false' ]; then
-              "[DRY RUN] rm -f ${file}"
+              echo "[DRY RUN] rm -f ${file}"
             else
               rm -f "${file}"
             fi


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

With https://github.com/camunda/camunda/pull/29221 a new step was added to the release workflow to delete version specific api changes (i.e. cleanup `ignored-changes.json`). On dry runs, the file should be left intact. However, on dry runs the step fails with the error:

> /home/runner/_work/_temp/26977de5-9b2c-4d7a-9acf-1b3fc11ddaa9.sh: line 4: [DRY RUN] rm -f ./zeebe/protocol/ignored-changes.json: No such file or directory

The intention was likely to print the dry run command. So this pull request adds `echo`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [x] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

Workflow run: https://github.com/camunda/camunda/actions/runs/14056852152/job/39358137481#step:15:33