### PR TITLE
[Backport release-8.8.0-alpha3] deps: Update dependency org.springframework.security:spring-security-bom to v6.4.4 (main)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -102,7 +102,7 @@
     <version.dmn-scala>1.10.1</version.dmn-scala>
     <version.rest-assured>5.5.1</version.rest-assured>
     <version.spring>6.2.3</version.spring>
-    <version.spring-security>6.4.3</version.spring-security>
+    <version.spring-security>6.4.4</version.spring-security>
     <version.spring-boot>3.4.3</version.spring-boot>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.2</version.kryo>


### PR DESCRIPTION
# Description
Backport of #29843 to `release-8.8.0-alpha3`.

relates to 