### PR TITLE
ci: new github workflow for license analysis with FOSSA

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,144 @@
+version: 3
+
+project:
+  id: camunda/camunda
+  labels:
+  - camunda
+  policy: Camunda8 Distribution
+  url: https://github.com/camunda/camunda
+
+paths:
+  exclude:
+  - .github/optimize/scripts/healthStatusReport
+  - c8run/e2e_tests
+  - qa/core-application-e2e-test-suite
+  - tasklist/qa/backup-restore-tests
+
+maven:
+  scope-exclude:
+  - import
+  - provided
+  - system
+  - test
+
+targets:
+  exclude:
+  # qa
+  - type: maven
+    path: bom/
+    target: io.camunda:camunda-qa
+  - type: maven
+    path: bom/
+    target: io.camunda:camunda-qa-integration-tests
+  - type: maven
+    path: bom/
+    target: io.camunda:camunda-qa-util
+  # testing
+  - type: maven
+    path: bom/
+    target: io.camunda:camunda-process-test-spring
+  # operate
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-backup-restore-tests
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-data-generator
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-it-tests
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-migration-performance-test
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-migration-tests
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-migration-tests-parent
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-migration-tests-test-fixture-110
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-migration-tests-test-fixture-120
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-migration-tests-test-fixture-130
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-migration-tests-test-fixture-800
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-migration-tests-test-fixture-810
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-migration-tests-test-fixture-820
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-migration-tests-test-fixture-830
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-migration-tests-test-fixture-840
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-migration-tests-test-fixture-850
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-query-performance-tests
+  - type: maven
+    path: bom/
+    target: io.camunda:operate-qa-util
+  # tasklist
+  - type: maven
+    path: bom/
+    target: io.camunda:tasklist-qa
+  - type: maven
+    path: bom/
+    target: io.camunda:tasklist-qa-backup-restore-tests
+  - type: maven
+    path: bom/
+    target: io.camunda:tasklist-qa-migration-tests
+  - type: maven
+    path: bom/
+    target: io.camunda:tasklist-qa-migration-tests-parent
+  - type: maven
+    path: bom/
+    target: io.camunda:tasklist-qa-migration-tests-test-fixture-810
+  - type: maven
+    path: bom/
+    target: io.camunda:tasklist-qa-migration-tests-test-fixture-820
+  - type: maven
+    path: bom/
+    target: io.camunda:tasklist-qa-migration-tests-test-fixture-830
+  - type: maven
+    path: bom/
+    target: io.camunda:tasklist-qa-migration-tests-test-fixture-840
+  - type: maven
+    path: bom/
+    target: io.camunda:tasklist-qa-migration-tests-test-fixture-850
+  - type: maven
+    path: bom/
+    target: io.camunda:tasklist-test-coverage
+  # zeebe
+  - type: maven
+    path: bom/
+    target: io.camunda:zeebe-qa
+  - type: maven
+    path: bom/
+    target: io.camunda:zeebe-qa-integration-tests
+  - type: maven
+    path: bom/
+    target: io.camunda:zeebe-qa-update-tests
+  - type: maven
+    path: bom/
+    target: io.camunda:zeebe-qa-util
+  - type: maven
+    path: bom/
+    target: io.camunda:zeebe-protocol-test-util
+  - type: maven
+    path: bom/
+    target: io.camunda:zeebe-test-util

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -1,0 +1,78 @@
+name: Check Licenses
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  analyze:
+    name: Analyze dependencies
+    permissions: {}
+    runs-on: ubuntu-latest
+    strategy:
+      # The matrix is needed to run separate analyses for the Single-App and Optimize
+      matrix:
+        project:
+        - name: single-app
+          path: ./
+          maven-config: |
+            -DskipQaBuild=true
+        # To be uncommented when Optimize is fully seperated
+        # Dedicated configs already exist, see optimize/.fossa.yml
+        # - name: optimize
+        #   path: ./optimize
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v4
+    # Import FOSSA_API_KEY secret from Vault
+    - name: Import Secrets
+      id: secrets
+      uses: hashicorp/vault-action@v3.0.0
+      with:
+        url: ${{ secrets.VAULT_ADDR }}
+        method: approle
+        roleId: ${{ secrets.VAULT_ROLE_ID }}
+        secretId: ${{ secrets.VAULT_SECRET_ID }}
+        secrets: |
+          secret/data/products/camunda/ci/camunda FOSSA_API_KEY;
+    - uses: ./.github/actions/setup-build
+      with:
+        vault-address: ${{ secrets.VAULT_ADDR }}
+        vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+        vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '>=1.23.1'
+        cache: false  # disabling since not working anyways without a cache-dependency-path specified
+    - name: Update Maven configs
+      if: matrix.project.maven-config != ''
+      env:
+        MAVEN_CONFIG: ${{ matrix.project.maven-config }}
+      run: |
+        echo "${MAVEN_CONFIG}" | tee ./.mvn/maven.config
+    - name: Setup fossa-cli
+      # TODO: use main branch
+      uses: camunda/infra-global-github-actions/fossa/setup@32470949e549396aa5f2c5def890de831b8ca107
+    - name: Adjust pom.xml files for FOSSA
+      if: matrix.project.name == 'single-app'
+      run: |
+        # The bom/pom.xml must be the actual root, otherwise, FOSSA won't detect the hierarchy correctly
+        yq -i \
+          '.project.modules.module += "./.."' \
+          parent/pom.xml
+        yq -i \
+          '.project.modules.module += "./../parent"' \
+          bom/pom.xml
+        # Remove bom and parent from the list of modules of ./pom.xml
+        yq -i \
+          'del(.project.modules.module[] | select(. == "bom" or . == "parent"))' \
+          pom.xml
+    - name: Analyze project
+      # TODO: use main branch
+      uses: camunda/infra-global-github-actions/fossa/analyze@32470949e549396aa5f2c5def890de831b8ca107
+      with:
+        api-key: ${{ steps.secrets.outputs.FOSSA_API_KEY }}
+        branch: ${{ github.ref_name }}
+        path: ${{ matrix.project.path }}
+        revision-id: ${{ github.sha }}

