### PR TITLE
[Backport main] fix: adjust remaining number types to strings in the API

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateDocumentBatchCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateDocumentBatchCommandImpl.java
@@ -29,6 +29,11 @@ import io.camunda.zeebe.client.impl.http.HttpClient;
 import io.camunda.zeebe.client.impl.http.HttpZeebeFuture;
 import io.camunda.zeebe.client.impl.response.DocumentReferenceBatchResponseImpl;
 import io.camunda.zeebe.client.impl.util.DocumentBuilder;
+<<<<<<< HEAD
+=======
+import io.camunda.zeebe.client.impl.util.ParseUtil;
+import io.camunda.zeebe.client.protocol.rest.DocumentCreationBatchResponse;
+>>>>>>> 0b906ae6 (fix: adjust remaining number types to strings in the API)
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.ArrayList;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateDocumentCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateDocumentCommandImpl.java
@@ -28,6 +28,11 @@ import io.camunda.zeebe.client.impl.http.HttpClient;
 import io.camunda.zeebe.client.impl.http.HttpZeebeFuture;
 import io.camunda.zeebe.client.impl.response.DocumentReferenceResponseImpl;
 import io.camunda.zeebe.client.impl.util.DocumentBuilder;
+<<<<<<< HEAD
+=======
+import io.camunda.zeebe.client.impl.util.ParseUtil;
+import io.camunda.zeebe.client.protocol.rest.DocumentReference;
+>>>>>>> 0b906ae6 (fix: adjust remaining number types to strings in the API)
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.HashMap;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DocumentMetadataImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DocumentMetadataImpl.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.client.impl.response;
 
 import io.camunda.client.impl.util.ParseUtil;
 import io.camunda.zeebe.client.api.response.DocumentMetadata;
+import io.camunda.zeebe.client.impl.util.ParseUtil;
 import java.time.OffsetDateTime;
 import java.util.Map;
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/util/ParseUtil.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/util/ParseUtil.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.util;
+
+public class ParseUtil {
+
+  public static Long parseLongOrNull(final String input) {
+    return input == null ? null : Long.parseLong(input);
+  }
+
+  public static String keyToString(final Long input) {
+    return input == null ? null : String.valueOf(input);
+  }
+}

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -2821,6 +2821,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DocumentReference"
+            application/vnd.camunda.api.keys.number+json:
+              schema:
+                $ref: "#/components/schemas/DocumentReferenceResult"
+            application/vnd.camunda.api.keys.string+json:
+              schema:
+                $ref: "#/components/schemas/DocumentReference"
         "400":
           $ref: "#/components/responses/InvalidData"
   /documents/batch:
@@ -2879,14 +2885,24 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/DocumentCreationBatchResponse"
+                $ref: "#/components/schemas/DocumentCreationBatchResponse"
+            application/vnd.camunda.api.keys.number+json:
+              schema:
+                $ref: "#/components/schemas/DocumentCreationBatchResult"
+            application/vnd.camunda.api.keys.string+json:
+              schema:
+                $ref: "#/components/schemas/DocumentCreationBatchResponse"
         "207":
           description: >
             Not all documents were uploaded successfully. More details are provided in the response body.
           content:
             application/json:
+              schema:
+                $ref: "#/components/schemas/DocumentCreationBatchResponse"
+            application/vnd.camunda.api.keys.number+json:
+              schema:
+                $ref: "#/components/schemas/DocumentCreationBatchResult"
+            application/vnd.camunda.api.keys.string+json:
               schema:
                 $ref: "#/components/schemas/DocumentCreationBatchResponse"
         "400":
@@ -6885,7 +6901,7 @@ components:
           description: The key of the message
           type: string
 
-    DocumentReference:
+    DocumentReferenceBase:
       type: object
       properties:
         camunda.document.type:
@@ -6902,8 +6918,21 @@ components:
         contentHash:
           type: string
           description: The hash of the document.
