### PR TITLE
[Backport release-8.7.0] fix: Improve REST API response when deployResources payload is too large

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
@@ -150,7 +150,7 @@ final class CommandApiRequestHandler
     } else {
       return Either.left(
           errorWriter
-              .errorCode(ErrorCode.MALFORMED_REQUEST)
+              .errorCode(ErrorCode.MAX_MESSAGE_SIZE_EXCEEDED)
               .errorMessage("Request size is above configured maxMessageSize."));
     }
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandlerTest.java
@@ -248,7 +248,8 @@ public class CommandApiRequestHandlerTest {
         .extracting(Either::getLeft)
         .extracting(ErrorResponse::getErrorCode, e -> BufferUtil.bufferAsString(e.getErrorData()))
         .containsExactly(
-            ErrorCode.MALFORMED_REQUEST, "Request size is above configured maxMessageSize.");
+            ErrorCode.MAX_MESSAGE_SIZE_EXCEEDED,
+            "Request size is above configured maxMessageSize.");
   }
 
   private CompletableFuture<Either<ErrorResponse, ExecuteCommandResponse>> handleRequest(

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -178,6 +178,17 @@ public final class GrpcErrorMapper {
         builder.setCode(Code.UNAVAILABLE_VALUE);
       }
       case MALFORMED_REQUEST -> builder.setCode(Code.INVALID_ARGUMENT_VALUE);
+<<<<<<< HEAD
+=======
+      case PARTITION_UNAVAILABLE -> {
+        logger.debug("Partition is currently unavailable: {}", error, rootError);
+        builder.setCode(Code.UNAVAILABLE_VALUE);
+      }
+      case MAX_MESSAGE_SIZE_EXCEEDED -> {
+        logger.debug("Max message size exceeded: {}", error, rootError);
+        builder.setCode(Code.RESOURCE_EXHAUSTED_VALUE);
+      }
+>>>>>>> 0bb07983 (fix: Improve REST API response when deployResources payload is too large)
       default -> {
         // all the following are for cases where retrying (with the same gateway) is not expected
         // to solve anything

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTest.java
@@ -180,4 +180,43 @@ final class GrpcErrorMapperTest {
     // then
     assertThat(statusException.getStatus().getCode()).isEqualTo(Code.ABORTED);
   }
+<<<<<<< HEAD
+=======
+
+  @Test
+  void shouldLogPartitionUnavailableErrorOnDebug() {
+    // given
+    final var brokerError =
+        new BrokerError(ErrorCode.PARTITION_UNAVAILABLE, "Partition unavailable");
+    final BrokerErrorException exception = new BrokerErrorException(brokerError);
+
+    // when
+    log.setLevel(Level.DEBUG);
+    final StatusRuntimeException statusException = errorMapper.mapError(exception, logger);
+
+    // then
+    assertThat(statusException.getStatus().getCode()).isEqualTo(Code.UNAVAILABLE);
+    assertThat(recorder.getAppendedEvents()).hasSize(1);
+    final LogEvent event = recorder.getAppendedEvents().getFirst();
+    assertThat(event.getLevel()).isEqualTo(Level.DEBUG);
+  }
+
+  @Test
+  void shouldLogMaxMessageSizeExceededErrorOnDebug() {
+    // given
+    final var brokerError =
+        new BrokerError(ErrorCode.MAX_MESSAGE_SIZE_EXCEEDED, "Max message size exceeded");
+    final BrokerErrorException exception = new BrokerErrorException(brokerError);
+
+    // when
+    log.setLevel(Level.DEBUG);
+    final StatusRuntimeException statusException = errorMapper.mapError(exception, logger);
+
+    // then
+    assertThat(statusException.getStatus().getCode()).isEqualTo(Code.RESOURCE_EXHAUSTED);
+    assertThat(recorder.getAppendedEvents()).hasSize(1);
+    final LogEvent event = recorder.getAppendedEvents().getFirst();
+    assertThat(event.getLevel()).isEqualTo(Level.DEBUG);
+  }
+>>>>>>> 0bb07983 (fix: Improve REST API response when deployResources payload is too large)
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RestErrorMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RestErrorMapper.java
@@ -198,6 +198,18 @@ public class RestErrorMapper {
             "Target broker was not the leader of the partition: {}", error, rootError);
         yield createProblemDetail(HttpStatus.SERVICE_UNAVAILABLE, message, title);
       }
+<<<<<<< HEAD
+=======
+      case PARTITION_UNAVAILABLE -> {
+        REST_GATEWAY_LOGGER.debug(
+            "Partition in target broker is currently unavailable: {}", error, rootError);
+        yield createProblemDetail(HttpStatus.SERVICE_UNAVAILABLE, message, title);
+      }
+      case MAX_MESSAGE_SIZE_EXCEEDED -> {
+        REST_GATEWAY_LOGGER.debug("Max message size exceeded: {}", error, rootError);
+        yield createProblemDetail(HttpStatus.PAYLOAD_TOO_LARGE, message, title);
+      }
+>>>>>>> 0bb07983 (fix: Improve REST API response when deployResources payload is too large)
       default -> {
         // all the following are for cases where retrying (with the same gateway) is not
         // expected
@@ -294,4 +306,53 @@ public class RestErrorMapper {
       final DocumentException e) {
     return mapProblemToResponse(mapDocumentHandlingExceptionToProblem(e));
   }
+<<<<<<< HEAD
+=======
+
+  public static ProblemDetail mapCamundaSearchExceptionToProblem(final CamundaSearchException cse) {
+    final CamundaSearchException.Reason reason = cse.getReason();
+    final String title = reason.name();
+    final String errorMessage = cse.getMessage();
+    final String logPrefix = "Expected to handle REST request, but: {}";
+    switch (reason) {
+      case NOT_FOUND:
+        {
+          REST_GATEWAY_LOGGER.debug(logPrefix, errorMessage);
+          return createProblemDetail(HttpStatus.NOT_FOUND, errorMessage, title);
+        }
+      case NOT_UNIQUE:
+        {
+          REST_GATEWAY_LOGGER.debug(logPrefix, errorMessage);
+          return createProblemDetail(HttpStatus.CONFLICT, errorMessage, title);
+        }
+      case CONNECTION_FAILED:
+        {
+          final String detail =
+              errorMessage + ". The search client could not connect to the search server.";
+          REST_GATEWAY_LOGGER.debug(logPrefix, detail);
+          return createProblemDetail(HttpStatus.SERVICE_UNAVAILABLE, detail, title);
+        }
+      case SEARCH_SERVER_FAILED:
+        {
+          final String detail =
+              errorMessage + ". The search server was unable to process the request.";
+          REST_GATEWAY_LOGGER.debug(logPrefix, detail);
+          return createProblemDetail(HttpStatus.INTERNAL_SERVER_ERROR, detail, title);
+        }
+      case SEARCH_CLIENT_FAILED:
+        {
+          final String detail =
+              errorMessage + ". The search client was unable to process the request.";
+          REST_GATEWAY_LOGGER.debug(logPrefix, detail);
+          return createProblemDetail(HttpStatus.INTERNAL_SERVER_ERROR, detail, title);
+        }
+      default:
+        {
+          REST_GATEWAY_LOGGER.debug(logPrefix, errorMessage);
+          return createProblemDetail(
+              HttpStatus.INTERNAL_SERVER_ERROR, errorMessage, "INTERNAL_ERROR");
+        }
+    }
+  }
+>>>>>>> 0bb07983 (fix: Improve REST API response when deployResources payload is too large)
 }

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -18,6 +18,11 @@
       <validValue name="INVALID_DEPLOYMENT_PARTITION">6</validValue>
       <validValue name="PROCESS_NOT_FOUND">7</validValue>
       <validValue name="RESOURCE_EXHAUSTED">8</validValue>
+<<<<<<< HEAD
+=======
+      <validValue name="PARTITION_UNAVAILABLE">9</validValue>
+      <validValue name="MAX_MESSAGE_SIZE_EXCEEDED">10</validValue>
+>>>>>>> 0bb07983 (fix: Improve REST API response when deployResources payload is too large)
     </enum>
 
     <enum name="ValueType" encodingType="uint8" description="The type of a record value">


### PR DESCRIPTION
# Description
Backport of #29980 to `release-8.7.0`.

relates to camunda/camunda#29965