### PR TITLE
fix: use single-node discovery to prevent quorum issues

### DIFF
--- a/c8run/internal/unix/unix.go
+++ b/c8run/internal/unix/unix.go
@@ -45,7 +45,7 @@ func (w *UnixC8Run) VersionCmd(javaBinaryPath string) *exec.Cmd {
 
 func (w *UnixC8Run) ElasticsearchCmd(elasticsearchVersion string, parentDir string) *exec.Cmd {
 	elasticsearchCmdString := filepath.Join(parentDir, "elasticsearch-"+elasticsearchVersion, "bin", "elasticsearch")
-	elasticsearchCmd := exec.Command(elasticsearchCmdString, "-E", "xpack.ml.enabled=false", "-E", "xpack.security.enabled=false")
+	elasticsearchCmd := exec.Command(elasticsearchCmdString, "-E", "xpack.ml.enabled=false", "-E", "xpack.security.enabled=false", "-E", "discovery.type=single-node")
 	elasticsearchCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	return elasticsearchCmd
 }

--- a/c8run/internal/windows/windows.go
+++ b/c8run/internal/windows/windows.go
@@ -35,7 +35,7 @@ func (w *WindowsC8Run) VersionCmd(javaBinaryPath string) *exec.Cmd {
 }
 
 func (w *WindowsC8Run) ElasticsearchCmd(elasticsearchVersion string, parentDir string) *exec.Cmd {
-	elasticsearchCmd := exec.Command(filepath.Join(parentDir, "elasticsearch-"+elasticsearchVersion, "bin", "elasticsearch.bat"), "-E", "xpack.ml.enabled=false", "-E", "xpack.security.enabled=false")
+	elasticsearchCmd := exec.Command(filepath.Join(parentDir, "elasticsearch-"+elasticsearchVersion, "bin", "elasticsearch.bat"), "-E", "xpack.ml.enabled=false", "-E", "xpack.security.enabled=false", "-E", "discovery.type=single-node")
 
 	elasticsearchCmd.SysProcAttr = &syscall.SysProcAttr{
 		CreationFlags: 0x08000000 | 0x00000200, // CREATE_NO_WINDOW, CREATE_NEW_PROCESS_GROUP : https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags


### PR DESCRIPTION
## Description

We recently learned of an issue in c8run where some people have elasticsearch instances that fail to find a quorum. it looks like by default the initial contact points is set to a dozen urls that all mean localhost, and that elasticsearch fails to identify which localhost to grant master. However, this doesn't make sense conceptually, so we will set single-node as the discovery type, as it is a single-node elastic cluster.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes https://github.com/camunda/team-distribution/issues/457
