### PR TITLE
refactor: rename id to mappingID

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/command/CreateMappingCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/client/api/command/CreateMappingCommandStep1.java
@@ -49,9 +49,9 @@ public interface CreateMappingCommandStep1 extends FinalCommandStep<CreateMappin
   /**
    * Set the id to create mapping with.
    *
-   * @param id the id value
+   * @param mappingId the mapping id value
    * @return the builder for this command. Call {@link #send()} to complete the command and send it
    *     to the broker.
    */
-  CreateMappingCommandStep1 id(final String id);
+  CreateMappingCommandStep1 mappingId(final String mappingId);
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/command/CreateMappingCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/command/CreateMappingCommandImpl.java
@@ -62,8 +62,8 @@ public class CreateMappingCommandImpl implements CreateMappingCommandStep1 {
   }
 
   @Override
-  public CreateMappingCommandStep1 id(final String id) {
-    mappingRequest.id(id);
+  public CreateMappingCommandStep1 mappingId(final String mappingId) {
+    mappingRequest.mappingId(mappingId);
     return this;
   }
 
@@ -78,7 +78,7 @@ public class CreateMappingCommandImpl implements CreateMappingCommandStep1 {
     ArgumentUtil.ensureNotNull("claimName", mappingRequest.getClaimName());
     ArgumentUtil.ensureNotNull("claimValue", mappingRequest.getClaimValue());
     ArgumentUtil.ensureNotNull("name", mappingRequest.getName());
-    ArgumentUtil.ensureNotNull("id", mappingRequest.getId());
+    ArgumentUtil.ensureNotNull("mappingId", mappingRequest.getMappingId());
     final HttpCamundaFuture<CreateMappingResponse> result = new HttpCamundaFuture<>();
     final CreateMappingResponseImpl response = new CreateMappingResponseImpl();
     httpClient.post(

--- a/clients/java/src/test/java/io/camunda/client/mapping/CreateMappingTest.java
+++ b/clients/java/src/test/java/io/camunda/client/mapping/CreateMappingTest.java
@@ -27,7 +27,7 @@ public class CreateMappingTest extends ClientRestTest {
   public static final String CLAIM_NAME = "claimName";
   public static final String CLAIM_VALUE = "claimValue";
   public static final String NAME = "mappingName";
-  public static final String ID = "mappingId";
+  public static final String MAPPING_ID = "mappingId";
 
   @Test
   void shouldCreateMapping() {
@@ -37,7 +37,7 @@ public class CreateMappingTest extends ClientRestTest {
         .claimName(CLAIM_NAME)
         .claimValue(CLAIM_VALUE)
         .name(NAME)
-        .id(ID)
+        .mappingId(MAPPING_ID)
         .send()
         .join();
 
@@ -47,7 +47,7 @@ public class CreateMappingTest extends ClientRestTest {
     assertThat(request.getClaimName()).isEqualTo(CLAIM_NAME);
     assertThat(request.getClaimValue()).isEqualTo(CLAIM_VALUE);
     assertThat(request.getName()).isEqualTo(NAME);
-    assertThat(request.getId()).isEqualTo(ID);
+    assertThat(request.getMappingId()).isEqualTo(MAPPING_ID);
   }
 
   @Test

--- a/identity/client/src/pages/groups/detail/mappings/AssignMappingsModal.tsx
+++ b/identity/client/src/pages/groups/detail/mappings/AssignMappingsModal.tsx
@@ -43,9 +43,9 @@ const AssignMappingsModal: FC<
 
   const unassignedMappings =
     mappingSearchResults?.items.filter(
-      ({ id }) =>
-        !assignedMappings.some((mapping) => mapping.id === id) &&
-        !selectedMappings.some((mapping) => mapping.id === id),
+      ({ mappingId }) =>
+        !assignedMappings.some((mapping) => mapping.mappingId === mappingId) &&
+        !selectedMappings.some((mapping) => mapping.mappingId === mappingId),
     ) || [];
 
   const onSelectMapping = (mapping: Mapping) => {
@@ -53,10 +53,10 @@ const AssignMappingsModal: FC<
   };
 
   const onUnselectMapping =
-    ({ id }: Mapping) =>
+    ({ mappingId }: Mapping) =>
     () => {
       setSelectedMappings(
-        selectedMappings.filter((mapping) => mapping.id !== id),
+        selectedMappings.filter((mapping) => mapping.mappingId !== mappingId),
       );
     };
 
@@ -68,8 +68,8 @@ const AssignMappingsModal: FC<
     setLoadingAssignMapping(true);
 
     const results = await Promise.all(
-      selectedMappings.map(({ id }) =>
-        callAssignMapping({ id, groupId: group.id }),
+      selectedMappings.map(({ mappingId }) =>
+        callAssignMapping({ mappingId, groupId: group.id }),
       ),
     );
 
@@ -107,13 +107,13 @@ const AssignMappingsModal: FC<
         <SelectedMappings>
           {selectedMappings.map((mapping) => (
             <Tag
-              key={mapping.id}
+              key={mapping.mappingId}
               onClose={onUnselectMapping(mapping)}
               size="md"
               type="blue"
               filter
             >
-              {mapping.id}
+              {mapping.mappingId}
             </Tag>
           ))}
         </SelectedMappings>
@@ -121,7 +121,7 @@ const AssignMappingsModal: FC<
       <DropdownSearch
         autoFocus
         items={unassignedMappings}
-        itemTitle={({ id }) => id}
+        itemTitle={({ mappingId }) => mappingId}
         itemSubTitle={({ name }) => name}
         placeholder={t("searchByMappingId")}
         onSelect={onSelectMapping}

--- a/identity/client/src/pages/groups/detail/mappings/DeleteModal.tsx
+++ b/identity/client/src/pages/groups/detail/mappings/DeleteModal.tsx
@@ -38,7 +38,7 @@ const DeleteModal: FC<RemoveGroupMappingModalProps> = ({
     if (groupId && mapping) {
       const { success } = await callUnassignMapping({
         groupId,
-        id: mapping.id,
+        mappingId: mapping.mappingId,
       });
 
       if (success) {

--- a/identity/client/src/pages/mappings/modals/AddModal.tsx
+++ b/identity/client/src/pages/mappings/modals/AddModal.tsx
@@ -36,7 +36,7 @@ const AddMappingModal: FC<UseModalProps> = ({ open, onClose, onSuccess }) => {
 
   const handleSubmit = async () => {
     const { success } = await apiCall({
-      id: mappingId,
+      mappingId: mappingId,
       name: mappingName,
       claimName,
       claimValue,

--- a/identity/client/src/pages/roles/detail/mappings/AssignMappingsModal.tsx
+++ b/identity/client/src/pages/roles/detail/mappings/AssignMappingsModal.tsx
@@ -43,9 +43,9 @@ const AssignMappingsModal: FC<
 
   const unassignedMappings =
     mappingSearchResults?.items.filter(
-      ({ id }) =>
-        !assignedMappings.some((mapping) => mapping.id === id) &&
-        !selectedMappings.some((mapping) => mapping.id === id),
+      ({ mappingId }) =>
+        !assignedMappings.some((mapping) => mapping.mappingId === mappingId) &&
+        !selectedMappings.some((mapping) => mapping.mappingId === mappingId),
     ) || [];
 
   const onSelectMapping = (mapping: Mapping) => {
@@ -53,10 +53,10 @@ const AssignMappingsModal: FC<
   };
 
   const onUnselectMapping =
-    ({ id }: Mapping) =>
+    ({ mappingId }: Mapping) =>
     () => {
       setSelectedMappings(
-        selectedMappings.filter((mapping) => mapping.id !== id),
+        selectedMappings.filter((mapping) => mapping.mappingId !== mappingId),
       );
     };
 
@@ -68,8 +68,8 @@ const AssignMappingsModal: FC<
     setLoadingAssignMapping(true);
 
     const results = await Promise.all(
-      selectedMappings.map(({ id }) =>
-        callAssignMapping({ id, roleId: role.id }),
+      selectedMappings.map(({ mappingId }) =>
+        callAssignMapping({ mappingId, roleId: role.id }),
       ),
     );
 
@@ -107,13 +107,13 @@ const AssignMappingsModal: FC<
         <SelectedMappings>
           {selectedMappings.map((mapping) => (
             <Tag
-              key={mapping.id}
+              key={mapping.mappingId}
               onClose={onUnselectMapping(mapping)}
               size="md"
               type="blue"
               filter
             >
-              {mapping.id}
+              {mapping.mappingId}
             </Tag>
           ))}
         </SelectedMappings>
@@ -121,7 +121,7 @@ const AssignMappingsModal: FC<
       <DropdownSearch
         autoFocus
         items={unassignedMappings}
-        itemTitle={({ id }) => id}
+        itemTitle={({ mappingId }) => mappingId}
         itemSubTitle={({ name }) => name}
         placeholder={t("searchByMappingId")}
         onSelect={onSelectMapping}

--- a/identity/client/src/pages/roles/detail/mappings/DeleteModal.tsx
+++ b/identity/client/src/pages/roles/detail/mappings/DeleteModal.tsx
@@ -38,7 +38,7 @@ const DeleteModal: FC<RemoveRoleMappingModalProps> = ({
     if (roleId && mapping) {
       const { success } = await callUnassignMapping({
         roleId,
-        id: mapping.id,
+        mappingId: mapping.mappingId,
       });
 
       if (success) {

--- a/identity/client/src/pages/tenants/detail/mappings/AssignMappingsModal.tsx
+++ b/identity/client/src/pages/tenants/detail/mappings/AssignMappingsModal.tsx
@@ -43,9 +43,9 @@ const AssignMappingsModal: FC<
 
   const unassignedMappings =
     mappingSearchResults?.items.filter(
-      ({ id }) =>
-        !assignedMappings.some((mapping) => mapping.id === id) &&
-        !selectedMappings.some((mapping) => mapping.id === id),
+      ({ mappingId }) =>
+        !assignedMappings.some((mapping) => mapping.mappingId === mappingId) &&
+        !selectedMappings.some((mapping) => mapping.mappingId === mappingId),
     ) || [];
 
   const onSelectMapping = (mapping: Mapping) => {
@@ -53,10 +53,10 @@ const AssignMappingsModal: FC<
   };
 
   const onUnselectMapping =
-    ({ id }: Mapping) =>
+    ({ mappingId }: Mapping) =>
     () => {
       setSelectedMappings(
-        selectedMappings.filter((mapping) => mapping.id !== id),
+        selectedMappings.filter((mapping) => mapping.mappingId !== mappingId),
       );
     };
 
@@ -68,8 +68,8 @@ const AssignMappingsModal: FC<
     setLoadingAssignMapping(true);
 
     const results = await Promise.all(
-      selectedMappings.map(({ id }) =>
-        callAssignMapping({ id, tenantId: tenant.id }),
+      selectedMappings.map(({ mappingId }) =>
+        callAssignMapping({ mappingId, tenantId: tenant.id }),
       ),
     );
 
@@ -107,13 +107,13 @@ const AssignMappingsModal: FC<
         <SelectedMappings>
           {selectedMappings.map((mapping) => (
             <Tag
-              key={mapping.id}
+              key={mapping.mappingId}
               onClose={onUnselectMapping(mapping)}
               size="md"
               type="blue"
               filter
             >
-              {mapping.id}
+              {mapping.mappingId}
             </Tag>
           ))}
         </SelectedMappings>
@@ -121,7 +121,7 @@ const AssignMappingsModal: FC<
       <DropdownSearch
         autoFocus
         items={unassignedMappings}
-        itemTitle={({ id }) => id}
+        itemTitle={({ mappingId }) => mappingId}
         itemSubTitle={({ name }) => name}
         placeholder={t("searchByMappingId")}
         onSelect={onSelectMapping}

--- a/identity/client/src/pages/tenants/detail/mappings/DeleteModal.tsx
+++ b/identity/client/src/pages/tenants/detail/mappings/DeleteModal.tsx
@@ -38,7 +38,7 @@ const DeleteModal: FC<RemoveTenantMappingModalProps> = ({
     if (tenant && mapping) {
       const { success } = await callUnassignMapping({
         tenantId: tenant,
-        id: mapping.id,
+        mappingId: mapping.mappingId,
       });
 
       if (success) {

--- a/identity/client/src/utility/api/groups/index.ts
+++ b/identity/client/src/utility/api/groups/index.ts
@@ -91,17 +91,17 @@ export const getMappingsByGroupId: ApiDefinition<
 > = ({ groupId }) =>
   apiPost(`${GROUPS_ENDPOINT}/${groupId}/mapping-rules/search`);
 
-type AssignGroupMappingParams = GetGroupMappingsParams & { id: string };
+type AssignGroupMappingParams = GetGroupMappingsParams & { mappingId: string };
 export const assignGroupMapping: ApiDefinition<
   undefined,
   AssignGroupMappingParams
-> = ({ groupId, id }) => {
-  return apiPut(`${GROUPS_ENDPOINT}/${groupId}/mapping-rules/${id}`);
+> = ({ groupId, mappingId }) => {
+  return apiPut(`${GROUPS_ENDPOINT}/${groupId}/mapping-rules/${mappingId}`);
 };
 
 type UnassignGroupMappingParams = AssignGroupMappingParams;
 export const unassignGroupMapping: ApiDefinition<
   undefined,
   UnassignGroupMappingParams
-> = ({ groupId, id }) =>
-  apiDelete(`${GROUPS_ENDPOINT}/${groupId}/mapping-rules/${id}`);
+> = ({ groupId, mappingId }) =>
+  apiDelete(`${GROUPS_ENDPOINT}/${groupId}/mapping-rules/${mappingId}`);

--- a/identity/client/src/utility/api/mappings/index.ts
+++ b/identity/client/src/utility/api/mappings/index.ts
@@ -18,7 +18,7 @@ export const MAPPINGS_ENDPOINT = "/mapping-rules";
 
 export type Mapping = EntityData & {
   mappingKey: string;
-  id: string;
+  mappingId: string;
   name: string;
   claimName: string;
   claimValue: string;
@@ -35,7 +35,7 @@ export const createMapping: ApiDefinition<undefined, CreateMappingParams> = (
 
 export type UpdateMappingParams = {
   mappingKey: string;
-  id: string;
+  mappingId: string;
   name: string;
   claimName: string;
   claimValue: string;

--- a/identity/client/src/utility/api/roles/index.ts
+++ b/identity/client/src/utility/api/roles/index.ts
@@ -56,17 +56,17 @@ export const getMappingsByRoleId: ApiDefinition<
   GetRoleMappingsParams
 > = ({ roleId }) => apiPost(`${ROLES_ENDPOINT}/${roleId}/mapping-rules/search`);
 
-type AssignRoleMappingParams = GetRoleMappingsParams & { id: string };
+type AssignRoleMappingParams = GetRoleMappingsParams & { mappingId: string };
 export const assignRoleMapping: ApiDefinition<
   undefined,
   AssignRoleMappingParams
-> = ({ roleId, id }) => {
-  return apiPut(`${ROLES_ENDPOINT}/${roleId}/mapping-rules/${id}`);
+> = ({ roleId, mappingId }) => {
+  return apiPut(`${ROLES_ENDPOINT}/${roleId}/mapping-rules/${mappingId}`);
 };
 
 type UnassignRoleMappingParams = AssignRoleMappingParams;
 export const unassignRoleMapping: ApiDefinition<
   undefined,
   UnassignRoleMappingParams
-> = ({ roleId, id }) =>
-  apiDelete(`${ROLES_ENDPOINT}/${roleId}/mapping-rules/${id}`);
+> = ({ roleId, mappingId }) =>
+  apiDelete(`${ROLES_ENDPOINT}/${roleId}/mapping-rules/${mappingId}`);

--- a/identity/client/src/utility/api/tenants/index.ts
+++ b/identity/client/src/utility/api/tenants/index.ts
@@ -121,17 +121,19 @@ export const getMappingsByTenantId: ApiDefinition<
 > = ({ tenantId }) =>
   apiPost(`${TENANTS_ENDPOINT}/${tenantId}/mapping-rules/search`);
 
-type AssignTenantMappingParams = GetTenantMappingsParams & { id: string };
+type AssignTenantMappingParams = GetTenantMappingsParams & {
+  mappingId: string;
+};
 export const assignTenantMapping: ApiDefinition<
   undefined,
   AssignTenantMappingParams
-> = ({ tenantId, id }) => {
-  return apiPut(`${TENANTS_ENDPOINT}/${tenantId}/mapping-rules/${id}`);
+> = ({ tenantId, mappingId }) => {
+  return apiPut(`${TENANTS_ENDPOINT}/${tenantId}/mapping-rules/${mappingId}`);
 };
 
 type UnassignTenantMappingParams = AssignTenantMappingParams;
 export const unassignTenantMapping: ApiDefinition<
   undefined,
   UnassignTenantMappingParams
-> = ({ tenantId, id }) =>
-  apiDelete(`${TENANTS_ENDPOINT}/${tenantId}/mapping-rules/${id}`);
+> = ({ tenantId, mappingId }) =>
+  apiDelete(`${TENANTS_ENDPOINT}/${tenantId}/mapping-rules/${mappingId}`);

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/MappingAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/MappingAuthorizationIT.java
@@ -113,7 +113,7 @@ class MappingAuthorizationIT {
         .newCreateMappingCommand()
         .claimName(name)
         .claimValue(value)
-        .id(mappingId)
+        .mappingId(mappingId)
         .name(mappingId)
         .send()
         .join();

--- a/service/src/main/java/io/camunda/service/MappingServices.java
+++ b/service/src/main/java/io/camunda/service/MappingServices.java
@@ -115,7 +115,7 @@ public class MappingServices
   }
 
   public CompletableFuture<MappingRecord> deleteMapping(final String mappingId) {
-    return sendBrokerRequest(new BrokerMappingDeleteRequest().setId(mappingId));
+    return sendBrokerRequest(new BrokerMappingDeleteRequest().setMappingId(mappingId));
   }
 
   public List<MappingEntity> getMatchingMappings(final Map<String, Object> claims) {

--- a/service/src/main/java/io/camunda/service/MappingServices.java
+++ b/service/src/main/java/io/camunda/service/MappingServices.java
@@ -74,7 +74,7 @@ public class MappingServices
             .setClaimName(request.claimName())
             .setClaimValue(request.claimValue())
             .setName(request.name())
-            .setMappingId(request.id()));
+            .setMappingId(request.mappingId()));
   }
 
   public CompletableFuture<MappingRecord> updateMapping(final MappingDTO request) {
@@ -83,7 +83,7 @@ public class MappingServices
             .setClaimName(request.claimName())
             .setClaimValue(request.claimValue())
             .setName(request.name())
-            .setMappingId(request.id()));
+            .setMappingId(request.mappingId()));
   }
 
   public MappingEntity getMapping(final Long mappingKey) {
@@ -139,5 +139,5 @@ public class MappingServices
     return Stream.of(String.valueOf(value));
   }
 
-  public record MappingDTO(String claimName, String claimValue, String name, String id) {}
+  public record MappingDTO(String claimName, String claimValue, String name, String mappingId) {}
 }

--- a/service/src/test/java/io/camunda/service/MappingServicesTest.java
+++ b/service/src/test/java/io/camunda/service/MappingServicesTest.java
@@ -191,7 +191,7 @@ public class MappingServicesTest {
     // then
     verify(mockBrokerClient).sendRequest(mappingUpdateRequestArgumentCaptor.capture());
     final var request = mappingUpdateRequestArgumentCaptor.getValue();
-    assertThat(request.getRequestWriter().getMappingId()).isEqualTo(mappingDTO.id());
+    assertThat(request.getRequestWriter().getMappingId()).isEqualTo(mappingDTO.mappingId());
     assertThat(request.getRequestWriter().getClaimName()).isEqualTo(mappingDTO.claimName());
     assertThat(request.getRequestWriter().getClaimValue()).isEqualTo(mappingDTO.claimValue());
     assertThat(request.getRequestWriter().getName()).isEqualTo(mappingDTO.name());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedMapping.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedMapping.java
@@ -91,8 +91,8 @@ public class PersistedMapping extends UnpackedObject implements DbValue {
     return BufferUtil.bufferAsString(mappingIdProp.getValue());
   }
 
-  public PersistedMapping setMappingId(final String id) {
-    mappingIdProp.setValue(id);
+  public PersistedMapping setMappingId(final String mappingId) {
+    mappingIdProp.setValue(mappingId);
     return this;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/DeleteMappingMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/DeleteMappingMultiPartitionTest.java
@@ -41,9 +41,14 @@ public class DeleteMappingMultiPartitionTest {
     // when
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
-    final var id = UUID.randomUUID().toString();
-    engine.mapping().newMapping(claimName).withClaimValue(claimValue).withMappingId(id).create();
-    engine.mapping().deleteMapping(id).delete();
+    final var mappingId = UUID.randomUUID().toString();
+    engine
+        .mapping()
+        .newMapping(claimName)
+        .withClaimValue(claimValue)
+        .withMappingId(mappingId)
+        .create();
+    engine.mapping().deleteMapping(mappingId).delete();
 
     // then
     assertThat(
@@ -91,9 +96,14 @@ public class DeleteMappingMultiPartitionTest {
     // when
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
-    final var id = UUID.randomUUID().toString();
-    engine.mapping().newMapping(claimName).withClaimValue(claimValue).withMappingId(id).create();
-    engine.mapping().deleteMapping(id).delete();
+    final var mappingId = UUID.randomUUID().toString();
+    engine
+        .mapping()
+        .newMapping(claimName)
+        .withClaimValue(claimValue)
+        .withMappingId(mappingId)
+        .create();
+    engine.mapping().deleteMapping(mappingId).delete();
 
     // then
     assertThat(
@@ -112,10 +122,15 @@ public class DeleteMappingMultiPartitionTest {
     }
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
-    final var id = UUID.randomUUID().toString();
+    final var mappingId = UUID.randomUUID().toString();
 
-    engine.mapping().newMapping(claimName).withClaimValue(claimValue).withMappingId(id).create();
-    engine.mapping().deleteMapping(id).delete();
+    engine
+        .mapping()
+        .newMapping(claimName)
+        .withClaimValue(claimValue)
+        .withMappingId(mappingId)
+        .create();
+    engine.mapping().deleteMapping(mappingId).delete();
 
     // Increase time to trigger a redistribution
     engine.increaseTime(Duration.ofMinutes(1));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingTest.java
@@ -211,22 +211,24 @@ public class MappingTest {
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
     final var name = UUID.randomUUID().toString();
-    final var id = UUID.randomUUID().toString();
+    final var mappingId = UUID.randomUUID().toString();
 
     engine
         .mapping()
         .newMapping(claimName)
         .withClaimValue(claimValue)
         .withName(name)
-        .withMappingId(id)
+        .withMappingId(mappingId)
         .create()
         .getValue();
 
     // when
-    final var deletedMapping = engine.mapping().deleteMapping(id).delete().getValue();
+    final var deletedMapping = engine.mapping().deleteMapping(mappingId).delete().getValue();
 
     // then
-    Assertions.assertThat(deletedMapping).isNotNull().hasFieldOrPropertyWithValue("mappingId", id);
+    Assertions.assertThat(deletedMapping)
+        .isNotNull()
+        .hasFieldOrPropertyWithValue("mappingId", mappingId);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingUpdateAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingUpdateAuthorizationTest.java
@@ -84,7 +84,7 @@ public class MappingUpdateAuthorizationTest {
     final var claimValue = UUID.randomUUID().toString();
     final var claimValueNew = UUID.randomUUID().toString();
     final var name = UUID.randomUUID().toString();
-    final var id = UUID.randomUUID().toString();
+    final var mappingId = UUID.randomUUID().toString();
 
     final var user = createUser();
     addPermissionsToUser(user, AuthorizationResourceType.MAPPING_RULE, PermissionType.UPDATE);
@@ -94,13 +94,13 @@ public class MappingUpdateAuthorizationTest {
         .newMapping(claimName)
         .withClaimValue(claimValue)
         .withName(name)
-        .withMappingId(id)
+        .withMappingId(mappingId)
         .create(DEFAULT_USER.getUsername());
 
     // when
     engine
         .mapping()
-        .updateMapping(id)
+        .updateMapping(mappingId)
         .withClaimValue(claimValue)
         .withClaimValue(claimValueNew)
         .withName(name)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingStateTest.java
@@ -36,11 +36,11 @@ public class MappingStateTest {
     final String claimName = "foo";
     final String claimValue = "bar";
     final String name = "name";
-    final String id = "id";
+    final String mappingId = "mappingId";
     final var mapping =
         new MappingRecord()
             .setMappingKey(key)
-            .setMappingId(id)
+            .setMappingId(mappingId)
             .setClaimName(claimName)
             .setName(name)
             .setClaimValue(claimValue);
@@ -51,7 +51,7 @@ public class MappingStateTest {
     // then
     final var persistedMapping = mappingState.get(key).get();
     assertThat(persistedMapping.getMappingKey()).isEqualTo(key);
-    assertThat(persistedMapping.getMappingId()).isEqualTo(id);
+    assertThat(persistedMapping.getMappingId()).isEqualTo(mappingId);
     assertThat(persistedMapping.getName()).isEqualTo(name);
     assertThat(persistedMapping.getClaimName()).isEqualTo(claimName);
     assertThat(persistedMapping.getClaimValue()).isEqualTo(claimValue);
@@ -72,7 +72,7 @@ public class MappingStateTest {
     final long key = 1L;
     final String claimName = "claimName";
     final String claimValue = "claimValue";
-    final String id = "id";
+    final String mappingId = "mappingId";
     final String name = "name";
     final var mapping =
         new MappingRecord()
@@ -80,7 +80,7 @@ public class MappingStateTest {
             .setClaimName(claimName)
             .setClaimValue(claimValue)
             .setName(name)
-            .setMappingId(id);
+            .setMappingId(mappingId);
     mappingState.create(mapping);
 
     // when
@@ -90,7 +90,7 @@ public class MappingStateTest {
     assertThat(retrievedMapping).isPresent();
     assertThat(retrievedMapping.get().getMappingKey()).isEqualTo(key);
     assertThat(retrievedMapping.get().getName()).isEqualTo(name);
-    assertThat(retrievedMapping.get().getMappingId()).isEqualTo(id);
+    assertThat(retrievedMapping.get().getMappingId()).isEqualTo(mappingId);
   }
 
   @Test
@@ -108,7 +108,7 @@ public class MappingStateTest {
     final long key = 1L;
     final String claimName = "claimName";
     final String claimValue = "claimValue";
-    final String id = "id";
+    final String mappingId = "mappingId";
     final String name = "name";
     final var mapping =
         new MappingRecord()
@@ -116,11 +116,11 @@ public class MappingStateTest {
             .setClaimName(claimName)
             .setClaimValue(claimValue)
             .setName(name)
-            .setMappingId(id);
+            .setMappingId(mappingId);
     mappingState.create(mapping);
 
     // when
-    final var retrievedMapping = mappingState.get(id);
+    final var retrievedMapping = mappingState.get(mappingId);
 
     // then
     assertThat(retrievedMapping).isPresent();
@@ -224,21 +224,21 @@ public class MappingStateTest {
     final long key = 1L;
     final String claimName = "foo";
     final String claimValue = "bar";
-    final String id = "id";
+    final String mappingId = "mappingId";
     final var mapping =
         new MappingRecord()
-            .setMappingId(id)
+            .setMappingId(mappingId)
             .setMappingKey(key)
             .setClaimName(claimName)
             .setClaimValue(claimValue);
     mappingState.create(mapping);
 
     // when
-    mappingState.delete(id);
+    mappingState.delete(mappingId);
 
     // then
     assertThat(mappingState.get(key)).isEmpty();
-    assertThat(mappingState.get(id)).isEmpty();
+    assertThat(mappingState.get(mappingId)).isEmpty();
     assertThat(mappingState.get(claimName, claimValue)).isEmpty();
   }
 
@@ -247,13 +247,13 @@ public class MappingStateTest {
     // given
     final long key = 1L;
     final String name = "name";
-    final String id = "id";
+    final String mappingId = "mappingId";
     final String claimName = "claimName";
     final String claimValue = "claimValue";
     final var mapping =
         new MappingRecord()
             .setMappingKey(key)
-            .setMappingId(id)
+            .setMappingId(mappingId)
             .setName(name)
             .setClaimName(claimName)
             .setClaimValue(claimValue);
@@ -266,15 +266,15 @@ public class MappingStateTest {
     final var updateMapping =
         new MappingRecord()
             .setMappingKey(key)
-            .setMappingId(id)
+            .setMappingId(mappingId)
             .setName(newName)
             .setClaimName(newClaimName)
             .setClaimValue(newClaimValue);
     mappingState.update(updateMapping);
 
     // then
-    assertThat(mappingState.get(id)).isNotEmpty();
-    final var mappingById = mappingState.get(id).get();
+    assertThat(mappingState.get(mappingId)).isNotEmpty();
+    final var mappingById = mappingState.get(mappingId).get();
     assertThat(mappingById.getName()).isEqualTo(newName);
     assertThat(mappingById.getClaimValue()).isEqualTo(newClaimValue);
     assertThat(mappingById.getClaimName()).isEqualTo(newClaimName);
@@ -283,6 +283,6 @@ public class MappingStateTest {
     assertThat(mappingState.get(newClaimName, newClaimValue)).isNotEmpty();
     final var mappingByClaim = mappingState.get(newClaimName, newClaimValue).get();
     assertThat(mappingByClaim.getName()).isEqualTo(newName);
-    assertThat(mappingByClaim.getMappingId()).isEqualTo(id);
+    assertThat(mappingByClaim.getMappingId()).isEqualTo(mappingId);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/MappingClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/MappingClient.java
@@ -26,12 +26,12 @@ public class MappingClient {
     return new MappingCreateClient(writer, name);
   }
 
-  public MappingDeleteClient deleteMapping(final String id) {
-    return new MappingDeleteClient(writer, id);
+  public MappingDeleteClient deleteMapping(final String mappingId) {
+    return new MappingDeleteClient(writer, mappingId);
   }
 
-  public MappingUpdateClient updateMapping(final String id) {
-    return new MappingUpdateClient(writer, id);
+  public MappingUpdateClient updateMapping(final String mappingId) {
+    return new MappingUpdateClient(writer, mappingId);
   }
 
   public static class MappingCreateClient {
@@ -65,8 +65,8 @@ public class MappingClient {
       return this;
     }
 
-    public MappingCreateClient withMappingId(final String id) {
-      mappingRecord.setMappingId(id);
+    public MappingCreateClient withMappingId(final String mappingId) {
+      mappingRecord.setMappingId(mappingId);
       return this;
     }
 
@@ -111,10 +111,10 @@ public class MappingClient {
     private final MappingRecord mappingRecord;
     private Function<Long, Record<MappingRecordValue>> expectation = SUCCESS_SUPPLIER;
 
-    public MappingDeleteClient(final CommandWriter writer, final String id) {
+    public MappingDeleteClient(final CommandWriter writer, final String mappingId) {
       this.writer = writer;
       mappingRecord = new MappingRecord();
-      mappingRecord.setMappingId(id);
+      mappingRecord.setMappingId(mappingId);
     }
 
     public Record<MappingRecordValue> delete() {
@@ -152,10 +152,10 @@ public class MappingClient {
     private final MappingRecord mappingRecord;
     private Function<String, Record<MappingRecordValue>> expectation = SUCCESS_SUPPLIER;
 
-    public MappingUpdateClient(final CommandWriter writer, final String id) {
+    public MappingUpdateClient(final CommandWriter writer, final String mappingId) {
       this.writer = writer;
       mappingRecord = new MappingRecord();
-      mappingRecord.setMappingId(id);
+      mappingRecord.setMappingId(mappingId);
     }
 
     public Record<MappingRecordValue> update() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MappingCreatedUpdatedHandler.java
@@ -47,7 +47,7 @@ public class MappingCreatedUpdatedHandler
 
   @Override
   public List<String> generateIds(final Record<MappingRecordValue> record) {
-    return List.of(String.valueOf(record.getValue().getMappingId()));
+    return List.of(record.getValue().getMappingId());
   }
 
   @Override

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5881,6 +5881,9 @@ components:
         name:
           type: string
           description: The name of the mapping.
+        mappingId:
+          type: string
+          description: The unique external id of the mapping.
       required:
         - claimName
         - claimValue
@@ -5890,11 +5893,11 @@ components:
       allOf:
         - $ref: "#/components/schemas/MappingRuleCreateUpdateRequest"
       properties:
-        id:
+        mappingId:
           type: string
           description: The unique external id of the mapping.
       required:
-        - id
+        - mappingId
     MappingRuleUpdateRequest:
       type: object
       allOf:
@@ -5911,7 +5914,7 @@ components:
         name:
           type: string
           description: The name of the mapping.
-        id:
+        mappingId:
           type: string
           description: The unique external id of the mapping.
         mappingKey:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5881,9 +5881,6 @@ components:
         name:
           type: string
           description: The name of the mapping.
-        mappingId:
-          type: string
-          description: The unique external id of the mapping.
       required:
         - claimName
         - claimValue

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -469,7 +469,7 @@ public class RequestMapper {
                 request.getClaimName(),
                 request.getClaimValue(),
                 request.getName(),
-                request.getId()));
+                request.getMappingId()));
   }
 
   public static Either<ProblemDetail, MappingDTO> toMappingDTO(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -565,7 +565,7 @@ public final class ResponseMapper {
             .mappingKey(KeyUtil.keyToString(record.getMappingKey()))
             .claimName(record.getClaimName())
             .claimValue(record.getClaimValue())
-            .id(record.getMappingId())
+            .mappingId(record.getMappingId())
             .name(record.getName());
     return new ResponseEntity<>(response, HttpStatus.CREATED);
   }
@@ -576,7 +576,7 @@ public final class ResponseMapper {
             .mappingKey(KeyUtil.keyToString(record.getMappingKey()))
             .claimName(record.getClaimName())
             .claimValue(record.getClaimValue())
-            .id(record.getMappingId())
+            .mappingId(record.getMappingId())
             .name(record.getName());
     return new ResponseEntity<>(response, HttpStatus.OK);
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/MappingValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/MappingValidator.java
@@ -39,18 +39,18 @@ public class MappingValidator {
         violations -> {
           violations.addAll(validateClaims(request.getClaimName(), request.getClaimValue()));
           violations.addAll(validateName(request.getName()));
-          violations.addAll(validateId(request.getId()));
+          violations.addAll(validateId(request.getMappingId()));
         });
   }
 
-  private static List<String> validateId(final String id) {
+  private static List<String> validateId(final String mappingId) {
     final List<String> violations = new ArrayList<>();
-    if (id == null || id.isBlank()) {
-      violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("id"));
-    } else if (id.length() > MAX_LENGTH) {
-      violations.add(ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted("id", MAX_LENGTH));
-    } else if (!ID_PATTERN.matcher(id).matches()) {
-      violations.add(ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted("id", ID_REGEX));
+    if (mappingId == null || mappingId.isBlank()) {
+      violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("mappingId"));
+    } else if (mappingId.length() > MAX_LENGTH) {
+      violations.add(ERROR_MESSAGE_TOO_MANY_CHARACTERS.formatted("mappingId", MAX_LENGTH));
+    } else if (!ID_PATTERN.matcher(mappingId).matches()) {
+      violations.add(ERROR_MESSAGE_ILLEGAL_CHARACTER.formatted("mappingId", ID_REGEX));
     }
     return violations;
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingControllerTest.java
@@ -87,7 +87,7 @@ public class MappingControllerTest extends RestControllerTest {
               "type": "about:blank",
               "status": 400,
               "title": "INVALID_ARGUMENT",
-              "detail": "No id provided.",
+              "detail": "No mappingId provided.",
               "instance": "%s"
             }"""
             .formatted(MAPPING_RULES_PATH));
@@ -102,7 +102,7 @@ public class MappingControllerTest extends RestControllerTest {
             .claimName("claim")
             .claimValue("claimValue")
             .name("name")
-            .id("");
+            .mappingId("");
 
     // when then
     assertRequestRejectedExceptionally(
@@ -112,7 +112,7 @@ public class MappingControllerTest extends RestControllerTest {
               "type": "about:blank",
               "status": 400,
               "title": "INVALID_ARGUMENT",
-              "detail": "No id provided.",
+              "detail": "No mappingId provided.",
               "instance": "%s"
             }"""
             .formatted(MAPPING_RULES_PATH));
@@ -123,7 +123,7 @@ public class MappingControllerTest extends RestControllerTest {
   void shouldRejectMappingCreationWithMissingClaimName() {
     // given
     final var request =
-        new MappingRuleCreateRequest().claimValue("claimValue").name("name").id("id");
+        new MappingRuleCreateRequest().claimValue("claimValue").name("name").mappingId("id");
 
     // when then
     assertRequestRejectedExceptionally(
@@ -144,7 +144,11 @@ public class MappingControllerTest extends RestControllerTest {
   void shouldRejectMappingCreationWitBlankClaimName() {
     // given
     final var request =
-        new MappingRuleCreateRequest().claimName("").claimValue("claimValue").name("name").id("id");
+        new MappingRuleCreateRequest()
+            .claimName("")
+            .claimValue("claimValue")
+            .name("name")
+            .mappingId("id");
 
     // when then
     assertRequestRejectedExceptionally(
@@ -164,7 +168,8 @@ public class MappingControllerTest extends RestControllerTest {
   @Test
   void shouldRejectMappingCreationWithMissingClaimValue() {
     // given
-    final var request = new MappingRuleCreateRequest().claimName("claimName").name("name").id("id");
+    final var request =
+        new MappingRuleCreateRequest().claimName("claimName").name("name").mappingId("id");
 
     // when then
     assertRequestRejectedExceptionally(
@@ -185,7 +190,11 @@ public class MappingControllerTest extends RestControllerTest {
   void shouldRejectMappingCreationWitBlankClaimValue() {
     // given
     final var request =
-        new MappingRuleCreateRequest().claimName("claimName").claimValue("").name("name").id("id");
+        new MappingRuleCreateRequest()
+            .claimName("claimName")
+            .claimValue("")
+            .name("name")
+            .mappingId("id");
 
     // when then
     assertRequestRejectedExceptionally(
@@ -206,7 +215,10 @@ public class MappingControllerTest extends RestControllerTest {
   void shouldRejectMappingCreationWithMissingName() {
     // given
     final var request =
-        new MappingRuleCreateRequest().claimName("claimName").claimValue("claimValue").id("id");
+        new MappingRuleCreateRequest()
+            .claimName("claimName")
+            .claimValue("claimValue")
+            .mappingId("id");
 
     // when then
     assertRequestRejectedExceptionally(
@@ -234,7 +246,7 @@ public class MappingControllerTest extends RestControllerTest {
     // given
     final var request =
         new MappingRuleCreateRequest()
-            .id(id)
+            .mappingId(id)
             .claimName("claimName")
             .claimValue("claimValue")
             .name("name");
@@ -247,7 +259,7 @@ public class MappingControllerTest extends RestControllerTest {
               "type": "about:blank",
               "status": 400,
               "title": "INVALID_ARGUMENT",
-              "detail": "The provided id contains illegal characters. It must match the pattern '%s'.",
+              "detail": "The provided mappingId contains illegal characters. It must match the pattern '%s'.",
               "instance": "%s"
             }"""
             .formatted(IdentifierPatterns.ID_PATTERN, MAPPING_RULES_PATH));
@@ -260,7 +272,7 @@ public class MappingControllerTest extends RestControllerTest {
     final var id = "x".repeat(257);
     final var request =
         new MappingRuleCreateRequest()
-            .id(id)
+            .mappingId(id)
             .claimName("claimName")
             .claimValue("claimValue")
             .name("name");
@@ -273,7 +285,7 @@ public class MappingControllerTest extends RestControllerTest {
               "type": "about:blank",
               "status": 400,
               "title": "INVALID_ARGUMENT",
-              "detail": "The provided id exceeds the limit of 256 characters.",
+              "detail": "The provided mappingId exceeds the limit of 256 characters.",
               "instance": "%s"
             }"""
             .formatted(MAPPING_RULES_PATH));

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerMappingCreateRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerMappingCreateRequest.java
@@ -38,8 +38,8 @@ public class BrokerMappingCreateRequest extends BrokerExecuteCommand<MappingReco
     return this;
   }
 
-  public BrokerMappingCreateRequest setMappingId(final String id) {
-    requestDto.setMappingId(id);
+  public BrokerMappingCreateRequest setMappingId(final String mappingId) {
+    requestDto.setMappingId(mappingId);
     return this;
   }
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerMappingDeleteRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerMappingDeleteRequest.java
@@ -22,7 +22,7 @@ public class BrokerMappingDeleteRequest extends BrokerExecuteCommand<MappingReco
     setPartitionId(Protocol.DEPLOYMENT_PARTITION);
   }
 
-  public BrokerMappingDeleteRequest setId(final String mappingId) {
+  public BrokerMappingDeleteRequest setMappingId(final String mappingId) {
     requestDto.setMappingId(mappingId);
     return this;
   }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerMappingUpdateRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerMappingUpdateRequest.java
@@ -38,8 +38,8 @@ public class BrokerMappingUpdateRequest extends BrokerExecuteCommand<MappingReco
     return this;
   }
 
-  public BrokerMappingUpdateRequest setMappingId(final String id) {
-    requestDto.setMappingId(id);
+  public BrokerMappingUpdateRequest setMappingId(final String mappingId) {
+    requestDto.setMappingId(mappingId);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/MappingRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/MappingRecord.java
@@ -75,8 +75,8 @@ public class MappingRecord extends UnifiedRecordValue implements MappingRecordVa
     return BufferUtil.bufferAsString(mappingIdProp.getValue());
   }
 
-  public MappingRecord setMappingId(final String id) {
-    mappingIdProp.setValue(id);
+  public MappingRecord setMappingId(final String mappingId) {
+    mappingIdProp.setValue(mappingId);
     return this;
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverGrpcIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverGrpcIT.java
@@ -191,7 +191,7 @@ public class OidcAuthOverGrpcIT {
     final var claimValue = UUID.randomUUID().toString();
     defaultMappingClient
         .newCreateMappingCommand()
-        .id(UUID.randomUUID().toString())
+        .mappingId(UUID.randomUUID().toString())
         .claimName(claimName)
         .claimValue(claimValue)
         .name(claimValue)
@@ -221,7 +221,7 @@ public class OidcAuthOverGrpcIT {
     final var processId = Strings.newRandomValidBpmnId();
     defaultMappingClient
         .newCreateMappingCommand()
-        .id(RESTRICTED_USER_ID)
+        .mappingId(RESTRICTED_USER_ID)
         .claimName(USER_ID_CLAIM_NAME)
         .claimValue(RESTRICTED_USER_ID)
         .name(RESTRICTED_USER_ID)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/OidcAuthOverRestIT.java
@@ -191,7 +191,7 @@ public class OidcAuthOverRestIT {
     final var claimValue = UUID.randomUUID().toString();
     defaultMappingClient
         .newCreateMappingCommand()
-        .id(UUID.randomUUID().toString())
+        .mappingId(UUID.randomUUID().toString())
         .claimName(claimName)
         .claimValue(claimValue)
         .name(claimValue)
@@ -221,7 +221,7 @@ public class OidcAuthOverRestIT {
     final var processId = Strings.newRandomValidBpmnId();
     defaultMappingClient
         .newCreateMappingCommand()
-        .id(RESTRICTED_USER_ID)
+        .mappingId(RESTRICTED_USER_ID)
         .claimName(USER_ID_CLAIM_NAME)
         .claimValue(RESTRICTED_USER_ID)
         .name(RESTRICTED_USER_ID)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignMappingToTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignMappingToTenantTest.java
@@ -53,7 +53,7 @@ class AssignMappingToTenantTest {
         .claimName(CLAIM_NAME)
         .claimValue(CLAIM_VALUE)
         .name(NAME)
-        .id(ID)
+        .mappingId(ID)
         .send()
         .join();
     mappingId = ID;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateMappingTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateMappingTest.java
@@ -49,7 +49,7 @@ public class CreateMappingTest {
             .claimName(CLAIM_NAME)
             .claimValue(CLAIM_VALUE)
             .name(NAME)
-            .id(ID)
+            .mappingId(ID)
             .send()
             .join();
 
@@ -91,7 +91,7 @@ public class CreateMappingTest {
                     .send()
                     .join())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("id");
+        .hasMessageContaining("mappingId");
   }
 
   @Test
@@ -117,7 +117,7 @@ public class CreateMappingTest {
         .claimName(CLAIM_NAME)
         .claimValue(CLAIM_VALUE)
         .name(NAME)
-        .id(Strings.newRandomValidIdentityId())
+        .mappingId(Strings.newRandomValidIdentityId())
         .send()
         .join();
 
@@ -129,7 +129,7 @@ public class CreateMappingTest {
                     .claimName(CLAIM_NAME)
                     .claimValue(CLAIM_VALUE)
                     .name(NAME)
-                    .id(Strings.newRandomValidIdentityId())
+                    .mappingId(Strings.newRandomValidIdentityId())
                     .send()
                     .join())
         .isInstanceOf(RuntimeException.class)
@@ -146,7 +146,7 @@ public class CreateMappingTest {
         .claimName("c1")
         .claimValue(CLAIM_VALUE)
         .name(NAME)
-        .id(ID)
+        .mappingId(ID)
         .send()
         .join();
 
@@ -158,7 +158,7 @@ public class CreateMappingTest {
                     .claimName("c2")
                     .claimValue(CLAIM_VALUE)
                     .name(NAME)
-                    .id(ID)
+                    .mappingId(ID)
                     .send()
                     .join())
         .isInstanceOf(RuntimeException.class)


### PR DESCRIPTION
## Description

 - Renamed `id` to `mappingId` in REST API DTOs and OpenAPI schema.
 - Updated backend request/response models and validation rules.
 - Modified web client components to reference mappingId instead of id.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

close: #30370
