### PR TITLE
fix: do not throw a NullPointerException when the firstSegment is null in SegmentedJournal

### DIFF
--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -152,7 +152,7 @@ public final class SegmentedJournal implements Journal {
 
   @Override
   public boolean isEmpty() {
-    return writer.getNextIndex() - getFirstSegment().index() == 0;
+    return writer.getNextIndex() - getFirstIndex() == 0;
   }
 
   @Override


### PR DESCRIPTION
## Description
I noticed when running some test repeatedly and running out of disk space that a call to `SegmentedJournal.isEmpty` would throw a `NullPointerException` because there `SegmentsManager.getFirstSegment` returns null. This is an expected condition but was not checked in this method.