### PR TITLE
feat: integrate secondary database access into Zeebe Engine for batch processing

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/search/SearchClientDatabaseConfiguration.java
@@ -10,7 +10,7 @@ package io.camunda.application.commons.search;
 import io.camunda.application.commons.search.SearchClientDatabaseConfiguration.SearchClientProperties;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.search.clients.DocumentBasedSearchClient;
-import io.camunda.search.clients.SearchClients;
+import io.camunda.search.clients.DocumentBasedSearchClients;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.configuration.DatabaseConfig;
 import io.camunda.search.connect.es.ElasticsearchConnector;
@@ -67,14 +67,14 @@ public class SearchClientDatabaseConfiguration {
 
   @Bean
   @ConditionalOnBean(DocumentBasedSearchClient.class)
-  public SearchClients searchClients(
+  public DocumentBasedSearchClients documentBasedSearchClients(
       final DocumentBasedSearchClient searchClient,
       final ConnectConfiguration connectConfiguration) {
     final IndexDescriptors indexDescriptors =
         new IndexDescriptors(
             connectConfiguration.getIndexPrefix(),
             connectConfiguration.getTypeEnum().isElasticSearch());
-    return new SearchClients(searchClient, indexDescriptors);
+    return new DocumentBasedSearchClients(searchClient, indexDescriptors);
   }
 
   @ConfigurationProperties("camunda.database")

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker;
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.application.commons.configuration.BrokerBasedConfiguration;
 import io.camunda.identity.sdk.IdentityConfiguration;
+import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -58,6 +59,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
   private final UserServices userServices;
   private final PasswordEncoder passwordEncoder;
   private final JwtDecoder jwtDecoder;
+  private final SearchClientsProxy searchClientsProxy;
 
   private Broker broker;
 
@@ -75,7 +77,8 @@ public class BrokerModuleConfiguration implements CloseableSilently {
       // The UserServices class is not available if you want to start-up the Standalone Broker
       @Autowired(required = false) final UserServices userServices,
       final PasswordEncoder passwordEncoder,
-      @Autowired(required = false) final JwtDecoder jwtDecoder) {
+      @Autowired(required = false) final JwtDecoder jwtDecoder,
+      final SearchClientsProxy searchClientsProxy) {
     this.configuration = configuration;
     this.identityConfiguration = identityConfiguration;
     this.springBrokerBridge = springBrokerBridge;
@@ -88,6 +91,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     this.userServices = userServices;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoder = jwtDecoder;
+    this.searchClientsProxy = searchClientsProxy;
   }
 
   @Bean
@@ -115,7 +119,8 @@ public class BrokerModuleConfiguration implements CloseableSilently {
             securityConfiguration,
             userServices,
             passwordEncoder,
-            jwtDecoder);
+            jwtDecoder,
+            searchClientsProxy);
     springBrokerBridge.registerShutdownHelper(
         errorCode -> shutdownHelper.initiateShutdown(errorCode));
     broker =

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -78,7 +78,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
       @Autowired(required = false) final UserServices userServices,
       final PasswordEncoder passwordEncoder,
       @Autowired(required = false) final JwtDecoder jwtDecoder,
-      final SearchClientsProxy searchClientsProxy) {
+      @Autowired(required = false) final SearchClientsProxy searchClientsProxy) {
     this.configuration = configuration;
     this.identityConfiguration = identityConfiguration;
     this.springBrokerBridge = springBrokerBridge;

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClients.java
@@ -57,13 +57,13 @@ import io.camunda.zeebe.util.CloseableSilently;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class SearchClients implements SearchClientsProxy, CloseableSilently {
+public class DocumentBasedSearchClients implements SearchClientsProxy, CloseableSilently {
 
   private final DocumentBasedSearchClient searchClient;
   private final ServiceTransformers transformers;
   private final SecurityContext securityContext;
 
-  public SearchClients(
+  public DocumentBasedSearchClients(
       final DocumentBasedSearchClient searchClient, final IndexDescriptors indexDescriptors) {
     this(
         searchClient,
@@ -71,7 +71,7 @@ public class SearchClients implements SearchClientsProxy, CloseableSilently {
         SecurityContext.withoutAuthentication());
   }
 
-  private SearchClients(
+  private DocumentBasedSearchClients(
       final DocumentBasedSearchClient searchClient,
       final ServiceTransformers transformers,
       final SecurityContext securityContext) {
@@ -96,8 +96,8 @@ public class SearchClients implements SearchClientsProxy, CloseableSilently {
   }
 
   @Override
-  public SearchClients withSecurityContext(final SecurityContext securityContext) {
-    return new SearchClients(searchClient, transformers, securityContext);
+  public DocumentBasedSearchClients withSecurityContext(final SecurityContext securityContext) {
+    return new DocumentBasedSearchClients(searchClient, transformers, securityContext);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
@@ -57,26 +57,7 @@ import io.camunda.zeebe.util.CloseableSilently;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class SearchClients
-    implements AuthorizationSearchClient,
-        DecisionDefinitionSearchClient,
-        DecisionInstanceSearchClient,
-        DecisionRequirementSearchClient,
-        FlowNodeInstanceSearchClient,
-        FormSearchClient,
-        IncidentSearchClient,
-        ProcessDefinitionSearchClient,
-        ProcessInstanceSearchClient,
-        RoleSearchClient,
-        TenantSearchClient,
-        UserTaskSearchClient,
-        UserSearchClient,
-        VariableSearchClient,
-        MappingSearchClient,
-        GroupSearchClient,
-        UsageMetricsSearchClient,
-        BatchOperationSearchClient,
-        CloseableSilently {
+public class SearchClients implements SearchClientsProxy, CloseableSilently {
 
   private final DocumentBasedSearchClient searchClient;
   private final ServiceTransformers transformers;

--- a/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
+++ b/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
@@ -8,24 +8,7 @@
 package io.camunda.search.rdbms;
 
 import io.camunda.db.rdbms.RdbmsService;
-import io.camunda.search.clients.AuthorizationSearchClient;
-import io.camunda.search.clients.BatchOperationSearchClient;
-import io.camunda.search.clients.DecisionDefinitionSearchClient;
-import io.camunda.search.clients.DecisionInstanceSearchClient;
-import io.camunda.search.clients.DecisionRequirementSearchClient;
-import io.camunda.search.clients.FlowNodeInstanceSearchClient;
-import io.camunda.search.clients.FormSearchClient;
-import io.camunda.search.clients.GroupSearchClient;
-import io.camunda.search.clients.IncidentSearchClient;
-import io.camunda.search.clients.MappingSearchClient;
-import io.camunda.search.clients.ProcessDefinitionSearchClient;
-import io.camunda.search.clients.ProcessInstanceSearchClient;
-import io.camunda.search.clients.RoleSearchClient;
-import io.camunda.search.clients.TenantSearchClient;
-import io.camunda.search.clients.UsageMetricsSearchClient;
-import io.camunda.search.clients.UserSearchClient;
-import io.camunda.search.clients.UserTaskSearchClient;
-import io.camunda.search.clients.VariableSearchClient;
+import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.BatchOperationEntity;
 import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
@@ -70,25 +53,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class RdbmsSearchClient
-    implements AuthorizationSearchClient,
-        DecisionDefinitionSearchClient,
-        DecisionInstanceSearchClient,
-        DecisionRequirementSearchClient,
-        FlowNodeInstanceSearchClient,
-        FormSearchClient,
-        IncidentSearchClient,
-        ProcessInstanceSearchClient,
-        ProcessDefinitionSearchClient,
-        UserTaskSearchClient,
-        UserSearchClient,
-        VariableSearchClient,
-        RoleSearchClient,
-        TenantSearchClient,
-        MappingSearchClient,
-        GroupSearchClient,
-        UsageMetricsSearchClient,
-        BatchOperationSearchClient {
+public class RdbmsSearchClient implements SearchClientsProxy {
 
   private static final Logger LOG = LoggerFactory.getLogger(RdbmsSearchClient.class);
 
@@ -307,6 +272,13 @@ public class RdbmsSearchClient
   }
 
   @Override
+  public List<ProcessDefinitionFlowNodeStatisticsEntity> processDefinitionFlowNodeStatistics(
+      final ProcessDefinitionStatisticsFilter filter) {
+    LOG.debug("[RDBMS Search Client] Query processDefinition statistics: {}", filter);
+    return rdbmsService.getProcessDefinitionReader().flowNodeStatistics(filter);
+  }
+
+  @Override
   public SearchQueryResult<BatchOperationEntity> searchBatchOperations(
       final BatchOperationQuery query) {
     LOG.debug("[RDBMS Search Client] Search for batch operations: {}", query);
@@ -325,12 +297,5 @@ public class RdbmsSearchClient
     // return rdbmsService.getBatchOperationReader().getItems(batchOperationKey);
     throw new UnsupportedOperationException(
         "BatchOperationSearchClient getBatchOperationItems not implemented yet.");
-  }
-
-  @Override
-  public List<ProcessDefinitionFlowNodeStatisticsEntity> processDefinitionFlowNodeStatistics(
-      final ProcessDefinitionStatisticsFilter filter) {
-    LOG.debug("[RDBMS Search Client] Query processDefinition statistics: {}", filter);
-    return rdbmsService.getProcessDefinitionReader().flowNodeStatistics(filter);
   }
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/SearchClientsProxy.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/SearchClientsProxy.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients;
+
+import io.camunda.security.auth.SecurityContext;
+
+public interface SearchClientsProxy
+    extends AuthorizationSearchClient,
+        DecisionDefinitionSearchClient,
+        DecisionInstanceSearchClient,
+        DecisionRequirementSearchClient,
+        FlowNodeInstanceSearchClient,
+        FormSearchClient,
+        IncidentSearchClient,
+        ProcessDefinitionSearchClient,
+        ProcessInstanceSearchClient,
+        RoleSearchClient,
+        TenantSearchClient,
+        UserTaskSearchClient,
+        UserSearchClient,
+        VariableSearchClient,
+        MappingSearchClient,
+        GroupSearchClient,
+        UsageMetricsSearchClient,
+        BatchOperationSearchClient {
+
+  @Override
+  SearchClientsProxy withSecurityContext(SecurityContext securityContext);
+}

--- a/zeebe/broker/pom.xml
+++ b/zeebe/broker/pom.xml
@@ -230,6 +230,11 @@
       <artifactId>camunda-service</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-client</artifactId>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -87,7 +87,8 @@ public final class Broker implements AutoCloseable {
             systemContext.getSecurityConfiguration(),
             systemContext.getUserServices(),
             systemContext.getPasswordEncoder(),
-            systemContext.getJwtDecoder());
+            systemContext.getJwtDecoder(),
+            systemContext.getSearchClientsProxy());
 
     brokerStartupActor = new BrokerStartupActor(startupContext);
     scheduler.submitActor(brokerStartupActor);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.bootstrap;
 
 import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.camunda.identity.sdk.IdentityConfiguration;
+import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.PartitionListener;
@@ -58,6 +59,8 @@ public interface BrokerStartupContext {
   ConcurrencyControl getConcurrencyControl();
 
   BrokerHealthCheckService getHealthCheckService();
+
+  SearchClientsProxy getSearchClientsProxy();
 
   void addPartitionListener(PartitionListener partitionListener);
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -12,6 +12,7 @@ import static java.util.Objects.requireNonNull;
 
 import io.atomix.cluster.messaging.ManagedMessagingService;
 import io.camunda.identity.sdk.IdentityConfiguration;
+import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.PartitionListener;
@@ -64,6 +65,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private final UserServices userServices;
   private final PasswordEncoder passwordEncoder;
   private final JwtDecoder jwtDecoder;
+  private final SearchClientsProxy searchClientsProxy;
 
   private ConcurrencyControl concurrencyControl;
   private DiskSpaceUsageMonitor diskSpaceUsageMonitor;
@@ -94,7 +96,8 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
       final SecurityConfiguration securityConfiguration,
       final UserServices userServices,
       final PasswordEncoder passwordEncoder,
-      final JwtDecoder jwtDecoder) {
+      final JwtDecoder jwtDecoder,
+      final SearchClientsProxy searchClientsProxy) {
 
     this.brokerInfo = requireNonNull(brokerInfo);
     this.configuration = requireNonNull(configuration);
@@ -111,6 +114,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
     this.userServices = userServices;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoder = jwtDecoder;
+    this.searchClientsProxy = searchClientsProxy;
     partitionListeners.addAll(additionalPartitionListeners);
   }
 
@@ -147,7 +151,8 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
         securityConfiguration,
         userServices,
         passwordEncoder,
-        jwtDecoder);
+        jwtDecoder,
+        null);
   }
 
   @Override
@@ -192,6 +197,11 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   @Override
   public BrokerHealthCheckService getHealthCheckService() {
     return healthCheckService;
+  }
+
+  @Override
+  public SearchClientsProxy getSearchClientsProxy() {
+    return searchClientsProxy;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -48,7 +48,8 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
             brokerStartupContext.getClusterConfigurationService(),
             brokerStartupContext.getMeterRegistry(),
             brokerStartupContext.getBrokerClient(),
-            brokerStartupContext.getSecurityConfiguration());
+            brokerStartupContext.getSecurityConfiguration(),
+            brokerStartupContext.getSearchClientsProxy());
     concurrencyControl.run(
         () -> {
           try {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -12,6 +12,7 @@ import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.atomix.primitive.partition.impl.DefaultPartitionManagementService;
 import io.atomix.raft.partition.RaftPartition;
+import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.PartitionRaftListener;
@@ -93,7 +94,8 @@ public final class PartitionManagerImpl
       final ClusterConfigurationService clusterConfigurationService,
       final MeterRegistry meterRegistry,
       final BrokerClient brokerClient,
-      final SecurityConfiguration securityConfig) {
+      final SecurityConfiguration securityConfig,
+      final SearchClientsProxy searchClientsProxy) {
     this.brokerCfg = brokerCfg;
     this.concurrencyControl = concurrencyControl;
     this.actorSchedulingService = actorSchedulingService;
@@ -124,7 +126,8 @@ public final class PartitionManagerImpl
             partitionRaftListeners,
             topologyManager,
             featureFlags,
-            securityConfig);
+            securityConfig,
+            searchClientsProxy);
     managementService =
         new DefaultPartitionManagementService(
             clusterServices.getMembershipService(), clusterServices.getCommunicationService());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.partitioning.startup;
 
 import io.atomix.raft.partition.RaftPartition;
+import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.PartitionRaftListener;
@@ -107,6 +108,7 @@ public final class ZeebePartitionFactory {
   private final FeatureFlags featureFlags;
   private final List<PartitionRaftListener> partitionRaftListeners;
   private final SecurityConfiguration securityConfig;
+  private final SearchClientsProxy searchClientsProxy;
 
   public ZeebePartitionFactory(
       final ActorSchedulingService actorSchedulingService,
@@ -122,7 +124,8 @@ public final class ZeebePartitionFactory {
       final List<PartitionRaftListener> partitionRaftListeners,
       final TopologyManagerImpl topologyManager,
       final FeatureFlags featureFlags,
-      final SecurityConfiguration securityConfig) {
+      final SecurityConfiguration securityConfig,
+      final SearchClientsProxy searchClientsProxy) {
     this.actorSchedulingService = actorSchedulingService;
     this.brokerCfg = brokerCfg;
     this.localBroker = localBroker;
@@ -137,6 +140,7 @@ public final class ZeebePartitionFactory {
     this.topologyManager = topologyManager;
     this.featureFlags = featureFlags;
     this.securityConfig = securityConfig;
+    this.searchClientsProxy = searchClientsProxy;
   }
 
   public ZeebePartition constructPartition(
@@ -232,7 +236,8 @@ public final class ZeebePartitionFactory {
           subscriptionCommandSender,
           partitionCommandSender,
           featureFlags,
-          jobStreamer);
+          jobStreamer,
+          searchClientsProxy);
     };
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirect
 
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.identity.sdk.IdentityConfiguration;
+import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.backup.azure.AzureBackupStore;
@@ -72,6 +73,7 @@ public final class SystemContext {
   private final UserServices userServices;
   private final PasswordEncoder passwordEncoder;
   private final JwtDecoder jwtDecoder;
+  private final SearchClientsProxy searchClientsProxy;
 
   public SystemContext(
       final Duration shutdownTimeout,
@@ -84,7 +86,8 @@ public final class SystemContext {
       final SecurityConfiguration securityConfiguration,
       final UserServices userServices,
       final PasswordEncoder passwordEncoder,
-      final JwtDecoder jwtDecoder) {
+      final JwtDecoder jwtDecoder,
+      final SearchClientsProxy searchClientsProxy) {
     this.shutdownTimeout = shutdownTimeout;
     this.brokerCfg = brokerCfg;
     this.identityConfiguration = identityConfiguration;
@@ -96,6 +99,7 @@ public final class SystemContext {
     this.userServices = userServices;
     this.passwordEncoder = passwordEncoder;
     this.jwtDecoder = jwtDecoder;
+    this.searchClientsProxy = searchClientsProxy;
     initSystemContext();
   }
 
@@ -120,7 +124,8 @@ public final class SystemContext {
         securityConfiguration,
         userServices,
         passwordEncoder,
-        jwtDecoder);
+        jwtDecoder,
+        null);
   }
 
   private void initSystemContext() {
@@ -377,5 +382,9 @@ public final class SystemContext {
 
   public JwtDecoder getJwtDecoder() {
     return jwtDecoder;
+  }
+
+  public SearchClientsProxy getSearchClientsProxy() {
+    return searchClientsProxy;
   }
 }

--- a/zeebe/engine/pom.xml
+++ b/zeebe/engine/pom.xml
@@ -297,10 +297,13 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>camunda-search-domain</artifactId>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
   <build>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing;
 
 import static io.camunda.zeebe.protocol.record.intent.DeploymentIntent.CREATE;
 
+import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.zeebe.dmn.DecisionEngineFactory;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.JobProcessingMetrics;
@@ -88,7 +89,8 @@ public final class EngineProcessors {
       final SubscriptionCommandSender subscriptionCommandSender,
       final InterPartitionCommandSender interPartitionCommandSender,
       final FeatureFlags featureFlags,
-      final JobStreamer jobStreamer) {
+      final JobStreamer jobStreamer,
+      final SearchClientsProxy searchClientsProxy) {
 
     final var processingState = typedRecordProcessorContext.getProcessingState();
     final var keyGenerator = processingState.getKeyGenerator();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/TestEngine.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/TestEngine.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.perf;
 import io.camunda.zeebe.engine.processing.EngineProcessors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
+import io.camunda.zeebe.engine.search.NoopSearchClientsProxy;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.engine.util.ProcessingExporterTransistor;
 import io.camunda.zeebe.engine.util.StreamProcessingComposite;
@@ -84,7 +85,8 @@ public final class TestEngine {
                             new SubscriptionCommandSender(partitionId, interPartitionCommandSender),
                             interPartitionCommandSender,
                             featureFlags,
-                            JobStreamer.noop())
+                            JobStreamer.noop(),
+                            new NoopSearchClientsProxy())
                         .withListener(
                             new ProcessingExporterTransistor(
                                 testStreams.getLogStream(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/search/NoopSearchClientsProxy.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/search/NoopSearchClientsProxy.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.search;
+
+import io.camunda.search.clients.SearchClientsProxy;
+import io.camunda.search.entities.AuthorizationEntity;
+import io.camunda.search.entities.BatchOperationEntity;
+import io.camunda.search.entities.BatchOperationEntity.BatchOperationItemEntity;
+import io.camunda.search.entities.DecisionDefinitionEntity;
+import io.camunda.search.entities.DecisionInstanceEntity;
+import io.camunda.search.entities.DecisionRequirementsEntity;
+import io.camunda.search.entities.FlowNodeInstanceEntity;
+import io.camunda.search.entities.FormEntity;
+import io.camunda.search.entities.GroupEntity;
+import io.camunda.search.entities.IncidentEntity;
+import io.camunda.search.entities.MappingEntity;
+import io.camunda.search.entities.ProcessDefinitionEntity;
+import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.entities.RoleEntity;
+import io.camunda.search.entities.TenantEntity;
+import io.camunda.search.entities.UserEntity;
+import io.camunda.search.entities.UserTaskEntity;
+import io.camunda.search.entities.VariableEntity;
+import io.camunda.search.query.AuthorizationQuery;
+import io.camunda.search.query.BatchOperationQuery;
+import io.camunda.search.query.DecisionDefinitionQuery;
+import io.camunda.search.query.DecisionInstanceQuery;
+import io.camunda.search.query.DecisionRequirementsQuery;
+import io.camunda.search.query.FlowNodeInstanceQuery;
+import io.camunda.search.query.FormQuery;
+import io.camunda.search.query.GroupQuery;
+import io.camunda.search.query.IncidentQuery;
+import io.camunda.search.query.MappingQuery;
+import io.camunda.search.query.ProcessDefinitionQuery;
+import io.camunda.search.query.ProcessInstanceQuery;
+import io.camunda.search.query.RoleQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.query.TenantQuery;
+import io.camunda.search.query.UsageMetricsQuery;
+import io.camunda.search.query.UserQuery;
+import io.camunda.search.query.UserTaskQuery;
+import io.camunda.search.query.VariableQuery;
+import io.camunda.security.auth.SecurityContext;
+import java.util.List;
+
+public class NoopSearchClientsProxy implements SearchClientsProxy {
+
+  @Override
+  public SearchQueryResult<AuthorizationEntity> searchAuthorizations(
+      final AuthorizationQuery filter) {
+    return null;
+  }
+
+  @Override
+  public List<AuthorizationEntity> findAllAuthorizations(final AuthorizationQuery filter) {
+    return List.of();
+  }
+
+  @Override
+  public SearchQueryResult<BatchOperationEntity> searchBatchOperations(
+      final BatchOperationQuery query) {
+    return null;
+  }
+
+  @Override
+  public List<BatchOperationItemEntity> getBatchOperationItems(final Long batchOperationKey) {
+    return List.of();
+  }
+
+  @Override
+  public SearchQueryResult<DecisionDefinitionEntity> searchDecisionDefinitions(
+      final DecisionDefinitionQuery filter) {
+    return null;
+  }
+
+  @Override
+  public SearchQueryResult<DecisionInstanceEntity> searchDecisionInstances(
+      final DecisionInstanceQuery filter) {
+    return null;
+  }
+
+  @Override
+  public SearchQueryResult<DecisionRequirementsEntity> searchDecisionRequirements(
+      final DecisionRequirementsQuery filter) {
+    return null;
+  }
+
+  @Override
+  public SearchQueryResult<FlowNodeInstanceEntity> searchFlowNodeInstances(
+      final FlowNodeInstanceQuery filter) {
+    return null;
+  }
+
+  @Override
+  public SearchQueryResult<FormEntity> searchForms(final FormQuery filter) {
+    return null;
+  }
+
+  @Override
+  public SearchQueryResult<GroupEntity> searchGroups(final GroupQuery query) {
+    return null;
+  }
+
+  @Override
+  public List<GroupEntity> findAllGroups(final GroupQuery query) {
+    return List.of();
+  }
+
+  @Override
+  public SearchQueryResult<IncidentEntity> searchIncidents(final IncidentQuery filter) {
+    return null;
+  }
+
+  @Override
+  public SearchQueryResult<MappingEntity> searchMappings(final MappingQuery filter) {
+    return null;
+  }
+
+  @Override
+  public List<MappingEntity> findAllMappings(final MappingQuery query) {
+    return List.of();
+  }
+
+  @Override
+  public SearchQueryResult<ProcessDefinitionEntity> searchProcessDefinitions(
+      final ProcessDefinitionQuery filter) {
+    return null;
+  }
+
+  @Override
+  public SearchQueryResult<ProcessInstanceEntity> searchProcessInstances(
+      final ProcessInstanceQuery query) {
+    return null;
+  }
+
+  @Override
+  public SearchQueryResult<RoleEntity> searchRoles(final RoleQuery filter) {
+    return null;
+  }
+
+  @Override
+  public List<RoleEntity> findAllRoles(final RoleQuery filter) {
+    return List.of();
+  }
+
+  @Override
+  public SearchQueryResult<TenantEntity> searchTenants(final TenantQuery filter) {
+    return null;
+  }
+
+  @Override
+  public List<TenantEntity> findAllTenants(final TenantQuery query) {
+    return List.of();
+  }
+
+  @Override
+  public SearchQueryResult<UserEntity> searchUsers(final UserQuery userQuery) {
+    return null;
+  }
+
+  @Override
+  public SearchQueryResult<UserTaskEntity> searchUserTasks(final UserTaskQuery filter) {
+    return null;
+  }
+
+  @Override
+  public SearchQueryResult<VariableEntity> searchVariables(final VariableQuery filter) {
+    return null;
+  }
+
+  @Override
+  public SearchClientsProxy withSecurityContext(final SecurityContext securityContext) {
+    return null;
+  }
+
+  @Override
+  public Long countAssignees(final UsageMetricsQuery query) {
+    return 0L;
+  }
+
+  @Override
+  public Long countProcessInstances(final UsageMetricsQuery query) {
+    return 0L;
+  }
+
+  @Override
+  public Long countDecisionInstances(final UsageMetricsQuery query) {
+    return 0L;
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.util;
 import static io.camunda.zeebe.test.util.record.RecordingExporter.jobRecords;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.search.clients.SearchClientsProxy;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.db.DbKey;
 import io.camunda.zeebe.db.DbValue;
@@ -112,6 +113,7 @@ public final class EngineRule extends ExternalResource {
   private ArrayList<TestInterPartitionCommandSender> interPartitionCommandSenders;
   private Consumer<SecurityConfiguration> securityConfigModifier = cfg -> {};
   private Consumer<EngineConfiguration> engineConfigModifier = cfg -> {};
+  private SearchClientsProxy searchClientsProxy;
 
   private EngineRule(final int partitionCount) {
     this(partitionCount, null);
@@ -204,6 +206,11 @@ public final class EngineRule extends ExternalResource {
     return this;
   }
 
+  public EngineRule withSearchClientsProxy(final SearchClientsProxy searchClientsProxy) {
+    this.searchClientsProxy = searchClientsProxy;
+    return this;
+  }
+
   private void startProcessors(final StreamProcessorMode mode, final boolean awaitOpening) {
     interPartitionCommandSenders = new ArrayList<>();
 
@@ -223,7 +230,8 @@ public final class EngineRule extends ExternalResource {
                         new SubscriptionCommandSender(partitionId, interPartitionCommandSender),
                         interPartitionCommandSender,
                         featureFlags,
-                        jobStreamer)
+                        jobStreamer,
+                        searchClientsProxy)
                     .withListener(
                         new ProcessingExporterTransistor(
                             environmentRule.getLogStream(partitionId)));

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -511,6 +511,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
       <scope>test</scope>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -381,6 +381,7 @@ public class ClusteringRule extends ExternalResource {
             new SecurityConfiguration(),
             null,
             null,
+            null,
             null);
 
     final Broker broker =

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/SearchClientsUtil.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/SearchClientsUtil.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.it.util;
 
-import io.camunda.search.clients.SearchClients;
+import io.camunda.search.clients.DocumentBasedSearchClients;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.connect.os.OpensearchConnector;
@@ -25,9 +25,9 @@ public class SearchClientsUtil {
     return new ElasticsearchSearchClient(elasticsearchClient);
   }
 
-  public static SearchClients createSearchClients(final String elasticsearchUrl) {
+  public static DocumentBasedSearchClients createSearchClients(final String elasticsearchUrl) {
     final var lowLevelSearchClient = createLowLevelSearchClient(elasticsearchUrl);
-    return new SearchClients(lowLevelSearchClient, new IndexDescriptors("", true));
+    return new DocumentBasedSearchClients(lowLevelSearchClient, new IndexDescriptors("", true));
   }
 
   public static OpensearchSearchClient createLowLevelOpensearchSearchClient(


### PR DESCRIPTION
## Description
This PR gives the Zeebe Broker and Engine access to the secondary database. This is necessary to enable the broker to query for entities in batch processing.

To allow this we:
- Introduced a SearchClientsProxy interface
    - The interface combines all search clients interfaces, and acts as a common ancestor for both document-based and RDBMS implementations
    - Enables passing the clients around as abstraction
- extended zeebe-broker and workflow-engine configuration to have access to secondary storage through the SearchClientsProxy

As aside hustle, I also renamed the `SearchClients` class to `DocumentBasedSearchClients` which better reflects what it actually does.

---
_**PS:** In a later implementation, this `SearchClientsProxy` is needed in the `EngineProcessors#createEngineProcessors` method but constructed on top level to access beans. To pass it through, the following components needed to be modified (in bottom up dependency order):_
- ZeebePartitionFactory
- PartitionManagerImpl
- PartitionManagerStep
- BrokerStartupContext and Impl
- Broker
- SystemContext and Impl


## Related issues

closes #29696 
