### PR TITLE
feat: backport of #27114 to 8.4

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -182,7 +182,13 @@ public final class EventAppliers implements EventApplier {
         new ProcessInstanceSequenceFlowTakenApplier(elementInstanceState, processState));
     register(
         ProcessInstanceIntent.ELEMENT_MIGRATED,
+        1,
         new ProcessInstanceElementMigratedApplier(elementInstanceState));
+    register(
+        ProcessInstanceIntent.ELEMENT_MIGRATED,
+        2,
+        new ProcessInstanceElementMigratedV2Applier(
+            elementInstanceState, processState, state.getMessageState()));
   }
 
   private void registerProcessInstanceCreationAppliers(final MutableProcessingState state) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedV2Applier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedV2Applier.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableMessageState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.concurrent.atomic.AtomicLong;
+import org.agrona.DirectBuffer;
+
+/** Applies state changes for `ProcessInstance:Element_Migrated` */
+final class ProcessInstanceElementMigratedV2Applier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  private final MutableElementInstanceState elementInstanceState;
+  private final ProcessState processState;
+  private final MutableMessageState messageState;
+
+  public ProcessInstanceElementMigratedV2Applier(
+      final MutableElementInstanceState elementInstanceState,
+      final ProcessState processState,
+      final MutableMessageState messageState) {
+    this.elementInstanceState = elementInstanceState;
+    this.processState = processState;
+    this.messageState = messageState;
+  }
+
+  @Override
+  public void applyState(final long elementInstanceKey, final ProcessInstanceRecord value) {
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+      migrateCorrelatedMessageStartEvent(elementInstanceKey, value);
+    }
+
+    final var previousProcessDefinitionKey = new AtomicLong();
+    elementInstanceState.updateInstance(
+        elementInstanceKey,
+        elementInstance -> {
+          previousProcessDefinitionKey.set(elementInstance.getValue().getProcessDefinitionKey());
+          elementInstance
+              .getValue()
+              .setProcessDefinitionKey(value.getProcessDefinitionKey())
+              .setBpmnProcessId(value.getBpmnProcessId())
+              .setVersion(value.getVersion())
+              .setElementId(value.getElementId())
+              .setFlowScopeKey(value.getFlowScopeKey());
+        });
+
+    if (value.getBpmnElementType() == BpmnElementType.PROCESS) {
+      elementInstanceState.deleteProcessInstanceKeyByDefinitionKey(
+          value.getProcessInstanceKey(), previousProcessDefinitionKey.get());
+      elementInstanceState.insertProcessInstanceKeyByDefinitionKey(
+          value.getProcessInstanceKey(), value.getProcessDefinitionKey());
+    }
+  }
+
+  private void migrateCorrelatedMessageStartEvent(
+      final long elementInstanceKey, final ProcessInstanceRecord value) {
+
+    final var instance = elementInstanceState.getInstance(elementInstanceKey).getValue();
+    final DirectBuffer previousBpmnProcessId = instance.getBpmnProcessIdBuffer();
+    final DirectBuffer currentBpmnProcessId = value.getBpmnProcessIdBuffer();
+    final DirectBuffer correlationKey =
+        messageState.getProcessInstanceCorrelationKey(value.getProcessInstanceKey());
+
+    if (isCorrelationKeyAbsent(correlationKey)) {
+      // no need to update correlation key relations since there isn't one
+      return;
+    }
+
+    final boolean isTargetWithMessageStartEvent =
+        processState
+            .getFlowElement(
+                value.getProcessDefinitionKey(),
+                value.getTenantId(),
+                value.getElementIdBuffer(),
+                ExecutableFlowElementContainer.class)
+            .hasMessageStartEvent();
+    final boolean hasBpmnProcessIdChanged =
+        !BufferUtil.equals(previousBpmnProcessId, currentBpmnProcessId);
+
+    if (isTargetWithMessageStartEvent && hasBpmnProcessIdChanged) {
+      // unlock the previous process instance's process id
+      messageState.removeActiveProcessInstance(previousBpmnProcessId, correlationKey);
+      // lock the new process instance's process id
+      messageState.putActiveProcessInstance(currentBpmnProcessId, correlationKey);
+    }
+
+    // clean up the correlation key relation if the target process doesn't have a message start
+    // event at all
+    if (!isTargetWithMessageStartEvent) {
+      messageState.removeActiveProcessInstance(previousBpmnProcessId, correlationKey);
+      messageState.removeProcessInstanceCorrelationKey(value.getProcessInstanceKey());
+    }
+  }
+
+  private boolean isCorrelationKeyAbsent(final DirectBuffer correlationKey) {
+    return correlationKey == null || correlationKey.capacity() == 0;
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceRejectionTest.java
@@ -1090,6 +1090,73 @@ public class MigrateProcessInstanceRejectionTest {
             });
   }
 
