### PR TITLE
Remove flakiness of SnapshotAfterScalingTest

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -762,6 +762,13 @@
       # Record positions defined to skip in this definition will be skipped in all exporters.
       # The value is a comma-separated list of records ids to skip. Whitespace is ignored.
       # skipRecords:
+      #
+      # Configures the rate at which exporter positions are distributed to the followers.
+      # This is useful for fail-over and taking snapshots. The follower is able to take snapshots based on
+      # replayed and distributed export position. When a follower takes over it can recover from the snapshot,
+      # it doesn't need to replay and export everything. It can for example can start from the last exported position it has received by the distribution mechanism.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPORTING_DISTRIBUTIONINTERVAL
+      # distributionInterval: 15s
 
     # exporters:
       # Configure exporters below

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -677,6 +677,13 @@
       # Record positions defined to skip in this definition will be skipped in all exporters.
       # The value is a comma-separated list of records ids to skip. Whitespace is ignored.
       # skipRecords:
+      #
+      # Configures the rate at which exporter positions are distributed to the followers.
+      # This is useful for fail-over and taking snapshots. The follower is able to take snapshots based on
+      # replayed and distributed export position. When a follower takes over it can recover from the snapshot,
+      # it doesn't need to replay and export everything. It can for example can start from the last exported position it has received by the distribution mechanism.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPORTING_DISTRIBUTIONINTERVAL
+      # distributionInterval: 15s
 
     # exporters:
       # Configure exporters below

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/BrokerCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/BrokerCfg.java
@@ -23,7 +23,7 @@ public class BrokerCfg {
   private ThreadsCfg threads = new ThreadsCfg();
   private DataCfg data = new DataCfg();
   private Map<String, ExporterCfg> exporters = new HashMap<>();
-  private ExportingCfg exporting = new ExportingCfg();
+  private ExportingCfg exporting = ExportingCfg.defaultExportingCfg();
   private EmbeddedGatewayCfg gateway = new EmbeddedGatewayCfg();
   private FlowControlCfg flowControl = new FlowControlCfg();
   private LimitCfg backpressure = new LimitCfg();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExportingCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExportingCfg.java
@@ -7,43 +7,24 @@
  */
 package io.camunda.zeebe.broker.system.configuration;
 
-import java.util.Objects;
+import static io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext.DEFAULT_DISTRIBUTION_INTERVAL;
+
+import java.time.Duration;
 import java.util.Set;
 
 /**
  * Exporting component configuration. This configuration pertains to configurations that are common
  * to all exporters.
  */
-public final class ExportingCfg implements ConfigurationEntry {
-  private Set<Long> skipRecords;
+public record ExportingCfg(Set<Long> skipRecords, Duration distributionInterval) {
 
-  public Set<Long> getSkipRecords() {
-    return skipRecords != null ? skipRecords : Set.of();
+  public ExportingCfg(final Set<Long> skipRecords, final Duration distributionInterval) {
+    this.skipRecords = skipRecords == null ? Set.of() : skipRecords;
+    this.distributionInterval =
+        distributionInterval == null ? DEFAULT_DISTRIBUTION_INTERVAL : distributionInterval;
   }
 
-  public void setSkipRecords(final Set<Long> skipRecords) {
-    this.skipRecords = skipRecords;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(skipRecords);
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final ExportingCfg that = (ExportingCfg) o;
-    return Objects.equals(skipRecords, that.skipRecords);
-  }
-
-  @Override
-  public String toString() {
-    return "ExporterCfg{" + "skipRecords='" + skipRecords + '}';
+  public static ExportingCfg defaultExportingCfg() {
+    return new ExportingCfg(null, null);
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.broker.exporter.stream.ExporterDirector.ExporterInitiali
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext.ExporterMode;
 import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ExportingCfg;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
@@ -26,7 +27,6 @@ import io.camunda.zeebe.stream.impl.SkipPositionsFilter;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -107,10 +107,9 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
   private ActorFuture<Void> openExporter(
       final PartitionTransitionContext context, final Role targetRole) {
     final var exporterDescriptors = getEnabledExporterDescriptors(context);
-    final ExportingCfg exportingCfg = context.getBrokerCfg().getExporting();
-    final var exporterFilter =
-        SkipPositionsFilter.of(
-            context.getBrokerCfg() != null ? exportingCfg.skipRecords() : Set.of());
+    final BrokerCfg brokerCfg = context.getBrokerCfg();
+    final ExportingCfg exportingCfg = brokerCfg.getExporting();
+    final var exporterFilter = SkipPositionsFilter.of(exportingCfg.skipRecords());
     final ExporterMode exporterMode =
         targetRole == Role.LEADER ? ExporterMode.ACTIVE : ExporterMode.PASSIVE;
     final ExporterDirectorContext exporterCtx =

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExporterConfigurationTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExporterConfigurationTest.java
@@ -9,11 +9,26 @@ package io.camunda.zeebe.broker.system.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class ExporterConfigurationTest {
+
+  @Test
+  void shouldHaveDefaultConfiguration() {
+    // given
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("default", Map.of());
+    final ExportingCfg exportingCfg = cfg.getExporting();
+
+    // then
+    assertThat(exportingCfg.skipRecords()).isEqualTo(Set.of());
+    assertThat(exportingCfg.distributionInterval()).isEqualTo(Duration.ofSeconds(15));
+  }
 
   @Test
   void shouldSetSkipPositionsFromEnvironment() {
@@ -25,7 +40,7 @@ class ExporterConfigurationTest {
     final ExportingCfg exportingCfg = cfg.getExporting();
 
     // then
-    assertThat(exportingCfg.getSkipRecords()).isEqualTo(Set.of(1L, 2L, 3L, 0L));
+    assertThat(exportingCfg.skipRecords()).isEqualTo(Set.of(1L, 2L, 3L, 0L));
   }
 
   @Test
@@ -37,17 +52,16 @@ class ExporterConfigurationTest {
     final BrokerCfg cfg = TestConfigReader.readConfig("exporters", environment);
     final ExportingCfg exportingCfg = cfg.getExporting();
     // then
-    assertThat(exportingCfg.getSkipRecords()).isEqualTo(Set.of(112233L, 445566L));
+    assertThat(exportingCfg.skipRecords()).isEqualTo(Set.of(112233L, 445566L));
   }
 
   @Test
   void shouldSetSkipPositions() {
     // given
-    final ExportingCfg exportingCfg = new ExportingCfg();
-    exportingCfg.setSkipRecords(Set.of(1L, 2L));
+    final ExportingCfg exportingCfg = new ExportingCfg(Set.of(1L, 2L), null);
 
     // then
-    assertThat(exportingCfg.getSkipRecords()).isEqualTo(Set.of(1L, 2L));
+    assertThat(exportingCfg.skipRecords()).isEqualTo(Set.of(1L, 2L));
   }
 
   @Test
@@ -60,6 +74,31 @@ class ExporterConfigurationTest {
     final ExportingCfg exportingCfg = cfg.getExporting();
 
     // then
-    assertThat(exportingCfg.getSkipRecords()).isEqualTo(Set.of(1L, 2L, 3L));
+    assertThat(exportingCfg.skipRecords()).isEqualTo(Set.of(1L, 2L, 3L));
+  }
+
+  @Test
+  void shouldSetDistributionIntervalFromEnvironment() {
+    // given
+    final var environment = new HashMap<String, String>();
+    environment.put("zeebe.broker.exporting.distributionInterval", "1s");
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("exporters", environment);
+    final ExportingCfg exportingCfg = cfg.getExporting();
+
+    // then
+    assertThat(exportingCfg.distributionInterval()).isEqualTo(Duration.ofSeconds(1));
+  }
+
+  @Test
+  void shouldSetDistributionIntervalFromConfigurationFile() {
+    // given
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("exporters", Map.of());
+    final ExportingCfg exportingCfg = cfg.getExporting();
+
+    // then
+    assertThat(exportingCfg.distributionInterval()).isEqualTo(Duration.ofSeconds(5));
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext;
 import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.partitions.TestPartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.PartitionTransitionTestArgumentProviders.TransitionsThatShouldCloseService;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.PartitionTransitionTestArgumentProviders.TransitionsThatShouldDoNothing;
@@ -65,6 +66,7 @@ class ExporterDirectorPartitionTransitionStepTest {
     when(actorSchedulingService.submitActor(any(), any()))
         .thenReturn(TestActorFuture.completedFuture(null));
     transitionContext.setActorSchedulingService(actorSchedulingService);
+    transitionContext.setBrokerCfg(new BrokerCfg());
 
     when(exporterDirectorFromPrevRole.closeAsync())
         .thenReturn(TestActorFuture.completedFuture(null));

--- a/zeebe/broker/src/test/resources/system/exporters.yaml
+++ b/zeebe/broker/src/test/resources/system/exporters.yaml
@@ -2,6 +2,7 @@ zeebe:
   broker:
     exporting:
       skipRecords: 112233, 445566
+      distributionInterval: 5s
     exporters:
       elasticsearch:
         className: io.camunda.zeebe.exporter.ElasticsearchExporter

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -27,6 +27,11 @@
       <artifactId>camunda-authentication</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-cluster-config</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>io.camunda</groupId>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/SnapshotAfterScalingTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/SnapshotAfterScalingTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.broker.system.configuration.ClusterCfg;
 import io.camunda.zeebe.broker.system.configuration.ConfigManagerCfg;
+import io.camunda.zeebe.broker.system.configuration.ExportingCfg;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
@@ -26,6 +27,7 @@ import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotId;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
 import java.util.Objects;
+import java.util.Set;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
@@ -41,6 +43,10 @@ final class SnapshotAfterScalingTest {
           .withGatewaysCount(1)
           .withBrokerConfig(
               broker -> {
+                broker
+                    .brokerConfig()
+                    .setExporting(new ExportingCfg(Set.of(), Duration.ofMillis(100)));
+
                 final ConfigManagerCfg configManagerCfg =
                     new ConfigManagerCfg(
                         new ClusterConfigurationGossiperConfig(
@@ -76,7 +82,10 @@ final class SnapshotAfterScalingTest {
     Awaitility.await()
         .until(
             () ->
-                RecordingExporter.messageRecords(MessageIntent.PUBLISHED).withPartitionId(1).count()
+                RecordingExporter.messageRecords(MessageIntent.PUBLISHED)
+                        .withPartitionId(1)
+                        .limit(1)
+                        .count()
                     == 1);
 
     // then

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/SnapshotAfterScalingTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/SnapshotAfterScalingTest.java
@@ -7,9 +7,13 @@
  */
 package io.camunda.zeebe.it.clustering.dynamic;
 
+import static io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig.DEFAULT_SYNC_REQUEST_TIMEOUT;
 import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertChangeIsPlanned;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.broker.system.configuration.ClusterCfg;
+import io.camunda.zeebe.broker.system.configuration.ConfigManagerCfg;
+import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
@@ -35,6 +39,15 @@ final class SnapshotAfterScalingTest {
           .withReplicationFactor(1)
           .withPartitionsCount(2)
           .withGatewaysCount(1)
+          .withBrokerConfig(
+              broker -> {
+                final ConfigManagerCfg configManagerCfg =
+                    new ConfigManagerCfg(
+                        new ClusterConfigurationGossiperConfig(
+                            Duration.ofSeconds(1), DEFAULT_SYNC_REQUEST_TIMEOUT, 3));
+                final ClusterCfg clusterCfg = broker.brokerConfig().getCluster();
+                clusterCfg.setConfigManager(configManagerCfg);
+              })
           .build()
           .start()
           .awaitCompleteTopology();


### PR DESCRIPTION
## Description

Mob session with @npepinpe and @entangled90 🙇🏼 🎉 

Flakiness:

 * Test was waiting for join request to be distributed with gossip
 * This was often done by gossip sync, as this interval per default is 10s
   and the Awaitility is also 10s the test becomes flaky
 * Reducing the interval to 1 second and increasing the fan out
   removes the flakiness

Test execution:

 * The test was quite slow, running ~10-15 seconds, we investigated this further
     * one issue was the RecordExporter costing up to 5 s, waiting for the count
     * another issue was the awaiting of distribution of exporter positions to the follower
 *  We are introducing a new option to configure distributionInterval
    * Interval that is used to decided when exporter positions should be distributed
   to followers
    * Configuring the exporter distributionInterval, allows to remove
   ~15 s wait time in the test (waiting for the follower to receive the pos.)
 * Setting the limit of the recording exporter, reduces the wait time of awaiting
   records by ~5 seconds


![2025-03-26_10-40](https://github.com/user-attachments/assets/c268558e-589b-4868-b803-159a8110d8d7)


## Related issues

closes #
