### PR TITLE
Trigger creating task listeners on user task creation

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnUserTaskBehavior.Use
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnVariableMappingBehavior;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUserTask;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.util.Either;
@@ -86,7 +87,7 @@ public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<Ex
             ok -> stateTransitionBehavior.transitionToActivated(context, element.getEventType()))
         .thenDo(
             result -> {
-              if (result.hasAssigneeProp()) {
+              if (result.lifecycleState == LifecycleState.CREATED && result.hasAssigneeProp()) {
                 assignUserTask(element, context, result.task(), result.getAssigneeProp());
               }
             });
@@ -153,8 +154,24 @@ public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<Ex
       final UserTaskProperties userTaskProperties) {
     final var userTaskRecord =
         userTaskBehavior.createNewUserTask(context, element, userTaskProperties);
-    userTaskBehavior.userTaskCreated(userTaskRecord);
-    return new UserTaskCreationResult(userTaskProperties, userTaskRecord);
+
+    final var lifecycleState =
+        element.getTaskListeners(ZeebeTaskListenerEventType.creating).stream()
+            .findFirst()
+            .map(
+                listener -> {
+                  jobBehavior.createNewTaskListenerJob(
+                      context, userTaskRecord, listener, userTaskRecord.getChangedAttributes());
+                  return LifecycleState.CREATING;
+                })
+            .orElseGet(
+                () -> {
+                  userTaskRecord.unsetAssignee();
+                  userTaskBehavior.userTaskCreated(userTaskRecord);
+                  return LifecycleState.CREATED;
+                });
+
+    return new UserTaskCreationResult(userTaskProperties, userTaskRecord, lifecycleState);
   }
 
   private void assignUserTask(
@@ -172,7 +189,8 @@ public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<Ex
             () -> userTaskBehavior.userTaskAssigned(userTaskRecord, assignee));
   }
 
-  private record UserTaskCreationResult(UserTaskProperties props, UserTaskRecord task) {
+  private record UserTaskCreationResult(
+      UserTaskProperties props, UserTaskRecord task, LifecycleState lifecycleState) {
 
     public String getAssigneeProp() {
       return props.getAssignee();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerBlockedTransitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerBlockedTransitionTest.java
@@ -175,6 +175,24 @@ public class TaskListenerBlockedTransitionTest {
   }
 
   @Test
+  public void shouldCreateFirstCreatingTaskListenerJob() {
+    // given
+    final long processInstanceKey =
+        helper.createProcessInstance(
+            helper.createProcessWithCreatingTaskListeners(listenerType + "_creating"));
+
+    // then: expect a job to be activated for the first `creating` listener
+    helper.assertActivatedJob(
+        processInstanceKey,
+        listenerType + "_creating",
+        job -> {
+          assertThat(job.getJobListenerEventType())
+              .describedAs("Expect job to have job listener type 'CREATING'")
+              .isEqualTo(JobListenerEventType.CREATING);
+        });
+  }
+
+  @Test
   public void shouldAssignUserTaskAfterAllAssignmentTaskListenersAreExecuted() {
     // given
     final long processInstanceKey =
@@ -359,9 +377,9 @@ public class TaskListenerBlockedTransitionTest {
 
     final Predicate<Record<?>> isUserTaskOrVariableDocumentWithElementInstanceKey =
         r -> {
-          if (r.getValue() instanceof UserTaskRecord utr) {
+          if (r.getValue() instanceof final UserTaskRecord utr) {
             return utr.getElementInstanceKey() == userTaskElementInstanceKey;
-          } else if (r.getValue() instanceof VariableDocumentRecord vdr) {
+          } else if (r.getValue() instanceof final VariableDocumentRecord vdr) {
             return vdr.getScopeKey() == userTaskElementInstanceKey;
           }
           return false;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTestHelper.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTestHelper.java
@@ -119,6 +119,10 @@ public class TaskListenerTestHelper {
     return createUserTaskWithTaskListeners(ZeebeTaskListenerEventType.completing, listenerTypes);
   }
 
+  BpmnModelInstance createProcessWithCreatingTaskListeners(final String... listenerTypes) {
+    return createUserTaskWithTaskListeners(ZeebeTaskListenerEventType.creating, listenerTypes);
+  }
+
   BpmnModelInstance createUserTaskWithTaskListeners(
       final ZeebeTaskListenerEventType listenerType, final String... listenerTypes) {
     return createProcessWithZeebeUserTask(

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -729,4 +729,11 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     processInstanceKeyProp.setValue(key);
     return this;
   }
+
+  public void unsetAssignee() {
+    assigneeProp.setValue(EMPTY_STRING);
+    final var changedAttributes = getChangedAttributes();
+    changedAttributes.remove(ASSIGNEE);
+    setChangedAttributes(changedAttributes);
+  }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -730,10 +730,11 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     return this;
   }
 
-  public void unsetAssignee() {
+  public UserTaskRecord unsetAssignee() {
     assigneeProp.setValue(EMPTY_STRING);
     final var changedAttributes = getChangedAttributes();
     changedAttributes.remove(ASSIGNEE);
     setChangedAttributes(changedAttributes);
+    return this;
   }
 }


### PR DESCRIPTION
## Description

We want to be able to trigger the creating listener when a user task is created. This happens automatically in the engine and there is no direct user trigger for this.

This is a very first PR for user task `creating` listeners that covers the creation of the first `creating` listener job.

`CREATING` job listener event type was already introduced as a part of [Introduce and recognize CANCELING and CREATING job listener event types](https://github.com/camunda/camunda/issues/28565) and covered in [feat: Introduce and support CREATING and CANCELING task listener event types](https://github.com/camunda/camunda/pull/30066) PR.

Allowing to deploy process with `creating` user task listener was also covered in [Introduce and recognize CANCELING and CREATING job listener event types](https://github.com/camunda/camunda/issues/28565) and implemented in [feat: Introduce and support CREATING and CANCELING task listener event types](https://github.com/camunda/camunda/pull/30066) PR.

What is covered by this PR:

- if there are no listeners defined, then we go from `creating` to `created` directly
- Added creation of the first `creating` listener job in `UserTaskProcessor` `createUserTask`
- `createUserTask()` now returns the lifecycle state of the user task at the end:
if it returns `CREATED` and the `result` has an `assignee` then we can assign the user task
- unset the `assignee` after `creating` before `created` to ensure we only write it on `creating`.
This will be used in the later tasks for `creating` task listeners as we will store the `assignee` in `creating` event. To avoid the user task actually being created with an assignee, it should be cleared in the `created` event.
Please see [Set assignee on the creating event](https://github.com/camunda/camunda/issues/29121) for more details.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #29119
