### PR TITLE
[Backport stable/8.7] Fix print dry run command to delete version specific api changes

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -189,7 +189,7 @@ jobs:
           IFS='\n' readarray -t files <<< $(find . -name 'ignored-changes.json')
           for file in "${files[@]}"; do
             if [ '${{ inputs.dryRun }}' = 'false' ]; then
-              "[DRY RUN] rm -f ${file}"
+              echo "[DRY RUN] rm -f ${file}"
             else
               rm -f "${file}"
             fi


### PR DESCRIPTION
# Description
Backport of #30128 to `stable/8.7`.

relates to 