### PR TITLE
feat: Updated so that this will build every night to verify c8run is …

### DIFF
--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -191,7 +191,7 @@ jobs:
             secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK;
 
       - name: Upload message to Slack on failure
-        if: failure()
+        if: ${{ failure() && github.event_name == 'schedule' }}
         env:
           SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.SLACK_DISTRO_BOT_WEBHOOK }}
         run: |
@@ -326,7 +326,7 @@ jobs:
           retention-days: 10
 
       - name: Upload message to Slack on failure
-        if: failure()
+        if: ${{ failure() && github.event_name == 'schedule' }}
         env:
           SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.SLACK_DISTRO_BOT_WEBHOOK }}
         run: |

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -175,7 +175,7 @@ jobs:
       - name: Upload message to Slack on failure
         if: ${{ failure() || github.event.inputs.alert_slack == true }}
         env:
-          SLACK_WEBHOOK_URL: ${{ steps.secrets.output.SLACK_DISTRO_BOT_WEBHOOK }}
+          SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.SLACK_DISTRO_BOT_WEBHOOK }}
         run: |
           curl -X POST -H 'Content-type: application/json' \
           --data '{
@@ -310,7 +310,7 @@ jobs:
       - name: Upload message to Slack on failure
         if: ${{ failure() || github.event.inputs.alert_slack == true }}
         env:
-          SLACK_WEBHOOK_URL: ${{ steps.secrets.output.SLACK_DISTRO_BOT_WEBHOOK }}
+          SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.SLACK_DISTRO_BOT_WEBHOOK }}
         run: |
           curl -X POST -H 'Content-type: application/json' \
           --data '{

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -13,6 +13,10 @@ on:
     paths:
       - "c8run/**"
       - ".github/workflows/c8run-build.yaml"
+  workflow_dispatch:
+  schedule:
+    # Run at 23:30 UTC every day
+    - cron: "30 23 * * *"
 
 permissions:
   actions: write
@@ -39,8 +43,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '>=1.23.1'
-          cache: false  # disabling since not working anyways without a cache-dependency-path specified
+          go-version: ">=1.23.1"
+          cache: false # disabling since not working anyways without a cache-dependency-path specified
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea # v6.5.1
@@ -114,8 +118,8 @@ jobs:
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
           os: ${{ matrix.os }}
           github-token: ${{ github.token }}
-          local-archive-build: 'true'
-          checkout: 'false'
+          local-archive-build: "true"
+          checkout: "false"
 
       - name: Install dependencies
         run: npm ci