+    DocumentReference:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/DocumentReferenceBase"
+      properties:
         metadata:
           $ref: "#/components/schemas/DocumentMetadata"
+    DocumentReferenceResult:
+      deprecated: true
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/DocumentReferenceBase"
+      properties:
+        metadata:
+          $ref: "#/components/schemas/DocumentDetails"
 
     DocumentCreationFailureDetail:
       type: object
@@ -6915,22 +6944,37 @@ components:
           type: string
           description: The detail of the failure.
 
+    DocumentCreationBatchResponseBase:
+      type: object
+      properties:
+        failedDocuments:
+          type: array
+          description: Documents that failed creation.
+          items:
+            $ref: "#/components/schemas/DocumentCreationFailureDetail"
     DocumentCreationBatchResponse:
+      type: object
       allOf:
-        - type: object
-          properties:
-            createdDocuments:
-              type: array
-              description: Documents that were successfully created.
-              items:
-                $ref: "#/components/schemas/DocumentReference"
-            failedDocuments:
-              type: array
-              description: Documents that failed creation.
-              items:
-                $ref: "#/components/schemas/DocumentCreationFailureDetail"
+        - $ref: "#/components/schemas/DocumentCreationBatchResponseBase"
+      properties:
+        createdDocuments:
+          type: array
+          description: Documents that were successfully created.
+          items:
+            $ref: "#/components/schemas/DocumentReference"
+    DocumentCreationBatchResult:
+      deprecated: true
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/DocumentCreationBatchResponseBase"
+      properties:
+        createdDocuments:
+          type: array
+          description: Documents that were successfully created.
+          items:
+            $ref: "#/components/schemas/DocumentReferenceResult"
 
-    DocumentMetadata:
+    DocumentMetadataBase:
       description: Information about the document.
       type: object
       properties:
@@ -6951,13 +6995,36 @@ components:
         processDefinitionId:
           type: string
           description: The ID of the process definition that created the document.
+<<<<<<< HEAD
         processInstanceKey:
           type: string
           description: The key of the process instance that created the document.
+=======
+>>>>>>> 0b906ae6 (fix: adjust remaining number types to strings in the API)
         customProperties:
           type: object
           description: Custom properties of the document.
           additionalProperties: true
+    DocumentMetadata:
+      description: Information about the document.
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/DocumentMetadataBase"
+      properties:
+        processInstanceKey:
+          type: string
+          description: The key of the process instance that created the document.
+    DocumentDetails:
+      deprecated: true
+      description: Information about the document.
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/DocumentMetadataBase"
+      properties:
+        processInstanceKey:
+          type: integer
+          format: int64
+          description: The key of the process instance that created the document.
 
     DocumentLinkRequest:
       type: object

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -103,7 +103,10 @@ import io.camunda.zeebe.gateway.protocol.rest.UserRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskAssignmentRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskCompletionRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskUpdateRequest;
+<<<<<<< HEAD
 import io.camunda.zeebe.gateway.protocol.rest.UserUpdateRequest;
+=======
+>>>>>>> 0b906ae6 (fix: adjust remaining number types to strings in the API)
 import io.camunda.zeebe.gateway.rest.util.KeyUtil;
 import io.camunda.zeebe.gateway.rest.validator.DocumentValidator;
 import io.camunda.zeebe.gateway.rest.validator.GroupRequestValidator;

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -24,6 +24,7 @@ import io.camunda.service.DocumentServices.DocumentErrorResponse;
 import io.camunda.service.DocumentServices.DocumentReferenceResponse;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.gateway.impl.job.JobActivationResult;
+<<<<<<< HEAD
 import io.camunda.zeebe.gateway.protocol.rest.ActivatedJobResult;
 import io.camunda.zeebe.gateway.protocol.rest.AuthorizationCreateResult;
 import io.camunda.zeebe.gateway.protocol.rest.BatchOperationCreatedResult;
