### PR TITLE
feat: Introduce `CREATE` and `CANCEL` user task commands

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -45,8 +45,6 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
       "Expected to resolve incident with key '%d', but no such incident was found";
   private static final String ELEMENT_NOT_IN_SUPPORTED_STATE_MSG =
       "Expected incident to refer to element in state ELEMENT_ACTIVATING or ELEMENT_COMPLETING, but element is in state %s";
-  private static final String LIFECYCLE_STATE_CONVERSION_NOT_SUPPORTED_MSG =
-      "Conversion from '%s' user task lifecycle state to failed user task command is not yet supported";
   private static final String UNEXPECTED_LIFECYCLE_STATE_CONVERSION_MSG =
       "Unexpected user task lifecycle state: '%s' encountered during conversion to failed user task command.";
 
@@ -223,12 +221,12 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
   private Either<String, UserTaskIntent> getFailedUserTaskCommandIntent(
       final LifecycleState lifecycleState) {
     return switch (lifecycleState) {
+      case CREATING -> Either.right(UserTaskIntent.CREATE);
       case ASSIGNING -> Either.right(UserTaskIntent.ASSIGN);
       case CLAIMING -> Either.right(UserTaskIntent.CLAIM);
       case UPDATING -> Either.right(UserTaskIntent.UPDATE);
       case COMPLETING -> Either.right(UserTaskIntent.COMPLETE);
-      case CREATING, CANCELING ->
-          Either.left(String.format(LIFECYCLE_STATE_CONVERSION_NOT_SUPPORTED_MSG, lifecycleState));
+      case CANCELING -> Either.right(UserTaskIntent.CANCEL);
       default ->
           Either.left(String.format(UNEXPECTED_LIFECYCLE_STATE_CONVERSION_MSG, lifecycleState));
     };

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandProcessors.java
@@ -12,9 +12,11 @@ import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAssignProcessor;
+import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCancelProcessor;
 import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskClaimProcessor;
 import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCommandProcessor;
 import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCompleteProcessor;
+import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCreateProcessor;
 import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskUpdateProcessor;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
@@ -46,6 +48,8 @@ public final class UserTaskCommandProcessors {
     commandToProcessor =
         new EnumMap<>(
             Map.of(
+                UserTaskIntent.CREATE,
+                new UserTaskCreateProcessor(),
                 UserTaskIntent.ASSIGN,
                 new UserTaskAssignProcessor(processingState, writers, authCheckBehavior),
                 UserTaskIntent.CLAIM,
@@ -55,7 +59,9 @@ public final class UserTaskCommandProcessors {
                     processingState, writers, bpmnBehaviors.variableBehavior(), authCheckBehavior),
                 UserTaskIntent.COMPLETE,
                 new UserTaskCompleteProcessor(
-                    processingState, eventHandle, writers, authCheckBehavior)));
+                    processingState, eventHandle, writers, authCheckBehavior),
+                UserTaskIntent.CANCEL,
+                new UserTaskCancelProcessor()));
     validateProcessorsSetup(commandToProcessor);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -93,7 +93,8 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
   public void processRecord(final TypedRecord<UserTaskRecord> command) {
     final UserTaskIntent intent = (UserTaskIntent) command.getIntent();
     switch (intent) {
-      case ASSIGN, CLAIM, COMPLETE, UPDATE -> processOperationCommand(command, intent);
+      case CREATE, ASSIGN, CLAIM, UPDATE, COMPLETE, CANCEL ->
+          processOperationCommand(command, intent);
       case COMPLETE_TASK_LISTENER -> processCompleteTaskListener(command);
       case DENY_TASK_LISTENER -> processDenyTaskListener(command);
       default -> throw new UnsupportedOperationException("Unexpected user task intent: " + intent);
@@ -314,9 +315,11 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
 
   private ZeebeTaskListenerEventType mapIntentToEventType(final UserTaskIntent intent) {
     return switch (intent) {
+      case CREATE -> ZeebeTaskListenerEventType.creating;
       case ASSIGN, CLAIM -> ZeebeTaskListenerEventType.assigning;
       case UPDATE -> ZeebeTaskListenerEventType.updating;
       case COMPLETE -> ZeebeTaskListenerEventType.completing;
+      case CANCEL -> ZeebeTaskListenerEventType.canceling;
       default ->
           throw new IllegalArgumentException("Unexpected user task intent: '%s'".formatted(intent));
     };

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCancelProcessor.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.usertask.processors;
+
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+public class UserTaskCancelProcessor implements UserTaskCommandProcessor {
+
+  @Override
+  public void onFinalizeCommand(
+      final TypedRecord<UserTaskRecord> command, final UserTaskRecord userTaskRecord) {
+    throw new UnsupportedOperationException(
+        "UserTaskCancelProcessor.onFinalizeCommand is not yet implemented. "
+            + "It should be covered by: https://github.com/camunda/camunda/issues/28570");
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCreateProcessor.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.usertask.processors;
+
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+public class UserTaskCreateProcessor implements UserTaskCommandProcessor {
+
+  @Override
+  public void onFinalizeCommand(
+      final TypedRecord<UserTaskRecord> command, final UserTaskRecord userTaskRecord) {
+    throw new UnsupportedOperationException(
+        "UserTaskCreateProcessor.onFinalizeCommand is not yet implemented. "
+            + "It should be covered by: https://github.com/camunda/camunda/issues/29122");
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserTaskIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserTaskIntent.java
@@ -102,7 +102,27 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
    * corrections within the same update transition are discarded, and the user task remains in its
    * prior state.
    */
-  UPDATE_DENIED(21);
+  UPDATE_DENIED(21),
+
+  /**
+   * Represents the `CREATE` command for a user task. This command is intended for internal use by
+   * Zeebe to finalize the creation of a user task after all `creating` task listener jobs have been
+   * completed or any related incidents have been resolved.
+   *
+   * @apiNote The engine manages this command internally. Writing this command directly won't
+   *     trigger user task creation. It shouldn't be used via client APIs.
+   */
+  CREATE(22),
+
+  /**
+   * Represents the `CANCEL` command for a user task. This command is intended for internal use by
+   * Zeebe to finalize the cancellation of a user task after all `canceling` task listener jobs have
+   * been completed or any related incidents have been resolved.
+   *
+   * @apiNote The engine manages this command internally. Writing this command directly won't
+   *     trigger user task cancellation. It shouldn't be used via client APIs.
+   */
+  CANCEL(23);
 
   private final short value;
   private final boolean shouldBanInstance;
@@ -166,6 +186,10 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
         return CLAIMING;
       case 21:
         return UPDATE_DENIED;
+      case 22:
+        return CREATE;
+      case 23:
+        return CANCEL;
       default:
         return UNKNOWN;
     }


### PR DESCRIPTION
## Description

This PR lays the groundwork for supporting `creating` and `canceling` user task listeners by
introducing the necessary user task command infrastructure.

### What's added
- Added `CREATE` and `CANCEL` commands to the `UserTaskIntent` enum.
  - These commands are for internal use only and do not directly trigger user task creation or cancellation.
- Introduced `UserTaskCreateProcessor` and `UserTaskCancelProcessor` with placeholder implementations.
  - Both processors throw UnsupportedOperationException and will be implemented in follow-up tasks:
    - #29122
    - #28570
- Registered the new processors in `UserTaskCommandProcessors`.
- Added mappings for new commands in `UserTaskProcessor` and `IncidentResolveProcessor`.

This will allows parallel implementation for `"creating"` and `"canceling"` listeners without merge conflicts, and prepares the engine to correctly route task lifecycle transitions after all dedicated listeners will be executed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #30262