+  @Test
+  public void shouldRejectMigrationIfItBreaksMessageCardinality() {
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess("process1")
+                    .startEvent("msg_start")
+                    .message("msg")
+                    .serviceTask("task1", t -> t.zeebeJobType("task"))
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess("process2")
+                    .startEvent("msg_start")
+                    .message("msg")
+                    .serviceTask("task2", t -> t.zeebeJobType("task"))
+                    .done())
+            .deploy();
+    ENGINE.message().withName("msg").withCorrelationKey("cardinality").publish();
+    final var processInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withElementType(BpmnElementType.START_EVENT)
+            .withElementId("msg_start")
+            .withBpmnProcessId("process1")
+            .getFirst()
+            .getValue()
+            .getProcessInstanceKey();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withElementType(BpmnElementType.START_EVENT)
+        .withElementId("msg_start")
+        .withBpmnProcessId("process2")
+        .getFirst()
+        .getValue()
+        .getProcessInstanceKey();
+
+    final long targetProcessDefinitionKey =
+        extractTargetProcessDefinitionKey(deployment, "process2");
+
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("task1", "task2")
+        .expectRejection()
+        .migrate();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .describedAs(
+            "Should be rejected since an instance with id 'process2' and correlation key 'cardinality' already exist")
+        .hasRejectionReason(
+            String.format(
+                """
+                Expected to migrate process instance '%d' \
+                but target process definition '%s' has an active instance triggered by a message start event with correlation key '%s'. \
+                Only one instance per correlation key is allowed for message start events.""",
+                processInstanceKey, targetProcessDefinitionKey, "cardinality"))
+        .hasKey(processInstanceKey);
+  }
+
   private static long extractTargetProcessDefinitionKey(
       final Record<DeploymentRecordValue> deployment, final String bpmnProcessId) {
     return deployment.getValue().getProcessesMetadata().stream()

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceWithMessageStartEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceWithMessageStartEventTest.java
@@ -1,0 +1,281 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import org.assertj.core.api.Assertions;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class MigrateProcessInstanceWithMessageStartEventTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  /**
+   * Verify published message can be correlated to the start event of the source process definition
+   * after the migration. Since target process definition has a different message name (msg2), a new
+   * process instance with message start event (msg1) should be allowed.
+   */
+  @Test
+  public void shouldAdjustMessageCardinalityTrackingWhenMigratedForProcessInstance() {
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent("msg_start")
+                    .message("msg1")
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent("msg_start")
+                    .message("msg2")
+                    .serviceTask("B", t -> t.zeebeJobType("B"))
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    ENGINE.message().withName("msg1").withCorrelationKey("cardinality").publish();
+    final var processInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withElementType(BpmnElementType.START_EVENT)
+            .withElementId("msg_start")
+            .withBpmnProcessId(processId)
+            .getFirst()
+            .getValue()
+            .getProcessInstanceKey();
+
+    // when
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    ENGINE.message().withName("msg1").withCorrelationKey("cardinality").publish();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withElementType(BpmnElementType.PROCESS)
+                .withBpmnProcessId(processId)
+                .withElementId(processId)
+                .skip(1) // skip the first activation
+                .exists())
+        .describedAs("Expect that a new process is created with message name 'msg1'.")
+        .isTrue();
+  }
+
+  /**
+   * Published message cannot be correlated to the start event of the target process definition
+   * after the migration until the target process is completed. Once the target process is
+   * completed, the message with the same correlation key should be correlated to the target
+   * process.
+   */
+  @Test
+  public void shouldAdjustMessageCardinalityTrackingWhenMigratedForTargetProcess() {
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent("msg_start")
+                    .message("msg1")
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent("msg_start")
+                    .message("msg2")
+                    .serviceTask("B", t -> t.zeebeJobType("B"))
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    ENGINE.message().withName("msg1").withCorrelationKey("cardinality").publish();
+    final var processInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withElementType(BpmnElementType.START_EVENT)
+            .withElementId("msg_start")
+            .withBpmnProcessId(processId)
+            .getFirst()
+            .getValue()
+            .getProcessInstanceKey();
+
+    // when
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    final long messagePosition =
+        ENGINE
+            .message()
+            .withName("msg2")
+            .withCorrelationKey("cardinality")
+            .publish()
+            .getSourceRecordPosition();
+
+    // broadcast a record to have something to limit the stream on
+    final var limitPosition = ENGINE.signal().withSignalName("dummy").broadcast().getPosition();
+    Assertions.assertThat(
+            RecordingExporter.records()
+                .between(messagePosition, limitPosition)
+                .processInstanceRecords()
+                .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .extracting(r -> r.getValue().getElementId())
+        .describedAs("Expect that the target process is not activated")
+        .doesNotContain(targetProcessId);
+
+    // complete existing target instance
+    ENGINE.job().ofInstance(processInstanceKey).withType("A").complete();
+
+    // start new target instance
+    ENGINE.message().withName("msg2").withCorrelationKey("cardinality").publish();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withElementType(BpmnElementType.PROCESS)
+                .withBpmnProcessId(targetProcessId)
+                .exists())
+        .describedAs(
+            "Expect that the target process is only activated with 'msg2' after the target process is completed.")
+        .isTrue();
+  }
+
+  /**
+   * After migrating a process instance started by a message, we expect that a buffered message with
+   * the same correlation key cannot be correlated to the migrated instance until the process
+   * instance completes. We expect that the buffered message is automatically correlated once the
+   * migrated instance finishes.
+   */
+  @Test
+  public void shouldAdjustMessageCardinalityTrackingWhenMigratedForTargetProcessWithMessageTTL() {
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent("msg_start")
+                    .message("msg1")
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent("msg_start")
+                    .message("msg2")
+                    .serviceTask("B", t -> t.zeebeJobType("B"))
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    ENGINE.message().withName("msg1").withCorrelationKey("cardinality").publish();
+    final var processInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withElementType(BpmnElementType.START_EVENT)
+            .withElementId("msg_start")
+            .withBpmnProcessId(processId)
+            .getFirst()
+            .getValue()
+            .getProcessInstanceKey();
+
+    // when
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    final long messagePosition =
+        ENGINE
+            .message()
+            .withName("msg2")
+            .withCorrelationKey("cardinality")
+            .withTimeToLive(Duration.ofMinutes(1)) // create message with TTL
+            .publish()
+            .getSourceRecordPosition();
+
+    // broadcast a record to have something to limit the stream on
+    final var limitPosition = ENGINE.signal().withSignalName("dummy").broadcast().getPosition();
+    Assertions.assertThat(
+            RecordingExporter.records()
+                .between(messagePosition, limitPosition)
+                .processInstanceRecords()
+                .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .extracting(r -> r.getValue().getElementId())
+        .describedAs("Expect that the target process is not activated")
+        .doesNotContain(targetProcessId);
+
+    // complete existing target instance
+    ENGINE.job().ofInstance(processInstanceKey).withType("A").complete();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withElementType(BpmnElementType.PROCESS)
+                .withBpmnProcessId(targetProcessId)
+                .withElementId(targetProcessId)
+                .exists())
+        .describedAs(
+            "Expect that the target process is only activated with 'msg2' after the target process is completed. But this time a buffered message is correlated.")
+        .isTrue();
+  }
+
+  private static long extractProcessDefinitionKeyByProcessId(
+      final Record<DeploymentRecordValue> deployment, final String processId) {
+    return deployment.getValue().getProcessesMetadata().stream()
+        .filter(p -> p.getBpmnProcessId().equals(processId))
+        .findAny()
+        .orElseThrow()
+        .getProcessDefinitionKey();
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Backport of https://github.com/camunda/camunda/pull/27114. I had to create the backport PR manually as differences are huge since 8.8 and it was easier than resolving conflicts.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
