### PR TITLE
Change thresholds in benchmark-dashboard.

### DIFF
--- a/monitor/grafana/medic-benchmark-dashboard.json
+++ b/monitor/grafana/medic-benchmark-dashboard.json
@@ -123,7 +123,7 @@
               },
               {
                 "color": "green",
-                "value": 290
+                "value": 100
               }
             ]
           },
@@ -208,7 +208,7 @@
               },
               {
                 "color": "green",
-                "value": 100
+                "value": 40
               }
             ]
           },


### PR DESCRIPTION
After the changes of PIs created in our normal benchmarks to 50 PIs/s we need to change the thresholds in the benchmarks dashboard to properly indicate when PI/s or FNIs/s are bellow the supposed.

Under normal circumstances we should have 50 PIs/s and 150 FNIs/s. The thresholds were set somewhat bellow the normal (as it was before) at 40 PI/s and 100 FNI/s.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
