### PR TITLE
build: skip Optimize build with -Dquickly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ This is a small overview of the contents of this repository:
 > [!NOTE]
 > All Camunda core modules are built and tested with JDK 21. Most modules use language level 21, exceptions are: camunda-client-java, camunda-process-test-java, zeebe-bpmn-model, zeebe-build-tools, camunda-client-java, zeebe-gateway-protocol zeebe-gateway-protocol-impl, zeebe-protocol, and zeebe-protocol-jackson which use language level 8.
 
-* **Quick build:** To **quickly** build all components for development, run the command: `mvn clean install -Dquickly` in the root folder.
+* **Quick build:** To **quickly** build all components for development, run the command: `mvn clean install -Dquickly` in the root folder. This flag is also used to skip Optimize, when building Camunda.
 * **Full build:** To build the full distribution for local usage (skipping tests and checks), run the command `mvn clean install -DskipChecks -DskipTests`.
 * **Full build without frontends:** To build the full distribution for local usage without frontends (skipping tests), run the command `mvn clean install -DskipChecks -DskipTests -PskipFrontendBuild`.
 * **Full build and test:** To fully build and test the Camunda distribution, run the command: `mvn clean install` in the root folder.

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
     <module>document</module>
     <module>security</module>
     <module>migration</module>
-    <module>optimize</module>
   </modules>
 
   <scm>
@@ -91,6 +90,19 @@
       </activation>
       <modules>
         <module>qa</module>
+      </modules>
+    </profile>
+
+    <profile>
+      <id>include-optimize</id>
+      <activation>
+        <property>
+          <name>quickly</name>
+          <value>!true</value>
+        </property>
+      </activation>
+      <modules>
+        <module>optimize</module>
       </modules>
     </profile>
   </profiles>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Using `-Dquickly` in maven now skips building any of the optimize modules.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

NA
