### PR TITLE
Configure header to show Mappings instead of Users when user is using OIDC

### DIFF
--- a/identity/client/src/components/global/useGlobalRoutes.tsx
+++ b/identity/client/src/components/global/useGlobalRoutes.tsx
@@ -6,17 +6,31 @@ import Roles from "src/pages/roles";
 import Tenants from "src/pages/tenants";
 import Mappings from "src/pages/mappings";
 import Authorizations from "src/pages/authorizations";
+import { isOIDC } from "src/configuration";
 
 export const useGlobalRoutes = () => {
   const { t } = useTranslate();
   const { pathname } = useLocation();
+  const authTypeDependentRoutes = isOIDC
+    ? [
+        {
+          path: "/mappings/*",
+          key: "/mappings",
+          label: t("Mappings"),
+          element: <Mappings />,
+        },
+      ]
+    : [
+        {
+          path: "/users/*",
+          key: "/users",
+          label: t("Users"),
+          element: <Users />,
+        },
+      ];
+
   const routes = [
-    {
-      path: "/users/*",
-      key: "/users",
-      label: t("Users"),
-      element: <Users />,
-    },
+    ...authTypeDependentRoutes,
     {
       path: "/groups/*",
       key: "/groups",
@@ -34,12 +48,6 @@ export const useGlobalRoutes = () => {
       key: "/tenants",
       label: t("Tenants"),
       element: <Tenants />,
-    },
-    {
-      path: "/mappings/*",
-      key: "/mappings",
-      label: t("Mappings"),
-      element: <Mappings />,
     },
     {
       path: "/authorizations/*",


### PR DESCRIPTION
## Description

Uses `isOIDC` helper function value (coming from env variable) to determine which link to show on the nav header (Users for non-OIDC and Mappings for OIDC).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #30073
blocked by #30072 
