### PR TITLE
try to not overwrite committed data when quorum of nodes experienced data loss

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -959,7 +959,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
                    creating an inconsistent timeline of events: \
                    THE CLUSTER SHOULD BE STOPPED IMMEDIATELY to further prevent inconsistencies.""",
                 firstCommitIndex, lastFlushedIndex, commitIndex);
-        throw new RuntimeException(errorMessage);
+        throw new IllegalStateException(errorMessage);
       }
       this.firstCommitIndex = firstCommitIndex;
       LOGGER.info(

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -878,10 +878,9 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
       LOGGER.error("Failed to close metastore", e);
     }
 
+    LOGGER.debug("Raft context closed");
     // close thread contexts
     threadContext.close();
-
-    LOGGER.debug("Raft context closed");
   }
 
   /** Unregisters server handlers on the configured protocol. */

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -704,7 +704,12 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
       return;
     }
 
-    LOGGER.info("Transitioning to {}", role);
+    LOGGER.info(
+        "Transitioning to {}: term={}, lastFlushedIdx={}, commitIdx={}",
+        role,
+        term,
+        raftLog.getLastIndex(),
+        raftLog.getCommitIndex());
 
     startTransition();
 
@@ -849,6 +854,11 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
 
   @Override
   public void close() {
+    LOGGER.debug(
+        "Closing RaftContext: term={}, commitIdx={}, lastFlushedIdx={}",
+        term,
+        raftLog.getCommitIndex(),
+        raftLog.getLastIndex());
     raftRoleMetrics.becomingInactive();
     started = false;
     // Unregister protocol listeners.
@@ -870,6 +880,8 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
 
     // close thread contexts
     threadContext.close();
+
+    LOGGER.debug("Raft context closed");
   }
 
   /** Unregisters server handlers on the configured protocol. */
@@ -923,10 +935,29 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
    *
    * @param firstCommitIndex The first commit index.
    */
-  public void setFirstCommitIndex(final long firstCommitIndex) {
+  public void setFirstCommitIndex(final long firstCommitIndex, final long lastFlushedIndex) {
     if (this.firstCommitIndex == 0) {
       if (firstCommitIndex == 0) {
         return;
+      }
+      // The previous leader may have crashed before updating the commit index on current leader.
+      // However, the data was already committed if the current leader had already flushed the
+      // message
+      // in its local storage.
+      // However, if the current leader has not received that message, we may be at risk of losing
+      // data.
+      if (firstCommitIndex < commitIndex && lastFlushedIndex < commitIndex) {
+        final var errorMessage =
+            String.format(
+                """
+                   A majority of nodes has lost committed data: firstCommitIndex(%d), lastflushedIndex(%d) < commitIndex(%d). \
+                   This node will become inactive to avoid overwriting previously committed data, \
+                   but the leader have formed a quorum and will continue to commit new events, \
+                   creating an inconsistent timeline of events: \
+                   THE CLUSTER SHOULD BE STOPPED IMMEDIATELY to further prevent inconsistencies.""",
+                firstCommitIndex, lastFlushedIndex, commitIndex);
+        LOGGER.error(errorMessage);
+        throw new RuntimeException(errorMessage);
       }
       this.firstCommitIndex = firstCommitIndex;
       LOGGER.info(

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -587,8 +587,8 @@ public class PassiveRole extends InactiveRole {
     // Append the entries to the log.
     appendEntries(request, future);
 
-    // If a snapshot replication was ongoing, reset it. Otherwise SnapshotReplicationListeners will
-    // wait for ever for the snapshot to be received.
+    // If a snapshot replication was ongoing, reset it. Otherwise, SnapshotReplicationListeners will
+    // wait forever for the snapshot to be received.
     abortPendingSnapshots();
     return future;
   }
@@ -760,7 +760,7 @@ public class PassiveRole extends InactiveRole {
     }
 
     // Set the first commit index.
-    raft.setFirstCommitIndex(request.commitIndex());
+    raft.setFirstCommitIndex(request.commitIndex(), lastLogIndex);
 
     // Update the context commit and global indices.
     final long previousCommitIndex = raft.setCommitIndex(commitIndex);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -71,6 +71,7 @@ import java.util.stream.Collectors;
 import org.jmock.lib.concurrent.DeterministicScheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 /**
  * Uses a DeterministicScheduler and controllable messaging layer to get a deterministic execution
@@ -222,7 +223,7 @@ public final class ControllableRaftContexts {
             memberId,
             m ->
                 (DeterministicSingleThreadContext)
-                    DeterministicSingleThreadContext.createContext());
+                    DeterministicSingleThreadContext.createContext(memberId));
   }
 
   private RaftStorage createStorage(
@@ -382,12 +383,17 @@ public final class ControllableRaftContexts {
   }
 
   public void restart(final MemberId memberId) {
-    raftServers.get(memberId).close();
+    final var raftcontext = raftServers.get(memberId);
+    try (final var ignored = MDC.putCloseable("actor-scheduler", memberId.toString())) {
+      raftServers.get(memberId).close();
+    }
     deterministicExecutors.remove(memberId).close();
     snapshotStores.get(memberId).close();
     MicrometerUtil.close(meterRegistries.get(memberId));
     final var newContext = createRaftContextForMember(random, Integer.parseInt(memberId.id()));
-    newContext.getCluster().bootstrap(raftServers.keySet());
+    try (final var ignored = MDC.putCloseable("actor-scheduler", memberId.toString())) {
+      newContext.getCluster().bootstrap(raftServers.keySet());
+    }
   }
 
   // This is a different from other operations, as it restarts the node and force operations on
@@ -396,7 +402,9 @@ public final class ControllableRaftContexts {
   // of one node at a time.
   public void restartWithDataLoss(final MemberId memberId) {
     LOG.info("Shutting down member {}", memberId.id());
-    raftServers.get(memberId).close();
+    try (final var ignored = MDC.putCloseable("actor-scheduler", memberId.toString())) {
+      raftServers.get(memberId).close();
+    }
     deterministicExecutors.remove(memberId).close();
     MicrometerUtil.close(meterRegistries.get(memberId));
     final var nodeBeforeRestart = raftServers.remove(memberId);
@@ -415,7 +423,9 @@ public final class ControllableRaftContexts {
       throw new UncheckedIOException(e);
     }
     final var newContext = createRaftContextForMember(random, Integer.parseInt(memberId.id()));
-    newContext.getCluster().bootstrap(raftServers.keySet());
+    try (final var ignored = MDC.putCloseable("actor-scheduler", memberId.toString())) {
+      newContext.getCluster().bootstrap(raftServers.keySet());
+    }
 
     raftServers.put(memberId, newContext);
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCorruptedDataTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCorruptedDataTest.java
@@ -36,7 +36,7 @@ public class RaftCorruptedDataTest {
     final var node1 = MemberId.from(servers[1].name());
     final var node2 = MemberId.from(servers[2].name());
 
-    raftRule.appendEntries(2000);
+    raftRule.appendEntries(100);
     raftRule.appendEntries(1);
     Awaitility.await("commitIndex is > 0 on all nodes")
         .until(() -> Arrays.stream(servers).allMatch(s -> s.getContext().getCommitIndex() >= 100));
@@ -62,9 +62,65 @@ public class RaftCorruptedDataTest {
     // wait for the two corrupted nodes to form quorum
     Awaitility.await("corrupted nodes form a quorum")
         .until(() -> server0.isLeader() || server1.isLeader());
+    // when
+    // the node with up-to-date log joins the cluster
+    final var server2 = raftRule.createServer(node2);
+
+    // then
+    // trigger bootstrap async
+    server2.bootstrap(node0, node1, node2);
+
+    // node does not become follower - goes to inactive as it detects that it has longer log
+    Awaitility.await("node becomes INACTIVE").until(() -> server2.getRole().equals(Role.INACTIVE));
+  }
+
+  @Test
+  @DisplayName(
+      "When nodes with corrupted data forms a quorum, the remaining one should not delete its files even if quorum term is > 1")
+  public void upToDateFollowerShouldNotLoseDataWhenQuorumExperienceCorruption2() throws Exception {
+    // given
+    // nodes 0, 1 experience corruption: all data is lost
+    final var servers = raftRule.getServers().toArray(RaftServer[]::new);
+    // name == memberId since the name is not specified
+    final var node0 = MemberId.from(servers[0].name());
+    final var node1 = MemberId.from(servers[1].name());
+    final var node2 = MemberId.from(servers[2].name());
+
+    raftRule.appendEntries(2000);
+    raftRule.appendEntries(1);
+    Awaitility.await("commitIndex is > 0 on all nodes")
+        .until(() -> Arrays.stream(servers).allMatch(s -> s.getContext().getCommitIndex() >= 100));
+
+    final var commitIndex = servers[2].getContext().getCommitIndex();
+
+    for (final RaftServer server : servers) {
+      raftRule.shutdownServer(server);
+    }
+
+    LOGGER.debug("All servers shut down");
+
+    raftRule.triggerDataLossOnNode(node0.id());
+    raftRule.triggerDataLossOnNode(node1.id());
+
+    LOGGER.debug("Data loss triggered on Broker-1/Broker-2");
+
+    // after shutdown the servers must be created from scratch with the same server name.
+    final var server0 = raftRule.createServer(node0);
+    final var server1 = raftRule.createServer(node1);
+
+    // bootstrap the nodes with data loss
+    CompletableFuture.allOf(
+            server0.bootstrap(node0, node1, node2), server1.bootstrap(node0, node1, node2))
+        .join();
+
+    // wait for the two corrupted nodes to form quorum
+    Awaitility.await("corrupted nodes form a quorum")
+        .until(() -> server0.isLeader() || server1.isLeader());
     raftRule.appendEntries(1000);
-    raftRule.takeCompactingSnapshot(server0, 500, 1);
-    raftRule.takeCompactingSnapshot(server1, 500, 1);
+    raftRule.restartLeader();
+
+    Awaitility.await("until the term is > 1")
+        .until(() -> raftRule.getLeader().get().getContext().getTerm() > 1);
 
     // when
     // the node with up-to-date log joins the cluster

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/impl/PriorityElectionTimerTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/impl/PriorityElectionTimerTest.java
@@ -17,6 +17,7 @@ package io.atomix.raft.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.atomix.cluster.MemberId;
 import io.atomix.raft.DeterministicSingleThreadContext;
 import java.time.Duration;
 import java.util.List;
@@ -33,7 +34,7 @@ final class PriorityElectionTimerTest {
 
   private final Logger log = LoggerFactory.getLogger(PriorityElectionTimerTest.class);
   private final DeterministicSingleThreadContext threadContext =
-      new DeterministicSingleThreadContext(new DeterministicScheduler());
+      new DeterministicSingleThreadContext(new DeterministicScheduler(), MemberId.from(""));
 
   @AfterEach
   void afterEach() {

--- a/zeebe/atomix/cluster/src/test/resources/log4j2-test.xml
+++ b/zeebe/atomix/cluster/src/test/resources/log4j2-test.xml
@@ -3,7 +3,7 @@
 
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%X{actor-name}] %-5level %logger{36} - %msg%n"/>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%X{actor-name} %X{actor-scheduler}] %-5level %logger{36} - %msg%n"/>
     </Console>
   </Appenders>
 


### PR DESCRIPTION
## Description
Validate that the `firstCommitIndex` is never strictly less than the persisted `commitIndex` in the `MetaStore`. 
The validation has been implemented in `firstCommitIndex` because that represent the commitIndex of the leader when the node first joins the cluster. 
If the leader's `commitIndex` & `lastFlushedIndex` is less than the persisted index, then the leader has experienced data loss.
Because the leader was elected with a quorum, this also means that a quorum of nodes experienced data loss.
To avoid losing any committed data, the follower will transition to INACTIVE.

Note that there may be cases where this euristic will not work, such as:
- the quorum of nodes with data loss has written enough messages in the log that their `logIdx` > `commitIndex` of the node with full data and their term > term of node with full data.



### Alternative approach
Potentially, the node with full data instead of going INACTIVE,  could trigger an election and propose as candidate. If there is some data committed by the quorum in-between it might not be elected anyway, however, if the quorum did not commit any data it might be able to become leader and send the missing data to the other nodes. 
What happens also depends on the raft's term that the quorum with data loss used to commit the new messages.
> [!WARNING] 
>Note that if the candidate manages to be elected as Leader, it may delete committed entries by the previous leader, which makes this alternative not feasible.


### Note
Raft does not guarantee anything when a quorum of nodes experienced data loss, so this euristic only tries to minimize data loss (if possible).
Moreover, when the nodes have a divergent history, manual intervetion is required because some committed messages will be missing in the other history. This means either deleting one of the histories or try to merge them (very hard)

## Related issues
closes #30057
