### PR TITLE
refactor: role should use mapping id instead of mapping key

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaOidcUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOidcUserService.java
@@ -68,7 +68,7 @@ public class CamundaOidcUserService extends OidcUserService {
       LOG.debug("No mappings found for these claims: {}", claims);
     }
 
-    final var assignedRoles = roleServices.getRolesByMemberKeys(mappingKeys);
+    final var assignedRoles = roleServices.getRolesByMemberIds(mappingIds);
 
     return new CamundaOidcUser(
         oidcUser,

--- a/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
@@ -52,9 +52,8 @@ public class CamundaUserDetailsService implements UserDetailsService {
             .findFirst()
             .orElseThrow(() -> new UsernameNotFoundException(username));
 
-    final Long userKey = storedUser.userKey();
-
-    final var roles = roleServices.findAll(RoleQuery.of(q -> q.filter(f -> f.memberKey(userKey))));
+    final var roles =
+        roleServices.findAll(RoleQuery.of(q -> q.filter(f -> f.memberIds(storedUser.username()))));
 
     final var authorizedApplications =
         authorizationServices.getAuthorizedApplications(
@@ -72,7 +71,7 @@ public class CamundaUserDetailsService implements UserDetailsService {
             .toList();
 
     return aCamundaUser()
-        .withUserKey(userKey)
+        .withUserKey(storedUser.userKey())
         .withName(storedUser.name())
         .withUsername(storedUser.username())
         .withPassword(storedUser.password())

--- a/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaOidcUserServiceTest.java
@@ -74,7 +74,8 @@ public class CamundaOidcUserServiceTest {
                 new MappingEntity("test-id-2", 7L, "group", "G1", "group-g1")));
 
     final var roleR1 = new RoleEntity(8L, "Role R1");
-    when(roleServices.getRolesByMemberKeys(Set.of(5L, 7L))).thenReturn(List.of(roleR1));
+    when(roleServices.getRolesByMemberIds(Set.of("test-id", "test-id-2")))
+        .thenReturn(List.of(roleR1));
     when(authorizationServices.getAuthorizedApplications(Set.of("5", "7", "8")))
         .thenReturn(List.of("*"));
 

--- a/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
@@ -61,7 +61,7 @@ public class CamundaUserDetailsServiceTest {
     when(authorizationServices.getAuthorizedApplications(any()))
         .thenReturn(List.of("operate", "identity"));
     final RoleEntity adminRole = new RoleEntity(2L, "ADMIN");
-    when(roleServices.findAll(RoleQuery.of(q -> q.filter(f -> f.memberKey(100L)))))
+    when(roleServices.findAll(RoleQuery.of(q -> q.filter(f -> f.memberIds(TEST_USER_ID)))))
         .thenReturn(List.of(adminRole));
 
     // when

--- a/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
+++ b/db/rdbms-schema/src/main/resources/db/changelog/rdbms-exporter/changesets/8.8.0.xml
@@ -418,7 +418,7 @@
       <column name="ROLE_KEY" type="BIGINT" >
         <constraints primaryKey="true"/>
       </column>
-      <column name="ENTITY_KEY" type="BIGINT" >
+      <column name="ENTITY_ID" type="VARCHAR(255)">
         <constraints primaryKey="true"/>
       </column>
       <column name="ENTITY_TYPE" type="VARCHAR(255)" />

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleReader.java
@@ -52,6 +52,6 @@ public class RoleReader extends AbstractEntityReader<RoleEntity> {
     return new RoleEntity(
         model.roleKey(),
         model.name(),
-        model.members().stream().map(RoleMemberDbModel::entityKey).collect(Collectors.toSet()));
+        model.members().stream().map(RoleMemberDbModel::entityId).collect(Collectors.toSet()));
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/RoleMemberDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/RoleMemberDbModel.java
@@ -9,33 +9,33 @@ package io.camunda.db.rdbms.write.domain;
 
 import io.camunda.util.ObjectBuilder;
 
-public record RoleMemberDbModel(Long roleKey, Long entityKey, String entityType) {
+public record RoleMemberDbModel(Long roleKey, String entityId, String entityType) {
 
   // create builder implementing ObjectBuilder
   public static class Builder implements ObjectBuilder<RoleMemberDbModel> {
 
     private Long roleKey;
-    private Long entityKey;
+    private String entityId;
     private String entityType;
 
-    public Builder roleKey(Long roleKey) {
+    public Builder roleKey(final Long roleKey) {
       this.roleKey = roleKey;
       return this;
     }
 
-    public Builder entityKey(Long entityKey) {
-      this.entityKey = entityKey;
+    public Builder entityId(final String entityId) {
+      this.entityId = entityId;
       return this;
     }
 
-    public Builder entityType(String entityType) {
+    public Builder entityType(final String entityType) {
       this.entityType = entityType;
       return this;
     }
 
     @Override
     public RoleMemberDbModel build() {
-      return new RoleMemberDbModel(roleKey, entityKey, entityType);
+      return new RoleMemberDbModel(roleKey, entityId, entityType);
     }
   }
 }

--- a/db/rdbms/src/main/resources/mapper/RoleMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/RoleMapper.xml
@@ -23,7 +23,7 @@
     r.ROLE_KEY,
     r.NAME,
     rm.ROLE_KEY AS MEMBER_ROLE_KEY,
-    rm.ENTITY_KEY AS MEMBER_ENTITY_KEY,
+    rm.ENTITY_ID AS MEMBER_ENTITY_ID,
     rm.ENTITY_TYPE AS MEMBER_ENTITY_TYPE
     FROM ${prefix}ROLES r
     LEFT JOIN ${prefix}ROLE_MEMBER rm ON r.ROLE_KEY = rm.ROLE_KEY
@@ -47,7 +47,7 @@
       javaType="java.util.List">
       <constructor>
         <idArg column="MEMBER_ROLE_KEY" javaType="java.lang.Long"/>
-        <idArg column="MEMBER_ENTITY_KEY" javaType="java.lang.Long"/>
+        <idArg column="MEMBER_ENTITY_ID" javaType="java.lang.String"/>
         <arg column="MEMBER_ENTITY_TYPE" javaType="java.lang.String"/>
       </constructor>
     </collection>
@@ -80,8 +80,8 @@
     id="insertMember"
     parameterType="io.camunda.db.rdbms.write.domain.RoleMemberDbModel"
     flushCache="true">
-    INSERT INTO ${prefix}ROLE_MEMBER (ROLE_KEY, ENTITY_KEY, ENTITY_TYPE)
-    VALUES (#{roleKey}, #{entityKey}, #{entityType})
+    INSERT INTO ${prefix}ROLE_MEMBER (ROLE_KEY, ENTITY_ID, ENTITY_TYPE)
+    VALUES (#{roleKey}, #{entityId}, #{entityType})
   </insert>
 
   <delete
@@ -91,7 +91,7 @@
     DELETE
     FROM ${prefix}ROLE_MEMBER
     WHERE ROLE_KEY = #{roleKey}
-      AND ENTITY_KEY = #{entityKey}
+      AND ENTITY_ID = #{entityId}
       AND ENTITY_TYPE = #{entityType}
   </delete>
 

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -402,14 +402,14 @@ class RdbmsExporterIT {
     assertThat(role.get().name()).isEqualTo(roleRecordValue.getName());
 
     // when
-    exporter.export(getRoleRecord(42L, RoleIntent.ENTITY_ADDED, 1337L));
+    exporter.export(getRoleRecord(42L, RoleIntent.ENTITY_ADDED, "roleEntityId"));
 
     // then
     final var updatedRole = rdbmsService.getRoleReader().findOne(roleRecord.getKey()).orElseThrow();
-    assertThat(updatedRole.assignedMemberKeys()).containsExactly(1337L);
+    assertThat(updatedRole.assignedMemberKeys()).containsExactly("roleEntityId");
 
     // when
-    exporter.export(getRoleRecord(42L, RoleIntent.ENTITY_REMOVED, 1337L));
+    exporter.export(getRoleRecord(42L, RoleIntent.ENTITY_REMOVED, "roleEntityId"));
 
     // then
     final var deletedRole = rdbmsService.getRoleReader().findOne(roleRecord.getKey()).orElseThrow();

--- a/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
+++ b/qa/acceptance-tests/src/test/java/io/camunda/it/rdbms/exporter/RecordFixtures.java
@@ -316,7 +316,7 @@ public class RecordFixtures {
   }
 
   protected static ImmutableRecord<RecordValue> getRoleRecord(
-      final Long roleKey, final RoleIntent intent, final Long entityKey) {
+      final Long roleKey, final RoleIntent intent, final String entityId) {
     final Record<RecordValue> recordValueRecord = FACTORY.generateRecord(ValueType.ROLE);
     return ImmutableRecord.builder()
         .from(recordValueRecord)
@@ -328,8 +328,8 @@ public class RecordFixtures {
             ImmutableRoleRecordValue.builder()
                 .from((RoleRecordValue) recordValueRecord.getValue())
                 .withRoleKey(roleKey)
-                .withEntityKey(entityKey != null ? entityKey : 0)
-                .withEntityType(entityKey != null ? EntityType.USER : null)
+                .withEntityId(entityId != null ? entityId : "")
+                .withEntityType(entityId != null ? EntityType.USER : null)
                 .build())
         .build();
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformer.java
@@ -9,8 +9,8 @@ package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.hasChildQuery;
-import static io.camunda.search.clients.query.SearchQueryBuilders.longTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.matchNone;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 
 import io.camunda.search.clients.query.SearchQuery;
@@ -30,12 +30,12 @@ public class RoleFilterTransformer extends IndexFilterTransformer<RoleFilter> {
         term(RoleIndex.JOIN, IdentityJoinRelationshipType.ROLE.getType()),
         filter.roleKey() == null ? null : term(RoleIndex.KEY, filter.roleKey()),
         filter.name() == null ? null : term(RoleIndex.NAME, filter.name()),
-        filter.memberKeys() == null
+        filter.memberIds() == null
             ? null
-            : filter.memberKeys().isEmpty()
+            : filter.memberIds().isEmpty()
                 ? matchNone()
                 : hasChildQuery(
                     IdentityJoinRelationshipType.MEMBER.getType(),
-                    longTerms(RoleIndex.MEMBER_KEY, filter.memberKeys())));
+                    stringTerms(RoleIndex.MEMBER_ID, filter.memberIds())));
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/RoleEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/RoleEntity.java
@@ -12,7 +12,7 @@ import java.io.Serializable;
 import java.util.Set;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record RoleEntity(Long roleKey, String name, Set<Long> assignedMemberKeys)
+public record RoleEntity(Long roleKey, String name, Set<String> assignedMemberKeys)
     implements Serializable {
   public RoleEntity(final Long roleKey, final String name) {
     this(roleKey, name, Set.of());

--- a/search/search-domain/src/main/java/io/camunda/search/filter/RoleFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/RoleFilter.java
@@ -10,15 +10,15 @@ package io.camunda.search.filter;
 import io.camunda.util.ObjectBuilder;
 import java.util.Set;
 
-public record RoleFilter(Long roleKey, String name, Set<Long> memberKeys) implements FilterBase {
+public record RoleFilter(Long roleKey, String name, Set<String> memberIds) implements FilterBase {
   public Builder toBuilder() {
-    return new Builder().roleKey(roleKey).name(name).memberKeys(memberKeys);
+    return new Builder().roleKey(roleKey).name(name).memberIds(memberIds);
   }
 
   public static final class Builder implements ObjectBuilder<RoleFilter> {
     private Long roleKey;
     private String name;
-    private Set<Long> memberKeys;
+    private Set<String> memberIds;
 
     public Builder roleKey(final Long value) {
       roleKey = value;
@@ -30,18 +30,18 @@ public record RoleFilter(Long roleKey, String name, Set<Long> memberKeys) implem
       return this;
     }
 
-    public Builder memberKeys(final Set<Long> value) {
-      memberKeys = value;
+    public Builder memberIds(final Set<String> value) {
+      memberIds = value;
       return this;
     }
 
-    public Builder memberKey(final Long... values) {
-      return memberKeys(Set.of(values));
+    public Builder memberIds(final String... values) {
+      return memberIds(Set.of(values));
     }
 
     @Override
     public RoleFilter build() {
-      return new RoleFilter(roleKey, name, memberKeys);
+      return new RoleFilter(roleKey, name, memberIds);
     }
   }
 }

--- a/service/src/main/java/io/camunda/service/RoleServices.java
+++ b/service/src/main/java/io/camunda/service/RoleServices.java
@@ -52,13 +52,14 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
         .searchRoles(query);
   }
 
-  public SearchQueryResult<RoleEntity> getMemberRoles(final long memberKey, final RoleQuery query) {
+  public SearchQueryResult<RoleEntity> getMemberRoles(
+      final String memberId, final RoleQuery query) {
     return search(
-        query.toBuilder().filter(query.filter().toBuilder().memberKey(memberKey).build()).build());
+        query.toBuilder().filter(query.filter().toBuilder().memberIds(memberId).build()).build());
   }
 
-  public List<RoleEntity> getRolesByMemberKeys(final Set<Long> memberKeys) {
-    return findAll(RoleQuery.of(q -> q.filter(f -> f.memberKeys(memberKeys))));
+  public List<RoleEntity> getRolesByMemberIds(final Set<String> memberIds) {
+    return findAll(RoleQuery.of(q -> q.filter(f -> f.memberIds(memberIds))));
   }
 
   public List<RoleEntity> findAll(final RoleQuery query) {
@@ -125,11 +126,11 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
   }
 
   public CompletableFuture<?> removeMember(
-      final Long roleKey, final EntityType entityType, final long entityKey) {
+      final Long roleKey, final EntityType entityType, final String entityId) {
     return sendBrokerRequest(
         BrokerRoleEntityRequest.createRemoveRequest()
             .setRoleId(String.valueOf(roleKey))
-            .setEntity(entityType, String.valueOf(entityKey)));
+            .setEntity(entityType, entityId));
   }
 
   public record CreateRoleRequest(String roleId, String name, String description) {}

--- a/service/src/test/java/io/camunda/service/RoleServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RoleServicesTest.java
@@ -169,10 +169,10 @@ public class RoleServicesTest {
   public void shouldRemoveUserFromRole() {
     // given
     final var roleKey = 100L;
-    final var entityKey = 42;
+    final var entityId = "entityId";
 
     // when
-    services.removeMember(roleKey, EntityType.USER, entityKey);
+    services.removeMember(roleKey, EntityType.USER, entityId);
 
     // then
     final BrokerRoleEntityRequest request = stubbedBrokerClient.getSingleBrokerRequest();
@@ -180,20 +180,20 @@ public class RoleServicesTest {
     assertThat(request.getValueType()).isEqualTo(ValueType.ROLE);
     final RoleRecord brokerRequestValue = request.getRequestWriter();
     assertThat(brokerRequestValue.getRoleId()).isEqualTo(String.valueOf(roleKey));
-    assertThat(brokerRequestValue.getEntityId()).isEqualTo(String.valueOf(entityKey));
+    assertThat(brokerRequestValue.getEntityId()).isEqualTo(String.valueOf(entityId));
     assertThat(brokerRequestValue.getEntityType()).isEqualTo(EntityType.USER);
   }
 
   @Test
-  public void shouldGetAllRolesByMemberKey() {
+  public void shouldGetAllRolesByMemberId() {
     // given
-    final var memberKey = 100L;
+    final var memberId = "memberId";
     final var roleEntity = mock(RoleEntity.class);
-    when(client.findAllRoles(RoleQuery.of(q -> q.filter(f -> f.memberKey(memberKey)))))
+    when(client.findAllRoles(RoleQuery.of(q -> q.filter(f -> f.memberIds(memberId)))))
         .thenReturn(List.of(roleEntity));
 
     // when
-    final var result = services.findAll(RoleQuery.of(q -> q.filter(f -> f.memberKey(memberKey))));
+    final var result = services.findAll(RoleQuery.of(q -> q.filter(f -> f.memberIds(memberId))));
 
     // then
     assertThat(result).isEqualTo(List.of(roleEntity));

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/RoleIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/index/RoleIndex.java
@@ -19,7 +19,7 @@ public class RoleIndex extends AbstractIndexDescriptor implements Prio5Backup {
 
   public static final String KEY = "key";
   public static final String NAME = "name";
-  public static final String MEMBER_KEY = "memberKey";
+  public static final String MEMBER_ID = "memberId";
   public static final String JOIN = "join";
 
   public static final EntityJoinRelationFactory<Long> JOIN_RELATION_FACTORY =

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleEntity.java
@@ -13,7 +13,7 @@ public class RoleEntity extends AbstractExporterEntity<RoleEntity> {
 
   private Long key;
   private String name;
-  private Long memberKey;
+  private String memberId;
   private EntityJoinRelation<Long> join;
 
   public Long getKey() {
@@ -34,12 +34,12 @@ public class RoleEntity extends AbstractExporterEntity<RoleEntity> {
     return this;
   }
 
-  public Long getMemberKey() {
-    return memberKey;
+  public String getMemberId() {
+    return memberId;
   }
 
-  public RoleEntity setMemberKey(final Long memberKey) {
-    this.memberKey = memberKey;
+  public RoleEntity setMemberId(final String memberId) {
+    this.memberId = memberId;
     return this;
   }
 
@@ -52,7 +52,7 @@ public class RoleEntity extends AbstractExporterEntity<RoleEntity> {
     return this;
   }
 
-  public static String getChildKey(final long roleKey, final long memberKey) {
-    return "%d-%d".formatted(roleKey, memberKey);
+  public static String getChildKey(final long roleKey, final String memberId) {
+    return "%d-%s".formatted(roleKey, memberId);
   }
 }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-role.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-role.json
@@ -11,8 +11,8 @@
       "name": {
         "type": "keyword"
       },
-      "memberKey": {
-        "type": "long"
+      "memberId": {
+        "type": "keyword"
       },
       "join": {
         "type": "join",

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-role.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-role.json
@@ -11,8 +11,8 @@
       "name": {
         "type": "keyword"
       },
-      "memberKey": {
-        "type": "long"
+      "memberId": {
+        "type": "keyword"
       },
       "join": {
         "type": "join",

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
@@ -122,6 +122,7 @@ public class MappingDeleteProcessor implements DistributedTypedRecordProcessor<M
 
   private void deleteMapping(final PersistedMapping mapping) {
     final var mappingKey = mapping.getMappingKey();
+    final var mappingId = mapping.getMappingId();
     deleteAuthorizations(mappingKey);
     for (final var tenantId : mapping.getTenantIdsList()) {
       final var tenant = tenantState.getTenantById(tenantId).orElseThrow();
@@ -140,7 +141,7 @@ public class MappingDeleteProcessor implements DistributedTypedRecordProcessor<M
           RoleIntent.ENTITY_REMOVED,
           new RoleRecord()
               .setRoleKey(roleKey)
-              .setEntityKey(mappingKey)
+              .setEntityId(mappingId)
               .setEntityType(EntityType.MAPPING));
     }
     for (final var groupKey : mapping.getGroupKeysList()) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
@@ -126,21 +126,18 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
           stateWriter.appendFollowUpEvent(
               roleKey,
               RoleIntent.ENTITY_REMOVED,
-              new RoleRecord()
-                  .setRoleKey(roleKey)
-                  .setEntityType(entityType)
-                  .setEntityKey(Long.parseLong(entityId)));
+              new RoleRecord().setRoleKey(roleKey).setEntityType(entityType).setEntityId(entityId));
         });
     roleState
         .getEntitiesByType(roleKey)
         .forEach(
-            (entityType, entityKeys) -> {
-              entityKeys.forEach(
-                  entityKey -> {
+            (entityType, entityIds) -> {
+              entityIds.forEach(
+                  entityId -> {
                     final var entityRecord =
                         new RoleRecord()
                             .setRoleKey(roleKey)
-                            .setEntityKey(entityKey)
+                            .setEntityId(entityId)
                             .setEntityType(entityType);
                     stateWriter.appendFollowUpEvent(
                         roleKey, RoleIntent.ENTITY_REMOVED, entityRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
@@ -157,7 +157,7 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
           new RoleRecord()
               .setRoleKey(role.getRoleKey())
               .setRoleId(roleId)
-              .setEntityKey(userKey)
+              .setEntityId(username)
               .setEntityType(EntityType.USER));
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleEntityAddedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleEntityAddedApplier.java
@@ -35,20 +35,19 @@ public class RoleEntityAddedApplier implements TypedEventApplier<RoleIntent, Rol
       case USER ->
           membershipState.insertRelation(
               EntityType.USER,
-              // TODO: Use entity id instead of key
-              Long.toString(value.getEntityKey()),
+              value.getEntityId(),
               RelationType.ROLE,
               // TODO: Use role id instead of key
               Long.toString(value.getRoleKey()));
       case MAPPING -> {
         roleState.addEntity(value);
-        mappingState.addRole(value.getEntityKey(), value.getRoleKey());
+        mappingState.addRole(value.getEntityId(), value.getRoleKey());
       }
       default ->
           throw new IllegalStateException(
               String.format(
-                  "Expected to add entity '%d' to role '%d', but entities of type '%s' cannot be added to roles",
-                  value.getEntityKey(), value.getRoleKey(), value.getEntityType()));
+                  "Expected to add entity '%s' to role '%d', but entities of type '%s' cannot be added to roles",
+                  value.getEntityId(), value.getRoleKey(), value.getEntityType()));
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleEntityRemovedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleEntityRemovedApplier.java
@@ -35,20 +35,19 @@ public class RoleEntityRemovedApplier implements TypedEventApplier<RoleIntent, R
       case USER ->
           membershipState.deleteRelation(
               EntityType.USER,
-              // TODO: Use entity id instead of key
-              Long.toString(value.getEntityKey()),
+              value.getEntityId(),
               RelationType.ROLE,
               // TODO: Use role id instead of key
               Long.toString(value.getRoleKey()));
       case MAPPING -> {
-        roleState.removeEntity(value.getRoleKey(), value.getEntityKey());
-        mappingState.removeRole(value.getEntityKey(), value.getRoleKey());
+        roleState.removeEntity(value.getRoleKey(), value.getEntityId());
+        mappingState.removeRole(value.getEntityId(), value.getRoleKey());
       }
       default ->
           throw new IllegalStateException(
               String.format(
-                  "Expected to remove entity '%d' from role '%d', but entities of type '%s' cannot be removed from roles",
-                  value.getEntityKey(), value.getRoleKey(), value.getEntityType()));
+                  "Expected to remove entity '%s' from role '%d', but entities of type '%s' cannot be removed from roles",
+                  value.getEntityId(), value.getRoleKey(), value.getEntityType()));
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
@@ -115,9 +115,9 @@ public class DbMappingState implements MutableMappingState {
   }
 
   @Override
-  public void addRole(final long mappingKey, final long roleKey) {
-    this.mappingKey.wrapLong(mappingKey);
-    final var fkClaim = claimByKeyColumnFamily.get(this.mappingKey);
+  public void addRole(final String mappingId, final long roleKey) {
+    this.mappingId.wrapString(mappingId);
+    final var fkClaim = claimByIdColumnFamily.get(this.mappingId);
     if (fkClaim != null) {
       final var claim = fkClaim.inner();
       final var persistedMapping = mappingColumnFamily.get(claim);
@@ -151,9 +151,9 @@ public class DbMappingState implements MutableMappingState {
   }
 
   @Override
-  public void removeRole(final long mappingKey, final long roleKey) {
-    this.mappingKey.wrapLong(mappingKey);
-    final var fkClaim = claimByKeyColumnFamily.get(this.mappingKey);
+  public void removeRole(final String mappingId, final long roleKey) {
+    this.mappingId.wrapString(mappingId);
+    final var fkClaim = claimByIdColumnFamily.get(this.mappingId);
     if (fkClaim != null) {
       final var claim = fkClaim.inner();
       final var persistedMapping = mappingColumnFamily.get(claim);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbRoleState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbRoleState.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbCompositeKey;
 import io.camunda.zeebe.db.impl.DbForeignKey;
-import io.camunda.zeebe.db.impl.DbLong;
 import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.engine.state.mutable.MutableRoleState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
@@ -31,10 +30,10 @@ public class DbRoleState implements MutableRoleState {
   private final ColumnFamily<DbString, PersistedRole> roleColumnFamily;
 
   private final DbForeignKey<DbString> fkRoleId;
-  private final DbLong entityKey;
-  private final DbCompositeKey<DbForeignKey<DbString>, DbLong> fkRoleIdAndEntityKey;
+  private final DbString entityId = new DbString();
+  private final DbCompositeKey<DbForeignKey<DbString>, DbString> fkRoleIdAndEntityKey;
   private final EntityTypeValue entityTypeValue = new EntityTypeValue();
-  private final ColumnFamily<DbCompositeKey<DbForeignKey<DbString>, DbLong>, EntityTypeValue>
+  private final ColumnFamily<DbCompositeKey<DbForeignKey<DbString>, DbString>, EntityTypeValue>
       entityTypeByRoleColumnFamily;
 
   public DbRoleState(
@@ -45,8 +44,7 @@ public class DbRoleState implements MutableRoleState {
             ZbColumnFamilies.ROLES, transactionContext, roleId, new PersistedRole());
 
     fkRoleId = new DbForeignKey<>(roleId, ZbColumnFamilies.ROLES);
-    entityKey = new DbLong();
-    fkRoleIdAndEntityKey = new DbCompositeKey<>(fkRoleId, entityKey);
+    fkRoleIdAndEntityKey = new DbCompositeKey<>(fkRoleId, entityId);
     entityTypeByRoleColumnFamily =
         zeebeDb.createColumnFamily(
             ZbColumnFamilies.ENTITY_BY_ROLE,
@@ -76,15 +74,15 @@ public class DbRoleState implements MutableRoleState {
   @Override
   public void addEntity(final RoleRecord roleRecord) {
     roleId.wrapString(String.valueOf(roleRecord.getRoleKey()));
-    entityKey.wrapLong(roleRecord.getEntityKey());
+    entityId.wrapString(roleRecord.getEntityId());
     entityTypeValue.setEntityType(roleRecord.getEntityType());
     entityTypeByRoleColumnFamily.insert(fkRoleIdAndEntityKey, entityTypeValue);
   }
 
   @Override
-  public void removeEntity(final long roleKey, final long entityKey) {
+  public void removeEntity(final long roleKey, final String entityId) {
     roleId.wrapString(String.valueOf(roleKey));
-    this.entityKey.wrapLong(entityKey);
+    this.entityId.wrapString(entityId);
     entityTypeByRoleColumnFamily.deleteExisting(fkRoleIdAndEntityKey);
   }
 
@@ -115,24 +113,24 @@ public class DbRoleState implements MutableRoleState {
   }
 
   @Override
-  public Optional<EntityType> getEntityType(final long roleKey, final long entityKey) {
+  public Optional<EntityType> getEntityType(final long roleKey, final String entityId) {
     roleId.wrapString(String.valueOf(roleKey));
-    this.entityKey.wrapLong(entityKey);
+    this.entityId.wrapString(entityId);
     final var result = entityTypeByRoleColumnFamily.get(fkRoleIdAndEntityKey);
     return Optional.ofNullable(result).map(EntityTypeValue::getEntityType);
   }
 
   @Override
-  public Map<EntityType, List<Long>> getEntitiesByType(final long roleKey) {
-    final Map<EntityType, List<Long>> entitiesMap = new HashMap<>();
+  public Map<EntityType, List<String>> getEntitiesByType(final long roleKey) {
+    final Map<EntityType, List<String>> entitiesMap = new HashMap<>();
     roleId.wrapString(String.valueOf(roleKey));
     entityTypeByRoleColumnFamily.whileEqualPrefix(
         fkRoleId,
         (compositeKey, entityTypeValue) -> {
           final var entityType = entityTypeValue.getEntityType();
-          final var entityKey = compositeKey.second().getValue();
+          final var entityId = compositeKey.second().toString();
           entitiesMap.putIfAbsent(entityType, new ArrayList<>());
-          entitiesMap.get(entityType).add(entityKey);
+          entitiesMap.get(entityType).add(entityId);
         });
     return entitiesMap;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/RoleState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/RoleState.java
@@ -19,7 +19,7 @@ public interface RoleState {
 
   Optional<PersistedRole> getRole(String roleId);
 
-  Optional<EntityType> getEntityType(long roleKey, long entityKey);
+  Optional<EntityType> getEntityType(long roleKey, String entityId);
 
-  Map<EntityType, List<Long>> getEntitiesByType(long roleKey);
+  Map<EntityType, List<String>> getEntitiesByType(long roleKey);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMappingState.java
@@ -16,13 +16,13 @@ public interface MutableMappingState extends MappingState {
 
   void update(MappingRecord mappingRecord);
 
-  void addRole(final long mappingKey, final long roleKey);
+  void addRole(final String mappingId, final long roleKey);
 
   void addTenant(final String mappingId, final String tenantId);
 
   void addGroup(final long mappingKey, final long groupKey);
 
-  void removeRole(final long mappingKey, final long roleKey);
+  void removeRole(final String mappingId, final long roleKey);
 
   void removeTenant(final long mappingKey, final String tenantId);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableRoleState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableRoleState.java
@@ -18,7 +18,7 @@ public interface MutableRoleState extends RoleState {
 
   void addEntity(final RoleRecord roleRecord);
 
-  void removeEntity(final long roleKey, final long entityKey);
+  void removeEntity(final long roleKey, final String entityId);
 
   void delete(final RoleRecord roleRecord);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -175,7 +175,7 @@ final class AuthorizationCheckBehaviorTest {
   void shouldBeAuthorizedWhenRoleHasPermissions() {
     // given
     final var user = createUser();
-    final var roleKey = createRole(user.getUserKey(), EntityType.USER);
+    final var roleKey = createRole(user.getUsername(), EntityType.USER);
     final var roleId = String.valueOf(roleKey);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
@@ -196,7 +196,7 @@ final class AuthorizationCheckBehaviorTest {
   void shouldGetResourceIdentifiersWhenRoleHasPermissions() {
     // given
     final var user = createUser();
-    final var roleKey = createRole(user.getUserKey(), EntityType.USER);
+    final var roleKey = createRole(user.getUsername(), EntityType.USER);
     final var roleId = String.valueOf(roleKey);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
@@ -347,8 +347,8 @@ final class AuthorizationCheckBehaviorTest {
     // given
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
-    final var mappingKey = createMapping(claimName, claimValue).getMappingKey();
-    final var roleKey = createRole(mappingKey, EntityType.MAPPING);
+    final var mappingId = createMapping(claimName, claimValue).getMappingId();
+    final var roleKey = createRole(mappingId, EntityType.MAPPING);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
@@ -519,8 +519,8 @@ final class AuthorizationCheckBehaviorTest {
     final var claimName = UUID.randomUUID().toString();
     final var claimValue = UUID.randomUUID().toString();
     final var mapping = createMapping(claimName, claimValue);
-    final var mappingKey = mapping.getMappingKey();
-    final var roleKey = createRole(mappingKey, EntityType.MAPPING);
+    final var mappingId = mapping.getMappingId();
+    final var roleKey = createRole(mappingId, EntityType.MAPPING);
     final var resourceType = AuthorizationResourceType.RESOURCE;
     final var permissionType = PermissionType.CREATE;
     final var resourceId = UUID.randomUUID().toString();
@@ -592,7 +592,7 @@ final class AuthorizationCheckBehaviorTest {
     return user;
   }
 
-  private long createRole(final long entityKey, final EntityType entityType) {
+  private long createRole(final String entityId, final EntityType entityType) {
     final var roleKey = random.nextLong();
     final var role =
         new RoleRecord()
@@ -600,7 +600,7 @@ final class AuthorizationCheckBehaviorTest {
             .setRoleId(Strings.newRandomValidIdentityId())
             .setName(UUID.randomUUID().toString())
             .setDescription(UUID.randomUUID().toString())
-            .setEntityKey(entityKey)
+            .setEntityId(entityId)
             .setEntityType(entityType);
     roleCreatedApplier.applyState(roleKey, role);
     roleEntityAddedApplier.applyState(roleKey, role);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
@@ -104,7 +104,7 @@ public class IdentitySetupInitializeTest {
         .hasTenantKey(tenantKey)
         .hasName(tenantName)
         .hasTenantId(tenantId);
-    assertThatEntityIsAssignedToRole(roleKey, userKey, EntityType.USER);
+    assertThatEntityIsAssignedToRole(roleKey, username, EntityType.USER);
     assertThatAllPermissionsAreAddedToRole(roleKey);
   }
 
@@ -139,7 +139,7 @@ public class IdentitySetupInitializeTest {
     // then
     assertUserIsNotCreated(initializeRecord.getSourceRecordPosition());
     assertThatEntityIsAssignedToRole(
-        initializeRecord.getValue().getDefaultRole().getRoleKey(), userKey, EntityType.USER);
+        initializeRecord.getValue().getDefaultRole().getRoleKey(), username, EntityType.USER);
   }
 
   @Test
@@ -166,7 +166,7 @@ public class IdentitySetupInitializeTest {
     // then
     assertRoleIsNotCreated(initializeRecord.getSourceRecordPosition());
     assertThatEntityIsAssignedToRole(
-        roleKey, initializeRecord.getValue().getUsers().getFirst().getUserKey(), EntityType.USER);
+        roleKey, initializeRecord.getValue().getUsers().getFirst().getUsername(), EntityType.USER);
     Assertions.assertThat(
             RecordingExporter.records()
                 .limit(r -> r.getIntent() == IdentitySetupIntent.INITIALIZED)
@@ -232,7 +232,7 @@ public class IdentitySetupInitializeTest {
     // then
     assertRoleIsNotCreated(initializeRecord.getSourceRecordPosition());
     assertUserIsNotCreated(initializeRecord.getSourceRecordPosition());
-    assertThatEntityIsAssignedToRole(roleKey, userKey, EntityType.USER);
+    assertThatEntityIsAssignedToRole(roleKey, username, EntityType.USER);
   }
 
   @Test
@@ -261,7 +261,7 @@ public class IdentitySetupInitializeTest {
             .withEmail(mail)
             .create()
             .getKey();
-    engine.role().addEntity(roleKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+    engine.role().addEntity(roleKey).withEntityId(username).withEntityType(EntityType.USER).add();
 
     // when
     final var initializeRecord =
@@ -350,12 +350,12 @@ public class IdentitySetupInitializeTest {
             m1 ->
                 assertThatEntityIsAssignedToRole(
                     initialized.getDefaultRole().getRoleKey(),
-                    m1.getMappingKey(),
+                    m1.getMappingId(),
                     EntityType.MAPPING),
             m2 ->
                 assertThatEntityIsAssignedToRole(
                     initialized.getDefaultRole().getRoleKey(),
-                    m2.getMappingKey(),
+                    m2.getMappingId(),
                     EntityType.MAPPING));
   }
 
@@ -435,13 +435,13 @@ public class IdentitySetupInitializeTest {
   }
 
   private void assertThatEntityIsAssignedToRole(
-      final long roleKey, final long entityKey, final EntityType entityType) {
+      final long roleKey, final String entityId, final EntityType entityType) {
     final var roleRecord =
-        RecordingExporter.roleRecords(RoleIntent.ENTITY_ADDED).withEntityKey(entityKey).getFirst();
+        RecordingExporter.roleRecords(RoleIntent.ENTITY_ADDED).withEntityId(entityId).getFirst();
     Assertions.assertThat(roleRecord.getKey()).isEqualTo(roleKey);
     assertThat(roleRecord.getValue())
         .hasRoleKey(roleKey)
-        .hasEntityKey(entityKey)
+        .hasEntityId(entityId)
         .hasEntityType(entityType);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -432,7 +432,7 @@ public class CommandDistributionIdempotencyTest {
                   return ENGINE
                       .role()
                       .addEntity(role.getKey())
-                      .withEntityKey(user.getKey())
+                      .withEntityId(user.getValue().getUsername())
                       .withEntityType(EntityType.USER)
                       .add();
                 }),
@@ -449,13 +449,13 @@ public class CommandDistributionIdempotencyTest {
                   ENGINE
                       .role()
                       .addEntity(role.getKey())
-                      .withEntityKey(user.getKey())
+                      .withEntityId(user.getValue().getUsername())
                       .withEntityType(EntityType.USER)
                       .add();
                   return ENGINE
                       .role()
                       .removeEntity(role.getKey())
-                      .withEntityKey(user.getKey())
+                      .withEntityId(user.getValue().getUsername())
                       .withEntityType(EntityType.USER)
                       .remove();
                 }),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/mapping/MappingTest.java
@@ -250,7 +250,7 @@ public class MappingTest {
     engine
         .role()
         .addEntity(role.getKey())
-        .withEntityKey(mappingRecord.getKey())
+        .withEntityId(mappingRecord.getValue().getMappingId())
         .withEntityType(EntityType.MAPPING)
         .add();
 
@@ -267,7 +267,7 @@ public class MappingTest {
     Assertions.assertThat(
             RecordingExporter.roleRecords(RoleIntent.ENTITY_REMOVED)
                 .withRoleKey(role.getKey())
-                .withEntityKey(mappingRecord.getKey())
+                .withEntityId(mappingRecord.getValue().getMappingId())
                 .exists())
         .isTrue();
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/AddEntityRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/AddEntityRoleMultiPartitionTest.java
@@ -40,7 +40,7 @@ public class AddEntityRoleMultiPartitionTest {
   @Test
   public void shouldDistributeRoleAddEntityCommand() {
     // when
-    final var userKey =
+    final var userName =
         engine
             .user()
             .newUser("foo")
@@ -48,10 +48,11 @@ public class AddEntityRoleMultiPartitionTest {
             .withName("Foo Bar")
             .withPassword("zabraboof")
             .create()
-            .getKey();
+            .getValue()
+            .getUsername();
     final var name = UUID.randomUUID().toString();
     final var roleKey = engine.role().newRole(name).create().getValue().getRoleKey();
-    engine.role().addEntity(roleKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+    engine.role().addEntity(roleKey).withEntityId(userName).withEntityType(EntityType.USER).add();
 
     assertThat(
             RecordingExporter.records()
@@ -102,7 +103,7 @@ public class AddEntityRoleMultiPartitionTest {
   @Test
   public void shouldDistributeInIdentityQueue() {
     // when
-    final var userKey =
+    final var userName =
         engine
             .user()
             .newUser("foo")
@@ -110,10 +111,11 @@ public class AddEntityRoleMultiPartitionTest {
             .withName("Foo Bar")
             .withPassword("zabraboof")
             .create()
-            .getKey();
+            .getValue()
+            .getUsername();
     final var name = UUID.randomUUID().toString();
     final var roleKey = engine.role().newRole(name).create().getValue().getRoleKey();
-    engine.role().addEntity(roleKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+    engine.role().addEntity(roleKey).withEntityId(userName).withEntityType(EntityType.USER).add();
 
     // then
     assertThat(
@@ -130,7 +132,7 @@ public class AddEntityRoleMultiPartitionTest {
     for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       interceptUserCreateForPartition(partitionId);
     }
-    final var userKey =
+    final var username =
         engine
             .user()
             .newUser("foo")
@@ -138,12 +140,13 @@ public class AddEntityRoleMultiPartitionTest {
             .withName("Foo Bar")
             .withPassword("zabraboof")
             .create()
-            .getKey();
+            .getValue()
+            .getUsername();
 
     // when
     final var name = UUID.randomUUID().toString();
     final var roleKey = engine.role().newRole(name).create().getValue().getRoleKey();
-    engine.role().addEntity(roleKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+    engine.role().addEntity(roleKey).withEntityId(username).withEntityType(EntityType.USER).add();
 
     // Increase time to trigger a redistribution
     engine.increaseTime(Duration.ofMinutes(1));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RemoveEntityRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RemoveEntityRoleMultiPartitionTest.java
@@ -40,7 +40,7 @@ public class RemoveEntityRoleMultiPartitionTest {
   @Test
   public void shouldDistributeRoleRemoveEntityCommand() {
     // when
-    final var userKey =
+    final var username =
         engine
             .user()
             .newUser("foo")
@@ -48,14 +48,15 @@ public class RemoveEntityRoleMultiPartitionTest {
             .withName("Foo Bar")
             .withPassword("zabraboof")
             .create()
-            .getKey();
+            .getValue()
+            .getUsername();
     final var name = UUID.randomUUID().toString();
     final var roleKey = engine.role().newRole(name).create().getValue().getRoleKey();
-    engine.role().addEntity(roleKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+    engine.role().addEntity(roleKey).withEntityId(username).withEntityType(EntityType.USER).add();
     engine
         .role()
         .removeEntity(roleKey)
-        .withEntityKey(userKey)
+        .withEntityId(username)
         .withEntityType(EntityType.USER)
         .remove();
 
@@ -108,7 +109,7 @@ public class RemoveEntityRoleMultiPartitionTest {
   @Test
   public void shouldDistributeInIdentityQueue() {
     // when
-    final var userKey =
+    final var username =
         engine
             .user()
             .newUser("foo")
@@ -116,14 +117,15 @@ public class RemoveEntityRoleMultiPartitionTest {
             .withName("Foo Bar")
             .withPassword("zabraboof")
             .create()
-            .getKey();
+            .getValue()
+            .getUsername();
     final var name = UUID.randomUUID().toString();
     final var roleKey = engine.role().newRole(name).create().getValue().getRoleKey();
-    engine.role().addEntity(roleKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+    engine.role().addEntity(roleKey).withEntityId(username).withEntityType(EntityType.USER).add();
     engine
         .role()
         .removeEntity(roleKey)
-        .withEntityKey(userKey)
+        .withEntityId(username)
         .withEntityType(EntityType.USER)
         .remove();
 
@@ -142,7 +144,7 @@ public class RemoveEntityRoleMultiPartitionTest {
     for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       interceptUserCreateForPartition(partitionId);
     }
-    final var userKey =
+    final var username =
         engine
             .user()
             .newUser("foo")
@@ -150,16 +152,17 @@ public class RemoveEntityRoleMultiPartitionTest {
             .withName("Foo Bar")
             .withPassword("zabraboof")
             .create()
-            .getKey();
+            .getValue()
+            .getUsername();
 
     // when
     final var name = UUID.randomUUID().toString();
     final var roleKey = engine.role().newRole(name).create().getValue().getRoleKey();
-    engine.role().addEntity(roleKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+    engine.role().addEntity(roleKey).withEntityId(username).withEntityType(EntityType.USER).add();
     engine
         .role()
         .removeEntity(roleKey)
-        .withEntityKey(userKey)
+        .withEntityId(username)
         .withEntityType(EntityType.USER)
         .remove();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/role/RoleTest.java
@@ -99,7 +99,7 @@ public class RoleTest {
   @Test
   @Ignore("https://github.com/camunda/camunda/issues/30116")
   public void shouldAddEntityToRole() {
-    final var userKey =
+    final var username =
         engine
             .user()
             .newUser("foo")
@@ -107,21 +107,22 @@ public class RoleTest {
             .withName("Foo Bar")
             .withPassword("zabraboof")
             .create()
-            .getKey();
+            .getValue()
+            .getUsername();
     final var name = UUID.randomUUID().toString();
     final var roleKey = engine.role().newRole(name).create().getValue().getRoleKey();
     final var updatedRole =
         engine
             .role()
             .addEntity(roleKey)
-            .withEntityKey(userKey)
+            .withEntityId(username)
             .withEntityType(EntityType.USER)
             .add()
             .getValue();
 
     Assertions.assertThat(updatedRole)
         .isNotNull()
-        .hasFieldOrPropertyWithValue("entityKey", userKey)
+        .hasFieldOrPropertyWithValue("entityId", username)
         .hasFieldOrPropertyWithValue("entityType", EntityType.USER);
   }
 
@@ -162,7 +163,7 @@ public class RoleTest {
         engine
             .role()
             .addEntity(roleKey)
-            .withEntityKey(1L)
+            .withEntityId("entityId")
             .withEntityType(EntityType.USER)
             .expectRejection()
             .add();
@@ -172,8 +173,8 @@ public class RoleTest {
     assertThat(notPresentUpdateRecord)
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
-            "Expected to add an entity with key '%s' and type '%s' to role with key '%s', but the entity doesn't exist."
-                .formatted(1L, EntityType.USER, roleKey));
+            "Expected to add an entity with id '%s' and type '%s' to role with key '%s', but the entity doesn't exist."
+                .formatted("entityId", EntityType.USER, roleKey));
   }
 
   @Test
@@ -183,7 +184,7 @@ public class RoleTest {
     final var name = UUID.randomUUID().toString();
     final var roleRecord = engine.role().newRole(name).create();
     final var roleKey = roleRecord.getValue().getRoleKey();
-    final var userKey =
+    final var username =
         engine
             .user()
             .newUser("foo")
@@ -191,15 +192,16 @@ public class RoleTest {
             .withName("Foo Bar")
             .withPassword("zabraboof")
             .create()
-            .getKey();
-    engine.role().addEntity(roleKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+            .getValue()
+            .getUsername();
+    engine.role().addEntity(roleKey).withEntityId(username).withEntityType(EntityType.USER).add();
 
     // when
     final var notPresentUpdateRecord =
         engine
             .role()
             .addEntity(roleKey)
-            .withEntityKey(userKey)
+            .withEntityId(username)
             .withEntityType(EntityType.USER)
             .expectRejection()
             .add();
@@ -208,14 +210,14 @@ public class RoleTest {
     assertThat(notPresentUpdateRecord)
         .hasRejectionType(RejectionType.ALREADY_EXISTS)
         .hasRejectionReason(
-            "Expected to add entity with key '%d' to role with key '%d', but the entity is already assigned to this role."
-                .formatted(userKey, roleKey));
+            "Expected to add entity with id '%s' to role with key '%d', but the entity is already assigned to this role."
+                .formatted(username, roleKey));
   }
 
   @Test
   @Ignore("https://github.com/camunda/camunda/issues/30117")
   public void shouldRemoveEntityFromRole() {
-    final var userKey =
+    final var username =
         engine
             .user()
             .newUser("foo")
@@ -223,15 +225,16 @@ public class RoleTest {
             .withName("Foo Bar")
             .withPassword("zabraboof")
             .create()
-            .getKey();
+            .getValue()
+            .getUsername();
     final var name = UUID.randomUUID().toString();
     final var roleKey = engine.role().newRole(name).create().getValue().getRoleKey();
-    engine.role().addEntity(roleKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+    engine.role().addEntity(roleKey).withEntityId(username).withEntityType(EntityType.USER).add();
     final var removedEntity =
         engine
             .role()
             .removeEntity(roleKey)
-            .withEntityKey(userKey)
+            .withEntityId(username)
             .withEntityType(EntityType.USER)
             .remove()
             .getValue();
@@ -239,7 +242,7 @@ public class RoleTest {
     Assertions.assertThat(removedEntity)
         .isNotNull()
         .hasFieldOrPropertyWithValue("roleKey", roleKey)
-        .hasFieldOrPropertyWithValue("entityKey", userKey)
+        .hasFieldOrPropertyWithValue("entityId", username)
         .hasFieldOrPropertyWithValue("entityType", EntityType.USER);
   }
 
@@ -280,7 +283,7 @@ public class RoleTest {
         engine
             .role()
             .removeEntity(roleKey)
-            .withEntityKey(1L)
+            .withEntityId("entityId")
             .withEntityType(EntityType.USER)
             .expectRejection()
             .remove();
@@ -290,8 +293,8 @@ public class RoleTest {
     assertThat(notPresentUpdateRecord)
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
-            "Expected to remove an entity with key '%s' and type '%s' from role with key '%s', but the entity doesn't exist."
-                .formatted(1L, EntityType.USER, roleKey));
+            "Expected to remove an entity with id '%s' and type '%s' from role with key '%s', but the entity doesn't exist."
+                .formatted("entityId", EntityType.USER, roleKey));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserTest.java
@@ -74,7 +74,7 @@ public class DeleteUserTest {
     ENGINE
         .role()
         .addEntity(role.getKey())
-        .withEntityKey(userRecord.getKey())
+        .withEntityId(userRecord.getValue().getUsername())
         .withEntityType(EntityType.USER)
         .add();
     ENGINE
@@ -97,7 +97,7 @@ public class DeleteUserTest {
     Assertions.assertThat(
             RecordingExporter.roleRecords(RoleIntent.ENTITY_REMOVED)
                 .withRoleKey(role.getKey())
-                .withEntityKey(userRecord.getKey())
+                .withEntityId(userRecord.getValue().getUsername())
                 .exists())
         .isTrue();
     Assertions.assertThat(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
@@ -133,11 +133,11 @@ public class MappingAppliersTest {
     mappingState.create(mappingRecord);
     // create role
     final long roleKey = 2L;
-    mappingState.addRole(mappingKey, roleKey);
+    mappingState.addRole(mappingId, roleKey);
     final var role =
         new RoleRecord()
             .setRoleKey(roleKey)
-            .setEntityKey(mappingKey)
+            .setEntityId(mappingId)
             .setEntityType(EntityType.MAPPING);
     roleState.create(role);
     roleState.addEntity(role);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/RoleAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/RoleAppliersTest.java
@@ -59,10 +59,9 @@ public class RoleAppliersTest {
   @Test
   void shouldAddEntityToRoleWithTypeUser() {
     // given
-    final long entityKey = 1L;
     userState.create(
         new UserRecord()
-            .setUserKey(entityKey)
+            .setUserKey(1L)
             .setUsername("username")
             .setName("Foo")
             .setEmail("foo@bar.com")
@@ -70,15 +69,13 @@ public class RoleAppliersTest {
     final long roleKey = 11L;
     final var roleRecord = new RoleRecord().setRoleKey(roleKey).setName("foo");
     roleState.create(roleRecord);
-    roleRecord.setEntityKey(entityKey).setEntityType(EntityType.USER);
+    roleRecord.setEntityId("username").setEntityType(EntityType.USER);
 
     // when
     roleEntityAddedApplier.applyState(roleKey, roleRecord);
 
     // then
-    assertThat(
-            membershipState.getMemberships(
-                EntityType.USER, Long.toString(entityKey), RelationType.ROLE))
+    assertThat(membershipState.getMemberships(EntityType.USER, "username", RelationType.ROLE))
         .singleElement()
         .isEqualTo(Long.toString(roleKey));
   }
@@ -86,24 +83,24 @@ public class RoleAppliersTest {
   @Test
   void shouldAddEntityToRoleWithTypeMapping() {
     // given
-    final long entityKey = 1L;
+    final var entityId = "entityId";
     mappingState.create(
         new MappingRecord()
-            .setMappingKey(entityKey)
+            .setMappingId(entityId)
             .setClaimName("claimName")
             .setClaimValue("claimValue"));
     final long roleKey = 11L;
     final var roleRecord = new RoleRecord().setRoleKey(roleKey).setName("foo");
     roleState.create(roleRecord);
-    roleRecord.setEntityKey(entityKey).setEntityType(EntityType.MAPPING);
+    roleRecord.setEntityId(entityId).setEntityType(EntityType.MAPPING);
 
     // when
     roleEntityAddedApplier.applyState(roleKey, roleRecord);
 
     // then
     assertThat(roleState.getEntitiesByType(roleKey).get(EntityType.MAPPING))
-        .containsExactly(entityKey);
-    final var persistedMapping = mappingState.get(entityKey).get();
+        .containsExactly(entityId);
+    final var persistedMapping = mappingState.get(entityId).get();
     assertThat(persistedMapping.getRoleKeysList()).containsExactly(roleKey);
   }
 
@@ -156,7 +153,7 @@ public class RoleAppliersTest {
     final long roleKey = 11L;
     final var roleRecord = new RoleRecord().setRoleKey(roleKey).setName("foo");
     roleState.create(roleRecord);
-    roleRecord.setEntityKey(userKey).setEntityType(EntityType.USER);
+    roleRecord.setEntityId(username).setEntityType(EntityType.USER);
     roleEntityAddedApplier.applyState(roleKey, roleRecord);
 
     // when
@@ -173,17 +170,17 @@ public class RoleAppliersTest {
   @Test
   void shouldRemoveEntityFromRoleWithTypeMapping() {
     // given
-    final long entityKey = 1L;
+    final var entityId = "entityId";
     mappingState.create(
         new MappingRecord()
-            .setMappingKey(entityKey)
+            .setMappingId(entityId)
             .setClaimName("claimName")
             .setClaimValue("claimValue"));
     final long roleKey = 11L;
-    mappingState.addRole(entityKey, 11L);
+    mappingState.addRole(entityId, 11L);
     final var roleRecord = new RoleRecord().setRoleKey(roleKey).setName("foo");
     roleState.create(roleRecord);
-    roleRecord.setEntityKey(entityKey).setEntityType(EntityType.MAPPING);
+    roleRecord.setEntityId(entityId).setEntityType(EntityType.MAPPING);
     roleState.addEntity(roleRecord);
 
     // when
@@ -191,7 +188,7 @@ public class RoleAppliersTest {
 
     // then
     assertThat(roleState.getEntitiesByType(roleKey)).isEmpty();
-    final var persistedMapping = mappingState.get(entityKey).get();
+    final var persistedMapping = mappingState.get(entityId).get();
     assertThat(persistedMapping.getRoleKeysList()).isEmpty();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingStateTest.java
@@ -133,53 +133,57 @@ public class MappingStateTest {
   @Test
   void shouldAddRole() {
     // given
-    final long key = 1L;
+    final String mappingId = Strings.newRandomValidIdentityId();
     final String claimName = "foo";
     final String claimValue = "bar";
     final var mapping =
-        new MappingRecord().setMappingKey(key).setClaimName(claimName).setClaimValue(claimValue);
+        new MappingRecord()
+            .setMappingId(mappingId)
+            .setClaimName(claimName)
+            .setClaimValue(claimValue);
     mappingState.create(mapping);
     final long roleKey = 1L;
 
     // when
-    mappingState.addRole(key, roleKey);
+    mappingState.addRole(mappingId, roleKey);
 
     // then
-    final var persistedMapping = mappingState.get(key).get();
+    final var persistedMapping = mappingState.get(mappingId).get();
     assertThat(persistedMapping.getRoleKeysList()).containsExactly(roleKey);
   }
 
   @Test
   void shouldRemoveRole() {
     // given
-    final long key = 1L;
+    final String mappingId = Strings.newRandomValidIdentityId();
     final String claimName = "foo";
     final String claimValue = "bar";
     final var mapping =
-        new MappingRecord().setMappingKey(key).setClaimName(claimName).setClaimValue(claimValue);
+        new MappingRecord()
+            .setMappingId(mappingId)
+            .setClaimName(claimName)
+            .setClaimValue(claimValue);
     mappingState.create(mapping);
     final long roleKey = 1L;
-    mappingState.addRole(key, roleKey);
+    mappingState.addRole(mappingId, roleKey);
 
     // when
-    mappingState.removeRole(key, roleKey);
+    mappingState.removeRole(mappingId, roleKey);
 
     // then
-    final var persistedMapping = mappingState.get(key).get();
+    final var persistedMapping = mappingState.get(mappingId).get();
     assertThat(persistedMapping.getRoleKeysList()).isEmpty();
   }
 
   @Test
   void shouldAddTenant() {
     // given
-    final long key = 1L;
     final String claimName = "foo";
     final String claimValue = "bar";
     final String mappingId = Strings.newRandomValidIdentityId();
     final var mapping =
         new MappingRecord()
             .setMappingId(mappingId)
-            .setMappingKey(key)
             .setClaimName(claimName)
             .setClaimValue(claimValue);
     mappingState.create(mapping);
@@ -189,7 +193,7 @@ public class MappingStateTest {
     mappingState.addTenant(mappingId, tenantId);
 
     // then
-    final var persistedMapping = mappingState.get(key).get();
+    final var persistedMapping = mappingState.get(mappingId).get();
     assertThat(persistedMapping.getTenantIdsList()).containsExactly(tenantId);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/RoleStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/RoleStateTest.java
@@ -95,11 +95,11 @@ public class RoleStateTest {
     roleState.create(roleRecord);
 
     // when
-    roleRecord.setEntityKey(2L).setEntityType(EntityType.USER);
+    roleRecord.setEntityId("roleEntityId").setEntityType(EntityType.USER);
     roleState.addEntity(roleRecord);
 
     // then
-    final var entityType = roleState.getEntityType(roleKey, 2L).get();
+    final var entityType = roleState.getEntityType(roleKey, "roleEntityId").get();
     assertThat(entityType).isEqualTo(EntityType.USER);
   }
 
@@ -110,20 +110,25 @@ public class RoleStateTest {
     final var roleKey = 123L;
     final var roleId = "123";
     final var roleName = "foo";
+    final var firstEntityId = "firstEntityId";
+    final var secondEntityId = "secondEntityId";
     final var roleRecord = new RoleRecord().setRoleKey(roleKey).setRoleId(roleId).setName(roleName);
     roleState.create(roleRecord);
-    roleRecord.setEntityKey(1L).setEntityType(EntityType.USER);
+    roleRecord.setEntityId(firstEntityId).setEntityType(EntityType.USER);
     roleState.addEntity(roleRecord);
     roleState.addEntity(
-        new RoleRecord().setRoleKey(roleKey).setEntityKey(2L).setEntityType(EntityType.USER));
+        new RoleRecord()
+            .setRoleKey(roleKey)
+            .setEntityId(secondEntityId)
+            .setEntityType(EntityType.USER));
 
     // when
-    roleState.removeEntity(roleKey, 1L);
+    roleState.removeEntity(roleKey, firstEntityId);
 
     // then
-    final var deletedEntity = roleState.getEntityType(roleKey, 1L);
+    final var deletedEntity = roleState.getEntityType(roleKey, firstEntityId);
     assertThat(deletedEntity).isEmpty();
-    final var entityType = roleState.getEntityType(roleKey, 2L).get();
+    final var entityType = roleState.getEntityType(roleKey, secondEntityId).get();
     assertThat(entityType).isEqualTo(EntityType.USER);
   }
 
@@ -134,9 +139,10 @@ public class RoleStateTest {
     final var roleKey = 123L;
     final var roleId = "123";
     final var roleName = "foo";
+    final var entityId = "entityId";
     final var roleRecord = new RoleRecord().setRoleKey(roleKey).setRoleId(roleId).setName(roleName);
     roleState.create(roleRecord);
-    roleRecord.setEntityKey(1L).setEntityType(EntityType.USER);
+    roleRecord.setEntityId(entityId).setEntityType(EntityType.USER);
     roleState.addEntity(roleRecord);
 
     // when
@@ -145,7 +151,7 @@ public class RoleStateTest {
     // then
     final var deletedRole = roleState.getRole(roleKey);
     assertThat(deletedRole).isEmpty();
-    final var deletedEntity = roleState.getEntityType(roleKey, 1L);
+    final var deletedEntity = roleState.getEntityType(roleKey, entityId);
     assertThat(deletedEntity).isEmpty();
   }
 
@@ -156,18 +162,20 @@ public class RoleStateTest {
     final var roleKey = 123L;
     final var roleId = "123";
     final var roleName = "foo";
+    final var firstEntityId = "firstEntityId";
+    final var secondEntityId = "secondEntityId";
     final var roleRecord = new RoleRecord().setRoleId(roleId).setRoleKey(roleKey).setName(roleName);
     roleState.create(roleRecord);
-    roleRecord.setEntityKey(1L).setEntityType(EntityType.USER);
+    roleRecord.setEntityId(firstEntityId).setEntityType(EntityType.USER);
     roleState.addEntity(roleRecord);
-    roleRecord.setEntityKey(2L).setEntityType(EntityType.UNSPECIFIED);
+    roleRecord.setEntityId(secondEntityId).setEntityType(EntityType.UNSPECIFIED);
     roleState.addEntity(roleRecord);
 
     // when
     final var entities = roleState.getEntitiesByType(roleKey);
 
     // then
-    assertThat(entities.get(EntityType.USER)).containsExactly(1L);
-    assertThat(entities.get(EntityType.UNSPECIFIED)).containsExactly(2L);
+    assertThat(entities.get(EntityType.USER)).containsExactly(firstEntityId);
+    assertThat(entities.get(EntityType.UNSPECIFIED)).containsExactly(secondEntityId);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/RoleClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/RoleClient.java
@@ -163,8 +163,8 @@ public class RoleClient {
       roleRecord.setRoleKey(key);
     }
 
-    public RoleAddEntityClient withEntityKey(final long entityKey) {
-      roleRecord.setEntityKey(entityKey);
+    public RoleAddEntityClient withEntityId(final String entityId) {
+      roleRecord.setEntityId(entityId);
       return this;
     }
 
@@ -210,8 +210,8 @@ public class RoleClient {
       roleRecord.setRoleKey(key);
     }
 
-    public RoleRemoveEntityClient withEntityKey(final long entityKey) {
-      roleRecord.setEntityKey(entityKey);
+    public RoleRemoveEntityClient withEntityId(final String entityId) {
+      roleRecord.setEntityId(entityId);
       return this;
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberAddedHandler.java
@@ -44,7 +44,7 @@ public class RoleMemberAddedHandler implements ExportHandler<RoleEntity, RoleRec
   @Override
   public List<String> generateIds(final Record<RoleRecordValue> record) {
     final RoleRecordValue value = record.getValue();
-    return List.of(RoleEntity.getChildKey(value.getRoleKey(), value.getEntityKey()));
+    return List.of(RoleEntity.getChildKey(value.getRoleKey(), value.getEntityId()));
   }
 
   @Override
@@ -55,7 +55,7 @@ public class RoleMemberAddedHandler implements ExportHandler<RoleEntity, RoleRec
   @Override
   public void updateEntity(final Record<RoleRecordValue> record, final RoleEntity entity) {
     entity
-        .setMemberKey(record.getValue().getEntityKey())
+        .setMemberId(record.getValue().getEntityId())
         .setJoin(RoleIndex.JOIN_RELATION_FACTORY.createChild(record.getValue().getRoleKey()));
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleMemberRemovedHandler.java
@@ -43,7 +43,7 @@ public class RoleMemberRemovedHandler implements ExportHandler<RoleEntity, RoleR
   @Override
   public List<String> generateIds(final Record<RoleRecordValue> record) {
     final RoleRecordValue value = record.getValue();
-    return List.of(RoleEntity.getChildKey(value.getRoleKey(), value.getEntityKey()));
+    return List.of(RoleEntity.getChildKey(value.getRoleKey(), value.getEntityId()));
   }
 
   @Override
@@ -54,7 +54,7 @@ public class RoleMemberRemovedHandler implements ExportHandler<RoleEntity, RoleR
   @Override
   public void updateEntity(final Record<RoleRecordValue> record, final RoleEntity entity) {
     entity
-        .setMemberKey(record.getValue().getEntityKey())
+        .setMemberId(record.getValue().getEntityId())
         .setJoin(RoleIndex.JOIN_RELATION_FACTORY.createChild(record.getValue().getRoleKey()));
   }
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/RoleExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/RoleExportHandler.java
@@ -54,14 +54,14 @@ public class RoleExportHandler implements RdbmsExportHandler<RoleRecordValue> {
           roleWriter.addMember(
               new RoleMemberDbModel.Builder()
                   .roleKey(value.getRoleKey())
-                  .entityKey(value.getEntityKey())
+                  .entityId(value.getEntityId())
                   .entityType(value.getEntityType().name())
                   .build());
       case RoleIntent.ENTITY_REMOVED ->
           roleWriter.removeMember(
               new RoleMemberDbModel.Builder()
                   .roleKey(value.getRoleKey())
-                  .entityKey(value.getEntityKey())
+                  .entityId(value.getEntityId())
                   .entityType(value.getEntityType().name())
                   .build());
       default -> LOG.warn("Unexpected intent {} for role record", record.getIntent());

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
@@ -82,7 +82,7 @@ public class UserController {
 
   @CamundaDeleteMapping(path = "/{userKey}/roles/{roleKey}")
   public CompletableFuture<ResponseEntity<Object>> removeRole(
-      @PathVariable final long userKey, @PathVariable final long roleKey) {
+      @PathVariable final String userKey, @PathVariable final long roleKey) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             roleServices

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
@@ -59,7 +59,7 @@ public class RoleControllerTest extends RestControllerTest {
     when(roleServices.createRole(request))
         .thenReturn(
             CompletableFuture.completedFuture(
-                new RoleRecord().setEntityKey(100L).setName(roleName)));
+                new RoleRecord().setEntityId("entityId").setName(roleName)));
 
     // when
     webClient

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/RoleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/RoleRecord.java
@@ -22,19 +22,16 @@ public class RoleRecord extends UnifiedRecordValue implements RoleRecordValue {
   private final StringProperty roleIdProp = new StringProperty("roleId", "");
   private final StringProperty nameProp = new StringProperty("name", "");
   private final StringProperty descriptionProp = new StringProperty("description", "");
-  // TODO remove entityKeyProp https://github.com/camunda/camunda/issues/30116
-  private final LongProperty entityKeyProp = new LongProperty("entityKey", -1L);
   private final StringProperty entityIdProp = new StringProperty("entityId", "");
   private final EnumProperty<EntityType> entityTypeProp =
       new EnumProperty<>("entityType", EntityType.class, EntityType.UNSPECIFIED);
 
   public RoleRecord() {
-    super(7);
+    super(6);
     declareProperty(roleKeyProp)
         .declareProperty(roleIdProp)
         .declareProperty(nameProp)
         .declareProperty(descriptionProp)
-        .declareProperty(entityKeyProp)
         .declareProperty(entityIdProp)
         .declareProperty(entityTypeProp);
   }
@@ -80,11 +77,6 @@ public class RoleRecord extends UnifiedRecordValue implements RoleRecordValue {
   }
 
   @Override
-  public long getEntityKey() {
-    return entityKeyProp.getValue();
-  }
-
-  @Override
   public String getEntityId() {
     return BufferUtil.bufferAsString(entityIdProp.getValue());
   }
@@ -101,11 +93,6 @@ public class RoleRecord extends UnifiedRecordValue implements RoleRecordValue {
 
   public RoleRecord setEntityType(final EntityType entityType) {
     entityTypeProp.setValue(entityType);
-    return this;
-  }
-
-  public RoleRecord setEntityKey(final long entityKey) {
-    entityKeyProp.setValue(entityKey);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2830,7 +2830,6 @@ final class JsonSerializableToJsonTest {
                     .setRoleId("id")
                     .setName("role")
                     .setDescription("description")
-                    .setEntityKey(2L)
                     .setEntityId("entityId")
                     .setEntityType(EntityType.USER),
         """
@@ -2839,7 +2838,6 @@ final class JsonSerializableToJsonTest {
           "roleId": "id",
           "name": "role",
           "description": "description",
-          "entityKey": 2,
           "entityId": "entityId",
           "entityType": "USER"
         }
@@ -2857,7 +2855,6 @@ final class JsonSerializableToJsonTest {
           "roleId": "",
           "name": "",
           "description": "",
-          "entityKey": -1,
           "entityId": "",
           "entityType": "UNSPECIFIED"
         }
@@ -3055,7 +3052,6 @@ final class JsonSerializableToJsonTest {
                             .setRoleId("id")
                             .setName("roleName")
                             .setDescription("description")
-                            .setEntityKey(2)
                             .setEntityId("entityId")
                             .setEntityType(EntityType.USER))
                     .addUser(
@@ -3095,7 +3091,6 @@ final class JsonSerializableToJsonTest {
           "roleId": "id",
           "name": "roleName",
           "description": "description",
-          "entityKey": 2,
           "entityId": "entityId",
           "entityType": "USER"
         },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/RoleRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/RoleRecordValue.java
@@ -35,9 +35,6 @@ public interface RoleRecordValue extends RecordValue {
   /** The description of the role. */
   String getDescription();
 
-  /** The key of a user/mapping to assign/remove from a role. */
-  long getEntityKey();
-
   /** The id of an entity to assign/remove from a role. */
   String getEntityId();
 

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -1017,7 +1017,7 @@ public class CompactRecordLogger {
         .append(", Name=")
         .append(formatId(value.getName()))
         .append(", EntityKey=")
-        .append(shortenKey(value.getEntityKey()))
+        .append(formatId(value.getEntityId()))
         .append("]");
 
     return builder.toString();

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RoleRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RoleRecordStream.java
@@ -34,7 +34,7 @@ public class RoleRecordStream extends ExporterRecordStream<RoleRecordValue, Role
     return valueFilter(v -> v.getName().equals(name));
   }
 
-  public RoleRecordStream withEntityKey(final long entityKey) {
-    return valueFilter(v -> v.getEntityKey() == entityKey);
+  public RoleRecordStream withEntityId(final String entityId) {
+    return valueFilter(v -> v.getEntityId().equals(entityId));
   }
 }


### PR DESCRIPTION
## Description

This PR is part of [#29534](https://github.com/camunda/camunda/issues/29534) – Store and retrieve related entities to a mapping using `mappingId` instead of `mappingKey`.
It refactors role management to use `mappingId` (String) instead of the previous `mappingKey` (Long). The changes include:

 - Updating method signatures and event creation in the engine to use string-based identifiers.

 - Modifying schema definitions, query filters, transformations, and integration tests to align with the new approach.

 - Adjusting database models and authentication services to reflect the updated identifier semantics.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
  - [ ] enable backports [when recommended](https://github.com/camunda/camunda/wiki/CI-&-Automation#when-to-backport-ci-changes)

## Related issues
first part of #29534
move to ready for review after : #30370 