### PR TITLE
[Backport release-8.8.0-alpha3] ci: increate timeout if IT Elasticsearch job to 15 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [ detect-changes ]
     name: "[IT] Elasticsearch"
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions: {}  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-8-default
     env:


### PR DESCRIPTION
# Description
Backport of #30175 to `release-8.8.0-alpha3`.

relates to 