@@ -41,6 +42,23 @@ import io.camunda.zeebe.gateway.protocol.rest.DocumentMetadata;
 import io.camunda.zeebe.gateway.protocol.rest.DocumentReference;
 import io.camunda.zeebe.gateway.protocol.rest.DocumentReference.CamundaDocumentTypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.EvaluateDecisionResult;
+=======
+import io.camunda.zeebe.gateway.protocol.rest.ActivatedJob;
+import io.camunda.zeebe.gateway.protocol.rest.CreateProcessInstanceResponse;
+import io.camunda.zeebe.gateway.protocol.rest.DeploymentDecision;
+import io.camunda.zeebe.gateway.protocol.rest.DeploymentDecisionRequirements;
+import io.camunda.zeebe.gateway.protocol.rest.DeploymentForm;
+import io.camunda.zeebe.gateway.protocol.rest.DeploymentMetadata;
+import io.camunda.zeebe.gateway.protocol.rest.DeploymentProcess;
+import io.camunda.zeebe.gateway.protocol.rest.DeploymentResource;
+import io.camunda.zeebe.gateway.protocol.rest.DeploymentResponse;
+import io.camunda.zeebe.gateway.protocol.rest.DocumentCreationBatchResult;
+import io.camunda.zeebe.gateway.protocol.rest.DocumentCreationFailureDetail;
+import io.camunda.zeebe.gateway.protocol.rest.DocumentDetails;
+import io.camunda.zeebe.gateway.protocol.rest.DocumentReferenceResult;
+import io.camunda.zeebe.gateway.protocol.rest.DocumentReferenceResult.CamundaDocumentTypeEnum;
+import io.camunda.zeebe.gateway.protocol.rest.EvaluateDecisionResponse;
+>>>>>>> 0b906ae6 (fix: adjust remaining number types to strings in the API)
 import io.camunda.zeebe.gateway.protocol.rest.EvaluatedDecisionInputItem;
 import io.camunda.zeebe.gateway.protocol.rest.EvaluatedDecisionOutputItem;
 import io.camunda.zeebe.gateway.protocol.rest.EvaluatedDecisionResult;
