### PR TITLE
[Backport release-8.7.0] fix: Improve REST API response when deployResources payload is too large

### DIFF
--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -177,7 +177,10 @@ public final class GrpcErrorMapper {
         logger.trace("Target broker was not the leader of the partition: {}", error, rootError);
         builder.setCode(Code.UNAVAILABLE_VALUE);
       }
-      case MALFORMED_REQUEST -> builder.setCode(Code.INVALID_ARGUMENT_VALUE);
+      case MALFORMED_REQUEST -> {
+        logger.debug("Malformed request: {}", message, rootError);
+        builder.setCode(Code.INVALID_ARGUMENT_VALUE);
+      }
       default -> {
         // all the following are for cases where retrying (with the same gateway) is not expected
         // to solve anything

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTest.java
@@ -180,4 +180,22 @@ final class GrpcErrorMapperTest {
     // then
     assertThat(statusException.getStatus().getCode()).isEqualTo(Code.ABORTED);
   }
+
+  @Test
+  void shouldLogMaxMessageSizeExceededErrorOnDebug() {
+    // given
+    final var brokerError =
+        new BrokerError(ErrorCode.MALFORMED_REQUEST, "Max message size exceeded");
+    final BrokerErrorException exception = new BrokerErrorException(brokerError);
+
+    // when
+    log.setLevel(Level.DEBUG);
+    final StatusRuntimeException statusException = errorMapper.mapError(exception, logger);
+
+    // then
+    assertThat(statusException.getStatus().getCode()).isEqualTo(Code.INVALID_ARGUMENT);
+    assertThat(recorder.getAppendedEvents()).hasSize(1);
+    final LogEvent event = recorder.getAppendedEvents().getFirst();
+    assertThat(event.getLevel()).isEqualTo(Level.DEBUG);
+  }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RestErrorMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RestErrorMapper.java
@@ -198,6 +198,10 @@ public class RestErrorMapper {
             "Target broker was not the leader of the partition: {}", error, rootError);
         yield createProblemDetail(HttpStatus.SERVICE_UNAVAILABLE, message, title);
       }
+      case MALFORMED_REQUEST -> {
+        REST_GATEWAY_LOGGER.debug("Malformed request: {}", error, rootError);
+        yield createProblemDetail(HttpStatus.BAD_REQUEST, message, title);
+      }
       default -> {
         // all the following are for cases where retrying (with the same gateway) is not
         // expected


### PR DESCRIPTION
# Description
Backport of #30148 (which was a backport of #29980) to `release-8.7.0`.

relates to camunda/camunda#29965