### PR TITLE
deps: upgrade spring-security to 6.3.8

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -98,7 +98,7 @@
     <version.dmn-scala>1.10.1</version.dmn-scala>
     <version.rest-assured>5.5.1</version.rest-assured>
     <version.spring>6.1.14</version.spring>
-    <version.spring-security>6.3.5</version.spring-security>
+    <version.spring-security>6.3.8</version.spring-security>
     <version.spring-boot>3.3.9</version.spring-boot>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.2</version.kryo>


### PR DESCRIPTION
<!-- Please link the related GitHub issue here -->

relates to https://github.com/camunda/camunda/issues/30151

CVE-2025-22228 is solved in spring-security 6.3.8 https://spring.io/security/cve-2025-22228

