### PR TITLE
ProcessCache.shouldRemoveExpiredItem fails intermittently

### DIFF
--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/cache/ProcessCacheTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/cache/ProcessCacheTest.java
@@ -164,23 +164,6 @@ class ProcessCacheTest {
   }
 
   @Test
-  void shouldRemoveExpiredItem() throws InterruptedException {
-    // given
-    configuration.getProcessCache().setExpirationIdleMillis(10L);
-    processCache = new ProcessCache(configuration, processFlowNodeProvider, brokerTopologyManager);
-    processCache.getCacheItem(1L);
-    getCache().cleanUp();
-    assertThat(getCacheMap()).hasSize(1);
-
-    // when - waiting ttl millis
-    Thread.sleep(10);
-    getCache().cleanUp();
-
-    // then - cache should be empty
-    assertThat(getCacheMap()).isEmpty();
-  }
-
-  @Test
   void shouldRefreshReadItemAndRemoveLeastRecentlyUsed() {
     // given
     configuration.getProcessCache().setMaxSize(2);


### PR DESCRIPTION
## Description

It was discovered that the ProcessCacheTest.shouldRemoveExpiredTimer has become flaky in the past few days. After debugging the issue I've come to the conclusion that the first assertion fails because of the 10ms cache ttl.
```java
  void shouldRemoveExpiredItem() throws InterruptedException {
    // given
    configuration.getProcessCache().setExpirationIdleMillis(10L);
    processCache = new ProcessCache(configuration, processFlowNodeProvider, brokerTopologyManager);
    processCache.getCacheItem(1L);
    getCache().cleanUp();
    assertThat(getCacheMap()).hasSize(1); // The test fails here
```
The simple fix is to increase the timeout, but that does not guarantee that it might fail again under extraordinary circumstances sometime in the future. Ultimately, it was decided that the test isn't useful anymore - it's testing the internals of Caffeine, not any Camunda features.

This PR removes the test.

closes #30134
