### PR TITLE
ci(Renovate): enable spring minor upgrades

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -42,7 +42,7 @@
       "enabled": false
     },
     {
-      "description": "Allow minor and patch updates for Spring and Spring-boot for our maintenance branches.",
+      "description": "Allow minor and patch updates for Spring and Spring-boot for our maintenance branches. Since Spring has a 1-year support cycle while C8 is supported for 18 months, we allow minor updates to help mitigate security risks.",
       "matchBaseBranches": [
         "/^stable\\/8\\..*/",
         "stable/operate-8.5"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -42,6 +42,17 @@
       "enabled": false
     },
     {
+      "description": "Allow minor and patch updates for Spring and Spring-boot for our maintenance branches.",
+      "matchBaseBranches": [
+        "/^stable\\/8\\..*/",
+        "stable/operate-8.5"
+      ],
+      "matchManagers": ["maven"],
+      "matchPackagePrefixes": ["org.springframework"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "enabled": true
+    },
+    {
       "matchManagers": ["maven"],
       "matchPackagePrefixes": ["org.opensearch.client", "org.elasticsearch", "co.elastic"],
       "matchUpdateTypes": ["minor", "major"],


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
[Slack discussion](https://camunda.slack.com/archives/C0633V0GTHT/p1742912402369779?thread_ts=1742803204.928289&cid=C0633V0GTHT)
Enables Spring minor updates on stable branches, since they have a shorter EOL than C8 minor versions

The Renovate lint CI failure is expected https://github.com/camunda/camunda/issues/28665

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