@@ -207,10 +225,10 @@ public final class ResponseMapper {
     final List<DocumentReferenceResponse> successful =
         responses.stream().filter(Either::isRight).map(Either::get).toList();
 
-    final var response = new DocumentCreationBatchResponse();
+    final var response = new DocumentCreationBatchResult();
 
     if (successful.size() == responses.size()) {
-      final List<DocumentReference> references =
+      final List<DocumentReferenceResult> references =
           successful.stream().map(ResponseMapper::transformDocumentReferenceResponse).toList();
       response.setCreatedDocuments(references);
       return ResponseEntity.status(HttpStatus.CREATED).body(response);
@@ -272,11 +290,11 @@ public final class ResponseMapper {
     return RestErrorMapper.createProblemDetail(status, detail, e.getClass().getSimpleName());
   }
 
-  private static DocumentReference transformDocumentReferenceResponse(
+  private static DocumentReferenceResult transformDocumentReferenceResponse(
       final DocumentReferenceResponse response) {
     final var internalMetadata = response.metadata();
     final var externalMetadata =
-        new DocumentMetadata()
+        new DocumentDetails()
             .expiresAt(
                 Optional.ofNullable(internalMetadata.expiresAt())
                     .map(Object::toString)
@@ -288,7 +306,7 @@ public final class ResponseMapper {
             .processInstanceKey(KeyUtil.keyToString(internalMetadata.processInstanceKey()));
     Optional.ofNullable(internalMetadata.customProperties())
         .ifPresent(map -> map.forEach(externalMetadata::putCustomPropertiesItem));
-    return new DocumentReference()
+    return new DocumentReferenceResult()
         .camundaDocumentType(CamundaDocumentTypeEnum.CAMUNDA)
         .documentId(response.documentId())
         .storeId(response.storeId())

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/util/KeyUtil.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/util/KeyUtil.java
@@ -7,13 +7,17 @@
  */
 package io.camunda.zeebe.gateway.rest.util;
 
+<<<<<<< HEAD
 import java.util.Optional;
 
+=======
+>>>>>>> 0b906ae6 (fix: adjust remaining number types to strings in the API)
 public class KeyUtil {
 
   public static Long keyToLong(final String key) {
     return key != null ? Long.parseLong(key) : null;
   }
+<<<<<<< HEAD
 
   public static String keyToString(final Long value) {
     return value != null ? String.valueOf(value) : null;
@@ -26,4 +30,6 @@ public class KeyUtil {
       return Optional.empty();
     }
   }
+=======
+>>>>>>> 0b906ae6 (fix: adjust remaining number types to strings in the API)
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
@@ -12,16 +12,27 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.document.api.DocumentMetadataModel;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.DocumentServices;
 import io.camunda.service.DocumentServices.DocumentContentResponse;
 import io.camunda.service.DocumentServices.DocumentCreateRequest;
 import io.camunda.service.DocumentServices.DocumentReferenceResponse;
+<<<<<<< HEAD
+=======
+import io.camunda.service.security.auth.Authentication;
+import io.camunda.zeebe.gateway.protocol.rest.DocumentDetails;
+>>>>>>> 0b906ae6 (fix: adjust remaining number types to strings in the API)
 import io.camunda.zeebe.gateway.protocol.rest.DocumentMetadata;
+import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.util.Either;
 import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
@@ -115,7 +126,7 @@ public class DocumentControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldCreateDocumentWithMetadata() {
+  void shouldCreateDocumentWithMetadataNumberKeys() {
     // given
     final var filename = "file.txt";
     final var contentType = MediaType.APPLICATION_OCTET_STREAM;
@@ -133,12 +144,13 @@ public class DocumentControllerTest extends RestControllerTest {
                     "default",
                     "dummy_hash",
                     new DocumentMetadataModel(
-                        contentType.toString(), filename, timestamp, 0L, null, null, Map.of()))));
+                        contentType.toString(), filename, timestamp, 0L, null, 123L, Map.of()))));
 
-    final var metadataToSend = new DocumentMetadata();
+    final var metadataToSend = new DocumentDetails();
     metadataToSend.setContentType(contentType.toString());
     metadataToSend.setFileName(filename);
     metadataToSend.setExpiresAt(timestamp.toString());
+    metadataToSend.setProcessInstanceKey(123L);
 
     final var multipartBodyBuilder = new MultipartBodyBuilder();
     multipartBodyBuilder.part("file", content).contentType(contentType).filename(filename);
@@ -150,7 +162,7 @@ public class DocumentControllerTest extends RestControllerTest {
         .uri(DOCUMENTS_BASE_URL)
         .contentType(MediaType.MULTIPART_FORM_DATA)
         .bodyValue(multipartBodyBuilder.build())
-        .accept(MediaType.APPLICATION_JSON)
+        .accept(RequestMapper.MEDIA_TYPE_KEYS_NUMBER)
         .exchange()
         .expectStatus()
         .isCreated()
@@ -164,7 +176,8 @@ public class DocumentControllerTest extends RestControllerTest {
                       "metadata": {
                         "contentType": "application/octet-stream",
                         "fileName": "file.txt",
-                        "expiresAt": "%s"
+                        "expiresAt": "%s",
+                        "processInstanceKey": 123
                       }
                     }
                     """,
@@ -187,6 +200,331 @@ public class DocumentControllerTest extends RestControllerTest {
     final var metadata = request.metadata();
     assertThat(metadata.fileName()).isEqualTo(filename);
     assertThat(metadata.contentType()).isEqualTo(contentType.toString());
+    assertThat(metadata.processInstanceKey()).isEqualTo(123L);
+  }
+
+  @Test
+  void shouldCreateDocumentWithMetadataStringKeys() {
+    // given
+    final var filename = "file.txt";
+    final var contentType = MediaType.APPLICATION_OCTET_STREAM;
+    final var content = new byte[] {1, 2, 3};
+
+    final var timestamp = OffsetDateTime.now();
+
+    final ArgumentCaptor<DocumentCreateRequest> requestCaptor =
+        ArgumentCaptor.forClass(DocumentCreateRequest.class);
+    when(documentServices.createDocument(any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new DocumentReferenceResponse(
+                    "documentId",
+                    "default",
+                    "dummy_hash",
+                    new DocumentMetadataModel(
+                        contentType.toString(), filename, timestamp, 0L, null, 123L, Map.of()))));
+
+    final var metadataToSend = new DocumentMetadata();
+    metadataToSend.setContentType(contentType.toString());
+    metadataToSend.setFileName(filename);
+    metadataToSend.setExpiresAt(timestamp.toString());
+    metadataToSend.setProcessInstanceKey("123");
+
+    final var multipartBodyBuilder = new MultipartBodyBuilder();
+    multipartBodyBuilder.part("file", content).contentType(contentType).filename(filename);
+    multipartBodyBuilder.part("metadata", metadataToSend).contentType(MediaType.APPLICATION_JSON);
+
+    // when/then
+    webClient
+        .post()
+        .uri(DOCUMENTS_BASE_URL)
+        .contentType(MediaType.MULTIPART_FORM_DATA)
+        .bodyValue(multipartBodyBuilder.build())
+        .accept(RequestMapper.MEDIA_TYPE_KEYS_STRING)
+        .exchange()
+        .expectStatus()
+        .isCreated()
+        .expectBody()
+        .json(
+            String.format(
+                """
+                    {
+                      "documentId": "documentId",
+                      "storeId": "default",
+                      "metadata": {
+                        "contentType": "application/octet-stream",
+                        "fileName": "file.txt",
+                        "expiresAt": "%s",
+                        "processInstanceKey": "123"
+                      }
+                    }
+                    """,
+                timestamp));
+
+    verify(documentServices).createDocument(requestCaptor.capture());
+
+    final DocumentCreateRequest request = requestCaptor.getValue();
+    assertThat(request.documentId()).isNull();
+    assertThat(request.storeId()).isNull();
+    assertThat(request.metadata()).isNotNull();
+    assertThat(request.contentInputStream()).isNotNull();
+
+    try (final var stream = request.contentInputStream()) {
+      assertThat(stream.readAllBytes()).isEqualTo(content);
+    } catch (final Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    final var metadata = request.metadata();
+    assertThat(metadata.fileName()).isEqualTo(filename);
+    assertThat(metadata.contentType()).isEqualTo(contentType.toString());
+    assertThat(metadata.processInstanceKey()).isEqualTo(123L);
+  }
+
+  @Test
+  void shouldCreateDocumentsBatchWithMetadataNumberKeys() throws JsonProcessingException {
+    // given
+    final var filename1 = "file.txt";
+    final var contentType = MediaType.APPLICATION_OCTET_STREAM;
+    final var content1 = new byte[] {1, 2, 3};
+    final var filename2 = "file2.txt";
+    final var content2 = new byte[] {4, 5};
+
+    final var timestamp = OffsetDateTime.now();
+
+    final ArgumentCaptor<List<DocumentCreateRequest>> requestCaptor =
+        ArgumentCaptor.forClass(List.class);
+    final var ref1 =
+        new DocumentReferenceResponse(
+            "documentId",
+            "default",
+            "dummy_hash",
+            new DocumentMetadataModel(
+                contentType.toString(), filename1, timestamp, 0L, null, 123L, Map.of()));
+    when(documentServices.createDocumentBatch(any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(List.of(Either.right(ref1), Either.right(ref1))));
+
+    final var om = new ObjectMapper();
+    final var multipartBodyBuilder = new MultipartBodyBuilder();
+    multipartBodyBuilder
+        .part("files", content1)
+        .header(
+            "X-Document-Metadata",
+            om.writeValueAsString(
+                new DocumentDetails()
+                    .contentType(contentType.toString())
+                    .fileName(filename1)
+                    .expiresAt(timestamp.toString())
+                    .processInstanceKey(123L)));
+    multipartBodyBuilder
+        .part("files", content2)
+        .header(
+            "X-Document-Metadata",
+            om.writeValueAsString(
+                new DocumentDetails()
+                    .contentType(contentType.toString())
+                    .fileName(filename2)
+                    .expiresAt(timestamp.toString())
+                    .processInstanceKey(123L)));
+
+    // when/then
+    webClient
+        .post()
+        .uri(DOCUMENTS_BASE_URL + "/batch")
+        .contentType(MediaType.MULTIPART_FORM_DATA)
+        .bodyValue(multipartBodyBuilder.build())
+        .accept(RequestMapper.MEDIA_TYPE_KEYS_NUMBER)
+        .exchange()
+        .expectStatus()
+        .isCreated()
+        .expectBody()
+        .json(
+            String.format(
+                """
+                    {
+                      "createdDocuments": [
+                        {
+                          "metadata": {
+                            "processInstanceKey": 123,
+                            "contentType": "application/octet-stream",
+                            "fileName": "file.txt",
+                            "expiresAt": "%s",
+                            "size": 0,
+                            "customProperties": {}
+                          },
+                          "camunda.document.type": "camunda",
+                          "storeId": "default",
+                          "documentId": "documentId",
+                          "contentHash": "dummy_hash"
+                        },
+                        {
+                          "metadata": {
+                            "processInstanceKey": 123,
+                            "contentType": "application/octet-stream",
+                            "fileName": "file.txt",
+                            "expiresAt": "%s",
+                            "size": 0,
+                            "customProperties": {}
+                          },
+                          "camunda.document.type": "camunda",
+                          "storeId": "default",
+                          "documentId": "documentId",
+                          "contentHash": "dummy_hash"
+                        }
+                      ],
+                      "failedDocuments": []
+                    }
+                    """
+                    .formatted(timestamp, timestamp),
+                timestamp));
+
+    verify(documentServices).createDocumentBatch(requestCaptor.capture());
+
+    final var values = requestCaptor.getValue();
+    assertThat(values).extracting(DocumentCreateRequest::documentId).containsOnlyNulls();
+    assertThat(values).extracting(DocumentCreateRequest::storeId).containsOnlyNulls();
+    assertThat(values).extracting(DocumentCreateRequest::contentInputStream).doesNotContainNull();
+
+    final var metadataValues = values.stream().map(DocumentCreateRequest::metadata).toList();
+    assertThat(metadataValues).doesNotContainNull();
+    assertThat(metadataValues)
+        .extracting(DocumentMetadataModel::fileName)
+        .containsExactlyInAnyOrder(filename1, filename2);
+    assertThat(metadataValues)
+        .extracting(DocumentMetadataModel::contentType)
+        .containsExactly(contentType.toString(), contentType.toString());
+    assertThat(metadataValues)
+        .extracting(DocumentMetadataModel::processInstanceKey)
+        .containsExactly(123L, 123L);
+
+    assertThat(values)
+        .<InputStream>extracting(DocumentCreateRequest::contentInputStream)
+        .map(InputStream::readAllBytes)
+        .containsExactlyInAnyOrder(content1, content2);
+  }
+
+  @Test
+  void shouldCreateDocumentsBatchWithMetadataStringKeys() throws JsonProcessingException {
+    // given
+    final var filename1 = "file.txt";
+    final var contentType = MediaType.APPLICATION_OCTET_STREAM;
+    final var content1 = new byte[] {1, 2, 3};
+    final var filename2 = "file2.txt";
+    final var content2 = new byte[] {4, 5};
+
+    final var timestamp = OffsetDateTime.now();
+
+    final ArgumentCaptor<List<DocumentCreateRequest>> requestCaptor =
+        ArgumentCaptor.forClass(List.class);
+    final var ref1 =
+        new DocumentReferenceResponse(
+            "documentId",
+            "default",
+            "dummy_hash",
+            new DocumentMetadataModel(
+                contentType.toString(), filename1, timestamp, 0L, null, 123L, Map.of()));
+    when(documentServices.createDocumentBatch(any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(List.of(Either.right(ref1), Either.right(ref1))));
+
+    final var om = new ObjectMapper();
+    final var multipartBodyBuilder = new MultipartBodyBuilder();
+    multipartBodyBuilder
+        .part("files", content1)
+        .header(
+            "X-Document-Metadata",
+            om.writeValueAsString(
+                new DocumentMetadata()
+                    .contentType(contentType.toString())
+                    .fileName(filename1)
+                    .expiresAt(timestamp.toString())
+                    .processInstanceKey("123")));
+    multipartBodyBuilder
+        .part("files", content2)
+        .header(
+            "X-Document-Metadata",
+            om.writeValueAsString(
+                new DocumentMetadata()
+                    .contentType(contentType.toString())
+                    .fileName(filename2)
+                    .expiresAt(timestamp.toString())
+                    .processInstanceKey("123")));
+
+    // when/then
+    webClient
+        .post()
+        .uri(DOCUMENTS_BASE_URL + "/batch")
+        .contentType(MediaType.MULTIPART_FORM_DATA)
+        .bodyValue(multipartBodyBuilder.build())
+        .accept(RequestMapper.MEDIA_TYPE_KEYS_STRING)
+        .exchange()
+        .expectStatus()
+        .isCreated()
+        .expectBody()
+        .json(
+            String.format(
+                """
+                    {
+                      "createdDocuments": [
+                        {
+                          "metadata": {
+                            "processInstanceKey": "123",
+                            "contentType": "application/octet-stream",
+                            "fileName": "file.txt",
+                            "expiresAt": "%s",
+                            "size": 0,
+                            "customProperties": {}
+                          },
+                          "camunda.document.type": "camunda",
+                          "storeId": "default",
+                          "documentId": "documentId",
+                          "contentHash": "dummy_hash"
+                        },
+                        {
+                          "metadata": {
+                            "processInstanceKey": "123",
+                            "contentType": "application/octet-stream",
+                            "fileName": "file.txt",
+                            "expiresAt": "%s",
+                            "size": 0,
+                            "customProperties": {}
+                          },
+                          "camunda.document.type": "camunda",
+                          "storeId": "default",
+                          "documentId": "documentId",
+                          "contentHash": "dummy_hash"
+                        }
+                      ],
+                      "failedDocuments": []
+                    }
+                    """
+                    .formatted(timestamp, timestamp),
+                timestamp));
+
+    verify(documentServices).createDocumentBatch(requestCaptor.capture());
+
+    final var values = requestCaptor.getValue();
+    assertThat(values).extracting(DocumentCreateRequest::documentId).containsOnlyNulls();
+    assertThat(values).extracting(DocumentCreateRequest::storeId).containsOnlyNulls();
+    assertThat(values).extracting(DocumentCreateRequest::contentInputStream).doesNotContainNull();
+
+    final var metadataValues = values.stream().map(DocumentCreateRequest::metadata).toList();
+    assertThat(metadataValues).doesNotContainNull();
+    assertThat(metadataValues)
+        .extracting(DocumentMetadataModel::fileName)
+        .containsExactlyInAnyOrder(filename1, filename2);
+    assertThat(metadataValues)
+        .extracting(DocumentMetadataModel::contentType)
+        .containsExactly(contentType.toString(), contentType.toString());
+    assertThat(metadataValues)
+        .extracting(DocumentMetadataModel::processInstanceKey)
+        .containsExactly(123L, 123L);
+
+    assertThat(values)
+        .<InputStream>extracting(DocumentCreateRequest::contentInputStream)
+        .map(InputStream::readAllBytes)
+        .containsExactlyInAnyOrder(content1, content2);
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #30216 to `main`.

relates to camunda/camunda#30082