### PR TITLE
Unflake ElasticsearchUpdateRegressionTest

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/migration/ElasticsearchUpdateRegressionTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/migration/ElasticsearchUpdateRegressionTest.java
@@ -88,6 +88,7 @@ public class ElasticsearchUpdateRegressionTest {
 
     // when
     testStandaloneBroker.start();
+    testStandaloneBroker.awaitCompleteTopology();
     final CamundaClient camundaClient = testStandaloneBroker.newClientBuilder().build();
     camundaClient
         .newDeployResourceCommand()


### PR DESCRIPTION
## Description

 Test [failed](https://github.com/camunda/camunda/actions/runs/14070422813/job/39403129098) with: 

```
[INFO] Stack trace
[INFO] io.camunda.client.api.command.ClientStatusException: Expected to execute command on partition 1, but either it does not exist, or the gateway is not yet aware of it
	at io.camunda.client.impl.CamundaClientFutureImpl.transformExecutionException(CamundaClientFutureImpl.java:115)
	at io.camunda.client.impl.CamundaClientFutureImpl.join(CamundaClientFutureImpl.java:53)
	at io.camunda.it.migration.ElasticsearchUpdateRegressionTest.shouldBeAbleToUpdateAndExport(ElasticsearchUpdateRegressionTest.java:97)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:387)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1312)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1843)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:[180](https://github.com/camunda/camunda/actions/runs/14070422813/job/39403129098#step:9:181)8)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:188)
Caused by: java.util.concurrent.ExecutionException: io.grpc.StatusRuntimeException: UNAVAILABLE: Expected to execute command on partition 1, but either it does not exist, or the gateway is not yet aware of it
	at java.base/java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396)
	at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2073)
	at io.camunda.client.impl.CamundaClientFutureImpl.join(CamundaClientFutureImpl.java:51)
```

 * when starting broker, it is not immediately ready
 * we need to await for the topology before sending any command, or retry

