### PR TITLE
fix: do not initialize BrokerInfo from config 

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.bootstrap.BrokerContext;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupContextImpl;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupProcess;
@@ -64,10 +65,11 @@ public final class Broker implements AutoCloseable {
 
     final ActorScheduler scheduler = this.systemContext.getScheduler();
     final BrokerInfo localBroker = createBrokerInfo(getConfig());
+    final var nodeId = MemberId.from(String.valueOf(getConfig().getCluster().getNodeId()));
 
     healthCheckService =
         new BrokerHealthCheckService(
-            localBroker,
+            nodeId,
             new HealthTreeMetrics(systemContext.getMeterRegistry(), Tag.of("partition", "none")));
 
     final var startupContext =
@@ -131,6 +133,10 @@ public final class Broker implements AutoCloseable {
     }
   }
 
+  /**
+   * Create an instance of BrokerInfo with the fields that can be initialized from the
+   * configuration. It does not initialize fields that are part of the ClusterConfiguration.
+   */
   private BrokerInfo createBrokerInfo(final BrokerCfg brokerCfg) {
     final var clusterCfg = brokerCfg.getCluster();
 
@@ -139,11 +145,6 @@ public final class Broker implements AutoCloseable {
             clusterCfg.getNodeId(),
             NetUtil.toSocketAddressString(
                 brokerCfg.getNetwork().getCommandApi().getAdvertisedAddress()));
-
-    result
-        .setClusterSize(clusterCfg.getClusterSize())
-        .setPartitionsCount(clusterCfg.getPartitionsCount())
-        .setReplicationFactor(clusterCfg.getReplicationFactor());
 
     final String version = VersionUtil.getVersion();
     if (version != null && !version.isBlank()) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterConfigurationManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/ClusterConfigurationManagerStep.java
@@ -40,6 +40,17 @@ public class ClusterConfigurationManagerStep
             (ignore, error) -> {
               if (error == null) {
                 brokerStartupContext.setClusterConfigurationService(clusterConfigurationService);
+                final var brokerInfo = brokerStartupContext.getBrokerInfo();
+                final var clusterConfiguration =
+                    brokerStartupContext
+                        .getBrokerClient()
+                        .getTopologyManager()
+                        .getClusterConfiguration();
+                brokerInfo
+                    .setClusterSize(clusterConfiguration.clusterSize())
+                    .setPartitionsCount(clusterConfiguration.partitionCount())
+                    .setReplicationFactor(clusterConfiguration.minReplicationFactor());
+
                 started.complete(brokerStartupContext);
               } else {
                 started.completeExceptionally(error);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -12,7 +12,6 @@ import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.PartitionRaftListener;
 import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
-import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.health.CriticalComponentsHealthMonitor;
@@ -101,11 +100,9 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
   private volatile boolean allPartitionsInstalled = false;
   private volatile boolean brokerStarted = false;
   private final HealthMonitor healthMonitor;
-  private final MemberId nodeId;
 
   public BrokerHealthCheckService(
-      final BrokerInfo localBroker, final HealthTreeMetrics healthGraphMetrics) {
-    nodeId = MemberId.from(String.valueOf(localBroker.getNodeId()));
+      final MemberId nodeId, final HealthTreeMetrics healthGraphMetrics) {
     healthMonitor =
         new CriticalComponentsHealthMonitor(
             "Broker-" + nodeId, actor, healthGraphMetrics, Optional.empty(), LOG);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
@@ -9,20 +9,20 @@ package io.camunda.zeebe.broker.system.monitoring;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
 
-import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
+import io.atomix.cluster.MemberId;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Test;
 
 public class BrokerHealthCheckServiceTest {
 
+  private final MemberId member = MemberId.from("member-1");
+
   @Test
   public void shouldNotBeReadyHealthyOrStartedBeforePartitionManagerIsRegistered() {
     // given
-    final var brokerInfo = mock(BrokerInfo.class);
     final var healthCheckService =
-        new BrokerHealthCheckService(brokerInfo, new HealthTreeMetrics(new SimpleMeterRegistry()));
+        new BrokerHealthCheckService(member, new HealthTreeMetrics(new SimpleMeterRegistry()));
 
     // when
 
@@ -42,9 +42,8 @@ public class BrokerHealthCheckServiceTest {
   @Test
   public void shouldThrowIllegalStateExceptionIfStatusIsUpdatedBeforePartitionsAreKnown() {
     // given
-    final var brokerInfo = mock(BrokerInfo.class);
     final var healthCheckService =
-        new BrokerHealthCheckService(brokerInfo, new HealthTreeMetrics(new SimpleMeterRegistry()));
+        new BrokerHealthCheckService(member, new HealthTreeMetrics(new SimpleMeterRegistry()));
 
     // when + then
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/BrokerInfo.java
@@ -111,6 +111,9 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   }
 
   public int getNodeId() {
+    if (nodeIdNullValue() == nodeId) {
+      throw new IllegalStateException("nodeId is not set");
+    }
     return nodeId;
   }
 
@@ -120,6 +123,9 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   }
 
   public int getPartitionsCount() {
+    if (partitionsCountNullValue() == partitionsCount) {
+      throw new IllegalStateException("partitionsCount is not set");
+    }
     return partitionsCount;
   }
 
@@ -129,6 +135,9 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   }
 
   public int getClusterSize() {
+    if (clusterSizeNullValue() == clusterSize) {
+      throw new IllegalStateException("clusterSize is not set");
+    }
     return clusterSize;
   }
 
@@ -138,6 +147,9 @@ public final class BrokerInfo implements BufferReader, BufferWriter {
   }
 
   public int getReplicationFactor() {
+    if (replicationFactorNullValue() == replicationFactor) {
+      throw new IllegalStateException("replicationFactor is not set");
+    }
     return replicationFactor;
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PersistedClusterTopologyTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PersistedClusterTopologyTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.it.clustering.dynamic;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.client.CamundaClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
@@ -42,11 +43,12 @@ public class PersistedClusterTopologyTest {
                   g.gatewayConfig()
                       .getCluster()
                       .getMembership()
+                      .setGossipInterval(Duration.ofMillis(100))
                       // Decrease the timeouts for fast convergence of gateway topology. When the
                       // broker is shutdown, the topology update takes at least 10 seconds with
                       // the
                       // default values.
-                      .setSyncInterval(Duration.ofSeconds(1))
+                      .setSyncInterval(Duration.ofMillis(100))
                       .setFailureTimeout(Duration.ofSeconds(5)))
           .build();
 
@@ -60,39 +62,50 @@ public class PersistedClusterTopologyTest {
     ///                      _____________________________
     //     START_EVENT ->   |         service1           |     -------> END_EVENT
     //                      |-----(message catch event)--|                 ^
-    //                                        |          _______________   |
-    //                                        |---------| serviceCatch | --|
-    //                                                  ---------------
+    //                                        |                            |
+    //                                        |----------------------------|
+    //
+
+    final var processDefinition =
+        Bpmn.createExecutableProcess("catch_event")
+            .startEvent()
+            .serviceTask("service1")
+            .zeebeJobType("service1")
+            .boundaryEvent(
+                "boundary_catch",
+                bi ->
+                    bi.message(
+                        bm -> bm.name("catch_event_message").zeebeCorrelationKey("=\"foo\"")))
+            .endEvent()
+            .done();
+
     final var deploymentEvent =
         client
             .newDeployResourceCommand()
-            .addResourceFromClasspath("processes/catch_event.bpmn")
+            .addProcessModel(processDefinition, "catch_event_process.bpmn")
             .send()
             .join();
 
     cluster.shutdown();
 
     // when
-    cluster.setPartitionCount(1);
+    cluster.brokers().forEach((id, b) -> b.brokerConfig().getCluster().setPartitionsCount(1));
     cluster.start();
     cluster.awaitCompleteTopology(
         CLUSTER_SIZE, PARTITION_COUNT, REPLICATION_FACTOR, Duration.ofSeconds(10));
 
-    final var processId =
-        client
-            .newCreateInstanceCommand()
-            .processDefinitionKey(
-                deploymentEvent.getProcesses().getFirst().getProcessDefinitionKey())
-            .send()
-            .join();
+    client
+        .newCreateInstanceCommand()
+        .processDefinitionKey(deploymentEvent.getProcesses().getFirst().getProcessDefinitionKey())
+        .send()
+        .join();
 
-    final var result =
-        client
-            .newPublishMessageCommand()
-            .messageName("catch_event")
-            .correlationKey("11")
-            .send()
-            .join();
+    client
+        .newPublishMessageCommand()
+        .messageName("catch_event_message")
+        .correlationKey("foo")
+        .send()
+        .join();
 
     // then
     // there are no jobs to activate because of the successful message catch event triggered

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PersistedClusterTopologyTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PersistedClusterTopologyTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.clustering.dynamic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import org.junit.jupiter.api.AutoClose;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+@ZeebeIntegration
+@Timeout(2 * 60)
+public class PersistedClusterTopologyTest {
+
+  private static final int CLUSTER_SIZE = 3;
+  private static final int PARTITION_COUNT = 3;
+  private static final int REPLICATION_FACTOR = 3;
+
+  @AutoClose private CamundaClient client;
+
+  @TestZeebe
+  private final TestCluster cluster =
+      TestCluster.builder()
+          .useRecordingExporter(true)
+          .withGatewaysCount(1)
+          .withEmbeddedGateway(true)
+          .withBrokersCount(CLUSTER_SIZE)
+          .withPartitionsCount(PARTITION_COUNT)
+          .withReplicationFactor(REPLICATION_FACTOR)
+          .withGatewayConfig(
+              g ->
+                  g.gatewayConfig()
+                      .getCluster()
+                      .getMembership()
+                      // Decrease the timeouts for fast convergence of gateway topology. When the
+                      // broker is shutdown, the topology update takes at least 10 seconds with
+                      // the
+                      // default values.
+                      .setSyncInterval(Duration.ofSeconds(1))
+                      .setFailureTimeout(Duration.ofSeconds(5)))
+          .build();
+
+  @Test
+  void canHandleTopologyRequestsWhenBroker0IsRemoved() {
+    // given
+    cluster.awaitCompleteTopology();
+    client = cluster.newClientBuilder().build();
+
+    ///  Overview of the process being deployed
+    ///                      _____________________________
+    //     START_EVENT ->   |         service1           |     -------> END_EVENT
+    //                      |-----(message catch event)--|                 ^
+    //                                        |          _______________   |
+    //                                        |---------| serviceCatch | --|
+    //                                                  ---------------
+    final var deploymentEvent =
+        client
+            .newDeployResourceCommand()
+            .addResourceFromClasspath("processes/catch_event.bpmn")
+            .send()
+            .join();
+
+    cluster.shutdown();
+
+    // when
+    cluster.setPartitionCount(1);
+    cluster.start();
+    cluster.awaitCompleteTopology(
+        CLUSTER_SIZE, PARTITION_COUNT, REPLICATION_FACTOR, Duration.ofSeconds(10));
+
+    final var processId =
+        client
+            .newCreateInstanceCommand()
+            .processDefinitionKey(
+                deploymentEvent.getProcesses().getFirst().getProcessDefinitionKey())
+            .send()
+            .join();
+
+    final var result =
+        client
+            .newPublishMessageCommand()
+            .messageName("catch_event")
+            .correlationKey("11")
+            .send()
+            .join();
+
+    // then
+    // there are no jobs to activate because of the successful message catch event triggered
+    final var activatedJobs =
+        client.newActivateJobsCommand().jobType("service1").maxJobsToActivate(1).send().join();
+    assertThat(activatedJobs.getJobs()).isEmpty();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/resources/processes/catch_event.bpmn
+++ b/zeebe/qa/integration-tests/src/test/resources/processes/catch_event.bpmn
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0a205ky" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.29.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="Process_1hxi2y5" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1xnqi7t</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1xnqi7t" sourceRef="StartEvent_1" targetRef="Activity_12d7i7n" />
+    <bpmn:endEvent id="Event_0z0e3ta">
+      <bpmn:incoming>Flow_1q2gddn</bpmn:incoming>
+      <bpmn:incoming>Flow_1c4pwky</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1q2gddn" sourceRef="Activity_12d7i7n" targetRef="Event_0z0e3ta" />
+    <bpmn:boundaryEvent id="Event_1mrcqki" attachedToRef="Activity_12d7i7n">
+      <bpmn:outgoing>Flow_19emq4q</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0w1t17r" messageRef="Message_3ce0n2t" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_19emq4q" sourceRef="Event_1mrcqki" targetRef="Activity_1ymyovs" />
+    <bpmn:sequenceFlow id="Flow_1c4pwky" sourceRef="Activity_1ymyovs" targetRef="Event_0z0e3ta" />
+    <bpmn:serviceTask id="Activity_12d7i7n" name="service1">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="service1" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1xnqi7t</bpmn:incoming>
+      <bpmn:outgoing>Flow_1q2gddn</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Activity_1ymyovs" name="serviceCatch">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="serviceCatch" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_19emq4q</bpmn:incoming>
+      <bpmn:outgoing>Flow_1c4pwky</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmn:message id="Message_3ce0n2t" name="catch_event">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=11" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1hxi2y5">
+      <bpmndi:BPMNShape id="StartEvent_1_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0z0e3ta_di" bpmnElement="Event_0z0e3ta">
+        <dc:Bounds x="542" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_06r1pum_di" bpmnElement="Activity_12d7i7n">
+        <dc:Bounds x="330" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_06om09f_di" bpmnElement="Activity_1ymyovs">
+        <dc:Bounds x="440" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ywyne3_di" bpmnElement="Event_1mrcqki">
+        <dc:Bounds x="362" y="142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1xnqi7t_di" bpmnElement="Flow_1xnqi7t">
+        <di:waypoint x="218" y="120" />
+        <di:waypoint x="330" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1q2gddn_di" bpmnElement="Flow_1q2gddn">
+        <di:waypoint x="430" y="120" />
+        <di:waypoint x="542" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19emq4q_di" bpmnElement="Flow_19emq4q">
+        <di:waypoint x="380" y="178" />
+        <di:waypoint x="380" y="230" />
+        <di:waypoint x="440" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c4pwky_di" bpmnElement="Flow_1c4pwky">
+        <di:waypoint x="490" y="190" />
+        <di:waypoint x="490" y="164" />
+        <di:waypoint x="560" y="164" />
+        <di:waypoint x="560" y="138" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
@@ -86,7 +86,7 @@ public final class TestCluster implements CloseableSilently {
   private final Map<MemberId, TestStandaloneGateway> gateways;
   private final Map<MemberId, TestStandaloneBroker> brokers;
   private final int replicationFactor;
-  private final int partitionsCount;
+  private int partitionsCount;
 
   /**
    * Creates a new cluster from the given parameters.
@@ -438,5 +438,10 @@ public final class TestCluster implements CloseableSilently {
         .filter(TestApplication::isGateway)
         .filter(TestGateway.class::isInstance)
         .map(node -> (TestGateway<?>) node);
+  }
+
+  public void setPartitionCount(final int count) {
+    partitionsCount = count;
+    brokers.forEach((id, b) -> b.brokerConfig().getCluster().setPartitionsCount(partitionsCount));
   }
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
@@ -86,7 +86,7 @@ public final class TestCluster implements CloseableSilently {
   private final Map<MemberId, TestStandaloneGateway> gateways;
   private final Map<MemberId, TestStandaloneBroker> brokers;
   private final int replicationFactor;
-  private int partitionsCount;
+  private final int partitionsCount;
 
   /**
    * Creates a new cluster from the given parameters.
@@ -438,10 +438,5 @@ public final class TestCluster implements CloseableSilently {
         .filter(TestApplication::isGateway)
         .filter(TestGateway.class::isInstance)
         .map(node -> (TestGateway<?>) node);
-  }
-
-  public void setPartitionCount(final int count) {
-    partitionsCount = count;
-    brokers.forEach((id, b) -> b.brokerConfig().getCluster().setPartitionsCount(partitionsCount));
   }
 }


### PR DESCRIPTION
## Description
`BrokerInfo` was initialized with values from the config, even though they should not be used once the cluster has bootstrapped.

With this change, the fields that were initialized from the `ClusterCfg` class are left empty and then initialized when the `ClusterTopologyManager` has started, which happens as a second step in the `BrokerStartupProcess` pipeline.

Before being completely initialized, `BrokerInfo` contains *null* values for partition count, clusterSize & replicationFactor which are defined in the SBE schema:
```java
   public static int partitionsCountNullValue()
    {
        return -2147483648;
    }

   public static int partitionsCountNullValue()
    {
        return -2147483648;
    }

   public static int replicationFactorNullValue()
    {
        return -2147483648;
    }
```
An `IllegalStateException` is thrown from each getters if the respective field has not been initialized yet.
In this way, we achieve similar results as creating `BrokerInfo` only when it can be initialized, but we avoid changing too much.

**NOTE**
Backporting this PR the other branches will fix the issue, avoiding the need to make 2 different PRs, so we can probably close PR #30110

## Related issues

relates #29612