@@ -150,6 +154,27 @@ jobs:
           path: ./c8run/log/*.log
           retention-days: 10
 
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@7709c609789c5e27b757a85817483caadbb5939a # v3.3.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK;
+
+      - name: Upload message to Slack on failure
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ steps.secrets.output.SLACK_DISTRO_BOT_WEBHOOK }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+          --data '{
+            "text": "Job *${{ github.job }}* in workflow *${{ github.workflow }}* failed for *${{ github.repository }}*!\nBranch: ${{ github.ref }}\nCommit: ${{ github.sha }}\nRun: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>\nLogs: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts|View Artifacts>"
+          }' \
+          $SLACK_WEBHOOK_URL
 
   test_c8run_windows:
     name: C8Run Test Windows
@@ -170,11 +195,12 @@ jobs:
           secrets: |
             secret/data/products/distribution/ci NEXUS_USERNAME;
             secret/data/products/distribution/ci NEXUS_PASSWORD;
+            secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK;
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '>=1.23.1'
-          cache: false  # disabling since not working anyways without a cache-dependency-path specified
+          go-version: ">=1.23.1"
+          cache: false # disabling since not working anyways without a cache-dependency-path specified
 
       - name: Download Camunda Core Dist
         uses: actions/download-artifact@v4
@@ -205,8 +231,8 @@ jobs:
 
       - uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '22'
+          distribution: "temurin"
+          java-version: "22"
 
       - name: Set env
         run: echo "JAVA_HOME=${JAVA_HOME_22_X64}" >> $GITHUB_ENV
@@ -273,3 +299,14 @@ jobs:
           name: c8run-logs
           path: .\c8run\log\*.log
           retention-days: 10
+
+      - name: Upload message to Slack on failure
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ steps.secrets.output.SLACK_DISTRO_BOT_WEBHOOK }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+          --data '{
+            "text": "Job *${{ github.job }}* in workflow *${{ github.workflow }}* failed for *${{ github.repository }}*!\nBranch: ${{ github.ref }}\nCommit: ${{ github.sha }}\nRun: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>\nLogs: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts|View Artifacts>"
+          }' \
+          $SLACK_WEBHOOK_URL

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -14,6 +14,13 @@ on:
       - "c8run/**"
       - ".github/workflows/c8run-build.yaml"
   workflow_dispatch:
+    inputs:
+      alert_slack:
+        description: Set this to force a message on the slack channel. Useful to debug alert issues on slack. NOTE.. This will always say it failed in the channel
+        required: true
+        default: false
+        type: boolean
+
   schedule:
     # Run at 23:30 UTC every day
     - cron: "30 23 * * *"
@@ -166,7 +173,7 @@ jobs:
             secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK;
 
       - name: Upload message to Slack on failure
-        if: failure()
+        if: ${{ failure() || github.event.inputs.alert_slack == true }}
         env:
           SLACK_WEBHOOK_URL: ${{ steps.secrets.output.SLACK_DISTRO_BOT_WEBHOOK }}
         run: |
@@ -301,7 +308,7 @@ jobs:
           retention-days: 10
 
       - name: Upload message to Slack on failure
-        if: failure()
+        if: ${{ failure() || github.event.inputs.alert_slack == true }}
         env:
           SLACK_WEBHOOK_URL: ${{ steps.secrets.output.SLACK_DISTRO_BOT_WEBHOOK }}
         run: |

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -50,32 +50,6 @@ jobs:
         with:
           working-directory: ./c8run
 
-  test_slack_alert_env_delete_me:
-    name: Testing slack intergration for alert_slack
-    runs-on: ubuntu-latest
-    timeout-minutes: 1
-    steps:
-      - name: Import Secrets
-        id: secrets
-        uses: hashicorp/vault-action@7709c609789c5e27b757a85817483caadbb5939a # v3.3.0
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secrets: |
-            secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK;
-
-      - name: Upload message to Slack on failure
-        env:
-          SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.SLACK_DISTRO_BOT_WEBHOOK }}
-        run: |
-          curl -X POST -H 'Content-type: application/json' \
-          --data '{
-            "text": "Job *${{ github.job }}* in workflow *${{ github.workflow }}* failed for *${{ github.repository }}*!\nBranch: ${{ github.ref }}\nCommit: ${{ github.sha }}\nRun: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>\nLogs: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts|View Artifacts>"
-          }' \
-          $SLACK_WEBHOOK_URL
-
   camunda-dist-build:
     name: Build camunda-dist
     runs-on: gcp-perf-core-16-default

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -13,14 +13,6 @@ on:
     paths:
       - "c8run/**"
       - ".github/workflows/c8run-build.yaml"
-  workflow_dispatch:
-    inputs:
-      alert_slack:
-        description: Set this to force a message on the slack channel. Useful to debug alert issues on slack. NOTE.. This will always say it failed in the channel
-        required: true
-        default: false
-        type: boolean
-
   schedule:
     # Run at 23:30 UTC every day
     - cron: "30 23 * * *"
@@ -57,6 +49,32 @@ jobs:
         uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea # v6.5.1
         with:
           working-directory: ./c8run
+
+  test_slack_alert_env_delete_me:
+    name: Testing slack intergration for alert_slack
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@7709c609789c5e27b757a85817483caadbb5939a # v3.3.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK;
+
+      - name: Upload message to Slack on failure
+        env:
+          SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.SLACK_DISTRO_BOT_WEBHOOK }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+          --data '{
+            "text": "Job *${{ github.job }}* in workflow *${{ github.workflow }}* failed for *${{ github.repository }}*!\nBranch: ${{ github.ref }}\nCommit: ${{ github.sha }}\nRun: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>\nLogs: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts|View Artifacts>"
+          }' \
+          $SLACK_WEBHOOK_URL
 
   camunda-dist-build:
     name: Build camunda-dist
@@ -173,7 +191,7 @@ jobs:
             secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK;
 
       - name: Upload message to Slack on failure
-        if: ${{ failure() || github.event.inputs.alert_slack == true }}
+        if: failure()
         env:
           SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.SLACK_DISTRO_BOT_WEBHOOK }}
         run: |
@@ -308,7 +326,7 @@ jobs:
           retention-days: 10
 
       - name: Upload message to Slack on failure
-        if: ${{ failure() || github.event.inputs.alert_slack == true }}
+        if: failure()
         env:
           SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.SLACK_DISTRO_BOT_WEBHOOK }}
         run: |

--- a/.github/workflows/c8run-slack-alert-env-testing-delete-me.yaml
+++ b/.github/workflows/c8run-slack-alert-env-testing-delete-me.yaml
@@ -1,0 +1,31 @@
+name: "C8Run: test slack integration"
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test_slack_alert:
+    name: C8Run test slack alert
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@7709c609789c5e27b757a85817483caadbb5939a # v3.3.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/distribution/ci SLACK_DISTRO_BOT_WEBHOOK;
+
+      - name: Upload message to Slack on failure
+        env:
+          SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.SLACK_DISTRO_BOT_WEBHOOK }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+          --data '{
+            "text": "Job *${{ github.job }}* in workflow *${{ github.workflow }}* failed for *${{ github.repository }}*!\nBranch: ${{ github.ref }}\nCommit: ${{ github.sha }}\nRun: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>\nLogs: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts|View Artifacts>"
+          }' \
+          $SLACK_WEBHOOK_URL


### PR DESCRIPTION
…still compatible with camunda

Issues:
- https://github.com/camunda/camunda/issues/29935
- https://github.com/camunda/camunda/issues/28574

- Upon failures, the slack #team-distribution-alerts channels is notifed via webhook
- We are doing this to catch issues with c8run using the latest camunda code. It was discussed to run this on every change however that seems overkill. It is assumed the feedback cycle time of max 24 hours about a breaking change is sufficient.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues

closes #