--- a/optimize/.fossa.yml
+++ b/optimize/.fossa.yml
@@ -1,0 +1,24 @@
+version: 3
+
+project:
+  id: camunda/optimize
+  labels:
+  - optimize
+  policy: Camunda8 Distribution
+  url: https://github.com/camunda/connectors
+
+maven:
+  scope-exclude:
+  - import
+  - provided
+  - system
+  - test
+
+targets:
+  exclude:
+  - type: maven
+    path: ./
+    target: io.camunda.optimize:optimize-qa
+  - type: maven
+    path: ./
+    target: io.camunda.optimize:optimize-schema-integrity-tests


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/751.

Add a new workflow to analyze licenses using FOSSA.

This workflow uploads only a dependency graph to FOSSA, the source code itself is not uploaded; The file-level scan of the dependencies is performed by the FOSSA platform asynchronously, making/keeping this workflow fast (execution time).

It currently analyzes licenses without enforcing any blocking checks and targets the main branch. Tag analysis will be added later, along with PR checks.

Dependencies within the `import`, `provided`, `system` and `test` (Maven) scopes are ignored.

The following projects are ignored (to be check/confirm during review):
- `./.github/optimize/scripts/healthStatusReport`
- `./c8run/e2e_tests`
- `./qa/core-application-e2e-test-suite`
- `./tasklist/qa/backup-restore-tests`

The following Maven modules are also ignored (to be check/confirm during review):
- .`/operate`
    - `io.camunda:operate-qa`
    - `io.camunda:operate-qa-backup-restore-tests`
    - `io.camunda:operate-qa-data-generator`
    - `io.camunda:operate-qa-it-tests`
    - `io.camunda:operate-qa-migration-performance-test`
    - `io.camunda:operate-qa-migration-tests`
    - `io.camunda:operate-qa-migration-tests-parent`
    - `io.camunda:operate-qa-migration-tests-test-fixture-110`
    - `io.camunda:operate-qa-migration-tests-test-fixture-120`
    - `io.camunda:operate-qa-migration-tests-test-fixture-130`
    - `io.camunda:operate-qa-migration-tests-test-fixture-800`
    - `io.camunda:operate-qa-migration-tests-test-fixture-810`
    - `io.camunda:operate-qa-migration-tests-test-fixture-820`
    - `io.camunda:operate-qa-migration-tests-test-fixture-830`
    - `io.camunda:operate-qa-migration-tests-test-fixture-840`
    - `io.camunda:operate-qa-migration-tests-test-fixture-850`
    - `io.camunda:operate-qa-query-performance-tests`
    - `io.camunda:operate-qa-util`
- `./qa`
    - `io.camunda:camunda-qa`
    - `io.camunda:camunda-qa-integration-tests`
    - `io.camunda:camunda-qa-util`
- `./tasklist`
    - `io.camunda:tasklist-qa`
    - `io.camunda:tasklist-qa-backup-restore-tests`
    - `io.camunda:tasklist-qa-migration-tests`
    - `io.camunda:tasklist-qa-migration-tests-parent`
    - `io.camunda:tasklist-qa-migration-tests-test-fixture-810`
    - `io.camunda:tasklist-qa-migration-tests-test-fixture-820`
    - `io.camunda:tasklist-qa-migration-tests-test-fixture-830`
    - `io.camunda:tasklist-qa-migration-tests-test-fixture-840`
    - `io.camunda:tasklist-qa-migration-tests-test-fixture-850`
    - `io.camunda:tasklist-test-coverage`
- `./testing`
    - `io.camunda:camunda-process-test-spring`
- `./zeebe`
    - `io.camunda:zeebe-qa`
    - `io.camunda:zeebe-qa-integration-tests`
    - `io.camunda:zeebe-qa-update-tests`
    - `io.camunda:zeebe-qa-util`
    - `io.camunda:zeebe-protocol-test-util`
    - `io.camunda:zeebe-test-util`

Test workflow run: https://github.com/camunda/camunda/actions/runs/14086556963

Before merging:
- [ ] check that https://github.com/camunda/infra-global-github-actions/pull/373 is merged (github composite actions)
    - [ ]  replace the @main ref by a commit hash 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
