### PR TITLE
fix: credentials provider tests flakiness

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/pom.xml
+++ b/clients/spring-boot-starter-camunda-sdk/pom.xml
@@ -131,12 +131,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.auth0</groupId>
-      <artifactId>java-jwt</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-commons</artifactId>
       <scope>test</scope>

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CredentialsProviderSelfManagedTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CredentialsProviderSelfManagedTest.java
@@ -19,8 +19,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.algorithms.Algorithm;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.camunda.client.CredentialsProvider;
@@ -30,7 +28,6 @@ import io.camunda.spring.client.jobhandling.CamundaClientExecutorService;
 import io.camunda.spring.client.properties.CamundaClientProperties;
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -84,8 +81,7 @@ public class CredentialsProviderSelfManagedTest {
   @Test
   void shouldHaveZeebeAuth() throws IOException {
     final Map<String, String> headers = new HashMap<>();
-    final String accessToken =
-        JWT.create().withExpiresAt(Instant.now().plusSeconds(300)).sign(Algorithm.none());
+    final String accessToken = "access-token";
     wm.stubFor(
         post("/auth-server")
             .willReturn(

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CredentialsProviderSelfManagedWithSSLTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/spring/client/config/CredentialsProviderSelfManagedWithSSLTest.java
@@ -19,8 +19,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.algorithms.Algorithm;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.camunda.client.CredentialsProvider;
@@ -30,7 +28,6 @@ import io.camunda.spring.client.jobhandling.CamundaClientExecutorService;
 import io.camunda.spring.client.properties.CamundaClientProperties;
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -115,8 +112,7 @@ public class CredentialsProviderSelfManagedWithSSLTest {
   @Test
   void shouldHaveZeebeAuth() throws IOException {
     final Map<String, String> headers = new HashMap<>();
-    final String accessToken =
-        JWT.create().withExpiresAt(Instant.now().plusSeconds(300)).sign(Algorithm.none());
+    final String accessToken = "access-token";
     wm.stubFor(
         post("/auth-server")
             .willReturn(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Since the refactor of the credential cache, just removing the cache file after each iteration is not enough anymore. There is no direct access to the in memory cache map, so using at each tests run a different token doesn't work. The scope of the tests is not related to the specific value of the token, so having the same string as a token is correct here

## Related issues

closes #30229 
closes #30228 
