### PR TITLE
feat: serialize pagination data types

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestPage.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestPage.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.client.api.search.request;
 
-import io.camunda.client.protocol.rest.PageObject;
 import java.util.List;
 
 public interface SearchRequestPage {
@@ -27,8 +26,8 @@ public interface SearchRequestPage {
   SearchRequestPage limit(final Integer value);
 
   /** Get previous page before the set of values. */
-  SearchRequestPage searchBefore(final List<PageObject> values);
+  SearchRequestPage searchBefore(final List<Object> values);
 
   /** Get next page after the set of values. */
-  SearchRequestPage searchAfter(final List<PageObject> values);
+  SearchRequestPage searchAfter(final List<Object> values);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestPage.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/request/SearchRequestPage.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.api.search.request;
 
+import io.camunda.client.protocol.rest.PageObject;
 import java.util.List;
 
 public interface SearchRequestPage {
@@ -26,8 +27,8 @@ public interface SearchRequestPage {
   SearchRequestPage limit(final Integer value);
 
   /** Get previous page before the set of values. */
-  SearchRequestPage searchBefore(final List<Object> values);
+  SearchRequestPage searchBefore(final List<PageObject> values);
 
   /** Get next page after the set of values. */
-  SearchRequestPage searchAfter(final List<Object> values);
+  SearchRequestPage searchAfter(final List<PageObject> values);
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/SearchResponsePage.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/SearchResponsePage.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.client.api.search.response;
 
+import io.camunda.client.protocol.rest.SortValueResponse;
 import java.util.List;
 
 public interface SearchResponsePage {
@@ -23,8 +24,8 @@ public interface SearchResponsePage {
   Long totalItems();
 
   /** The sort values of the first item in the returned page. */
-  List<Object> firstSortValues();
+  List<SortValueResponse> firstSortValues();
 
   /** The sort values of the last item in the returned page. */
-  List<Object> lastSortValues();
+  List<SortValueResponse> lastSortValues();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/SearchResponsePage.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/SearchResponsePage.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.client.api.search.response;
 
-import io.camunda.client.protocol.rest.PageObject;
 import java.util.List;
 
 public interface SearchResponsePage {
@@ -24,8 +23,8 @@ public interface SearchResponsePage {
   Long totalItems();
 
   /** The sort values of the first item in the returned page. */
-  List<PageObject> firstSortValues();
+  List<Object> firstSortValues();
 
   /** The sort values of the last item in the returned page. */
-  List<PageObject> lastSortValues();
+  List<Object> lastSortValues();
 }

--- a/clients/java/src/main/java/io/camunda/client/api/search/response/SearchResponsePage.java
+++ b/clients/java/src/main/java/io/camunda/client/api/search/response/SearchResponsePage.java
@@ -15,7 +15,7 @@
  */
 package io.camunda.client.api.search.response;
 
-import io.camunda.client.protocol.rest.SortValueResponse;
+import io.camunda.client.protocol.rest.PageObject;
 import java.util.List;
 
 public interface SearchResponsePage {
@@ -24,8 +24,8 @@ public interface SearchResponsePage {
   Long totalItems();
 
   /** The sort values of the first item in the returned page. */
-  List<SortValueResponse> firstSortValues();
+  List<PageObject> firstSortValues();
 
   /** The sort values of the last item in the returned page. */
-  List<SortValueResponse> lastSortValues();
+  List<PageObject> lastSortValues();
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestPageImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestPageImpl.java
@@ -16,6 +16,7 @@
 package io.camunda.client.impl.search.request;
 
 import io.camunda.client.api.search.request.SearchRequestPage;
+import io.camunda.client.protocol.rest.PageObject;
 import io.camunda.client.protocol.rest.SearchQueryPageRequest;
 import java.util.List;
 
@@ -42,13 +43,13 @@ public class SearchRequestPageImpl
   }
 
   @Override
-  public SearchRequestPage searchBefore(final List<Object> values) {
+  public SearchRequestPage searchBefore(final List<PageObject> values) {
     page.setSearchBefore(values);
     return this;
   }
 
   @Override
-  public SearchRequestPage searchAfter(final List<Object> values) {
+  public SearchRequestPage searchAfter(final List<PageObject> values) {
     page.setSearchAfter(values);
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestPageImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/request/SearchRequestPageImpl.java
@@ -16,7 +16,7 @@
 package io.camunda.client.impl.search.request;
 
 import io.camunda.client.api.search.request.SearchRequestPage;
-import io.camunda.client.protocol.rest.PageObject;
+import io.camunda.client.impl.util.PageObjectMapper;
 import io.camunda.client.protocol.rest.SearchQueryPageRequest;
 import java.util.List;
 
@@ -43,14 +43,15 @@ public class SearchRequestPageImpl
   }
 
   @Override
-  public SearchRequestPage searchBefore(final List<PageObject> values) {
-    page.setSearchBefore(values);
+  public SearchRequestPage searchBefore(final List<Object> values) {
+    page.setSearchBefore(PageObjectMapper.fromObjectList(values));
     return this;
   }
 
   @Override
-  public SearchRequestPage searchAfter(final List<PageObject> values) {
-    page.setSearchAfter(values);
+  public SearchRequestPage searchAfter(final List<Object> values) {
+
+    page.setSearchAfter(PageObjectMapper.fromObjectList(values));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -116,7 +116,10 @@ public final class SearchResponseMapper {
 
   private static SearchResponsePage toSearchResponsePage(
       final SearchQueryPageResponse pageResponse) {
-    return new SearchResponsePageImpl(pageResponse.getTotalItems(), null, null);
+    return new SearchResponsePageImpl(
+        pageResponse.getTotalItems(),
+        pageResponse.getFirstSortValues(),
+        pageResponse.getLastSortValues());
   }
 
   public static SearchResponse<DecisionRequirements> toDecisionRequirementsSearchResponse(
@@ -141,43 +144,5 @@ public final class SearchResponseMapper {
     return Optional.ofNullable(items)
         .map(i -> i.stream().map(mapper).collect(Collectors.toList()))
         .orElse(Collections.emptyList());
-  }
-
-  private static String determineValueType(final Object rawObj) {
-    if (rawObj == null) return "null";
-
-    String rawValue = rawObj.toString().trim();
-
-    // Boolean detection
-    if ("true".equalsIgnoreCase(rawValue) || "false".equalsIgnoreCase(rawValue)) {
-      return "boolean";
-    }
-
-    // Integer (int64) detection
-    try {
-      Long.parseLong(rawValue);
-      return "int64";
-    } catch (NumberFormatException ignored) {
-    }
-
-    // Float detection
-    try {
-      Double.parseDouble(rawValue);
-      return "float";
-    } catch (NumberFormatException ignored) {
-    }
-
-    // Date detection (optional – simplified ISO8601 check)
-    if (rawValue.matches("\\d{4}-\\d{2}-\\d{2}T.*Z")) {
-      return "date";
-    }
-
-    // Quoted string: remove quotes if present
-    if (rawValue.startsWith("\"") && rawValue.endsWith("\"")) {
-      return "string";
-    }
-
-    // Fallback: treat everything else as string
-    return "string";
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponseMapper.java
@@ -116,10 +116,7 @@ public final class SearchResponseMapper {
 
   private static SearchResponsePage toSearchResponsePage(
       final SearchQueryPageResponse pageResponse) {
-    return new SearchResponsePageImpl(
-        pageResponse.getTotalItems(),
-        pageResponse.getFirstSortValues(),
-        pageResponse.getLastSortValues());
+    return new SearchResponsePageImpl(pageResponse.getTotalItems(), null, null);
   }
 
   public static SearchResponse<DecisionRequirements> toDecisionRequirementsSearchResponse(
@@ -144,5 +141,43 @@ public final class SearchResponseMapper {
     return Optional.ofNullable(items)
         .map(i -> i.stream().map(mapper).collect(Collectors.toList()))
         .orElse(Collections.emptyList());
+  }
+
+  private static String determineValueType(final Object rawObj) {
+    if (rawObj == null) return "null";
+
+    String rawValue = rawObj.toString().trim();
+
+    // Boolean detection
+    if ("true".equalsIgnoreCase(rawValue) || "false".equalsIgnoreCase(rawValue)) {
+      return "boolean";
+    }
+
+    // Integer (int64) detection
+    try {
+      Long.parseLong(rawValue);
+      return "int64";
+    } catch (NumberFormatException ignored) {
+    }
+
+    // Float detection
+    try {
+      Double.parseDouble(rawValue);
+      return "float";
+    } catch (NumberFormatException ignored) {
+    }
+
+    // Date detection (optional – simplified ISO8601 check)
+    if (rawValue.matches("\\d{4}-\\d{2}-\\d{2}T.*Z")) {
+      return "date";
+    }
+
+    // Quoted string: remove quotes if present
+    if (rawValue.startsWith("\"") && rawValue.endsWith("\"")) {
+      return "string";
+    }
+
+    // Fallback: treat everything else as string
+    return "string";
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponsePageImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponsePageImpl.java
@@ -16,6 +16,7 @@
 package io.camunda.client.impl.search.response;
 
 import io.camunda.client.api.search.response.SearchResponsePage;
+import io.camunda.client.impl.util.PageObjectMapper;
 import io.camunda.client.protocol.rest.PageObject;
 import java.util.List;
 
@@ -40,12 +41,12 @@ public class SearchResponsePageImpl implements SearchResponsePage {
   }
 
   @Override
-  public List<PageObject> firstSortValues() {
-    return firstSortValues;
+  public List<Object> firstSortValues() {
+    return PageObjectMapper.toObjectList(firstSortValues);
   }
 
   @Override
-  public List<PageObject> lastSortValues() {
-    return lastSortValues;
+  public List<Object> lastSortValues() {
+    return PageObjectMapper.toObjectList(lastSortValues);
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponsePageImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponsePageImpl.java
@@ -16,19 +16,19 @@
 package io.camunda.client.impl.search.response;
 
 import io.camunda.client.api.search.response.SearchResponsePage;
-import io.camunda.client.protocol.rest.SortValueResponse;
+import io.camunda.client.protocol.rest.PageObject;
 import java.util.List;
 
 public class SearchResponsePageImpl implements SearchResponsePage {
 
   private final long totalItems;
-  private final List<SortValueResponse> firstSortValues;
-  private final List<SortValueResponse> lastSortValues;
+  private final List<PageObject> firstSortValues;
+  private final List<PageObject> lastSortValues;
 
   public SearchResponsePageImpl(
       final long totalItems,
-      final List<SortValueResponse> firstSortValues,
-      final List<SortValueResponse> lastSortValues) {
+      final List<PageObject> firstSortValues,
+      final List<PageObject> lastSortValues) {
     this.totalItems = totalItems;
     this.firstSortValues = firstSortValues;
     this.lastSortValues = lastSortValues;
@@ -40,12 +40,12 @@ public class SearchResponsePageImpl implements SearchResponsePage {
   }
 
   @Override
-  public List<SortValueResponse> firstSortValues() {
+  public List<PageObject> firstSortValues() {
     return firstSortValues;
   }
 
   @Override
-  public List<SortValueResponse> lastSortValues() {
+  public List<PageObject> lastSortValues() {
     return lastSortValues;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponsePageImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/search/response/SearchResponsePageImpl.java
@@ -16,18 +16,19 @@
 package io.camunda.client.impl.search.response;
 
 import io.camunda.client.api.search.response.SearchResponsePage;
+import io.camunda.client.protocol.rest.SortValueResponse;
 import java.util.List;
 
 public class SearchResponsePageImpl implements SearchResponsePage {
 
   private final long totalItems;
-  private final List<Object> firstSortValues;
-  private final List<Object> lastSortValues;
+  private final List<SortValueResponse> firstSortValues;
+  private final List<SortValueResponse> lastSortValues;
 
   public SearchResponsePageImpl(
       final long totalItems,
-      final List<Object> firstSortValues,
-      final List<Object> lastSortValues) {
+      final List<SortValueResponse> firstSortValues,
+      final List<SortValueResponse> lastSortValues) {
     this.totalItems = totalItems;
     this.firstSortValues = firstSortValues;
     this.lastSortValues = lastSortValues;
@@ -39,12 +40,12 @@ public class SearchResponsePageImpl implements SearchResponsePage {
   }
 
   @Override
-  public List<Object> firstSortValues() {
+  public List<SortValueResponse> firstSortValues() {
     return firstSortValues;
   }
 
   @Override
-  public List<Object> lastSortValues() {
+  public List<SortValueResponse> lastSortValues() {
     return lastSortValues;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/util/PageObjectMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/PageObjectMapper.java
@@ -21,6 +21,9 @@ import java.util.stream.Collectors;
 
 public class PageObjectMapper {
   public static List<PageObject> fromObjectList(final List<Object> values) {
+    if (values == null) {
+      return null;
+    }
     return values.stream().map(PageObjectMapper::fromObject).collect(Collectors.toList());
   }
 
@@ -53,7 +56,7 @@ public class PageObjectMapper {
     final PageObject.TypeEnum type = pageObject.getType();
 
     if (type == PageObject.TypeEnum.STRING) {
-      return rawValue.replaceAll("^\"|\"$", ""); // unescape quotes
+      return rawValue.replaceAll("^\"|\"$", "");
     } else if (type == PageObject.TypeEnum.INT64) {
       return Long.parseLong(rawValue);
     } else if (type == PageObject.TypeEnum.FLOAT) {
@@ -61,7 +64,7 @@ public class PageObjectMapper {
     } else if (type == PageObject.TypeEnum.BOOLEAN) {
       return Boolean.parseBoolean(rawValue);
     } else {
-      return rawValue; // Fallback to raw value
+      return rawValue;
     }
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/util/PageObjectMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/PageObjectMapper.java
@@ -55,16 +55,15 @@ public class PageObjectMapper {
     final String rawValue = pageObject.getValue();
     final PageObject.TypeEnum type = pageObject.getType();
 
-    if (type == PageObject.TypeEnum.STRING) {
-      return rawValue.replaceAll("^\"|\"$", "");
-    } else if (type == PageObject.TypeEnum.INT64) {
-      return Long.parseLong(rawValue);
-    } else if (type == PageObject.TypeEnum.FLOAT) {
-      return Double.parseDouble(rawValue);
-    } else if (type == PageObject.TypeEnum.BOOLEAN) {
-      return Boolean.parseBoolean(rawValue);
-    } else {
-      return rawValue;
+    switch (type) {
+      case INT64:
+        return Long.parseLong(rawValue);
+      case FLOAT:
+        return Double.parseDouble(rawValue);
+      case BOOLEAN:
+        return Boolean.parseBoolean(rawValue);
+      default:
+        return rawValue;
     }
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/util/PageObjectMapper.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/util/PageObjectMapper.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.util;
+
+import io.camunda.client.protocol.rest.PageObject;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class PageObjectMapper {
+  public static List<PageObject> fromObjectList(final List<Object> values) {
+    return values.stream().map(PageObjectMapper::fromObject).collect(Collectors.toList());
+  }
+
+  public static PageObject fromObject(final Object value) {
+    try {
+      if (value instanceof PageObject) {
+        final PageObject pageObject = (PageObject) value;
+        return new PageObject().value(pageObject.getValue()).type(pageObject.getType());
+      }
+
+      return new PageObject()
+          .value(value != null ? value.toString() : null)
+          .type(PageObject.TypeEnum.OBJECT);
+
+    } catch (final Exception e) {
+      throw new IllegalArgumentException("Failed to convert value to PageObject: " + value, e);
+    }
+  }
+
+  public static List<Object> toObjectList(final List<PageObject> pageObjects) {
+    return pageObjects.stream().map(PageObjectMapper::toObject).collect(Collectors.toList());
+  }
+
+  public static Object toObject(final PageObject pageObject) {
+    if (pageObject == null || pageObject.getValue() == null || pageObject.getType() == null) {
+      return null;
+    }
+
+    final String rawValue = pageObject.getValue();
+    final PageObject.TypeEnum type = pageObject.getType();
+
+    if (type == PageObject.TypeEnum.STRING) {
+      return rawValue.replaceAll("^\"|\"$", ""); // unescape quotes
+    } else if (type == PageObject.TypeEnum.INT64) {
+      return Long.parseLong(rawValue);
+    } else if (type == PageObject.TypeEnum.FLOAT) {
+      return Double.parseDouble(rawValue);
+    } else if (type == PageObject.TypeEnum.BOOLEAN) {
+      return Boolean.parseBoolean(rawValue);
+    } else {
+      return rawValue; // Fallback to raw value
+    }
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/impl/util/PageObjectMapperTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/util/PageObjectMapperTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.client.impl.util;
+
+import static org.assertj.core.api.Assertions.*;
+
+import io.camunda.client.protocol.rest.PageObject;
+import io.camunda.client.protocol.rest.PageObject.TypeEnum;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class PageObjectMapperTest {
+
+  @Test
+  void shouldMapStringToPageObject() {
+    final PageObject result = PageObjectMapper.fromObject("foo");
+    assertThat(result.getValue()).isEqualTo("foo");
+    assertThat(result.getType()).isEqualTo(TypeEnum.OBJECT);
+  }
+
+  @Test
+  void shouldReturnSamePageObjectWhenAlreadyPageObject() {
+    final PageObject original = new PageObject().value("bar").type(TypeEnum.STRING);
+    final PageObject result = PageObjectMapper.fromObject(original);
+
+    assertThat(result).isNotSameAs(original);
+    assertThat(result.getValue()).isEqualTo("bar");
+    assertThat(result.getType()).isEqualTo(TypeEnum.STRING);
+  }
+
+  @Test
+  void shouldConvertListOfObjectsToPageObjects() {
+    final List<Object> input = Arrays.asList("a", 42L, true);
+    final List<PageObject> result = PageObjectMapper.fromObjectList(input);
+
+    assertThat(result).hasSize(3);
+    assertThat(result.get(0).getValue()).isEqualTo("a");
+    assertThat(result.get(1).getValue()).isEqualTo("42");
+    assertThat(result.get(2).getValue()).isEqualTo("true");
+  }
+
+  @Test
+  void shouldConvertPageObjectToLong() {
+    final PageObject input = new PageObject().value("123456789").type(TypeEnum.INT64);
+    final Object result = PageObjectMapper.toObject(input);
+    assertThat(result).isInstanceOf(Long.class).isEqualTo(123456789L);
+  }
+
+  @Test
+  void shouldConvertPageObjectToFloat() {
+    final PageObject input = new PageObject().value("3.14").type(TypeEnum.FLOAT);
+    final Object result = PageObjectMapper.toObject(input);
+    assertThat(result).isInstanceOf(Double.class).isEqualTo(3.14);
+  }
+
+  @Test
+  void shouldConvertPageObjectToBoolean() {
+    final PageObject input = new PageObject().value("true").type(TypeEnum.BOOLEAN);
+    final Object result = PageObjectMapper.toObject(input);
+    assertThat(result).isInstanceOf(Boolean.class).isEqualTo(true);
+  }
+
+  @Test
+  void shouldConvertUnknownPageObjectToRawString() {
+    final PageObject input = new PageObject().value("raw").type(TypeEnum.OBJECT);
+    final Object result = PageObjectMapper.toObject(input);
+    assertThat(result).isEqualTo("raw");
+  }
+
+  @Test
+  void shouldConvertListOfPageObjectsToObjects() {
+    final List<PageObject> input =
+        Arrays.asList(
+            new PageObject().value("42").type(TypeEnum.INT64),
+            new PageObject().value("true").type(TypeEnum.BOOLEAN),
+            new PageObject().value("hello").type(TypeEnum.OBJECT));
+
+    final List<Object> result = PageObjectMapper.toObjectList(input);
+    assertThat(result).containsExactly(42L, true, "hello");
+  }
+
+  @Test
+  void shouldReturnNullWhenFromNullObjectList() {
+    final List<PageObject> result = PageObjectMapper.fromObjectList(null);
+    assertThat(result).isNull();
+  }
+
+  @Test
+  void shouldReturnNullWhenPageObjectIsInvalid() {
+    final PageObject invalid = new PageObject().value(null).type(null);
+    final Object result = PageObjectMapper.toObject(invalid);
+    assertThat(result).isNull();
+  }
+
+  @Test
+  void shouldHandleNullValueInFromObject() {
+    final PageObject result = PageObjectMapper.fromObject(null);
+
+    assertThat(result.getValue()).isNull();
+    assertThat(result.getType()).isEqualTo(PageObject.TypeEnum.OBJECT);
+  }
+}

--- a/clients/java/src/test/java/io/camunda/client/incident/SearchIncidentTest.java
+++ b/clients/java/src/test/java/io/camunda/client/incident/SearchIncidentTest.java
@@ -150,11 +150,11 @@ public class SearchIncidentTest extends ClientRestTest {
   void shouldSearchWithFullPagination() {
     // when
     final PageObject pageObjectB = new PageObject();
-    pageObjectB.value("\"a\"");
+    pageObjectB.value("a");
     pageObjectB.type(TypeEnum.STRING);
 
     final PageObject pageObjectA = new PageObject();
-    pageObjectA.value("\"a\"");
+    pageObjectA.value("a");
     pageObjectA.type(TypeEnum.STRING);
 
     client

--- a/clients/java/src/test/java/io/camunda/client/incident/SearchIncidentTest.java
+++ b/clients/java/src/test/java/io/camunda/client/incident/SearchIncidentTest.java
@@ -26,6 +26,7 @@ import io.camunda.client.impl.search.request.SearchRequestSortMapper;
 import io.camunda.client.protocol.rest.*;
 import io.camunda.client.protocol.rest.IncidentFilter.ErrorTypeEnum;
 import io.camunda.client.protocol.rest.IncidentFilter.StateEnum;
+import io.camunda.client.protocol.rest.PageObject.TypeEnum;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import java.util.Arrays;
@@ -148,14 +149,22 @@ public class SearchIncidentTest extends ClientRestTest {
   @Test
   void shouldSearchWithFullPagination() {
     // when
+    final PageObject pageObjectB = new PageObject();
+    pageObjectB.value("\"a\"");
+    pageObjectB.type(TypeEnum.STRING);
+
+    final PageObject pageObjectA = new PageObject();
+    pageObjectA.value("\"a\"");
+    pageObjectA.type(TypeEnum.STRING);
+
     client
         .newIncidentSearchRequest()
         .page(
             p ->
                 p.from(23)
                     .limit(5)
-                    .searchBefore(Arrays.asList("b"))
-                    .searchAfter(Arrays.asList("a")))
+                    .searchBefore(Arrays.asList(pageObjectB))
+                    .searchAfter(Arrays.asList(pageObjectA)))
         .send()
         .join();
 
@@ -164,8 +173,8 @@ public class SearchIncidentTest extends ClientRestTest {
     final SearchQueryPageRequest pageRequest = request.getPage();
     assertThat(pageRequest.getFrom()).isEqualTo(23);
     assertThat(pageRequest.getLimit()).isEqualTo(5);
-    assertThat(pageRequest.getSearchBefore()).isEqualTo(Arrays.asList("b"));
-    assertThat(pageRequest.getSearchAfter()).isEqualTo(Arrays.asList("a"));
+    assertThat(pageRequest.getSearchBefore()).isEqualTo(Arrays.asList(pageObjectB));
+    assertThat(pageRequest.getSearchAfter()).isEqualTo(Arrays.asList(pageObjectA));
   }
 
   /*

--- a/clients/java/src/test/java/io/camunda/client/process/QueryProcessDefinitionTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/QueryProcessDefinitionTest.java
@@ -21,6 +21,8 @@ import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.impl.search.request.SearchRequestSort;
 import io.camunda.client.impl.search.request.SearchRequestSortMapper;
+import io.camunda.client.protocol.rest.PageObject;
+import io.camunda.client.protocol.rest.PageObject.TypeEnum;
 import io.camunda.client.protocol.rest.ProcessDefinitionFilter;
 import io.camunda.client.protocol.rest.ProcessDefinitionSearchQuery;
 import io.camunda.client.protocol.rest.SearchQueryPageRequest;
@@ -155,6 +157,14 @@ public class QueryProcessDefinitionTest extends ClientRestTest {
 
   @Test
   void shouldSearchWithFullPagination() {
+    final PageObject pageObjectB = new PageObject();
+    pageObjectB.value("\"a\"");
+    pageObjectB.type(TypeEnum.STRING);
+
+    final PageObject pageObjectA = new PageObject();
+    pageObjectA.value("\"a\"");
+    pageObjectA.type(TypeEnum.STRING);
+
     // when
     client
         .newProcessDefinitionSearchRequest()
@@ -162,8 +172,8 @@ public class QueryProcessDefinitionTest extends ClientRestTest {
             p ->
                 p.from(23)
                     .limit(5)
-                    .searchBefore(Collections.singletonList("b"))
-                    .searchAfter(Collections.singletonList("a")))
+                    .searchBefore(Collections.singletonList(pageObjectB))
+                    .searchAfter(Collections.singletonList(pageObjectA)))
         .send()
         .join();
 
@@ -174,8 +184,8 @@ public class QueryProcessDefinitionTest extends ClientRestTest {
     assertThat(pageRequest).isNotNull();
     assertThat(pageRequest.getFrom()).isEqualTo(23);
     assertThat(pageRequest.getLimit()).isEqualTo(5);
-    assertThat(pageRequest.getSearchBefore()).isEqualTo(Collections.singletonList("b"));
-    assertThat(pageRequest.getSearchAfter()).isEqualTo(Collections.singletonList("a"));
+    assertThat(pageRequest.getSearchBefore()).isEqualTo(Collections.singletonList(pageObjectB));
+    assertThat(pageRequest.getSearchAfter()).isEqualTo(Collections.singletonList(pageObjectA));
   }
 
   private void assertSort(

--- a/clients/java/src/test/java/io/camunda/client/process/QueryProcessDefinitionTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/QueryProcessDefinitionTest.java
@@ -158,11 +158,11 @@ public class QueryProcessDefinitionTest extends ClientRestTest {
   @Test
   void shouldSearchWithFullPagination() {
     final PageObject pageObjectB = new PageObject();
-    pageObjectB.value("\"a\"");
+    pageObjectB.value("a");
     pageObjectB.type(TypeEnum.STRING);
 
     final PageObject pageObjectA = new PageObject();
-    pageObjectA.value("\"a\"");
+    pageObjectA.value("a");
     pageObjectA.type(TypeEnum.STRING);
 
     // when

--- a/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
@@ -259,11 +259,11 @@ public class QueryProcessInstanceTest extends ClientRestTest {
   void shouldSearchWithFullPagination() {
     // when
     final PageObject pageObjectB = new PageObject();
-    pageObjectB.value("\"a\"");
+    pageObjectB.value("a");
     pageObjectB.type(TypeEnum.STRING);
 
     final PageObject pageObjectA = new PageObject();
-    pageObjectA.value("\"a\"");
+    pageObjectA.value("a");
     pageObjectA.type(TypeEnum.STRING);
 
     client

--- a/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/client/process/QueryProcessInstanceTest.java
@@ -23,6 +23,7 @@ import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.client.impl.search.request.SearchRequestSort;
 import io.camunda.client.impl.search.request.SearchRequestSortMapper;
 import io.camunda.client.protocol.rest.*;
+import io.camunda.client.protocol.rest.PageObject.TypeEnum;
 import io.camunda.client.util.ClientRestTest;
 import io.camunda.client.util.RestGatewayService;
 import java.time.OffsetDateTime;
@@ -257,14 +258,22 @@ public class QueryProcessInstanceTest extends ClientRestTest {
   @Test
   void shouldSearchWithFullPagination() {
     // when
+    final PageObject pageObjectB = new PageObject();
+    pageObjectB.value("\"a\"");
+    pageObjectB.type(TypeEnum.STRING);
+
+    final PageObject pageObjectA = new PageObject();
+    pageObjectA.value("\"a\"");
+    pageObjectA.type(TypeEnum.STRING);
+
     client
         .newProcessInstanceSearchRequest()
         .page(
             p ->
                 p.from(23)
                     .limit(5)
-                    .searchBefore(Collections.singletonList("b"))
-                    .searchAfter(Collections.singletonList("a")))
+                    .searchBefore(Collections.singletonList(pageObjectB))
+                    .searchAfter(Collections.singletonList(pageObjectA)))
         .send()
         .join();
 
@@ -275,8 +284,8 @@ public class QueryProcessInstanceTest extends ClientRestTest {
     assertThat(pageRequest).isNotNull();
     assertThat(pageRequest.getFrom()).isEqualTo(23);
     assertThat(pageRequest.getLimit()).isEqualTo(5);
-    assertThat(pageRequest.getSearchBefore()).isEqualTo(Collections.singletonList("b"));
-    assertThat(pageRequest.getSearchAfter()).isEqualTo(Collections.singletonList("a"));
+    assertThat(pageRequest.getSearchBefore()).isEqualTo(Collections.singletonList(pageObjectB));
+    assertThat(pageRequest.getSearchAfter()).isEqualTo(Collections.singletonList(pageObjectA));
   }
 
   private void assertSort(

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/DecisionSearchTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/DecisionSearchTest.java
@@ -18,6 +18,8 @@ import io.camunda.client.api.response.DecisionRequirements;
 import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.client.api.search.response.DecisionDefinition;
 import io.camunda.client.impl.search.response.DecisionDefinitionImpl;
+import io.camunda.client.protocol.rest.PageObject;
+import io.camunda.client.protocol.rest.PageObject.TypeEnum;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -475,7 +477,11 @@ class DecisionSearchTest {
     final var resultAfter =
         camundaClient
             .newDecisionRequirementsSearchRequest()
-            .page(p -> p.searchAfter(Collections.singletonList(key)))
+            .page(
+                p ->
+                    p.searchAfter(
+                        Collections.singletonList(
+                            new PageObject().value(String.valueOf(key)).type(TypeEnum.INT64))))
             .send()
             .join();
 
@@ -485,7 +491,11 @@ class DecisionSearchTest {
     final var resultBefore =
         camundaClient
             .newDecisionRequirementsSearchRequest()
-            .page(p -> p.searchBefore(Collections.singletonList(keyAfter)))
+            .page(
+                p ->
+                    p.searchBefore(
+                        Collections.singletonList(
+                            new PageObject().value(String.valueOf(keyAfter)).type(TypeEnum.INT64))))
             .send()
             .join();
     assertThat(result.items().size()).isEqualTo(1);

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentSearchTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentSearchTest.java
@@ -24,6 +24,7 @@ import io.camunda.client.api.response.Process;
 import io.camunda.client.api.search.enums.IncidentErrorType;
 import io.camunda.client.api.search.enums.IncidentState;
 import io.camunda.client.api.search.response.Incident;
+import io.camunda.client.impl.util.PageObjectMapper;
 import io.camunda.client.protocol.rest.PageObject;
 import io.camunda.client.protocol.rest.PageObject.TypeEnum;
 import io.camunda.qa.util.multidb.MultiDbTest;
@@ -562,6 +563,10 @@ class IncidentSearchTest {
     final var secondIncidentKey = resultAll.items().get(1).getIncidentKey();
     final var firstIncidentKey = resultAll.items().get(0).getIncidentKey();
 
+    final List<PageObject> pageObjects =
+        Collections.singletonList(
+            new PageObject().value(String.valueOf(secondIncidentKey)).type(TypeEnum.INT64));
+
     final var resultSearchBefore =
         camundaClient
             .newIncidentSearchRequest()
@@ -569,11 +574,7 @@ class IncidentSearchTest {
                 p ->
                     p.limit(2)
                         .searchAfter(null)
-                        .searchBefore(
-                            Collections.singletonList(
-                                new PageObject()
-                                    .value(String.valueOf(secondIncidentKey))
-                                    .type(TypeEnum.INT64))))
+                        .searchBefore(PageObjectMapper.toObjectList(pageObjects)))
             .send()
             .join();
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentSearchTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentSearchTest.java
@@ -24,6 +24,8 @@ import io.camunda.client.api.response.Process;
 import io.camunda.client.api.search.enums.IncidentErrorType;
 import io.camunda.client.api.search.enums.IncidentState;
 import io.camunda.client.api.search.response.Incident;
+import io.camunda.client.protocol.rest.PageObject;
+import io.camunda.client.protocol.rest.PageObject.TypeEnum;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import io.camunda.webapps.schema.entities.incident.ErrorType;
 import java.util.ArrayList;
@@ -536,7 +538,14 @@ class IncidentSearchTest {
     final var resultSearchAfter =
         camundaClient
             .newIncidentSearchRequest()
-            .page(p -> p.limit(2).searchAfter(Collections.singletonList(secondIncidentKey)))
+            .page(
+                p ->
+                    p.limit(2)
+                        .searchAfter(
+                            Collections.singletonList(
+                                new PageObject()
+                                    .value(String.valueOf(secondIncidentKey))
+                                    .type(TypeEnum.INT64))))
             .send()
             .join();
 
@@ -556,7 +565,15 @@ class IncidentSearchTest {
     final var resultSearchBefore =
         camundaClient
             .newIncidentSearchRequest()
-            .page(p -> p.limit(2).searchBefore(Collections.singletonList(secondIncidentKey)))
+            .page(
+                p ->
+                    p.limit(2)
+                        .searchAfter(null)
+                        .searchBefore(
+                            Collections.singletonList(
+                                new PageObject()
+                                    .value(String.valueOf(secondIncidentKey))
+                                    .type(TypeEnum.INT64))))
             .send()
             .join();
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessDefinitionSearchTest.java
@@ -16,6 +16,7 @@ import io.camunda.client.api.command.ProblemException;
 import io.camunda.client.api.response.DeploymentEvent;
 import io.camunda.client.api.response.Process;
 import io.camunda.client.api.search.response.ProcessDefinition;
+import io.camunda.client.protocol.rest.SortValueResponse;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -23,6 +24,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -92,11 +94,17 @@ public class ProcessDefinitionSearchTest {
             .page(p -> p.limit(1))
             .send()
             .join();
+
+    final List<Object> lastSortValuesFirstPage =
+        firstPage.page().lastSortValues().stream()
+            .map(SortValueResponse::getValue)
+            .collect(Collectors.toList());
+
     final var secondPage =
         camundaClient
             .newProcessDefinitionSearchRequest()
             .sort(s -> s.processDefinitionKey().desc())
-            .page(p -> p.limit(1).searchAfter(firstPage.page().lastSortValues()))
+            .page(p -> p.limit(1).searchAfter(lastSortValuesFirstPage))
             .send()
             .join();
 
@@ -127,11 +135,15 @@ public class ProcessDefinitionSearchTest {
             .page(p -> p.limit(2))
             .send()
             .join();
+    final List<Object> firstPageLastSortValues =
+        firstPage.page().lastSortValues().stream()
+            .map(SortValueResponse::getValue)
+            .collect(Collectors.toList());
     final var secondPage =
         camundaClient
             .newProcessDefinitionSearchRequest()
             .sort(s -> s.processDefinitionId().desc())
-            .page(p -> p.limit(1).searchAfter(firstPage.page().lastSortValues()))
+            .page(p -> p.limit(1).searchAfter(firstPageLastSortValues))
             .send()
             .join();
 
@@ -156,19 +168,27 @@ public class ProcessDefinitionSearchTest {
             .page(p -> p.limit(2))
             .send()
             .join();
+    final List<Object> firstPageLastSortValues =
+        firstPage.page().lastSortValues().stream()
+            .map(SortValueResponse::getValue)
+            .collect(Collectors.toList());
     final var secondPage =
         camundaClient
             .newProcessDefinitionSearchRequest()
             .sort(s -> s.processDefinitionId().desc())
-            .page(p -> p.limit(1).searchAfter(firstPage.page().lastSortValues()))
+            .page(p -> p.limit(1).searchAfter(firstPageLastSortValues))
             .send()
             .join();
     // when
+    final List<Object> secondPageFirstSortValue =
+        secondPage.page().firstSortValues().stream()
+            .map(SortValueResponse::getValue)
+            .collect(Collectors.toList());
     final var firstPageAgain =
         camundaClient
             .newProcessDefinitionSearchRequest()
             .sort(s -> s.processDefinitionId().desc())
-            .page(p -> p.limit(2).searchBefore(secondPage.page().firstSortValues()))
+            .page(p -> p.limit(2).searchBefore(secondPageFirstSortValue))
             .send()
             .join();
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceSearchTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceSearchTest.java
@@ -34,6 +34,8 @@ import io.camunda.client.api.search.filter.StringFilterProperty;
 import io.camunda.client.api.search.response.FlowNodeInstance;
 import io.camunda.client.api.search.response.ProcessInstance;
 import io.camunda.client.api.worker.JobWorker;
+import io.camunda.client.protocol.rest.PageObject;
+import io.camunda.client.protocol.rest.PageObject.TypeEnum;
 import io.camunda.qa.util.multidb.MultiDbTest;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
@@ -812,7 +814,11 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
     final var resultAfter =
         camundaClient
             .newProcessInstanceSearchRequest()
-            .page(p -> p.searchAfter(Collections.singletonList(key)))
+            .page(
+                p ->
+                    p.searchAfter(
+                        Collections.singletonList(
+                            new PageObject().type(TypeEnum.INT64).value(String.valueOf(key)))))
             .send()
             .join();
 
@@ -822,7 +828,11 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
     final var resultBefore =
         camundaClient
             .newProcessInstanceSearchRequest()
-            .page(p -> p.searchBefore(Collections.singletonList(keyAfter)))
+            .page(
+                p ->
+                    p.searchBefore(
+                        Collections.singletonList(
+                            new PageObject().type(TypeEnum.INT64).value(String.valueOf(keyAfter)))))
             .send()
             .join();
     assertThat(result.items().size()).isEqualTo(2);
@@ -839,7 +849,11 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
     final var resultAfter =
         camundaClient
             .newFlownodeInstanceSearchRequest()
-            .page(p -> p.searchAfter(Collections.singletonList(key)))
+            .page(
+                p ->
+                    p.searchAfter(
+                        Collections.singletonList(
+                            new PageObject().type(TypeEnum.INT64).value(String.valueOf(key)))))
             .send()
             .join();
 
@@ -849,7 +863,11 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
     final var resultBefore =
         camundaClient
             .newFlownodeInstanceSearchRequest()
-            .page(p -> p.searchBefore(Collections.singletonList(keyAfter)))
+            .page(
+                p ->
+                    p.searchBefore(
+                        Collections.singletonList(
+                            new PageObject().type(TypeEnum.INT64).value(String.valueOf(keyAfter)))))
             .send()
             .join();
     assertThat(result.items().size()).isEqualTo(2);
@@ -1194,7 +1212,11 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
     final var resultAfter =
         camundaClient
             .newFlownodeInstanceSearchRequest()
-            .page(p -> p.searchAfter(Collections.singletonList(key)))
+            .page(
+                p ->
+                    p.searchAfter(
+                        Collections.singletonList(
+                            new PageObject().type(TypeEnum.INT64).value(String.valueOf(key)))))
             .send()
             .join();
 
@@ -1204,7 +1226,11 @@ public class ProcessInstanceAndFlowNodeInstanceSearchTest {
     final var resultBefore =
         camundaClient
             .newFlownodeInstanceSearchRequest()
-            .page(p -> p.searchBefore(Collections.singletonList(keyAfter)))
+            .page(
+                p ->
+                    p.searchBefore(
+                        Collections.singletonList(
+                            new PageObject().type(TypeEnum.INT64).value(String.valueOf(keyAfter)))))
             .send()
             .join();
     assertThat(result.items().size()).isEqualTo(2);

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskSearchTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskSearchTest.java
@@ -508,7 +508,7 @@ class UserTaskSearchTest {
     // Assert First and Last Sort Value matches the first and last item
     // We need to make use of toString, such the test work with ES/OS
     final List<String> firstSortValues =
-        result.page().firstSortValues().stream().map(pageObject -> pageObject.toString()).toList();
+        result.page().firstSortValues().stream().map(Object::toString).toList();
     String creationDateMillis = convertDateIfNeeded(firstSortValues.getFirst());
     String userTaskKey = firstSortValues.getLast();
 
@@ -519,7 +519,7 @@ class UserTaskSearchTest {
     assertThat(userTaskKey).isEqualTo(Long.toString(firstItem.getUserTaskKey()));
 
     final List<String> lastSortValues =
-        result.page().lastSortValues().stream().map(pageObject -> pageObject.toString()).toList();
+        result.page().lastSortValues().stream().map(Object::toString).toList();
     creationDateMillis = convertDateIfNeeded(lastSortValues.getFirst());
     userTaskKey = lastSortValues.getLast();
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskSearchTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskSearchTest.java
@@ -508,20 +508,7 @@ class UserTaskSearchTest {
     // Assert First and Last Sort Value matches the first and last item
     // We need to make use of toString, such the test work with ES/OS
     final List<String> firstSortValues =
-        result.page().firstSortValues().stream()
-            .map(
-                pageObject -> {
-                  final String raw = pageObject.getValue();
-                  final TypeEnum type = pageObject.getType();
-
-                  // To extract the case when it is already String (OpenSearch)
-                  if (type == TypeEnum.STRING) {
-                    return raw.substring(1, raw.length() - 1);
-                  }
-
-                  return raw;
-                })
-            .toList();
+        result.page().firstSortValues().stream().map(pageObject -> pageObject.toString()).toList();
     String creationDateMillis = convertDateIfNeeded(firstSortValues.getFirst());
     String userTaskKey = firstSortValues.getLast();
 
@@ -532,20 +519,7 @@ class UserTaskSearchTest {
     assertThat(userTaskKey).isEqualTo(Long.toString(firstItem.getUserTaskKey()));
 
     final List<String> lastSortValues =
-        result.page().lastSortValues().stream()
-            .map(
-                pageObject -> {
-                  final String raw = pageObject.getValue();
-                  final TypeEnum type = pageObject.getType();
-
-                  // To extract the case when it is already String (OpenSearch)
-                  if (type == TypeEnum.STRING) {
-                    return raw.substring(1, raw.length() - 1);
-                  }
-
-                  return raw;
-                })
-            .toList();
+        result.page().lastSortValues().stream().map(pageObject -> pageObject.toString()).toList();
     creationDateMillis = convertDateIfNeeded(lastSortValues.getFirst());
     userTaskKey = lastSortValues.getLast();
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskSearchTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskSearchTest.java
@@ -508,7 +508,20 @@ class UserTaskSearchTest {
     // Assert First and Last Sort Value matches the first and last item
     // We need to make use of toString, such the test work with ES/OS
     final List<String> firstSortValues =
-        result.page().firstSortValues().stream().map(PageObject::getValue).toList();
+        result.page().firstSortValues().stream()
+            .map(
+                pageObject -> {
+                  final String raw = pageObject.getValue();
+                  final TypeEnum type = pageObject.getType();
+
+                  // To extract the case when it is already String (OpenSearch)
+                  if (type == TypeEnum.STRING) {
+                    return raw.substring(1, raw.length() - 1);
+                  }
+
+                  return raw;
+                })
+            .toList();
     String creationDateMillis = convertDateIfNeeded(firstSortValues.getFirst());
     String userTaskKey = firstSortValues.getLast();
 
@@ -519,7 +532,20 @@ class UserTaskSearchTest {
     assertThat(userTaskKey).isEqualTo(Long.toString(firstItem.getUserTaskKey()));
 
     final List<String> lastSortValues =
-        result.page().lastSortValues().stream().map(PageObject::getValue).toList();
+        result.page().lastSortValues().stream()
+            .map(
+                pageObject -> {
+                  final String raw = pageObject.getValue();
+                  final TypeEnum type = pageObject.getType();
+
+                  // To extract the case when it is already String (OpenSearch)
+                  if (type == TypeEnum.STRING) {
+                    return raw.substring(1, raw.length() - 1);
+                  }
+
+                  return raw;
+                })
+            .toList();
     creationDateMillis = convertDateIfNeeded(lastSortValues.getFirst());
     userTaskKey = lastSortValues.getLast();
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskSearchTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskSearchTest.java
@@ -43,7 +43,6 @@ class UserTaskSearchTest {
 
   @BeforeAll
   static void beforeAll() {
-
     deployProcess("process", "simple.bpmn", "test", "", "");
     deployProcess("process-2", "simple-2.bpmn", "test-2", "group", "user");
     deployProcess("process-3", "simple-3.bpmn", "test-3", "", "", "30");

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6591,6 +6591,13 @@ components:
         type:
             type: string
             description: The data type of the sort value.
+            enum:
+                - string
+                - int64
+                - float
+                - boolean
+                - date
+                - object
     DecisionRequirementsSearchQuerySortRequest:
       type: object
       properties:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6575,12 +6575,22 @@ components:
           description: The sort values of the first item in the result set. Use this in the `searchBefore` field of an ensuing request.
           type: array
           items:
-            type: object
+            $ref: "#/components/schemas/SortValueResponse"
         lastSortValues:
           description: The sort values of the last item in the result set. Use this in the `searchAfter` field of an ensuing request.
           type: array
           items:
-            type: object
+            $ref: "#/components/schemas/SortValueResponse"
+    SortValueResponse:
+      description: Value and type of a sort field.
+      type: object
+      properties:
+        value:
+          type: object
+          description: The sort values of the item in the result set. .
+        type:
+            type: string
+            description: The data type of the sort value.
     DecisionRequirementsSearchQuerySortRequest:
       type: object
       properties:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6587,10 +6587,10 @@ components:
       properties:
         value:
           type: string
-          description: The sort values of the item in the result set. .
+          description: The serialized value of the respective sort field of an item in the result set.
         type:
             type: string
-            description: The data type of the sort value.
+            description: The data type of the sort field value.
             enum:
                 - string
                 - int64

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -6550,12 +6550,12 @@ components:
           description: Items to search after. Correlates to the `lastSortValues` property of a previous search response.
           type: array
           items:
-            type: object
+            $ref: "#/components/schemas/PageObject"
         searchBefore:
           description: Items to search before. Correlates to the `firstSortValues` property of a previous search response.
           type: array
           items:
-            type: object
+            $ref: "#/components/schemas/PageObject"
     SearchQueryResponse:
       type: object
       properties:
@@ -6575,18 +6575,18 @@ components:
           description: The sort values of the first item in the result set. Use this in the `searchBefore` field of an ensuing request.
           type: array
           items:
-            $ref: "#/components/schemas/SortValueResponse"
+            $ref: "#/components/schemas/PageObject"
         lastSortValues:
           description: The sort values of the last item in the result set. Use this in the `searchAfter` field of an ensuing request.
           type: array
           items:
-            $ref: "#/components/schemas/SortValueResponse"
-    SortValueResponse:
+            $ref: "#/components/schemas/PageObject"
+    PageObject:
       description: Value and type of a sort field.
       type: object
       properties:
         value:
-          type: object
+          type: string
           description: The sort values of the item in the result set. .
         type:
             type: string
@@ -6596,7 +6596,6 @@ components:
                 - int64
                 - float
                 - boolean
-                - date
                 - object
     DecisionRequirementsSearchQuerySortRequest:
       type: object

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -1409,7 +1409,6 @@ public final class SearchQueryRequestMapper {
     final TypeEnum type = pageObject.getType();
 
     return switch (type) {
-      case STRING -> rawValue.substring(1, rawValue.length() - 1).replace("\\\"", "\"");
       case BOOLEAN -> Boolean.parseBoolean(rawValue);
       case INT64 -> Long.parseLong(rawValue);
       case FLOAT -> Double.parseDouble(rawValue);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -1409,8 +1409,7 @@ public final class SearchQueryRequestMapper {
     final TypeEnum type = pageObject.getType();
 
     return switch (type) {
-      case STRING ->
-          rawValue.substring(1, rawValue.length() - 1).replace("\\\"", "\""); // remove outer quotes
+      case STRING -> rawValue.substring(1, rawValue.length() - 1).replace("\\\"", "\"");
       case BOOLEAN -> Boolean.parseBoolean(rawValue);
       case INT64 -> Long.parseLong(rawValue);
       case FLOAT -> Double.parseDouble(rawValue);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -79,6 +79,7 @@ import io.camunda.zeebe.gateway.protocol.rest.RoleResult;
 import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.SearchQueryPageResponse;
 import io.camunda.zeebe.gateway.protocol.rest.SortValueResponse;
+import io.camunda.zeebe.gateway.protocol.rest.SortValueResponse.TypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.TenantResult;
 import io.camunda.zeebe.gateway.protocol.rest.TenantSearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.UsageMetricsResponse;
@@ -294,20 +295,24 @@ public final class SearchQueryResponseMapper {
                         .map(
                             obj -> {
                               final String type = determineValueType(obj);
-                              return new SortValueResponse().value(obj).type(type);
+                              return new SortValueResponse()
+                                  .value(obj)
+                                  .type(TypeEnum.valueOf(type));
                             })
                         .collect(Collectors.toList()))
             .orElse(emptyList());
 
     final List<SortValueResponse> lastSortValues =
-        ofNullable(result.firstSortValues())
+        ofNullable(result.lastSortValues())
             .map(
                 array ->
                     Arrays.stream(array)
                         .map(
                             obj -> {
                               final String type = determineValueType(obj);
-                              return new SortValueResponse().value(obj).type(type);
+                              return new SortValueResponse()
+                                  .value(obj)
+                                  .type(TypeEnum.valueOf(type));
                             })
                         .collect(Collectors.toList()))
             .orElse(emptyList());
@@ -771,35 +776,23 @@ public final class SearchQueryResponseMapper {
   }
 
   private static String determineValueType(final Object value) {
-    if (value == null) {
-      return "null";
-    }
-
     if (value instanceof Boolean) {
-      return "boolean";
+      return TypeEnum.BOOLEAN.name();
     }
-
     if (value instanceof String) {
-      return "string";
+      return TypeEnum.STRING.name();
     }
-
-    if (value instanceof Integer) {
-      return "int64";
+    if (value instanceof Integer || value instanceof Long) {
+      return TypeEnum.INT64.name();
     }
-
-    if (value instanceof Long) {
-      return "int64";
-    }
-
     if (value instanceof Float || value instanceof Double) {
-      return "float";
+      return TypeEnum.FLOAT.name();
     }
-
     if (value instanceof java.time.Instant || value instanceof java.util.Date) {
-      return "date";
+      return TypeEnum.DATE.name();
     }
 
-    return "object"; // Fallback
+    return TypeEnum.OBJECT.name(); // Fallback
   }
 
   private record RuleIdentifier(String ruleId, int ruleIndex) {}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -789,7 +789,7 @@ public final class SearchQueryResponseMapper {
       return TypeEnum.FLOAT.name();
     }
 
-    return TypeEnum.OBJECT.name(); // Fallback
+    return TypeEnum.OBJECT.name();
   }
 
   private static String serializeValueToString(final Object value) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -793,6 +793,11 @@ public final class SearchQueryResponseMapper {
   }
 
   private static String serializeValue(final Object value) {
+    // Add value check for null
+    if (value == null) {
+      return null;
+    }
+
     // OpenSearch already is returning String for Sorted Values
     if (value instanceof String
         && !(value.toString().startsWith("\"") && value.toString().endsWith("\""))) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -796,11 +796,6 @@ public final class SearchQueryResponseMapper {
     if (value == null) {
       return null;
     }
-
-    if (value instanceof String) {
-      return "\"" + value + "\"";
-    }
-
     return value.toString();
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -296,7 +296,7 @@ public final class SearchQueryResponseMapper {
                             obj -> {
                               final String type = determineValueType(obj);
                               return new PageObject()
-                                  .value(serializeValue(obj))
+                                  .value(serializeValueToString(obj))
                                   .type(TypeEnum.valueOf(type));
                             })
                         .collect(Collectors.toList()))
@@ -311,7 +311,7 @@ public final class SearchQueryResponseMapper {
                             obj -> {
                               final String type = determineValueType(obj);
                               return new PageObject()
-                                  .value(serializeValue(obj))
+                                  .value(serializeValueToString(obj))
                                   .type(TypeEnum.valueOf(type));
                             })
                         .collect(Collectors.toList()))
@@ -792,15 +792,12 @@ public final class SearchQueryResponseMapper {
     return TypeEnum.OBJECT.name(); // Fallback
   }
 
-  private static String serializeValue(final Object value) {
-    // Add value check for null
+  private static String serializeValueToString(final Object value) {
     if (value == null) {
       return null;
     }
 
-    // OpenSearch already is returning String for Sorted Values
-    if (value instanceof String
-        && !(value.toString().startsWith("\"") && value.toString().endsWith("\""))) {
+    if (value instanceof String) {
       return "\"" + value + "\"";
     }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -11,7 +11,6 @@ import static io.camunda.zeebe.gateway.rest.ResponseMapper.formatDate;
 import static java.util.Collections.emptyList;
 import static java.util.Optional.ofNullable;
 
-import com.google.gson.Gson;
 import io.camunda.search.entities.AdHocSubprocessActivityEntity;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.BatchOperationEntity;
@@ -100,8 +99,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public final class SearchQueryResponseMapper {
-
-  private static final Gson gson = new Gson();
 
   private SearchQueryResponseMapper() {}
 
@@ -796,7 +793,13 @@ public final class SearchQueryResponseMapper {
   }
 
   private static String serializeValue(final Object value) {
-    return gson.toJson(value);
+    // OpenSearch already is returning String for Sorted Values
+    if (value instanceof String
+        && !(value.toString().startsWith("\"") && value.toString().endsWith("\""))) {
+      return "\"" + value + "\"";
+    }
+
+    return value.toString();
   }
 
   private record RuleIdentifier(String ruleId, int ruleIndex) {}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
@@ -58,10 +58,10 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
               "page": {
                   "totalItems": 1,
                    "firstSortValues": [
-                    { "value": "\\"f\\"", "type": "string" }
+                    { "value": "f", "type": "string" }
                   ],
                   "lastSortValues": [
-                    { "value": "\\"v\\"", "type": "string" }
+                    { "value": "v", "type": "string" }
                   ]
               }
           }""";

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
@@ -57,9 +57,11 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
               ],
               "page": {
                   "totalItems": 1,
-                  "firstSortValues": ["f"],
+                   "firstSortValues": [
+                    { "value": "\\"f\\"", "type": "string" }
+                  ],
                   "lastSortValues": [
-                      "v"
+                    { "value": "\\"v\\"", "type": "string" }
                   ]
               }
           }""";

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
@@ -67,10 +67,10 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
                "page": {
                    "totalItems": 1,
                     "firstSortValues": [
-                      { "value": "\\"f\\"", "type": "string" }
+                      { "value": "f", "type": "string" }
                     ],
                     "lastSortValues": [
-                      { "value": "\\"v\\"", "type": "string" }
+                      { "value": "v", "type": "string" }
                     ]
                }
            }""";

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
@@ -66,10 +66,12 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
                ],
                "page": {
                    "totalItems": 1,
-                   "firstSortValues": ["f"],
-                   "lastSortValues": [
-                       "v"
-                   ]
+                    "firstSortValues": [
+                      { "value": "\\"f\\"", "type": "string" }
+                    ],
+                    "lastSortValues": [
+                      { "value": "\\"v\\"", "type": "string" }
+                    ]
                }
            }""";
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryControllerTest.java
@@ -56,10 +56,12 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
               ],
               "page": {
                   "totalItems": 1,
-                  "firstSortValues": ["f"],
-                  "lastSortValues": [
-                      "v"
-                  ]
+              "firstSortValues": [
+                { "value": "\\"f\\"", "type": "string" }
+              ],
+              "lastSortValues": [
+                { "value": "\\"v\\"", "type": "string" }
+              ]
               }
           }""";
   static final SearchQueryResult<DecisionRequirementsEntity> SEARCH_QUERY_RESULT =

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryControllerTest.java
@@ -57,10 +57,10 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
               "page": {
                   "totalItems": 1,
               "firstSortValues": [
-                { "value": "\\"f\\"", "type": "string" }
+                { "value": "f", "type": "string" }
               ],
               "lastSortValues": [
-                { "value": "\\"v\\"", "type": "string" }
+                { "value": "v", "type": "string" }
               ]
               }
           }""";

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/FlowNodeInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/FlowNodeInstanceQueryControllerTest.java
@@ -61,10 +61,12 @@ public class FlowNodeInstanceQueryControllerTest extends RestControllerTest {
               ],
               "page": {
                   "totalItems": 1,
-                  "firstSortValues": ["f"],
-                  "lastSortValues": [
-                      "v"
-                  ]
+                "firstSortValues": [
+                  { "value": "\\"f\\"", "type": "string" }
+                ],
+                "lastSortValues": [
+                  { "value": "\\"v\\"", "type": "string" }
+                ]
               }
           }""";
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/FlowNodeInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/FlowNodeInstanceQueryControllerTest.java
@@ -62,10 +62,10 @@ public class FlowNodeInstanceQueryControllerTest extends RestControllerTest {
               "page": {
                   "totalItems": 1,
                 "firstSortValues": [
-                  { "value": "\\"f\\"", "type": "string" }
+                  { "value": "f", "type": "string" }
                 ],
                 "lastSortValues": [
-                  { "value": "\\"v\\"", "type": "string" }
+                  { "value": "v", "type": "string" }
                 ]
               }
           }""";

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
@@ -58,10 +58,12 @@ public class IncidentQueryControllerTest extends RestControllerTest {
               ],
               "page": {
                   "totalItems": 1,
-                  "firstSortValues": ["f"],
-                  "lastSortValues": [
-                      "v"
-                  ]
+              "firstSortValues": [
+                { "value": "\\"f\\"", "type": "string" }
+              ],
+              "lastSortValues": [
+                { "value": "\\"v\\"", "type": "string" }
+              ]
               }
           }""";
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
@@ -59,10 +59,10 @@ public class IncidentQueryControllerTest extends RestControllerTest {
               "page": {
                   "totalItems": 1,
               "firstSortValues": [
-                { "value": "\\"f\\"", "type": "string" }
+                { "value": "f", "type": "string" }
               ],
               "lastSortValues": [
-                { "value": "\\"v\\"", "type": "string" }
+                { "value": "v", "type": "string" }
               ]
               }
           }""";

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
@@ -83,9 +83,11 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
           ],
           "page": {
               "totalItems": 1,
-              "firstSortValues": ["f"],
+              "firstSortValues": [
+                { "value": "\\"f\\"", "type": "string" }
+              ],
               "lastSortValues": [
-                  "v"
+                { "value": "\\"v\\"", "type": "string" }
               ]
           }
       }""";

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
@@ -84,10 +84,10 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
           "page": {
               "totalItems": 1,
               "firstSortValues": [
-                { "value": "\\"f\\"", "type": "string" }
+                { "value": "f", "type": "string" }
               ],
               "lastSortValues": [
-                { "value": "\\"v\\"", "type": "string" }
+                { "value": "v", "type": "string" }
               ]
           }
       }""";

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -104,10 +104,12 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
               ],
               "page": {
                   "totalItems": 1,
-                  "firstSortValues": ["f"],
-                  "lastSortValues": [
-                      "v"
-                  ]
+              "firstSortValues": [
+                { "value": "\\"f\\"", "type": "string" }
+              ],
+              "lastSortValues": [
+                { "value": "\\"v\\"", "type": "string" }
+              ]
               }
           }
           """;
@@ -353,8 +355,8 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
         """
             {
                 "page": {
-                    "searchAfter": ["a"],
-                    "searchBefore": ["b"]
+                    "searchAfter": [{"value": "\\"a\\"", "type": "string"}],
+                    "searchBefore": [{"value": "\\"b\\"", "type": "string"}]
                 }
             }""";
     final var expectedResponse =
@@ -544,7 +546,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
 
   @ParameterizedTest
   @EnumSource(ProcessInstanceStateEnum.class)
-  void shouldSearchProcessInstancesByState(ProcessInstanceStateEnum state) {
+  void shouldSearchProcessInstancesByState(final ProcessInstanceStateEnum state) {
     // given
     final var request =
         """

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -105,10 +105,10 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
               "page": {
                   "totalItems": 1,
               "firstSortValues": [
-                { "value": "\\"f\\"", "type": "string" }
+                { "value": "f", "type": "string" }
               ],
               "lastSortValues": [
-                { "value": "\\"v\\"", "type": "string" }
+                { "value": "v", "type": "string" }
               ]
               }
           }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -85,10 +85,12 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
               ],
               "page": {
                   "totalItems": 1,
-                  "firstSortValues": ["f"],
-                  "lastSortValues": [
-                      "v"
-                  ]
+              "firstSortValues": [
+                { "value": "\\"f\\"", "type": "string" }
+              ],
+              "lastSortValues": [
+                { "value": "\\"v\\"", "type": "string" }
+              ]
               }
           }""";
 
@@ -109,10 +111,12 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         ],
         "page": {
           "totalItems": 1,
-          "firstSortValues": ["f"],
-          "lastSortValues": [
-            "v"
-          ]
+              "firstSortValues": [
+                { "value": "\\"f\\"", "type": "string" }
+              ],
+              "lastSortValues": [
+                { "value": "\\"v\\"", "type": "string" }
+              ]
         }
       }
       """;
@@ -466,8 +470,8 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         """
             {
                 "page": {
-                    "searchAfter": ["a"],
-                    "searchBefore": ["b"]
+                    "searchAfter": [{"value": "\\"a\\"", "type": "string"}],
+                    "searchBefore": [{"value": "\\"b\\"", "type": "string"}]
                 }
             }""";
     final var expectedResponse =

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -86,10 +86,10 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
               "page": {
                   "totalItems": 1,
               "firstSortValues": [
-                { "value": "\\"f\\"", "type": "string" }
+                { "value": "f", "type": "string" }
               ],
               "lastSortValues": [
-                { "value": "\\"v\\"", "type": "string" }
+                { "value": "v", "type": "string" }
               ]
               }
           }""";
@@ -112,10 +112,10 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         "page": {
           "totalItems": 1,
               "firstSortValues": [
-                { "value": "\\"f\\"", "type": "string" }
+                { "value": "f", "type": "string" }
               ],
               "lastSortValues": [
-                { "value": "\\"v\\"", "type": "string" }
+                { "value": "v", "type": "string" }
               ]
         }
       }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
@@ -72,10 +72,10 @@ public class VariablesQueryControllerTest extends RestControllerTest {
               "page": {
                   "totalItems": 1,
               "firstSortValues": [
-                { "value": "\\"f\\"", "type": "string" }
+                { "value": "f", "type": "string" }
               ],
               "lastSortValues": [
-                { "value": "\\"v\\"", "type": "string" }
+                { "value": "v", "type": "string" }
               ]
               }
           }""";

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
@@ -71,10 +71,12 @@ public class VariablesQueryControllerTest extends RestControllerTest {
               ],
               "page": {
                   "totalItems": 1,
-                  "firstSortValues": ["f"],
-                  "lastSortValues": [
-                      "v"
-                  ]
+                 "firstSortValues": [
+                     { "value": "f", "type": "string" }
+                   ],
+                   "lastSortValues": [
+                     { "value": "v", "type": "string" }
+                   ]
               }
           }""";
 
@@ -276,8 +278,8 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         """
             {
                 "page": {
-                    "searchAfter": ["a"],
-                    "searchBefore": ["b"]
+                    "searchAfter": [{"value": "\\"a\\"", "type": "string"}],
+                    "searchBefore": [{"value": "\\"b\\"", "type": "string"}]
                 }
             }""";
     final var expectedResponse =

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
@@ -71,12 +71,12 @@ public class VariablesQueryControllerTest extends RestControllerTest {
               ],
               "page": {
                   "totalItems": 1,
-                 "firstSortValues": [
-                     { "value": "f", "type": "string" }
-                   ],
-                   "lastSortValues": [
-                     { "value": "v", "type": "string" }
-                   ]
+              "firstSortValues": [
+                { "value": "\\"f\\"", "type": "string" }
+              ],
+              "lastSortValues": [
+                { "value": "\\"v\\"", "type": "string" }
+              ]
               }
           }""";
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -71,8 +71,12 @@ public class TenantQueryControllerTest extends RestControllerTest {
          ],
          "page": {
            "totalItems": %s,
-           "firstSortValues": ["f"],
-           "lastSortValues": ["v"]
+              "firstSortValues": [
+                { "value": "\\"f\\"", "type": "string" }
+              ],
+              "lastSortValues": [
+                { "value": "\\"v\\"", "type": "string" }
+              ]
          }
        }
       """;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -21,8 +21,6 @@ import io.camunda.search.sort.TenantSort;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.TenantServices;
 import io.camunda.service.UserServices;
-import io.camunda.zeebe.gateway.protocol.rest.PageObject;
-import io.camunda.zeebe.gateway.protocol.rest.PageObject.TypeEnum;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.util.List;
 import java.util.Set;
@@ -221,10 +219,8 @@ public class TenantQueryControllerTest extends RestControllerTest {
             new SearchQueryResult.Builder<TenantEntity>()
                 .total(TENANT_ENTITIES.size())
                 .items(TENANT_ENTITIES)
-                .firstSortValues(
-                    new PageObject[] {new PageObject().value("\"f\"").type(TypeEnum.STRING)})
-                .lastSortValues(
-                    new PageObject[] {new PageObject().value("\"v\"").type(TypeEnum.STRING)})
+                .firstSortValues(new Object[] {"f"})
+                .lastSortValues(new Object[] {"v"})
                 .build());
 
     // when / then

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -72,10 +72,10 @@ public class TenantQueryControllerTest extends RestControllerTest {
          "page": {
            "totalItems": %s,
               "firstSortValues": [
-                { "value": "\\"f\\"", "type": "string" }
+                { "value": "f", "type": "string" }
               ],
               "lastSortValues": [
-                { "value": "\\"v\\"", "type": "string" }
+                { "value": "v", "type": "string" }
               ]
          }
        }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -21,6 +21,8 @@ import io.camunda.search.sort.TenantSort;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.TenantServices;
 import io.camunda.service.UserServices;
+import io.camunda.zeebe.gateway.protocol.rest.PageObject;
+import io.camunda.zeebe.gateway.protocol.rest.PageObject.TypeEnum;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.util.List;
 import java.util.Set;
@@ -219,8 +221,10 @@ public class TenantQueryControllerTest extends RestControllerTest {
             new SearchQueryResult.Builder<TenantEntity>()
                 .total(TENANT_ENTITIES.size())
                 .items(TENANT_ENTITIES)
-                .firstSortValues(new Object[] {"f"})
-                .lastSortValues(new Object[] {"v"})
+                .firstSortValues(
+                    new PageObject[] {new PageObject().value("\"f\"").type(TypeEnum.STRING)})
+                .lastSortValues(
+                    new PageObject[] {new PageObject().value("\"v\"").type(TypeEnum.STRING)})
                 .build());
 
     // when / then
@@ -341,8 +345,8 @@ public class TenantQueryControllerTest extends RestControllerTest {
             """
                 {
                     "page": {
-                        "searchAfter": ["a"],
-                        "searchBefore": ["b"]
+                        "searchAfter": [{"value": "\\"a\\"", "type": "string"}],
+                        "searchBefore": [{"value": "\\"b\\"", "type": "string"}]
                     }
                 }""",
             String.format(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
@@ -53,10 +53,12 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
              ],
              "page": {
                "totalItems": 1,
-               "firstSortValues": ["f"],
-               "lastSortValues": [
-                 "v"
-               ]
+                "firstSortValues": [
+                  { "value": "\\"f\\"", "type": "string" }
+                ],
+                "lastSortValues": [
+                  { "value": "\\"v\\"", "type": "string" }
+                ]
              }
            }""";
   private static final String AUTHORIZATION_SEARCH_URL = "/v2/authorizations/search";
@@ -263,8 +265,8 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
             """
                 {
                     "page": {
-                        "searchAfter": ["a"],
-                        "searchBefore": ["b"]
+                        "searchAfter": [{"value": "\\"a\\"", "type": "string"}],
+                        "searchBefore": [{"value": "\\"b\\"", "type": "string"}]
                     }
                 }""",
             String.format(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
@@ -54,10 +54,10 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
              "page": {
                "totalItems": 1,
                 "firstSortValues": [
-                  { "value": "\\"f\\"", "type": "string" }
+                  { "value": "f", "type": "string" }
                 ],
                 "lastSortValues": [
-                  { "value": "\\"v\\"", "type": "string" }
+                  { "value": "v", "type": "string" }
                 ]
              }
            }""";

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
@@ -59,8 +59,12 @@ public class GroupQueryControllerTest extends RestControllerTest {
         ],
         "page":{
           "totalItems":3,
-          "firstSortValues":["f"],
-          "lastSortValues":["v"]
+                "firstSortValues": [
+                  { "value": "\\"f\\"", "type": "string" }
+                ],
+                "lastSortValues": [
+                  { "value": "\\"v\\"", "type": "string" }
+                ]
         }
       }
       """;
@@ -190,8 +194,12 @@ public class GroupQueryControllerTest extends RestControllerTest {
              ],
              "page": {
                "totalItems": 3,
-               "firstSortValues": ["f"],
-               "lastSortValues": ["v"]
+                "firstSortValues": [
+                  { "value": "\\"f\\"", "type": "string" }
+                ],
+                "lastSortValues": [
+                  { "value": "\\"v\\"", "type": "string" }
+                ]
              }
            }"""
                 .formatted(groupKey1, groupName1, groupKey2, groupName2, groupKey3, groupName3));
@@ -343,8 +351,8 @@ public class GroupQueryControllerTest extends RestControllerTest {
             """
                 {
                     "page": {
-                        "searchAfter": ["a"],
-                        "searchBefore": ["b"]
+                        "searchAfter": [{"value": "\\"a\\"", "type": "string"}],
+                        "searchBefore": [{"value": "\\"b\\"", "type": "string"}]
                     }
                 }""",
             String.format(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
@@ -60,10 +60,10 @@ public class GroupQueryControllerTest extends RestControllerTest {
         "page":{
           "totalItems":3,
                 "firstSortValues": [
-                  { "value": "\\"f\\"", "type": "string" }
+                  { "value": "f", "type": "string" }
                 ],
                 "lastSortValues": [
-                  { "value": "\\"v\\"", "type": "string" }
+                  { "value": "v", "type": "string" }
                 ]
         }
       }
@@ -195,10 +195,10 @@ public class GroupQueryControllerTest extends RestControllerTest {
              "page": {
                "totalItems": 3,
                 "firstSortValues": [
-                  { "value": "\\"f\\"", "type": "string" }
+                  { "value": "f", "type": "string" }
                 ],
                 "lastSortValues": [
-                  { "value": "\\"v\\"", "type": "string" }
+                  { "value": "v", "type": "string" }
                 ]
              }
            }"""

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingQueryControllerTest.java
@@ -155,8 +155,12 @@ public class MappingQueryControllerTest extends RestControllerTest {
              ],
              "page": {
                "totalItems": 3,
-               "firstSortValues": ["f"],
-               "lastSortValues": ["v"]
+            "firstSortValues": [
+              { "value": "\\"f\\"", "type": "string" }
+            ],
+            "lastSortValues": [
+              { "value": "\\"v\\"", "type": "string" }
+            ]
              }
            }""");
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingQueryControllerTest.java
@@ -156,10 +156,10 @@ public class MappingQueryControllerTest extends RestControllerTest {
              "page": {
                "totalItems": 3,
             "firstSortValues": [
-              { "value": "\\"f\\"", "type": "string" }
+              { "value": "f", "type": "string" }
             ],
             "lastSortValues": [
-              { "value": "\\"v\\"", "type": "string" }
+              { "value": "v", "type": "string" }
             ]
              }
            }""");

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -147,10 +147,10 @@ public class RoleQueryControllerTest extends RestControllerTest {
              "page": {
                "totalItems": 3,
                 "firstSortValues": [
-                  { "value": "\\"f\\"", "type": "string" }
+                  { "value": "f", "type": "string" }
                 ],
                 "lastSortValues": [
-                  { "value": "\\"v\\"", "type": "string" }
+                  { "value": "v", "type": "string" }
                 ]
              }
            }""");

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -146,8 +146,12 @@ public class RoleQueryControllerTest extends RestControllerTest {
              ],
              "page": {
                "totalItems": 3,
-               "firstSortValues": ["f"],
-               "lastSortValues": ["v"]
+                "firstSortValues": [
+                  { "value": "\\"f\\"", "type": "string" }
+                ],
+                "lastSortValues": [
+                  { "value": "\\"v\\"", "type": "string" }
+                ]
              }
            }""");
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserQueryControllerTest.java
@@ -48,10 +48,12 @@ public class UserQueryControllerTest extends RestControllerTest {
               ],
               "page": {
                   "totalItems": 1,
-                  "firstSortValues": ["f"],
-                  "lastSortValues": [
-                      "v"
-                  ]
+                   "firstSortValues": [
+                         { "value": "\\"f\\"", "type": "string" }
+                   ],
+                   "lastSortValues": [
+                          { "value": "\\"v\\"", "type": "string" }
+                   ]
               }
           }""";
   private static final String USERS_SEARCH_URL = "/v2/users/search";
@@ -239,8 +241,8 @@ public class UserQueryControllerTest extends RestControllerTest {
             """
                 {
                     "page": {
-                        "searchAfter": ["a"],
-                        "searchBefore": ["b"]
+                        "searchAfter": [{"value": "\\"a\\"", "type": "string"}],
+                        "searchBefore": [{"value": "\\"b\\"", "type": "string"}]
                     }
                 }""",
             String.format(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserQueryControllerTest.java
@@ -49,10 +49,10 @@ public class UserQueryControllerTest extends RestControllerTest {
               "page": {
                   "totalItems": 1,
                    "firstSortValues": [
-                         { "value": "\\"f\\"", "type": "string" }
+                         { "value": "f", "type": "string" }
                    ],
                    "lastSortValues": [
-                          { "value": "\\"v\\"", "type": "string" }
+                          { "value": "v", "type": "string" }
                    ]
               }
           }""";


### PR DESCRIPTION
## Description

This pull request updates the pagination format in the C8 REST API search endpoints, specifically the structure of firstSortValues and lastSortValues.

Previously, these fields were represented as arrays of raw values. With this change, each sort value is now serialized as an object containing two fields:
- value: the JSON-escaped string representation of the original value
- type: the original data type (string, int64, boolean, etc.)

Example: 
```
  ...,
  "page": {
    "firstSortValues": [
      { "value": "\"foo\"", "type": "string" },
      { "value": "12345678", "type": "int64" },
      { "value": "true", "type": "boolean" }
    ],
    ...
  }
  ...
}
```
This new structure allows for consistent and type-aware handling of pagination tokens across different backends (e.g., OpenSearch, Elasticsearch, RDBMS).

To support this change, the following updates were made:
✅ Serialization of SearchQueryResult pagination fields (firstSortValues, lastSortValues) now wraps values with their type, and ensures the value is stringified JSON.
✅ Deserialization of pagination tokens (searchBefore, searchAfter) in SearchRequest is updated to parse the string values back into their respective types based on the type field.
✅ Add PageObjectMapper for client dont use generate classes 
🧪 Integration and unit tests were updated and extended to validate the new serialization and deserialization behavior.


## Related issues

closes https://github.com/camunda/camunda/issues/29359
